### PR TITLE
C#: Make CFG library shared

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Caching.qll
@@ -18,7 +18,7 @@ module Stages {
 
     cached
     private predicate forceCachingInSameStageRev() {
-      exists(SplitImpl si)
+      exists(Split s)
       or
       exists(SuccessorType st)
       or

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -183,7 +183,7 @@ module ControlFlow {
     }
 
     /** Gets a successor node of a given type, if any. */
-    Node getASuccessorByType(SuccessorType t) { result = getASuccessorByType(this, t) }
+    Node getASuccessorByType(SuccessorType t) { result = getASuccessor(this, t) }
 
     /** Gets an immediate successor, if any. */
     Node getASuccessor() { result = getASuccessorByType(_) }
@@ -255,9 +255,15 @@ module ControlFlow {
 
       override Callable getEnclosingCallable() { result = this.getCallable() }
 
-      override Location getLocation() { result = getCallable().getLocation() }
+      private Assignable getAssignable() { this = TEntryNode(result) }
 
-      override string toString() { result = "enter " + getCallable().toString() }
+      override Location getLocation() {
+        result in [this.getCallable().getLocation(), this.getAssignable().getLocation()]
+      }
+
+      override string toString() {
+        result = "enter " + [this.getCallable().toString(), this.getAssignable().toString()]
+      }
     }
 
     /** A node for a callable exit point, annotated with the type of exit. */
@@ -314,7 +320,7 @@ module ControlFlow {
      * different splits for the element.
      */
     class ElementNode extends Node, TElementNode {
-      private Splitting::Splits splits;
+      private Splits splits;
       private ControlFlowElement cfe;
 
       ElementNode() { this = TElementNode(cfe, splits) }

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -1,0 +1,945 @@
+/** Provides language-independent definitions for AST-to-CFG construction. */
+
+private import ControlFlowGraphImplSpecific
+
+/** An element with associated control flow. */
+abstract class ControlFlowTree extends ControlFlowTreeBase {
+  /** Holds if `first` is the first element executed within this element. */
+  pragma[nomagic]
+  abstract predicate first(ControlFlowElement first);
+
+  /**
+   * Holds if `last` with completion `c` is a potential last element executed
+   * within this element.
+   */
+  pragma[nomagic]
+  abstract predicate last(ControlFlowElement last, Completion c);
+
+  /** Holds if abnormal execution of `child` should propagate upwards. */
+  abstract predicate propagatesAbnormal(ControlFlowElement child);
+
+  /**
+   * Holds if `succ` is a control flow successor for `pred`, given that `pred`
+   * finishes with completion `c`.
+   */
+  pragma[nomagic]
+  abstract predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c);
+}
+
+/**
+ * Holds if `first` is the first element executed within control flow
+ * element `cft`.
+ */
+predicate first(ControlFlowTree cft, ControlFlowElement first) { cft.first(first) }
+
+/**
+ * Holds if `last` with completion `c` is a potential last element executed
+ * within control flow element `cft`.
+ */
+predicate last(ControlFlowTree cft, ControlFlowElement last, Completion c) {
+  cft.last(last, c)
+  or
+  exists(ControlFlowElement cfe |
+    cft.propagatesAbnormal(cfe) and
+    last(cfe, last, c) and
+    not completionIsNormal(c)
+  )
+}
+
+/**
+ * Holds if `succ` is a control flow successor for `pred`, given that `pred`
+ * finishes with completion `c`.
+ */
+pragma[nomagic]
+predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+  any(ControlFlowTree cft).succ(pred, succ, c)
+}
+
+/** An element that is executed in pre-order. */
+abstract class PreOrderTree extends ControlFlowTree {
+  final override predicate first(ControlFlowElement first) { first = this }
+}
+
+/** An element that is executed in post-order. */
+abstract class PostOrderTree extends ControlFlowTree {
+  override predicate last(ControlFlowElement last, Completion c) {
+    last = this and
+    completionIsValidFor(c, last)
+  }
+}
+
+/**
+ * An element where the children are evaluated following a standard left-to-right
+ * evaluation. The actual evaluation order is determined by the predicate
+ * `getChildElement()`.
+ */
+abstract class StandardTree extends ControlFlowTree {
+  /** Gets the `i`th child element, in order of evaluation. */
+  abstract ControlFlowElement getChildElement(int i);
+
+  private ControlFlowElement getChildElementRanked(int i) {
+    result =
+      rank[i + 1](ControlFlowElement child, int j |
+        child = this.getChildElement(j)
+      |
+        child order by j
+      )
+  }
+
+  /** Gets the first child node of this element. */
+  final ControlFlowElement getFirstChildElement() { result = this.getChildElementRanked(0) }
+
+  /** Gets the last child node of this node. */
+  final ControlFlowElement getLastChildElement() {
+    exists(int last |
+      result = this.getChildElementRanked(last) and
+      not exists(this.getChildElementRanked(last + 1))
+    )
+  }
+
+  /** Holds if this element has no children. */
+  predicate isLeafElement() { not exists(this.getFirstChildElement()) }
+
+  override predicate propagatesAbnormal(ControlFlowElement child) {
+    child = this.getChildElement(_)
+  }
+
+  pragma[nomagic]
+  override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+    exists(int i |
+      last(this.getChildElementRanked(i), pred, c) and
+      completionIsNormal(c) and
+      first(this.getChildElementRanked(i + 1), succ)
+    )
+  }
+}
+
+/** A standard element that is executed in pre-order. */
+abstract class StandardPreOrderTree extends StandardTree, PreOrderTree {
+  override predicate last(ControlFlowElement last, Completion c) {
+    last(this.getLastChildElement(), last, c)
+    or
+    this.isLeafElement() and
+    completionIsValidFor(c, this) and
+    last = this
+  }
+
+  override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+    StandardTree.super.succ(pred, succ, c)
+    or
+    pred = this and
+    first(this.getFirstChildElement(), succ) and
+    completionIsSimple(c)
+  }
+}
+
+/** A standard element that is executed in post-order. */
+abstract class StandardPostOrderTree extends StandardTree, PostOrderTree {
+  override predicate first(ControlFlowElement first) {
+    first(this.getFirstChildElement(), first)
+    or
+    not exists(this.getFirstChildElement()) and
+    first = this
+  }
+
+  override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+    StandardTree.super.succ(pred, succ, c)
+    or
+    last(this.getLastChildElement(), pred, c) and
+    succ = this and
+    completionIsNormal(c)
+  }
+}
+
+/** An element that is a leaf in the control flow graph. */
+abstract class LeafTree extends PreOrderTree, PostOrderTree {
+  override predicate propagatesAbnormal(ControlFlowElement child) { none() }
+
+  override predicate succ(ControlFlowElement pred, ControlFlowElement succ, Completion c) { none() }
+}
+
+/**
+ * Holds if split kinds `sk1` and `sk2` may overlap. That is, they may apply
+ * to at least one common AST node inside `scope`.
+ */
+private predicate overlapping(CfgScope scope, SplitKind sk1, SplitKind sk2) {
+  exists(ControlFlowElement e |
+    sk1.appliesTo(e) and
+    sk2.appliesTo(e) and
+    scope = getCfgScope(e)
+  )
+}
+
+/**
+ * A split kind. Each control flow node can have at most one split of a
+ * given kind.
+ */
+abstract class SplitKind extends SplitKindBase {
+  /** Gets a split of this kind. */
+  SplitImpl getASplit() { result.getKind() = this }
+
+  /** Holds if some split of this kind applies to AST node `n`. */
+  predicate appliesTo(ControlFlowElement n) { this.getASplit().appliesTo(n) }
+
+  /**
+   * Gets a unique integer representing this split kind. The integer is used
+   * to represent sets of splits as ordered lists.
+   */
+  abstract int getListOrder();
+
+  /** Gets the rank of this split kind among all overlapping kinds for `c`. */
+  private int getRank(CfgScope scope) {
+    this = rank[result](SplitKind sk | overlapping(scope, this, sk) | sk order by sk.getListOrder())
+  }
+
+  /**
+   * Holds if this split kind is enabled for AST node `n`. For performance reasons,
+   * the number of splits is restricted by the `maxSplits()` predicate.
+   */
+  predicate isEnabled(ControlFlowElement n) {
+    this.appliesTo(n) and
+    this.getRank(getCfgScope(n)) <= maxSplits()
+  }
+
+  /**
+   * Gets the rank of this split kind among all the split kinds that apply to
+   * AST node `n`. The rank is based on the order defined by `getListOrder()`.
+   */
+  int getListRank(ControlFlowElement n) {
+    this.isEnabled(n) and
+    this = rank[result](SplitKind sk | sk.appliesTo(n) | sk order by sk.getListOrder())
+  }
+
+  /** Gets a textual representation of this split kind. */
+  abstract string toString();
+}
+
+/** Provides the interface for implementing an entity to split on. */
+abstract class SplitImpl extends Split {
+  /** Gets the kind of this split. */
+  abstract SplitKind getKind();
+
+  /**
+   * Holds if this split is entered when control passes from `pred` to `succ` with
+   * completion `c`.
+   *
+   * Invariant: `hasEntry(pred, succ, c) implies succ(pred, succ, c)`.
+   */
+  abstract predicate hasEntry(ControlFlowElement pred, ControlFlowElement succ, Completion c);
+
+  /**
+   * Holds if this split is entered when control passes from `scope` to the entry point
+   * `first`.
+   *
+   * Invariant: `hasEntryScope(scope, first) implies scopeFirst(scope, first)`.
+   */
+  abstract predicate hasEntryScope(CfgScope scope, ControlFlowElement first);
+
+  /**
+   * Holds if this split is left when control passes from `pred` to `succ` with
+   * completion `c`.
+   *
+   * Invariant: `hasExit(pred, succ, c) implies succ(pred, succ, c)`.
+   */
+  abstract predicate hasExit(ControlFlowElement pred, ControlFlowElement succ, Completion c);
+
+  /**
+   * Holds if this split is left when control passes from `last` out of the enclosing
+   * scope `scope` with completion `c`.
+   *
+   * Invariant: `hasExitScope(scope, last, c) implies scopeLast(scope, last, c)`
+   */
+  abstract predicate hasExitScope(CfgScope scope, ControlFlowElement last, Completion c);
+
+  /**
+   * Holds if this split is maintained when control passes from `pred` to `succ` with
+   * completion `c`.
+   *
+   * Invariant: `hasSuccessor(pred, succ, c) implies succ(pred, succ, c)`
+   */
+  abstract predicate hasSuccessor(ControlFlowElement pred, ControlFlowElement succ, Completion c);
+
+  /** Holds if this split applies to control flow element `cfe`. */
+  final predicate appliesTo(ControlFlowElement cfe) {
+    this.hasEntry(_, cfe, _)
+    or
+    this.hasEntryScope(_, cfe)
+    or
+    exists(ControlFlowElement pred | this.appliesTo(pred) | this.hasSuccessor(pred, cfe, _))
+  }
+
+  /** The `succ` relation restricted to predecessors `pred` that this split applies to. */
+  pragma[noinline]
+  final predicate appliesSucc(ControlFlowElement pred, ControlFlowElement succ, Completion c) {
+    this.appliesTo(pred) and
+    succ(pred, succ, c)
+  }
+}
+
+/**
+ * A set of control flow node splits. The set is represented by a list of splits,
+ * ordered by ascending rank.
+ */
+class Splits extends TSplits {
+  /** Gets a textual representation of this set of splits. */
+  string toString() { result = splitsToString(this) }
+
+  /** Gets a split belonging to this set of splits. */
+  SplitImpl getASplit() {
+    exists(SplitImpl head, Splits tail | this = TSplitsCons(head, tail) |
+      result = head
+      or
+      result = tail.getASplit()
+    )
+  }
+}
+
+private predicate succEntrySplitsFromRank(
+  CfgScope pred, ControlFlowElement succ, Splits splits, int rnk
+) {
+  splits = TSplitsNil() and
+  scopeFirst(pred, succ) and
+  rnk = 0
+  or
+  exists(SplitImpl head, Splits tail | succEntrySplitsCons(pred, succ, head, tail, rnk) |
+    splits = TSplitsCons(head, tail)
+  )
+}
+
+private predicate succEntrySplitsCons(
+  CfgScope pred, ControlFlowElement succ, SplitImpl head, Splits tail, int rnk
+) {
+  succEntrySplitsFromRank(pred, succ, tail, rnk - 1) and
+  head.hasEntryScope(pred, succ) and
+  rnk = head.getKind().getListRank(succ)
+}
+
+/**
+ * Holds if `succ` with splits `succSplits` is the first element that is executed
+ * when entering callable `pred`.
+ */
+pragma[noinline]
+private predicate succEntrySplits(
+  CfgScope pred, ControlFlowElement succ, Splits succSplits, SuccessorType t
+) {
+  exists(int rnk |
+    scopeFirst(pred, succ) and
+    successorTypeIsSimple(t) and
+    succEntrySplitsFromRank(pred, succ, succSplits, rnk)
+  |
+    rnk = 0 and
+    not any(SplitImpl split).hasEntryScope(pred, succ)
+    or
+    rnk = max(SplitImpl split | split.hasEntryScope(pred, succ) | split.getKind().getListRank(succ))
+  )
+}
+
+/**
+ * Holds if `pred` with splits `predSplits` can exit the enclosing callable
+ * `succ` with type `t`.
+ */
+private predicate succExitSplits(
+  ControlFlowElement pred, Splits predSplits, CfgScope succ, SuccessorType t
+) {
+  exists(Reachability::SameSplitsBlock b, Completion c | pred = b.getAnElement() |
+    b.isReachable(predSplits) and
+    t = getAMatchingSuccessorType(c) and
+    scopeLast(succ, pred, c) and
+    forall(SplitImpl predSplit | predSplit = predSplits.getASplit() |
+      predSplit.hasExitScope(succ, pred, c)
+    )
+  )
+}
+
+/**
+ * Provides a predicate for the successor relation with split information,
+ * as well as logic used to construct the type `TSplits` representing sets
+ * of splits. Only sets of splits that can be reached are constructed, hence
+ * the predicates are mutually recursive.
+ *
+ * For the successor relation
+ *
+ * ```ql
+ * succSplits(ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits, Completion c)
+ * ```
+ *
+ * the following invariants are maintained:
+ *
+ * 1. `pred` is reachable with split set `predSplits`.
+ * 2. For all `split` in `predSplits`:
+ *    - If `split.hasSuccessor(pred, succ, c)` then `split` in `succSplits`.
+ * 3. For all `split` in `predSplits`:
+ *    - If `split.hasExit(pred, succ, c)` and not `split.hasEntry(pred, succ, c)` then
+ *      `split` not in `succSplits`.
+ * 4. For all `split` with kind not in `predSplits`:
+ *    - If `split.hasEntry(pred, succ, c)` then `split` in `succSplits`.
+ * 5. For all `split` in `succSplits`:
+ *    - `split.hasSuccessor(pred, succ, c)` and `split` in `predSplits`, or
+ *    - `split.hasEntry(pred, succ, c)`.
+ *
+ * The algorithm divides into four cases:
+ *
+ * 1. The set of splits for the successor is the same as the set of splits
+ *    for the predecessor:
+ *    a) The successor is in the same `SameSplitsBlock` as the predecessor.
+ *    b) The successor is *not* in the same `SameSplitsBlock` as the predecessor.
+ * 2. The set of splits for the successor is different from the set of splits
+ *    for the predecessor:
+ *    a) The set of splits for the successor is *maybe* non-empty.
+ *    b) The set of splits for the successor is *always* empty.
+ *
+ * Only case 2a may introduce new sets of splits, so only predicates from
+ * this case are used in the definition of `TSplits`.
+ *
+ * The predicates in this module are named after the cases above.
+ */
+private module SuccSplits {
+  private predicate succInvariant1(
+    Reachability::SameSplitsBlock b, ControlFlowElement pred, Splits predSplits,
+    ControlFlowElement succ, Completion c
+  ) {
+    pred = b.getAnElement() and
+    b.isReachable(predSplits) and
+    succ(pred, succ, c)
+  }
+
+  private predicate case1b0(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c
+  ) {
+    exists(Reachability::SameSplitsBlock b |
+      // Invariant 1
+      succInvariant1(b, pred, predSplits, succ, c)
+    |
+      (succ = b.getAnElement() implies succ = b) and
+      // Invariant 4
+      not exists(SplitImpl split | split.hasEntry(pred, succ, c))
+    )
+  }
+
+  /**
+   * Case 1b.
+   *
+   * Invariants 1 and 4 hold in the base case, and invariants 2, 3, and 5 are
+   * maintained for all splits in `predSplits` (= `succSplits`), except
+   * possibly for the splits in `except`.
+   *
+   * The predicate is written using explicit recursion, as opposed to a `forall`,
+   * to avoid negative recursion.
+   */
+  private predicate case1bForall(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, Splits except
+  ) {
+    case1b0(pred, predSplits, succ, c) and
+    except = predSplits
+    or
+    exists(SplitImpl split |
+      case1bForallCons(pred, predSplits, succ, c, split, except) and
+      split.hasSuccessor(pred, succ, c)
+    )
+  }
+
+  pragma[noinline]
+  private predicate case1bForallCons(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c,
+    SplitImpl exceptHead, Splits exceptTail
+  ) {
+    case1bForall(pred, predSplits, succ, c, TSplitsCons(exceptHead, exceptTail))
+  }
+
+  private predicate case1(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c
+  ) {
+    // Case 1a
+    exists(Reachability::SameSplitsBlock b | succInvariant1(b, pred, predSplits, succ, c) |
+      succ = b.getAnElement() and
+      not succ = b
+    )
+    or
+    // Case 1b
+    case1bForall(pred, predSplits, succ, c, TSplitsNil())
+  }
+
+  pragma[noinline]
+  private SplitImpl succInvariant1GetASplit(
+    Reachability::SameSplitsBlock b, ControlFlowElement pred, Splits predSplits,
+    ControlFlowElement succ, Completion c
+  ) {
+    succInvariant1(b, pred, predSplits, succ, c) and
+    result = predSplits.getASplit()
+  }
+
+  private predicate case2aux(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c
+  ) {
+    exists(Reachability::SameSplitsBlock b |
+      succInvariant1(b, pred, predSplits, succ, c) and
+      (succ = b.getAnElement() implies succ = b)
+    |
+      succInvariant1GetASplit(b, pred, predSplits, succ, c).hasExit(pred, succ, c)
+      or
+      any(SplitImpl split).hasEntry(pred, succ, c)
+    )
+  }
+
+  /**
+   * Holds if `succSplits` should not inherit a split of kind `sk` from
+   * `predSplits`, except possibly because of a split in `except`.
+   *
+   * The predicate is written using explicit recursion, as opposed to a `forall`,
+   * to avoid negative recursion.
+   */
+  private predicate case2aNoneInheritedOfKindForall(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, SplitKind sk,
+    Splits except
+  ) {
+    case2aux(pred, predSplits, succ, c) and
+    sk.appliesTo(succ) and
+    except = predSplits
+    or
+    exists(Splits mid, SplitImpl split |
+      case2aNoneInheritedOfKindForall(pred, predSplits, succ, c, sk, mid) and
+      mid = TSplitsCons(split, except)
+    |
+      split.getKind() = any(SplitKind sk0 | sk0 != sk and sk0.appliesTo(succ))
+      or
+      split.hasExit(pred, succ, c)
+    )
+  }
+
+  pragma[nomagic]
+  private predicate entryOfKind(
+    ControlFlowElement pred, ControlFlowElement succ, Completion c, SplitImpl split, SplitKind sk
+  ) {
+    split.hasEntry(pred, succ, c) and
+    sk = split.getKind()
+  }
+
+  /** Holds if `succSplits` should not have a split of kind `sk`. */
+  pragma[nomagic]
+  private predicate case2aNoneOfKind(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, SplitKind sk
+  ) {
+    // None inherited from predecessor
+    case2aNoneInheritedOfKindForall(pred, predSplits, succ, c, sk, TSplitsNil()) and
+    // None newly entered into
+    not entryOfKind(pred, succ, c, _, sk)
+  }
+
+  /** Holds if `succSplits` should not have a split of kind `sk` at rank `rnk`. */
+  pragma[nomagic]
+  private predicate case2aNoneAtRank(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, int rnk
+  ) {
+    exists(SplitKind sk | case2aNoneOfKind(pred, predSplits, succ, c, sk) |
+      rnk = sk.getListRank(succ)
+    )
+  }
+
+  pragma[nomagic]
+  private SplitImpl case2auxGetAPredecessorSplit(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c
+  ) {
+    case2aux(pred, predSplits, succ, c) and
+    result = predSplits.getASplit()
+  }
+
+  /** Gets a split that should be in `succSplits`. */
+  pragma[nomagic]
+  private SplitImpl case2aSome(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, SplitKind sk
+  ) {
+    (
+      // Inherited from predecessor
+      result = case2auxGetAPredecessorSplit(pred, predSplits, succ, c) and
+      result.hasSuccessor(pred, succ, c)
+      or
+      // Newly entered into
+      exists(SplitKind sk0 |
+        case2aNoneInheritedOfKindForall(pred, predSplits, succ, c, sk0, TSplitsNil())
+      |
+        entryOfKind(pred, succ, c, result, sk0)
+      )
+    ) and
+    sk = result.getKind()
+  }
+
+  /** Gets a split that should be in `succSplits` at rank `rnk`. */
+  pragma[nomagic]
+  SplitImpl case2aSomeAtRank(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, int rnk
+  ) {
+    exists(SplitKind sk | result = case2aSome(pred, predSplits, succ, c, sk) |
+      rnk = sk.getListRank(succ)
+    )
+  }
+
+  /**
+   * Case 2a.
+   *
+   * As opposed to the other cases, in this case we need to construct a new set
+   * of splits `succSplits`. Since this involves constructing the very IPA type,
+   * we cannot recurse directly over the structure of `succSplits`. Instead, we
+   * recurse over the ranks of all splits that *might* be in `succSplits`.
+   *
+   * - Invariant 1 holds in the base case,
+   * - invariant 2 holds for all splits with rank at least `rnk`,
+   * - invariant 3 holds for all splits in `predSplits`,
+   * - invariant 4 holds for all splits in `succSplits` with rank at least `rnk`,
+   *   and
+   * - invariant 4 holds for all splits in `succSplits` with rank at least `rnk`.
+   */
+  predicate case2aFromRank(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    Completion c, int rnk
+  ) {
+    case2aux(pred, predSplits, succ, c) and
+    succSplits = TSplitsNil() and
+    rnk = max(any(SplitKind sk).getListRank(succ)) + 1
+    or
+    case2aFromRank(pred, predSplits, succ, succSplits, c, rnk + 1) and
+    case2aNoneAtRank(pred, predSplits, succ, c, rnk)
+    or
+    exists(Splits mid, SplitImpl split | split = case2aCons(pred, predSplits, succ, mid, c, rnk) |
+      succSplits = TSplitsCons(split, mid)
+    )
+  }
+
+  pragma[noinline]
+  private SplitImpl case2aCons(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    Completion c, int rnk
+  ) {
+    case2aFromRank(pred, predSplits, succ, succSplits, c, rnk + 1) and
+    result = case2aSomeAtRank(pred, predSplits, succ, c, rnk)
+  }
+
+  /**
+   * Case 2b.
+   *
+   * Invariants 1, 4, and 5 hold in the base case, and invariants 2 and 3 are
+   * maintained for all splits in `predSplits`, except possibly for the splits
+   * in `except`.
+   *
+   * The predicate is written using explicit recursion, as opposed to a `forall`,
+   * to avoid negative recursion.
+   */
+  private predicate case2bForall(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, Splits except
+  ) {
+    // Invariant 1
+    case2aux(pred, predSplits, succ, c) and
+    // Invariants 4 and 5
+    not any(SplitKind sk).appliesTo(succ) and
+    except = predSplits
+    or
+    exists(SplitImpl split | case2bForallCons(pred, predSplits, succ, c, split, except) |
+      // Invariants 2 and 3
+      split.hasExit(pred, succ, c)
+    )
+  }
+
+  pragma[noinline]
+  private predicate case2bForallCons(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c,
+    SplitImpl exceptHead, Splits exceptTail
+  ) {
+    case2bForall(pred, predSplits, succ, c, TSplitsCons(exceptHead, exceptTail))
+  }
+
+  private predicate case2(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    Completion c
+  ) {
+    case2aFromRank(pred, predSplits, succ, succSplits, c, 1)
+    or
+    case2bForall(pred, predSplits, succ, c, TSplitsNil()) and
+    succSplits = TSplitsNil()
+  }
+
+  /**
+   * Holds if `succ` with splits `succSplits` is a successor of type `t` for `pred`
+   * with splits `predSplits`.
+   */
+  predicate succSplits(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    Completion c
+  ) {
+    case1(pred, predSplits, succ, c) and
+    succSplits = predSplits
+    or
+    case2(pred, predSplits, succ, succSplits, c)
+  }
+}
+
+import SuccSplits
+
+/** Provides logic for calculating reachable control flow nodes. */
+private module Reachability {
+  /**
+   * Holds if `cfe` is a control flow element where the set of possible splits may
+   * be different from the set of possible splits for one of `cfe`'s predecessors.
+   * That is, `cfe` starts a new block of elements with the same set of splits.
+   */
+  private predicate startsSplits(ControlFlowElement cfe) {
+    scopeFirst(_, cfe)
+    or
+    exists(SplitImpl s |
+      s.hasEntry(_, cfe, _)
+      or
+      s.hasExit(_, cfe, _)
+    )
+    or
+    exists(ControlFlowElement pred, SplitImpl split, Completion c | succ(pred, cfe, c) |
+      split.appliesTo(pred) and
+      not split.hasSuccessor(pred, cfe, c)
+    )
+  }
+
+  private predicate intraSplitsSucc(ControlFlowElement pred, ControlFlowElement succ) {
+    succ(pred, succ, _) and
+    not startsSplits(succ)
+  }
+
+  private predicate splitsBlockContains(ControlFlowElement start, ControlFlowElement cfe) =
+    fastTC(intraSplitsSucc/2)(start, cfe)
+
+  /**
+   * A block of control flow elements where the set of splits is guaranteed
+   * to remain unchanged, represented by the first element in the block.
+   */
+  class SameSplitsBlock extends ControlFlowElement {
+    SameSplitsBlock() { startsSplits(this) }
+
+    /** Gets a control flow element in this block. */
+    ControlFlowElement getAnElement() {
+      splitsBlockContains(this, result)
+      or
+      result = this
+    }
+
+    pragma[noinline]
+    private SameSplitsBlock getASuccessor(Splits predSplits, Splits succSplits) {
+      exists(ControlFlowElement pred | pred = this.getAnElement() |
+        succSplits(pred, predSplits, result, succSplits, _)
+      )
+    }
+
+    /**
+     * Holds if the elements of this block are reachable from a callable entry
+     *  point, with the splits `splits`.
+     */
+    predicate isReachable(Splits splits) {
+      // Base case
+      succEntrySplits(_, this, splits, _)
+      or
+      // Recursive case
+      exists(SameSplitsBlock pred, Splits predSplits | pred.isReachable(predSplits) |
+        this = pred.getASuccessor(predSplits, splits)
+      )
+    }
+  }
+}
+
+cached
+private module Cached {
+  /**
+   * If needed, call this predicate from `ControlFlowGraphImplSpecific.qll` in order to
+   * force a stage-dependency on the `ControlFlowGraphImplShared.qll` stage and therby
+   * collapsing the two stages.
+   */
+  cached
+  predicate forceCachingInSameStage() { any() }
+
+  cached
+  newtype TSplits =
+    TSplitsNil() or
+    TSplitsCons(SplitImpl head, Splits tail) {
+      exists(
+        ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Completion c, int rnk
+      |
+        case2aFromRank(pred, predSplits, succ, tail, c, rnk + 1) and
+        head = case2aSomeAtRank(pred, predSplits, succ, c, rnk)
+      )
+      or
+      succEntrySplitsCons(_, _, head, tail, _)
+    }
+
+  cached
+  string splitsToString(Splits splits) {
+    splits = TSplitsNil() and
+    result = ""
+    or
+    exists(SplitImpl head, Splits tail, string headString, string tailString |
+      splits = TSplitsCons(head, tail)
+    |
+      headString = head.toString() and
+      tailString = tail.toString() and
+      if tailString = ""
+      then result = headString
+      else
+        if headString = ""
+        then result = tailString
+        else result = headString + ", " + tailString
+    )
+  }
+
+  /**
+   * Internal representation of control flow nodes in the control flow graph.
+   * The control flow graph is pruned for unreachable nodes.
+   */
+  cached
+  newtype TNode =
+    TEntryNode(CfgScope scope) { succEntrySplits(scope, _, _, _) } or
+    TAnnotatedExitNode(CfgScope scope, boolean normal) {
+      exists(Reachability::SameSplitsBlock b, SuccessorType t | b.isReachable(_) |
+        succExitSplits(b.getAnElement(), _, scope, t) and
+        if isAbnormalExitType(t) then normal = false else normal = true
+      )
+    } or
+    TExitNode(CfgScope scope) {
+      exists(Reachability::SameSplitsBlock b | b.isReachable(_) |
+        succExitSplits(b.getAnElement(), _, scope, _)
+      )
+    } or
+    TElementNode(ControlFlowElement cfe, Splits splits) {
+      exists(Reachability::SameSplitsBlock b | b.isReachable(splits) | cfe = b.getAnElement())
+    }
+
+  /** Gets a successor node of a given flow type, if any. */
+  cached
+  TNode getASuccessor(TNode pred, SuccessorType t) {
+    // Callable entry node -> callable body
+    exists(ControlFlowElement succElement, Splits succSplits, CfgScope scope |
+      result = TElementNode(succElement, succSplits) and
+      pred = TEntryNode(scope) and
+      succEntrySplits(scope, succElement, succSplits, t)
+    )
+    or
+    exists(ControlFlowElement predElement, Splits predSplits |
+      pred = TElementNode(predElement, predSplits)
+    |
+      // Element node -> callable exit (annotated)
+      exists(CfgScope scope, boolean normal |
+        result = TAnnotatedExitNode(scope, normal) and
+        succExitSplits(predElement, predSplits, scope, t) and
+        if isAbnormalExitType(t) then normal = false else normal = true
+      )
+      or
+      // Element node -> element node
+      exists(ControlFlowElement succElement, Splits succSplits, Completion c |
+        result = TElementNode(succElement, succSplits)
+      |
+        succSplits(predElement, predSplits, succElement, succSplits, c) and
+        t = getAMatchingSuccessorType(c)
+      )
+    )
+    or
+    // Callable exit (annotated) -> callable exit
+    exists(CfgScope scope |
+      pred = TAnnotatedExitNode(scope, _) and
+      result = TExitNode(scope) and
+      successorTypeIsSimple(t)
+    )
+  }
+
+  /**
+   * Gets a first control flow element executed within `cfe`.
+   */
+  cached
+  ControlFlowElement getAControlFlowEntryNode(ControlFlowElement cfe) { first(cfe, result) }
+
+  /**
+   * Gets a potential last control flow element executed within `cfe`.
+   */
+  cached
+  ControlFlowElement getAControlFlowExitNode(ControlFlowElement cfe) { last(cfe, result, _) }
+}
+
+import Cached
+
+/**
+ * Import this module into a `.ql` file of `@kind graph` to render a CFG. The
+ * graph is restricted to nodes from `RelevantNode`.
+ */
+module TestOutput {
+  abstract class RelevantNode extends Node { }
+
+  query predicate nodes(RelevantNode n, string attr, string val) {
+    attr = "semmle.order" and
+    val =
+      any(int i |
+        n =
+          rank[i](RelevantNode p, Location l |
+            l = p.getLocation()
+          |
+            p
+            order by
+              l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+              l.getStartColumn()
+          )
+      ).toString()
+  }
+
+  query predicate edges(RelevantNode pred, RelevantNode succ, string attr, string val) {
+    exists(SuccessorType t | succ = getASuccessor(pred, t) |
+      attr = "semmle.label" and
+      if successorTypeIsSimple(t) then val = "" else val = t.toString()
+    )
+  }
+}
+
+/** Provides a set of splitting-related consistency queries. */
+module Consistency {
+  query predicate nonUniqueSetRepresentation(Splits s1, Splits s2) {
+    forex(Split s | s = s1.getASplit() | s = s2.getASplit()) and
+    forex(Split s | s = s2.getASplit() | s = s1.getASplit()) and
+    s1 != s2
+  }
+
+  query predicate breakInvariant2(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    SplitImpl split, Completion c
+  ) {
+    succSplits(pred, predSplits, succ, succSplits, c) and
+    split = predSplits.getASplit() and
+    split.hasSuccessor(pred, succ, c) and
+    not split = succSplits.getASplit()
+  }
+
+  query predicate breakInvariant3(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    SplitImpl split, Completion c
+  ) {
+    succSplits(pred, predSplits, succ, succSplits, c) and
+    split = predSplits.getASplit() and
+    split.hasExit(pred, succ, c) and
+    not split.hasEntry(pred, succ, c) and
+    split = succSplits.getASplit()
+  }
+
+  query predicate breakInvariant4(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    SplitImpl split, Completion c
+  ) {
+    succSplits(pred, predSplits, succ, succSplits, c) and
+    split.hasEntry(pred, succ, c) and
+    not split.getKind() = predSplits.getASplit().getKind() and
+    not split = succSplits.getASplit()
+  }
+
+  query predicate breakInvariant5(
+    ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
+    SplitImpl split, Completion c
+  ) {
+    succSplits(pred, predSplits, succ, succSplits, c) and
+    split = succSplits.getASplit() and
+    not (split.hasSuccessor(pred, succ, c) and split = predSplits.getASplit()) and
+    not split.hasEntry(pred, succ, c)
+  }
+
+  query predicate multipleSuccessors(Node node, SuccessorType t, Node successor) {
+    not node instanceof TEntryNode and
+    strictcount(getASuccessor(node, t)) > 1 and
+    successor = getASuccessor(node, t)
+  }
+}

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplSpecific.qll
@@ -1,0 +1,69 @@
+private import csharp as CS
+private import ControlFlowGraphImpl as Impl
+private import Completion as Comp
+private import Splitting as Splitting
+private import SuccessorType as ST
+private import semmle.code.csharp.Caching
+
+class ControlFlowTreeBase = Impl::ControlFlowTree::Range;
+
+class ControlFlowElement = CS::ControlFlowElement;
+
+class Completion = Comp::Completion;
+
+/**
+ * Hold if `c` represents normal evaluation of a statement or an
+ * expression.
+ */
+predicate completionIsNormal(Completion c) { c instanceof Comp::NormalCompletion }
+
+/**
+ * Hold if `c` represents simple (normal) evaluation of a statement or an
+ * expression.
+ */
+predicate completionIsSimple(Completion c) { c instanceof Comp::SimpleCompletion }
+
+/** Holds if `c` is a valid completion for `e`. */
+predicate completionIsValidFor(Completion c, ControlFlowElement e) { c.isValidFor(e) }
+
+class CfgScope = Impl::CfgScope;
+
+/** Gets the CFG scope for `e`. */
+CfgScope getCfgScope(ControlFlowElement e) {
+  Stages::ControlFlowStage::forceCachingInSameStage() and
+  result = e.getEnclosingCallable()
+}
+
+predicate scopeFirst = Impl::scopeFirst/2;
+
+predicate scopeLast = Impl::scopeLast/3;
+
+/** The maximum number of splits allowed for a given node. */
+int maxSplits() { result = 5 }
+
+class SplitKindBase = Splitting::TSplitKind;
+
+class Split = Splitting::Split;
+
+class SuccessorType = ST::SuccessorType;
+
+/** Gets a successor type that matches completion `c`. */
+SuccessorType getAMatchingSuccessorType(Completion c) { result = c.getAMatchingSuccessorType() }
+
+/**
+ * Hold if `c` represents simple (normal) evaluation of a statement or an
+ * expression.
+ */
+predicate successorTypeIsSimple(SuccessorType t) {
+  t instanceof ST::SuccessorTypes::NormalSuccessor
+}
+
+/** Holds if `t` is an abnormal exit type out of a callable. */
+predicate isAbnormalExitType(SuccessorType t) {
+  t instanceof ST::SuccessorTypes::ExceptionSuccessor or
+  t instanceof ST::SuccessorTypes::ExitSuccessor
+}
+
+class Location = CS::Location;
+
+class Node = CS::ControlFlow::Node;

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -677,7 +677,7 @@
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | exit Initializers | 16 |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | exit Initializers | 16 |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | exit M | 22 |
-| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | 2 |
+| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:16:18:20 | ... = ... | 3 |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor | 9 |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 12 |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 9 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Consistency.expected
@@ -1,7 +1,7 @@
-preBasicBlockConsistency
 nonUniqueSetRepresentation
 breakInvariant2
 breakInvariant3
 breakInvariant4
 breakInvariant5
 multipleSuccessors
+preBasicBlockConsistency

--- a/csharp/ql/test/library-tests/controlflow/graph/Consistency.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/Consistency.ql
@@ -4,6 +4,7 @@ import semmle.code.csharp.controlflow.internal.PreBasicBlocks
 import ControlFlow
 import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl
 import semmle.code.csharp.controlflow.internal.Splitting
+import Consistency
 
 predicate bbStartInconsistency(ControlFlowElement cfe) {
   exists(ControlFlow::BasicBlock bb | bb.getFirstNode() = cfe.getAControlFlowNode()) and
@@ -48,59 +49,4 @@ query predicate preBasicBlockConsistency(ControlFlowElement cfe1, ControlFlowEle
   or
   bbIntraSuccInconsistency(cfe1, cfe2) and
   s = "intra succ inconsistency"
-}
-
-query predicate nonUniqueSetRepresentation(Splits s1, Splits s2) {
-  forex(Nodes::Split s | s = s1.getASplit() | s = s2.getASplit()) and
-  forex(Nodes::Split s | s = s2.getASplit() | s = s1.getASplit()) and
-  s1 != s2
-}
-
-query predicate breakInvariant2(
-  ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
-  SplitImpl split, Completion c
-) {
-  succSplits(pred, predSplits, succ, succSplits, c) and
-  split = predSplits.getASplit() and
-  split.hasSuccessor(pred, succ, c) and
-  not split = succSplits.getASplit()
-}
-
-query predicate breakInvariant3(
-  ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
-  SplitImpl split, Completion c
-) {
-  succSplits(pred, predSplits, succ, succSplits, c) and
-  split = predSplits.getASplit() and
-  split.hasExit(pred, succ, c) and
-  not split.hasEntry(pred, succ, c) and
-  split = succSplits.getASplit()
-}
-
-query predicate breakInvariant4(
-  ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
-  SplitImpl split, Completion c
-) {
-  succSplits(pred, predSplits, succ, succSplits, c) and
-  split.hasEntry(pred, succ, c) and
-  not split.getKind() = predSplits.getASplit().getKind() and
-  not split = succSplits.getASplit()
-}
-
-query predicate breakInvariant5(
-  ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits,
-  SplitImpl split, Completion c
-) {
-  succSplits(pred, predSplits, succ, succSplits, c) and
-  split = succSplits.getASplit() and
-  not (split.hasSuccessor(pred, succ, c) and split = predSplits.getASplit()) and
-  not split.hasEntry(pred, succ, c)
-}
-
-query predicate multipleSuccessors(
-  ControlFlow::Node node, SuccessorType t, ControlFlow::Node successor
-) {
-  not node instanceof ControlFlow::Nodes::EntryNode and
-  strictcount(node.getASuccessorByType(t)) > 1 and
-  successor = node.getASuccessorByType(t)
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -2504,6 +2504,7 @@ dominance
 | Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:59:15:60 | "" |
 | Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:37:15:63 | { ..., ... } |
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers |
+| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:20:18:20 | 1 |
 | Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor |
@@ -6631,6 +6632,7 @@ postDominance
 | Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:59:15:60 | "" |
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:39:15:39 | access to local variable i |
 | Initializers.cs:18:16:18:20 | ... = ... | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:16 | enter H |
 | Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:23:23:23:27 | ... = ... |
 | Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | enter NoConstructor |
@@ -11274,7 +11276,7 @@ blockDominance
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | enter Initializers |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | enter Initializers |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | enter M |
-| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:16:18:16 | enter H |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | enter NoConstructor |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | enter Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | enter Sub |
@@ -14866,7 +14868,7 @@ postBlockDominance
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | enter Initializers |
 | Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | enter Initializers |
 | Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | enter M |
-| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:16:18:16 | enter H |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | enter NoConstructor |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | enter Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | enter Sub |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1,4926 +1,14451 @@
-| AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i | semmle.label | successor |
-| AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | AccessorCalls.cs:5:23:5:25 | exit get_Item | semmle.label | successor |
-| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | semmle.label | successor |
-| AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:37:5:39 | {...} | semmle.label | successor |
-| AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | AccessorCalls.cs:5:33:5:35 | exit set_Item | semmle.label | successor |
-| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | semmle.label | successor |
-| AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:36:7:38 | {...} | semmle.label | successor |
-| AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | AccessorCalls.cs:7:32:7:34 | exit add_Event | semmle.label | successor |
-| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | semmle.label | successor |
-| AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:47:7:49 | {...} | semmle.label | successor |
-| AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | AccessorCalls.cs:7:40:7:45 | exit remove_Event | semmle.label | successor |
-| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | semmle.label | successor |
-| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | AccessorCalls.cs:10:10:10:11 | exit M1 | semmle.label | successor |
-| AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; | semmle.label | successor |
-| AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:21:13:24 | this access | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; | semmle.label | successor |
-| AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; | semmle.label | successor |
-| AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:19:14:22 | this access | semmle.label | successor |
-| AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 | semmle.label | successor |
-| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:23:15:23 | access to parameter e | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:23 | ... += ... | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; | semmle.label | successor |
-| AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | semmle.label | successor |
-| AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | AccessorCalls.cs:19:10:19:11 | exit M2 | semmle.label | successor |
-| AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; | semmle.label | successor |
-| AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:23:22:26 | this access | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; | semmle.label | successor |
-| AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; | semmle.label | successor |
-| AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:21:23:24 | this access | semmle.label | successor |
-| AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 | semmle.label | successor |
-| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:25:24:25 | access to parameter e | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:25 | ... += ... | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; | semmle.label | successor |
-| AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | semmle.label | successor |
-| AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event | semmle.label | successor |
-| AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | AccessorCalls.cs:28:10:28:11 | exit M3 | semmle.label | successor |
-| AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; | semmle.label | successor |
-| AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:31:9:31:20 | ...; | semmle.label | successor |
-| AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:19 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:32:9:32:18 | ...; | semmle.label | successor |
-| AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | semmle.label | successor |
-| AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:36:5:40:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | AccessorCalls.cs:35:10:35:11 | exit M4 | semmle.label | successor |
-| AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; | semmle.label | successor |
-| AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:22 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:38:9:38:22 | ...; | semmle.label | successor |
-| AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:21 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:39:9:39:20 | ...; | semmle.label | successor |
-| AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ | semmle.label | successor |
-| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | semmle.label | successor |
-| AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | AccessorCalls.cs:42:10:42:11 | exit M5 | semmle.label | successor |
-| AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; | semmle.label | successor |
-| AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:17 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; | semmle.label | successor |
-| AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | semmle.label | successor |
-| AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 | semmle.label | successor |
-| AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... | semmle.label | successor |
-| AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:50:5:54:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | AccessorCalls.cs:49:10:49:11 | exit M6 | semmle.label | successor |
-| AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; | semmle.label | successor |
-| AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:30 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:36 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:19 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; | semmle.label | successor |
-| AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:34 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... + ... | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | semmle.label | successor |
-| AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access | semmle.label | successor |
-| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 | semmle.label | successor |
-| AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... | semmle.label | successor |
-| AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:57:5:59:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | AccessorCalls.cs:56:10:56:11 | exit M7 | semmle.label | successor |
-| AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; | semmle.label | successor |
-| AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | semmle.label | successor |
-| AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:37:58:43 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 | semmle.label | successor |
-| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:9:58:85 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:33:58:44 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:22:58:30 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:74:58:74 | 0 | semmle.label | successor |
-| AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:77:58:80 | this access | semmle.label | successor |
-| AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:82:58:82 | 1 | semmle.label | successor |
-| AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:62:5:64:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | AccessorCalls.cs:61:10:61:11 | exit M8 | semmle.label | successor |
-| AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; | semmle.label | successor |
-| AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | semmle.label | successor |
-| AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:41:63:44 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:41:63:49 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 | semmle.label | successor |
-| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:9:63:97 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:37:63:50 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:24:63:34 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field | semmle.label | successor |
-| AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:75 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:80 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:84:63:84 | 0 | semmle.label | successor |
-| AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:87:63:90 | this access | semmle.label | successor |
-| AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:92 | access to field x | semmle.label | successor |
-| AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:94:63:94 | 1 | semmle.label | successor |
-| AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer | semmle.label | successor |
-| AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:67:5:74:5 | {...} | semmle.label | successor |
-| AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | AccessorCalls.cs:66:10:66:11 | exit M9 | semmle.label | successor |
-| AccessorCalls.cs:67:5:74:5 | {...} | AccessorCalls.cs:68:9:68:22 | ... ...; | semmle.label | successor |
-| AccessorCalls.cs:68:9:68:22 | ... ...; | AccessorCalls.cs:68:21:68:21 | access to parameter o | semmle.label | successor |
-| AccessorCalls.cs:68:17:68:21 | dynamic d = ... | AccessorCalls.cs:69:9:69:36 | ...; | semmle.label | successor |
-| AccessorCalls.cs:68:21:68:21 | access to parameter o | AccessorCalls.cs:68:17:68:21 | dynamic d = ... | semmle.label | successor |
-| AccessorCalls.cs:69:9:69:9 | access to local variable d | AccessorCalls.cs:69:24:69:24 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:69:9:69:20 | dynamic access to member MaybeProp1 | AccessorCalls.cs:69:9:69:35 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:69:9:69:35 | ... = ... | AccessorCalls.cs:70:9:70:22 | ...; | semmle.label | successor |
-| AccessorCalls.cs:69:9:69:36 | ...; | AccessorCalls.cs:69:9:69:9 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:69:24:69:24 | access to local variable d | AccessorCalls.cs:69:24:69:35 | dynamic access to member MaybeProp2 | semmle.label | successor |
-| AccessorCalls.cs:69:24:69:35 | dynamic access to member MaybeProp2 | AccessorCalls.cs:69:9:69:20 | dynamic access to member MaybeProp1 | semmle.label | successor |
-| AccessorCalls.cs:70:9:70:9 | access to local variable d | AccessorCalls.cs:70:9:70:19 | dynamic access to member MaybeProp | semmle.label | successor |
-| AccessorCalls.cs:70:9:70:19 | dynamic access to member MaybeProp | AccessorCalls.cs:70:9:70:21 | dynamic call to operator ++ | semmle.label | successor |
-| AccessorCalls.cs:70:9:70:21 | dynamic call to operator ++ | AccessorCalls.cs:71:9:71:26 | ...; | semmle.label | successor |
-| AccessorCalls.cs:70:9:70:22 | ...; | AccessorCalls.cs:70:9:70:9 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:9 | access to local variable d | AccessorCalls.cs:71:9:71:9 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:9 | access to local variable d | AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent | AccessorCalls.cs:71:9:71:25 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent | AccessorCalls.cs:71:25:71:25 | access to parameter e | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:25 | ... = ... | AccessorCalls.cs:72:9:72:21 | ...; | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:25 | dynamic call to operator + | AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent | semmle.label | successor |
-| AccessorCalls.cs:71:9:71:26 | ...; | AccessorCalls.cs:71:9:71:9 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:71:25:71:25 | access to parameter e | AccessorCalls.cs:71:9:71:25 | dynamic call to operator + | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:9 | access to local variable d | AccessorCalls.cs:72:11:72:11 | 0 | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:9 | access to local variable d | AccessorCalls.cs:72:11:72:11 | 0 | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:12 | dynamic access to element | AccessorCalls.cs:72:9:72:20 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:12 | dynamic access to element | AccessorCalls.cs:72:17:72:17 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:20 | ... = ... | AccessorCalls.cs:73:9:73:84 | ...; | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:20 | dynamic call to operator + | AccessorCalls.cs:72:9:72:12 | dynamic access to element | semmle.label | successor |
-| AccessorCalls.cs:72:9:72:21 | ...; | AccessorCalls.cs:72:9:72:9 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:72:11:72:11 | 0 | AccessorCalls.cs:72:9:72:9 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:72:11:72:11 | 0 | AccessorCalls.cs:72:9:72:12 | dynamic access to element | semmle.label | successor |
-| AccessorCalls.cs:72:17:72:17 | access to local variable d | AccessorCalls.cs:72:19:72:19 | 1 | semmle.label | successor |
-| AccessorCalls.cs:72:17:72:20 | dynamic access to element | AccessorCalls.cs:72:9:72:20 | dynamic call to operator + | semmle.label | successor |
-| AccessorCalls.cs:72:19:72:19 | 1 | AccessorCalls.cs:72:17:72:20 | dynamic access to element | semmle.label | successor |
-| AccessorCalls.cs:73:9:73:44 | (..., ...) | AccessorCalls.cs:73:49:73:49 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:73:9:73:83 | ... = ... | AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | semmle.label | successor |
-| AccessorCalls.cs:73:9:73:84 | ...; | AccessorCalls.cs:73:10:73:10 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:73:10:73:10 | access to local variable d | AccessorCalls.cs:73:24:73:27 | this access | semmle.label | successor |
-| AccessorCalls.cs:73:10:73:21 | dynamic access to member MaybeProp1 | AccessorCalls.cs:73:24:73:32 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:73:24:73:27 | this access | AccessorCalls.cs:73:39:73:39 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:73:24:73:32 | access to property Prop | AccessorCalls.cs:73:39:73:42 | dynamic access to element | semmle.label | successor |
-| AccessorCalls.cs:73:35:73:43 | (..., ...) | AccessorCalls.cs:73:9:73:44 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:73:39:73:39 | access to local variable d | AccessorCalls.cs:73:41:73:41 | 0 | semmle.label | successor |
-| AccessorCalls.cs:73:39:73:42 | dynamic access to element | AccessorCalls.cs:73:9:73:83 | ... = ... | semmle.label | successor |
-| AccessorCalls.cs:73:41:73:41 | 0 | AccessorCalls.cs:73:35:73:43 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:73:48:73:83 | (..., ...) | AccessorCalls.cs:73:10:73:21 | dynamic access to member MaybeProp1 | semmle.label | successor |
-| AccessorCalls.cs:73:49:73:49 | access to local variable d | AccessorCalls.cs:73:49:73:60 | dynamic access to member MaybeProp1 | semmle.label | successor |
-| AccessorCalls.cs:73:49:73:60 | dynamic access to member MaybeProp1 | AccessorCalls.cs:73:63:73:66 | this access | semmle.label | successor |
-| AccessorCalls.cs:73:63:73:66 | this access | AccessorCalls.cs:73:63:73:71 | access to property Prop | semmle.label | successor |
-| AccessorCalls.cs:73:63:73:71 | access to property Prop | AccessorCalls.cs:73:75:73:75 | 0 | semmle.label | successor |
-| AccessorCalls.cs:73:74:73:82 | (..., ...) | AccessorCalls.cs:73:48:73:83 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:73:75:73:75 | 0 | AccessorCalls.cs:73:78:73:78 | access to local variable d | semmle.label | successor |
-| AccessorCalls.cs:73:78:73:78 | access to local variable d | AccessorCalls.cs:73:80:73:80 | 1 | semmle.label | successor |
-| AccessorCalls.cs:73:78:73:81 | dynamic access to element | AccessorCalls.cs:73:74:73:82 | (..., ...) | semmle.label | successor |
-| AccessorCalls.cs:73:80:73:80 | 1 | AccessorCalls.cs:73:78:73:81 | dynamic access to element | semmle.label | successor |
-| ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:27:3:27 | 0 | semmle.label | successor |
-| ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | ArrayCreation.cs:3:11:3:12 | exit M1 | semmle.label | successor |
-| ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | semmle.label | successor |
-| ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | semmle.label | successor |
-| ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:28:5:28 | 0 | semmle.label | successor |
-| ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | ArrayCreation.cs:5:12:5:13 | exit M2 | semmle.label | successor |
-| ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | semmle.label | successor |
-| ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:31:5:31 | 1 | semmle.label | successor |
-| ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | semmle.label | successor |
-| ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:19:7:36 | 2 | semmle.label | successor |
-| ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | ArrayCreation.cs:7:11:7:12 | exit M3 | semmle.label | successor |
-| ArrayCreation.cs:7:19:7:36 | 2 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | semmle.label | successor |
-| ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | ArrayCreation.cs:7:31:7:31 | 0 | semmle.label | successor |
-| ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | semmle.label | successor |
-| ArrayCreation.cs:7:31:7:31 | 0 | ArrayCreation.cs:7:34:7:34 | 1 | semmle.label | successor |
-| ArrayCreation.cs:7:34:7:34 | 1 | ArrayCreation.cs:7:29:7:36 | { ..., ... } | semmle.label | successor |
-| ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:20:9:52 | 2 | semmle.label | successor |
-| ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | ArrayCreation.cs:9:12:9:13 | exit M4 | semmle.label | successor |
-| ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | 2 | semmle.label | successor |
-| ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | semmle.label | successor |
-| ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | ArrayCreation.cs:9:35:9:35 | 0 | semmle.label | successor |
-| ArrayCreation.cs:9:31:9:52 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | semmle.label | successor |
-| ArrayCreation.cs:9:33:9:40 | { ..., ... } | ArrayCreation.cs:9:45:9:45 | 2 | semmle.label | successor |
-| ArrayCreation.cs:9:35:9:35 | 0 | ArrayCreation.cs:9:38:9:38 | 1 | semmle.label | successor |
-| ArrayCreation.cs:9:38:9:38 | 1 | ArrayCreation.cs:9:33:9:40 | { ..., ... } | semmle.label | successor |
-| ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:31:9:52 | { ..., ... } | semmle.label | successor |
-| ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:48:9:48 | 3 | semmle.label | successor |
-| ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | semmle.label | successor |
-| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:8:5:12:5 | {...} | semmle.label | successor |
-| Assert.cs:7:10:7:11 | exit M1 (abnormal) | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
-| Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
-| Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; | semmle.label | successor |
-| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; | semmle.label | successor |
-| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | semmle.label | true |
-| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | semmle.label | false |
-| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
-| Assert.cs:9:24:9:27 | null | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:9:31:9:32 | "" | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) | semmle.label | exit |
-| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; | semmle.label | successor |
-| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s | semmle.label | successor |
-| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null | semmle.label | successor |
-| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | semmle.label | false |
-| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | semmle.label | true |
-| Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... | semmle.label | successor |
-| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 (normal) | semmle.label | successor |
-| Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length | semmle.label | successor |
-| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:15:5:19:5 | {...} | semmle.label | successor |
-| Assert.cs:14:10:14:11 | exit M2 (abnormal) | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
-| Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
-| Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; | semmle.label | successor |
-| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; | semmle.label | successor |
-| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null | semmle.label | true |
-| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" | semmle.label | false |
-| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
-| Assert.cs:16:24:16:27 | null | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:16:31:16:32 | "" | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; | semmle.label | successor |
-| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s | semmle.label | successor |
-| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | semmle.label | non-null |
-| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | semmle.label | null |
-| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 (normal) | semmle.label | successor |
-| Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length | semmle.label | successor |
-| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:22:5:26:5 | {...} | semmle.label | successor |
-| Assert.cs:21:10:21:11 | exit M3 (abnormal) | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
-| Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
-| Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; | semmle.label | successor |
-| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; | semmle.label | successor |
-| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null | semmle.label | true |
-| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" | semmle.label | false |
-| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
-| Assert.cs:23:24:23:27 | null | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:23:31:23:32 | "" | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; | semmle.label | successor |
-| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s | semmle.label | successor |
-| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | semmle.label | null |
-| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | semmle.label | non-null |
-| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 (normal) | semmle.label | successor |
-| Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length | semmle.label | successor |
-| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:29:5:33:5 | {...} | semmle.label | successor |
-| Assert.cs:28:10:28:11 | exit M4 (abnormal) | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
-| Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
-| Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; | semmle.label | successor |
-| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; | semmle.label | successor |
-| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null | semmle.label | true |
-| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" | semmle.label | false |
-| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
-| Assert.cs:30:24:30:27 | null | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:30:31:30:32 | "" | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; | semmle.label | successor |
-| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s | semmle.label | successor |
-| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null | semmle.label | successor |
-| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | semmle.label | false |
-| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | semmle.label | true |
-| Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... | semmle.label | successor |
-| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 (normal) | semmle.label | successor |
-| Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length | semmle.label | successor |
-| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:36:5:40:5 | {...} | semmle.label | successor |
-| Assert.cs:35:10:35:11 | exit M5 (abnormal) | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
-| Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
-| Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; | semmle.label | successor |
-| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; | semmle.label | successor |
-| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null | semmle.label | true |
-| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" | semmle.label | false |
-| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
-| Assert.cs:37:24:37:27 | null | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:37:31:37:32 | "" | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; | semmle.label | successor |
-| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s | semmle.label | successor |
-| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null | semmle.label | successor |
-| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | semmle.label | false |
-| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | semmle.label | true |
-| Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... | semmle.label | successor |
-| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 (normal) | semmle.label | successor |
-| Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length | semmle.label | successor |
-| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:43:5:47:5 | {...} | semmle.label | successor |
-| Assert.cs:42:10:42:11 | exit M6 (abnormal) | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
-| Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
-| Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; | semmle.label | successor |
-| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; | semmle.label | successor |
-| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null | semmle.label | true |
-| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" | semmle.label | false |
-| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
-| Assert.cs:44:24:44:27 | null | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:44:31:44:32 | "" | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; | semmle.label | successor |
-| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s | semmle.label | successor |
-| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null | semmle.label | successor |
-| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... | semmle.label | successor |
-| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 (normal) | semmle.label | successor |
-| Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length | semmle.label | successor |
-| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:50:5:54:5 | {...} | semmle.label | successor |
-| Assert.cs:49:10:49:11 | exit M7 (abnormal) | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
-| Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
-| Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; | semmle.label | successor |
-| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; | semmle.label | successor |
-| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null | semmle.label | true |
-| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" | semmle.label | false |
-| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
-| Assert.cs:51:24:51:27 | null | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:51:31:51:32 | "" | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; | semmle.label | successor |
-| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s | semmle.label | successor |
-| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null | semmle.label | successor |
-| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... | semmle.label | successor |
-| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 (normal) | semmle.label | successor |
-| Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length | semmle.label | successor |
-| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} | semmle.label | successor |
-| Assert.cs:56:10:56:11 | exit M8 (abnormal) | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
-| Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
-| Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; | semmle.label | successor |
-| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | semmle.label | successor |
-| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | semmle.label | successor |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null | semmle.label | true |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" | semmle.label | false |
-| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | semmle.label | successor |
-| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | semmle.label | successor |
-| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; | semmle.label | successor |
-| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | semmle.label | successor |
-| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | semmle.label | successor |
-| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): false] null | semmle.label | successor |
-| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): true] null | semmle.label | successor |
-| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | semmle.label | false |
-| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | semmle.label | true |
-| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | semmle.label | false |
-| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | semmle.label | true |
-| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
-| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | semmle.label | true |
-| Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | semmle.label | successor |
-| Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | semmle.label | successor |
-| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:23:59:36 | [false] ... && ... | semmle.label | false |
-| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:36 | [true] ... && ... | semmle.label | true |
-| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 (normal) | semmle.label | successor |
-| Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length | semmle.label | successor |
-| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} | semmle.label | successor |
-| Assert.cs:63:10:63:11 | exit M9 (abnormal) | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
-| Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
-| Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; | semmle.label | successor |
-| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | semmle.label | successor |
-| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | semmle.label | successor |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null | semmle.label | true |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" | semmle.label | false |
-| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | semmle.label | successor |
-| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | semmle.label | successor |
-| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; | semmle.label | successor |
-| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | semmle.label | successor |
-| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | semmle.label | successor |
-| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): false] null | semmle.label | successor |
-| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): true] null | semmle.label | successor |
-| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | semmle.label | false |
-| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | semmle.label | false |
-| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | semmle.label | successor |
-| Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | semmle.label | successor |
-| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:37 | [false] ... \|\| ... | semmle.label | false |
-| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:24:66:37 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 (normal) | semmle.label | successor |
-| Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length | semmle.label | successor |
-| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} | semmle.label | successor |
-| Assert.cs:70:10:70:12 | exit M10 (abnormal) | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
-| Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
-| Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; | semmle.label | successor |
-| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | semmle.label | successor |
-| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | semmle.label | successor |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null | semmle.label | true |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" | semmle.label | false |
-| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | semmle.label | successor |
-| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | semmle.label | successor |
-| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; | semmle.label | successor |
-| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | semmle.label | successor |
-| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | semmle.label | successor |
-| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): false] null | semmle.label | successor |
-| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): true] null | semmle.label | successor |
-| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | semmle.label | false |
-| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | semmle.label | true |
-| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | semmle.label | false |
-| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | semmle.label | true |
-| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
-| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | semmle.label | true |
-| Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | semmle.label | successor |
-| Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | semmle.label | successor |
-| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:23:73:36 | [false] ... && ... | semmle.label | false |
-| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:36 | [true] ... && ... | semmle.label | true |
-| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 (normal) | semmle.label | successor |
-| Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length | semmle.label | successor |
-| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} | semmle.label | successor |
-| Assert.cs:77:10:77:12 | exit M11 (abnormal) | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
-| Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
-| Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; | semmle.label | successor |
-| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | semmle.label | successor |
-| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | semmle.label | successor |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null | semmle.label | true |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" | semmle.label | false |
-| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | semmle.label | successor |
-| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | semmle.label | successor |
-| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; | semmle.label | successor |
-| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | semmle.label | successor |
-| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | semmle.label | successor |
-| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): false] null | semmle.label | successor |
-| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): true] null | semmle.label | successor |
-| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | semmle.label | false |
-| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | semmle.label | false |
-| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | semmle.label | successor |
-| Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | semmle.label | successor |
-| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:37 | [false] ... \|\| ... | semmle.label | false |
-| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:24:80:37 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 (normal) | semmle.label | successor |
-| Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length | semmle.label | successor |
-| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:85:5:129:5 | {...} | semmle.label | successor |
-| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
-| Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
-| Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; | semmle.label | successor |
-| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | semmle.label | successor |
-| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | semmle.label | successor |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exit |
-| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exit |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): false] null | semmle.label | successor |
-| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | semmle.label | false |
-| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | semmle.label | true |
-| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | semmle.label | false |
-| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | semmle.label | true |
-| Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | semmle.label | successor |
-| Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | semmle.label | non-null |
-| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | semmle.label | null |
-| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | semmle.label | non-null |
-| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | semmle.label | null |
-| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | semmle.label | null |
-| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | semmle.label | non-null |
-| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | semmle.label | null |
-| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | semmle.label | non-null |
-| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): false] null | semmle.label | successor |
-| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
-| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | semmle.label | true |
-| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
-| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
-| Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | semmle.label | successor |
-| Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): false] null | semmle.label | successor |
-| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
-| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | semmle.label | true |
-| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
-| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
-| Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | semmle.label | successor |
-| Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): false] null | semmle.label | successor |
-| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | semmle.label | true |
-| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | semmle.label | false |
-| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
-| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | false |
-| Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | semmle.label | successor |
-| Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): false] null | semmle.label | successor |
-| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | semmle.label | true |
-| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | semmle.label | false |
-| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
-| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | false |
-| Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | semmle.label | successor |
-| Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | semmle.label | successor |
-| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
-| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
-| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | semmle.label | false |
-| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
-| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null | semmle.label | successor |
-| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | semmle.label | false |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | semmle.label | true |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | semmle.label | false |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | semmle.label | true |
-| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
-| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
-| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
-| Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | semmle.label | successor |
-| Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | semmle.label | false |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | semmle.label | true |
-| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | semmle.label | true |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | semmle.label | false |
-| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | false |
-| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
-| Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | semmle.label | false |
-| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | semmle.label | true |
-| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | semmle.label | false |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | semmle.label | true |
-| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
-| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
-| Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | semmle.label | true |
-| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | semmle.label | exception(AssertFailedException) |
-| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; | semmle.label | successor |
-| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... | semmle.label | true |
-| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | semmle.label | false |
-| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | semmle.label | false |
-| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | semmle.label | true |
-| Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:127:24:127:38 | [false] ... \|\| ... | semmle.label | false |
-| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [false] !... | semmle.label | true |
-| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 (normal) | semmle.label | successor |
-| Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s | semmle.label | successor |
-| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length | semmle.label | successor |
-| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine | semmle.label | successor |
-| Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:135:5:136:5 | {...} | semmle.label | successor |
-| Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | Assert.cs:131:18:131:32 | exit AssertTrueFalse | semmle.label | successor |
-| Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | semmle.label | successor |
-| Assert.cs:138:10:138:12 | enter M13 | Assert.cs:139:5:142:5 | {...} | semmle.label | successor |
-| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | exit M13 | semmle.label | successor |
-| Assert.cs:138:10:138:12 | exit M13 (normal) | Assert.cs:138:10:138:12 | exit M13 | semmle.label | successor |
-| Assert.cs:139:5:142:5 | {...} | Assert.cs:140:9:140:36 | ...; | semmle.label | successor |
-| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 (abnormal) | semmle.label | exception(Exception) |
-| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 (abnormal) | semmle.label | exception(Exception) |
-| Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse | Assert.cs:141:9:141:15 | return ...; | semmle.label | successor |
-| Assert.cs:140:9:140:35 | this access | Assert.cs:140:25:140:26 | access to parameter b1 | semmle.label | successor |
-| Assert.cs:140:9:140:36 | ...; | Assert.cs:140:9:140:35 | this access | semmle.label | successor |
-| Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | semmle.label | false |
-| Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:29:140:30 | access to parameter b2 | semmle.label | true |
-| Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | semmle.label | false |
-| Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | semmle.label | true |
-| Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | semmle.label | true |
-| Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | semmle.label | false |
-| Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | semmle.label | successor |
-| Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | semmle.label | successor |
-| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse | semmle.label | successor |
-| Assert.cs:141:9:141:15 | return ...; | Assert.cs:138:10:138:12 | exit M13 (normal) | semmle.label | return |
-| Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} | semmle.label | successor |
-| Assignments.cs:3:10:3:10 | exit M (normal) | Assignments.cs:3:10:3:10 | exit M | semmle.label | successor |
-| Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; | semmle.label | successor |
-| Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |
-| Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; | semmle.label | successor |
-| Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:13:5:17 | Int32 x = ... | semmle.label | successor |
-| Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:14:6:14 | 1 | semmle.label | successor |
-| Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:14 | ... = ... | semmle.label | successor |
-| Assignments.cs:6:9:6:14 | ... = ... | Assignments.cs:8:9:8:22 | ... ...; | semmle.label | successor |
-| Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:9 | access to local variable x | semmle.label | successor |
-| Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:9:6:14 | ... + ... | semmle.label | successor |
-| Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:21:8:21 | 0 | semmle.label | successor |
-| Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:9:9:9:15 | ...; | semmle.label | successor |
-| Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | (...) ... | semmle.label | successor |
-| Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:17:8:21 | dynamic d = ... | semmle.label | successor |
-| Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:14:9:14 | 2 | semmle.label | successor |
-| Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:11:9:11:34 | ... ...; | semmle.label | successor |
-| Assignments.cs:9:9:9:14 | dynamic call to operator - | Assignments.cs:9:9:9:14 | ... = ... | semmle.label | successor |
-| Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:9 | access to local variable d | semmle.label | successor |
-| Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:9:9:14 | dynamic call to operator - | semmle.label | successor |
-| Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:17:11:33 | object creation of type Assignments | semmle.label | successor |
-| Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:12:9:12:18 | ...; | semmle.label | successor |
-| Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:13:11:33 | Assignments a = ... | semmle.label | successor |
-| Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:14:12:17 | this access | semmle.label | successor |
-| Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:14:9:14:36 | ...; | semmle.label | successor |
-| Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:9:12:17 | ... = ... | semmle.label | successor |
-| Assignments.cs:12:9:12:18 | ...; | Assignments.cs:12:9:12:9 | access to local variable a | semmle.label | successor |
-| Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + | semmle.label | successor |
-| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... | semmle.label | successor |
-| Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... | semmle.label | successor |
-| Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M (normal) | semmle.label | successor |
-| Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access | semmle.label | successor |
-| Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event | semmle.label | successor |
-| Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:33:14:35 | {...} | semmle.label | successor |
-| Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | Assignments.cs:14:18:14:35 | exit (...) => ... | semmle.label | successor |
-| Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | semmle.label | successor |
-| Assignments.cs:17:40:17:40 | enter + | Assignments.cs:18:5:20:5 | {...} | semmle.label | successor |
-| Assignments.cs:17:40:17:40 | exit + (normal) | Assignments.cs:17:40:17:40 | exit + | semmle.label | successor |
-| Assignments.cs:18:5:20:5 | {...} | Assignments.cs:19:16:19:16 | access to parameter x | semmle.label | successor |
-| Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | exit + (normal) | semmle.label | return |
-| Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:19:9:19:17 | return ...; | semmle.label | successor |
-| BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:4:5:18:5 | {...} | semmle.label | successor |
-| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 | semmle.label | successor |
-| BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:5:9:17:9 | try {...} ... | semmle.label | successor |
-| BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:6:9:12:9 | {...} | semmle.label | successor |
-| BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:7:33:7:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:26:7:28 | String arg | semmle.label | non-empty |
-| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:14:9:17:9 | {...} | semmle.label | empty |
-| BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:8:13:11:13 | {...} | semmle.label | successor |
-| BreakInTry.cs:7:33:7:36 | access to parameter args | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:8:13:11:13 | {...} | BreakInTry.cs:9:17:10:26 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:9:17:10:26 | if (...) ... | BreakInTry.cs:9:21:9:23 | access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:9:21:9:23 | access to local variable arg | BreakInTry.cs:9:28:9:31 | null | semmle.label | successor |
-| BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:10:21:10:26 | break; | semmle.label | true |
-| BreakInTry.cs:9:28:9:31 | null | BreakInTry.cs:9:21:9:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:10:21:10:26 | break; | BreakInTry.cs:14:9:17:9 | {...} | semmle.label | break |
-| BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:15:13:16:17 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:15:13:16:17 | if (...) ... | BreakInTry.cs:15:17:15:20 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:15:17:15:20 | access to parameter args | BreakInTry.cs:15:25:15:28 | null | semmle.label | successor |
-| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 (normal) | semmle.label | false |
-| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:16:17:16:17 | ; | semmle.label | true |
-| BreakInTry.cs:15:25:15:28 | null | BreakInTry.cs:15:17:15:28 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:3:10:3:11 | exit M1 (normal) | semmle.label | successor |
-| BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:21:5:36:5 | {...} | semmle.label | successor |
-| BreakInTry.cs:20:10:20:11 | exit M2 (normal) | BreakInTry.cs:20:10:20:11 | exit M2 | semmle.label | successor |
-| BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:22:29:22:32 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:22:22:24 | String arg | semmle.label | non-empty |
-| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:35:7:35:7 | ; | semmle.label | empty |
-| BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:23:9:34:9 | {...} | semmle.label | successor |
-| BreakInTry.cs:22:29:22:32 | access to parameter args | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:24:13:33:13 | try {...} ... | semmle.label | successor |
-| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:25:13:28:13 | {...} | semmle.label | successor |
-| BreakInTry.cs:25:13:28:13 | {...} | BreakInTry.cs:26:17:27:26 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:26:17:27:26 | if (...) ... | BreakInTry.cs:26:21:26:23 | access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:26:21:26:23 | access to local variable arg | BreakInTry.cs:26:28:26:31 | null | semmle.label | successor |
-| BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:27:21:27:26 | break; | semmle.label | true |
-| BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:30:13:33:13 | {...} | semmle.label | false |
-| BreakInTry.cs:26:28:26:31 | null | BreakInTry.cs:26:21:26:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:30:13:33:13 | [finally: break] {...} | semmle.label | break |
-| BreakInTry.cs:30:13:33:13 | [finally: break] {...} | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | semmle.label | successor |
-| BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:31:17:32:21 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | semmle.label | successor |
-| BreakInTry.cs:31:17:32:21 | if (...) ... | BreakInTry.cs:31:21:31:24 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | BreakInTry.cs:31:29:31:32 | [finally: break] null | semmle.label | successor |
-| BreakInTry.cs:31:21:31:24 | access to parameter args | BreakInTry.cs:31:29:31:32 | null | semmle.label | successor |
-| BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:32:21:32:21 | ; | semmle.label | true |
-| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; | semmle.label | true |
-| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:35:7:35:7 | ; | semmle.label | false |
-| BreakInTry.cs:31:29:31:32 | [finally: break] null | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | semmle.label | successor |
-| BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:32 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:35:7:35:7 | ; | semmle.label | break |
-| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 (normal) | semmle.label | successor |
-| BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:39:5:54:5 | {...} | semmle.label | successor |
-| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 | semmle.label | successor |
-| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:40:9:52:9 | try {...} ... | semmle.label | successor |
-| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:41:9:44:9 | {...} | semmle.label | successor |
-| BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:42:13:43:23 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:42:13:43:23 | if (...) ... | BreakInTry.cs:42:17:42:20 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:42:17:42:20 | access to parameter args | BreakInTry.cs:42:25:42:28 | null | semmle.label | successor |
-| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:43:17:43:23 | return ...; | semmle.label | true |
-| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:46:9:52:9 | {...} | semmle.label | false |
-| BreakInTry.cs:42:25:42:28 | null | BreakInTry.cs:42:17:42:28 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | semmle.label | return |
-| BreakInTry.cs:46:9:52:9 | [finally: return] {...} | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | semmle.label | successor |
-| BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | semmle.label | return |
-| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | semmle.label | non-empty |
-| BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | String arg | semmle.label | non-empty |
-| BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:53:7:53:7 | ; | semmle.label | empty |
-| BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:48:13:51:13 | {...} | semmle.label | successor |
-| BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:48:13:51:13 | [finally: return] {...} | semmle.label | successor |
-| BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:47:33:47:36 | access to parameter args | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:48:13:51:13 | [finally: return] {...} | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | semmle.label | successor |
-| BreakInTry.cs:48:13:51:13 | {...} | BreakInTry.cs:49:17:50:26 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:49:17:50:26 | if (...) ... | BreakInTry.cs:49:21:49:23 | access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | BreakInTry.cs:49:28:49:31 | [finally: return] null | semmle.label | successor |
-| BreakInTry.cs:49:21:49:23 | access to local variable arg | BreakInTry.cs:49:28:49:31 | null | semmle.label | successor |
-| BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:50:21:50:26 | break; | semmle.label | true |
-| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; | semmle.label | true |
-| BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | semmle.label | successor |
-| BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | semmle.label | return |
-| BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:53:7:53:7 | ; | semmle.label | break |
-| BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | semmle.label | successor |
-| BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:57:5:71:5 | {...} | semmle.label | successor |
-| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 | semmle.label | successor |
-| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:58:9:70:9 | try {...} ... | semmle.label | successor |
-| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:59:9:62:9 | {...} | semmle.label | successor |
-| BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:60:13:61:23 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:60:13:61:23 | if (...) ... | BreakInTry.cs:60:17:60:20 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:60:17:60:20 | access to parameter args | BreakInTry.cs:60:25:60:28 | null | semmle.label | successor |
-| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:61:17:61:23 | return ...; | semmle.label | true |
-| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:64:9:70:9 | {...} | semmle.label | false |
-| BreakInTry.cs:60:25:60:28 | null | BreakInTry.cs:60:17:60:28 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | semmle.label | return |
-| BreakInTry.cs:64:9:70:9 | [finally: return] {...} | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | semmle.label | successor |
-| BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args | semmle.label | successor |
-| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | return |
-| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | semmle.label | non-empty |
-| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | empty |
-| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | String arg | semmle.label | non-empty |
-| BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:66:13:69:13 | {...} | semmle.label | successor |
-| BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:66:13:69:13 | [finally: return] {...} | semmle.label | successor |
-| BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:65:33:65:36 | access to parameter args | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| BreakInTry.cs:66:13:69:13 | [finally: return] {...} | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | semmle.label | successor |
-| BreakInTry.cs:66:13:69:13 | {...} | BreakInTry.cs:67:17:68:26 | if (...) ... | semmle.label | successor |
-| BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:67:17:68:26 | if (...) ... | BreakInTry.cs:67:21:67:23 | access to local variable arg | semmle.label | successor |
-| BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | BreakInTry.cs:67:28:67:31 | [finally: return] null | semmle.label | successor |
-| BreakInTry.cs:67:21:67:23 | access to local variable arg | BreakInTry.cs:67:28:67:31 | null | semmle.label | successor |
-| BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | semmle.label | true |
-| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | semmle.label | false |
-| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | semmle.label | true |
-| BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | semmle.label | successor |
-| BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... | semmle.label | successor |
-| BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | return |
-| BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | semmle.label | break |
-| CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} | semmle.label | successor |
-| CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | CompileTimeOperators.cs:5:9:5:15 | exit Default | semmle.label | successor |
-| CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) | semmle.label | successor |
-| CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | semmle.label | return |
-| CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:9:7:28 | return ...; | semmle.label | successor |
-| CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:11:5:13:5 | {...} | semmle.label | successor |
-| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof | semmle.label | successor |
-| CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | semmle.label | successor |
-| CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | semmle.label | return |
-| CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | CompileTimeOperators.cs:12:9:12:27 | return ...; | semmle.label | successor |
-| CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:16:5:18:5 | {...} | semmle.label | successor |
-| CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | CompileTimeOperators.cs:15:10:15:15 | exit Typeof | semmle.label | successor |
-| CompileTimeOperators.cs:16:5:18:5 | {...} | CompileTimeOperators.cs:17:16:17:26 | typeof(...) | semmle.label | successor |
-| CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | semmle.label | return |
-| CompileTimeOperators.cs:17:16:17:26 | typeof(...) | CompileTimeOperators.cs:17:9:17:27 | return ...; | semmle.label | successor |
-| CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:21:5:23:5 | {...} | semmle.label | successor |
-| CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | CompileTimeOperators.cs:20:12:20:17 | exit Nameof | semmle.label | successor |
-| CompileTimeOperators.cs:21:5:23:5 | {...} | CompileTimeOperators.cs:22:16:22:24 | nameof(...) | semmle.label | successor |
-| CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | semmle.label | return |
-| CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:22:9:22:25 | return ...; | semmle.label | successor |
-| CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:29:5:41:5 | {...} | semmle.label | successor |
-| CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | CompileTimeOperators.cs:28:10:28:10 | exit M | semmle.label | successor |
-| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... | semmle.label | successor |
-| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:31:9:34:9 | {...} | semmle.label | successor |
-| CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; | semmle.label | successor |
-| CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | semmle.label | goto(End) |
-| CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | semmle.label | successor |
-| CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | CompileTimeOperators.cs:40:9:40:11 | End: | semmle.label | goto(End) |
-| CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | semmle.label | successor |
-| CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | semmle.label | successor |
-| CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:40:14:40:38 | ...; | semmle.label | successor |
-| CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | semmle.label | successor |
-| CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" | semmle.label | successor |
-| CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | semmle.label | successor |
-| ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i | semmle.label | successor |
-| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 | semmle.label | successor |
-| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | null |
-| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:28:3:38 | call to method ToString | semmle.label | non-null |
-| ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | null |
-| ConditionalAccess.cs:3:28:3:38 | call to method ToString | ConditionalAccess.cs:3:40:3:49 | call to method ToLower | semmle.label | non-null |
-| ConditionalAccess.cs:3:40:3:49 | call to method ToLower | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s | semmle.label | successor |
-| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 | semmle.label | successor |
-| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | semmle.label | null |
-| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:28:5:34 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:5:28:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | semmle.label | successor |
-| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 | semmle.label | successor |
-| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | semmle.label | non-null |
-| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | semmle.label | null |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | null |
-| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:49:7:55 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | null |
-| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | semmle.label | non-null |
-| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | semmle.label | null |
-| ConditionalAccess.cs:7:49:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s | semmle.label | successor |
-| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 | semmle.label | successor |
-| ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:27:9:33 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:38:9:38 | 0 | semmle.label | null |
-| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | semmle.label | non-null |
-| ConditionalAccess.cs:9:27:9:33 | access to property Length | ConditionalAccess.cs:9:38:9:38 | 0 | semmle.label | null |
-| ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | semmle.label | successor |
-| ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:12:5:17:5 | {...} | semmle.label | successor |
-| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 | semmle.label | successor |
-| ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:13:9:16:21 | if (...) ... | semmle.label | successor |
-| ConditionalAccess.cs:13:9:16:21 | if (...) ... | ConditionalAccess.cs:13:13:13:13 | access to parameter s | semmle.label | successor |
-| ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:15:13:21 | access to property Length | semmle.label | non-null |
-| ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:25:13:25 | 0 | semmle.label | null |
-| ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:14:20:14:20 | 0 | semmle.label | true |
-| ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:16:20:16:20 | 1 | semmle.label | false |
-| ConditionalAccess.cs:13:15:13:21 | access to property Length | ConditionalAccess.cs:13:25:13:25 | 0 | semmle.label | successor |
-| ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:13:25:13:25 | (...) ... | semmle.label | successor |
-| ConditionalAccess.cs:13:25:13:25 | (...) ... | ConditionalAccess.cs:13:13:13:25 | ... > ... | semmle.label | successor |
-| ConditionalAccess.cs:14:13:14:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | semmle.label | return |
-| ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:13:14:21 | return ...; | semmle.label | successor |
-| ConditionalAccess.cs:16:13:16:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | semmle.label | return |
-| ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:13:16:21 | return ...; | semmle.label | successor |
-| ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | semmle.label | successor |
-| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 | semmle.label | successor |
-| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | semmle.label | null |
-| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | semmle.label | non-null |
-| ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:43:19:60 | call to method CommaJoinWith | semmle.label | successor |
-| ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:22:5:26:5 | {...} | semmle.label | successor |
-| ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | ConditionalAccess.cs:21:10:21:11 | exit M7 | semmle.label | successor |
-| ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; | semmle.label | successor |
-| ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null | semmle.label | successor |
-| ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; | semmle.label | successor |
-| ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | semmle.label | null |
-| ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:18:23:29 | (...) ... | semmle.label | successor |
-| ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:24:24:24 | access to parameter i | semmle.label | successor |
-| ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:25:9:25:33 | ...; | semmle.label | successor |
-| ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:27:24:37 | call to method ToString | semmle.label | non-null |
-| ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... | semmle.label | successor |
-| ConditionalAccess.cs:24:27:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" | semmle.label | successor |
-| ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s | semmle.label | non-null |
-| ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... | semmle.label | successor |
-| ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:16:25:32 | call to method CommaJoinWith | semmle.label | successor |
-| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:32:30:32 | 0 | semmle.label | successor |
-| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out | semmle.label | successor |
-| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | semmle.label | successor |
-| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... | semmle.label | successor |
-| ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:33:5:36:5 | {...} | semmle.label | successor |
-| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 | semmle.label | successor |
-| ConditionalAccess.cs:33:5:36:5 | {...} | ConditionalAccess.cs:34:9:34:14 | ...; | semmle.label | successor |
-| ConditionalAccess.cs:34:9:34:13 | ... = ... | ConditionalAccess.cs:35:9:35:25 | ...; | semmle.label | successor |
-| ConditionalAccess.cs:34:9:34:14 | ...; | ConditionalAccess.cs:34:13:34:13 | 0 | semmle.label | successor |
-| ConditionalAccess.cs:34:13:34:13 | 0 | ConditionalAccess.cs:34:9:34:13 | ... = ... | semmle.label | successor |
-| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | semmle.label | null |
-| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:35:14:35:24 | call to method Out | semmle.label | non-null |
-| ConditionalAccess.cs:35:9:35:12 | this access | ConditionalAccess.cs:35:9:35:12 | access to property Prop | semmle.label | successor |
-| ConditionalAccess.cs:35:9:35:25 | ...; | ConditionalAccess.cs:35:9:35:12 | this access | semmle.label | successor |
-| ConditionalAccess.cs:35:14:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | semmle.label | successor |
-| ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | semmle.label | successor |
-| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith | semmle.label | successor |
-| ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | ConditionalAccess.cs:41:75:41:78 | ", " | semmle.label | successor |
-| ConditionalAccess.cs:41:70:41:78 | ... + ... | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | semmle.label | successor |
-| ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | semmle.label | successor |
-| ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:70:41:78 | ... + ... | semmle.label | successor |
-| ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:70:41:83 | ... + ... | semmle.label | successor |
-| Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:4:5:9:5 | {...} | semmle.label | successor |
-| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr | semmle.label | successor |
-| Conditions.cs:4:5:9:5 | {...} | Conditions.cs:5:9:6:16 | if (...) ... | semmle.label | successor |
-| Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:5:13:5:15 | access to parameter inc | semmle.label | successor |
-| Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | semmle.label | true |
-| Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | semmle.label | false |
-| Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | semmle.label | successor |
-| Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | semmle.label | successor |
-| Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | semmle.label | successor |
-| Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | semmle.label | successor |
-| Conditions.cs:7:13:7:16 | [false] !... | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | false |
-| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:8:13:8:16 | ...; | semmle.label | true |
-| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:13:7:16 | [true] !... | semmle.label | false |
-| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:13:7:16 | [false] !... | semmle.label | true |
-| Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- | semmle.label | successor |
-| Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | semmle.label | successor |
-| Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x | semmle.label | successor |
-| Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} | semmle.label | successor |
-| Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:11:9:11:10 | exit M1 | semmle.label | successor |
-| Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 | semmle.label | successor |
-| Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... | semmle.label | successor |
-| Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:13:13:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:13:14:13 | access to parameter b | semmle.label | successor |
-| Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | semmle.label | true |
-| Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | semmle.label | false |
-| Conditions.cs:15:13:15:13 | [b (line 11): true] access to local variable x | Conditions.cs:15:13:15:15 | [b (line 11): true] ...++ | semmle.label | successor |
-| Conditions.cs:15:13:15:15 | [b (line 11): true] ...++ | Conditions.cs:16:9:18:20 | [b (line 11): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | Conditions.cs:15:13:15:13 | [b (line 11): true] access to local variable x | semmle.label | successor |
-| Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:16:13:16:13 | [b (line 11): false] access to local variable x | semmle.label | successor |
-| Conditions.cs:16:9:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:16:13:16:13 | [b (line 11): true] access to local variable x | semmle.label | successor |
-| Conditions.cs:16:13:16:13 | [b (line 11): false] access to local variable x | Conditions.cs:16:17:16:17 | [b (line 11): false] 0 | semmle.label | successor |
-| Conditions.cs:16:13:16:13 | [b (line 11): true] access to local variable x | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | semmle.label | successor |
-| Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | semmle.label | true |
-| Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | semmle.label | true |
-| Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:16:17:16:17 | [b (line 11): false] 0 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | semmle.label | successor |
-| Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | semmle.label | successor |
-| Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:17:17:17:18 | [false] !... | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:18:17:18:20 | ...; | semmle.label | true |
-| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:17:17:18 | [true] !... | semmle.label | false |
-| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:17:17:18 | [false] !... | semmle.label | true |
-| Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- | semmle.label | successor |
-| Conditions.cs:18:17:18:19 | ...-- | Conditions.cs:19:16:19:16 | access to local variable x | semmle.label | successor |
-| Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 (normal) | semmle.label | return |
-| Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; | semmle.label | successor |
-| Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:23:5:31:5 | {...} | semmle.label | successor |
-| Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:22:9:22:10 | exit M2 | semmle.label | successor |
-| Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 | semmle.label | successor |
-| Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:13:24:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:13:25:14 | access to parameter b1 | semmle.label | successor |
-| Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:26:13:27:20 | if (...) ... | semmle.label | true |
-| Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:28:9:29:16 | if (...) ... | semmle.label | false |
-| Conditions.cs:26:13:27:20 | if (...) ... | Conditions.cs:26:17:26:18 | access to parameter b2 | semmle.label | successor |
-| Conditions.cs:26:17:26:18 | access to parameter b2 | Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | semmle.label | true |
-| Conditions.cs:26:17:26:18 | access to parameter b2 | Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... | semmle.label | false |
-| Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x | Conditions.cs:27:17:27:19 | [b2 (line 22): true] ...++ | semmle.label | successor |
-| Conditions.cs:27:17:27:19 | [b2 (line 22): true] ...++ | Conditions.cs:28:9:29:16 | [b2 (line 22): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x | semmle.label | successor |
-| Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 | semmle.label | successor |
-| Conditions.cs:28:9:29:16 | [b2 (line 22): true] if (...) ... | Conditions.cs:28:13:28:14 | [b2 (line 22): true] access to parameter b2 | semmle.label | successor |
-| Conditions.cs:28:9:29:16 | if (...) ... | Conditions.cs:28:13:28:14 | access to parameter b2 | semmle.label | successor |
-| Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 | Conditions.cs:30:16:30:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:28:13:28:14 | [b2 (line 22): true] access to parameter b2 | Conditions.cs:29:13:29:16 | ...; | semmle.label | true |
-| Conditions.cs:28:13:28:14 | access to parameter b2 | Conditions.cs:29:13:29:16 | ...; | semmle.label | true |
-| Conditions.cs:28:13:28:14 | access to parameter b2 | Conditions.cs:30:16:30:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:29:13:29:13 | access to local variable x | Conditions.cs:29:13:29:15 | ...++ | semmle.label | successor |
-| Conditions.cs:29:13:29:15 | ...++ | Conditions.cs:30:16:30:16 | access to local variable x | semmle.label | successor |
-| Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:30:9:30:17 | return ...; | Conditions.cs:22:9:22:10 | exit M2 (normal) | semmle.label | return |
-| Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; | semmle.label | successor |
-| Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:34:5:44:5 | {...} | semmle.label | successor |
-| Conditions.cs:33:9:33:10 | exit M3 (normal) | Conditions.cs:33:9:33:10 | exit M3 | semmle.label | successor |
-| Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 | semmle.label | successor |
-| Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; | semmle.label | successor |
-| Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:13:35:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:18:36:22 | false | semmle.label | successor |
-| Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:37:9:38:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:36:18:36:22 | false | Conditions.cs:36:13:36:22 | Boolean b2 = ... | semmle.label | successor |
-| Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 | semmle.label | successor |
-| Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:38:13:38:20 | ...; | semmle.label | true |
-| Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:39:9:40:16 | if (...) ... | semmle.label | false |
-| Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:39:9:40:16 | if (...) ... | semmle.label | successor |
-| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:18:38:19 | access to parameter b1 | semmle.label | successor |
-| Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:19 | ... = ... | semmle.label | successor |
-| Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 | semmle.label | successor |
-| Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | semmle.label | true |
-| Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:41:9:42:16 | [b2 (line 39): false] if (...) ... | semmle.label | false |
-| Conditions.cs:40:13:40:13 | [b2 (line 39): true] access to local variable x | Conditions.cs:40:13:40:15 | [b2 (line 39): true] ...++ | semmle.label | successor |
-| Conditions.cs:40:13:40:15 | [b2 (line 39): true] ...++ | Conditions.cs:41:9:42:16 | [b2 (line 39): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | Conditions.cs:40:13:40:13 | [b2 (line 39): true] access to local variable x | semmle.label | successor |
-| Conditions.cs:41:9:42:16 | [b2 (line 39): false] if (...) ... | Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 | semmle.label | successor |
-| Conditions.cs:41:9:42:16 | [b2 (line 39): true] if (...) ... | Conditions.cs:41:13:41:14 | [b2 (line 39): true] access to local variable b2 | semmle.label | successor |
-| Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 | Conditions.cs:43:16:43:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:41:13:41:14 | [b2 (line 39): true] access to local variable b2 | Conditions.cs:42:13:42:16 | ...; | semmle.label | true |
-| Conditions.cs:42:13:42:13 | access to local variable x | Conditions.cs:42:13:42:15 | ...++ | semmle.label | successor |
-| Conditions.cs:42:13:42:15 | ...++ | Conditions.cs:43:16:43:16 | access to local variable x | semmle.label | successor |
-| Conditions.cs:42:13:42:16 | ...; | Conditions.cs:42:13:42:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:33:9:33:10 | exit M3 (normal) | semmle.label | return |
-| Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; | semmle.label | successor |
-| Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:47:5:55:5 | {...} | semmle.label | successor |
-| Conditions.cs:46:9:46:10 | exit M4 (normal) | Conditions.cs:46:9:46:10 | exit M4 | semmle.label | successor |
-| Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 | semmle.label | successor |
-| Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... | semmle.label | successor |
-| Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:13:48:17 | Int32 y = ... | semmle.label | successor |
-| Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:16:49:16 | access to parameter x | semmle.label | successor |
-| Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | Conditions.cs:49:16:49:18 | [b (line 46): false] ...-- | semmle.label | successor |
-| Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x | Conditions.cs:49:16:49:18 | [b (line 46): true] ...-- | semmle.label | successor |
-| Conditions.cs:49:16:49:16 | access to parameter x | Conditions.cs:49:16:49:18 | ...-- | semmle.label | successor |
-| Conditions.cs:49:16:49:18 | ...-- | Conditions.cs:49:22:49:22 | 0 | semmle.label | successor |
-| Conditions.cs:49:16:49:18 | [b (line 46): false] ...-- | Conditions.cs:49:22:49:22 | [b (line 46): false] 0 | semmle.label | successor |
-| Conditions.cs:49:16:49:18 | [b (line 46): true] ...-- | Conditions.cs:49:22:49:22 | [b (line 46): true] 0 | semmle.label | successor |
-| Conditions.cs:49:16:49:22 | ... > ... | Conditions.cs:50:9:53:9 | {...} | semmle.label | true |
-| Conditions.cs:49:16:49:22 | ... > ... | Conditions.cs:54:16:54:16 | access to local variable y | semmle.label | false |
-| Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | Conditions.cs:50:9:53:9 | [b (line 46): false] {...} | semmle.label | true |
-| Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | Conditions.cs:54:16:54:16 | access to local variable y | semmle.label | false |
-| Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | Conditions.cs:50:9:53:9 | [b (line 46): true] {...} | semmle.label | true |
-| Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | Conditions.cs:54:16:54:16 | access to local variable y | semmle.label | false |
-| Conditions.cs:49:22:49:22 | 0 | Conditions.cs:49:16:49:22 | ... > ... | semmle.label | successor |
-| Conditions.cs:49:22:49:22 | [b (line 46): false] 0 | Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | semmle.label | successor |
-| Conditions.cs:49:22:49:22 | [b (line 46): true] 0 | Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | semmle.label | successor |
-| Conditions.cs:50:9:53:9 | [b (line 46): false] {...} | Conditions.cs:51:13:52:20 | [b (line 46): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:50:9:53:9 | [b (line 46): true] {...} | Conditions.cs:51:13:52:20 | [b (line 46): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:50:9:53:9 | {...} | Conditions.cs:51:13:52:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:51:13:52:20 | [b (line 46): false] if (...) ... | Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:51:13:52:20 | [b (line 46): true] if (...) ... | Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:51:13:52:20 | if (...) ... | Conditions.cs:51:17:51:17 | access to parameter b | semmle.label | successor |
-| Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | semmle.label | false |
-| Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | semmle.label | true |
-| Conditions.cs:51:17:51:17 | access to parameter b | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | semmle.label | false |
-| Conditions.cs:51:17:51:17 | access to parameter b | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | semmle.label | true |
-| Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ | semmle.label | successor |
-| Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ | Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x | semmle.label | successor |
-| Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y | semmle.label | successor |
-| Conditions.cs:54:9:54:17 | return ...; | Conditions.cs:46:9:46:10 | exit M4 (normal) | semmle.label | return |
-| Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; | semmle.label | successor |
-| Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:58:5:68:5 | {...} | semmle.label | successor |
-| Conditions.cs:57:9:57:10 | exit M5 (normal) | Conditions.cs:57:9:57:10 | exit M5 | semmle.label | successor |
-| Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 | semmle.label | successor |
-| Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... | semmle.label | successor |
-| Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:13:59:17 | Int32 y = ... | semmle.label | successor |
-| Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:16:60:16 | access to parameter x | semmle.label | successor |
-| Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | Conditions.cs:60:16:60:18 | [b (line 57): false] ...-- | semmle.label | successor |
-| Conditions.cs:60:16:60:16 | [b (line 57): true] access to parameter x | Conditions.cs:60:16:60:18 | [b (line 57): true] ...-- | semmle.label | successor |
-| Conditions.cs:60:16:60:16 | access to parameter x | Conditions.cs:60:16:60:18 | ...-- | semmle.label | successor |
-| Conditions.cs:60:16:60:18 | ...-- | Conditions.cs:60:22:60:22 | 0 | semmle.label | successor |
-| Conditions.cs:60:16:60:18 | [b (line 57): false] ...-- | Conditions.cs:60:22:60:22 | [b (line 57): false] 0 | semmle.label | successor |
-| Conditions.cs:60:16:60:18 | [b (line 57): true] ...-- | Conditions.cs:60:22:60:22 | [b (line 57): true] 0 | semmle.label | successor |
-| Conditions.cs:60:16:60:22 | ... > ... | Conditions.cs:61:9:64:9 | {...} | semmle.label | true |
-| Conditions.cs:60:16:60:22 | ... > ... | Conditions.cs:65:9:66:16 | if (...) ... | semmle.label | false |
-| Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | Conditions.cs:61:9:64:9 | [b (line 57): false] {...} | semmle.label | true |
-| Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | Conditions.cs:65:9:66:16 | [b (line 57): false] if (...) ... | semmle.label | false |
-| Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... | Conditions.cs:61:9:64:9 | [b (line 57): true] {...} | semmle.label | true |
-| Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... | Conditions.cs:65:9:66:16 | [b (line 57): true] if (...) ... | semmle.label | false |
-| Conditions.cs:60:22:60:22 | 0 | Conditions.cs:60:16:60:22 | ... > ... | semmle.label | successor |
-| Conditions.cs:60:22:60:22 | [b (line 57): false] 0 | Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | semmle.label | successor |
-| Conditions.cs:60:22:60:22 | [b (line 57): true] 0 | Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... | semmle.label | successor |
-| Conditions.cs:61:9:64:9 | [b (line 57): false] {...} | Conditions.cs:62:13:63:20 | [b (line 57): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:61:9:64:9 | [b (line 57): true] {...} | Conditions.cs:62:13:63:20 | [b (line 57): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:61:9:64:9 | {...} | Conditions.cs:62:13:63:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:62:13:63:20 | [b (line 57): false] if (...) ... | Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:62:13:63:20 | [b (line 57): true] if (...) ... | Conditions.cs:62:17:62:17 | [b (line 57): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:62:13:63:20 | if (...) ... | Conditions.cs:62:17:62:17 | access to parameter b | semmle.label | successor |
-| Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | semmle.label | false |
-| Conditions.cs:62:17:62:17 | [b (line 57): true] access to parameter b | Conditions.cs:63:17:63:20 | [b (line 57): true] ...; | semmle.label | true |
-| Conditions.cs:62:17:62:17 | access to parameter b | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | semmle.label | false |
-| Conditions.cs:62:17:62:17 | access to parameter b | Conditions.cs:63:17:63:20 | [b (line 57): true] ...; | semmle.label | true |
-| Conditions.cs:63:17:63:17 | [b (line 57): true] access to local variable y | Conditions.cs:63:17:63:19 | [b (line 57): true] ...++ | semmle.label | successor |
-| Conditions.cs:63:17:63:19 | [b (line 57): true] ...++ | Conditions.cs:60:16:60:16 | [b (line 57): true] access to parameter x | semmle.label | successor |
-| Conditions.cs:63:17:63:20 | [b (line 57): true] ...; | Conditions.cs:63:17:63:17 | [b (line 57): true] access to local variable y | semmle.label | successor |
-| Conditions.cs:65:9:66:16 | [b (line 57): false] if (...) ... | Conditions.cs:65:13:65:13 | [b (line 57): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:65:9:66:16 | [b (line 57): true] if (...) ... | Conditions.cs:65:13:65:13 | [b (line 57): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:65:9:66:16 | if (...) ... | Conditions.cs:65:13:65:13 | access to parameter b | semmle.label | successor |
-| Conditions.cs:65:13:65:13 | [b (line 57): false] access to parameter b | Conditions.cs:67:16:67:16 | access to local variable y | semmle.label | false |
-| Conditions.cs:65:13:65:13 | [b (line 57): true] access to parameter b | Conditions.cs:66:13:66:16 | ...; | semmle.label | true |
-| Conditions.cs:65:13:65:13 | access to parameter b | Conditions.cs:66:13:66:16 | ...; | semmle.label | true |
-| Conditions.cs:65:13:65:13 | access to parameter b | Conditions.cs:67:16:67:16 | access to local variable y | semmle.label | false |
-| Conditions.cs:66:13:66:13 | access to local variable y | Conditions.cs:66:13:66:15 | ...++ | semmle.label | successor |
-| Conditions.cs:66:13:66:15 | ...++ | Conditions.cs:67:16:67:16 | access to local variable y | semmle.label | successor |
-| Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:13 | access to local variable y | semmle.label | successor |
-| Conditions.cs:67:9:67:17 | return ...; | Conditions.cs:57:9:57:10 | exit M5 (normal) | semmle.label | return |
-| Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; | semmle.label | successor |
-| Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:71:5:84:5 | {...} | semmle.label | successor |
-| Conditions.cs:70:9:70:10 | exit M6 (normal) | Conditions.cs:70:9:70:10 | exit M6 | semmle.label | successor |
-| Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss | semmle.label | successor |
-| Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:25 | access to property Length | semmle.label | successor |
-| Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:29:72:29 | 0 | semmle.label | successor |
-| Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:13:72:29 | Boolean b = ... | semmle.label | successor |
-| Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:17:72:29 | ... > ... | semmle.label | successor |
-| Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:17:73:17 | 0 | semmle.label | successor |
-| Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:74:27:74:28 | access to parameter ss | semmle.label | successor |
-| Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:13:73:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:22:74:22 | String _ | semmle.label | non-empty |
-| Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:81:9:82:16 | if (...) ... | semmle.label | empty |
-| Conditions.cs:74:22:74:22 | String _ | Conditions.cs:75:9:80:9 | {...} | semmle.label | successor |
-| Conditions.cs:74:27:74:28 | access to parameter ss | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| Conditions.cs:75:9:80:9 | {...} | Conditions.cs:76:13:77:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:76:13:77:20 | if (...) ... | Conditions.cs:76:17:76:17 | access to local variable b | semmle.label | successor |
-| Conditions.cs:76:17:76:17 | access to local variable b | Conditions.cs:77:17:77:20 | ...; | semmle.label | true |
-| Conditions.cs:76:17:76:17 | access to local variable b | Conditions.cs:78:13:79:26 | if (...) ... | semmle.label | false |
-| Conditions.cs:77:17:77:17 | access to local variable x | Conditions.cs:77:17:77:19 | ...++ | semmle.label | successor |
-| Conditions.cs:77:17:77:19 | ...++ | Conditions.cs:78:13:79:26 | if (...) ... | semmle.label | successor |
-| Conditions.cs:77:17:77:20 | ...; | Conditions.cs:77:17:77:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:78:13:79:26 | if (...) ... | Conditions.cs:78:17:78:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:78:17:78:17 | access to local variable x | Conditions.cs:78:21:78:21 | 0 | semmle.label | successor |
-| Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | false |
-| Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:79:17:79:26 | ...; | semmle.label | true |
-| Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:21 | ... > ... | semmle.label | successor |
-| Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false | semmle.label | successor |
-| Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... | semmle.label | successor |
-| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b | semmle.label | successor |
-| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | semmle.label | true |
-| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ | semmle.label | successor |
-| Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:83:16:83:16 | access to local variable x | semmle.label | successor |
-| Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x | semmle.label | successor |
-| Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 (normal) | semmle.label | return |
-| Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; | semmle.label | successor |
-| Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:87:5:100:5 | {...} | semmle.label | successor |
-| Conditions.cs:86:9:86:10 | exit M7 (normal) | Conditions.cs:86:9:86:10 | exit M7 | semmle.label | successor |
-| Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss | semmle.label | successor |
-| Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; | semmle.label | successor |
-| Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:25 | access to property Length | semmle.label | successor |
-| Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:29:88:29 | 0 | semmle.label | successor |
-| Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:13:88:29 | Boolean b = ... | semmle.label | successor |
-| Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:17:88:29 | ... > ... | semmle.label | successor |
-| Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:17:89:17 | 0 | semmle.label | successor |
-| Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:90:27:90:28 | access to parameter ss | semmle.label | successor |
-| Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:13:89:17 | Int32 x = ... | semmle.label | successor |
-| Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:22:90:22 | String _ | semmle.label | non-empty |
-| Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:99:16:99:16 | access to local variable x | semmle.label | empty |
-| Conditions.cs:90:22:90:22 | String _ | Conditions.cs:91:9:98:9 | {...} | semmle.label | successor |
-| Conditions.cs:90:27:90:28 | access to parameter ss | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| Conditions.cs:91:9:98:9 | {...} | Conditions.cs:92:13:93:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:92:13:93:20 | if (...) ... | Conditions.cs:92:17:92:17 | access to local variable b | semmle.label | successor |
-| Conditions.cs:92:17:92:17 | access to local variable b | Conditions.cs:93:17:93:20 | ...; | semmle.label | true |
-| Conditions.cs:92:17:92:17 | access to local variable b | Conditions.cs:94:13:95:26 | if (...) ... | semmle.label | false |
-| Conditions.cs:93:17:93:17 | access to local variable x | Conditions.cs:93:17:93:19 | ...++ | semmle.label | successor |
-| Conditions.cs:93:17:93:19 | ...++ | Conditions.cs:94:13:95:26 | if (...) ... | semmle.label | successor |
-| Conditions.cs:93:17:93:20 | ...; | Conditions.cs:93:17:93:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:94:13:95:26 | if (...) ... | Conditions.cs:94:17:94:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:94:17:94:17 | access to local variable x | Conditions.cs:94:21:94:21 | 0 | semmle.label | successor |
-| Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:95:17:95:26 | ...; | semmle.label | true |
-| Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:96:13:97:20 | if (...) ... | semmle.label | false |
-| Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:17:94:21 | ... > ... | semmle.label | successor |
-| Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:96:13:97:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:21:95:25 | false | semmle.label | successor |
-| Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:25 | ... = ... | semmle.label | successor |
-| Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b | semmle.label | successor |
-| Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | semmle.label | false |
-| Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:97:17:97:20 | ...; | semmle.label | true |
-| Conditions.cs:97:17:97:17 | access to local variable x | Conditions.cs:97:17:97:19 | ...++ | semmle.label | successor |
-| Conditions.cs:97:17:97:19 | ...++ | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:86:9:86:10 | exit M7 (normal) | semmle.label | return |
-| Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; | semmle.label | successor |
-| Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:103:5:111:5 | {...} | semmle.label | successor |
-| Conditions.cs:102:12:102:13 | exit M8 (normal) | Conditions.cs:102:12:102:13 | exit M8 | semmle.label | successor |
-| Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; | semmle.label | successor |
-| Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b | semmle.label | successor |
-| Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... | semmle.label | successor |
-| Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:28 | call to method ToString | semmle.label | successor |
-| Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:13:104:28 | String x = ... | semmle.label | successor |
-| Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:105:13:105:13 | access to parameter b | semmle.label | successor |
-| Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | semmle.label | true |
-| Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | semmle.label | false |
-| Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:18:106:19 | [b (line 102): true] "" | semmle.label | successor |
-| Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | semmle.label | successor |
-| Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | Conditions.cs:107:9:109:24 | [b (line 102): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | semmle.label | successor |
-| Conditions.cs:106:18:106:19 | [b (line 102): true] "" | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... | semmle.label | successor |
-| Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:107:13:107:13 | [b (line 102): false] access to local variable x | semmle.label | successor |
-| Conditions.cs:107:9:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:107:13:107:13 | [b (line 102): true] access to local variable x | semmle.label | successor |
-| Conditions.cs:107:13:107:13 | [b (line 102): false] access to local variable x | Conditions.cs:107:13:107:20 | [b (line 102): false] access to property Length | semmle.label | successor |
-| Conditions.cs:107:13:107:13 | [b (line 102): true] access to local variable x | Conditions.cs:107:13:107:20 | [b (line 102): true] access to property Length | semmle.label | successor |
-| Conditions.cs:107:13:107:20 | [b (line 102): false] access to property Length | Conditions.cs:107:24:107:24 | [b (line 102): false] 0 | semmle.label | successor |
-| Conditions.cs:107:13:107:20 | [b (line 102): true] access to property Length | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | semmle.label | successor |
-| Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | semmle.label | true |
-| Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | semmle.label | true |
-| Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:107:24:107:24 | [b (line 102): false] 0 | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | semmle.label | successor |
-| Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | semmle.label | successor |
-| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:108:17:108:18 | [false] !... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | false |
-| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:109:17:109:24 | ...; | semmle.label | true |
-| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [true] !... | semmle.label | false |
-| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [false] !... | semmle.label | true |
-| Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" | semmle.label | successor |
-| Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... | semmle.label | successor |
-| Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:110:16:110:16 | access to local variable x | semmle.label | successor |
-| Conditions.cs:109:17:109:24 | ...; | Conditions.cs:109:17:109:17 | access to local variable x | semmle.label | successor |
-| Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:17:109:23 | ... + ... | semmle.label | successor |
-| Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:102:12:102:13 | exit M8 (normal) | semmle.label | return |
-| Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; | semmle.label | successor |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:114:5:124:5 | {...} | semmle.label | successor |
-| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 | semmle.label | successor |
-| Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; | semmle.label | successor |
-| Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
-| Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... | semmle.label | successor |
-| Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... | semmle.label | successor |
-| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:22:116:22 | 0 | semmle.label | successor |
-| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:25:116:25 | access to local variable i | semmle.label | successor |
-| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:18:116:22 | Int32 i = ... | semmle.label | successor |
-| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:29:116:32 | access to parameter args | semmle.label | successor |
-| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 (normal) | semmle.label | false |
-| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | semmle.label | true |
-| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:39 | access to property Length | semmle.label | successor |
-| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:25:116:39 | ... < ... | semmle.label | successor |
-| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ | semmle.label | successor |
-| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:116:25:116:25 | access to local variable i | semmle.label | successor |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; | semmle.label | successor |
-| Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i | semmle.label | successor |
-| Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... | semmle.label | successor |
-| Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:29:118:32 | access to parameter args | semmle.label | successor |
-| Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:17:118:43 | Boolean last = ... | semmle.label | successor |
-| Conditions.cs:118:29:118:32 | access to parameter args | Conditions.cs:118:29:118:39 | access to property Length | semmle.label | successor |
-| Conditions.cs:118:29:118:39 | access to property Length | Conditions.cs:118:43:118:43 | 1 | semmle.label | successor |
-| Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:24:118:43 | ... == ... | semmle.label | successor |
-| Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:29:118:43 | ... - ... | semmle.label | successor |
-| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:18:119:21 | access to local variable last | semmle.label | successor |
-| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | semmle.label | false |
-| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | semmle.label | true |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | semmle.label | true |
-| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | semmle.label | false |
-| Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | semmle.label | successor |
-| Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | semmle.label | successor |
-| Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | semmle.label | successor |
-| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | semmle.label | successor |
-| Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:42:116:42 | access to local variable i | semmle.label | false |
-| Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; | semmle.label | true |
-| Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:42:116:42 | access to local variable i | semmle.label | successor |
-| Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:21:122:24 | null | semmle.label | successor |
-| Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... | semmle.label | successor |
-| Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} | semmle.label | successor |
-| Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... | semmle.label | successor |
-| Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true | semmle.label | successor |
-| Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | semmle.label | true |
-| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | semmle.label | true |
-| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
-| Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} | semmle.label | true |
-| Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... | semmle.label | successor |
-| Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | semmle.label | successor |
-| Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | semmle.label | successor |
-| Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
-| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access | semmle.label | successor |
-| Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | semmle.label | false |
-| Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | semmle.label | successor |
-| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | semmle.label | true |
-| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | semmle.label | successor |
-| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
-| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | semmle.label | successor |
-| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | semmle.label | false |
-| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | semmle.label | true |
-| Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 | semmle.label | successor |
-| Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | semmle.label | successor |
-| Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
-| Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | semmle.label | successor |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | semmle.label | false |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | semmle.label | successor |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | semmle.label | successor |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | semmle.label | false |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | semmle.label | true |
-| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | semmle.label | successor |
-| Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | semmle.label | successor |
-| Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | semmle.label | successor |
-| Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | semmle.label | successor |
-| Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | semmle.label | successor |
-| Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
-| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} | semmle.label | successor |
-| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
-| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; | semmle.label | successor |
-| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:17 | access to parameter b | semmle.label | successor |
-| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | semmle.label | successor |
-| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | semmle.label | successor |
-| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | semmle.label | true |
-| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | semmle.label | false |
-| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | semmle.label | successor |
-| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | semmle.label | successor |
-| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | semmle.label | successor |
-| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | semmle.label | successor |
-| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | semmle.label | successor |
-| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | semmle.label | successor |
-| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | semmle.label | false |
-| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; | semmle.label | true |
-| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 (normal) | semmle.label | successor |
-| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:40:147:43 | "a = " | semmle.label | successor |
-| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:13:147:48 | call to method WriteLine | semmle.label | successor |
-| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:45:147:45 | access to local variable s | semmle.label | successor |
-| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:38:147:47 | $"..." | semmle.label | successor |
-| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 (normal) | semmle.label | successor |
-| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:40:149:43 | "b = " | semmle.label | successor |
-| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:13:149:48 | call to method WriteLine | semmle.label | successor |
-| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:45:149:45 | access to local variable s | semmle.label | successor |
-| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:38:149:47 | $"..." | semmle.label | successor |
-| ExitMethods.cs:8:10:8:11 | enter M1 | ExitMethods.cs:9:5:12:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:8:10:8:11 | exit M1 (normal) | ExitMethods.cs:8:10:8:11 | exit M1 | semmle.label | successor |
-| ExitMethods.cs:9:5:12:5 | {...} | ExitMethods.cs:10:9:10:25 | ...; | semmle.label | successor |
-| ExitMethods.cs:10:9:10:24 | call to method ErrorMaybe | ExitMethods.cs:11:9:11:15 | return ...; | semmle.label | successor |
-| ExitMethods.cs:10:9:10:25 | ...; | ExitMethods.cs:10:20:10:23 | true | semmle.label | successor |
-| ExitMethods.cs:10:20:10:23 | true | ExitMethods.cs:10:9:10:24 | call to method ErrorMaybe | semmle.label | successor |
-| ExitMethods.cs:11:9:11:15 | return ...; | ExitMethods.cs:8:10:8:11 | exit M1 (normal) | semmle.label | return |
-| ExitMethods.cs:14:10:14:11 | enter M2 | ExitMethods.cs:15:5:18:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:14:10:14:11 | exit M2 (normal) | ExitMethods.cs:14:10:14:11 | exit M2 | semmle.label | successor |
-| ExitMethods.cs:15:5:18:5 | {...} | ExitMethods.cs:16:9:16:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:16:9:16:25 | call to method ErrorMaybe | ExitMethods.cs:17:9:17:15 | return ...; | semmle.label | successor |
-| ExitMethods.cs:16:9:16:26 | ...; | ExitMethods.cs:16:20:16:24 | false | semmle.label | successor |
-| ExitMethods.cs:16:20:16:24 | false | ExitMethods.cs:16:9:16:25 | call to method ErrorMaybe | semmle.label | successor |
-| ExitMethods.cs:17:9:17:15 | return ...; | ExitMethods.cs:14:10:14:11 | exit M2 (normal) | semmle.label | return |
-| ExitMethods.cs:20:10:20:11 | enter M3 | ExitMethods.cs:21:5:24:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:20:10:20:11 | exit M3 (abnormal) | ExitMethods.cs:20:10:20:11 | exit M3 | semmle.label | successor |
-| ExitMethods.cs:21:5:24:5 | {...} | ExitMethods.cs:22:9:22:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:22:9:22:25 | call to method ErrorAlways | ExitMethods.cs:20:10:20:11 | exit M3 (abnormal) | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:22:9:22:25 | call to method ErrorAlways | ExitMethods.cs:20:10:20:11 | exit M3 (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:22:9:22:26 | ...; | ExitMethods.cs:22:21:22:24 | true | semmle.label | successor |
-| ExitMethods.cs:22:21:22:24 | true | ExitMethods.cs:22:9:22:25 | call to method ErrorAlways | semmle.label | successor |
-| ExitMethods.cs:26:10:26:11 | enter M4 | ExitMethods.cs:27:5:30:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:26:10:26:11 | exit M4 (abnormal) | ExitMethods.cs:26:10:26:11 | exit M4 | semmle.label | successor |
-| ExitMethods.cs:27:5:30:5 | {...} | ExitMethods.cs:28:9:28:15 | ...; | semmle.label | successor |
-| ExitMethods.cs:28:9:28:14 | call to method Exit | ExitMethods.cs:26:10:26:11 | exit M4 (abnormal) | semmle.label | exit |
-| ExitMethods.cs:28:9:28:14 | this access | ExitMethods.cs:28:9:28:14 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:28:9:28:15 | ...; | ExitMethods.cs:28:9:28:14 | this access | semmle.label | successor |
-| ExitMethods.cs:32:10:32:11 | enter M5 | ExitMethods.cs:33:5:36:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:32:10:32:11 | exit M5 (abnormal) | ExitMethods.cs:32:10:32:11 | exit M5 | semmle.label | successor |
-| ExitMethods.cs:33:5:36:5 | {...} | ExitMethods.cs:34:9:34:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:34:9:34:25 | call to method ApplicationExit | ExitMethods.cs:32:10:32:11 | exit M5 (abnormal) | semmle.label | exit |
-| ExitMethods.cs:34:9:34:25 | this access | ExitMethods.cs:34:9:34:25 | call to method ApplicationExit | semmle.label | successor |
-| ExitMethods.cs:34:9:34:26 | ...; | ExitMethods.cs:34:9:34:25 | this access | semmle.label | successor |
-| ExitMethods.cs:38:10:38:11 | enter M6 | ExitMethods.cs:39:5:52:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:38:10:38:11 | exit M6 (normal) | ExitMethods.cs:38:10:38:11 | exit M6 | semmle.label | successor |
-| ExitMethods.cs:39:5:52:5 | {...} | ExitMethods.cs:40:9:51:9 | try {...} ... | semmle.label | successor |
-| ExitMethods.cs:40:9:51:9 | try {...} ... | ExitMethods.cs:41:9:43:9 | {...} | semmle.label | successor |
-| ExitMethods.cs:41:9:43:9 | {...} | ExitMethods.cs:42:13:42:31 | ...; | semmle.label | successor |
-| ExitMethods.cs:42:13:42:30 | call to method ErrorAlways | ExitMethods.cs:44:9:47:9 | [exception: ArgumentException] catch (...) {...} | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:42:13:42:30 | call to method ErrorAlways | ExitMethods.cs:44:9:47:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| ExitMethods.cs:42:13:42:31 | ...; | ExitMethods.cs:42:25:42:29 | false | semmle.label | successor |
-| ExitMethods.cs:42:25:42:29 | false | ExitMethods.cs:42:13:42:30 | call to method ErrorAlways | semmle.label | successor |
-| ExitMethods.cs:44:9:47:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:45:9:47:9 | {...} | semmle.label | match |
-| ExitMethods.cs:44:9:47:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:45:9:47:9 | {...} | semmle.label | match |
-| ExitMethods.cs:44:9:47:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:9:51:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
-| ExitMethods.cs:45:9:47:9 | {...} | ExitMethods.cs:46:13:46:19 | return ...; | semmle.label | successor |
-| ExitMethods.cs:46:13:46:19 | return ...; | ExitMethods.cs:38:10:38:11 | exit M6 (normal) | semmle.label | return |
-| ExitMethods.cs:48:9:51:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:49:9:51:9 | {...} | semmle.label | match |
-| ExitMethods.cs:49:9:51:9 | {...} | ExitMethods.cs:50:13:50:19 | return ...; | semmle.label | successor |
-| ExitMethods.cs:50:13:50:19 | return ...; | ExitMethods.cs:38:10:38:11 | exit M6 (normal) | semmle.label | return |
-| ExitMethods.cs:54:10:54:11 | enter M7 | ExitMethods.cs:55:5:58:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:54:10:54:11 | exit M7 (abnormal) | ExitMethods.cs:54:10:54:11 | exit M7 | semmle.label | successor |
-| ExitMethods.cs:55:5:58:5 | {...} | ExitMethods.cs:56:9:56:23 | ...; | semmle.label | successor |
-| ExitMethods.cs:56:9:56:22 | call to method ErrorAlways2 | ExitMethods.cs:54:10:54:11 | exit M7 (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:56:9:56:23 | ...; | ExitMethods.cs:56:9:56:22 | call to method ErrorAlways2 | semmle.label | successor |
-| ExitMethods.cs:60:10:60:11 | enter M8 | ExitMethods.cs:61:5:64:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:60:10:60:11 | exit M8 (abnormal) | ExitMethods.cs:60:10:60:11 | exit M8 | semmle.label | successor |
-| ExitMethods.cs:61:5:64:5 | {...} | ExitMethods.cs:62:9:62:23 | ...; | semmle.label | successor |
-| ExitMethods.cs:62:9:62:22 | call to method ErrorAlways3 | ExitMethods.cs:60:10:60:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:62:9:62:23 | ...; | ExitMethods.cs:62:9:62:22 | call to method ErrorAlways3 | semmle.label | successor |
-| ExitMethods.cs:66:17:66:26 | enter ErrorMaybe | ExitMethods.cs:67:5:70:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (abnormal) | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe | semmle.label | successor |
-| ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (normal) | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe | semmle.label | successor |
-| ExitMethods.cs:67:5:70:5 | {...} | ExitMethods.cs:68:9:69:34 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:68:9:69:34 | if (...) ... | ExitMethods.cs:68:13:68:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:68:13:68:13 | access to parameter b | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (normal) | semmle.label | false |
-| ExitMethods.cs:68:13:68:13 | access to parameter b | ExitMethods.cs:69:19:69:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:69:13:69:34 | throw ...; | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:69:19:69:33 | object creation of type Exception | ExitMethods.cs:69:13:69:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:72:17:72:27 | enter ErrorAlways | ExitMethods.cs:73:5:78:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:72:17:72:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:72:17:72:27 | exit ErrorAlways | semmle.label | successor |
-| ExitMethods.cs:73:5:78:5 | {...} | ExitMethods.cs:74:9:77:45 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:74:9:77:45 | if (...) ... | ExitMethods.cs:74:13:74:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:74:13:74:13 | access to parameter b | ExitMethods.cs:75:19:75:33 | object creation of type Exception | semmle.label | true |
-| ExitMethods.cs:74:13:74:13 | access to parameter b | ExitMethods.cs:77:41:77:43 | "b" | semmle.label | false |
-| ExitMethods.cs:75:13:75:34 | throw ...; | ExitMethods.cs:72:17:72:27 | exit ErrorAlways (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:75:19:75:33 | object creation of type Exception | ExitMethods.cs:75:13:75:34 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:77:13:77:45 | throw ...; | ExitMethods.cs:72:17:72:27 | exit ErrorAlways (abnormal) | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:77:19:77:44 | object creation of type ArgumentException | ExitMethods.cs:77:13:77:45 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:77:41:77:43 | "b" | ExitMethods.cs:77:19:77:44 | object creation of type ArgumentException | semmle.label | successor |
-| ExitMethods.cs:80:17:80:28 | enter ErrorAlways2 | ExitMethods.cs:81:5:83:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:80:17:80:28 | exit ErrorAlways2 (abnormal) | ExitMethods.cs:80:17:80:28 | exit ErrorAlways2 | semmle.label | successor |
-| ExitMethods.cs:81:5:83:5 | {...} | ExitMethods.cs:82:15:82:29 | object creation of type Exception | semmle.label | successor |
-| ExitMethods.cs:82:9:82:30 | throw ...; | ExitMethods.cs:80:17:80:28 | exit ErrorAlways2 (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:82:15:82:29 | object creation of type Exception | ExitMethods.cs:82:9:82:30 | throw ...; | semmle.label | successor |
-| ExitMethods.cs:85:17:85:28 | enter ErrorAlways3 | ExitMethods.cs:85:41:85:55 | object creation of type Exception | semmle.label | successor |
-| ExitMethods.cs:85:17:85:28 | exit ErrorAlways3 (abnormal) | ExitMethods.cs:85:17:85:28 | exit ErrorAlways3 | semmle.label | successor |
-| ExitMethods.cs:85:35:85:55 | throw ... | ExitMethods.cs:85:17:85:28 | exit ErrorAlways3 (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:85:41:85:55 | object creation of type Exception | ExitMethods.cs:85:35:85:55 | throw ... | semmle.label | successor |
-| ExitMethods.cs:87:10:87:13 | enter Exit | ExitMethods.cs:88:5:90:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:87:10:87:13 | exit Exit (abnormal) | ExitMethods.cs:87:10:87:13 | exit Exit | semmle.label | successor |
-| ExitMethods.cs:88:5:90:5 | {...} | ExitMethods.cs:89:9:89:28 | ...; | semmle.label | successor |
-| ExitMethods.cs:89:9:89:27 | call to method Exit | ExitMethods.cs:87:10:87:13 | exit Exit (abnormal) | semmle.label | exit |
-| ExitMethods.cs:89:9:89:28 | ...; | ExitMethods.cs:89:26:89:26 | 0 | semmle.label | successor |
-| ExitMethods.cs:89:26:89:26 | 0 | ExitMethods.cs:89:9:89:27 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:92:10:92:18 | enter ExitInTry | ExitMethods.cs:93:5:103:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:92:10:92:18 | exit ExitInTry (abnormal) | ExitMethods.cs:92:10:92:18 | exit ExitInTry | semmle.label | successor |
-| ExitMethods.cs:93:5:103:5 | {...} | ExitMethods.cs:94:9:102:9 | try {...} ... | semmle.label | successor |
-| ExitMethods.cs:94:9:102:9 | try {...} ... | ExitMethods.cs:95:9:97:9 | {...} | semmle.label | successor |
-| ExitMethods.cs:95:9:97:9 | {...} | ExitMethods.cs:96:13:96:19 | ...; | semmle.label | successor |
-| ExitMethods.cs:96:13:96:18 | call to method Exit | ExitMethods.cs:92:10:92:18 | exit ExitInTry (abnormal) | semmle.label | exit |
-| ExitMethods.cs:96:13:96:18 | this access | ExitMethods.cs:96:13:96:18 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:96:13:96:19 | ...; | ExitMethods.cs:96:13:96:18 | this access | semmle.label | successor |
-| ExitMethods.cs:105:10:105:24 | enter ApplicationExit | ExitMethods.cs:106:5:108:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:105:10:105:24 | exit ApplicationExit (abnormal) | ExitMethods.cs:105:10:105:24 | exit ApplicationExit | semmle.label | successor |
-| ExitMethods.cs:106:5:108:5 | {...} | ExitMethods.cs:107:9:107:48 | ...; | semmle.label | successor |
-| ExitMethods.cs:107:9:107:47 | call to method Exit | ExitMethods.cs:105:10:105:24 | exit ApplicationExit (abnormal) | semmle.label | exit |
-| ExitMethods.cs:107:9:107:48 | ...; | ExitMethods.cs:107:9:107:47 | call to method Exit | semmle.label | successor |
-| ExitMethods.cs:110:13:110:21 | enter ThrowExpr | ExitMethods.cs:111:5:113:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:110:13:110:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:110:13:110:21 | exit ThrowExpr | semmle.label | successor |
-| ExitMethods.cs:110:13:110:21 | exit ThrowExpr (normal) | ExitMethods.cs:110:13:110:21 | exit ThrowExpr | semmle.label | successor |
-| ExitMethods.cs:111:5:113:5 | {...} | ExitMethods.cs:112:16:112:20 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:112:9:112:77 | return ...; | ExitMethods.cs:110:13:110:21 | exit ThrowExpr (normal) | semmle.label | return |
-| ExitMethods.cs:112:16:112:20 | access to parameter input | ExitMethods.cs:112:25:112:25 | 0 | semmle.label | successor |
-| ExitMethods.cs:112:16:112:25 | ... != ... | ExitMethods.cs:112:29:112:29 | 1 | semmle.label | true |
-| ExitMethods.cs:112:16:112:25 | ... != ... | ExitMethods.cs:112:69:112:75 | "input" | semmle.label | false |
-| ExitMethods.cs:112:16:112:76 | ... ? ... : ... | ExitMethods.cs:112:9:112:77 | return ...; | semmle.label | successor |
-| ExitMethods.cs:112:25:112:25 | 0 | ExitMethods.cs:112:25:112:25 | (...) ... | semmle.label | successor |
-| ExitMethods.cs:112:25:112:25 | (...) ... | ExitMethods.cs:112:16:112:25 | ... != ... | semmle.label | successor |
-| ExitMethods.cs:112:29:112:29 | 1 | ExitMethods.cs:112:29:112:29 | (...) ... | semmle.label | successor |
-| ExitMethods.cs:112:29:112:29 | (...) ... | ExitMethods.cs:112:33:112:37 | access to parameter input | semmle.label | successor |
-| ExitMethods.cs:112:29:112:37 | ... / ... | ExitMethods.cs:112:16:112:76 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:112:33:112:37 | access to parameter input | ExitMethods.cs:112:29:112:37 | ... / ... | semmle.label | successor |
-| ExitMethods.cs:112:41:112:76 | throw ... | ExitMethods.cs:110:13:110:21 | exit ThrowExpr (abnormal) | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:112:47:112:76 | object creation of type ArgumentException | ExitMethods.cs:112:41:112:76 | throw ... | semmle.label | successor |
-| ExitMethods.cs:112:69:112:75 | "input" | ExitMethods.cs:112:47:112:76 | object creation of type ArgumentException | semmle.label | successor |
-| ExitMethods.cs:115:16:115:34 | enter ExtensionMethodCall | ExitMethods.cs:116:5:118:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:115:16:115:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:115:16:115:34 | exit ExtensionMethodCall | semmle.label | successor |
-| ExitMethods.cs:116:5:118:5 | {...} | ExitMethods.cs:117:16:117:16 | access to parameter s | semmle.label | successor |
-| ExitMethods.cs:117:9:117:39 | return ...; | ExitMethods.cs:115:16:115:34 | exit ExtensionMethodCall (normal) | semmle.label | return |
-| ExitMethods.cs:117:16:117:16 | access to parameter s | ExitMethods.cs:117:27:117:29 | - | semmle.label | successor |
-| ExitMethods.cs:117:16:117:30 | call to method Contains | ExitMethods.cs:117:34:117:34 | 0 | semmle.label | true |
-| ExitMethods.cs:117:16:117:30 | call to method Contains | ExitMethods.cs:117:38:117:38 | 1 | semmle.label | false |
-| ExitMethods.cs:117:16:117:38 | ... ? ... : ... | ExitMethods.cs:117:9:117:39 | return ...; | semmle.label | successor |
-| ExitMethods.cs:117:27:117:29 | - | ExitMethods.cs:117:16:117:30 | call to method Contains | semmle.label | successor |
-| ExitMethods.cs:117:34:117:34 | 0 | ExitMethods.cs:117:16:117:38 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:117:38:117:38 | 1 | ExitMethods.cs:117:16:117:38 | ... ? ... : ... | semmle.label | successor |
-| ExitMethods.cs:120:17:120:32 | enter FailingAssertion | ExitMethods.cs:121:5:124:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:120:17:120:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:120:17:120:32 | exit FailingAssertion | semmle.label | successor |
-| ExitMethods.cs:121:5:124:5 | {...} | ExitMethods.cs:122:9:122:29 | ...; | semmle.label | successor |
-| ExitMethods.cs:122:9:122:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:120:17:120:32 | exit FailingAssertion (abnormal) | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:122:9:122:29 | ...; | ExitMethods.cs:122:23:122:27 | false | semmle.label | successor |
-| ExitMethods.cs:122:23:122:27 | false | ExitMethods.cs:122:9:122:28 | [assertion failure] call to method IsTrue | semmle.label | false |
-| ExitMethods.cs:126:17:126:33 | enter FailingAssertion2 | ExitMethods.cs:127:5:130:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:126:17:126:33 | exit FailingAssertion2 (abnormal) | ExitMethods.cs:126:17:126:33 | exit FailingAssertion2 | semmle.label | successor |
-| ExitMethods.cs:127:5:130:5 | {...} | ExitMethods.cs:128:9:128:27 | ...; | semmle.label | successor |
-| ExitMethods.cs:128:9:128:26 | call to method FailingAssertion | ExitMethods.cs:126:17:126:33 | exit FailingAssertion2 (abnormal) | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:128:9:128:26 | this access | ExitMethods.cs:128:9:128:26 | call to method FailingAssertion | semmle.label | successor |
-| ExitMethods.cs:128:9:128:27 | ...; | ExitMethods.cs:128:9:128:26 | this access | semmle.label | successor |
-| ExitMethods.cs:132:10:132:20 | enter AssertFalse | ExitMethods.cs:132:48:132:48 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:132:10:132:20 | exit AssertFalse (abnormal) | ExitMethods.cs:132:10:132:20 | exit AssertFalse | semmle.label | successor |
-| ExitMethods.cs:132:10:132:20 | exit AssertFalse (normal) | ExitMethods.cs:132:10:132:20 | exit AssertFalse | semmle.label | successor |
-| ExitMethods.cs:132:33:132:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:132:10:132:20 | exit AssertFalse (abnormal) | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:132:33:132:49 | [assertion success] call to method IsFalse | ExitMethods.cs:132:10:132:20 | exit AssertFalse (normal) | semmle.label | successor |
-| ExitMethods.cs:132:48:132:48 | access to parameter b | ExitMethods.cs:132:33:132:49 | [assertion failure] call to method IsFalse | semmle.label | true |
-| ExitMethods.cs:132:48:132:48 | access to parameter b | ExitMethods.cs:132:33:132:49 | [assertion success] call to method IsFalse | semmle.label | false |
-| ExitMethods.cs:134:17:134:33 | enter FailingAssertion3 | ExitMethods.cs:135:5:138:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:134:17:134:33 | exit FailingAssertion3 (abnormal) | ExitMethods.cs:134:17:134:33 | exit FailingAssertion3 | semmle.label | successor |
-| ExitMethods.cs:135:5:138:5 | {...} | ExitMethods.cs:136:9:136:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:136:9:136:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:134:17:134:33 | exit FailingAssertion3 (abnormal) | semmle.label | exception(AssertFailedException) |
-| ExitMethods.cs:136:9:136:25 | this access | ExitMethods.cs:136:21:136:24 | true | semmle.label | successor |
-| ExitMethods.cs:136:9:136:26 | ...; | ExitMethods.cs:136:9:136:25 | this access | semmle.label | successor |
-| ExitMethods.cs:136:21:136:24 | true | ExitMethods.cs:136:9:136:25 | [assertion failure] call to method AssertFalse | semmle.label | true |
-| ExitMethods.cs:140:17:140:42 | enter ExceptionDispatchInfoThrow | ExitMethods.cs:141:5:147:5 | {...} | semmle.label | successor |
-| ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow (abnormal) | ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow | semmle.label | successor |
-| ExitMethods.cs:141:5:147:5 | {...} | ExitMethods.cs:142:9:145:53 | if (...) ... | semmle.label | successor |
-| ExitMethods.cs:142:9:145:53 | if (...) ... | ExitMethods.cs:142:13:142:13 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:142:13:142:13 | access to parameter b | ExitMethods.cs:143:13:143:43 | ...; | semmle.label | true |
-| ExitMethods.cs:142:13:142:13 | access to parameter b | ExitMethods.cs:145:13:145:53 | ...; | semmle.label | false |
-| ExitMethods.cs:143:13:143:42 | call to method Throw | ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow (abnormal) | semmle.label | exception(ArgumentException) |
-| ExitMethods.cs:143:13:143:43 | ...; | ExitMethods.cs:143:41:143:41 | access to parameter e | semmle.label | successor |
-| ExitMethods.cs:143:41:143:41 | access to parameter e | ExitMethods.cs:143:13:143:42 | call to method Throw | semmle.label | successor |
-| ExitMethods.cs:145:13:145:44 | call to method Capture | ExitMethods.cs:145:13:145:52 | call to method Throw | semmle.label | successor |
-| ExitMethods.cs:145:13:145:52 | call to method Throw | ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow (abnormal) | semmle.label | exception(Exception) |
-| ExitMethods.cs:145:13:145:53 | ...; | ExitMethods.cs:145:43:145:43 | access to parameter e | semmle.label | successor |
-| ExitMethods.cs:145:43:145:43 | access to parameter e | ExitMethods.cs:145:13:145:44 | call to method Capture | semmle.label | successor |
-| Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} | semmle.label | successor |
-| Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | Extensions.cs:5:23:5:29 | exit ToInt32 | semmle.label | successor |
-| Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s | semmle.label | successor |
-| Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | semmle.label | return |
-| Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:9:7:30 | return ...; | semmle.label | successor |
-| Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:7:16:7:29 | call to method Parse | semmle.label | successor |
-| Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:11:5:13:5 | {...} | semmle.label | successor |
-| Extensions.cs:10:24:10:29 | exit ToBool (normal) | Extensions.cs:10:24:10:29 | exit ToBool | semmle.label | successor |
-| Extensions.cs:11:5:13:5 | {...} | Extensions.cs:12:16:12:16 | access to parameter f | semmle.label | successor |
-| Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | exit ToBool (normal) | semmle.label | return |
-| Extensions.cs:12:16:12:16 | access to parameter f | Extensions.cs:12:18:12:18 | access to parameter s | semmle.label | successor |
-| Extensions.cs:12:16:12:19 | delegate call | Extensions.cs:12:9:12:20 | return ...; | semmle.label | successor |
-| Extensions.cs:12:18:12:18 | access to parameter s | Extensions.cs:12:16:12:19 | delegate call | semmle.label | successor |
-| Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:48:15:50 | "0" | semmle.label | successor |
-| Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | Extensions.cs:15:23:15:33 | exit CallToInt32 | semmle.label | successor |
-| Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | semmle.label | successor |
-| Extensions.cs:15:48:15:50 | "0" | Extensions.cs:15:40:15:51 | call to method ToInt32 | semmle.label | successor |
-| Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:21:5:26:5 | {...} | semmle.label | successor |
-| Extensions.cs:20:17:20:20 | exit Main (normal) | Extensions.cs:20:17:20:20 | exit Main | semmle.label | successor |
-| Extensions.cs:21:5:26:5 | {...} | Extensions.cs:22:9:22:20 | ...; | semmle.label | successor |
-| Extensions.cs:22:9:22:9 | access to parameter s | Extensions.cs:22:9:22:19 | call to method ToInt32 | semmle.label | successor |
-| Extensions.cs:22:9:22:19 | call to method ToInt32 | Extensions.cs:23:9:23:31 | ...; | semmle.label | successor |
-| Extensions.cs:22:9:22:20 | ...; | Extensions.cs:22:9:22:9 | access to parameter s | semmle.label | successor |
-| Extensions.cs:23:9:23:30 | call to method ToInt32 | Extensions.cs:24:9:24:46 | ...; | semmle.label | successor |
-| Extensions.cs:23:9:23:31 | ...; | Extensions.cs:23:28:23:29 | "" | semmle.label | successor |
-| Extensions.cs:23:28:23:29 | "" | Extensions.cs:23:9:23:30 | call to method ToInt32 | semmle.label | successor |
-| Extensions.cs:24:9:24:45 | call to method ToBool | Extensions.cs:25:9:25:34 | ...; | semmle.label | successor |
-| Extensions.cs:24:9:24:46 | ...; | Extensions.cs:24:27:24:32 | "true" | semmle.label | successor |
-| Extensions.cs:24:27:24:32 | "true" | Extensions.cs:24:35:24:44 | access to method Parse | semmle.label | successor |
-| Extensions.cs:24:35:24:44 | access to method Parse | Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> | semmle.label | successor |
-| Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> | Extensions.cs:24:9:24:45 | call to method ToBool | semmle.label | successor |
-| Extensions.cs:25:9:25:14 | "true" | Extensions.cs:25:23:25:32 | access to method Parse | semmle.label | successor |
-| Extensions.cs:25:9:25:33 | call to method ToBool | Extensions.cs:20:17:20:20 | exit Main (normal) | semmle.label | successor |
-| Extensions.cs:25:9:25:34 | ...; | Extensions.cs:25:9:25:14 | "true" | semmle.label | successor |
-| Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | semmle.label | successor |
-| Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:9:25:33 | call to method ToBool | semmle.label | successor |
-| Finally.cs:7:10:7:11 | enter M1 | Finally.cs:8:5:17:5 | {...} | semmle.label | successor |
-| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | exit M1 | semmle.label | successor |
-| Finally.cs:7:10:7:11 | exit M1 (normal) | Finally.cs:7:10:7:11 | exit M1 | semmle.label | successor |
-| Finally.cs:8:5:17:5 | {...} | Finally.cs:9:9:16:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:10:9:12:9 | {...} | semmle.label | successor |
-| Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:38 | ...; | semmle.label | successor |
-| Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:14:9:16:9 | {...} | semmle.label | successor |
-| Finally.cs:11:13:11:38 | ...; | Finally.cs:11:31:11:36 | "Try1" | semmle.label | successor |
-| Finally.cs:11:31:11:36 | "Try1" | Finally.cs:11:13:11:37 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:14:9:16:9 | {...} | Finally.cs:15:13:15:41 | ...; | semmle.label | successor |
-| Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:15:13:15:40 | call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (normal) | semmle.label | successor |
-| Finally.cs:15:13:15:41 | ...; | Finally.cs:15:31:15:39 | "Finally" | semmle.label | successor |
-| Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
-| Finally.cs:15:31:15:39 | "Finally" | Finally.cs:15:13:15:40 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" | Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:19:10:19:11 | enter M2 | Finally.cs:20:5:52:5 | {...} | semmle.label | successor |
-| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | exit M2 | semmle.label | successor |
-| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | exit M2 | semmle.label | successor |
-| Finally.cs:20:5:52:5 | {...} | Finally.cs:21:9:51:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:22:9:25:9 | {...} | semmle.label | successor |
-| Finally.cs:22:9:25:9 | {...} | Finally.cs:23:13:23:38 | ...; | semmle.label | successor |
-| Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:24:13:24:19 | return ...; | semmle.label | successor |
-| Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:23:13:23:38 | ...; | Finally.cs:23:31:23:36 | "Try2" | semmle.label | successor |
-| Finally.cs:23:31:23:36 | "Try2" | Finally.cs:23:13:23:37 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:24:13:24:19 | return ...; | Finally.cs:49:9:51:9 | [finally: return] {...} | semmle.label | return |
-| Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex | semmle.label | match |
-| Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
-| Finally.cs:26:38:26:39 | [exception: Exception] IOException ex | Finally.cs:26:48:26:51 | [exception: Exception] true | semmle.label | successor |
-| Finally.cs:26:48:26:51 | [exception: Exception] true | Finally.cs:27:9:29:9 | {...} | semmle.label | true |
-| Finally.cs:27:9:29:9 | {...} | Finally.cs:28:13:28:18 | throw ...; | semmle.label | successor |
-| Finally.cs:28:13:28:18 | throw ...; | Finally.cs:49:9:51:9 | [finally: exception(IOException)] {...} | semmle.label | exception(IOException) |
-| Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex | semmle.label | match |
-| Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
-| Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex | Finally.cs:31:9:40:9 | {...} | semmle.label | successor |
-| Finally.cs:31:9:40:9 | {...} | Finally.cs:32:13:39:13 | try {...} ... | semmle.label | successor |
-| Finally.cs:32:13:39:13 | try {...} ... | Finally.cs:33:13:35:13 | {...} | semmle.label | successor |
-| Finally.cs:33:13:35:13 | {...} | Finally.cs:34:17:34:32 | if (...) ... | semmle.label | successor |
-| Finally.cs:34:17:34:32 | if (...) ... | Finally.cs:34:21:34:24 | true | semmle.label | successor |
-| Finally.cs:34:21:34:24 | true | Finally.cs:34:27:34:32 | throw ...; | semmle.label | true |
-| Finally.cs:34:27:34:32 | throw ...; | Finally.cs:37:13:39:13 | [finally: exception(ArgumentException)] {...} | semmle.label | exception(ArgumentException) |
-| Finally.cs:37:13:39:13 | [finally: exception(ArgumentException)] {...} | Finally.cs:38:37:38:42 | [finally: exception(ArgumentException)] "Boo!" | semmle.label | successor |
-| Finally.cs:38:17:38:44 | [finally: exception(ArgumentException)] throw ...; | Finally.cs:49:9:51:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:38:23:38:43 | [finally: exception(ArgumentException)] object creation of type Exception | Finally.cs:38:17:38:44 | [finally: exception(ArgumentException)] throw ...; | semmle.label | successor |
-| Finally.cs:38:37:38:42 | [finally: exception(ArgumentException)] "Boo!" | Finally.cs:38:23:38:43 | [finally: exception(ArgumentException)] object creation of type Exception | semmle.label | successor |
-| Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | Finally.cs:42:9:43:9 | {...} | semmle.label | match |
-| Finally.cs:42:9:43:9 | {...} | Finally.cs:49:9:51:9 | {...} | semmle.label | successor |
-| Finally.cs:49:9:51:9 | [finally: exception(Exception)] {...} | Finally.cs:50:13:50:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:49:9:51:9 | [finally: exception(IOException)] {...} | Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; | semmle.label | successor |
-| Finally.cs:49:9:51:9 | [finally: return] {...} | Finally.cs:50:13:50:41 | [finally: return] ...; | semmle.label | successor |
-| Finally.cs:49:9:51:9 | {...} | Finally.cs:50:13:50:41 | ...; | semmle.label | successor |
-| Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) | semmle.label | exception(IOException) |
-| Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (normal) | semmle.label | return |
-| Finally.cs:50:13:50:40 | call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (normal) | semmle.label | successor |
-| Finally.cs:50:13:50:41 | ...; | Finally.cs:50:31:50:39 | "Finally" | semmle.label | successor |
-| Finally.cs:50:13:50:41 | [finally: exception(Exception)] ...; | Finally.cs:50:31:50:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
-| Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; | Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" | semmle.label | successor |
-| Finally.cs:50:13:50:41 | [finally: return] ...; | Finally.cs:50:31:50:39 | [finally: return] "Finally" | semmle.label | successor |
-| Finally.cs:50:31:50:39 | "Finally" | Finally.cs:50:13:50:40 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:50:31:50:39 | [finally: exception(Exception)] "Finally" | Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" | Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:50:31:50:39 | [finally: return] "Finally" | Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | semmle.label | successor |
-| Finally.cs:54:10:54:11 | enter M3 | Finally.cs:55:5:72:5 | {...} | semmle.label | successor |
-| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | exit M3 | semmle.label | successor |
-| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | exit M3 | semmle.label | successor |
-| Finally.cs:55:5:72:5 | {...} | Finally.cs:56:9:71:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:57:9:60:9 | {...} | semmle.label | successor |
-| Finally.cs:57:9:60:9 | {...} | Finally.cs:58:13:58:38 | ...; | semmle.label | successor |
-| Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:59:13:59:19 | return ...; | semmle.label | successor |
-| Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:58:13:58:38 | ...; | Finally.cs:58:31:58:36 | "Try3" | semmle.label | successor |
-| Finally.cs:58:31:58:36 | "Try3" | Finally.cs:58:13:58:37 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:59:13:59:19 | return ...; | Finally.cs:69:9:71:9 | [finally: return] {...} | semmle.label | return |
-| Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex | semmle.label | match |
-| Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | semmle.label | no-match |
-| Finally.cs:61:38:61:39 | [exception: Exception] IOException ex | Finally.cs:61:48:61:51 | [exception: Exception] true | semmle.label | successor |
-| Finally.cs:61:48:61:51 | [exception: Exception] true | Finally.cs:62:9:64:9 | {...} | semmle.label | true |
-| Finally.cs:62:9:64:9 | {...} | Finally.cs:63:13:63:18 | throw ...; | semmle.label | successor |
-| Finally.cs:63:13:63:18 | throw ...; | Finally.cs:69:9:71:9 | [finally: exception(IOException)] {...} | semmle.label | exception(IOException) |
-| Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | Finally.cs:65:26:65:26 | [exception: Exception] Exception e | semmle.label | match |
-| Finally.cs:65:26:65:26 | [exception: Exception] Exception e | Finally.cs:65:35:65:35 | [exception: Exception] access to local variable e | semmle.label | successor |
-| Finally.cs:65:35:65:35 | [exception: Exception] access to local variable e | Finally.cs:65:35:65:43 | [exception: Exception] access to property Message | semmle.label | successor |
-| Finally.cs:65:35:65:43 | [exception: Exception] access to property Message | Finally.cs:65:48:65:51 | [exception: Exception] null | semmle.label | successor |
-| Finally.cs:65:35:65:51 | [exception: Exception] ... != ... | Finally.cs:66:9:67:9 | {...} | semmle.label | true |
-| Finally.cs:65:35:65:51 | [exception: Exception] ... != ... | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:65:48:65:51 | [exception: Exception] null | Finally.cs:65:35:65:51 | [exception: Exception] ... != ... | semmle.label | successor |
-| Finally.cs:66:9:67:9 | {...} | Finally.cs:69:9:71:9 | {...} | semmle.label | successor |
-| Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} | Finally.cs:70:13:70:41 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:69:9:71:9 | [finally: exception(IOException)] {...} | Finally.cs:70:13:70:41 | [finally: exception(IOException)] ...; | semmle.label | successor |
-| Finally.cs:69:9:71:9 | [finally: return] {...} | Finally.cs:70:13:70:41 | [finally: return] ...; | semmle.label | successor |
-| Finally.cs:69:9:71:9 | {...} | Finally.cs:70:13:70:41 | ...; | semmle.label | successor |
-| Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | semmle.label | exception(IOException) |
-| Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (normal) | semmle.label | return |
-| Finally.cs:70:13:70:40 | call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (normal) | semmle.label | successor |
-| Finally.cs:70:13:70:41 | ...; | Finally.cs:70:31:70:39 | "Finally" | semmle.label | successor |
-| Finally.cs:70:13:70:41 | [finally: exception(Exception)] ...; | Finally.cs:70:31:70:39 | [finally: exception(Exception)] "Finally" | semmle.label | successor |
-| Finally.cs:70:13:70:41 | [finally: exception(IOException)] ...; | Finally.cs:70:31:70:39 | [finally: exception(IOException)] "Finally" | semmle.label | successor |
-| Finally.cs:70:13:70:41 | [finally: return] ...; | Finally.cs:70:31:70:39 | [finally: return] "Finally" | semmle.label | successor |
-| Finally.cs:70:31:70:39 | "Finally" | Finally.cs:70:13:70:40 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:70:31:70:39 | [finally: exception(Exception)] "Finally" | Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:70:31:70:39 | [finally: exception(IOException)] "Finally" | Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:70:31:70:39 | [finally: return] "Finally" | Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | semmle.label | successor |
-| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:75:5:101:5 | {...} | semmle.label | successor |
-| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | exit M4 | semmle.label | successor |
-| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | exit M4 | semmle.label | successor |
-| Finally.cs:75:5:101:5 | {...} | Finally.cs:76:9:76:19 | ... ...; | semmle.label | successor |
-| Finally.cs:76:9:76:19 | ... ...; | Finally.cs:76:17:76:18 | 10 | semmle.label | successor |
-| Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:77:9:100:9 | while (...) ... | semmle.label | successor |
-| Finally.cs:76:17:76:18 | 10 | Finally.cs:76:13:76:18 | Int32 i = ... | semmle.label | successor |
-| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | successor |
-| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:20:77:20 | 0 | semmle.label | successor |
-| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | false |
-| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:78:9:100:9 | {...} | semmle.label | true |
-| Finally.cs:77:20:77:20 | 0 | Finally.cs:77:16:77:20 | ... > ... | semmle.label | successor |
-| Finally.cs:78:9:100:9 | {...} | Finally.cs:79:13:99:13 | try {...} ... | semmle.label | successor |
-| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:80:13:87:13 | {...} | semmle.label | successor |
-| Finally.cs:80:13:87:13 | {...} | Finally.cs:81:17:82:27 | if (...) ... | semmle.label | successor |
-| Finally.cs:81:17:82:27 | if (...) ... | Finally.cs:81:21:81:21 | access to local variable i | semmle.label | successor |
-| Finally.cs:81:21:81:21 | access to local variable i | Finally.cs:81:26:81:26 | 0 | semmle.label | successor |
-| Finally.cs:81:21:81:26 | ... == ... | Finally.cs:82:21:82:27 | return ...; | semmle.label | true |
-| Finally.cs:81:21:81:26 | ... == ... | Finally.cs:83:17:84:29 | if (...) ... | semmle.label | false |
-| Finally.cs:81:26:81:26 | 0 | Finally.cs:81:21:81:26 | ... == ... | semmle.label | successor |
-| Finally.cs:82:21:82:27 | return ...; | Finally.cs:89:13:99:13 | [finally: return] {...} | semmle.label | return |
-| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:83:21:83:21 | access to local variable i | semmle.label | successor |
-| Finally.cs:83:21:83:21 | access to local variable i | Finally.cs:83:26:83:26 | 1 | semmle.label | successor |
-| Finally.cs:83:21:83:26 | ... == ... | Finally.cs:84:21:84:29 | continue; | semmle.label | true |
-| Finally.cs:83:21:83:26 | ... == ... | Finally.cs:85:17:86:26 | if (...) ... | semmle.label | false |
-| Finally.cs:83:26:83:26 | 1 | Finally.cs:83:21:83:26 | ... == ... | semmle.label | successor |
-| Finally.cs:84:21:84:29 | continue; | Finally.cs:89:13:99:13 | [finally: continue] {...} | semmle.label | continue |
-| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:85:21:85:21 | access to local variable i | semmle.label | successor |
-| Finally.cs:85:21:85:21 | access to local variable i | Finally.cs:85:26:85:26 | 2 | semmle.label | successor |
-| Finally.cs:85:21:85:26 | ... == ... | Finally.cs:86:21:86:26 | break; | semmle.label | true |
-| Finally.cs:85:21:85:26 | ... == ... | Finally.cs:89:13:99:13 | {...} | semmle.label | false |
-| Finally.cs:85:26:85:26 | 2 | Finally.cs:85:21:85:26 | ... == ... | semmle.label | successor |
-| Finally.cs:86:21:86:26 | break; | Finally.cs:89:13:99:13 | [finally: break] {...} | semmle.label | break |
-| Finally.cs:89:13:99:13 | [finally: break] {...} | Finally.cs:90:17:98:17 | [finally: break] try {...} ... | semmle.label | successor |
-| Finally.cs:89:13:99:13 | [finally: continue] {...} | Finally.cs:90:17:98:17 | [finally: continue] try {...} ... | semmle.label | successor |
-| Finally.cs:89:13:99:13 | [finally: return] {...} | Finally.cs:90:17:98:17 | [finally: return] try {...} ... | semmle.label | successor |
-| Finally.cs:89:13:99:13 | {...} | Finally.cs:90:17:98:17 | try {...} ... | semmle.label | successor |
-| Finally.cs:90:17:98:17 | [finally: break] try {...} ... | Finally.cs:91:17:94:17 | [finally: break] {...} | semmle.label | successor |
-| Finally.cs:90:17:98:17 | [finally: continue] try {...} ... | Finally.cs:91:17:94:17 | [finally: continue] {...} | semmle.label | successor |
-| Finally.cs:90:17:98:17 | [finally: return] try {...} ... | Finally.cs:91:17:94:17 | [finally: return] {...} | semmle.label | successor |
-| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:91:17:94:17 | {...} | semmle.label | successor |
-| Finally.cs:91:17:94:17 | [finally: break] {...} | Finally.cs:92:21:93:46 | [finally: break] if (...) ... | semmle.label | successor |
-| Finally.cs:91:17:94:17 | [finally: continue] {...} | Finally.cs:92:21:93:46 | [finally: continue] if (...) ... | semmle.label | successor |
-| Finally.cs:91:17:94:17 | [finally: return] {...} | Finally.cs:92:21:93:46 | [finally: return] if (...) ... | semmle.label | successor |
-| Finally.cs:91:17:94:17 | {...} | Finally.cs:92:21:93:46 | if (...) ... | semmle.label | successor |
-| Finally.cs:92:21:93:46 | [finally: break] if (...) ... | Finally.cs:92:25:92:25 | [finally: break] access to local variable i | semmle.label | successor |
-| Finally.cs:92:21:93:46 | [finally: continue] if (...) ... | Finally.cs:92:25:92:25 | [finally: continue] access to local variable i | semmle.label | successor |
-| Finally.cs:92:21:93:46 | [finally: return] if (...) ... | Finally.cs:92:25:92:25 | [finally: return] access to local variable i | semmle.label | successor |
-| Finally.cs:92:21:93:46 | if (...) ... | Finally.cs:92:25:92:25 | access to local variable i | semmle.label | successor |
-| Finally.cs:92:25:92:25 | [finally: break] access to local variable i | Finally.cs:92:30:92:30 | [finally: break] 3 | semmle.label | successor |
-| Finally.cs:92:25:92:25 | [finally: continue] access to local variable i | Finally.cs:92:30:92:30 | [finally: continue] 3 | semmle.label | successor |
-| Finally.cs:92:25:92:25 | [finally: return] access to local variable i | Finally.cs:92:30:92:30 | [finally: return] 3 | semmle.label | successor |
-| Finally.cs:92:25:92:25 | access to local variable i | Finally.cs:92:30:92:30 | 3 | semmle.label | successor |
-| Finally.cs:92:25:92:30 | ... == ... | Finally.cs:93:31:93:45 | object creation of type Exception | semmle.label | true |
-| Finally.cs:92:25:92:30 | ... == ... | Finally.cs:96:17:98:17 | {...} | semmle.label | false |
-| Finally.cs:92:25:92:30 | [finally: break] ... == ... | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | semmle.label | true |
-| Finally.cs:92:25:92:30 | [finally: break] ... == ... | Finally.cs:96:17:98:17 | [finally: break] {...} | semmle.label | false |
-| Finally.cs:92:25:92:30 | [finally: continue] ... == ... | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | semmle.label | true |
-| Finally.cs:92:25:92:30 | [finally: continue] ... == ... | Finally.cs:96:17:98:17 | [finally: continue] {...} | semmle.label | false |
-| Finally.cs:92:25:92:30 | [finally: return] ... == ... | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | semmle.label | true |
-| Finally.cs:92:25:92:30 | [finally: return] ... == ... | Finally.cs:96:17:98:17 | [finally: return] {...} | semmle.label | false |
-| Finally.cs:92:30:92:30 | 3 | Finally.cs:92:25:92:30 | ... == ... | semmle.label | successor |
-| Finally.cs:92:30:92:30 | [finally: break] 3 | Finally.cs:92:25:92:30 | [finally: break] ... == ... | semmle.label | successor |
-| Finally.cs:92:30:92:30 | [finally: continue] 3 | Finally.cs:92:25:92:30 | [finally: continue] ... == ... | semmle.label | successor |
-| Finally.cs:92:30:92:30 | [finally: return] 3 | Finally.cs:92:25:92:30 | [finally: return] ... == ... | semmle.label | successor |
-| Finally.cs:93:25:93:46 | [finally: break] throw ...; | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:25:93:46 | [finally: continue] throw ...; | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:25:93:46 | [finally: return] throw ...; | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:25:93:46 | throw ...; | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: break] throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: continue] throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: return] throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:25:93:46 | throw ...; | semmle.label | successor |
-| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:97:21:97:24 | [finally: break] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:97:21:97:24 | [finally: continue] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:97:21:97:24 | [finally: return] ...; | semmle.label | successor |
-| Finally.cs:96:17:98:17 | {...} | Finally.cs:97:21:97:24 | ...; | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:97:21:97:23 | [finally: break] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:97:21:97:23 | [finally: return] ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:97:21:97:23 | ...-- | semmle.label | successor |
-| Finally.cs:97:21:97:23 | ...-- | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | break |
-| Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:77:16:77:16 | access to local variable i | semmle.label | continue |
-| Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | semmle.label | return |
-| Finally.cs:97:21:97:24 | ...; | Finally.cs:97:21:97:21 | access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:97:21:97:21 | [finally: break] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | semmle.label | successor |
-| Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:97:21:97:21 | [finally: return] access to local variable i | semmle.label | successor |
-| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:104:5:119:5 | {...} | semmle.label | successor |
-| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 | semmle.label | successor |
-| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 | semmle.label | successor |
-| Finally.cs:104:5:119:5 | {...} | Finally.cs:105:9:118:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:106:9:111:9 | {...} | semmle.label | successor |
-| Finally.cs:106:9:111:9 | {...} | Finally.cs:107:13:108:23 | if (...) ... | semmle.label | successor |
-| Finally.cs:107:13:108:23 | if (...) ... | Finally.cs:107:17:107:21 | this access | semmle.label | successor |
-| Finally.cs:107:17:107:21 | access to field Field | Finally.cs:107:17:107:28 | access to property Length | semmle.label | successor |
-| Finally.cs:107:17:107:21 | access to field Field | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:107:17:107:21 | this access | Finally.cs:107:17:107:21 | access to field Field | semmle.label | successor |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:33:107:33 | 0 | semmle.label | successor |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:107:17:107:33 | ... == ... | Finally.cs:108:17:108:23 | return ...; | semmle.label | true |
-| Finally.cs:107:17:107:33 | ... == ... | Finally.cs:109:13:110:49 | if (...) ... | semmle.label | false |
-| Finally.cs:107:33:107:33 | 0 | Finally.cs:107:17:107:33 | ... == ... | semmle.label | successor |
-| Finally.cs:108:17:108:23 | return ...; | Finally.cs:113:9:118:9 | [finally: return] {...} | semmle.label | return |
-| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:109:17:109:21 | this access | semmle.label | successor |
-| Finally.cs:109:17:109:21 | access to field Field | Finally.cs:109:17:109:28 | access to property Length | semmle.label | successor |
-| Finally.cs:109:17:109:21 | access to field Field | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:109:17:109:21 | this access | Finally.cs:109:17:109:21 | access to field Field | semmle.label | successor |
-| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:109:33:109:33 | 1 | semmle.label | successor |
-| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:109:17:109:33 | ... == ... | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | semmle.label | true |
-| Finally.cs:109:17:109:33 | ... == ... | Finally.cs:113:9:118:9 | {...} | semmle.label | false |
-| Finally.cs:109:33:109:33 | 1 | Finally.cs:109:17:109:33 | ... == ... | semmle.label | successor |
-| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | semmle.label | exception(OutOfMemoryException) |
-| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:17:110:49 | throw ...; | semmle.label | successor |
-| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | successor |
-| Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
-| Finally.cs:113:9:118:9 | [finally: return] {...} | Finally.cs:114:13:115:41 | [finally: return] if (...) ... | semmle.label | successor |
-| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:13:115:41 | if (...) ... | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
-| Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:114:19:114:23 | [finally: return] this access | semmle.label | successor |
-| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:19:114:23 | this access | semmle.label | successor |
-| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | semmle.label | false |
-| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | false |
-| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | false |
-| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | semmle.label | false |
-| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:116:13:117:37 | if (...) ... | semmle.label | false |
-| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | semmle.label | true |
-| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | semmle.label | true |
-| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | true |
-| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:115:17:115:41 | [finally: return] ...; | semmle.label | true |
-| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:115:17:115:41 | ...; | semmle.label | true |
-| Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: return] access to field Field | Finally.cs:114:19:114:30 | [finally: return] access to property Length | semmle.label | successor |
-| Finally.cs:114:19:114:23 | [finally: return] this access | Finally.cs:114:19:114:23 | [finally: return] access to field Field | semmle.label | successor |
-| Finally.cs:114:19:114:23 | access to field Field | Finally.cs:114:19:114:30 | access to property Length | semmle.label | successor |
-| Finally.cs:114:19:114:23 | this access | Finally.cs:114:19:114:23 | access to field Field | semmle.label | successor |
-| Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(Exception)] 0 | semmle.label | successor |
-| Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(NullReferenceException)] 0 | semmle.label | successor |
-| Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(OutOfMemoryException)] 0 | semmle.label | successor |
-| Finally.cs:114:19:114:30 | [finally: return] access to property Length | Finally.cs:114:35:114:35 | [finally: return] 0 | semmle.label | successor |
-| Finally.cs:114:19:114:30 | access to property Length | Finally.cs:114:35:114:35 | 0 | semmle.label | successor |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [false] !... | semmle.label | true |
-| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [true] !... | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | semmle.label | false |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [false, finally: return] !... | semmle.label | true |
-| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [true, finally: return] !... | semmle.label | false |
-| Finally.cs:114:35:114:35 | 0 | Finally.cs:114:19:114:35 | ... == ... | semmle.label | successor |
-| Finally.cs:114:35:114:35 | [finally: exception(Exception)] 0 | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | semmle.label | successor |
-| Finally.cs:114:35:114:35 | [finally: exception(NullReferenceException)] 0 | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | semmle.label | successor |
-| Finally.cs:114:35:114:35 | [finally: exception(OutOfMemoryException)] 0 | Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | semmle.label | successor |
-| Finally.cs:114:35:114:35 | [finally: return] 0 | Finally.cs:114:19:114:35 | [finally: return] ... == ... | semmle.label | successor |
-| Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | semmle.label | successor |
-| Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | semmle.label | successor |
-| Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | semmle.label | successor |
-| Finally.cs:115:17:115:40 | call to method WriteLine | Finally.cs:116:13:117:37 | if (...) ... | semmle.label | successor |
-| Finally.cs:115:17:115:41 | ...; | Finally.cs:115:35:115:39 | this access | semmle.label | successor |
-| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:115:35:115:39 | [finally: exception(Exception)] this access | semmle.label | successor |
-| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
-| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
-| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:115:35:115:39 | [finally: return] this access | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: exception(Exception)] access to field Field | Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: exception(Exception)] this access | Finally.cs:115:35:115:39 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] this access | Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] access to field Field | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: return] access to field Field | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine | semmle.label | successor |
-| Finally.cs:115:35:115:39 | [finally: return] this access | Finally.cs:115:35:115:39 | [finally: return] access to field Field | semmle.label | successor |
-| Finally.cs:115:35:115:39 | access to field Field | Finally.cs:115:17:115:40 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:115:35:115:39 | this access | Finally.cs:115:35:115:39 | access to field Field | semmle.label | successor |
-| Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:116:17:116:21 | [finally: exception(Exception)] this access | semmle.label | successor |
-| Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] this access | semmle.label | successor |
-| Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] this access | semmle.label | successor |
-| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:116:17:116:21 | [finally: return] this access | semmle.label | successor |
-| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:116:17:116:21 | this access | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: exception(Exception)] access to field Field | Finally.cs:116:17:116:28 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: exception(Exception)] this access | Finally.cs:116:17:116:21 | [finally: exception(Exception)] access to field Field | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:116:17:116:28 | [finally: exception(NullReferenceException)] access to property Length | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] this access | Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] access to field Field | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:116:17:116:28 | [finally: exception(OutOfMemoryException)] access to property Length | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] access to field Field | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: return] access to field Field | Finally.cs:116:17:116:28 | [finally: return] access to property Length | semmle.label | successor |
-| Finally.cs:116:17:116:21 | [finally: return] this access | Finally.cs:116:17:116:21 | [finally: return] access to field Field | semmle.label | successor |
-| Finally.cs:116:17:116:21 | access to field Field | Finally.cs:116:17:116:28 | access to property Length | semmle.label | successor |
-| Finally.cs:116:17:116:21 | this access | Finally.cs:116:17:116:21 | access to field Field | semmle.label | successor |
-| Finally.cs:116:17:116:28 | [finally: exception(Exception)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(Exception)] 0 | semmle.label | successor |
-| Finally.cs:116:17:116:28 | [finally: exception(NullReferenceException)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(NullReferenceException)] 0 | semmle.label | successor |
-| Finally.cs:116:17:116:28 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(OutOfMemoryException)] 0 | semmle.label | successor |
-| Finally.cs:116:17:116:28 | [finally: return] access to property Length | Finally.cs:116:32:116:32 | [finally: return] 0 | semmle.label | successor |
-| Finally.cs:116:17:116:28 | access to property Length | Finally.cs:116:32:116:32 | 0 | semmle.label | successor |
-| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | false |
-| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:117:17:117:37 | ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(NullReferenceException) |
-| Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(OutOfMemoryException) |
-| Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | semmle.label | true |
-| Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | return |
-| Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:117:17:117:37 | [finally: return] ...; | semmle.label | true |
-| Finally.cs:116:32:116:32 | 0 | Finally.cs:116:17:116:32 | ... > ... | semmle.label | successor |
-| Finally.cs:116:32:116:32 | [finally: exception(Exception)] 0 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | semmle.label | successor |
-| Finally.cs:116:32:116:32 | [finally: exception(NullReferenceException)] 0 | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | semmle.label | successor |
-| Finally.cs:116:32:116:32 | [finally: exception(OutOfMemoryException)] 0 | Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | semmle.label | successor |
-| Finally.cs:116:32:116:32 | [finally: return] 0 | Finally.cs:116:17:116:32 | [finally: return] ... > ... | semmle.label | successor |
-| Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(NullReferenceException) |
-| Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | semmle.label | exception(OutOfMemoryException) |
-| Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | return |
-| Finally.cs:117:17:117:36 | call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (normal) | semmle.label | successor |
-| Finally.cs:117:17:117:37 | ...; | Finally.cs:117:35:117:35 | 1 | semmle.label | successor |
-| Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | Finally.cs:117:35:117:35 | [finally: exception(Exception)] 1 | semmle.label | successor |
-| Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | Finally.cs:117:35:117:35 | [finally: exception(NullReferenceException)] 1 | semmle.label | successor |
-| Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 | semmle.label | successor |
-| Finally.cs:117:17:117:37 | [finally: return] ...; | Finally.cs:117:35:117:35 | [finally: return] 1 | semmle.label | successor |
-| Finally.cs:117:35:117:35 | 1 | Finally.cs:117:17:117:36 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:117:35:117:35 | [finally: exception(Exception)] 1 | Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:117:35:117:35 | [finally: exception(NullReferenceException)] 1 | Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 | Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:117:35:117:35 | [finally: return] 1 | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | semmle.label | successor |
-| Finally.cs:121:10:121:11 | enter M6 | Finally.cs:122:5:131:5 | {...} | semmle.label | successor |
-| Finally.cs:121:10:121:11 | exit M6 (normal) | Finally.cs:121:10:121:11 | exit M6 | semmle.label | successor |
-| Finally.cs:122:5:131:5 | {...} | Finally.cs:123:9:130:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:123:9:130:9 | try {...} ... | Finally.cs:124:9:126:9 | {...} | semmle.label | successor |
-| Finally.cs:124:9:126:9 | {...} | Finally.cs:125:13:125:41 | ... ...; | semmle.label | successor |
-| Finally.cs:125:13:125:41 | ... ...; | Finally.cs:125:24:125:24 | 0 | semmle.label | successor |
-| Finally.cs:125:17:125:40 | Double temp = ... | Finally.cs:121:10:121:11 | exit M6 (normal) | semmle.label | successor |
-| Finally.cs:125:24:125:24 | 0 | Finally.cs:125:24:125:24 | (...) ... | semmle.label | successor |
-| Finally.cs:125:24:125:24 | (...) ... | Finally.cs:125:28:125:40 | access to constant E | semmle.label | successor |
-| Finally.cs:125:24:125:40 | ... / ... | Finally.cs:125:17:125:40 | Double temp = ... | semmle.label | successor |
-| Finally.cs:125:28:125:40 | access to constant E | Finally.cs:125:24:125:40 | ... / ... | semmle.label | successor |
-| Finally.cs:133:10:133:11 | enter M7 | Finally.cs:134:5:145:5 | {...} | semmle.label | successor |
-| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 | semmle.label | successor |
-| Finally.cs:134:5:145:5 | {...} | Finally.cs:135:9:143:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:136:9:138:9 | {...} | semmle.label | successor |
-| Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:37 | ...; | semmle.label | successor |
-| Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:140:9:143:9 | {...} | semmle.label | successor |
-| Finally.cs:137:13:137:37 | ...; | Finally.cs:137:31:137:35 | "Try" | semmle.label | successor |
-| Finally.cs:137:31:137:35 | "Try" | Finally.cs:137:13:137:36 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" | semmle.label | successor |
-| Finally.cs:140:9:143:9 | {...} | Finally.cs:141:41:141:42 | "" | semmle.label | successor |
-| Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | semmle.label | exception(ArgumentException) |
-| Finally.cs:141:13:141:44 | throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | semmle.label | exception(ArgumentException) |
-| Finally.cs:141:19:141:43 | [finally: exception(Exception)] object creation of type ArgumentException | Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:141:19:141:43 | object creation of type ArgumentException | Finally.cs:141:13:141:44 | throw ...; | semmle.label | successor |
-| Finally.cs:141:41:141:42 | "" | Finally.cs:141:19:141:43 | object creation of type ArgumentException | semmle.label | successor |
-| Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" | Finally.cs:141:19:141:43 | [finally: exception(Exception)] object creation of type ArgumentException | semmle.label | successor |
-| Finally.cs:147:10:147:11 | enter M8 | Finally.cs:148:5:170:5 | {...} | semmle.label | successor |
-| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | exit M8 | semmle.label | successor |
-| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | exit M8 | semmle.label | successor |
-| Finally.cs:148:5:170:5 | {...} | Finally.cs:149:9:169:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:150:9:153:9 | {...} | semmle.label | successor |
-| Finally.cs:150:9:153:9 | {...} | Finally.cs:151:13:152:50 | if (...) ... | semmle.label | successor |
-| Finally.cs:151:13:152:50 | if (...) ... | Finally.cs:151:17:151:20 | access to parameter args | semmle.label | successor |
-| Finally.cs:151:17:151:20 | access to parameter args | Finally.cs:151:25:151:28 | null | semmle.label | successor |
-| Finally.cs:151:17:151:28 | ... == ... | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | semmle.label | true |
-| Finally.cs:151:17:151:28 | ... == ... | Finally.cs:155:9:169:9 | {...} | semmle.label | false |
-| Finally.cs:151:25:151:28 | null | Finally.cs:151:17:151:28 | ... == ... | semmle.label | successor |
-| Finally.cs:152:17:152:50 | throw ...; | Finally.cs:155:9:169:9 | [finally: exception(ArgumentNullException)] {...} | semmle.label | exception(ArgumentNullException) |
-| Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:152:17:152:50 | throw ...; | semmle.label | successor |
-| Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:155:9:169:9 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:156:13:168:13 | [finally: exception(ArgumentNullException)] try {...} ... | semmle.label | successor |
-| Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:156:13:168:13 | [finally: exception(Exception)] try {...} ... | semmle.label | successor |
-| Finally.cs:155:9:169:9 | {...} | Finally.cs:156:13:168:13 | try {...} ... | semmle.label | successor |
-| Finally.cs:156:13:168:13 | [finally: exception(ArgumentNullException)] try {...} ... | Finally.cs:157:13:160:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | successor |
-| Finally.cs:156:13:168:13 | [finally: exception(Exception)] try {...} ... | Finally.cs:157:13:160:13 | [finally: exception(Exception)] {...} | semmle.label | successor |
-| Finally.cs:156:13:168:13 | try {...} ... | Finally.cs:157:13:160:13 | {...} | semmle.label | successor |
-| Finally.cs:157:13:160:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:158:17:159:45 | [finally: exception(ArgumentNullException)] if (...) ... | semmle.label | successor |
-| Finally.cs:157:13:160:13 | [finally: exception(Exception)] {...} | Finally.cs:158:17:159:45 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:157:13:160:13 | {...} | Finally.cs:158:17:159:45 | if (...) ... | semmle.label | successor |
-| Finally.cs:158:17:159:45 | [finally: exception(ArgumentNullException)] if (...) ... | Finally.cs:158:21:158:24 | [finally: exception(ArgumentNullException)] access to parameter args | semmle.label | successor |
-| Finally.cs:158:17:159:45 | [finally: exception(Exception)] if (...) ... | Finally.cs:158:21:158:24 | [finally: exception(Exception)] access to parameter args | semmle.label | successor |
-| Finally.cs:158:17:159:45 | if (...) ... | Finally.cs:158:21:158:24 | access to parameter args | semmle.label | successor |
-| Finally.cs:158:21:158:24 | [finally: exception(ArgumentNullException)] access to parameter args | Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | semmle.label | successor |
-| Finally.cs:158:21:158:24 | [finally: exception(Exception)] access to parameter args | Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | semmle.label | successor |
-| Finally.cs:158:21:158:24 | access to parameter args | Finally.cs:158:21:158:31 | access to property Length | semmle.label | successor |
-| Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 | semmle.label | successor |
-| Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 | semmle.label | successor |
-| Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:158:21:158:31 | access to property Length | Finally.cs:158:36:158:36 | 1 | semmle.label | successor |
-| Finally.cs:158:21:158:31 | access to property Length | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:158:21:158:31 | access to property Length | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} | semmle.label | exception(NullReferenceException) |
-| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:147:10:147:11 | exit M8 (normal) | semmle.label | false |
-| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:159:41:159:43 | "1" | semmle.label | true |
-| Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(ArgumentNullException) |
-| Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | semmle.label | true |
-| Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | semmle.label | true |
-| Finally.cs:158:36:158:36 | 1 | Finally.cs:158:21:158:36 | ... == ... | semmle.label | successor |
-| Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 | Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | semmle.label | successor |
-| Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 | Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | semmle.label | successor |
-| Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:159:21:159:45 | throw ...; | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; | semmle.label | successor |
-| Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception | Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:159:27:159:44 | object creation of type Exception | Finally.cs:159:21:159:45 | throw ...; | semmle.label | successor |
-| Finally.cs:159:27:159:44 | object creation of type Exception | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:159:41:159:43 | "1" | Finally.cs:159:27:159:44 | object creation of type Exception | semmle.label | successor |
-| Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | semmle.label | successor |
-| Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception | semmle.label | successor |
-| Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | Finally.cs:161:30:161:30 | [exception: Exception] Exception e | semmle.label | match |
-| Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} | Finally.cs:161:30:161:30 | [exception: NullReferenceException] Exception e | semmle.label | match |
-| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: Exception] Exception e | semmle.label | match |
-| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e | semmle.label | match |
-| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: Exception] Exception e | semmle.label | match |
-| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: NullReferenceException] Exception e | semmle.label | match |
-| Finally.cs:161:30:161:30 | [exception: Exception] Exception e | Finally.cs:161:39:161:39 | [exception: Exception] access to local variable e | semmle.label | successor |
-| Finally.cs:161:30:161:30 | [exception: NullReferenceException] Exception e | Finally.cs:161:39:161:39 | [exception: NullReferenceException] access to local variable e | semmle.label | successor |
-| Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: Exception] Exception e | Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: Exception] access to local variable e | semmle.label | successor |
-| Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e | Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e | semmle.label | successor |
-| Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: Exception] Exception e | Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: Exception] access to local variable e | semmle.label | successor |
-| Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: NullReferenceException] Exception e | Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: NullReferenceException] access to local variable e | semmle.label | successor |
-| Finally.cs:161:39:161:39 | [exception: Exception] access to local variable e | Finally.cs:161:39:161:47 | [exception: Exception] access to property Message | semmle.label | successor |
-| Finally.cs:161:39:161:39 | [exception: NullReferenceException] access to local variable e | Finally.cs:161:39:161:47 | [exception: NullReferenceException] access to property Message | semmle.label | successor |
-| Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: Exception] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: Exception] access to property Message | semmle.label | successor |
-| Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message | semmle.label | successor |
-| Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: Exception] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: Exception] access to property Message | semmle.label | successor |
-| Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: NullReferenceException] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: NullReferenceException] access to property Message | semmle.label | successor |
-| Finally.cs:161:39:161:47 | [exception: Exception] access to property Message | Finally.cs:161:52:161:54 | [exception: Exception] "1" | semmle.label | successor |
-| Finally.cs:161:39:161:47 | [exception: NullReferenceException] access to property Message | Finally.cs:161:52:161:54 | [exception: NullReferenceException] "1" | semmle.label | successor |
-| Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: Exception] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: Exception] "1" | semmle.label | successor |
-| Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] "1" | semmle.label | successor |
-| Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: Exception] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: Exception] "1" | semmle.label | successor |
-| Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: NullReferenceException] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: NullReferenceException] "1" | semmle.label | successor |
-| Finally.cs:161:39:161:54 | [exception: Exception] ... == ... | Finally.cs:162:13:164:13 | {...} | semmle.label | true |
-| Finally.cs:161:39:161:54 | [exception: Exception] ... == ... | Finally.cs:165:13:168:13 | catch {...} | semmle.label | false |
-| Finally.cs:161:39:161:54 | [exception: NullReferenceException] ... == ... | Finally.cs:162:13:164:13 | {...} | semmle.label | true |
-| Finally.cs:161:39:161:54 | [exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | catch {...} | semmle.label | false |
-| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: Exception] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | true |
-| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: Exception] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} | semmle.label | false |
-| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | true |
-| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} | semmle.label | false |
-| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: Exception] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | semmle.label | true |
-| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: Exception] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | semmle.label | false |
-| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | semmle.label | true |
-| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | semmle.label | false |
-| Finally.cs:161:52:161:54 | [exception: Exception] "1" | Finally.cs:161:39:161:54 | [exception: Exception] ... == ... | semmle.label | successor |
-| Finally.cs:161:52:161:54 | [exception: NullReferenceException] "1" | Finally.cs:161:39:161:54 | [exception: NullReferenceException] ... == ... | semmle.label | successor |
-| Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: Exception] "1" | Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: Exception] ... == ... | semmle.label | successor |
-| Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] "1" | Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ... | semmle.label | successor |
-| Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: Exception] "1" | Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: Exception] ... == ... | semmle.label | successor |
-| Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: NullReferenceException] "1" | Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... | semmle.label | successor |
-| Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:163:17:163:43 | [finally: exception(ArgumentNullException)] ...; | semmle.label | successor |
-| Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | Finally.cs:163:17:163:43 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:162:13:164:13 | {...} | Finally.cs:163:17:163:43 | ...; | semmle.label | successor |
-| Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(ArgumentNullException) |
-| Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:163:17:163:42 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (normal) | semmle.label | successor |
-| Finally.cs:163:17:163:43 | ...; | Finally.cs:163:35:163:38 | access to parameter args | semmle.label | successor |
-| Finally.cs:163:17:163:43 | [finally: exception(ArgumentNullException)] ...; | Finally.cs:163:35:163:38 | [finally: exception(ArgumentNullException)] access to parameter args | semmle.label | successor |
-| Finally.cs:163:17:163:43 | [finally: exception(Exception)] ...; | Finally.cs:163:35:163:38 | [finally: exception(Exception)] access to parameter args | semmle.label | successor |
-| Finally.cs:163:35:163:38 | [finally: exception(ArgumentNullException)] access to parameter args | Finally.cs:163:40:163:40 | [finally: exception(ArgumentNullException)] 0 | semmle.label | successor |
-| Finally.cs:163:35:163:38 | [finally: exception(Exception)] access to parameter args | Finally.cs:163:40:163:40 | [finally: exception(Exception)] 0 | semmle.label | successor |
-| Finally.cs:163:35:163:38 | access to parameter args | Finally.cs:163:40:163:40 | 0 | semmle.label | successor |
-| Finally.cs:163:35:163:41 | [finally: exception(ArgumentNullException)] access to array element | Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:163:35:163:41 | [finally: exception(Exception)] access to array element | Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:163:35:163:41 | access to array element | Finally.cs:163:17:163:42 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:163:40:163:40 | 0 | Finally.cs:163:35:163:41 | access to array element | semmle.label | successor |
-| Finally.cs:163:40:163:40 | [finally: exception(ArgumentNullException)] 0 | Finally.cs:163:35:163:41 | [finally: exception(ArgumentNullException)] access to array element | semmle.label | successor |
-| Finally.cs:163:40:163:40 | [finally: exception(Exception)] 0 | Finally.cs:163:35:163:41 | [finally: exception(Exception)] access to array element | semmle.label | successor |
-| Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} | Finally.cs:166:13:168:13 | [finally: exception(ArgumentNullException)] {...} | semmle.label | successor |
-| Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | Finally.cs:166:13:168:13 | [finally: exception(Exception)] {...} | semmle.label | successor |
-| Finally.cs:165:13:168:13 | catch {...} | Finally.cs:166:13:168:13 | {...} | semmle.label | successor |
-| Finally.cs:166:13:168:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; | semmle.label | successor |
-| Finally.cs:166:13:168:13 | [finally: exception(Exception)] {...} | Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:166:13:168:13 | {...} | Finally.cs:167:17:167:38 | ...; | semmle.label | successor |
-| Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(ArgumentNullException) |
-| Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:167:17:167:37 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (normal) | semmle.label | successor |
-| Finally.cs:167:17:167:38 | ...; | Finally.cs:167:35:167:36 | "" | semmle.label | successor |
-| Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; | Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" | semmle.label | successor |
-| Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; | Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | semmle.label | successor |
-| Finally.cs:167:35:167:36 | "" | Finally.cs:167:17:167:37 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" | Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:176:10:176:11 | enter M9 | Finally.cs:177:5:193:5 | {...} | semmle.label | successor |
-| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | exit M9 | semmle.label | successor |
-| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | exit M9 | semmle.label | successor |
-| Finally.cs:177:5:193:5 | {...} | Finally.cs:178:9:192:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:179:9:181:9 | {...} | semmle.label | successor |
-| Finally.cs:179:9:181:9 | {...} | Finally.cs:180:13:180:43 | if (...) ... | semmle.label | successor |
-| Finally.cs:180:13:180:43 | if (...) ... | Finally.cs:180:17:180:18 | access to parameter b1 | semmle.label | successor |
-| Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | semmle.label | true |
-| Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | semmle.label | false |
-| Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:183:9:192:9 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | semmle.label | successor |
-| Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} | semmle.label | exception(Exception) |
-| Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:184:13:191:13 | [b1 (line 176): false] try {...} ... | semmle.label | successor |
-| Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:184:13:191:13 | [finally: exception(Exception), b1 (line 176): true] try {...} ... | semmle.label | successor |
-| Finally.cs:183:9:192:9 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:184:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] try {...} ... | semmle.label | successor |
-| Finally.cs:184:13:191:13 | [b1 (line 176): false] try {...} ... | Finally.cs:185:13:187:13 | [b1 (line 176): false] {...} | semmle.label | successor |
-| Finally.cs:184:13:191:13 | [finally: exception(Exception), b1 (line 176): true] try {...} ... | Finally.cs:185:13:187:13 | [finally: exception(Exception), b1 (line 176): true] {...} | semmle.label | successor |
-| Finally.cs:184:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] try {...} ... | Finally.cs:185:13:187:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | semmle.label | successor |
-| Finally.cs:185:13:187:13 | [b1 (line 176): false] {...} | Finally.cs:186:17:186:47 | [b1 (line 176): false] if (...) ... | semmle.label | successor |
-| Finally.cs:185:13:187:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:186:17:186:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | semmle.label | successor |
-| Finally.cs:185:13:187:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:186:17:186:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | semmle.label | successor |
-| Finally.cs:186:17:186:47 | [b1 (line 176): false] if (...) ... | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | semmle.label | successor |
-| Finally.cs:186:17:186:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | semmle.label | successor |
-| Finally.cs:186:17:186:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | semmle.label | successor |
-| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (normal) | semmle.label | false |
-| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(ExceptionA) |
-| Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; | semmle.label | successor |
-| Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; | semmle.label | successor |
-| Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; | semmle.label | successor |
-| Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | semmle.label | exception(Exception) |
-| Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | semmle.label | match |
-| Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | semmle.label | true |
-| Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | semmle.label | true |
-| Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | semmle.label | true |
-| Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | semmle.label | true |
-| Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | semmle.label | true |
-| Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | semmle.label | true |
-| Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:190:17:190:47 | [b1 (line 176): false] if (...) ... | semmle.label | successor |
-| Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:190:17:190:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | semmle.label | successor |
-| Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:190:17:190:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | semmle.label | successor |
-| Finally.cs:190:17:190:47 | [b1 (line 176): false] if (...) ... | Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | semmle.label | successor |
-| Finally.cs:190:17:190:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 | semmle.label | successor |
-| Finally.cs:190:17:190:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | semmle.label | successor |
-| Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | Finally.cs:176:10:176:11 | exit M9 (normal) | semmle.label | false |
-| Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:176:10:176:11 | exit M9 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
-| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:196:5:214:5 | {...} | semmle.label | successor |
-| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | exit M10 | semmle.label | successor |
-| Finally.cs:195:10:195:12 | exit M10 (normal) | Finally.cs:195:10:195:12 | exit M10 | semmle.label | successor |
-| Finally.cs:196:5:214:5 | {...} | Finally.cs:197:9:212:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:198:9:200:9 | {...} | semmle.label | successor |
-| Finally.cs:198:9:200:9 | {...} | Finally.cs:199:13:199:43 | if (...) ... | semmle.label | successor |
-| Finally.cs:199:13:199:43 | if (...) ... | Finally.cs:199:17:199:18 | access to parameter b1 | semmle.label | successor |
-| Finally.cs:199:17:199:18 | access to parameter b1 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | semmle.label | true |
-| Finally.cs:199:17:199:18 | access to parameter b1 | Finally.cs:202:9:212:9 | {...} | semmle.label | false |
-| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:202:9:212:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:21:199:43 | throw ...; | semmle.label | successor |
-| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:203:13:210:13 | [finally: exception(Exception)] try {...} ... | semmle.label | successor |
-| Finally.cs:202:9:212:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:203:13:210:13 | [finally: exception(ExceptionA)] try {...} ... | semmle.label | successor |
-| Finally.cs:202:9:212:9 | {...} | Finally.cs:203:13:210:13 | try {...} ... | semmle.label | successor |
-| Finally.cs:203:13:210:13 | [finally: exception(Exception)] try {...} ... | Finally.cs:204:13:206:13 | [finally: exception(Exception)] {...} | semmle.label | successor |
-| Finally.cs:203:13:210:13 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:204:13:206:13 | [finally: exception(ExceptionA)] {...} | semmle.label | successor |
-| Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:204:13:206:13 | {...} | semmle.label | successor |
-| Finally.cs:204:13:206:13 | [finally: exception(Exception)] {...} | Finally.cs:205:17:205:47 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:204:13:206:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:205:17:205:47 | [finally: exception(ExceptionA)] if (...) ... | semmle.label | successor |
-| Finally.cs:204:13:206:13 | {...} | Finally.cs:205:17:205:47 | if (...) ... | semmle.label | successor |
-| Finally.cs:205:17:205:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | semmle.label | successor |
-| Finally.cs:205:17:205:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | semmle.label | successor |
-| Finally.cs:205:17:205:47 | if (...) ... | Finally.cs:205:21:205:22 | access to parameter b2 | semmle.label | successor |
-| Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | semmle.label | false |
-| Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | semmle.label | false |
-| Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | semmle.label | true |
-| Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:208:13:210:13 | {...} | semmle.label | false |
-| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | semmle.label | exception(ExceptionB) |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
-| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:25:205:47 | throw ...; | semmle.label | successor |
-| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | semmle.label | successor |
-| Finally.cs:208:13:210:13 | {...} | Finally.cs:209:17:209:47 | if (...) ... | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:209:21:209:22 | access to parameter b3 | semmle.label | successor |
-| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
-| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | semmle.label | false |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionB) |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | semmle.label | false |
-| Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | semmle.label | true |
-| Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; | semmle.label | false |
-| Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:25:209:47 | throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionC) |
-| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
-| Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:25:209:47 | throw ...; | semmle.label | successor |
-| Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | semmle.label | successor |
-| Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | semmle.label | successor |
-| Finally.cs:211:13:211:16 | this access | Finally.cs:211:26:211:28 | "0" | semmle.label | successor |
-| Finally.cs:211:13:211:28 | ... = ... | Finally.cs:213:9:213:25 | ...; | semmle.label | successor |
-| Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | Finally.cs:195:10:195:12 | exit M10 (abnormal) | semmle.label | exception(ExceptionA) |
-| Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:16 | this access | semmle.label | successor |
-| Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | semmle.label | successor |
-| Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access | semmle.label | successor |
-| Finally.cs:211:26:211:28 | "0" | Finally.cs:211:13:211:28 | ... = ... | semmle.label | successor |
-| Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | semmle.label | successor |
-| Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | semmle.label | successor |
-| Finally.cs:213:9:213:12 | this access | Finally.cs:213:22:213:24 | "1" | semmle.label | successor |
-| Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | exit M10 (normal) | semmle.label | successor |
-| Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:12 | this access | semmle.label | successor |
-| Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:24 | ... = ... | semmle.label | successor |
-| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:217:5:231:5 | {...} | semmle.label | successor |
-| Finally.cs:216:10:216:12 | exit M11 (normal) | Finally.cs:216:10:216:12 | exit M11 | semmle.label | successor |
-| Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} | semmle.label | successor |
-| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; | semmle.label | successor |
-| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:222:9:225:9 | catch {...} | semmle.label | exception(Exception) |
-| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} | semmle.label | successor |
-| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:31:220:35 | "Try" | semmle.label | successor |
-| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:36 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:223:9:225:9 | {...} | semmle.label | successor |
-| Finally.cs:223:9:225:9 | {...} | Finally.cs:224:13:224:39 | ...; | semmle.label | successor |
-| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} | semmle.label | successor |
-| Finally.cs:224:13:224:39 | ...; | Finally.cs:224:31:224:37 | "Catch" | semmle.label | successor |
-| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:38 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:227:9:229:9 | {...} | Finally.cs:228:13:228:41 | ...; | semmle.label | successor |
-| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:230:9:230:34 | ...; | semmle.label | successor |
-| Finally.cs:228:13:228:41 | ...; | Finally.cs:228:31:228:39 | "Finally" | semmle.label | successor |
-| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:40 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 (normal) | semmle.label | successor |
-| Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" | semmle.label | successor |
-| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:234:5:261:5 | {...} | semmle.label | successor |
-| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | exit M12 | semmle.label | successor |
-| Finally.cs:233:10:233:12 | exit M12 (normal) | Finally.cs:233:10:233:12 | exit M12 | semmle.label | successor |
-| Finally.cs:234:5:261:5 | {...} | Finally.cs:235:9:259:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:236:9:255:9 | {...} | semmle.label | successor |
-| Finally.cs:236:9:255:9 | {...} | Finally.cs:237:13:253:13 | try {...} ... | semmle.label | successor |
-| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:238:13:241:13 | {...} | semmle.label | successor |
-| Finally.cs:238:13:241:13 | {...} | Finally.cs:239:17:240:43 | if (...) ... | semmle.label | successor |
-| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:239:21:239:22 | access to parameter b1 | semmle.label | successor |
-| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | semmle.label | true |
-| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:243:13:253:13 | {...} | semmle.label | false |
-| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:21:240:43 | throw ...; | semmle.label | successor |
-| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | semmle.label | successor |
-| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | semmle.label | successor |
-| Finally.cs:243:13:253:13 | {...} | Finally.cs:244:17:252:17 | try {...} ... | semmle.label | successor |
-| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | semmle.label | successor |
-| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | semmle.label | successor |
-| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:245:17:248:17 | {...} | semmle.label | successor |
-| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | semmle.label | successor |
-| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | semmle.label | successor |
-| Finally.cs:245:17:248:17 | {...} | Finally.cs:246:21:247:47 | if (...) ... | semmle.label | successor |
-| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | semmle.label | successor |
-| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | semmle.label | successor |
-| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:246:25:246:26 | access to parameter b2 | semmle.label | successor |
-| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | semmle.label | true |
-| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | semmle.label | false |
-| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | semmle.label | true |
-| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | semmle.label | false |
-| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | semmle.label | true |
-| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} | semmle.label | false |
-| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | semmle.label | successor |
-| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | semmle.label | successor |
-| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; | semmle.label | successor |
-| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | semmle.label | successor |
-| Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:55 | ...; | semmle.label | successor |
-| Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | semmle.label | exception(ExceptionA) |
-| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; | semmle.label | successor |
-| Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | semmle.label | successor |
-| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:54 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} | semmle.label | successor |
-| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:31:254:43 | "Mid finally" | semmle.label | successor |
-| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:13:254:44 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | semmle.label | successor |
-| Finally.cs:257:9:259:9 | {...} | Finally.cs:258:13:258:47 | ...; | semmle.label | successor |
-| Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | semmle.label | exception(ExceptionA) |
-| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:260:9:260:34 | ...; | semmle.label | successor |
-| Finally.cs:258:13:258:47 | ...; | Finally.cs:258:31:258:45 | "Outer finally" | semmle.label | successor |
-| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | semmle.label | successor |
-| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | semmle.label | successor |
-| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:13:258:46 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (normal) | semmle.label | successor |
-| Finally.cs:260:9:260:34 | ...; | Finally.cs:260:27:260:32 | "Done" | semmle.label | successor |
-| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:9:260:33 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:263:10:263:12 | enter M13 | Finally.cs:264:5:274:5 | {...} | semmle.label | successor |
-| Finally.cs:263:10:263:12 | exit M13 (abnormal) | Finally.cs:263:10:263:12 | exit M13 | semmle.label | successor |
-| Finally.cs:263:10:263:12 | exit M13 (normal) | Finally.cs:263:10:263:12 | exit M13 | semmle.label | successor |
-| Finally.cs:264:5:274:5 | {...} | Finally.cs:265:9:273:9 | try {...} ... | semmle.label | successor |
-| Finally.cs:265:9:273:9 | try {...} ... | Finally.cs:266:9:268:9 | {...} | semmle.label | successor |
-| Finally.cs:266:9:268:9 | {...} | Finally.cs:267:13:267:35 | ...; | semmle.label | successor |
-| Finally.cs:267:13:267:34 | call to method WriteLine | Finally.cs:270:9:273:9 | [finally: exception(Exception)] {...} | semmle.label | exception(Exception) |
-| Finally.cs:267:13:267:34 | call to method WriteLine | Finally.cs:270:9:273:9 | {...} | semmle.label | successor |
-| Finally.cs:267:13:267:35 | ...; | Finally.cs:267:31:267:33 | "1" | semmle.label | successor |
-| Finally.cs:267:31:267:33 | "1" | Finally.cs:267:13:267:34 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:270:9:273:9 | [finally: exception(Exception)] {...} | Finally.cs:271:13:271:35 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:270:9:273:9 | {...} | Finally.cs:271:13:271:35 | ...; | semmle.label | successor |
-| Finally.cs:271:13:271:34 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:272:13:272:19 | [finally: exception(Exception)] ...; | semmle.label | successor |
-| Finally.cs:271:13:271:34 | call to method WriteLine | Finally.cs:272:13:272:19 | ...; | semmle.label | successor |
-| Finally.cs:271:13:271:35 | ...; | Finally.cs:271:31:271:33 | "3" | semmle.label | successor |
-| Finally.cs:271:13:271:35 | [finally: exception(Exception)] ...; | Finally.cs:271:31:271:33 | [finally: exception(Exception)] "3" | semmle.label | successor |
-| Finally.cs:271:31:271:33 | "3" | Finally.cs:271:13:271:34 | call to method WriteLine | semmle.label | successor |
-| Finally.cs:271:31:271:33 | [finally: exception(Exception)] "3" | Finally.cs:271:13:271:34 | [finally: exception(Exception)] call to method WriteLine | semmle.label | successor |
-| Finally.cs:272:13:272:13 | [finally: exception(Exception)] access to parameter i | Finally.cs:272:18:272:18 | [finally: exception(Exception)] 3 | semmle.label | successor |
-| Finally.cs:272:13:272:13 | access to parameter i | Finally.cs:272:18:272:18 | 3 | semmle.label | successor |
-| Finally.cs:272:13:272:18 | ... + ... | Finally.cs:272:13:272:18 | ... = ... | semmle.label | successor |
-| Finally.cs:272:13:272:18 | ... = ... | Finally.cs:263:10:263:12 | exit M13 (normal) | semmle.label | successor |
-| Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... + ... | Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... = ... | semmle.label | successor |
-| Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... = ... | Finally.cs:263:10:263:12 | exit M13 (abnormal) | semmle.label | exception(Exception) |
-| Finally.cs:272:13:272:19 | ...; | Finally.cs:272:13:272:13 | access to parameter i | semmle.label | successor |
-| Finally.cs:272:13:272:19 | [finally: exception(Exception)] ...; | Finally.cs:272:13:272:13 | [finally: exception(Exception)] access to parameter i | semmle.label | successor |
-| Finally.cs:272:18:272:18 | 3 | Finally.cs:272:13:272:18 | ... + ... | semmle.label | successor |
-| Finally.cs:272:18:272:18 | [finally: exception(Exception)] 3 | Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... + ... | semmle.label | successor |
-| Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} | semmle.label | successor |
-| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 | semmle.label | successor |
-| Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args | semmle.label | successor |
-| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) | semmle.label | empty |
-| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg | semmle.label | non-empty |
-| Foreach.cs:8:22:8:24 | String arg | Foreach.cs:9:13:9:13 | ; | semmle.label | successor |
-| Foreach.cs:8:29:8:32 | access to parameter args | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:9:13:9:13 | ; | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:13:5:16:5 | {...} | semmle.label | successor |
-| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 | semmle.label | successor |
-| Foreach.cs:13:5:16:5 | {...} | Foreach.cs:14:27:14:30 | access to parameter args | semmle.label | successor |
-| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) | semmle.label | empty |
-| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ | semmle.label | non-empty |
-| Foreach.cs:14:22:14:22 | String _ | Foreach.cs:15:13:15:13 | ; | semmle.label | successor |
-| Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:15:13:15:13 | ; | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:19:5:22:5 | {...} | semmle.label | successor |
-| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 | semmle.label | successor |
-| Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:27 | access to parameter e | semmle.label | successor |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) | semmle.label | empty |
-| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x | semmle.label | non-empty |
-| Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; | semmle.label | successor |
-| Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:29:20:38 | call to method ToArray | semmle.label | non-null |
-| Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:43:20:68 | call to method Empty | semmle.label | null |
-| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:27:20:68 | ... ?? ... | semmle.label | non-null |
-| Foreach.cs:20:29:20:38 | call to method ToArray | Foreach.cs:20:43:20:68 | call to method Empty | semmle.label | null |
-| Foreach.cs:20:43:20:68 | call to method Empty | Foreach.cs:20:27:20:68 | ... ?? ... | semmle.label | successor |
-| Foreach.cs:21:11:21:11 | ; | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:25:5:28:5 | {...} | semmle.label | successor |
-| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 | semmle.label | successor |
-| Foreach.cs:25:5:28:5 | {...} | Foreach.cs:26:36:26:39 | access to parameter args | semmle.label | successor |
-| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 (normal) | semmle.label | empty |
-| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x | semmle.label | non-empty |
-| Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:27:11:27:11 | ; | semmle.label | successor |
-| Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:30:26:30 | Int32 y | semmle.label | successor |
-| Foreach.cs:26:30:26:30 | Int32 y | Foreach.cs:26:18:26:31 | (..., ...) | semmle.label | successor |
-| Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:27:11:27:11 | ; | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:31:5:34:5 | {...} | semmle.label | successor |
-| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 | semmle.label | successor |
-| Foreach.cs:31:5:34:5 | {...} | Foreach.cs:32:32:32:35 | access to parameter args | semmle.label | successor |
-| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 (normal) | semmle.label | empty |
-| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x | semmle.label | non-empty |
-| Foreach.cs:32:18:32:27 | (..., ...) | Foreach.cs:33:11:33:11 | ; | semmle.label | successor |
-| Foreach.cs:32:23:32:23 | String x | Foreach.cs:32:26:32:26 | Int32 y | semmle.label | successor |
-| Foreach.cs:32:26:32:26 | Int32 y | Foreach.cs:32:18:32:27 | (..., ...) | semmle.label | successor |
-| Foreach.cs:32:32:32:35 | access to parameter args | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:33:11:33:11 | ; | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:37:5:40:5 | {...} | semmle.label | successor |
-| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 | semmle.label | successor |
-| Foreach.cs:37:5:40:5 | {...} | Foreach.cs:38:39:38:42 | access to parameter args | semmle.label | successor |
-| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 (normal) | semmle.label | empty |
-| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x | semmle.label | non-empty |
-| Foreach.cs:38:18:38:34 | (..., ...) | Foreach.cs:39:11:39:11 | ; | semmle.label | successor |
-| Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:33:38:33 | Int32 y | semmle.label | successor |
-| Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:18:38:34 | (..., ...) | semmle.label | successor |
-| Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Foreach.cs:39:11:39:11 | ; | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H | semmle.label | successor |
-| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H | semmle.label | successor |
-| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access | semmle.label | successor |
-| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access | semmle.label | successor |
-| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 | semmle.label | successor |
-| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 | semmle.label | successor |
-| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... | semmle.label | successor |
-| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... | semmle.label | successor |
-| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... | semmle.label | successor |
-| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... | semmle.label | successor |
-| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H | semmle.label | successor |
-| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H | semmle.label | successor |
-| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:8:20:8:22 | {...} | semmle.label | successor |
-| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:10:28:10:30 | {...} | semmle.label | successor |
-| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 | semmle.label | successor |
-| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 | semmle.label | successor |
-| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G | semmle.label | successor |
-| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G | semmle.label | successor |
-| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
-| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
-| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | call to constructor Object | semmle.label | successor |
-| Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | exit Initializers | semmle.label | successor |
-| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers (normal) | semmle.label | successor |
-| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
-| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | call to constructor Object | semmle.label | successor |
-| Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | exit Initializers | semmle.label | successor |
-| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers (normal) | semmle.label | successor |
-| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} | semmle.label | successor |
-| Initializers.cs:12:10:12:10 | exit M (normal) | Initializers.cs:12:10:12:10 | exit M | semmle.label | successor |
-| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:14:9:14:54 | ... ...; | semmle.label | successor |
-| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:34:14:35 | "" | semmle.label | successor |
-| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:15:9:15:64 | ... ...; | semmle.label | successor |
-| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:44:14:44 | 0 | semmle.label | successor |
-| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:17:14:53 | object creation of type Initializers | semmle.label | successor |
-| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:13:14:53 | Initializers i = ... | semmle.label | successor |
-| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:51:14:51 | 1 | semmle.label | successor |
-| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:40:14:44 | ... = ... | semmle.label | successor |
-| Initializers.cs:14:47:14:47 | access to property G | Initializers.cs:14:47:14:51 | ... = ... | semmle.label | successor |
-| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:38:14:53 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:47:14:47 | access to property G | semmle.label | successor |
-| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:18:15:63 | 2 | semmle.label | successor |
-| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M (normal) | semmle.label | successor |
-| Initializers.cs:15:18:15:63 | 2 | Initializers.cs:15:18:15:63 | array creation of type Initializers[] | semmle.label | successor |
-| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:39:15:39 | access to local variable i | semmle.label | successor |
-| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | semmle.label | successor |
-| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:59:15:60 | "" | semmle.label | successor |
-| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:37:15:63 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers | semmle.label | successor |
-| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:20:18:20 | 1 | semmle.label | successor |
-| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | semmle.label | successor |
-| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
-| Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor | semmle.label | successor |
-| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
-| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access | semmle.label | successor |
-| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
-| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | semmle.label | successor |
-| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 | semmle.label | successor |
-| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 | semmle.label | successor |
-| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:31:24:31:33 | {...} | semmle.label | successor |
-| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:35:27:35:40 | {...} | semmle.label | successor |
-| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | semmle.label | successor |
-| Initializers.cs:31:9:31:11 | exit Sub (normal) | Initializers.cs:31:9:31:11 | exit Sub | semmle.label | successor |
-| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
-| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:31 | ...; | semmle.label | successor |
-| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:30:31:30 | 3 | semmle.label | successor |
-| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub (normal) | semmle.label | successor |
-| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:26 | this access | semmle.label | successor |
-| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:30 | ... = ... | semmle.label | successor |
-| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:22:33:25 | call to constructor Sub | semmle.label | successor |
-| Initializers.cs:33:9:33:11 | exit Sub (normal) | Initializers.cs:33:9:33:11 | exit Sub | semmle.label | successor |
-| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:29:33:38 | {...} | semmle.label | successor |
-| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:36 | ...; | semmle.label | successor |
-| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:35:33:35 | access to parameter i | semmle.label | successor |
-| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub (normal) | semmle.label | successor |
-| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access | semmle.label | successor |
-| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... | semmle.label | successor |
-| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
-| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | call to constructor NoConstructor | semmle.label | successor |
-| Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | exit Sub | semmle.label | successor |
-| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; | semmle.label | successor |
-| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i | semmle.label | successor |
-| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub (normal) | semmle.label | successor |
-| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:29 | this access | semmle.label | successor |
-| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:37:35:37 | access to parameter j | semmle.label | successor |
-| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:29:35:37 | ... = ... | semmle.label | successor |
-| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:37 | ... + ... | semmle.label | successor |
-| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:52:5:66:5 | {...} | semmle.label | successor |
-| Initializers.cs:51:10:51:13 | exit Test (normal) | Initializers.cs:51:10:51:13 | exit Test | semmle.label | successor |
-| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; | semmle.label | successor |
-| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | semmle.label | successor |
-| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; | semmle.label | successor |
-| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:53:54:53 | 0 | semmle.label | successor |
-| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | semmle.label | successor |
-| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:52:54:63 | ... = ... | semmle.label | successor |
-| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:67:54:67 | 1 | semmle.label | successor |
-| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:58:54:63 | "Zero" | semmle.label | successor |
-| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:52:54:54 | access to indexer | semmle.label | successor |
-| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:66:54:76 | ... = ... | semmle.label | successor |
-| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:80:54:80 | access to parameter i | semmle.label | successor |
-| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:72:54:76 | "One" | semmle.label | successor |
-| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:66:54:68 | access to indexer | semmle.label | successor |
-| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:79:54:93 | ... = ... | semmle.label | successor |
-| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:50:54:95 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:84:54:84 | 2 | semmle.label | successor |
-| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:89:54:93 | "Two" | semmle.label | successor |
-| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:84 | ... + ... | semmle.label | successor |
-| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer | semmle.label | successor |
-| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound | semmle.label | successor |
-| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test (normal) | semmle.label | successor |
-| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:34:59:34 | 0 | semmle.label | successor |
-| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... | semmle.label | successor |
-| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:37:60:37 | 3 | semmle.label | successor |
-| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:13:59:76 | ... = ... | semmle.label | successor |
-| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:33:59:44 | ... = ... | semmle.label | successor |
-| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:48:59:48 | 1 | semmle.label | successor |
-| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:39:59:44 | "Zero" | semmle.label | successor |
-| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:33:59:35 | access to indexer | semmle.label | successor |
-| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:47:59:57 | ... = ... | semmle.label | successor |
-| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:61:59:61 | access to parameter i | semmle.label | successor |
-| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:53:59:57 | "One" | semmle.label | successor |
-| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:47:59:49 | access to indexer | semmle.label | successor |
-| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:60:59:74 | ... = ... | semmle.label | successor |
-| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:65:59:65 | 2 | semmle.label | successor |
-| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:70:59:74 | "Two" | semmle.label | successor |
-| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:61:59:65 | ... + ... | semmle.label | successor |
-| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:60:59:66 | access to indexer | semmle.label | successor |
-| Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:13:60:80 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:29:61:29 | 0 | semmle.label | successor |
-| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | semmle.label | successor |
-| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:36:60:48 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:52:60:52 | 2 | semmle.label | successor |
-| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:42:60:48 | "Three" | semmle.label | successor |
-| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:36:60:38 | access to indexer | semmle.label | successor |
-| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:51:60:61 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:65:60:65 | access to parameter i | semmle.label | successor |
-| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:57:60:61 | "Two" | semmle.label | successor |
-| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:51:60:53 | access to indexer | semmle.label | successor |
-| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:64:60:78 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:34:60:80 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:69:60:69 | 1 | semmle.label | successor |
-| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:74:60:78 | "One" | semmle.label | successor |
-| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:65:60:69 | ... + ... | semmle.label | successor |
-| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:64:60:70 | access to indexer | semmle.label | successor |
-| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:30:62:30 | 0 | semmle.label | successor |
-| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:13:61:58 | ... = ... | semmle.label | successor |
-| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:43:61:43 | access to parameter i | semmle.label | successor |
-| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:34:61:39 | "Zero" | semmle.label | successor |
-| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:28:61:39 | ... = ... | semmle.label | successor |
-| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:47:61:47 | 1 | semmle.label | successor |
-| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:52:61:56 | "One" | semmle.label | successor |
-| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:43:61:47 | ... + ... | semmle.label | successor |
-| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:42:61:56 | ... = ... | semmle.label | successor |
-| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:32:63:32 | 1 | semmle.label | successor |
-| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:13:62:60 | ... = ... | semmle.label | successor |
-| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:44:62:44 | 1 | semmle.label | successor |
-| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:33:62:33 | 1 | semmle.label | successor |
-| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:38:62:40 | "i" | semmle.label | successor |
-| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:29:62:40 | ... = ... | semmle.label | successor |
-| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:47:62:47 | access to parameter i | semmle.label | successor |
-| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:51:62:51 | 0 | semmle.label | successor |
-| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:56:62:58 | "1" | semmle.label | successor |
-| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:47:62:51 | ... + ... | semmle.label | successor |
-| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:43:62:58 | ... = ... | semmle.label | successor |
-| Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:13:63:60 | ... = ... | semmle.label | successor |
-| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:33:64:33 | 0 | semmle.label | successor |
-| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:13:63:25 | access to property ArrayProperty | semmle.label | successor |
-| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:45:63:45 | access to parameter i | semmle.label | successor |
-| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:37:63:41 | "One" | semmle.label | successor |
-| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:31:63:41 | ... = ... | semmle.label | successor |
-| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:29:63:60 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:49:63:49 | 2 | semmle.label | successor |
-| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:54:63:58 | "Two" | semmle.label | successor |
-| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:45:63:49 | ... + ... | semmle.label | successor |
-| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:44:63:58 | ... = ... | semmle.label | successor |
-| Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:13:64:63 | ... = ... | semmle.label | successor |
-| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:58:9:65:9 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | semmle.label | successor |
-| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:47:64:47 | 1 | semmle.label | successor |
-| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:36:64:36 | 1 | semmle.label | successor |
-| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:41:64:43 | "i" | semmle.label | successor |
-| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:32:64:43 | ... = ... | semmle.label | successor |
-| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:30:64:63 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:50:64:50 | access to parameter i | semmle.label | successor |
-| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:54:64:54 | 0 | semmle.label | successor |
-| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:59:64:61 | "1" | semmle.label | successor |
-| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:54 | ... + ... | semmle.label | successor |
-| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... | semmle.label | successor |
-| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 | semmle.label | successor |
-| LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:23 | access to property Length | semmle.label | successor |
-| LoopUnrolling.cs:9:13:9:23 | access to property Length | LoopUnrolling.cs:9:28:9:28 | 0 | semmle.label | successor |
-| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; | semmle.label | true |
-| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args | semmle.label | false |
-| LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:13:9:28 | ... == ... | semmle.label | successor |
-| LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | semmle.label | return |
-| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | semmle.label | non-empty |
-| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | semmle.label | non-empty |
-| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | semmle.label | successor |
-| LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:16:5:20:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 | semmle.label | successor |
-| LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:48 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:18:17:47 | 3 | semmle.label | successor |
-| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:17:18:17:47 | 3 | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:33:17:35 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:38:17:40 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:43:17:45 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:31:17:47 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:19:13:19:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:31:19:31 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:23:5:27:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 | semmle.label | successor |
-| LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:24:29:24:32 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg | semmle.label | non-empty |
-| LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:34:25:37 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:24:29:24:32 | access to parameter args | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | semmle.label | non-empty |
-| LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | semmle.label | empty |
-| LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | semmle.label | non-empty |
-| LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:26:17:26:40 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:25:34:25:37 | access to parameter args | LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:26:17:26:39 | call to method WriteLine | LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:26:17:26:40 | ...; | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | semmle.label | successor |
-| LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:26:17:26:39 | call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:30:5:34:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | LoopUnrolling.cs:29:10:29:11 | exit M4 | semmle.label | successor |
-| LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:31:9:31:31 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:31:29:31:29 | 0 | semmle.label | successor |
-| LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 | semmle.label | successor |
-| LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | 3 | semmle.label | successor |
-| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:39:9:39:48 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:38:18:38:47 | 3 | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:33:38:35 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:38:38:40 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:43:38:45 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:31:38:47 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:39:18:39:47 | 3 | semmle.label | successor |
-| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:40:27:40:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:39:18:39:47 | 3 | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:33:39:35 | "0" | semmle.label | successor |
-| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | semmle.label | successor |
-| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:38:39:40 | "1" | semmle.label | successor |
-| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:43:39:45 | "2" | semmle.label | successor |
-| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:31:39:47 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:31:41:32 | access to local variable ys | semmle.label | successor |
-| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y | semmle.label | non-empty |
-| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | semmle.label | empty |
-| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y | semmle.label | non-empty |
-| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:42:17:42:41 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:42:35:42:35 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:39:42:39 | access to local variable y | semmle.label | successor |
-| LoopUnrolling.cs:42:35:42:39 | ... + ... | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:35:42:39 | ... + ... | semmle.label | successor |
-| LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:46:5:53:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:47:9:47:48 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:47:18:47:47 | 3 | semmle.label | successor |
-| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:48:27:48:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:47:18:47:47 | 3 | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:33:47:35 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:38:47:40 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:43:47:45 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:31:47:47 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:22:48:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:49:9:52:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:50:9:50:13 | Label: | semmle.label | successor |
-| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:16:50:36 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:51:13:51:23 | goto ...; | semmle.label | successor |
-| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:34:50:34 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:9:50:13 | Label: | semmle.label | goto(Label) |
-| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:56:5:65:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 | semmle.label | successor |
-| LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:48 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:18:57:47 | 3 | semmle.label | successor |
-| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:57:18:57:47 | 3 | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:33:57:35 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:38:57:40 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:43:57:45 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:31:57:47 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | semmle.label | non-empty |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | semmle.label | non-empty |
-| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:59:9:64:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | semmle.label | successor |
-| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | semmle.label | successor |
-| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:60:13:61:37 | if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | semmle.label | successor |
-| LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | semmle.label | successor |
-| LoopUnrolling.cs:60:13:61:37 | if (...) ... | LoopUnrolling.cs:60:17:60:17 | access to parameter b | semmle.label | successor |
-| LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | semmle.label | false |
-| LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | semmle.label | true |
-| LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | semmle.label | true |
-| LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | semmle.label | false |
-| LoopUnrolling.cs:61:17:61:36 | [b (line 55): true] call to method WriteLine | LoopUnrolling.cs:62:13:63:37 | [b (line 55): true] if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:61:35:61:35 | [b (line 55): true] access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:61:35:61:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:61:17:61:36 | [b (line 55): true] call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:17:62:17 | [b (line 55): false] access to parameter b | semmle.label | successor |
-| LoopUnrolling.cs:62:13:63:37 | [b (line 55): true] if (...) ... | LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b | semmle.label | successor |
-| LoopUnrolling.cs:62:17:62:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | semmle.label | false |
-| LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | semmle.label | true |
-| LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:68:5:74:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | successor |
-| LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:69:9:70:19 | if (...) ... | semmle.label | successor |
-| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:14:69:17 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:71:9:71:21 | ...; | semmle.label | false |
-| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:70:13:70:19 | return ...; | semmle.label | true |
-| LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:23 | call to method Any | semmle.label | successor |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [false] !... | semmle.label | true |
-| LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:13:69:23 | [true] !... | semmle.label | false |
-| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | semmle.label | return |
-| LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear | semmle.label | successor |
-| LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | LoopUnrolling.cs:76:10:76:11 | exit M9 | semmle.label | successor |
-| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 | semmle.label | successor |
-| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 | semmle.label | successor |
-| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | LoopUnrolling.cs:85:10:85:12 | exit M10 | semmle.label | successor |
-| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 | semmle.label | successor |
-| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 | semmle.label | successor |
-| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 | semmle.label | successor |
-| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 | semmle.label | successor |
-| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 | semmle.label | successor |
-| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | semmle.label | empty |
-| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:98:9:100:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:99:13:99:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:99:31:99:31 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
-| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | throw ... | semmle.label | successor |
-| MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:33:7:36 | null | semmle.label | successor |
-| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:7:33:7:36 | null | MultiImplementationA.cs:7:27:7:37 | throw ...; | semmle.label | successor |
-| MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
-| MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:53:7:56 | null | semmle.label | successor |
-| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:7:53:7:56 | null | MultiImplementationA.cs:7:47:7:57 | throw ...; | semmle.label | successor |
-| MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null | semmle.label | successor |
-| MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 | semmle.label | successor |
-| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
-| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
-| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
-| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
-| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:23:8:32 | throw ... | semmle.label | successor |
-| MultiImplementationA.cs:13:16:13:16 | this access | MultiImplementationA.cs:13:20:13:20 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:13:16:13:20 | ... = ... | MultiImplementationA.cs:24:16:24:16 | this access | semmle.label | successor |
-| MultiImplementationA.cs:13:20:13:20 | 0 | MultiImplementationA.cs:13:16:13:20 | ... = ... | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:49:15:49 | access to parameter s | semmle.label | successor |
-| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | semmle.label | return |
-| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | semmle.label | return |
-| MultiImplementationA.cs:15:49:15:49 | access to parameter s | MultiImplementationA.cs:15:42:15:50 | return ...; | semmle.label | successor |
-| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item | semmle.label | successor |
-| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | semmle.label | successor |
-| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | semmle.label | successor |
-| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) | semmle.label | successor |
-| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:21:18:21 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | exit M2 | semmle.label | successor |
-| MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:13:16:13:16 | this access | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:29 | ...; | semmle.label | successor |
-| MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:28:20:28 | access to parameter i | semmle.label | successor |
-| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:20:24:20:29 | ...; | MultiImplementationA.cs:20:24:20:24 | this access | semmle.label | successor |
-| MultiImplementationA.cs:20:28:20:28 | access to parameter i | MultiImplementationA.cs:20:24:20:28 | ... = ... | semmle.label | successor |
-| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 | semmle.label | successor |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 | semmle.label | successor |
-| MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationA.cs:21:27:21:29 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | semmle.label | successor |
-| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | semmle.label | successor |
-| MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null | semmle.label | successor |
-| MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null | semmle.label | successor |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | semmle.label | successor |
-| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | semmle.label | successor |
-| MultiImplementationA.cs:24:16:24:16 | access to property P | MultiImplementationA.cs:24:32:24:34 | ... = ... | semmle.label | successor |
-| MultiImplementationA.cs:24:16:24:16 | this access | MultiImplementationA.cs:24:34:24:34 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:24:32:24:34 | ... = ... | MultiImplementationA.cs:20:22:20:31 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:24:34:24:34 | 0 | MultiImplementationA.cs:24:16:24:16 | access to property P | semmle.label | successor |
-| MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null | semmle.label | successor |
-| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | semmle.label | successor |
-| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | semmle.label | successor |
-| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationA.cs:30:28:30:37 | throw ... | semmle.label | successor |
-| MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 | semmle.label | successor |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
-| MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:22:36:25 | null | semmle.label | successor |
-| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:36:22:36:25 | null | MultiImplementationA.cs:36:16:36:26 | throw ...; | semmle.label | successor |
-| MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:14:37:28 | {...} | semmle.label | successor |
-| MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | MultiImplementationA.cs:37:9:37:10 | exit M2 | semmle.label | successor |
-| MultiImplementationA.cs:37:14:37:28 | {...} | MultiImplementationA.cs:37:22:37:25 | null | semmle.label | successor |
-| MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationA.cs:37:22:37:25 | null | MultiImplementationA.cs:37:16:37:26 | throw ...; | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (abnormal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | successor |
-| MultiImplementationB.cs:3:22:3:22 | exit get_P1 (normal) | MultiImplementationB.cs:3:22:3:22 | exit get_P1 | semmle.label | successor |
-| MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:4:21:4:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (abnormal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | MultiImplementationB.cs:4:21:4:23 | exit get_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:34:4:34 | 1 | semmle.label | successor |
-| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | semmle.label | return |
-| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationB.cs:4:21:4:23 | exit get_P2 (normal) | semmle.label | return |
-| MultiImplementationB.cs:4:34:4:34 | 1 | MultiImplementationB.cs:4:27:4:35 | return ...; | semmle.label | successor |
-| MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:4:39:4:41 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (abnormal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | MultiImplementationB.cs:4:39:4:41 | exit set_P2 | semmle.label | successor |
-| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationB.cs:4:39:4:41 | exit set_P2 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null | semmle.label | successor |
-| MultiImplementationB.cs:5:16:5:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 | semmle.label | successor |
-| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
-| MultiImplementationB.cs:5:16:5:16 | exit M (abnormal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
-| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | exit M | semmle.label | successor |
-| MultiImplementationB.cs:5:16:5:16 | exit M (normal) | MultiImplementationB.cs:5:16:5:16 | exit M | semmle.label | successor |
-| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | exit M (normal) | semmle.label | successor |
-| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationB.cs:5:16:5:16 | exit M (normal) | semmle.label | successor |
-| MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationB.cs:11:20:11:20 | 1 | semmle.label | successor |
-| MultiImplementationB.cs:11:16:11:20 | ... = ... | MultiImplementationB.cs:22:16:22:16 | this access | semmle.label | successor |
-| MultiImplementationB.cs:11:20:11:20 | 1 | MultiImplementationB.cs:11:16:11:20 | ... = ... | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | exit get_Item (normal) | MultiImplementationB.cs:12:31:12:40 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationB.cs:12:31:12:40 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:31:12:40 | throw ... | semmle.label | successor |
-| MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:13:36:13:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:36:13:38 | exit get_Item (normal) | MultiImplementationB.cs:13:36:13:38 | exit get_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:48:13:51 | null | semmle.label | successor |
-| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationB.cs:13:36:13:38 | exit get_Item (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:13:48:13:51 | null | MultiImplementationB.cs:13:42:13:52 | throw ...; | semmle.label | successor |
-| MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:13:56:13:58 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | MultiImplementationB.cs:13:56:13:58 | exit set_Item | semmle.label | successor |
-| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | semmle.label | successor |
-| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationB.cs:13:56:13:58 | exit set_Item (normal) | semmle.label | successor |
-| MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:14:17:14:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | MultiImplementationB.cs:14:17:14:18 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:16:9:16:31 | M2(...) | semmle.label | successor |
-| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationB.cs:14:17:14:18 | exit M1 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:27:16:30 | null | semmle.label | successor |
-| MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | exit M2 | semmle.label | successor |
-| MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:21:16:30 | throw ... | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:11:16:11:16 | this access | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:18:12:18:13 | exit C2 (normal) | MultiImplementationB.cs:18:12:18:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:30:18:33 | null | semmle.label | successor |
-| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationB.cs:18:12:18:13 | exit C2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:24:18:34 | throw ...; | semmle.label | successor |
-| MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 | semmle.label | successor |
-| MultiImplementationB.cs:19:12:19:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 | semmle.label | successor |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | MultiImplementationB.cs:19:12:19:13 | exit C2 | semmle.label | successor |
-| MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationB.cs:19:27:19:29 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | semmle.label | successor |
-| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationB.cs:19:12:19:13 | exit C2 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:20:6:20:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationB.cs:20:6:20:7 | exit ~C2 (normal) | MultiImplementationB.cs:20:6:20:7 | exit ~C2 | semmle.label | successor |
-| MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:19:20:22 | null | semmle.label | successor |
-| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationB.cs:20:6:20:7 | exit ~C2 (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:20:19:20:22 | null | MultiImplementationB.cs:20:13:20:23 | throw ...; | semmle.label | successor |
-| MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null | semmle.label | successor |
-| MultiImplementationB.cs:21:28:21:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null | semmle.label | successor |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (normal) | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion | semmle.label | successor |
-| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationB.cs:21:28:21:35 | exit implicit conversion (abnormal) | semmle.label | exception(NullReferenceException) |
-| MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:50:21:59 | throw ... | semmle.label | successor |
-| MultiImplementationB.cs:22:16:22:16 | access to property P | MultiImplementationB.cs:22:32:22:34 | ... = ... | semmle.label | successor |
-| MultiImplementationB.cs:22:16:22:16 | this access | MultiImplementationB.cs:22:34:22:34 | 1 | semmle.label | successor |
-| MultiImplementationB.cs:22:32:22:34 | ... = ... | MultiImplementationB.cs:18:22:18:36 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:22:34:22:34 | 1 | MultiImplementationB.cs:22:16:22:16 | access to property P | semmle.label | successor |
-| MultiImplementationB.cs:27:21:27:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null | semmle.label | successor |
-| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 | semmle.label | successor |
-| MultiImplementationB.cs:27:21:27:23 | exit get_P3 (abnormal) | MultiImplementationB.cs:27:21:27:23 | exit get_P3 | semmle.label | successor |
-| MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} | semmle.label | successor |
-| MultiImplementationB.cs:32:9:32:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 | semmle.label | successor |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 (abnormal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | MultiImplementationB.cs:32:9:32:10 | exit M1 | semmle.label | successor |
-| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | semmle.label | successor |
-| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationB.cs:32:9:32:10 | exit M1 (normal) | semmle.label | successor |
-| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i | semmle.label | successor |
-| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 | semmle.label | successor |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:28 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:28:3:28 | 0 | semmle.label | null |
-| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | semmle.label | successor |
-| NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:23:3:28 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b | semmle.label | successor |
-| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 | semmle.label | successor |
-| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | semmle.label | successor |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | semmle.label | false |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | semmle.label | true |
-| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:30:5:34 | false | semmle.label | null |
-| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:43:5:43 | 1 | semmle.label | false |
-| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:39:5:39 | 0 | semmle.label | true |
-| NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | semmle.label | false |
-| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | semmle.label | successor |
-| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | semmle.label | successor |
-| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 | semmle.label | successor |
-| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 | semmle.label | successor |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | semmle.label | null |
-| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | semmle.label | successor |
-| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" | semmle.label | null |
-| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:46:7:53 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b | semmle.label | successor |
-| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 | semmle.label | successor |
-| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | semmle.label | successor |
-| NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s | semmle.label | true |
-| NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s | semmle.label | false |
-| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:51:9:52 | "" | semmle.label | null |
-| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | semmle.label | non-null |
-| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | semmle.label | null |
-| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | semmle.label | non-null |
-| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | semmle.label | null |
-| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:58 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 | semmle.label | successor |
-| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 | semmle.label | successor |
-| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | semmle.label | successor |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | semmle.label | false |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | semmle.label | true |
-| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | semmle.label | null |
-| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:68:11:68 | 1 | semmle.label | false |
-| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:64:11:64 | 0 | semmle.label | true |
-| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | semmle.label | false |
-| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | semmle.label | true |
-| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | semmle.label | false |
-| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | semmle.label | true |
-| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | semmle.label | false |
-| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | semmle.label | true |
-| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | semmle.label | successor |
-| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | semmle.label | successor |
-| NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} | semmle.label | successor |
-| NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | exit M6 | semmle.label | successor |
-| NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; | semmle.label | successor |
-| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:23:15:26 | null | semmle.label | successor |
-| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; | semmle.label | successor |
-| NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 | semmle.label | null |
-| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:13:15:31 | Int32 j = ... | semmle.label | successor |
-| NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... | semmle.label | successor |
-| NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:17:15:31 | ... ?? ... | semmle.label | successor |
-| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:18 | "" | semmle.label | successor |
-| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; | semmle.label | successor |
-| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:25 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:13:16:25 | String s = ... | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | semmle.label | successor |
-| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:19:17:19 | access to parameter i | semmle.label | successor |
-| NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | semmle.label | non-null |
-| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:24 | ... = ... | semmle.label | successor |
-| NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... | semmle.label | successor |
-| PartialImplementationA.cs:3:12:3:18 | call to constructor Object | PartialImplementationB.cs:3:16:3:16 | this access | semmle.label | successor |
-| PartialImplementationA.cs:3:12:3:18 | enter Partial | PartialImplementationA.cs:3:12:3:18 | call to constructor Object | semmle.label | successor |
-| PartialImplementationA.cs:3:12:3:18 | exit Partial (normal) | PartialImplementationA.cs:3:12:3:18 | exit Partial | semmle.label | successor |
-| PartialImplementationA.cs:3:27:3:29 | {...} | PartialImplementationA.cs:3:12:3:18 | exit Partial (normal) | semmle.label | successor |
-| PartialImplementationB.cs:3:16:3:16 | this access | PartialImplementationB.cs:3:20:3:20 | 0 | semmle.label | successor |
-| PartialImplementationB.cs:3:16:3:16 | this access | PartialImplementationB.cs:3:20:3:20 | 0 | semmle.label | successor |
-| PartialImplementationB.cs:3:16:3:20 | ... = ... | PartialImplementationB.cs:5:16:5:16 | this access | semmle.label | successor |
-| PartialImplementationB.cs:3:16:3:20 | ... = ... | PartialImplementationB.cs:5:16:5:16 | this access | semmle.label | successor |
-| PartialImplementationB.cs:3:20:3:20 | 0 | PartialImplementationB.cs:3:16:3:20 | ... = ... | semmle.label | successor |
-| PartialImplementationB.cs:3:20:3:20 | 0 | PartialImplementationB.cs:3:16:3:20 | ... = ... | semmle.label | successor |
-| PartialImplementationB.cs:4:12:4:18 | call to constructor Object | PartialImplementationB.cs:3:16:3:16 | this access | semmle.label | successor |
-| PartialImplementationB.cs:4:12:4:18 | enter Partial | PartialImplementationB.cs:4:12:4:18 | call to constructor Object | semmle.label | successor |
-| PartialImplementationB.cs:4:12:4:18 | exit Partial (normal) | PartialImplementationB.cs:4:12:4:18 | exit Partial | semmle.label | successor |
-| PartialImplementationB.cs:4:22:4:24 | {...} | PartialImplementationB.cs:4:12:4:18 | exit Partial (normal) | semmle.label | successor |
-| PartialImplementationB.cs:5:16:5:16 | access to property P | PartialImplementationB.cs:5:32:5:34 | ... = ... | semmle.label | successor |
-| PartialImplementationB.cs:5:16:5:16 | access to property P | PartialImplementationB.cs:5:32:5:34 | ... = ... | semmle.label | successor |
-| PartialImplementationB.cs:5:16:5:16 | this access | PartialImplementationB.cs:5:34:5:34 | 0 | semmle.label | successor |
-| PartialImplementationB.cs:5:16:5:16 | this access | PartialImplementationB.cs:5:34:5:34 | 0 | semmle.label | successor |
-| PartialImplementationB.cs:5:32:5:34 | ... = ... | PartialImplementationA.cs:3:27:3:29 | {...} | semmle.label | successor |
-| PartialImplementationB.cs:5:32:5:34 | ... = ... | PartialImplementationB.cs:4:22:4:24 | {...} | semmle.label | successor |
-| PartialImplementationB.cs:5:34:5:34 | 0 | PartialImplementationB.cs:5:16:5:16 | access to property P | semmle.label | successor |
-| PartialImplementationB.cs:5:34:5:34 | 0 | PartialImplementationB.cs:5:16:5:16 | access to property P | semmle.label | successor |
-| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:6:5:43:5 | {...} | semmle.label | successor |
-| Patterns.cs:5:10:5:11 | exit M1 (normal) | Patterns.cs:5:10:5:11 | exit M1 | semmle.label | successor |
-| Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; | semmle.label | successor |
-| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null | semmle.label | successor |
-| Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... | semmle.label | successor |
-| Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... | semmle.label | successor |
-| Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o | semmle.label | successor |
-| Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:18:8:23 | Int32 i1 | semmle.label | successor |
-| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | semmle.label | false |
-| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} | semmle.label | true |
-| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:43 | ...; | semmle.label | successor |
-| Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | successor |
-| Patterns.cs:10:13:10:43 | ...; | Patterns.cs:10:33:10:36 | "int " | semmle.label | successor |
-| Patterns.cs:10:31:10:41 | $"..." | Patterns.cs:10:13:10:42 | call to method WriteLine | semmle.label | successor |
-| Patterns.cs:10:33:10:36 | "int " | Patterns.cs:10:38:10:39 | access to local variable i1 | semmle.label | successor |
-| Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:10:31:10:41 | $"..." | semmle.label | successor |
-| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:18 | access to local variable o | semmle.label | successor |
-| Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:12:23:12:31 | String s1 | semmle.label | successor |
-| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | semmle.label | false |
-| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} | semmle.label | true |
-| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:46 | ...; | semmle.label | successor |
-| Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | successor |
-| Patterns.cs:14:13:14:46 | ...; | Patterns.cs:14:33:14:39 | "string " | semmle.label | successor |
-| Patterns.cs:14:31:14:44 | $"..." | Patterns.cs:14:13:14:45 | call to method WriteLine | semmle.label | successor |
-| Patterns.cs:14:33:14:39 | "string " | Patterns.cs:14:41:14:42 | access to local variable s1 | semmle.label | successor |
-| Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:14:31:14:44 | $"..." | semmle.label | successor |
-| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:18 | access to local variable o | semmle.label | successor |
-| Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:16:23:16:28 | Object v1 | semmle.label | successor |
-| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | false |
-| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} | semmle.label | true |
-| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:20:9:38:9 | switch (...) {...} | semmle.label | successor |
-| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:17:20:17 | access to local variable o | semmle.label | successor |
-| Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:22:13:22:23 | case ...: | semmle.label | successor |
-| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:18:22:22 | "xyz" | semmle.label | successor |
-| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:23:17:23:22 | break; | semmle.label | match |
-| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:24:13:24:36 | case ...: | semmle.label | no-match |
-| Patterns.cs:23:17:23:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
-| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:18:24:23 | Int32 i2 | semmle.label | successor |
-| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:30:24:31 | access to local variable i2 | semmle.label | match |
-| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:27:13:27:24 | case ...: | semmle.label | no-match |
-| Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:24:35:24:35 | 0 | semmle.label | successor |
-| Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:25:17:25:52 | ...; | semmle.label | true |
-| Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:27:13:27:24 | case ...: | semmle.label | false |
-| Patterns.cs:24:35:24:35 | 0 | Patterns.cs:24:30:24:35 | ... > ... | semmle.label | successor |
-| Patterns.cs:25:17:25:51 | call to method WriteLine | Patterns.cs:26:17:26:22 | break; | semmle.label | successor |
-| Patterns.cs:25:17:25:52 | ...; | Patterns.cs:25:37:25:45 | "positive " | semmle.label | successor |
-| Patterns.cs:25:35:25:50 | $"..." | Patterns.cs:25:17:25:51 | call to method WriteLine | semmle.label | successor |
-| Patterns.cs:25:37:25:45 | "positive " | Patterns.cs:25:47:25:48 | access to local variable i2 | semmle.label | successor |
-| Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:25:35:25:50 | $"..." | semmle.label | successor |
-| Patterns.cs:26:17:26:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
-| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | Int32 i3 | semmle.label | successor |
-| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:28:17:28:47 | ...; | semmle.label | match |
-| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:30:13:30:27 | case ...: | semmle.label | no-match |
-| Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:29:17:29:22 | break; | semmle.label | successor |
-| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:28:37:28:40 | "int " | semmle.label | successor |
-| Patterns.cs:28:35:28:45 | $"..." | Patterns.cs:28:17:28:46 | call to method WriteLine | semmle.label | successor |
-| Patterns.cs:28:37:28:40 | "int " | Patterns.cs:28:42:28:43 | access to local variable i3 | semmle.label | successor |
-| Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:28:35:28:45 | $"..." | semmle.label | successor |
-| Patterns.cs:29:17:29:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
-| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:18:30:26 | String s2 | semmle.label | successor |
-| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:31:17:31:50 | ...; | semmle.label | match |
-| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:33:13:33:24 | case ...: | semmle.label | no-match |
-| Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:32:17:32:22 | break; | semmle.label | successor |
-| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:31:37:31:43 | "string " | semmle.label | successor |
-| Patterns.cs:31:35:31:48 | $"..." | Patterns.cs:31:17:31:49 | call to method WriteLine | semmle.label | successor |
-| Patterns.cs:31:37:31:43 | "string " | Patterns.cs:31:45:31:46 | access to local variable s2 | semmle.label | successor |
-| Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:31:35:31:48 | $"..." | semmle.label | successor |
-| Patterns.cs:32:17:32:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
-| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:18:33:23 | Object v2 | semmle.label | successor |
-| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:34:17:34:22 | break; | semmle.label | match |
-| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:35:13:35:20 | default: | semmle.label | no-match |
-| Patterns.cs:34:17:34:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
-| Patterns.cs:35:13:35:20 | default: | Patterns.cs:36:17:36:52 | ...; | semmle.label | successor |
-| Patterns.cs:36:17:36:51 | call to method WriteLine | Patterns.cs:37:17:37:22 | break; | semmle.label | successor |
-| Patterns.cs:36:17:36:52 | ...; | Patterns.cs:36:35:36:50 | "Something else" | semmle.label | successor |
-| Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine | semmle.label | successor |
-| Patterns.cs:37:17:37:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | semmle.label | break |
-| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o | semmle.label | successor |
-| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:11 | exit M1 (normal) | semmle.label | successor |
-| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:48:9:48:9 | access to parameter c | semmle.label | successor |
-| Patterns.cs:47:24:47:25 | exit M2 (normal) | Patterns.cs:47:24:47:25 | exit M2 | semmle.label | successor |
-| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:48:18:48:20 | a | semmle.label | successor |
-| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:47:24:47:25 | exit M2 (normal) | semmle.label | successor |
-| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:9:48:20 | ... is ... | semmle.label | successor |
-| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:14:48:20 | not ... | semmle.label | successor |
-| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:9 | access to parameter c | semmle.label | successor |
-| Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | exit M3 | semmle.label | successor |
-| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:18:51:21 | null | semmle.label | successor |
-| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | semmle.label | false |
-| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | semmle.label | true |
-| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 (normal) | semmle.label | successor |
-| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:9:51:21 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [match] not ... | semmle.label | no-match |
-| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [no-match] not ... | semmle.label | match |
-| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:30:51:30 | 1 | semmle.label | successor |
-| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | semmle.label | successor |
-| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:30 | ... is ... | semmle.label | successor |
-| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:39:51:39 | 2 | semmle.label | successor |
-| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... | semmle.label | successor |
-| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:34:51:39 | ... is ... | semmle.label | successor |
-| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:9:54:9 | access to parameter c | semmle.label | successor |
-| Patterns.cs:53:24:53:25 | exit M4 (normal) | Patterns.cs:53:24:53:25 | exit M4 | semmle.label | successor |
-| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:18:54:37 | Patterns u | semmle.label | successor |
-| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | exit M4 (normal) | semmle.label | successor |
-| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:9:54:37 | ... is ... | semmle.label | successor |
-| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | { ... } | semmle.label | no-match |
-| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 | semmle.label | match |
-| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:14:54:37 | not ... | semmle.label | successor |
-| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:54:18:54:37 | { ... } | semmle.label | match |
-| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:54:18:54:37 | { ... } | semmle.label | no-match |
-| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [match] { ... } | semmle.label | match |
-| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [no-match] { ... } | semmle.label | no-match |
-| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:57:5:63:5 | {...} | semmle.label | successor |
-| Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | exit M5 | semmle.label | successor |
-| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:16:58:16 | access to parameter i | semmle.label | successor |
-| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | exit M5 (normal) | semmle.label | return |
-| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:17:60:17 | 1 | semmle.label | successor |
-| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; | semmle.label | successor |
-| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:22:60:28 | "not 1" | semmle.label | match |
-| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:13:61:13 | _ | semmle.label | no-match |
-| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [match] not ... | semmle.label | no-match |
-| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [no-match] not ... | semmle.label | match |
-| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... | semmle.label | successor |
-| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" | semmle.label | match |
-| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... | semmle.label | successor |
-| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:66:5:72:5 | {...} | semmle.label | successor |
-| Patterns.cs:65:26:65:27 | exit M6 (normal) | Patterns.cs:65:26:65:27 | exit M6 | semmle.label | successor |
-| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:67:16:67:16 | 2 | semmle.label | successor |
-| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | exit M6 (normal) | semmle.label | return |
-| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:17:69:17 | 2 | semmle.label | successor |
-| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; | semmle.label | successor |
-| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 | semmle.label | no-match |
-| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... | semmle.label | match |
-| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | semmle.label | match |
-| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... | semmle.label | successor |
-| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:75:5:83:5 | {...} | semmle.label | successor |
-| Patterns.cs:74:26:74:27 | exit M7 (normal) | Patterns.cs:74:26:74:27 | exit M7 | semmle.label | successor |
-| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:76:16:76:16 | access to parameter i | semmle.label | successor |
-| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:74:26:74:27 | exit M7 (normal) | semmle.label | return |
-| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:78:15:78:15 | 1 | semmle.label | successor |
-| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:9:82:10 | return ...; | semmle.label | successor |
-| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:20:78:24 | "> 1" | semmle.label | match |
-| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:79:15:79:15 | 0 | semmle.label | no-match |
-| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | > ... | semmle.label | successor |
-| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:24 | ... => ... | semmle.label | successor |
-| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:20:79:24 | "< 0" | semmle.label | match |
-| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:80:13:80:13 | 1 | semmle.label | no-match |
-| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... | semmle.label | successor |
-| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:24 | ... => ... | semmle.label | successor |
-| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" | semmle.label | match |
-| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:13:81:13 | _ | semmle.label | no-match |
-| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:20 | ... => ... | semmle.label | successor |
-| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" | semmle.label | match |
-| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } | semmle.label | successor |
-| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:20 | ... => ... | semmle.label | successor |
-| Patterns.cs:85:26:85:27 | enter M8 | Patterns.cs:85:39:85:39 | access to parameter i | semmle.label | successor |
-| Patterns.cs:85:26:85:27 | exit M8 (normal) | Patterns.cs:85:26:85:27 | exit M8 | semmle.label | successor |
-| Patterns.cs:85:39:85:39 | access to parameter i | Patterns.cs:85:44:85:44 | 1 | semmle.label | successor |
-| Patterns.cs:85:39:85:53 | [false] ... is ... | Patterns.cs:85:67:85:69 | "2" | semmle.label | false |
-| Patterns.cs:85:39:85:53 | [true] ... is ... | Patterns.cs:85:57:85:63 | "not 2" | semmle.label | true |
-| Patterns.cs:85:39:85:69 | ... ? ... : ... | Patterns.cs:85:26:85:27 | exit M8 (normal) | semmle.label | successor |
-| Patterns.cs:85:44:85:44 | 1 | Patterns.cs:85:44:85:53 | [match] ... or ... | semmle.label | match |
-| Patterns.cs:85:44:85:44 | 1 | Patterns.cs:85:53:85:53 | 2 | semmle.label | no-match |
-| Patterns.cs:85:44:85:53 | [match] ... or ... | Patterns.cs:85:39:85:53 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:85:44:85:53 | [no-match] ... or ... | Patterns.cs:85:39:85:53 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:85:49:85:53 | [match] not ... | Patterns.cs:85:44:85:53 | [match] ... or ... | semmle.label | match |
-| Patterns.cs:85:49:85:53 | [no-match] not ... | Patterns.cs:85:44:85:53 | [no-match] ... or ... | semmle.label | no-match |
-| Patterns.cs:85:53:85:53 | 2 | Patterns.cs:85:49:85:53 | [match] not ... | semmle.label | no-match |
-| Patterns.cs:85:53:85:53 | 2 | Patterns.cs:85:49:85:53 | [no-match] not ... | semmle.label | match |
-| Patterns.cs:85:57:85:63 | "not 2" | Patterns.cs:85:39:85:69 | ... ? ... : ... | semmle.label | successor |
-| Patterns.cs:85:67:85:69 | "2" | Patterns.cs:85:39:85:69 | ... ? ... : ... | semmle.label | successor |
-| Patterns.cs:87:26:87:27 | enter M9 | Patterns.cs:87:39:87:39 | access to parameter i | semmle.label | successor |
-| Patterns.cs:87:26:87:27 | exit M9 (normal) | Patterns.cs:87:26:87:27 | exit M9 | semmle.label | successor |
-| Patterns.cs:87:39:87:39 | access to parameter i | Patterns.cs:87:44:87:44 | 1 | semmle.label | successor |
-| Patterns.cs:87:39:87:54 | [false] ... is ... | Patterns.cs:87:64:87:70 | "not 1" | semmle.label | false |
-| Patterns.cs:87:39:87:54 | [true] ... is ... | Patterns.cs:87:58:87:60 | "1" | semmle.label | true |
-| Patterns.cs:87:39:87:70 | ... ? ... : ... | Patterns.cs:87:26:87:27 | exit M9 (normal) | semmle.label | successor |
-| Patterns.cs:87:44:87:44 | 1 | Patterns.cs:87:44:87:54 | [no-match] ... and ... | semmle.label | no-match |
-| Patterns.cs:87:44:87:44 | 1 | Patterns.cs:87:54:87:54 | 2 | semmle.label | match |
-| Patterns.cs:87:44:87:54 | [match] ... and ... | Patterns.cs:87:39:87:54 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:87:44:87:54 | [no-match] ... and ... | Patterns.cs:87:39:87:54 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:87:50:87:54 | [match] not ... | Patterns.cs:87:44:87:54 | [match] ... and ... | semmle.label | match |
-| Patterns.cs:87:50:87:54 | [no-match] not ... | Patterns.cs:87:44:87:54 | [no-match] ... and ... | semmle.label | no-match |
-| Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:50:87:54 | [match] not ... | semmle.label | no-match |
-| Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:50:87:54 | [no-match] not ... | semmle.label | match |
-| Patterns.cs:87:58:87:60 | "1" | Patterns.cs:87:39:87:70 | ... ? ... : ... | semmle.label | successor |
-| Patterns.cs:87:64:87:70 | "not 1" | Patterns.cs:87:39:87:70 | ... ? ... : ... | semmle.label | successor |
-| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:94:5:99:5 | {...} | semmle.label | successor |
-| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:93:17:93:19 | exit M10 | semmle.label | successor |
-| Patterns.cs:94:5:99:5 | {...} | Patterns.cs:95:9:98:9 | if (...) ... | semmle.label | successor |
-| Patterns.cs:95:9:98:9 | if (...) ... | Patterns.cs:95:13:95:16 | this access | semmle.label | successor |
-| Patterns.cs:95:13:95:16 | this access | Patterns.cs:95:29:95:31 | access to constant A | semmle.label | successor |
-| Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:93:17:93:19 | exit M10 (normal) | semmle.label | false |
-| Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:96:9:98:9 | {...} | semmle.label | true |
-| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | semmle.label | match |
-| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } | semmle.label | match |
-| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | semmle.label | no-match |
-| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } | semmle.label | no-match |
-| Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:29:95:38 | [match] ... or ... | semmle.label | match |
-| Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:36:95:38 | access to constant B | semmle.label | no-match |
-| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } | semmle.label | match |
-| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } | semmle.label | no-match |
-| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [match] ... or ... | semmle.label | match |
-| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [no-match] ... or ... | semmle.label | no-match |
-| Patterns.cs:96:9:98:9 | {...} | Patterns.cs:97:13:97:39 | ...; | semmle.label | successor |
-| Patterns.cs:97:13:97:38 | call to method WriteLine | Patterns.cs:93:17:93:19 | exit M10 (normal) | semmle.label | successor |
-| Patterns.cs:97:13:97:39 | ...; | Patterns.cs:97:31:97:37 | "not C" | semmle.label | successor |
-| Patterns.cs:97:31:97:37 | "not C" | Patterns.cs:97:13:97:38 | call to method WriteLine | semmle.label | successor |
-| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} | semmle.label | successor |
-| PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 | semmle.label | successor |
-| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; | semmle.label | successor |
-| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 (normal) | semmle.label | successor |
-| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:27:7:27 | access to parameter s | semmle.label | successor |
-| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:28 | call to method WriteLine | semmle.label | successor |
-| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:11:5:15:5 | {...} | semmle.label | successor |
-| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 | semmle.label | successor |
-| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... | semmle.label | successor |
-| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s | semmle.label | successor |
-| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null | semmle.label | successor |
-| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; | semmle.label | false |
-| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; | semmle.label | true |
-| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [false] ... is ... | semmle.label | no-match |
-| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [true] ... is ... | semmle.label | match |
-| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
-| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | exit M2 (normal) | semmle.label | successor |
-| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s | semmle.label | successor |
-| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:28 | call to method WriteLine | semmle.label | successor |
-| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:18:5:22:5 | {...} | semmle.label | successor |
-| PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | successor |
-| PostDominance.cs:17:10:17:11 | exit M3 (normal) | PostDominance.cs:17:10:17:11 | exit M3 | semmle.label | successor |
-| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... | semmle.label | successor |
-| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s | semmle.label | successor |
-| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null | semmle.label | successor |
-| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; | semmle.label | false |
-| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | semmle.label | true |
-| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [false] ... is ... | semmle.label | no-match |
-| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [true] ... is ... | semmle.label | match |
-| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | semmle.label | exception(ArgumentNullException) |
-| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; | semmle.label | successor |
-| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | semmle.label | successor |
-| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | exit M3 (normal) | semmle.label | successor |
-| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:27:21:27 | access to parameter s | semmle.label | successor |
-| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:28 | call to method WriteLine | semmle.label | successor |
-| Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:28:7:31 | null | semmle.label | successor |
-| Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:16:7:21 | exit Method | semmle.label | successor |
-| Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method (normal) | semmle.label | successor |
-| Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:41:8:44 | null | semmle.label | successor |
-| Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | Qualifiers.cs:8:23:8:34 | exit StaticMethod | semmle.label | successor |
-| Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | semmle.label | successor |
-| Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:11:5:31:5 | {...} | semmle.label | successor |
-| Qualifiers.cs:10:10:10:10 | exit M (normal) | Qualifiers.cs:10:10:10:10 | exit M | semmle.label | successor |
-| Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; | semmle.label | successor |
-| Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access | semmle.label | successor |
-| Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; | semmle.label | successor |
-| Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | semmle.label | successor |
-| Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | access to field Field | semmle.label | successor |
-| Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:14:9:14:21 | ...; | semmle.label | successor |
-| Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:13:13:20 | this access | semmle.label | successor |
-| Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:9:13:20 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | access to property Property | semmle.label | successor |
-| Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:16:9:16:23 | ...; | semmle.label | successor |
-| Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:13:14:20 | this access | semmle.label | successor |
-| Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:9:14:20 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | call to method Method | semmle.label | successor |
-| Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:17:9:17:26 | ...; | semmle.label | successor |
-| Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:13:16:16 | this access | semmle.label | successor |
-| Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:22 | access to field Field | semmle.label | successor |
-| Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:9:16:22 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:18:9:18:26 | ...; | semmle.label | successor |
-| Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:13:17:16 | this access | semmle.label | successor |
-| Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:25 | access to property Property | semmle.label | successor |
-| Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:9:17:25 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:20:9:20:24 | ...; | semmle.label | successor |
-| Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:13:18:16 | this access | semmle.label | successor |
-| Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:25 | call to method Method | semmle.label | successor |
-| Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:9:18:25 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:21:9:21:27 | ...; | semmle.label | successor |
-| Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:13:20:23 | access to field StaticField | semmle.label | successor |
-| Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:23 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:22:9:22:27 | ...; | semmle.label | successor |
-| Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:13:21:26 | access to property StaticProperty | semmle.label | successor |
-| Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:26 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:24:9:24:35 | ...; | semmle.label | successor |
-| Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:13:22:26 | call to method StaticMethod | semmle.label | successor |
-| Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:26 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:25:9:25:38 | ...; | semmle.label | successor |
-| Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:13:24:34 | access to field StaticField | semmle.label | successor |
-| Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:34 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:26:9:26:38 | ...; | semmle.label | successor |
-| Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:13:25:37 | access to property StaticProperty | semmle.label | successor |
-| Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:37 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:28:9:28:41 | ...; | semmle.label | successor |
-| Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:13:26:37 | call to method StaticMethod | semmle.label | successor |
-| Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:37 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:29:9:29:47 | ...; | semmle.label | successor |
-| Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:13:28:34 | access to field StaticField | semmle.label | successor |
-| Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:40 | access to field Field | semmle.label | successor |
-| Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:9:28:40 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:30:9:30:47 | ...; | semmle.label | successor |
-| Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty | semmle.label | successor |
-| Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property | semmle.label | successor |
-| Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... | semmle.label | successor |
-| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M (normal) | semmle.label | successor |
-| Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod | semmle.label | successor |
-| Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method | semmle.label | successor |
-| Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... | semmle.label | successor |
-| Switch.cs:5:10:5:11 | enter M1 | Switch.cs:6:5:8:5 | {...} | semmle.label | successor |
-| Switch.cs:5:10:5:11 | exit M1 (normal) | Switch.cs:5:10:5:11 | exit M1 | semmle.label | successor |
-| Switch.cs:6:5:8:5 | {...} | Switch.cs:7:9:7:22 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:7:9:7:22 | switch (...) {...} | Switch.cs:7:17:7:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | exit M1 (normal) | semmle.label | successor |
-| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:11:5:33:5 | {...} | semmle.label | successor |
-| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | exit M2 | semmle.label | successor |
-| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | exit M2 | semmle.label | successor |
-| Switch.cs:11:5:33:5 | {...} | Switch.cs:12:9:32:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:12:17:12:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:14:13:14:21 | case ...: | semmle.label | successor |
-| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:18:14:20 | "a" | semmle.label | successor |
-| Switch.cs:14:18:14:20 | "a" | Switch.cs:15:17:15:23 | return ...; | semmle.label | match |
-| Switch.cs:14:18:14:20 | "a" | Switch.cs:16:13:16:19 | case ...: | semmle.label | no-match |
-| Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
-| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:18:16:18 | 0 | semmle.label | successor |
-| Switch.cs:16:18:16:18 | 0 | Switch.cs:17:23:17:37 | object creation of type Exception | semmle.label | match |
-| Switch.cs:16:18:16:18 | 0 | Switch.cs:18:13:18:22 | case ...: | semmle.label | no-match |
-| Switch.cs:17:17:17:38 | throw ...; | Switch.cs:10:10:10:11 | exit M2 (abnormal) | semmle.label | exception(Exception) |
-| Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:17:17:38 | throw ...; | semmle.label | successor |
-| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:18:18:21 | null | semmle.label | successor |
-| Switch.cs:18:18:18:21 | null | Switch.cs:19:17:19:29 | goto default; | semmle.label | match |
-| Switch.cs:18:18:18:21 | null | Switch.cs:20:13:20:23 | case ...: | semmle.label | no-match |
-| Switch.cs:19:17:19:29 | goto default; | Switch.cs:30:13:30:20 | default: | semmle.label | goto(default) |
-| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:18:20:22 | Int32 i | semmle.label | successor |
-| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:21:17:22:27 | if (...) ... | semmle.label | match |
-| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:24:13:24:56 | case ...: | semmle.label | no-match |
-| Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:21:21:21:21 | access to parameter o | semmle.label | successor |
-| Switch.cs:21:21:21:21 | access to parameter o | Switch.cs:21:26:21:29 | null | semmle.label | successor |
-| Switch.cs:21:21:21:29 | ... == ... | Switch.cs:22:21:22:27 | return ...; | semmle.label | true |
-| Switch.cs:21:21:21:29 | ... == ... | Switch.cs:23:27:23:27 | 0 | semmle.label | false |
-| Switch.cs:21:26:21:29 | null | Switch.cs:21:21:21:29 | ... == ... | semmle.label | successor |
-| Switch.cs:22:21:22:27 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
-| Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:16:13:16:19 | case ...: | semmle.label | goto(0) |
-| Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; | semmle.label | successor |
-| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s | semmle.label | successor |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:32 | access to local variable s | semmle.label | match |
-| Switch.cs:24:18:24:25 | String s | Switch.cs:27:13:27:39 | case ...: | semmle.label | no-match |
-| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | access to property Length | semmle.label | successor |
-| Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:43:24:43 | 0 | semmle.label | successor |
-| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:55 | [false] ... && ... | semmle.label | false |
-| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:48:24:48 | access to local variable s | semmle.label | true |
-| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:27:13:27:39 | case ...: | semmle.label | false |
-| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:25:17:25:37 | ...; | semmle.label | true |
-| Switch.cs:24:43:24:43 | 0 | Switch.cs:24:32:24:43 | ... > ... | semmle.label | successor |
-| Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:53:24:55 | "a" | semmle.label | successor |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [false] ... && ... | semmle.label | false |
-| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [true] ... && ... | semmle.label | true |
-| Switch.cs:24:53:24:55 | "a" | Switch.cs:24:48:24:55 | ... != ... | semmle.label | successor |
-| Switch.cs:25:17:25:36 | call to method WriteLine | Switch.cs:26:17:26:23 | return ...; | semmle.label | successor |
-| Switch.cs:25:17:25:37 | ...; | Switch.cs:25:35:25:35 | access to local variable s | semmle.label | successor |
-| Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | call to method WriteLine | semmle.label | successor |
-| Switch.cs:26:17:26:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d | semmle.label | successor |
-| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | call to method Throw | semmle.label | match |
-| Switch.cs:27:18:27:25 | Double d | Switch.cs:30:13:30:20 | default: | semmle.label | no-match |
-| Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | exit M2 (abnormal) | semmle.label | exception(Exception) |
-| Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | return ...; | semmle.label | successor |
-| Switch.cs:29:17:29:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | semmle.label | return |
-| Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; | semmle.label | successor |
-| Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:13:28:17 | Label: | semmle.label | goto(Label) |
-| Switch.cs:35:10:35:11 | enter M3 | Switch.cs:36:5:42:5 | {...} | semmle.label | successor |
-| Switch.cs:35:10:35:11 | exit M3 (abnormal) | Switch.cs:35:10:35:11 | exit M3 | semmle.label | successor |
-| Switch.cs:36:5:42:5 | {...} | Switch.cs:37:9:41:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:37:17:37:23 | call to method Throw | semmle.label | successor |
-| Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | exit M3 (abnormal) | semmle.label | exception(Exception) |
-| Switch.cs:44:10:44:11 | enter M4 | Switch.cs:45:5:53:5 | {...} | semmle.label | successor |
-| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 | semmle.label | successor |
-| Switch.cs:45:5:53:5 | {...} | Switch.cs:46:9:52:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:46:17:46:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:48:13:48:23 | case ...: | semmle.label | successor |
-| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:18:48:20 | access to type Int32 | semmle.label | successor |
-| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:49:17:49:22 | break; | semmle.label | match |
-| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:50:13:50:39 | case ...: | semmle.label | no-match |
-| Switch.cs:49:17:49:22 | break; | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | break |
-| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:18:50:21 | access to type Boolean | semmle.label | successor |
-| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | no-match |
-| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:30:50:30 | access to parameter o | semmle.label | match |
-| Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:35:50:38 | null | semmle.label | successor |
-| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | false |
-| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; | semmle.label | true |
-| Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:38 | ... != ... | semmle.label | successor |
-| Switch.cs:51:17:51:22 | break; | Switch.cs:44:10:44:11 | exit M4 (normal) | semmle.label | break |
-| Switch.cs:55:10:55:11 | enter M5 | Switch.cs:56:5:64:5 | {...} | semmle.label | successor |
-| Switch.cs:55:10:55:11 | exit M5 (normal) | Switch.cs:55:10:55:11 | exit M5 | semmle.label | successor |
-| Switch.cs:56:5:64:5 | {...} | Switch.cs:57:9:63:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:57:17:57:17 | 1 | semmle.label | successor |
-| Switch.cs:57:17:57:17 | 1 | Switch.cs:57:21:57:21 | 2 | semmle.label | successor |
-| Switch.cs:57:17:57:21 | ... + ... | Switch.cs:59:13:59:19 | case ...: | semmle.label | successor |
-| Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:21 | ... + ... | semmle.label | successor |
-| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 | semmle.label | successor |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:19 | case ...: | semmle.label | no-match |
-| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 | semmle.label | successor |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | break; | semmle.label | match |
-| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 (normal) | semmle.label | break |
-| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:67:5:75:5 | {...} | semmle.label | successor |
-| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 | semmle.label | successor |
-| Switch.cs:67:5:75:5 | {...} | Switch.cs:68:9:74:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:25:68:25 | access to parameter s | semmle.label | successor |
-| Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:23 | case ...: | semmle.label | successor |
-| Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | (...) ... | semmle.label | successor |
-| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | semmle.label | successor |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:20 | case ...: | semmle.label | no-match |
-| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" | semmle.label | successor |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 (normal) | semmle.label | no-match |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | break; | semmle.label | match |
-| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | exit M6 (normal) | semmle.label | break |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:78:5:89:5 | {...} | semmle.label | successor |
-| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 | semmle.label | successor |
-| Switch.cs:78:5:89:5 | {...} | Switch.cs:79:9:87:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i | semmle.label | successor |
-| Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: | semmle.label | successor |
-| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 | semmle.label | successor |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:24:82:27 | true | semmle.label | match |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:19 | case ...: | semmle.label | no-match |
-| Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | semmle.label | return |
-| Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; | semmle.label | successor |
-| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 | semmle.label | successor |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... | semmle.label | match |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:88:16:88:20 | false | semmle.label | no-match |
-| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:21 | access to parameter j | semmle.label | successor |
-| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:25:84:25 | 2 | semmle.label | successor |
-| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; | semmle.label | true |
-| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true | semmle.label | false |
-| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:21:84:25 | ... > ... | semmle.label | successor |
-| Switch.cs:85:21:85:26 | break; | Switch.cs:88:16:88:20 | false | semmle.label | break |
-| Switch.cs:86:17:86:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | semmle.label | return |
-| Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; | semmle.label | successor |
-| Switch.cs:88:9:88:21 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | semmle.label | return |
-| Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; | semmle.label | successor |
-| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:92:5:99:5 | {...} | semmle.label | successor |
-| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 | semmle.label | successor |
-| Switch.cs:92:5:99:5 | {...} | Switch.cs:93:9:97:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: | semmle.label | successor |
-| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 | semmle.label | successor |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:24:96:27 | true | semmle.label | match |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:98:16:98:20 | false | semmle.label | no-match |
-| Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | exit M8 (normal) | semmle.label | return |
-| Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; | semmle.label | successor |
-| Switch.cs:98:9:98:21 | return ...; | Switch.cs:91:10:91:11 | exit M8 (normal) | semmle.label | return |
-| Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; | semmle.label | successor |
-| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:102:5:109:5 | {...} | semmle.label | successor |
-| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 | semmle.label | successor |
-| Switch.cs:102:5:109:5 | {...} | Switch.cs:103:9:107:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:17:103:17 | access to parameter s | semmle.label | successor |
-| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:19:103:25 | access to property Length | semmle.label | non-null |
-| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:105:13:105:19 | case ...: | semmle.label | null |
-| Switch.cs:103:19:103:25 | access to property Length | Switch.cs:105:13:105:19 | case ...: | semmle.label | successor |
-| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 | semmle.label | successor |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:28:105:28 | 0 | semmle.label | match |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:19 | case ...: | semmle.label | no-match |
-| Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | semmle.label | return |
-| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; | semmle.label | successor |
-| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 | semmle.label | successor |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:28:106:28 | 1 | semmle.label | match |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:108:17:108:17 | 1 | semmle.label | no-match |
-| Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | semmle.label | return |
-| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; | semmle.label | successor |
-| Switch.cs:108:9:108:18 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | semmle.label | return |
-| Switch.cs:108:16:108:17 | -... | Switch.cs:108:9:108:18 | return ...; | semmle.label | successor |
-| Switch.cs:108:17:108:17 | 1 | Switch.cs:108:16:108:17 | -... | semmle.label | successor |
-| Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:34:111:48 | object creation of type Exception | semmle.label | successor |
-| Switch.cs:111:17:111:21 | exit Throw (abnormal) | Switch.cs:111:17:111:21 | exit Throw | semmle.label | successor |
-| Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | exit Throw (abnormal) | semmle.label | exception(Exception) |
-| Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:28:111:48 | throw ... | semmle.label | successor |
-| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:114:5:121:5 | {...} | semmle.label | successor |
-| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 | semmle.label | successor |
-| Switch.cs:114:5:121:5 | {...} | Switch.cs:115:9:119:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:17:115:17 | access to parameter s | semmle.label | successor |
-| Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:24 | access to property Length | semmle.label | successor |
-| Switch.cs:115:17:115:24 | access to property Length | Switch.cs:117:13:117:35 | case ...: | semmle.label | successor |
-| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 | semmle.label | successor |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:25:117:25 | access to parameter s | semmle.label | match |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:118:13:118:34 | case ...: | semmle.label | no-match |
-| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:30:117:34 | "foo" | semmle.label | successor |
-| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:44:117:44 | 1 | semmle.label | true |
-| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | semmle.label | false |
-| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:34 | ... == ... | semmle.label | successor |
-| Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | semmle.label | return |
-| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; | semmle.label | successor |
-| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | semmle.label | successor |
-| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:25 | access to parameter s | semmle.label | match |
-| Switch.cs:118:18:118:18 | 2 | Switch.cs:120:17:120:17 | 1 | semmle.label | no-match |
-| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:30:118:33 | "fu" | semmle.label | successor |
-| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | semmle.label | true |
-| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | semmle.label | false |
-| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:33 | ... == ... | semmle.label | successor |
-| Switch.cs:118:36:118:44 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | semmle.label | return |
-| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; | semmle.label | successor |
-| Switch.cs:120:9:120:18 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | semmle.label | return |
-| Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; | semmle.label | successor |
-| Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... | semmle.label | successor |
-| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} | semmle.label | successor |
-| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 | semmle.label | successor |
-| Switch.cs:124:5:127:5 | {...} | Switch.cs:125:9:126:19 | if (...) ... | semmle.label | successor |
-| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:13 | access to parameter o | semmle.label | successor |
-| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:29 | Boolean b | semmle.label | successor |
-| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | false |
-| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:126:13:126:19 | return ...; | semmle.label | true |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b | semmle.label | match |
-| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:37 | _ | semmle.label | no-match |
-| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | semmle.label | false |
-| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:13:125:48 | [true] ... switch { ... } | semmle.label | true |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... | semmle.label | false |
-| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... | semmle.label | true |
-| Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false | semmle.label | match |
-| Switch.cs:125:37:125:46 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | semmle.label | false |
-| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | [false] ... => ... | semmle.label | false |
-| Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | exit M11 (normal) | semmle.label | return |
-| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:130:5:132:5 | {...} | semmle.label | successor |
-| Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | exit M12 | semmle.label | successor |
-| Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 (normal) | semmle.label | return |
-| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:35 | String s | semmle.label | successor |
-| Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | Switch.cs:131:56:131:66 | call to method ToString | semmle.label | non-null |
-| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:9:131:67 | return ...; | semmle.label | null |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s | semmle.label | match |
-| Switch.cs:131:28:131:35 | String s | Switch.cs:131:43:131:43 | _ | semmle.label | no-match |
-| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | semmle.label | non-null |
-| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:131:17:131:53 | [null] ... switch { ... } | semmle.label | null |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [non-null] ... => ... | semmle.label | non-null |
-| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [null] ... => ... | semmle.label | null |
-| Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null | semmle.label | match |
-| Switch.cs:131:43:131:51 | [null] ... => ... | Switch.cs:131:17:131:53 | [null] ... switch { ... } | semmle.label | null |
-| Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:51 | [null] ... => ... | semmle.label | null |
-| Switch.cs:131:56:131:66 | call to method ToString | Switch.cs:131:9:131:67 | return ...; | semmle.label | successor |
-| Switch.cs:134:9:134:11 | enter M13 | Switch.cs:135:5:142:5 | {...} | semmle.label | successor |
-| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 | semmle.label | successor |
-| Switch.cs:135:5:142:5 | {...} | Switch.cs:136:9:141:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:136:17:136:17 | access to parameter i | semmle.label | successor |
-| Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:139:13:139:19 | case ...: | semmle.label | successor |
-| Switch.cs:138:13:138:20 | default: | Switch.cs:138:30:138:30 | 1 | semmle.label | successor |
-| Switch.cs:138:22:138:31 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | semmle.label | return |
-| Switch.cs:138:29:138:30 | -... | Switch.cs:138:22:138:31 | return ...; | semmle.label | successor |
-| Switch.cs:138:30:138:30 | 1 | Switch.cs:138:29:138:30 | -... | semmle.label | successor |
-| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:18:139:18 | 1 | semmle.label | successor |
-| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:28:139:28 | 1 | semmle.label | match |
-| Switch.cs:139:18:139:18 | 1 | Switch.cs:140:13:140:19 | case ...: | semmle.label | no-match |
-| Switch.cs:139:21:139:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | semmle.label | return |
-| Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | return ...; | semmle.label | successor |
-| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:18:140:18 | 2 | semmle.label | successor |
-| Switch.cs:140:18:140:18 | 2 | Switch.cs:138:13:138:20 | default: | semmle.label | no-match |
-| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:28:140:28 | 2 | semmle.label | match |
-| Switch.cs:140:21:140:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | semmle.label | return |
-| Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; | semmle.label | successor |
-| Switch.cs:144:9:144:11 | enter M14 | Switch.cs:145:5:152:5 | {...} | semmle.label | successor |
-| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 | semmle.label | successor |
-| Switch.cs:145:5:152:5 | {...} | Switch.cs:146:9:151:9 | switch (...) {...} | semmle.label | successor |
-| Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:146:17:146:17 | access to parameter i | semmle.label | successor |
-| Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:148:13:148:19 | case ...: | semmle.label | successor |
-| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:18:148:18 | 1 | semmle.label | successor |
-| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:28:148:28 | 1 | semmle.label | match |
-| Switch.cs:148:18:148:18 | 1 | Switch.cs:150:13:150:19 | case ...: | semmle.label | no-match |
-| Switch.cs:148:21:148:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | semmle.label | return |
-| Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | return ...; | semmle.label | successor |
-| Switch.cs:149:13:149:20 | default: | Switch.cs:149:30:149:30 | 1 | semmle.label | successor |
-| Switch.cs:149:22:149:31 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | semmle.label | return |
-| Switch.cs:149:29:149:30 | -... | Switch.cs:149:22:149:31 | return ...; | semmle.label | successor |
-| Switch.cs:149:30:149:30 | 1 | Switch.cs:149:29:149:30 | -... | semmle.label | successor |
-| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 | semmle.label | successor |
-| Switch.cs:150:18:150:18 | 2 | Switch.cs:149:13:149:20 | default: | semmle.label | no-match |
-| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:28:150:28 | 2 | semmle.label | match |
-| Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | semmle.label | return |
-| Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; | semmle.label | successor |
-| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:155:5:161:5 | {...} | semmle.label | successor |
-| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
-| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
-| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; | semmle.label | successor |
-| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:17 | access to parameter b | semmle.label | successor |
-| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... | semmle.label | successor |
-| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:31 | true | semmle.label | successor |
-| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" | semmle.label | match |
-| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:45 | false | semmle.label | no-match |
-| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
-| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:38 | ... => ... | semmle.label | successor |
-| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) | semmle.label | exception(InvalidOperationException) |
-| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | semmle.label | match |
-| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
-| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... | semmle.label | successor |
-| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b | semmle.label | successor |
-| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | semmle.label | true |
-| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | semmle.label | false |
-| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 (normal) | semmle.label | successor |
-| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:40:158:43 | "a = " | semmle.label | successor |
-| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:13:158:48 | call to method WriteLine | semmle.label | successor |
-| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:45:158:45 | access to local variable s | semmle.label | successor |
-| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:38:158:47 | $"..." | semmle.label | successor |
-| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 (normal) | semmle.label | successor |
-| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:40:160:43 | "b = " | semmle.label | successor |
-| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:13:160:48 | call to method WriteLine | semmle.label | successor |
-| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s | semmle.label | successor |
-| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:38:160:47 | $"..." | semmle.label | successor |
-| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} | semmle.label | successor |
-| TypeAccesses.cs:3:10:3:10 | exit M (normal) | TypeAccesses.cs:3:10:3:10 | exit M | semmle.label | successor |
-| TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; | semmle.label | successor |
-| TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |
-| TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; | semmle.label | successor |
-| TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:13:5:25 | String s = ... | semmle.label | successor |
-| TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:17:5:25 | (...) ... | semmle.label | successor |
-| TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:7:9:7:25 | if (...) ... | semmle.label | successor |
-| TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:13:6:13 | access to parameter o | semmle.label | successor |
-| TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:23 | ... as ... | semmle.label | successor |
-| TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... | semmle.label | successor |
-| TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o | semmle.label | successor |
-| TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:18:7:22 | Int32 j | semmle.label | successor |
-| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | false |
-| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; | semmle.label | true |
-| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | semmle.label | no-match |
-| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [true] ... is ... | semmle.label | match |
-| TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:8:9:8:28 | ... ...; | semmle.label | successor |
-| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) | semmle.label | successor |
-| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M (normal) | semmle.label | successor |
-| TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... | semmle.label | successor |
-| VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:6:5:11:5 | {...} | semmle.label | successor |
-| VarDecls.cs:5:18:5:19 | exit M1 (normal) | VarDecls.cs:5:18:5:19 | exit M1 | semmle.label | successor |
-| VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } | semmle.label | successor |
-| VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings | semmle.label | successor |
-| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings | semmle.label | successor |
-| VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:35:7:35 | 0 | semmle.label | successor |
-| VarDecls.cs:7:27:7:36 | (...) ... | VarDecls.cs:7:22:7:36 | Char* c1 = ... | semmle.label | successor |
-| VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:27:7:36 | (...) ... | semmle.label | successor |
-| VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:27:7:36 | access to array element | semmle.label | successor |
-| VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:8:9:10:9 | {...} | semmle.label | successor |
-| VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:52:7:52 | 1 | semmle.label | successor |
-| VarDecls.cs:7:44:7:53 | (...) ... | VarDecls.cs:7:39:7:53 | Char* c2 = ... | semmle.label | successor |
-| VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:44:7:53 | (...) ... | semmle.label | successor |
-| VarDecls.cs:7:52:7:52 | 1 | VarDecls.cs:7:44:7:53 | access to array element | semmle.label | successor |
-| VarDecls.cs:8:9:10:9 | {...} | VarDecls.cs:9:27:9:28 | access to local variable c1 | semmle.label | successor |
-| VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:5:18:5:19 | exit M1 (normal) | semmle.label | return |
-| VarDecls.cs:9:20:9:28 | (...) ... | VarDecls.cs:9:13:9:29 | return ...; | semmle.label | successor |
-| VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... | semmle.label | successor |
-| VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:14:5:17:5 | {...} | semmle.label | successor |
-| VarDecls.cs:13:12:13:13 | exit M2 (normal) | VarDecls.cs:13:12:13:13 | exit M2 | semmle.label | successor |
-| VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; | semmle.label | successor |
-| VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s | semmle.label | successor |
-| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s | semmle.label | successor |
-| VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... | semmle.label | successor |
-| VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 | semmle.label | successor |
-| VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... | semmle.label | successor |
-| VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 (normal) | semmle.label | return |
-| VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:16:21:16:22 | access to local variable s2 | semmle.label | successor |
-| VarDecls.cs:16:16:16:22 | ... + ... | VarDecls.cs:16:9:16:23 | return ...; | semmle.label | successor |
-| VarDecls.cs:16:21:16:22 | access to local variable s2 | VarDecls.cs:16:16:16:22 | ... + ... | semmle.label | successor |
-| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:20:5:26:5 | {...} | semmle.label | successor |
-| VarDecls.cs:19:7:19:8 | exit M3 (normal) | VarDecls.cs:19:7:19:8 | exit M3 | semmle.label | successor |
-| VarDecls.cs:20:5:26:5 | {...} | VarDecls.cs:21:9:22:13 | using (...) {...} | semmle.label | successor |
-| VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C | semmle.label | successor |
-| VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; | semmle.label | successor |
-| VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:24:9:25:29 | using (...) {...} | semmle.label | successor |
-| VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C | semmle.label | successor |
-| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C | semmle.label | successor |
-| VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... | semmle.label | successor |
-| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:20 | access to parameter b | semmle.label | successor |
-| VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... | semmle.label | successor |
-| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 (normal) | semmle.label | return |
-| VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | semmle.label | true |
-| VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y | semmle.label | false |
-| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:13:25:29 | return ...; | semmle.label | successor |
-| VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
-| VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:20:25:28 | ... ? ... : ... | semmle.label | successor |
-| VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:51:28:53 | {...} | semmle.label | successor |
-| VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | exit Dispose | semmle.label | successor |
-| VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose (normal) | semmle.label | successor |
-| cflow.cs:5:17:5:20 | enter Main | cflow.cs:6:5:35:5 | {...} | semmle.label | successor |
-| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main | semmle.label | successor |
-| cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; | semmle.label | successor |
-| cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args | semmle.label | successor |
-| cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; | semmle.label | successor |
-| cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:27 | access to property Length | semmle.label | successor |
-| cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:13:7:27 | Int32 a = ... | semmle.label | successor |
-| cflow.cs:9:9:9:39 | ... = ... | cflow.cs:11:9:12:49 | if (...) ... | semmle.label | successor |
-| cflow.cs:9:9:9:40 | ...; | cflow.cs:9:13:9:29 | object creation of type ControlFlow | semmle.label | successor |
-| cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:38:9:38 | access to local variable a | semmle.label | successor |
-| cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:9:9:39 | ... = ... | semmle.label | successor |
-| cflow.cs:9:38:9:38 | access to local variable a | cflow.cs:9:13:9:39 | call to method Switch | semmle.label | successor |
-| cflow.cs:11:9:12:49 | if (...) ... | cflow.cs:11:13:11:13 | access to local variable a | semmle.label | successor |
-| cflow.cs:11:13:11:13 | access to local variable a | cflow.cs:11:17:11:17 | 3 | semmle.label | successor |
-| cflow.cs:11:13:11:17 | ... > ... | cflow.cs:12:13:12:49 | ...; | semmle.label | true |
-| cflow.cs:11:13:11:17 | ... > ... | cflow.cs:14:9:17:9 | while (...) ... | semmle.label | false |
-| cflow.cs:11:17:11:17 | 3 | cflow.cs:11:13:11:17 | ... > ... | semmle.label | successor |
-| cflow.cs:12:13:12:48 | call to method WriteLine | cflow.cs:14:9:17:9 | while (...) ... | semmle.label | successor |
-| cflow.cs:12:13:12:49 | ...; | cflow.cs:12:31:12:47 | "more than a few" | semmle.label | successor |
-| cflow.cs:12:31:12:47 | "more than a few" | cflow.cs:12:13:12:48 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:14:16:14:16 | access to local variable a | semmle.label | successor |
-| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:14:20:14:20 | 0 | semmle.label | successor |
-| cflow.cs:14:16:14:20 | ... > ... | cflow.cs:15:9:17:9 | {...} | semmle.label | true |
-| cflow.cs:14:16:14:20 | ... > ... | cflow.cs:19:9:22:25 | do ... while (...); | semmle.label | false |
-| cflow.cs:14:20:14:20 | 0 | cflow.cs:14:16:14:20 | ... > ... | semmle.label | successor |
-| cflow.cs:15:9:17:9 | {...} | cflow.cs:16:13:16:41 | ...; | semmle.label | successor |
-| cflow.cs:16:13:16:40 | call to method WriteLine | cflow.cs:14:16:14:16 | access to local variable a | semmle.label | successor |
-| cflow.cs:16:13:16:41 | ...; | cflow.cs:16:31:16:31 | access to local variable a | semmle.label | successor |
-| cflow.cs:16:31:16:31 | access to local variable a | cflow.cs:16:31:16:33 | ...-- | semmle.label | successor |
-| cflow.cs:16:31:16:33 | ...-- | cflow.cs:16:37:16:39 | 100 | semmle.label | successor |
-| cflow.cs:16:31:16:39 | ... * ... | cflow.cs:16:13:16:40 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:16:37:16:39 | 100 | cflow.cs:16:31:16:39 | ... * ... | semmle.label | successor |
-| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:20:9:22:9 | {...} | semmle.label | successor |
-| cflow.cs:20:9:22:9 | {...} | cflow.cs:21:13:21:36 | ...; | semmle.label | successor |
-| cflow.cs:21:13:21:35 | call to method WriteLine | cflow.cs:22:18:22:18 | access to local variable a | semmle.label | successor |
-| cflow.cs:21:13:21:36 | ...; | cflow.cs:21:32:21:32 | access to local variable a | semmle.label | successor |
-| cflow.cs:21:31:21:34 | -... | cflow.cs:21:13:21:35 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:21:32:21:32 | access to local variable a | cflow.cs:21:32:21:34 | ...++ | semmle.label | successor |
-| cflow.cs:21:32:21:34 | ...++ | cflow.cs:21:31:21:34 | -... | semmle.label | successor |
-| cflow.cs:22:18:22:18 | access to local variable a | cflow.cs:22:22:22:23 | 10 | semmle.label | successor |
-| cflow.cs:22:18:22:23 | ... < ... | cflow.cs:20:9:22:9 | {...} | semmle.label | true |
-| cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... | semmle.label | false |
-| cflow.cs:22:22:22:23 | 10 | cflow.cs:22:18:22:23 | ... < ... | semmle.label | successor |
-| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:22:24:22 | 1 | semmle.label | successor |
-| cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i | semmle.label | successor |
-| cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... | semmle.label | successor |
-| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 | semmle.label | successor |
-| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main (normal) | semmle.label | false |
-| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:25:9:34:9 | {...} | semmle.label | true |
-| cflow.cs:24:30:24:31 | 20 | cflow.cs:24:25:24:31 | ... <= ... | semmle.label | successor |
-| cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ | semmle.label | successor |
-| cflow.cs:24:34:24:36 | ...++ | cflow.cs:24:25:24:25 | access to local variable i | semmle.label | successor |
-| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:13:33:37 | if (...) ... | semmle.label | successor |
-| cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:26:17:26:17 | access to local variable i | semmle.label | successor |
-| cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:21:26:21 | 3 | semmle.label | successor |
-| cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:26:26:26 | 0 | semmle.label | successor |
-| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | semmle.label | false |
-| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:31:26:31 | access to local variable i | semmle.label | true |
-| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:28:18:33:37 | if (...) ... | semmle.label | false |
-| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:27:17:27:46 | ...; | semmle.label | true |
-| cflow.cs:26:21:26:21 | 3 | cflow.cs:26:17:26:21 | ... % ... | semmle.label | successor |
-| cflow.cs:26:26:26:26 | 0 | cflow.cs:26:17:26:26 | ... == ... | semmle.label | successor |
-| cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:35:26:35 | 5 | semmle.label | successor |
-| cflow.cs:26:31:26:35 | ... % ... | cflow.cs:26:40:26:40 | 0 | semmle.label | successor |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | semmle.label | false |
-| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [true] ... && ... | semmle.label | true |
-| cflow.cs:26:35:26:35 | 5 | cflow.cs:26:31:26:35 | ... % ... | semmle.label | successor |
-| cflow.cs:26:40:26:40 | 0 | cflow.cs:26:31:26:40 | ... == ... | semmle.label | successor |
-| cflow.cs:27:17:27:45 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i | semmle.label | successor |
-| cflow.cs:27:17:27:46 | ...; | cflow.cs:27:35:27:44 | "FizzBuzz" | semmle.label | successor |
-| cflow.cs:27:35:27:44 | "FizzBuzz" | cflow.cs:27:17:27:45 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:28:22:28:22 | access to local variable i | semmle.label | successor |
-| cflow.cs:28:22:28:22 | access to local variable i | cflow.cs:28:26:28:26 | 3 | semmle.label | successor |
-| cflow.cs:28:22:28:26 | ... % ... | cflow.cs:28:31:28:31 | 0 | semmle.label | successor |
-| cflow.cs:28:22:28:31 | ... == ... | cflow.cs:29:17:29:42 | ...; | semmle.label | true |
-| cflow.cs:28:22:28:31 | ... == ... | cflow.cs:30:18:33:37 | if (...) ... | semmle.label | false |
-| cflow.cs:28:26:28:26 | 3 | cflow.cs:28:22:28:26 | ... % ... | semmle.label | successor |
-| cflow.cs:28:31:28:31 | 0 | cflow.cs:28:22:28:31 | ... == ... | semmle.label | successor |
-| cflow.cs:29:17:29:41 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i | semmle.label | successor |
-| cflow.cs:29:17:29:42 | ...; | cflow.cs:29:35:29:40 | "Fizz" | semmle.label | successor |
-| cflow.cs:29:35:29:40 | "Fizz" | cflow.cs:29:17:29:41 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:30:22:30:22 | access to local variable i | semmle.label | successor |
-| cflow.cs:30:22:30:22 | access to local variable i | cflow.cs:30:26:30:26 | 5 | semmle.label | successor |
-| cflow.cs:30:22:30:26 | ... % ... | cflow.cs:30:31:30:31 | 0 | semmle.label | successor |
-| cflow.cs:30:22:30:31 | ... == ... | cflow.cs:31:17:31:42 | ...; | semmle.label | true |
-| cflow.cs:30:22:30:31 | ... == ... | cflow.cs:33:17:33:37 | ...; | semmle.label | false |
-| cflow.cs:30:26:30:26 | 5 | cflow.cs:30:22:30:26 | ... % ... | semmle.label | successor |
-| cflow.cs:30:31:30:31 | 0 | cflow.cs:30:22:30:31 | ... == ... | semmle.label | successor |
-| cflow.cs:31:17:31:41 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i | semmle.label | successor |
-| cflow.cs:31:17:31:42 | ...; | cflow.cs:31:35:31:40 | "Buzz" | semmle.label | successor |
-| cflow.cs:31:35:31:40 | "Buzz" | cflow.cs:31:17:31:41 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:33:17:33:36 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i | semmle.label | successor |
-| cflow.cs:33:17:33:37 | ...; | cflow.cs:33:35:33:35 | access to local variable i | semmle.label | successor |
-| cflow.cs:33:35:33:35 | access to local variable i | cflow.cs:33:17:33:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:37:17:37:22 | enter Switch | cflow.cs:38:5:68:5 | {...} | semmle.label | successor |
-| cflow.cs:37:17:37:22 | exit Switch (abnormal) | cflow.cs:37:17:37:22 | exit Switch | semmle.label | successor |
-| cflow.cs:37:17:37:22 | exit Switch (normal) | cflow.cs:37:17:37:22 | exit Switch | semmle.label | successor |
-| cflow.cs:38:5:68:5 | {...} | cflow.cs:39:9:50:9 | switch (...) {...} | semmle.label | successor |
-| cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:39:17:39:17 | access to parameter a | semmle.label | successor |
-| cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:41:13:41:19 | case ...: | semmle.label | successor |
-| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:18:41:18 | 1 | semmle.label | successor |
-| cflow.cs:41:18:41:18 | 1 | cflow.cs:42:17:42:39 | ...; | semmle.label | match |
-| cflow.cs:41:18:41:18 | 1 | cflow.cs:44:13:44:19 | case ...: | semmle.label | no-match |
-| cflow.cs:42:17:42:38 | call to method WriteLine | cflow.cs:43:27:43:27 | 2 | semmle.label | successor |
-| cflow.cs:42:17:42:39 | ...; | cflow.cs:42:35:42:37 | "1" | semmle.label | successor |
-| cflow.cs:42:35:42:37 | "1" | cflow.cs:42:17:42:38 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:43:17:43:28 | goto case ...; | cflow.cs:44:13:44:19 | case ...: | semmle.label | goto(2) |
-| cflow.cs:43:27:43:27 | 2 | cflow.cs:43:17:43:28 | goto case ...; | semmle.label | successor |
-| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:18:44:18 | 2 | semmle.label | successor |
-| cflow.cs:44:18:44:18 | 2 | cflow.cs:45:17:45:39 | ...; | semmle.label | match |
-| cflow.cs:44:18:44:18 | 2 | cflow.cs:47:13:47:19 | case ...: | semmle.label | no-match |
-| cflow.cs:45:17:45:38 | call to method WriteLine | cflow.cs:46:27:46:27 | 1 | semmle.label | successor |
-| cflow.cs:45:17:45:39 | ...; | cflow.cs:45:35:45:37 | "2" | semmle.label | successor |
-| cflow.cs:45:35:45:37 | "2" | cflow.cs:45:17:45:38 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:46:17:46:28 | goto case ...; | cflow.cs:41:13:41:19 | case ...: | semmle.label | goto(1) |
-| cflow.cs:46:27:46:27 | 1 | cflow.cs:46:17:46:28 | goto case ...; | semmle.label | successor |
-| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:18:47:18 | 3 | semmle.label | successor |
-| cflow.cs:47:18:47:18 | 3 | cflow.cs:48:17:48:39 | ...; | semmle.label | match |
-| cflow.cs:47:18:47:18 | 3 | cflow.cs:51:9:59:9 | switch (...) {...} | semmle.label | no-match |
-| cflow.cs:48:17:48:38 | call to method WriteLine | cflow.cs:49:17:49:22 | break; | semmle.label | successor |
-| cflow.cs:48:17:48:39 | ...; | cflow.cs:48:35:48:37 | "3" | semmle.label | successor |
-| cflow.cs:48:35:48:37 | "3" | cflow.cs:48:17:48:38 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:49:17:49:22 | break; | cflow.cs:51:9:59:9 | switch (...) {...} | semmle.label | break |
-| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:51:17:51:17 | access to parameter a | semmle.label | successor |
-| cflow.cs:51:17:51:17 | access to parameter a | cflow.cs:53:13:53:20 | case ...: | semmle.label | successor |
-| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:18:53:19 | 42 | semmle.label | successor |
-| cflow.cs:53:18:53:19 | 42 | cflow.cs:54:17:54:48 | ...; | semmle.label | match |
-| cflow.cs:53:18:53:19 | 42 | cflow.cs:56:13:56:20 | default: | semmle.label | no-match |
-| cflow.cs:54:17:54:47 | call to method WriteLine | cflow.cs:55:17:55:22 | break; | semmle.label | successor |
-| cflow.cs:54:17:54:48 | ...; | cflow.cs:54:35:54:46 | "The answer" | semmle.label | successor |
-| cflow.cs:54:35:54:46 | "The answer" | cflow.cs:54:17:54:47 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:55:17:55:22 | break; | cflow.cs:60:9:66:9 | switch (...) {...} | semmle.label | break |
-| cflow.cs:56:13:56:20 | default: | cflow.cs:57:17:57:52 | ...; | semmle.label | successor |
-| cflow.cs:57:17:57:51 | call to method WriteLine | cflow.cs:58:17:58:22 | break; | semmle.label | successor |
-| cflow.cs:57:17:57:52 | ...; | cflow.cs:57:35:57:50 | "Not the answer" | semmle.label | successor |
-| cflow.cs:57:35:57:50 | "Not the answer" | cflow.cs:57:17:57:51 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:58:17:58:22 | break; | cflow.cs:60:9:66:9 | switch (...) {...} | semmle.label | break |
-| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:60:27:60:31 | this access | semmle.label | successor |
-| cflow.cs:60:17:60:32 | call to method Parse | cflow.cs:62:13:62:19 | case ...: | semmle.label | successor |
-| cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:17:60:32 | call to method Parse | semmle.label | successor |
-| cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | access to field Field | semmle.label | successor |
-| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 | semmle.label | successor |
-| cflow.cs:62:18:62:18 | 0 | cflow.cs:63:17:64:55 | if (...) ... | semmle.label | match |
-| cflow.cs:62:18:62:18 | 0 | cflow.cs:67:16:67:16 | access to parameter a | semmle.label | no-match |
-| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:27 | this access | semmle.label | successor |
-| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:65:17:65:22 | break; | semmle.label | false |
-| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | semmle.label | true |
-| cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:32:63:33 | "" | semmle.label | successor |
-| cflow.cs:63:23:63:27 | this access | cflow.cs:63:23:63:27 | access to field Field | semmle.label | successor |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [false] !... | semmle.label | true |
-| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [true] !... | semmle.label | false |
-| cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:33 | ... == ... | semmle.label | successor |
-| cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch (abnormal) | semmle.label | exception(NullReferenceException) |
-| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; | semmle.label | successor |
-| cflow.cs:65:17:65:22 | break; | cflow.cs:67:16:67:16 | access to parameter a | semmle.label | break |
-| cflow.cs:67:9:67:17 | return ...; | cflow.cs:37:17:37:22 | exit Switch (normal) | semmle.label | return |
-| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:9:67:17 | return ...; | semmle.label | successor |
-| cflow.cs:70:18:70:18 | enter M | cflow.cs:71:5:82:5 | {...} | semmle.label | successor |
-| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M | semmle.label | successor |
-| cflow.cs:71:5:82:5 | {...} | cflow.cs:72:9:73:19 | if (...) ... | semmle.label | successor |
-| cflow.cs:72:9:73:19 | if (...) ... | cflow.cs:72:13:72:13 | access to parameter s | semmle.label | successor |
-| cflow.cs:72:13:72:13 | access to parameter s | cflow.cs:72:18:72:21 | null | semmle.label | successor |
-| cflow.cs:72:13:72:21 | ... == ... | cflow.cs:73:13:73:19 | return ...; | semmle.label | true |
-| cflow.cs:72:13:72:21 | ... == ... | cflow.cs:74:9:81:9 | if (...) ... | semmle.label | false |
-| cflow.cs:72:18:72:21 | null | cflow.cs:72:13:72:21 | ... == ... | semmle.label | successor |
-| cflow.cs:73:13:73:19 | return ...; | cflow.cs:70:18:70:18 | exit M (normal) | semmle.label | return |
-| cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:13:74:13 | access to parameter s | semmle.label | successor |
-| cflow.cs:74:13:74:13 | access to parameter s | cflow.cs:74:13:74:20 | access to property Length | semmle.label | successor |
-| cflow.cs:74:13:74:20 | access to property Length | cflow.cs:74:24:74:24 | 0 | semmle.label | successor |
-| cflow.cs:74:13:74:24 | ... > ... | cflow.cs:75:9:77:9 | {...} | semmle.label | true |
-| cflow.cs:74:13:74:24 | ... > ... | cflow.cs:79:9:81:9 | {...} | semmle.label | false |
-| cflow.cs:74:24:74:24 | 0 | cflow.cs:74:13:74:24 | ... > ... | semmle.label | successor |
-| cflow.cs:75:9:77:9 | {...} | cflow.cs:76:13:76:33 | ...; | semmle.label | successor |
-| cflow.cs:76:13:76:32 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M (normal) | semmle.label | successor |
-| cflow.cs:76:13:76:33 | ...; | cflow.cs:76:31:76:31 | access to parameter s | semmle.label | successor |
-| cflow.cs:76:31:76:31 | access to parameter s | cflow.cs:76:13:76:32 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:79:9:81:9 | {...} | cflow.cs:80:13:80:48 | ...; | semmle.label | successor |
-| cflow.cs:80:13:80:47 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M (normal) | semmle.label | successor |
-| cflow.cs:80:13:80:48 | ...; | cflow.cs:80:31:80:46 | "<empty string>" | semmle.label | successor |
-| cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:13:80:47 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:85:5:88:5 | {...} | semmle.label | successor |
-| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 | semmle.label | successor |
-| cflow.cs:85:5:88:5 | {...} | cflow.cs:86:9:87:33 | if (...) ... | semmle.label | successor |
-| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:13 | access to parameter s | semmle.label | successor |
-| cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:18:86:21 | null | semmle.label | successor |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:37 | [false] ... && ... | semmle.label | false |
-| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s | semmle.label | true |
-| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | false |
-| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:87:13:87:33 | ...; | semmle.label | true |
-| cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:21 | ... != ... | semmle.label | successor |
-| cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:33 | access to property Length | semmle.label | successor |
-| cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:37:86:37 | 0 | semmle.label | successor |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [false] ... && ... | semmle.label | false |
-| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [true] ... && ... | semmle.label | true |
-| cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:37 | ... > ... | semmle.label | successor |
-| cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:84:18:84:19 | exit M2 (normal) | semmle.label | successor |
-| cflow.cs:87:13:87:33 | ...; | cflow.cs:87:31:87:31 | access to parameter s | semmle.label | successor |
-| cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:87:13:87:32 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:90:18:90:19 | enter M3 | cflow.cs:91:5:104:5 | {...} | semmle.label | successor |
-| cflow.cs:90:18:90:19 | exit M3 (abnormal) | cflow.cs:90:18:90:19 | exit M3 | semmle.label | successor |
-| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 | semmle.label | successor |
-| cflow.cs:91:5:104:5 | {...} | cflow.cs:92:9:93:49 | if (...) ... | semmle.label | successor |
-| cflow.cs:92:9:93:49 | if (...) ... | cflow.cs:92:20:92:20 | access to parameter s | semmle.label | successor |
-| cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:93:45:93:47 | "s" | semmle.label | true |
-| cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:94:9:94:29 | ...; | semmle.label | false |
-| cflow.cs:92:20:92:20 | access to parameter s | cflow.cs:92:23:92:26 | null | semmle.label | successor |
-| cflow.cs:92:23:92:26 | null | cflow.cs:92:13:92:27 | call to method Equals | semmle.label | successor |
-| cflow.cs:93:13:93:49 | throw ...; | cflow.cs:90:18:90:19 | exit M3 (abnormal) | semmle.label | exception(ArgumentNullException) |
-| cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | cflow.cs:93:13:93:49 | throw ...; | semmle.label | successor |
-| cflow.cs:93:45:93:47 | "s" | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | semmle.label | successor |
-| cflow.cs:94:9:94:28 | call to method WriteLine | cflow.cs:96:9:97:55 | if (...) ... | semmle.label | successor |
-| cflow.cs:94:9:94:29 | ...; | cflow.cs:94:27:94:27 | access to parameter s | semmle.label | successor |
-| cflow.cs:94:27:94:27 | access to parameter s | cflow.cs:94:9:94:28 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:96:9:97:55 | if (...) ... | cflow.cs:96:13:96:17 | this access | semmle.label | successor |
-| cflow.cs:96:13:96:17 | access to field Field | cflow.cs:96:22:96:25 | null | semmle.label | successor |
-| cflow.cs:96:13:96:17 | this access | cflow.cs:96:13:96:17 | access to field Field | semmle.label | successor |
-| cflow.cs:96:13:96:25 | ... != ... | cflow.cs:97:13:97:55 | ...; | semmle.label | true |
-| cflow.cs:96:13:96:25 | ... != ... | cflow.cs:99:9:100:42 | if (...) ... | semmle.label | false |
-| cflow.cs:96:22:96:25 | null | cflow.cs:96:13:96:25 | ... != ... | semmle.label | successor |
-| cflow.cs:97:13:97:54 | call to method WriteLine | cflow.cs:99:9:100:42 | if (...) ... | semmle.label | successor |
-| cflow.cs:97:13:97:55 | ...; | cflow.cs:97:31:97:47 | object creation of type ControlFlow | semmle.label | successor |
-| cflow.cs:97:31:97:47 | object creation of type ControlFlow | cflow.cs:97:31:97:53 | access to field Field | semmle.label | successor |
-| cflow.cs:97:31:97:53 | access to field Field | cflow.cs:97:13:97:54 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:99:13:99:17 | this access | semmle.label | successor |
-| cflow.cs:99:13:99:17 | access to field Field | cflow.cs:99:22:99:25 | null | semmle.label | successor |
-| cflow.cs:99:13:99:17 | this access | cflow.cs:99:13:99:17 | access to field Field | semmle.label | successor |
-| cflow.cs:99:13:99:25 | ... != ... | cflow.cs:100:13:100:42 | ...; | semmle.label | true |
-| cflow.cs:99:13:99:25 | ... != ... | cflow.cs:102:9:103:36 | if (...) ... | semmle.label | false |
-| cflow.cs:99:22:99:25 | null | cflow.cs:99:13:99:25 | ... != ... | semmle.label | successor |
-| cflow.cs:100:13:100:41 | call to method WriteLine | cflow.cs:102:9:103:36 | if (...) ... | semmle.label | successor |
-| cflow.cs:100:13:100:42 | ...; | cflow.cs:100:31:100:34 | this access | semmle.label | successor |
-| cflow.cs:100:31:100:34 | this access | cflow.cs:100:31:100:40 | access to field Field | semmle.label | successor |
-| cflow.cs:100:31:100:40 | access to field Field | cflow.cs:100:13:100:41 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:102:13:102:16 | this access | semmle.label | successor |
-| cflow.cs:102:13:102:16 | this access | cflow.cs:102:13:102:21 | access to property Prop | semmle.label | successor |
-| cflow.cs:102:13:102:21 | access to property Prop | cflow.cs:102:26:102:29 | null | semmle.label | successor |
-| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 (normal) | semmle.label | false |
-| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:103:13:103:36 | ...; | semmle.label | true |
-| cflow.cs:102:26:102:29 | null | cflow.cs:102:13:102:29 | ... != ... | semmle.label | successor |
-| cflow.cs:103:13:103:35 | call to method WriteLine | cflow.cs:90:18:90:19 | exit M3 (normal) | semmle.label | successor |
-| cflow.cs:103:13:103:36 | ...; | cflow.cs:103:31:103:34 | this access | semmle.label | successor |
-| cflow.cs:103:31:103:34 | access to property Prop | cflow.cs:103:13:103:35 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:103:31:103:34 | this access | cflow.cs:103:31:103:34 | access to property Prop | semmle.label | successor |
-| cflow.cs:106:18:106:19 | enter M4 | cflow.cs:107:5:117:5 | {...} | semmle.label | successor |
-| cflow.cs:106:18:106:19 | exit M4 (normal) | cflow.cs:106:18:106:19 | exit M4 | semmle.label | successor |
-| cflow.cs:107:5:117:5 | {...} | cflow.cs:108:9:115:9 | if (...) ... | semmle.label | successor |
-| cflow.cs:108:9:115:9 | if (...) ... | cflow.cs:108:13:108:13 | access to parameter s | semmle.label | successor |
-| cflow.cs:108:13:108:13 | access to parameter s | cflow.cs:108:18:108:21 | null | semmle.label | successor |
-| cflow.cs:108:13:108:21 | ... != ... | cflow.cs:109:9:115:9 | {...} | semmle.label | true |
-| cflow.cs:108:13:108:21 | ... != ... | cflow.cs:116:9:116:29 | ...; | semmle.label | false |
-| cflow.cs:108:18:108:21 | null | cflow.cs:108:13:108:21 | ... != ... | semmle.label | successor |
-| cflow.cs:109:9:115:9 | {...} | cflow.cs:110:13:113:13 | while (...) ... | semmle.label | successor |
-| cflow.cs:110:13:113:13 | while (...) ... | cflow.cs:110:20:110:23 | true | semmle.label | successor |
-| cflow.cs:110:20:110:23 | true | cflow.cs:111:13:113:13 | {...} | semmle.label | true |
-| cflow.cs:111:13:113:13 | {...} | cflow.cs:112:17:112:37 | ...; | semmle.label | successor |
-| cflow.cs:112:17:112:36 | call to method WriteLine | cflow.cs:110:20:110:23 | true | semmle.label | successor |
-| cflow.cs:112:17:112:37 | ...; | cflow.cs:112:35:112:35 | access to parameter s | semmle.label | successor |
-| cflow.cs:112:35:112:35 | access to parameter s | cflow.cs:112:17:112:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:106:18:106:19 | exit M4 (normal) | semmle.label | successor |
-| cflow.cs:116:9:116:29 | ...; | cflow.cs:116:27:116:27 | access to parameter s | semmle.label | successor |
-| cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:119:20:119:21 | enter M5 | cflow.cs:120:5:124:5 | {...} | semmle.label | successor |
-| cflow.cs:119:20:119:21 | exit M5 (normal) | cflow.cs:119:20:119:21 | exit M5 | semmle.label | successor |
-| cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; | semmle.label | successor |
-| cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s | semmle.label | successor |
-| cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; | semmle.label | successor |
-| cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:13:121:17 | String x = ... | semmle.label | successor |
-| cflow.cs:122:9:122:19 | ... = ... | cflow.cs:123:16:123:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:122:9:122:20 | ...; | cflow.cs:122:13:122:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " | semmle.label | successor |
-| cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... | semmle.label | successor |
-| cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... | semmle.label | successor |
-| cflow.cs:123:9:123:17 | return ...; | cflow.cs:119:20:119:21 | exit M5 (normal) | semmle.label | return |
-| cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:9:123:17 | return ...; | semmle.label | successor |
-| cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:23:127:60 | {...} | semmle.label | successor |
-| cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | exit get_Prop | semmle.label | successor |
-| cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:36 | this access | semmle.label | successor |
-| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop (normal) | semmle.label | return |
-| cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:41:127:44 | null | semmle.label | successor |
-| cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | access to field Field | semmle.label | successor |
-| cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:48:127:49 | "" | semmle.label | true |
-| cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:53:127:57 | this access | semmle.label | false |
-| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:25:127:58 | return ...; | semmle.label | successor |
-| cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:44 | ... == ... | semmle.label | successor |
-| cflow.cs:127:48:127:49 | "" | cflow.cs:127:32:127:57 | ... ? ... : ... | semmle.label | successor |
-| cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:32:127:57 | ... ? ... : ... | semmle.label | successor |
-| cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field | semmle.label | successor |
-| cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} | semmle.label | successor |
-| cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:62:127:64 | exit set_Prop | semmle.label | successor |
-| cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; | semmle.label | successor |
-| cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value | semmle.label | successor |
-| cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop (normal) | semmle.label | successor |
-| cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access | semmle.label | successor |
-| cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... | semmle.label | successor |
-| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:130:5:132:5 | {...} | semmle.label | successor |
-| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | call to constructor Object | semmle.label | successor |
-| cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | exit ControlFlow | semmle.label | successor |
-| cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; | semmle.label | successor |
-| cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s | semmle.label | successor |
-| cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow (normal) | semmle.label | successor |
-| cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access | semmle.label | successor |
-| cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... | semmle.label | successor |
-| cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:31:134:31 | access to parameter i | semmle.label | successor |
-| cflow.cs:134:5:134:15 | exit ControlFlow (normal) | cflow.cs:134:5:134:15 | exit ControlFlow | semmle.label | successor |
-| cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:39:134:41 | {...} | semmle.label | successor |
-| cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:35:134:36 | "" | semmle.label | successor |
-| cflow.cs:134:31:134:31 | access to parameter i | cflow.cs:134:31:134:31 | (...) ... | semmle.label | successor |
-| cflow.cs:134:31:134:36 | ... + ... | cflow.cs:134:26:134:29 | call to constructor ControlFlow | semmle.label | successor |
-| cflow.cs:134:35:134:36 | "" | cflow.cs:134:31:134:36 | ... + ... | semmle.label | successor |
-| cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | exit ControlFlow (normal) | semmle.label | successor |
-| cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:33:136:33 | 0 | semmle.label | successor |
-| cflow.cs:136:12:136:22 | exit ControlFlow (normal) | cflow.cs:136:12:136:22 | exit ControlFlow | semmle.label | successor |
-| cflow.cs:136:28:136:31 | call to constructor ControlFlow | cflow.cs:136:40:136:42 | {...} | semmle.label | successor |
-| cflow.cs:136:33:136:33 | 0 | cflow.cs:136:37:136:37 | 1 | semmle.label | successor |
-| cflow.cs:136:33:136:37 | ... + ... | cflow.cs:136:28:136:31 | call to constructor ControlFlow | semmle.label | successor |
-| cflow.cs:136:37:136:37 | 1 | cflow.cs:136:33:136:37 | ... + ... | semmle.label | successor |
-| cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | exit ControlFlow (normal) | semmle.label | successor |
-| cflow.cs:138:40:138:40 | enter + | cflow.cs:139:5:142:5 | {...} | semmle.label | successor |
-| cflow.cs:138:40:138:40 | exit + (normal) | cflow.cs:138:40:138:40 | exit + | semmle.label | successor |
-| cflow.cs:139:5:142:5 | {...} | cflow.cs:140:9:140:29 | ...; | semmle.label | successor |
-| cflow.cs:140:9:140:28 | call to method WriteLine | cflow.cs:141:16:141:16 | access to parameter y | semmle.label | successor |
-| cflow.cs:140:9:140:29 | ...; | cflow.cs:140:27:140:27 | access to parameter x | semmle.label | successor |
-| cflow.cs:140:27:140:27 | access to parameter x | cflow.cs:140:9:140:28 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:141:9:141:17 | return ...; | cflow.cs:138:40:138:40 | exit + (normal) | semmle.label | return |
-| cflow.cs:141:16:141:16 | access to parameter y | cflow.cs:141:9:141:17 | return ...; | semmle.label | successor |
-| cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:37:144:54 | {...} | semmle.label | successor |
-| cflow.cs:144:33:144:35 | exit get_Item (normal) | cflow.cs:144:33:144:35 | exit get_Item | semmle.label | successor |
-| cflow.cs:144:37:144:54 | {...} | cflow.cs:144:46:144:46 | access to parameter i | semmle.label | successor |
-| cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | exit get_Item (normal) | semmle.label | return |
-| cflow.cs:144:46:144:46 | (...) ... | cflow.cs:144:50:144:51 | "" | semmle.label | successor |
-| cflow.cs:144:46:144:46 | access to parameter i | cflow.cs:144:46:144:46 | (...) ... | semmle.label | successor |
-| cflow.cs:144:46:144:51 | ... + ... | cflow.cs:144:39:144:52 | return ...; | semmle.label | successor |
-| cflow.cs:144:50:144:51 | "" | cflow.cs:144:46:144:51 | ... + ... | semmle.label | successor |
-| cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:60:144:62 | {...} | semmle.label | successor |
-| cflow.cs:144:56:144:58 | exit set_Item (normal) | cflow.cs:144:56:144:58 | exit set_Item | semmle.label | successor |
-| cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | exit set_Item (normal) | semmle.label | successor |
-| cflow.cs:146:10:146:12 | enter For | cflow.cs:147:5:177:5 | {...} | semmle.label | successor |
-| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For | semmle.label | successor |
-| cflow.cs:147:5:177:5 | {...} | cflow.cs:148:9:148:18 | ... ...; | semmle.label | successor |
-| cflow.cs:148:9:148:18 | ... ...; | cflow.cs:148:17:148:17 | 0 | semmle.label | successor |
-| cflow.cs:148:13:148:17 | Int32 x = ... | cflow.cs:149:9:150:33 | for (...;...;...) ... | semmle.label | successor |
-| cflow.cs:148:17:148:17 | 0 | cflow.cs:148:13:148:17 | Int32 x = ... | semmle.label | successor |
-| cflow.cs:149:9:150:33 | for (...;...;...) ... | cflow.cs:149:16:149:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:149:20:149:21 | 10 | semmle.label | successor |
-| cflow.cs:149:16:149:21 | ... < ... | cflow.cs:150:13:150:33 | ...; | semmle.label | true |
-| cflow.cs:149:16:149:21 | ... < ... | cflow.cs:152:9:157:9 | for (...;...;...) ... | semmle.label | false |
-| cflow.cs:149:20:149:21 | 10 | cflow.cs:149:16:149:21 | ... < ... | semmle.label | successor |
-| cflow.cs:149:24:149:26 | ++... | cflow.cs:149:16:149:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:149:26:149:26 | access to local variable x | cflow.cs:149:24:149:26 | ++... | semmle.label | successor |
-| cflow.cs:150:13:150:32 | call to method WriteLine | cflow.cs:149:26:149:26 | access to local variable x | semmle.label | successor |
-| cflow.cs:150:13:150:33 | ...; | cflow.cs:150:31:150:31 | access to local variable x | semmle.label | successor |
-| cflow.cs:150:31:150:31 | access to local variable x | cflow.cs:150:13:150:32 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:153:9:157:9 | {...} | semmle.label | successor |
-| cflow.cs:152:18:152:18 | access to local variable x | cflow.cs:152:18:152:20 | ...++ | semmle.label | successor |
-| cflow.cs:152:18:152:20 | ...++ | cflow.cs:153:9:157:9 | {...} | semmle.label | successor |
-| cflow.cs:153:9:157:9 | {...} | cflow.cs:154:13:154:33 | ...; | semmle.label | successor |
-| cflow.cs:154:13:154:32 | call to method WriteLine | cflow.cs:155:13:156:22 | if (...) ... | semmle.label | successor |
-| cflow.cs:154:13:154:33 | ...; | cflow.cs:154:31:154:31 | access to local variable x | semmle.label | successor |
-| cflow.cs:154:31:154:31 | access to local variable x | cflow.cs:154:13:154:32 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:155:13:156:22 | if (...) ... | cflow.cs:155:17:155:17 | access to local variable x | semmle.label | successor |
-| cflow.cs:155:17:155:17 | access to local variable x | cflow.cs:155:21:155:22 | 20 | semmle.label | successor |
-| cflow.cs:155:17:155:22 | ... > ... | cflow.cs:152:18:152:18 | access to local variable x | semmle.label | false |
-| cflow.cs:155:17:155:22 | ... > ... | cflow.cs:156:17:156:22 | break; | semmle.label | true |
-| cflow.cs:155:21:155:22 | 20 | cflow.cs:155:17:155:22 | ... > ... | semmle.label | successor |
-| cflow.cs:156:17:156:22 | break; | cflow.cs:159:9:165:9 | for (...;...;...) ... | semmle.label | break |
-| cflow.cs:159:9:165:9 | for (...;...;...) ... | cflow.cs:160:9:165:9 | {...} | semmle.label | successor |
-| cflow.cs:160:9:165:9 | {...} | cflow.cs:161:13:161:33 | ...; | semmle.label | successor |
-| cflow.cs:161:13:161:32 | call to method WriteLine | cflow.cs:162:13:162:16 | ...; | semmle.label | successor |
-| cflow.cs:161:13:161:33 | ...; | cflow.cs:161:31:161:31 | access to local variable x | semmle.label | successor |
-| cflow.cs:161:31:161:31 | access to local variable x | cflow.cs:161:13:161:32 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:162:13:162:13 | access to local variable x | cflow.cs:162:13:162:15 | ...++ | semmle.label | successor |
-| cflow.cs:162:13:162:15 | ...++ | cflow.cs:163:13:164:22 | if (...) ... | semmle.label | successor |
-| cflow.cs:162:13:162:16 | ...; | cflow.cs:162:13:162:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:163:13:164:22 | if (...) ... | cflow.cs:163:17:163:17 | access to local variable x | semmle.label | successor |
-| cflow.cs:163:17:163:17 | access to local variable x | cflow.cs:163:21:163:22 | 30 | semmle.label | successor |
-| cflow.cs:163:17:163:22 | ... > ... | cflow.cs:160:9:165:9 | {...} | semmle.label | false |
-| cflow.cs:163:17:163:22 | ... > ... | cflow.cs:164:17:164:22 | break; | semmle.label | true |
-| cflow.cs:163:21:163:22 | 30 | cflow.cs:163:17:163:22 | ... > ... | semmle.label | successor |
-| cflow.cs:164:17:164:22 | break; | cflow.cs:167:9:171:9 | for (...;...;...) ... | semmle.label | break |
-| cflow.cs:167:9:171:9 | for (...;...;...) ... | cflow.cs:167:16:167:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:167:20:167:21 | 40 | semmle.label | successor |
-| cflow.cs:167:16:167:21 | ... < ... | cflow.cs:168:9:171:9 | {...} | semmle.label | true |
-| cflow.cs:167:16:167:21 | ... < ... | cflow.cs:173:9:176:9 | for (...;...;...) ... | semmle.label | false |
-| cflow.cs:167:20:167:21 | 40 | cflow.cs:167:16:167:21 | ... < ... | semmle.label | successor |
-| cflow.cs:168:9:171:9 | {...} | cflow.cs:169:13:169:33 | ...; | semmle.label | successor |
-| cflow.cs:169:13:169:32 | call to method WriteLine | cflow.cs:170:13:170:16 | ...; | semmle.label | successor |
-| cflow.cs:169:13:169:33 | ...; | cflow.cs:169:31:169:31 | access to local variable x | semmle.label | successor |
-| cflow.cs:169:31:169:31 | access to local variable x | cflow.cs:169:13:169:32 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:170:13:170:13 | access to local variable x | cflow.cs:170:13:170:15 | ...++ | semmle.label | successor |
-| cflow.cs:170:13:170:15 | ...++ | cflow.cs:167:16:167:16 | access to local variable x | semmle.label | successor |
-| cflow.cs:170:13:170:16 | ...; | cflow.cs:170:13:170:13 | access to local variable x | semmle.label | successor |
-| cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:173:22:173:22 | 0 | semmle.label | successor |
-| cflow.cs:173:18:173:22 | Int32 i = ... | cflow.cs:173:29:173:29 | 0 | semmle.label | successor |
-| cflow.cs:173:22:173:22 | 0 | cflow.cs:173:18:173:22 | Int32 i = ... | semmle.label | successor |
-| cflow.cs:173:25:173:29 | Int32 j = ... | cflow.cs:173:32:173:32 | access to local variable i | semmle.label | successor |
-| cflow.cs:173:29:173:29 | 0 | cflow.cs:173:25:173:29 | Int32 j = ... | semmle.label | successor |
-| cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:173:36:173:36 | access to local variable j | semmle.label | successor |
-| cflow.cs:173:32:173:36 | ... + ... | cflow.cs:173:40:173:41 | 10 | semmle.label | successor |
-| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For (normal) | semmle.label | false |
-| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:174:9:176:9 | {...} | semmle.label | true |
-| cflow.cs:173:36:173:36 | access to local variable j | cflow.cs:173:32:173:36 | ... + ... | semmle.label | successor |
-| cflow.cs:173:40:173:41 | 10 | cflow.cs:173:32:173:41 | ... < ... | semmle.label | successor |
-| cflow.cs:173:44:173:44 | access to local variable i | cflow.cs:173:44:173:46 | ...++ | semmle.label | successor |
-| cflow.cs:173:44:173:46 | ...++ | cflow.cs:173:49:173:49 | access to local variable j | semmle.label | successor |
-| cflow.cs:173:49:173:49 | access to local variable j | cflow.cs:173:49:173:51 | ...++ | semmle.label | successor |
-| cflow.cs:173:49:173:51 | ...++ | cflow.cs:173:32:173:32 | access to local variable i | semmle.label | successor |
-| cflow.cs:174:9:176:9 | {...} | cflow.cs:175:13:175:37 | ...; | semmle.label | successor |
-| cflow.cs:175:13:175:36 | call to method WriteLine | cflow.cs:173:44:173:44 | access to local variable i | semmle.label | successor |
-| cflow.cs:175:13:175:37 | ...; | cflow.cs:175:31:175:31 | access to local variable i | semmle.label | successor |
-| cflow.cs:175:31:175:31 | access to local variable i | cflow.cs:175:35:175:35 | access to local variable j | semmle.label | successor |
-| cflow.cs:175:31:175:35 | ... + ... | cflow.cs:175:13:175:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:175:35:175:35 | access to local variable j | cflow.cs:175:31:175:35 | ... + ... | semmle.label | successor |
-| cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:180:5:183:5 | {...} | semmle.label | successor |
-| cflow.cs:179:10:179:16 | exit Lambdas (normal) | cflow.cs:179:10:179:16 | exit Lambdas | semmle.label | successor |
-| cflow.cs:180:5:183:5 | {...} | cflow.cs:181:9:181:38 | ... ...; | semmle.label | successor |
-| cflow.cs:181:9:181:38 | ... ...; | cflow.cs:181:28:181:37 | (...) => ... | semmle.label | successor |
-| cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | cflow.cs:182:9:182:62 | ... ...; | semmle.label | successor |
-| cflow.cs:181:28:181:37 | (...) => ... | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | semmle.label | successor |
-| cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:33:181:33 | access to parameter x | semmle.label | successor |
-| cflow.cs:181:28:181:37 | exit (...) => ... (normal) | cflow.cs:181:28:181:37 | exit (...) => ... | semmle.label | successor |
-| cflow.cs:181:33:181:33 | access to parameter x | cflow.cs:181:37:181:37 | 1 | semmle.label | successor |
-| cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | exit (...) => ... (normal) | semmle.label | successor |
-| cflow.cs:181:37:181:37 | 1 | cflow.cs:181:33:181:37 | ... + ... | semmle.label | successor |
-| cflow.cs:182:9:182:62 | ... ...; | cflow.cs:182:28:182:61 | delegate(...) { ... } | semmle.label | successor |
-| cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:179:10:179:16 | exit Lambdas (normal) | semmle.label | successor |
-| cflow.cs:182:28:182:61 | delegate(...) { ... } | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | semmle.label | successor |
-| cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:45:182:61 | {...} | semmle.label | successor |
-| cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | cflow.cs:182:28:182:61 | exit delegate(...) { ... } | semmle.label | successor |
-| cflow.cs:182:45:182:61 | {...} | cflow.cs:182:54:182:54 | access to parameter x | semmle.label | successor |
-| cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | semmle.label | return |
-| cflow.cs:182:54:182:54 | access to parameter x | cflow.cs:182:58:182:58 | 1 | semmle.label | successor |
-| cflow.cs:182:54:182:58 | ... + ... | cflow.cs:182:47:182:59 | return ...; | semmle.label | successor |
-| cflow.cs:182:58:182:58 | 1 | cflow.cs:182:54:182:58 | ... + ... | semmle.label | successor |
-| cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:186:5:191:5 | {...} | semmle.label | successor |
-| cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | exit LogicalOr | semmle.label | successor |
-| cflow.cs:186:5:191:5 | {...} | cflow.cs:187:9:190:52 | if (...) ... | semmle.label | successor |
-| cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:13 | 1 | semmle.label | successor |
-| cflow.cs:187:13:187:13 | 1 | cflow.cs:187:18:187:18 | 2 | semmle.label | successor |
-| cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:23:187:23 | 2 | semmle.label | false |
-| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:187:34:187:34 | 1 | semmle.label | false |
-| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:190:13:190:52 | ...; | semmle.label | false |
-| cflow.cs:187:18:187:18 | 2 | cflow.cs:187:13:187:18 | ... == ... | semmle.label | successor |
-| cflow.cs:187:23:187:23 | 2 | cflow.cs:187:28:187:28 | 3 | semmle.label | successor |
-| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:13:187:28 | [false] ... \|\| ... | semmle.label | false |
-| cflow.cs:187:28:187:28 | 3 | cflow.cs:187:23:187:28 | ... == ... | semmle.label | successor |
-| cflow.cs:187:34:187:34 | 1 | cflow.cs:187:39:187:39 | 3 | semmle.label | successor |
-| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:49 | [false] ... && ... | semmle.label | false |
-| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:187:13:187:50 | [false] ... \|\| ... | semmle.label | false |
-| cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:39 | ... == ... | semmle.label | successor |
-| cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr (normal) | semmle.label | successor |
-| cflow.cs:190:13:190:52 | ...; | cflow.cs:190:31:190:50 | "This should happen" | semmle.label | successor |
-| cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:51 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:194:5:206:5 | {...} | semmle.label | successor |
-| cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | successor |
-| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans | semmle.label | successor |
-| cflow.cs:194:5:206:5 | {...} | cflow.cs:195:9:195:57 | ... ...; | semmle.label | successor |
-| cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:21 | this access | semmle.label | successor |
-| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:9:198:49 | if (...) ... | semmle.label | successor |
-| cflow.cs:195:17:195:21 | access to field Field | cflow.cs:195:17:195:28 | access to property Length | semmle.label | successor |
-| cflow.cs:195:17:195:21 | this access | cflow.cs:195:17:195:21 | access to field Field | semmle.label | successor |
-| cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:32:195:32 | 0 | semmle.label | successor |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:56 | ... && ... | semmle.label | false |
-| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:39:195:43 | this access | semmle.label | true |
-| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:13:195:56 | Boolean b = ... | semmle.label | successor |
-| cflow.cs:195:32:195:32 | 0 | cflow.cs:195:17:195:32 | ... > ... | semmle.label | successor |
-| cflow.cs:195:37:195:56 | !... | cflow.cs:195:17:195:56 | ... && ... | semmle.label | successor |
-| cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:50 | access to property Length | semmle.label | successor |
-| cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | access to field Field | semmle.label | successor |
-| cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:55:195:55 | 1 | semmle.label | successor |
-| cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:37:195:56 | !... | semmle.label | successor |
-| cflow.cs:195:55:195:55 | 1 | cflow.cs:195:39:195:55 | ... == ... | semmle.label | successor |
-| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:15:197:19 | this access | semmle.label | successor |
-| cflow.cs:197:13:197:47 | [false] !... | cflow.cs:200:9:205:9 | if (...) ... | semmle.label | false |
-| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:198:13:198:49 | ...; | semmle.label | true |
-| cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:26 | access to property Length | semmle.label | successor |
-| cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:19 | access to field Field | semmle.label | successor |
-| cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:31:197:31 | 0 | semmle.label | successor |
-| cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:35:197:39 | false | semmle.label | true |
-| cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:43:197:46 | true | semmle.label | false |
-| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:197:13:197:47 | [true] !... | semmle.label | false |
-| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:197:13:197:47 | [false] !... | semmle.label | true |
-| cflow.cs:197:31:197:31 | 0 | cflow.cs:197:15:197:31 | ... == ... | semmle.label | successor |
-| cflow.cs:197:35:197:39 | false | cflow.cs:197:15:197:46 | [false] ... ? ... : ... | semmle.label | false |
-| cflow.cs:197:43:197:46 | true | cflow.cs:197:15:197:46 | [true] ... ? ... : ... | semmle.label | true |
-| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:200:9:205:9 | if (...) ... | semmle.label | successor |
-| cflow.cs:198:13:198:49 | ...; | cflow.cs:198:17:198:21 | this access | semmle.label | successor |
-| cflow.cs:198:17:198:21 | access to field Field | cflow.cs:198:17:198:28 | access to property Length | semmle.label | successor |
-| cflow.cs:198:17:198:21 | this access | cflow.cs:198:17:198:21 | access to field Field | semmle.label | successor |
-| cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:33:198:33 | 0 | semmle.label | successor |
-| cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:37:198:41 | false | semmle.label | true |
-| cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:45:198:48 | true | semmle.label | false |
-| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:13:198:48 | ... = ... | semmle.label | successor |
-| cflow.cs:198:33:198:33 | 0 | cflow.cs:198:17:198:33 | ... == ... | semmle.label | successor |
-| cflow.cs:198:37:198:41 | false | cflow.cs:198:17:198:48 | ... ? ... : ... | semmle.label | successor |
-| cflow.cs:198:45:198:48 | true | cflow.cs:198:17:198:48 | ... ? ... : ... | semmle.label | successor |
-| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:19 | this access | semmle.label | successor |
-| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:44 | this access | semmle.label | false |
-| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | semmle.label | true |
-| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | semmle.label | false |
-| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:201:9:205:9 | {...} | semmle.label | true |
-| cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:26 | access to property Length | semmle.label | successor |
-| cflow.cs:200:15:200:19 | this access | cflow.cs:200:15:200:19 | access to field Field | semmle.label | successor |
-| cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:31:200:31 | 0 | semmle.label | successor |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [false] !... | semmle.label | true |
-| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [true] !... | semmle.label | false |
-| cflow.cs:200:31:200:31 | 0 | cflow.cs:200:15:200:31 | ... == ... | semmle.label | successor |
-| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:200:13:200:62 | [false] ... \|\| ... | semmle.label | false |
-| cflow.cs:200:37:200:62 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | semmle.label | true |
-| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:200:37:200:62 | [true] !... | semmle.label | false |
-| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:200:37:200:62 | [false] !... | semmle.label | true |
-| cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:51 | access to property Length | semmle.label | successor |
-| cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | access to field Field | semmle.label | successor |
-| cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:56:200:56 | 1 | semmle.label | successor |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:61 | [false] ... && ... | semmle.label | false |
-| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b | semmle.label | true |
-| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:38:200:62 | [true] !... | semmle.label | false |
-| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:38:200:62 | [false] !... | semmle.label | true |
-| cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:56 | ... == ... | semmle.label | successor |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [false] ... && ... | semmle.label | false |
-| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... | semmle.label | true |
-| cflow.cs:201:9:205:9 | {...} | cflow.cs:202:13:204:13 | {...} | semmle.label | successor |
-| cflow.cs:202:13:204:13 | {...} | cflow.cs:203:23:203:37 | object creation of type Exception | semmle.label | successor |
-| cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | semmle.label | exception(Exception) |
-| cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:203:17:203:38 | throw ...; | semmle.label | successor |
-| cflow.cs:208:10:208:11 | enter Do | cflow.cs:209:5:222:5 | {...} | semmle.label | successor |
-| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do | semmle.label | successor |
-| cflow.cs:209:5:222:5 | {...} | cflow.cs:210:9:221:36 | do ... while (...); | semmle.label | successor |
-| cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:211:9:221:9 | {...} | semmle.label | successor |
-| cflow.cs:211:9:221:9 | {...} | cflow.cs:212:13:212:25 | ...; | semmle.label | successor |
-| cflow.cs:212:13:212:17 | access to field Field | cflow.cs:212:22:212:24 | "a" | semmle.label | successor |
-| cflow.cs:212:13:212:17 | this access | cflow.cs:212:13:212:17 | access to field Field | semmle.label | successor |
-| cflow.cs:212:13:212:17 | this access | cflow.cs:212:13:212:17 | this access | semmle.label | successor |
-| cflow.cs:212:13:212:24 | ... + ... | cflow.cs:212:13:212:24 | ... = ... | semmle.label | successor |
-| cflow.cs:212:13:212:24 | ... = ... | cflow.cs:213:13:216:13 | if (...) ... | semmle.label | successor |
-| cflow.cs:212:13:212:25 | ...; | cflow.cs:212:13:212:17 | this access | semmle.label | successor |
-| cflow.cs:212:22:212:24 | "a" | cflow.cs:212:13:212:24 | ... + ... | semmle.label | successor |
-| cflow.cs:213:13:216:13 | if (...) ... | cflow.cs:213:17:213:21 | this access | semmle.label | successor |
-| cflow.cs:213:17:213:21 | access to field Field | cflow.cs:213:17:213:28 | access to property Length | semmle.label | successor |
-| cflow.cs:213:17:213:21 | this access | cflow.cs:213:17:213:21 | access to field Field | semmle.label | successor |
-| cflow.cs:213:17:213:28 | access to property Length | cflow.cs:213:32:213:32 | 0 | semmle.label | successor |
-| cflow.cs:213:17:213:32 | ... > ... | cflow.cs:214:13:216:13 | {...} | semmle.label | true |
-| cflow.cs:213:17:213:32 | ... > ... | cflow.cs:217:13:220:13 | if (...) ... | semmle.label | false |
-| cflow.cs:213:32:213:32 | 0 | cflow.cs:213:17:213:32 | ... > ... | semmle.label | successor |
-| cflow.cs:214:13:216:13 | {...} | cflow.cs:215:17:215:25 | continue; | semmle.label | successor |
-| cflow.cs:215:17:215:25 | continue; | cflow.cs:221:18:221:22 | this access | semmle.label | continue |
-| cflow.cs:217:13:220:13 | if (...) ... | cflow.cs:217:17:217:21 | this access | semmle.label | successor |
-| cflow.cs:217:17:217:21 | access to field Field | cflow.cs:217:17:217:28 | access to property Length | semmle.label | successor |
-| cflow.cs:217:17:217:21 | this access | cflow.cs:217:17:217:21 | access to field Field | semmle.label | successor |
-| cflow.cs:217:17:217:28 | access to property Length | cflow.cs:217:32:217:32 | 0 | semmle.label | successor |
-| cflow.cs:217:17:217:32 | ... < ... | cflow.cs:218:13:220:13 | {...} | semmle.label | true |
-| cflow.cs:217:17:217:32 | ... < ... | cflow.cs:221:18:221:22 | this access | semmle.label | false |
-| cflow.cs:217:32:217:32 | 0 | cflow.cs:217:17:217:32 | ... < ... | semmle.label | successor |
-| cflow.cs:218:13:220:13 | {...} | cflow.cs:219:17:219:22 | break; | semmle.label | successor |
-| cflow.cs:219:17:219:22 | break; | cflow.cs:208:10:208:11 | exit Do (normal) | semmle.label | break |
-| cflow.cs:221:18:221:22 | access to field Field | cflow.cs:221:18:221:29 | access to property Length | semmle.label | successor |
-| cflow.cs:221:18:221:22 | this access | cflow.cs:221:18:221:22 | access to field Field | semmle.label | successor |
-| cflow.cs:221:18:221:29 | access to property Length | cflow.cs:221:33:221:34 | 10 | semmle.label | successor |
-| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:208:10:208:11 | exit Do (normal) | semmle.label | false |
-| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:211:9:221:9 | {...} | semmle.label | true |
-| cflow.cs:221:33:221:34 | 10 | cflow.cs:221:18:221:34 | ... < ... | semmle.label | successor |
-| cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:225:5:238:5 | {...} | semmle.label | successor |
-| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach | semmle.label | successor |
-| cflow.cs:225:5:238:5 | {...} | cflow.cs:226:57:226:59 | "a" | semmle.label | successor |
-| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach (normal) | semmle.label | empty |
-| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:22:226:22 | String x | semmle.label | non-empty |
-| cflow.cs:226:22:226:22 | String x | cflow.cs:227:9:237:9 | {...} | semmle.label | successor |
-| cflow.cs:226:27:226:64 | call to method Repeat | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| cflow.cs:226:57:226:59 | "a" | cflow.cs:226:62:226:63 | 10 | semmle.label | successor |
-| cflow.cs:226:62:226:63 | 10 | cflow.cs:226:27:226:64 | call to method Repeat | semmle.label | successor |
-| cflow.cs:227:9:237:9 | {...} | cflow.cs:228:13:228:23 | ...; | semmle.label | successor |
-| cflow.cs:228:13:228:17 | access to field Field | cflow.cs:228:22:228:22 | access to local variable x | semmle.label | successor |
-| cflow.cs:228:13:228:17 | this access | cflow.cs:228:13:228:17 | access to field Field | semmle.label | successor |
-| cflow.cs:228:13:228:17 | this access | cflow.cs:228:13:228:17 | this access | semmle.label | successor |
-| cflow.cs:228:13:228:22 | ... + ... | cflow.cs:228:13:228:22 | ... = ... | semmle.label | successor |
-| cflow.cs:228:13:228:22 | ... = ... | cflow.cs:229:13:232:13 | if (...) ... | semmle.label | successor |
-| cflow.cs:228:13:228:23 | ...; | cflow.cs:228:13:228:17 | this access | semmle.label | successor |
-| cflow.cs:228:22:228:22 | access to local variable x | cflow.cs:228:13:228:22 | ... + ... | semmle.label | successor |
-| cflow.cs:229:13:232:13 | if (...) ... | cflow.cs:229:17:229:21 | this access | semmle.label | successor |
-| cflow.cs:229:17:229:21 | access to field Field | cflow.cs:229:17:229:28 | access to property Length | semmle.label | successor |
-| cflow.cs:229:17:229:21 | this access | cflow.cs:229:17:229:21 | access to field Field | semmle.label | successor |
-| cflow.cs:229:17:229:28 | access to property Length | cflow.cs:229:32:229:32 | 0 | semmle.label | successor |
-| cflow.cs:229:17:229:32 | ... > ... | cflow.cs:230:13:232:13 | {...} | semmle.label | true |
-| cflow.cs:229:17:229:32 | ... > ... | cflow.cs:233:13:236:13 | if (...) ... | semmle.label | false |
-| cflow.cs:229:32:229:32 | 0 | cflow.cs:229:17:229:32 | ... > ... | semmle.label | successor |
-| cflow.cs:230:13:232:13 | {...} | cflow.cs:231:17:231:25 | continue; | semmle.label | successor |
-| cflow.cs:231:17:231:25 | continue; | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | semmle.label | continue |
-| cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:233:17:233:21 | this access | semmle.label | successor |
-| cflow.cs:233:17:233:21 | access to field Field | cflow.cs:233:17:233:28 | access to property Length | semmle.label | successor |
-| cflow.cs:233:17:233:21 | this access | cflow.cs:233:17:233:21 | access to field Field | semmle.label | successor |
-| cflow.cs:233:17:233:28 | access to property Length | cflow.cs:233:32:233:32 | 0 | semmle.label | successor |
-| cflow.cs:233:17:233:32 | ... < ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | semmle.label | false |
-| cflow.cs:233:17:233:32 | ... < ... | cflow.cs:234:13:236:13 | {...} | semmle.label | true |
-| cflow.cs:233:32:233:32 | 0 | cflow.cs:233:17:233:32 | ... < ... | semmle.label | successor |
-| cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; | semmle.label | successor |
-| cflow.cs:235:17:235:22 | break; | cflow.cs:224:10:224:16 | exit Foreach (normal) | semmle.label | break |
-| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:241:5:259:5 | {...} | semmle.label | successor |
-| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto | semmle.label | successor |
-| cflow.cs:241:5:259:5 | {...} | cflow.cs:242:9:242:13 | Label: | semmle.label | successor |
-| cflow.cs:242:9:242:13 | Label: | cflow.cs:242:16:242:45 | if (...) ... | semmle.label | successor |
-| cflow.cs:242:16:242:45 | if (...) ... | cflow.cs:242:23:242:27 | this access | semmle.label | successor |
-| cflow.cs:242:20:242:40 | [false] !... | cflow.cs:244:9:244:41 | if (...) ... | semmle.label | false |
-| cflow.cs:242:20:242:40 | [true] !... | cflow.cs:242:43:242:45 | {...} | semmle.label | true |
-| cflow.cs:242:21:242:40 | [false] !... | cflow.cs:242:20:242:40 | [true] !... | semmle.label | false |
-| cflow.cs:242:21:242:40 | [true] !... | cflow.cs:242:20:242:40 | [false] !... | semmle.label | true |
-| cflow.cs:242:23:242:27 | access to field Field | cflow.cs:242:23:242:34 | access to property Length | semmle.label | successor |
-| cflow.cs:242:23:242:27 | this access | cflow.cs:242:23:242:27 | access to field Field | semmle.label | successor |
-| cflow.cs:242:23:242:34 | access to property Length | cflow.cs:242:39:242:39 | 0 | semmle.label | successor |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [false] !... | semmle.label | true |
-| cflow.cs:242:23:242:39 | ... == ... | cflow.cs:242:21:242:40 | [true] !... | semmle.label | false |
-| cflow.cs:242:39:242:39 | 0 | cflow.cs:242:23:242:39 | ... == ... | semmle.label | successor |
-| cflow.cs:242:43:242:45 | {...} | cflow.cs:244:9:244:41 | if (...) ... | semmle.label | successor |
-| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:13:244:17 | this access | semmle.label | successor |
-| cflow.cs:244:13:244:17 | access to field Field | cflow.cs:244:13:244:24 | access to property Length | semmle.label | successor |
-| cflow.cs:244:13:244:17 | this access | cflow.cs:244:13:244:17 | access to field Field | semmle.label | successor |
-| cflow.cs:244:13:244:24 | access to property Length | cflow.cs:244:28:244:28 | 0 | semmle.label | successor |
-| cflow.cs:244:13:244:28 | ... > ... | cflow.cs:244:31:244:41 | goto ...; | semmle.label | true |
-| cflow.cs:244:13:244:28 | ... > ... | cflow.cs:246:9:258:9 | switch (...) {...} | semmle.label | false |
-| cflow.cs:244:28:244:28 | 0 | cflow.cs:244:13:244:28 | ... > ... | semmle.label | successor |
-| cflow.cs:244:31:244:41 | goto ...; | cflow.cs:242:9:242:13 | Label: | semmle.label | goto(Label) |
-| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:246:17:246:21 | this access | semmle.label | successor |
-| cflow.cs:246:17:246:21 | access to field Field | cflow.cs:246:17:246:28 | access to property Length | semmle.label | successor |
-| cflow.cs:246:17:246:21 | this access | cflow.cs:246:17:246:21 | access to field Field | semmle.label | successor |
-| cflow.cs:246:17:246:28 | access to property Length | cflow.cs:246:32:246:32 | 3 | semmle.label | successor |
-| cflow.cs:246:17:246:32 | ... + ... | cflow.cs:248:13:248:19 | case ...: | semmle.label | successor |
-| cflow.cs:246:32:246:32 | 3 | cflow.cs:246:17:246:32 | ... + ... | semmle.label | successor |
-| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:18:248:18 | 0 | semmle.label | successor |
-| cflow.cs:248:18:248:18 | 0 | cflow.cs:249:17:249:29 | goto default; | semmle.label | match |
-| cflow.cs:248:18:248:18 | 0 | cflow.cs:250:13:250:19 | case ...: | semmle.label | no-match |
-| cflow.cs:249:17:249:29 | goto default; | cflow.cs:255:13:255:20 | default: | semmle.label | goto(default) |
-| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:18:250:18 | 1 | semmle.label | successor |
-| cflow.cs:250:18:250:18 | 1 | cflow.cs:251:17:251:37 | ...; | semmle.label | match |
-| cflow.cs:250:18:250:18 | 1 | cflow.cs:253:13:253:19 | case ...: | semmle.label | no-match |
-| cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:252:17:252:22 | break; | semmle.label | successor |
-| cflow.cs:251:17:251:37 | ...; | cflow.cs:251:35:251:35 | 1 | semmle.label | successor |
-| cflow.cs:251:35:251:35 | 1 | cflow.cs:251:17:251:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:252:17:252:22 | break; | cflow.cs:240:10:240:13 | exit Goto (normal) | semmle.label | break |
-| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:18:253:18 | 2 | semmle.label | successor |
-| cflow.cs:253:18:253:18 | 2 | cflow.cs:254:17:254:27 | goto ...; | semmle.label | match |
-| cflow.cs:253:18:253:18 | 2 | cflow.cs:255:13:255:20 | default: | semmle.label | no-match |
-| cflow.cs:254:17:254:27 | goto ...; | cflow.cs:242:9:242:13 | Label: | semmle.label | goto(Label) |
-| cflow.cs:255:13:255:20 | default: | cflow.cs:256:17:256:37 | ...; | semmle.label | successor |
-| cflow.cs:256:17:256:36 | call to method WriteLine | cflow.cs:257:17:257:22 | break; | semmle.label | successor |
-| cflow.cs:256:17:256:37 | ...; | cflow.cs:256:35:256:35 | 0 | semmle.label | successor |
-| cflow.cs:256:35:256:35 | 0 | cflow.cs:256:17:256:36 | call to method WriteLine | semmle.label | successor |
-| cflow.cs:257:17:257:22 | break; | cflow.cs:240:10:240:13 | exit Goto (normal) | semmle.label | break |
-| cflow.cs:261:49:261:53 | enter Yield | cflow.cs:262:5:277:5 | {...} | semmle.label | successor |
-| cflow.cs:261:49:261:53 | exit Yield (normal) | cflow.cs:261:49:261:53 | exit Yield | semmle.label | successor |
-| cflow.cs:262:5:277:5 | {...} | cflow.cs:263:22:263:22 | 0 | semmle.label | successor |
-| cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:264:9:267:9 | for (...;...;...) ... | semmle.label | successor |
-| cflow.cs:263:22:263:22 | 0 | cflow.cs:263:9:263:23 | yield return ...; | semmle.label | successor |
-| cflow.cs:264:9:267:9 | for (...;...;...) ... | cflow.cs:264:22:264:22 | 1 | semmle.label | successor |
-| cflow.cs:264:18:264:22 | Int32 i = ... | cflow.cs:264:25:264:25 | access to local variable i | semmle.label | successor |
-| cflow.cs:264:22:264:22 | 1 | cflow.cs:264:18:264:22 | Int32 i = ... | semmle.label | successor |
-| cflow.cs:264:25:264:25 | access to local variable i | cflow.cs:264:29:264:30 | 10 | semmle.label | successor |
-| cflow.cs:264:25:264:30 | ... < ... | cflow.cs:265:9:267:9 | {...} | semmle.label | true |
-| cflow.cs:264:25:264:30 | ... < ... | cflow.cs:268:9:276:9 | try {...} ... | semmle.label | false |
-| cflow.cs:264:29:264:30 | 10 | cflow.cs:264:25:264:30 | ... < ... | semmle.label | successor |
-| cflow.cs:264:33:264:33 | access to local variable i | cflow.cs:264:33:264:35 | ...++ | semmle.label | successor |
-| cflow.cs:264:33:264:35 | ...++ | cflow.cs:264:25:264:25 | access to local variable i | semmle.label | successor |
-| cflow.cs:265:9:267:9 | {...} | cflow.cs:266:26:266:26 | access to local variable i | semmle.label | successor |
-| cflow.cs:266:13:266:27 | yield return ...; | cflow.cs:264:33:264:33 | access to local variable i | semmle.label | successor |
-| cflow.cs:266:26:266:26 | access to local variable i | cflow.cs:266:13:266:27 | yield return ...; | semmle.label | successor |
-| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:269:9:272:9 | {...} | semmle.label | successor |
-| cflow.cs:269:9:272:9 | {...} | cflow.cs:270:13:270:24 | yield break; | semmle.label | successor |
-| cflow.cs:270:13:270:24 | yield break; | cflow.cs:274:9:276:9 | [finally: return] {...} | semmle.label | return |
-| cflow.cs:274:9:276:9 | [finally: return] {...} | cflow.cs:275:13:275:42 | [finally: return] ...; | semmle.label | successor |
-| cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:261:49:261:53 | exit Yield (normal) | semmle.label | return |
-| cflow.cs:275:13:275:42 | [finally: return] ...; | cflow.cs:275:31:275:40 | [finally: return] "not dead" | semmle.label | successor |
-| cflow.cs:275:31:275:40 | [finally: return] "not dead" | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | semmle.label | successor |
-| cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:24:282:27 | call to constructor ControlFlow | semmle.label | successor |
-| cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | cflow.cs:282:5:282:18 | exit ControlFlowSub | semmle.label | successor |
-| cflow.cs:282:24:282:27 | call to constructor ControlFlow | cflow.cs:282:31:282:33 | {...} | semmle.label | successor |
-| cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | semmle.label | successor |
-| cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | semmle.label | successor |
-| cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | cflow.cs:284:5:284:18 | exit ControlFlowSub | semmle.label | successor |
-| cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | cflow.cs:284:39:284:41 | {...} | semmle.label | successor |
-| cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | semmle.label | successor |
-| cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:34:286:34 | access to parameter i | semmle.label | successor |
-| cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | cflow.cs:286:5:286:18 | exit ControlFlowSub | semmle.label | successor |
-| cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | cflow.cs:286:48:286:50 | {...} | semmle.label | successor |
-| cflow.cs:286:34:286:34 | access to parameter i | cflow.cs:286:34:286:45 | call to method ToString | semmle.label | successor |
-| cflow.cs:286:34:286:45 | call to method ToString | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | semmle.label | successor |
-| cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | semmle.label | successor |
-| cflow.cs:291:12:291:12 | enter M | cflow.cs:291:38:291:38 | access to parameter f | semmle.label | successor |
-| cflow.cs:291:12:291:12 | exit M (normal) | cflow.cs:291:12:291:12 | exit M | semmle.label | successor |
-| cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:40:291:40 | 0 | semmle.label | successor |
-| cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M (normal) | semmle.label | successor |
-| cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:41 | delegate call | semmle.label | successor |
-| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:52:296:54 | {...} | semmle.label | successor |
-| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | call to constructor Object | semmle.label | successor |
-| cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | exit NegationInConstructor | semmle.label | successor |
-| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | semmle.label | successor |
-| cflow.cs:298:10:298:10 | enter M | cflow.cs:299:5:301:5 | {...} | semmle.label | successor |
-| cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:298:10:298:10 | exit M | semmle.label | successor |
-| cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:73 | ...; | semmle.label | successor |
-| cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M (normal) | semmle.label | successor |
-| cflow.cs:300:9:300:73 | ...; | cflow.cs:300:38:300:38 | 0 | semmle.label | successor |
-| cflow.cs:300:38:300:38 | 0 | cflow.cs:300:46:300:46 | access to parameter i | semmle.label | successor |
-| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:64 | ... && ... | semmle.label | false |
-| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:56:300:56 | access to parameter s | semmle.label | true |
-| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:70:300:71 | "" | semmle.label | successor |
-| cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:50:300:50 | 0 | semmle.label | successor |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [false] !... | semmle.label | true |
-| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [true] !... | semmle.label | false |
-| cflow.cs:300:50:300:50 | 0 | cflow.cs:300:46:300:50 | ... > ... | semmle.label | successor |
-| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:61:300:64 | null | semmle.label | successor |
-| cflow.cs:300:56:300:64 | ... != ... | cflow.cs:300:44:300:64 | ... && ... | semmle.label | successor |
-| cflow.cs:300:61:300:64 | null | cflow.cs:300:56:300:64 | ... != ... | semmle.label | successor |
-| cflow.cs:300:70:300:71 | "" | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | semmle.label | successor |
+AccessorCalls.cs:
+#    5| enter get_Item
+#-----|  -> access to parameter i
+
+#    5| exit get_Item
+
+#    5| exit get_Item (normal)
+#-----|  -> exit get_Item
+
+#    5| access to parameter i
+#-----|  -> exit get_Item (normal)
+
+#    5| enter set_Item
+#-----|  -> {...}
+
+#    5| exit set_Item
+
+#    5| exit set_Item (normal)
+#-----|  -> exit set_Item
+
+#    5| {...}
+#-----|  -> exit set_Item (normal)
+
+#    7| enter add_Event
+#-----|  -> {...}
+
+#    7| exit add_Event
+
+#    7| exit add_Event (normal)
+#-----|  -> exit add_Event
+
+#    7| {...}
+#-----|  -> exit add_Event (normal)
+
+#    7| enter remove_Event
+#-----|  -> {...}
+
+#    7| exit remove_Event
+
+#    7| exit remove_Event (normal)
+#-----|  -> exit remove_Event
+
+#    7| {...}
+#-----|  -> exit remove_Event (normal)
+
+#   10| enter M1
+#-----|  -> {...}
+
+#   10| exit M1
+
+#   10| exit M1 (normal)
+#-----|  -> exit M1
+
+#   11| {...}
+#-----|  -> ...;
+
+#   12| ...;
+#-----|  -> this access
+
+#   12| ... = ...
+#-----|  -> ...;
+
+#   12| this access
+#-----|  -> this access
+
+#   12| access to field Field
+#-----|  -> ... = ...
+
+#   12| this access
+#-----|  -> access to field Field
+
+#   13| ...;
+#-----|  -> this access
+
+#   13| ... = ...
+#-----|  -> ...;
+
+#   13| access to property Prop
+#-----|  -> ... = ...
+
+#   13| this access
+#-----|  -> this access
+
+#   13| access to property Prop
+#-----|  -> access to property Prop
+
+#   13| this access
+#-----|  -> access to property Prop
+
+#   14| ...;
+#-----|  -> this access
+
+#   14| ... = ...
+#-----|  -> ...;
+
+#   14| access to indexer
+#-----|  -> ... = ...
+
+#   14| this access
+#-----|  -> 0
+
+#   14| 0
+#-----|  -> this access
+
+#   14| access to indexer
+#-----|  -> access to indexer
+
+#   14| this access
+#-----|  -> 1
+
+#   14| 1
+#-----|  -> access to indexer
+
+#   15| ...;
+#-----|  -> this access
+
+#   15| ... += ...
+#-----|  -> ...;
+
+#   15| access to event Event
+#-----|  -> ... += ...
+
+#   15| this access
+#-----|  -> access to parameter e
+
+#   15| access to parameter e
+#-----|  -> access to event Event
+
+#   16| ...;
+#-----|  -> this access
+
+#   16| ... -= ...
+#-----|  -> exit M1 (normal)
+
+#   16| access to event Event
+#-----|  -> ... -= ...
+
+#   16| this access
+#-----|  -> access to parameter e
+
+#   16| access to parameter e
+#-----|  -> access to event Event
+
+#   19| enter M2
+#-----|  -> {...}
+
+#   19| exit M2
+
+#   19| exit M2 (normal)
+#-----|  -> exit M2
+
+#   20| {...}
+#-----|  -> ...;
+
+#   21| ...;
+#-----|  -> this access
+
+#   21| ... = ...
+#-----|  -> ...;
+
+#   21| access to field x
+#-----|  -> this access
+
+#   21| this access
+#-----|  -> access to field x
+
+#   21| access to field Field
+#-----|  -> ... = ...
+
+#   21| access to field x
+#-----|  -> access to field Field
+
+#   21| this access
+#-----|  -> access to field x
+
+#   22| ...;
+#-----|  -> this access
+
+#   22| ... = ...
+#-----|  -> ...;
+
+#   22| access to property Prop
+#-----|  -> ... = ...
+
+#   22| access to field x
+#-----|  -> this access
+
+#   22| this access
+#-----|  -> access to field x
+
+#   22| access to property Prop
+#-----|  -> access to property Prop
+
+#   22| access to field x
+#-----|  -> access to property Prop
+
+#   22| this access
+#-----|  -> access to field x
+
+#   23| ...;
+#-----|  -> this access
+
+#   23| ... = ...
+#-----|  -> ...;
+
+#   23| access to indexer
+#-----|  -> ... = ...
+
+#   23| access to field x
+#-----|  -> 0
+
+#   23| this access
+#-----|  -> access to field x
+
+#   23| 0
+#-----|  -> this access
+
+#   23| access to indexer
+#-----|  -> access to indexer
+
+#   23| access to field x
+#-----|  -> 1
+
+#   23| this access
+#-----|  -> access to field x
+
+#   23| 1
+#-----|  -> access to indexer
+
+#   24| ...;
+#-----|  -> this access
+
+#   24| ... += ...
+#-----|  -> ...;
+
+#   24| access to event Event
+#-----|  -> ... += ...
+
+#   24| access to field x
+#-----|  -> access to parameter e
+
+#   24| this access
+#-----|  -> access to field x
+
+#   24| access to parameter e
+#-----|  -> access to event Event
+
+#   25| ...;
+#-----|  -> this access
+
+#   25| ... -= ...
+#-----|  -> exit M2 (normal)
+
+#   25| access to event Event
+#-----|  -> ... -= ...
+
+#   25| access to field x
+#-----|  -> access to parameter e
+
+#   25| this access
+#-----|  -> access to field x
+
+#   25| access to parameter e
+#-----|  -> access to event Event
+
+#   28| enter M3
+#-----|  -> {...}
+
+#   28| exit M3
+
+#   28| exit M3 (normal)
+#-----|  -> exit M3
+
+#   29| {...}
+#-----|  -> ...;
+
+#   30| ...;
+#-----|  -> this access
+
+#   30| ...++
+#-----|  -> ...;
+
+#   30| access to field Field
+#-----|  -> ...++
+
+#   30| this access
+#-----|  -> access to field Field
+
+#   31| ...;
+#-----|  -> this access
+
+#   31| ...++
+#-----|  -> ...;
+
+#   31| access to property Prop
+#-----|  -> ...++
+
+#   31| this access
+#-----|  -> access to property Prop
+
+#   32| ...;
+#-----|  -> this access
+
+#   32| ...++
+#-----|  -> exit M3 (normal)
+
+#   32| access to indexer
+#-----|  -> ...++
+
+#   32| this access
+#-----|  -> 0
+
+#   32| 0
+#-----|  -> access to indexer
+
+#   35| enter M4
+#-----|  -> {...}
+
+#   35| exit M4
+
+#   35| exit M4 (normal)
+#-----|  -> exit M4
+
+#   36| {...}
+#-----|  -> ...;
+
+#   37| ...;
+#-----|  -> this access
+
+#   37| ...++
+#-----|  -> ...;
+
+#   37| access to field Field
+#-----|  -> ...++
+
+#   37| access to field x
+#-----|  -> access to field Field
+
+#   37| this access
+#-----|  -> access to field x
+
+#   38| ...;
+#-----|  -> this access
+
+#   38| ...++
+#-----|  -> ...;
+
+#   38| access to property Prop
+#-----|  -> ...++
+
+#   38| access to field x
+#-----|  -> access to property Prop
+
+#   38| this access
+#-----|  -> access to field x
+
+#   39| ...;
+#-----|  -> this access
+
+#   39| ...++
+#-----|  -> exit M4 (normal)
+
+#   39| access to indexer
+#-----|  -> ...++
+
+#   39| access to field x
+#-----|  -> 0
+
+#   39| this access
+#-----|  -> access to field x
+
+#   39| 0
+#-----|  -> access to indexer
+
+#   42| enter M5
+#-----|  -> {...}
+
+#   42| exit M5
+
+#   42| exit M5 (normal)
+#-----|  -> exit M5
+
+#   43| {...}
+#-----|  -> ...;
+
+#   44| ...;
+#-----|  -> this access
+
+#   44| ... = ...
+#-----|  -> ...;
+
+#   44| this access
+#-----|  -> this access
+
+#   44| ... + ...
+#-----|  -> ... = ...
+
+#   44| access to field Field
+#-----|  -> this access
+
+#   44| this access
+#-----|  -> access to field Field
+
+#   44| access to field Field
+#-----|  -> ... + ...
+
+#   44| this access
+#-----|  -> access to field Field
+
+#   45| ...;
+#-----|  -> this access
+
+#   45| ... = ...
+#-----|  -> ...;
+
+#   45| access to property Prop
+#-----|  -> ... = ...
+
+#   45| this access
+#-----|  -> this access
+
+#   45| ... + ...
+#-----|  -> access to property Prop
+
+#   45| access to property Prop
+#-----|  -> this access
+
+#   45| this access
+#-----|  -> access to property Prop
+
+#   45| access to property Prop
+#-----|  -> ... + ...
+
+#   45| this access
+#-----|  -> access to property Prop
+
+#   46| ...;
+#-----|  -> this access
+
+#   46| ... = ...
+#-----|  -> exit M5 (normal)
+
+#   46| access to indexer
+#-----|  -> ... = ...
+
+#   46| this access
+#-----|  -> 0
+
+#   46| ... + ...
+#-----|  -> access to indexer
+
+#   46| access to indexer
+#-----|  -> this access
+
+#   46| this access
+#-----|  -> 0
+
+#   46| 0
+#-----|  -> this access
+
+#   46| 0
+#-----|  -> access to indexer
+
+#   46| access to indexer
+#-----|  -> ... + ...
+
+#   46| this access
+#-----|  -> 0
+
+#   46| 0
+#-----|  -> access to indexer
+
+#   49| enter M6
+#-----|  -> {...}
+
+#   49| exit M6
+
+#   49| exit M6 (normal)
+#-----|  -> exit M6
+
+#   50| {...}
+#-----|  -> ...;
+
+#   51| ...;
+#-----|  -> this access
+
+#   51| ... = ...
+#-----|  -> ...;
+
+#   51| access to field x
+#-----|  -> this access
+
+#   51| this access
+#-----|  -> access to field x
+
+#   51| ... + ...
+#-----|  -> ... = ...
+
+#   51| access to field Field
+#-----|  -> this access
+
+#   51| access to field x
+#-----|  -> access to field Field
+
+#   51| this access
+#-----|  -> access to field x
+
+#   51| access to field Field
+#-----|  -> ... + ...
+
+#   51| access to field x
+#-----|  -> access to field Field
+
+#   51| this access
+#-----|  -> access to field x
+
+#   52| ...;
+#-----|  -> this access
+
+#   52| ... = ...
+#-----|  -> ...;
+
+#   52| access to property Prop
+#-----|  -> ... = ...
+
+#   52| access to field x
+#-----|  -> this access
+
+#   52| this access
+#-----|  -> access to field x
+
+#   52| ... + ...
+#-----|  -> access to property Prop
+
+#   52| access to property Prop
+#-----|  -> this access
+
+#   52| access to field x
+#-----|  -> access to property Prop
+
+#   52| this access
+#-----|  -> access to field x
+
+#   52| access to property Prop
+#-----|  -> ... + ...
+
+#   52| access to field x
+#-----|  -> access to property Prop
+
+#   52| this access
+#-----|  -> access to field x
+
+#   53| ...;
+#-----|  -> this access
+
+#   53| ... = ...
+#-----|  -> exit M6 (normal)
+
+#   53| access to indexer
+#-----|  -> ... = ...
+
+#   53| access to field x
+#-----|  -> 0
+
+#   53| this access
+#-----|  -> access to field x
+
+#   53| ... + ...
+#-----|  -> access to indexer
+
+#   53| access to indexer
+#-----|  -> this access
+
+#   53| access to field x
+#-----|  -> 0
+
+#   53| this access
+#-----|  -> access to field x
+
+#   53| 0
+#-----|  -> this access
+
+#   53| 0
+#-----|  -> access to indexer
+
+#   53| access to indexer
+#-----|  -> ... + ...
+
+#   53| access to field x
+#-----|  -> 0
+
+#   53| this access
+#-----|  -> access to field x
+
+#   53| 0
+#-----|  -> access to indexer
+
+#   56| enter M7
+#-----|  -> {...}
+
+#   56| exit M7
+
+#   56| exit M7 (normal)
+#-----|  -> exit M7
+
+#   57| {...}
+#-----|  -> ...;
+
+#   58| ...;
+#-----|  -> this access
+
+#   58| ... = ...
+#-----|  -> exit M7 (normal)
+
+#   58| (..., ...)
+#-----|  -> this access
+
+#   58| this access
+#-----|  -> this access
+
+#   58| access to property Prop
+#-----|  -> access to indexer
+
+#   58| this access
+#-----|  -> this access
+
+#   58| (..., ...)
+#-----|  -> (..., ...)
+
+#   58| access to indexer
+#-----|  -> ... = ...
+
+#   58| this access
+#-----|  -> 0
+
+#   58| 0
+#-----|  -> (..., ...)
+
+#   58| (..., ...)
+#-----|  -> access to property Prop
+
+#   58| access to field Field
+#-----|  -> this access
+
+#   58| this access
+#-----|  -> access to field Field
+
+#   58| access to property Prop
+#-----|  -> 0
+
+#   58| this access
+#-----|  -> access to property Prop
+
+#   58| (..., ...)
+#-----|  -> (..., ...)
+
+#   58| 0
+#-----|  -> this access
+
+#   58| access to indexer
+#-----|  -> (..., ...)
+
+#   58| this access
+#-----|  -> 1
+
+#   58| 1
+#-----|  -> access to indexer
+
+#   61| enter M8
+#-----|  -> {...}
+
+#   61| exit M8
+
+#   61| exit M8 (normal)
+#-----|  -> exit M8
+
+#   62| {...}
+#-----|  -> ...;
+
+#   63| ...;
+#-----|  -> this access
+
+#   63| ... = ...
+#-----|  -> exit M8 (normal)
+
+#   63| (..., ...)
+#-----|  -> this access
+
+#   63| access to field x
+#-----|  -> this access
+
+#   63| this access
+#-----|  -> access to field x
+
+#   63| access to property Prop
+#-----|  -> access to indexer
+
+#   63| access to field x
+#-----|  -> this access
+
+#   63| this access
+#-----|  -> access to field x
+
+#   63| (..., ...)
+#-----|  -> (..., ...)
+
+#   63| access to indexer
+#-----|  -> ... = ...
+
+#   63| access to field x
+#-----|  -> 0
+
+#   63| this access
+#-----|  -> access to field x
+
+#   63| 0
+#-----|  -> (..., ...)
+
+#   63| (..., ...)
+#-----|  -> access to property Prop
+
+#   63| access to field Field
+#-----|  -> this access
+
+#   63| access to field x
+#-----|  -> access to field Field
+
+#   63| this access
+#-----|  -> access to field x
+
+#   63| access to property Prop
+#-----|  -> 0
+
+#   63| access to field x
+#-----|  -> access to property Prop
+
+#   63| this access
+#-----|  -> access to field x
+
+#   63| (..., ...)
+#-----|  -> (..., ...)
+
+#   63| 0
+#-----|  -> this access
+
+#   63| access to indexer
+#-----|  -> (..., ...)
+
+#   63| access to field x
+#-----|  -> 1
+
+#   63| this access
+#-----|  -> access to field x
+
+#   63| 1
+#-----|  -> access to indexer
+
+#   66| enter M9
+#-----|  -> {...}
+
+#   66| exit M9
+
+#   66| exit M9 (normal)
+#-----|  -> exit M9
+
+#   67| {...}
+#-----|  -> ... ...;
+
+#   68| ... ...;
+#-----|  -> access to parameter o
+
+#   68| dynamic d = ...
+#-----|  -> ...;
+
+#   68| access to parameter o
+#-----|  -> dynamic d = ...
+
+#   69| ...;
+#-----|  -> access to local variable d
+
+#   69| ... = ...
+#-----|  -> ...;
+
+#   69| dynamic access to member MaybeProp1
+#-----|  -> ... = ...
+
+#   69| access to local variable d
+#-----|  -> access to local variable d
+
+#   69| dynamic access to member MaybeProp2
+#-----|  -> dynamic access to member MaybeProp1
+
+#   69| access to local variable d
+#-----|  -> dynamic access to member MaybeProp2
+
+#   70| ...;
+#-----|  -> access to local variable d
+
+#   70| dynamic call to operator ++
+#-----|  -> ...;
+
+#   70| dynamic access to member MaybeProp
+#-----|  -> dynamic call to operator ++
+
+#   70| access to local variable d
+#-----|  -> dynamic access to member MaybeProp
+
+#   71| ...;
+#-----|  -> access to local variable d
+
+#   71| ... = ...
+#-----|  -> ...;
+
+#   71| dynamic access to member MaybeEvent
+#-----|  -> ... = ...
+
+#   71| access to local variable d
+#-----|  -> access to local variable d
+
+#   71| dynamic call to operator +
+#-----|  -> dynamic access to member MaybeEvent
+
+#   71| dynamic access to member MaybeEvent
+#-----|  -> access to parameter e
+
+#   71| access to local variable d
+#-----|  -> dynamic access to member MaybeEvent
+
+#   71| access to parameter e
+#-----|  -> dynamic call to operator +
+
+#   72| ...;
+#-----|  -> access to local variable d
+
+#   72| ... = ...
+#-----|  -> ...;
+
+#   72| dynamic access to element
+#-----|  -> ... = ...
+
+#   72| access to local variable d
+#-----|  -> 0
+
+#   72| dynamic call to operator +
+#-----|  -> dynamic access to element
+
+#   72| dynamic access to element
+#-----|  -> access to local variable d
+
+#   72| access to local variable d
+#-----|  -> 0
+
+#   72| 0
+#-----|  -> access to local variable d
+
+#   72| 0
+#-----|  -> dynamic access to element
+
+#   72| dynamic access to element
+#-----|  -> dynamic call to operator +
+
+#   72| access to local variable d
+#-----|  -> 1
+
+#   72| 1
+#-----|  -> dynamic access to element
+
+#   73| ...;
+#-----|  -> access to local variable d
+
+#   73| ... = ...
+#-----|  -> exit M9 (normal)
+
+#   73| (..., ...)
+#-----|  -> access to local variable d
+
+#   73| dynamic access to member MaybeProp1
+#-----|  -> access to property Prop
+
+#   73| access to local variable d
+#-----|  -> this access
+
+#   73| access to property Prop
+#-----|  -> dynamic access to element
+
+#   73| this access
+#-----|  -> access to local variable d
+
+#   73| (..., ...)
+#-----|  -> (..., ...)
+
+#   73| dynamic access to element
+#-----|  -> ... = ...
+
+#   73| access to local variable d
+#-----|  -> 0
+
+#   73| 0
+#-----|  -> (..., ...)
+
+#   73| (..., ...)
+#-----|  -> dynamic access to member MaybeProp1
+
+#   73| dynamic access to member MaybeProp1
+#-----|  -> this access
+
+#   73| access to local variable d
+#-----|  -> dynamic access to member MaybeProp1
+
+#   73| access to property Prop
+#-----|  -> 0
+
+#   73| this access
+#-----|  -> access to property Prop
+
+#   73| (..., ...)
+#-----|  -> (..., ...)
+
+#   73| 0
+#-----|  -> access to local variable d
+
+#   73| dynamic access to element
+#-----|  -> (..., ...)
+
+#   73| access to local variable d
+#-----|  -> 1
+
+#   73| 1
+#-----|  -> dynamic access to element
+
+ArrayCreation.cs:
+#    3| enter M1
+#-----|  -> 0
+
+#    3| exit M1
+
+#    3| exit M1 (normal)
+#-----|  -> exit M1
+
+#    3| array creation of type Int32[]
+#-----|  -> exit M1 (normal)
+
+#    3| 0
+#-----|  -> array creation of type Int32[]
+
+#    5| enter M2
+#-----|  -> 0
+
+#    5| exit M2
+
+#    5| exit M2 (normal)
+#-----|  -> exit M2
+
+#    5| array creation of type Int32[,]
+#-----|  -> exit M2 (normal)
+
+#    5| 0
+#-----|  -> 1
+
+#    5| 1
+#-----|  -> array creation of type Int32[,]
+
+#    7| enter M3
+#-----|  -> 2
+
+#    7| exit M3
+
+#    7| exit M3 (normal)
+#-----|  -> exit M3
+
+#    7| array creation of type Int32[]
+#-----|  -> 0
+
+#    7| 2
+#-----|  -> array creation of type Int32[]
+
+#    7| { ..., ... }
+#-----|  -> exit M3 (normal)
+
+#    7| 0
+#-----|  -> 1
+
+#    7| 1
+#-----|  -> { ..., ... }
+
+#    9| enter M4
+#-----|  -> 2
+
+#    9| exit M4
+
+#    9| exit M4 (normal)
+#-----|  -> exit M4
+
+#    9| array creation of type Int32[,]
+#-----|  -> 0
+
+#    9| 2
+#-----|  -> 2
+
+#    9| 2
+#-----|  -> array creation of type Int32[,]
+
+#    9| { ..., ... }
+#-----|  -> exit M4 (normal)
+
+#    9| { ..., ... }
+#-----|  -> 2
+
+#    9| 0
+#-----|  -> 1
+
+#    9| 1
+#-----|  -> { ..., ... }
+
+#    9| { ..., ... }
+#-----|  -> { ..., ... }
+
+#    9| 2
+#-----|  -> 3
+
+#    9| 3
+#-----|  -> { ..., ... }
+
+Assert.cs:
+#    7| enter M1
+#-----|  -> {...}
+
+#    7| exit M1
+
+#    7| exit M1 (abnormal)
+#-----|  -> exit M1
+
+#    7| exit M1 (normal)
+#-----|  -> exit M1
+
+#    8| {...}
+#-----|  -> ... ...;
+
+#    9| ... ...;
+#-----|  -> access to parameter b
+
+#    9| String s = ...
+#-----|  -> ...;
+
+#    9| ... ? ... : ...
+#-----|  -> String s = ...
+
+#    9| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#    9| null
+#-----|  -> ... ? ... : ...
+
+#    9| ""
+#-----|  -> ... ? ... : ...
+
+#   10| ...;
+#-----|  -> access to local variable s
+
+#   10| [assertion failure] call to method Assert
+#-----| exit -> exit M1 (abnormal)
+
+#   10| [assertion success] call to method Assert
+#-----|  -> ...;
+
+#   10| ... != ...
+#-----| false -> [assertion failure] call to method Assert
+#-----| true -> [assertion success] call to method Assert
+
+#   10| access to local variable s
+#-----|  -> null
+
+#   10| null
+#-----|  -> ... != ...
+
+#   11| ...;
+#-----|  -> access to local variable s
+
+#   11| call to method WriteLine
+#-----|  -> exit M1 (normal)
+
+#   11| access to property Length
+#-----|  -> call to method WriteLine
+
+#   11| access to local variable s
+#-----|  -> access to property Length
+
+#   14| enter M2
+#-----|  -> {...}
+
+#   14| exit M2
+
+#   14| exit M2 (abnormal)
+#-----|  -> exit M2
+
+#   14| exit M2 (normal)
+#-----|  -> exit M2
+
+#   15| {...}
+#-----|  -> ... ...;
+
+#   16| ... ...;
+#-----|  -> access to parameter b
+
+#   16| String s = ...
+#-----|  -> ...;
+
+#   16| ... ? ... : ...
+#-----|  -> String s = ...
+
+#   16| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#   16| null
+#-----|  -> ... ? ... : ...
+
+#   16| ""
+#-----|  -> ... ? ... : ...
+
+#   17| ...;
+#-----|  -> access to local variable s
+
+#   17| [assertion failure] call to method IsNull
+#-----| exception(AssertFailedException) -> exit M2 (abnormal)
+
+#   17| [assertion success] call to method IsNull
+#-----|  -> ...;
+
+#   17| access to local variable s
+#-----| non-null -> [assertion failure] call to method IsNull
+#-----| null -> [assertion success] call to method IsNull
+
+#   18| ...;
+#-----|  -> access to local variable s
+
+#   18| call to method WriteLine
+#-----|  -> exit M2 (normal)
+
+#   18| access to property Length
+#-----|  -> call to method WriteLine
+
+#   18| access to local variable s
+#-----|  -> access to property Length
+
+#   21| enter M3
+#-----|  -> {...}
+
+#   21| exit M3
+
+#   21| exit M3 (abnormal)
+#-----|  -> exit M3
+
+#   21| exit M3 (normal)
+#-----|  -> exit M3
+
+#   22| {...}
+#-----|  -> ... ...;
+
+#   23| ... ...;
+#-----|  -> access to parameter b
+
+#   23| String s = ...
+#-----|  -> ...;
+
+#   23| ... ? ... : ...
+#-----|  -> String s = ...
+
+#   23| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#   23| null
+#-----|  -> ... ? ... : ...
+
+#   23| ""
+#-----|  -> ... ? ... : ...
+
+#   24| ...;
+#-----|  -> access to local variable s
+
+#   24| [assertion failure] call to method IsNotNull
+#-----| exception(AssertFailedException) -> exit M3 (abnormal)
+
+#   24| [assertion success] call to method IsNotNull
+#-----|  -> ...;
+
+#   24| access to local variable s
+#-----| null -> [assertion failure] call to method IsNotNull
+#-----| non-null -> [assertion success] call to method IsNotNull
+
+#   25| ...;
+#-----|  -> access to local variable s
+
+#   25| call to method WriteLine
+#-----|  -> exit M3 (normal)
+
+#   25| access to property Length
+#-----|  -> call to method WriteLine
+
+#   25| access to local variable s
+#-----|  -> access to property Length
+
+#   28| enter M4
+#-----|  -> {...}
+
+#   28| exit M4
+
+#   28| exit M4 (abnormal)
+#-----|  -> exit M4
+
+#   28| exit M4 (normal)
+#-----|  -> exit M4
+
+#   29| {...}
+#-----|  -> ... ...;
+
+#   30| ... ...;
+#-----|  -> access to parameter b
+
+#   30| String s = ...
+#-----|  -> ...;
+
+#   30| ... ? ... : ...
+#-----|  -> String s = ...
+
+#   30| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#   30| null
+#-----|  -> ... ? ... : ...
+
+#   30| ""
+#-----|  -> ... ? ... : ...
+
+#   31| ...;
+#-----|  -> access to local variable s
+
+#   31| [assertion failure] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M4 (abnormal)
+
+#   31| [assertion success] call to method IsTrue
+#-----|  -> ...;
+
+#   31| ... == ...
+#-----| false -> [assertion failure] call to method IsTrue
+#-----| true -> [assertion success] call to method IsTrue
+
+#   31| access to local variable s
+#-----|  -> null
+
+#   31| null
+#-----|  -> ... == ...
+
+#   32| ...;
+#-----|  -> access to local variable s
+
+#   32| call to method WriteLine
+#-----|  -> exit M4 (normal)
+
+#   32| access to property Length
+#-----|  -> call to method WriteLine
+
+#   32| access to local variable s
+#-----|  -> access to property Length
+
+#   35| enter M5
+#-----|  -> {...}
+
+#   35| exit M5
+
+#   35| exit M5 (abnormal)
+#-----|  -> exit M5
+
+#   35| exit M5 (normal)
+#-----|  -> exit M5
+
+#   36| {...}
+#-----|  -> ... ...;
+
+#   37| ... ...;
+#-----|  -> access to parameter b
+
+#   37| String s = ...
+#-----|  -> ...;
+
+#   37| ... ? ... : ...
+#-----|  -> String s = ...
+
+#   37| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#   37| null
+#-----|  -> ... ? ... : ...
+
+#   37| ""
+#-----|  -> ... ? ... : ...
+
+#   38| ...;
+#-----|  -> access to local variable s
+
+#   38| [assertion failure] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M5 (abnormal)
+
+#   38| [assertion success] call to method IsTrue
+#-----|  -> ...;
+
+#   38| ... != ...
+#-----| false -> [assertion failure] call to method IsTrue
+#-----| true -> [assertion success] call to method IsTrue
+
+#   38| access to local variable s
+#-----|  -> null
+
+#   38| null
+#-----|  -> ... != ...
+
+#   39| ...;
+#-----|  -> access to local variable s
+
+#   39| call to method WriteLine
+#-----|  -> exit M5 (normal)
+
+#   39| access to property Length
+#-----|  -> call to method WriteLine
+
+#   39| access to local variable s
+#-----|  -> access to property Length
+
+#   42| enter M6
+#-----|  -> {...}
+
+#   42| exit M6
+
+#   42| exit M6 (abnormal)
+#-----|  -> exit M6
+
+#   42| exit M6 (normal)
+#-----|  -> exit M6
+
+#   43| {...}
+#-----|  -> ... ...;
+
+#   44| ... ...;
+#-----|  -> access to parameter b
+
+#   44| String s = ...
+#-----|  -> ...;
+
+#   44| ... ? ... : ...
+#-----|  -> String s = ...
+
+#   44| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#   44| null
+#-----|  -> ... ? ... : ...
+
+#   44| ""
+#-----|  -> ... ? ... : ...
+
+#   45| ...;
+#-----|  -> access to local variable s
+
+#   45| [assertion failure] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M6 (abnormal)
+
+#   45| [assertion success] call to method IsFalse
+#-----|  -> ...;
+
+#   45| ... != ...
+#-----| true -> [assertion failure] call to method IsFalse
+#-----| false -> [assertion success] call to method IsFalse
+
+#   45| access to local variable s
+#-----|  -> null
+
+#   45| null
+#-----|  -> ... != ...
+
+#   46| ...;
+#-----|  -> access to local variable s
+
+#   46| call to method WriteLine
+#-----|  -> exit M6 (normal)
+
+#   46| access to property Length
+#-----|  -> call to method WriteLine
+
+#   46| access to local variable s
+#-----|  -> access to property Length
+
+#   49| enter M7
+#-----|  -> {...}
+
+#   49| exit M7
+
+#   49| exit M7 (abnormal)
+#-----|  -> exit M7
+
+#   49| exit M7 (normal)
+#-----|  -> exit M7
+
+#   50| {...}
+#-----|  -> ... ...;
+
+#   51| ... ...;
+#-----|  -> access to parameter b
+
+#   51| String s = ...
+#-----|  -> ...;
+
+#   51| ... ? ... : ...
+#-----|  -> String s = ...
+
+#   51| access to parameter b
+#-----| true -> null
+#-----| false -> ""
+
+#   51| null
+#-----|  -> ... ? ... : ...
+
+#   51| ""
+#-----|  -> ... ? ... : ...
+
+#   52| ...;
+#-----|  -> access to local variable s
+
+#   52| [assertion failure] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M7 (abnormal)
+
+#   52| [assertion success] call to method IsFalse
+#-----|  -> ...;
+
+#   52| ... == ...
+#-----| true -> [assertion failure] call to method IsFalse
+#-----| false -> [assertion success] call to method IsFalse
+
+#   52| access to local variable s
+#-----|  -> null
+
+#   52| null
+#-----|  -> ... == ...
+
+#   53| ...;
+#-----|  -> access to local variable s
+
+#   53| call to method WriteLine
+#-----|  -> exit M7 (normal)
+
+#   53| access to property Length
+#-----|  -> call to method WriteLine
+
+#   53| access to local variable s
+#-----|  -> access to property Length
+
+#   56| enter M8
+#-----|  -> {...}
+
+#   56| exit M8
+
+#   56| exit M8 (abnormal)
+#-----|  -> exit M8
+
+#   56| exit M8 (normal)
+#-----|  -> exit M8
+
+#   57| {...}
+#-----|  -> ... ...;
+
+#   58| ... ...;
+#-----|  -> access to parameter b
+
+#   58| [b (line 56): false] String s = ...
+#-----|  -> [b (line 56): false] ...;
+
+#   58| [b (line 56): true] String s = ...
+#-----|  -> [b (line 56): true] ...;
+
+#   58| [b (line 56): false] ... ? ... : ...
+#-----|  -> [b (line 56): false] String s = ...
+
+#   58| [b (line 56): true] ... ? ... : ...
+#-----|  -> [b (line 56): true] String s = ...
+
+#   58| access to parameter b
+#-----| true -> [b (line 56): true] null
+#-----| false -> [b (line 56): false] ""
+
+#   58| [b (line 56): true] null
+#-----|  -> [b (line 56): true] ... ? ... : ...
+
+#   58| [b (line 56): false] ""
+#-----|  -> [b (line 56): false] ... ? ... : ...
+
+#   59| [b (line 56): false] ...;
+#-----|  -> [b (line 56): false] access to local variable s
+
+#   59| [b (line 56): true] ...;
+#-----|  -> [b (line 56): true] access to local variable s
+
+#   59| [assertion failure] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M8 (abnormal)
+
+#   59| [assertion success] call to method IsTrue
+#-----|  -> ...;
+
+#   59| [false] ... && ...
+#-----| false -> [assertion failure] call to method IsTrue
+
+#   59| [true] ... && ...
+#-----| true -> [assertion success] call to method IsTrue
+
+#   59| [b (line 56): false] ... != ...
+#-----| false -> [false] ... && ...
+#-----| true -> [b (line 56): false] access to parameter b
+
+#   59| [b (line 56): true] ... != ...
+#-----| false -> [false] ... && ...
+#-----| true -> [b (line 56): true] access to parameter b
+
+#   59| [b (line 56): false] access to local variable s
+#-----|  -> [b (line 56): false] null
+
+#   59| [b (line 56): true] access to local variable s
+#-----|  -> [b (line 56): true] null
+
+#   59| [b (line 56): false] null
+#-----|  -> [b (line 56): false] ... != ...
+
+#   59| [b (line 56): true] null
+#-----|  -> [b (line 56): true] ... != ...
+
+#   59| [b (line 56): false] access to parameter b
+#-----| false -> [false] ... && ...
+
+#   59| [b (line 56): true] access to parameter b
+#-----| true -> [true] ... && ...
+
+#   60| ...;
+#-----|  -> access to local variable s
+
+#   60| call to method WriteLine
+#-----|  -> exit M8 (normal)
+
+#   60| access to property Length
+#-----|  -> call to method WriteLine
+
+#   60| access to local variable s
+#-----|  -> access to property Length
+
+#   63| enter M9
+#-----|  -> {...}
+
+#   63| exit M9
+
+#   63| exit M9 (abnormal)
+#-----|  -> exit M9
+
+#   63| exit M9 (normal)
+#-----|  -> exit M9
+
+#   64| {...}
+#-----|  -> ... ...;
+
+#   65| ... ...;
+#-----|  -> access to parameter b
+
+#   65| [b (line 63): false] String s = ...
+#-----|  -> [b (line 63): false] ...;
+
+#   65| [b (line 63): true] String s = ...
+#-----|  -> [b (line 63): true] ...;
+
+#   65| [b (line 63): false] ... ? ... : ...
+#-----|  -> [b (line 63): false] String s = ...
+
+#   65| [b (line 63): true] ... ? ... : ...
+#-----|  -> [b (line 63): true] String s = ...
+
+#   65| access to parameter b
+#-----| true -> [b (line 63): true] null
+#-----| false -> [b (line 63): false] ""
+
+#   65| [b (line 63): true] null
+#-----|  -> [b (line 63): true] ... ? ... : ...
+
+#   65| [b (line 63): false] ""
+#-----|  -> [b (line 63): false] ... ? ... : ...
+
+#   66| [b (line 63): false] ...;
+#-----|  -> [b (line 63): false] access to local variable s
+
+#   66| [b (line 63): true] ...;
+#-----|  -> [b (line 63): true] access to local variable s
+
+#   66| [assertion failure] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M9 (abnormal)
+
+#   66| [assertion success] call to method IsFalse
+#-----|  -> ...;
+
+#   66| [false] ... || ...
+#-----| false -> [assertion success] call to method IsFalse
+
+#   66| [true] ... || ...
+#-----| true -> [assertion failure] call to method IsFalse
+
+#   66| [b (line 63): false] ... == ...
+#-----| true -> [true] ... || ...
+#-----| false -> [b (line 63): false] access to parameter b
+
+#   66| [b (line 63): true] ... == ...
+#-----| true -> [true] ... || ...
+#-----| false -> [b (line 63): true] access to parameter b
+
+#   66| [b (line 63): false] access to local variable s
+#-----|  -> [b (line 63): false] null
+
+#   66| [b (line 63): true] access to local variable s
+#-----|  -> [b (line 63): true] null
+
+#   66| [b (line 63): false] null
+#-----|  -> [b (line 63): false] ... == ...
+
+#   66| [b (line 63): true] null
+#-----|  -> [b (line 63): true] ... == ...
+
+#   66| [b (line 63): false] access to parameter b
+#-----| false -> [false] ... || ...
+
+#   66| [b (line 63): true] access to parameter b
+#-----| true -> [true] ... || ...
+
+#   67| ...;
+#-----|  -> access to local variable s
+
+#   67| call to method WriteLine
+#-----|  -> exit M9 (normal)
+
+#   67| access to property Length
+#-----|  -> call to method WriteLine
+
+#   67| access to local variable s
+#-----|  -> access to property Length
+
+#   70| enter M10
+#-----|  -> {...}
+
+#   70| exit M10
+
+#   70| exit M10 (abnormal)
+#-----|  -> exit M10
+
+#   70| exit M10 (normal)
+#-----|  -> exit M10
+
+#   71| {...}
+#-----|  -> ... ...;
+
+#   72| ... ...;
+#-----|  -> access to parameter b
+
+#   72| [b (line 70): false] String s = ...
+#-----|  -> [b (line 70): false] ...;
+
+#   72| [b (line 70): true] String s = ...
+#-----|  -> [b (line 70): true] ...;
+
+#   72| [b (line 70): false] ... ? ... : ...
+#-----|  -> [b (line 70): false] String s = ...
+
+#   72| [b (line 70): true] ... ? ... : ...
+#-----|  -> [b (line 70): true] String s = ...
+
+#   72| access to parameter b
+#-----| true -> [b (line 70): true] null
+#-----| false -> [b (line 70): false] ""
+
+#   72| [b (line 70): true] null
+#-----|  -> [b (line 70): true] ... ? ... : ...
+
+#   72| [b (line 70): false] ""
+#-----|  -> [b (line 70): false] ... ? ... : ...
+
+#   73| [b (line 70): false] ...;
+#-----|  -> [b (line 70): false] access to local variable s
+
+#   73| [b (line 70): true] ...;
+#-----|  -> [b (line 70): true] access to local variable s
+
+#   73| [assertion failure] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M10 (abnormal)
+
+#   73| [assertion success] call to method IsTrue
+#-----|  -> ...;
+
+#   73| [false] ... && ...
+#-----| false -> [assertion failure] call to method IsTrue
+
+#   73| [true] ... && ...
+#-----| true -> [assertion success] call to method IsTrue
+
+#   73| [b (line 70): false] ... == ...
+#-----| false -> [false] ... && ...
+#-----| true -> [b (line 70): false] access to parameter b
+
+#   73| [b (line 70): true] ... == ...
+#-----| false -> [false] ... && ...
+#-----| true -> [b (line 70): true] access to parameter b
+
+#   73| [b (line 70): false] access to local variable s
+#-----|  -> [b (line 70): false] null
+
+#   73| [b (line 70): true] access to local variable s
+#-----|  -> [b (line 70): true] null
+
+#   73| [b (line 70): false] null
+#-----|  -> [b (line 70): false] ... == ...
+
+#   73| [b (line 70): true] null
+#-----|  -> [b (line 70): true] ... == ...
+
+#   73| [b (line 70): false] access to parameter b
+#-----| false -> [false] ... && ...
+
+#   73| [b (line 70): true] access to parameter b
+#-----| true -> [true] ... && ...
+
+#   74| ...;
+#-----|  -> access to local variable s
+
+#   74| call to method WriteLine
+#-----|  -> exit M10 (normal)
+
+#   74| access to property Length
+#-----|  -> call to method WriteLine
+
+#   74| access to local variable s
+#-----|  -> access to property Length
+
+#   77| enter M11
+#-----|  -> {...}
+
+#   77| exit M11
+
+#   77| exit M11 (abnormal)
+#-----|  -> exit M11
+
+#   77| exit M11 (normal)
+#-----|  -> exit M11
+
+#   78| {...}
+#-----|  -> ... ...;
+
+#   79| ... ...;
+#-----|  -> access to parameter b
+
+#   79| [b (line 77): false] String s = ...
+#-----|  -> [b (line 77): false] ...;
+
+#   79| [b (line 77): true] String s = ...
+#-----|  -> [b (line 77): true] ...;
+
+#   79| [b (line 77): false] ... ? ... : ...
+#-----|  -> [b (line 77): false] String s = ...
+
+#   79| [b (line 77): true] ... ? ... : ...
+#-----|  -> [b (line 77): true] String s = ...
+
+#   79| access to parameter b
+#-----| true -> [b (line 77): true] null
+#-----| false -> [b (line 77): false] ""
+
+#   79| [b (line 77): true] null
+#-----|  -> [b (line 77): true] ... ? ... : ...
+
+#   79| [b (line 77): false] ""
+#-----|  -> [b (line 77): false] ... ? ... : ...
+
+#   80| [b (line 77): false] ...;
+#-----|  -> [b (line 77): false] access to local variable s
+
+#   80| [b (line 77): true] ...;
+#-----|  -> [b (line 77): true] access to local variable s
+
+#   80| [assertion failure] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M11 (abnormal)
+
+#   80| [assertion success] call to method IsFalse
+#-----|  -> ...;
+
+#   80| [false] ... || ...
+#-----| false -> [assertion success] call to method IsFalse
+
+#   80| [true] ... || ...
+#-----| true -> [assertion failure] call to method IsFalse
+
+#   80| [b (line 77): false] ... != ...
+#-----| true -> [true] ... || ...
+#-----| false -> [b (line 77): false] access to parameter b
+
+#   80| [b (line 77): true] ... != ...
+#-----| true -> [true] ... || ...
+#-----| false -> [b (line 77): true] access to parameter b
+
+#   80| [b (line 77): false] access to local variable s
+#-----|  -> [b (line 77): false] null
+
+#   80| [b (line 77): true] access to local variable s
+#-----|  -> [b (line 77): true] null
+
+#   80| [b (line 77): false] null
+#-----|  -> [b (line 77): false] ... != ...
+
+#   80| [b (line 77): true] null
+#-----|  -> [b (line 77): true] ... != ...
+
+#   80| [b (line 77): false] access to parameter b
+#-----| false -> [false] ... || ...
+
+#   80| [b (line 77): true] access to parameter b
+#-----| true -> [true] ... || ...
+
+#   81| ...;
+#-----|  -> access to local variable s
+
+#   81| call to method WriteLine
+#-----|  -> exit M11 (normal)
+
+#   81| access to property Length
+#-----|  -> call to method WriteLine
+
+#   81| access to local variable s
+#-----|  -> access to property Length
+
+#   84| enter M12
+#-----|  -> {...}
+
+#   84| exit M12
+
+#   84| exit M12 (abnormal)
+#-----|  -> exit M12
+
+#   84| exit M12 (normal)
+#-----|  -> exit M12
+
+#   85| {...}
+#-----|  -> ... ...;
+
+#   86| ... ...;
+#-----|  -> access to parameter b
+
+#   86| [b (line 84): false] String s = ...
+#-----|  -> [b (line 84): false] ...;
+
+#   86| [b (line 84): true] String s = ...
+#-----|  -> [b (line 84): true] ...;
+
+#   86| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] String s = ...
+
+#   86| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] String s = ...
+
+#   86| access to parameter b
+#-----| true -> [b (line 84): true] null
+#-----| false -> [b (line 84): false] ""
+
+#   86| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#   86| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#   87| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   87| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   87| [assertion failure, b (line 84): false] call to method Assert
+#-----| exit -> exit M12 (abnormal)
+
+#   87| [assertion failure, b (line 84): true] call to method Assert
+#-----| exit -> exit M12 (abnormal)
+
+#   87| [assertion success, b (line 84): false] call to method Assert
+#-----|  -> [b (line 84): false] ...;
+
+#   87| [assertion success, b (line 84): true] call to method Assert
+#-----|  -> [b (line 84): true] ...;
+
+#   87| [b (line 84): false] ... != ...
+#-----| false -> [assertion failure, b (line 84): false] call to method Assert
+#-----| true -> [assertion success, b (line 84): false] call to method Assert
+
+#   87| [b (line 84): true] ... != ...
+#-----| false -> [assertion failure, b (line 84): true] call to method Assert
+#-----| true -> [assertion success, b (line 84): true] call to method Assert
+
+#   87| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] null
+
+#   87| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#   87| [b (line 84): false] null
+#-----|  -> [b (line 84): false] ... != ...
+
+#   87| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... != ...
+
+#   88| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   88| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   88| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#   88| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#   88| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#   88| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#   88| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#   88| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#   90| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#   90| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#   90| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#   90| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#   90| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#   90| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#   90| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#   90| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#   90| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#   90| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#   91| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   91| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   91| [assertion failure, b (line 84): false] call to method IsNull
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#   91| [assertion failure, b (line 84): true] call to method IsNull
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#   91| [assertion success, b (line 84): false] call to method IsNull
+#-----|  -> [b (line 84): false] ...;
+
+#   91| [assertion success, b (line 84): true] call to method IsNull
+#-----|  -> [b (line 84): true] ...;
+
+#   91| [b (line 84): false] access to local variable s
+#-----| non-null -> [assertion failure, b (line 84): false] call to method IsNull
+#-----| null -> [assertion success, b (line 84): false] call to method IsNull
+
+#   91| [b (line 84): true] access to local variable s
+#-----| non-null -> [assertion failure, b (line 84): true] call to method IsNull
+#-----| null -> [assertion success, b (line 84): true] call to method IsNull
+
+#   92| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   92| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   92| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#   92| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#   92| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#   92| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#   92| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#   92| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#   94| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#   94| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#   94| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#   94| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#   94| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#   94| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#   94| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#   94| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#   94| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#   94| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#   95| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   95| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   95| [assertion failure, b (line 84): false] call to method IsNotNull
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#   95| [assertion failure, b (line 84): true] call to method IsNotNull
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#   95| [assertion success, b (line 84): false] call to method IsNotNull
+#-----|  -> [b (line 84): false] ...;
+
+#   95| [assertion success, b (line 84): true] call to method IsNotNull
+#-----|  -> [b (line 84): true] ...;
+
+#   95| [b (line 84): false] access to local variable s
+#-----| null -> [assertion failure, b (line 84): false] call to method IsNotNull
+#-----| non-null -> [assertion success, b (line 84): false] call to method IsNotNull
+
+#   95| [b (line 84): true] access to local variable s
+#-----| null -> [assertion failure, b (line 84): true] call to method IsNotNull
+#-----| non-null -> [assertion success, b (line 84): true] call to method IsNotNull
+
+#   96| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   96| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   96| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#   96| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#   96| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#   96| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#   96| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#   96| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#   98| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#   98| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#   98| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#   98| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#   98| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#   98| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#   98| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#   98| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#   98| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#   98| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#   99| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#   99| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#   99| [assertion failure, b (line 84): false] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#   99| [assertion failure, b (line 84): true] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#   99| [assertion success, b (line 84): false] call to method IsTrue
+#-----|  -> [b (line 84): false] ...;
+
+#   99| [assertion success, b (line 84): true] call to method IsTrue
+#-----|  -> [b (line 84): true] ...;
+
+#   99| [b (line 84): false] ... == ...
+#-----| false -> [assertion failure, b (line 84): false] call to method IsTrue
+#-----| true -> [assertion success, b (line 84): false] call to method IsTrue
+
+#   99| [b (line 84): true] ... == ...
+#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
+#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
+
+#   99| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] null
+
+#   99| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#   99| [b (line 84): false] null
+#-----|  -> [b (line 84): false] ... == ...
+
+#   99| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... == ...
+
+#  100| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  100| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  100| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#  100| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  100| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#  100| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  100| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#  100| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  102| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#  102| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  102| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#  102| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  102| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#  102| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  102| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#  102| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  102| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  102| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#  103| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  103| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  103| [assertion failure, b (line 84): false] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  103| [assertion failure, b (line 84): true] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  103| [assertion success, b (line 84): false] call to method IsTrue
+#-----|  -> [b (line 84): false] ...;
+
+#  103| [assertion success, b (line 84): true] call to method IsTrue
+#-----|  -> [b (line 84): true] ...;
+
+#  103| [b (line 84): false] ... != ...
+#-----| false -> [assertion failure, b (line 84): false] call to method IsTrue
+#-----| true -> [assertion success, b (line 84): false] call to method IsTrue
+
+#  103| [b (line 84): true] ... != ...
+#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
+#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
+
+#  103| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] null
+
+#  103| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  103| [b (line 84): false] null
+#-----|  -> [b (line 84): false] ... != ...
+
+#  103| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... != ...
+
+#  104| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  104| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  104| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#  104| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  104| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#  104| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  104| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#  104| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  106| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#  106| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  106| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#  106| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  106| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#  106| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  106| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#  106| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  106| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  106| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#  107| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  107| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  107| [assertion failure, b (line 84): false] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  107| [assertion failure, b (line 84): true] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  107| [assertion success, b (line 84): false] call to method IsFalse
+#-----|  -> [b (line 84): false] ...;
+
+#  107| [assertion success, b (line 84): true] call to method IsFalse
+#-----|  -> [b (line 84): true] ...;
+
+#  107| [b (line 84): false] ... != ...
+#-----| true -> [assertion failure, b (line 84): false] call to method IsFalse
+#-----| false -> [assertion success, b (line 84): false] call to method IsFalse
+
+#  107| [b (line 84): true] ... != ...
+#-----| true -> [assertion failure, b (line 84): true] call to method IsFalse
+#-----| false -> [assertion success, b (line 84): true] call to method IsFalse
+
+#  107| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] null
+
+#  107| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  107| [b (line 84): false] null
+#-----|  -> [b (line 84): false] ... != ...
+
+#  107| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... != ...
+
+#  108| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  108| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  108| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#  108| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  108| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#  108| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  108| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#  108| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  110| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#  110| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  110| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#  110| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  110| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#  110| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  110| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#  110| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  110| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  110| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#  111| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  111| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  111| [assertion failure, b (line 84): false] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  111| [assertion failure, b (line 84): true] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  111| [assertion success, b (line 84): false] call to method IsFalse
+#-----|  -> [b (line 84): false] ...;
+
+#  111| [assertion success, b (line 84): true] call to method IsFalse
+#-----|  -> [b (line 84): true] ...;
+
+#  111| [b (line 84): false] ... == ...
+#-----| true -> [assertion failure, b (line 84): false] call to method IsFalse
+#-----| false -> [assertion success, b (line 84): false] call to method IsFalse
+
+#  111| [b (line 84): true] ... == ...
+#-----| true -> [assertion failure, b (line 84): true] call to method IsFalse
+#-----| false -> [assertion success, b (line 84): true] call to method IsFalse
+
+#  111| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] null
+
+#  111| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  111| [b (line 84): false] null
+#-----|  -> [b (line 84): false] ... == ...
+
+#  111| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... == ...
+
+#  112| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  112| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  112| [b (line 84): false] call to method WriteLine
+#-----|  -> [b (line 84): false] ...;
+
+#  112| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  112| [b (line 84): false] access to property Length
+#-----|  -> [b (line 84): false] call to method WriteLine
+
+#  112| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  112| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] access to property Length
+
+#  112| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  114| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to parameter b
+
+#  114| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  114| [b (line 84): false] ... = ...
+#-----|  -> [b (line 84): false] ...;
+
+#  114| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  114| [b (line 84): false] ... ? ... : ...
+#-----|  -> [b (line 84): false] ... = ...
+
+#  114| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  114| [b (line 84): false] access to parameter b
+#-----| false -> [b (line 84): false] ""
+
+#  114| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  114| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  114| [b (line 84): false] ""
+#-----|  -> [b (line 84): false] ... ? ... : ...
+
+#  115| [b (line 84): false] ...;
+#-----|  -> [b (line 84): false] access to local variable s
+
+#  115| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  115| [assertion failure, b (line 84): false] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  115| [assertion failure, b (line 84): true] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  115| [assertion success, b (line 84): true] call to method IsTrue
+#-----|  -> [b (line 84): true] ...;
+
+#  115| [false, b (line 84): false] ... && ...
+#-----| false -> [assertion failure, b (line 84): false] call to method IsTrue
+
+#  115| [false, b (line 84): true] ... && ...
+#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
+
+#  115| [true, b (line 84): true] ... && ...
+#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
+
+#  115| [b (line 84): false] ... != ...
+#-----| false -> [false, b (line 84): false] ... && ...
+#-----| true -> [b (line 84): false] access to parameter b
+
+#  115| [b (line 84): true] ... != ...
+#-----| false -> [false, b (line 84): true] ... && ...
+#-----| true -> [b (line 84): true] access to parameter b
+
+#  115| [b (line 84): false] access to local variable s
+#-----|  -> [b (line 84): false] null
+
+#  115| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  115| [b (line 84): false] null
+#-----|  -> [b (line 84): false] ... != ...
+
+#  115| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... != ...
+
+#  115| [b (line 84): false] access to parameter b
+#-----| false -> [false, b (line 84): false] ... && ...
+
+#  115| [b (line 84): true] access to parameter b
+#-----| true -> [true, b (line 84): true] ... && ...
+
+#  116| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  116| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  116| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  116| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  118| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  118| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  118| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  118| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  118| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  119| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  119| [assertion failure, b (line 84): true] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  119| [assertion success, b (line 84): true] call to method IsFalse
+#-----|  -> [b (line 84): true] ...;
+
+#  119| [false, b (line 84): true] ... || ...
+#-----| false -> [assertion success, b (line 84): true] call to method IsFalse
+
+#  119| [true, b (line 84): true] ... || ...
+#-----| true -> [assertion failure, b (line 84): true] call to method IsFalse
+
+#  119| [b (line 84): true] ... == ...
+#-----| true -> [true, b (line 84): true] ... || ...
+#-----| false -> [b (line 84): true] access to parameter b
+
+#  119| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  119| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... == ...
+
+#  119| [false, b (line 84): true] !...
+#-----| false -> [false, b (line 84): true] ... || ...
+
+#  119| [b (line 84): true] access to parameter b
+#-----| true -> [false, b (line 84): true] !...
+
+#  120| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  120| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  120| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  120| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  122| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  122| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  122| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  122| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  122| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  123| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  123| [assertion failure, b (line 84): true] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  123| [assertion success, b (line 84): true] call to method IsTrue
+#-----|  -> [b (line 84): true] ...;
+
+#  123| [false, b (line 84): true] ... && ...
+#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
+
+#  123| [true, b (line 84): true] ... && ...
+#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
+
+#  123| [b (line 84): true] ... == ...
+#-----| false -> [false, b (line 84): true] ... && ...
+#-----| true -> [b (line 84): true] access to parameter b
+
+#  123| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  123| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... == ...
+
+#  123| [b (line 84): true] access to parameter b
+#-----| true -> [true, b (line 84): true] ... && ...
+
+#  124| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  124| [b (line 84): true] call to method WriteLine
+#-----|  -> [b (line 84): true] ...;
+
+#  124| [b (line 84): true] access to property Length
+#-----|  -> [b (line 84): true] call to method WriteLine
+
+#  124| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] access to property Length
+
+#  126| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to parameter b
+
+#  126| [b (line 84): true] ... = ...
+#-----|  -> [b (line 84): true] ...;
+
+#  126| [b (line 84): true] ... ? ... : ...
+#-----|  -> [b (line 84): true] ... = ...
+
+#  126| [b (line 84): true] access to parameter b
+#-----| true -> [b (line 84): true] null
+
+#  126| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... ? ... : ...
+
+#  127| [b (line 84): true] ...;
+#-----|  -> [b (line 84): true] access to local variable s
+
+#  127| [assertion failure] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit M12 (abnormal)
+
+#  127| [assertion success] call to method IsFalse
+#-----|  -> ...;
+
+#  127| [false] ... || ...
+#-----| false -> [assertion success] call to method IsFalse
+
+#  127| [true] ... || ...
+#-----| true -> [assertion failure] call to method IsFalse
+
+#  127| [b (line 84): true] ... != ...
+#-----| true -> [true] ... || ...
+#-----| false -> [b (line 84): true] access to parameter b
+
+#  127| [b (line 84): true] access to local variable s
+#-----|  -> [b (line 84): true] null
+
+#  127| [b (line 84): true] null
+#-----|  -> [b (line 84): true] ... != ...
+
+#  127| [false] !...
+#-----| false -> [false] ... || ...
+
+#  127| [b (line 84): true] access to parameter b
+#-----| true -> [false] !...
+
+#  128| ...;
+#-----|  -> access to local variable s
+
+#  128| call to method WriteLine
+#-----|  -> exit M12 (normal)
+
+#  128| access to property Length
+#-----|  -> call to method WriteLine
+
+#  128| access to local variable s
+#-----|  -> access to property Length
+
+#  131| enter AssertTrueFalse
+#-----|  -> {...}
+
+#  131| exit AssertTrueFalse
+
+#  131| exit AssertTrueFalse (normal)
+#-----|  -> exit AssertTrueFalse
+
+#  135| {...}
+#-----|  -> exit AssertTrueFalse (normal)
+
+#  138| enter M13
+#-----|  -> {...}
+
+#  138| exit M13
+
+#  138| exit M13 (abnormal)
+#-----|  -> exit M13
+
+#  138| exit M13 (normal)
+#-----|  -> exit M13
+
+#  139| {...}
+#-----|  -> ...;
+
+#  140| ...;
+#-----|  -> this access
+
+#  140| [assertion failure] call to method AssertTrueFalse
+#-----| exception(Exception) -> exit M13 (abnormal)
+
+#  140| [assertion failure] call to method AssertTrueFalse
+#-----| exception(Exception) -> exit M13 (abnormal)
+
+#  140| [assertion success] call to method AssertTrueFalse
+#-----|  -> return ...;
+
+#  140| this access
+#-----|  -> access to parameter b1
+
+#  140| access to parameter b1
+#-----| true -> access to parameter b2
+#-----| false -> [assertion failure] access to parameter b2
+
+#  140| access to parameter b2
+#-----| true -> [assertion failure] access to parameter b3
+#-----| false -> [assertion success] access to parameter b3
+
+#  140| [assertion failure] access to parameter b2
+#-----| true -> [assertion failure] access to parameter b3
+
+#  140| [assertion failure] access to parameter b3
+#-----|  -> [assertion failure] call to method AssertTrueFalse
+
+#  140| [assertion failure] access to parameter b3
+#-----|  -> [assertion failure] call to method AssertTrueFalse
+
+#  140| [assertion success] access to parameter b3
+#-----|  -> [assertion success] call to method AssertTrueFalse
+
+#  141| return ...;
+#-----| return -> exit M13 (normal)
+
+Assignments.cs:
+#    3| enter M
+#-----|  -> {...}
+
+#    3| exit M
+
+#    3| exit M (normal)
+#-----|  -> exit M
+
+#    4| {...}
+#-----|  -> ... ...;
+
+#    5| ... ...;
+#-----|  -> 0
+
+#    5| Int32 x = ...
+#-----|  -> ...;
+
+#    5| 0
+#-----|  -> Int32 x = ...
+
+#    6| ...;
+#-----|  -> access to local variable x
+
+#    6| ... = ...
+#-----|  -> ... ...;
+
+#    6| ... + ...
+#-----|  -> ... = ...
+
+#    6| access to local variable x
+#-----|  -> 1
+
+#    6| 1
+#-----|  -> ... + ...
+
+#    8| ... ...;
+#-----|  -> 0
+
+#    8| dynamic d = ...
+#-----|  -> ...;
+
+#    8| (...) ...
+#-----|  -> dynamic d = ...
+
+#    8| 0
+#-----|  -> (...) ...
+
+#    9| ...;
+#-----|  -> access to local variable d
+
+#    9| ... = ...
+#-----|  -> ... ...;
+
+#    9| dynamic call to operator -
+#-----|  -> ... = ...
+
+#    9| access to local variable d
+#-----|  -> 2
+
+#    9| 2
+#-----|  -> dynamic call to operator -
+
+#   11| ... ...;
+#-----|  -> object creation of type Assignments
+
+#   11| Assignments a = ...
+#-----|  -> ...;
+
+#   11| object creation of type Assignments
+#-----|  -> Assignments a = ...
+
+#   12| ...;
+#-----|  -> access to local variable a
+
+#   12| ... = ...
+#-----|  -> ...;
+
+#   12| call to operator +
+#-----|  -> ... = ...
+
+#   12| access to local variable a
+#-----|  -> this access
+
+#   12| this access
+#-----|  -> call to operator +
+
+#   14| ...;
+#-----|  -> this access
+
+#   14| ... += ...
+#-----|  -> exit M (normal)
+
+#   14| access to event Event
+#-----|  -> ... += ...
+
+#   14| this access
+#-----|  -> (...) => ...
+
+#   14| enter (...) => ...
+#-----|  -> {...}
+
+#   14| (...) => ...
+#-----|  -> access to event Event
+
+#   14| exit (...) => ...
+
+#   14| exit (...) => ... (normal)
+#-----|  -> exit (...) => ...
+
+#   14| {...}
+#-----|  -> exit (...) => ... (normal)
+
+#   17| enter +
+#-----|  -> {...}
+
+#   17| exit +
+
+#   17| exit + (normal)
+#-----|  -> exit +
+
+#   18| {...}
+#-----|  -> access to parameter x
+
+#   19| return ...;
+#-----| return -> exit + (normal)
+
+#   19| access to parameter x
+#-----|  -> return ...;
+
+BreakInTry.cs:
+#    3| enter M1
+#-----|  -> {...}
+
+#    3| exit M1
+
+#    3| exit M1 (normal)
+#-----|  -> exit M1
+
+#    4| {...}
+#-----|  -> try {...} ...
+
+#    5| try {...} ...
+#-----|  -> {...}
+
+#    6| {...}
+#-----|  -> access to parameter args
+
+#    7| foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+#-----| empty -> {...}
+
+#    7| String arg
+#-----|  -> {...}
+
+#    7| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#    8| {...}
+#-----|  -> if (...) ...
+
+#    9| if (...) ...
+#-----|  -> access to local variable arg
+
+#    9| ... == ...
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> break;
+
+#    9| access to local variable arg
+#-----|  -> null
+
+#    9| null
+#-----|  -> ... == ...
+
+#   10| break;
+#-----| break -> {...}
+
+#   14| {...}
+#-----|  -> if (...) ...
+
+#   15| if (...) ...
+#-----|  -> access to parameter args
+
+#   15| ... == ...
+#-----| true -> ;
+#-----| false -> exit M1 (normal)
+
+#   15| access to parameter args
+#-----|  -> null
+
+#   15| null
+#-----|  -> ... == ...
+
+#   16| ;
+#-----|  -> exit M1 (normal)
+
+#   20| enter M2
+#-----|  -> {...}
+
+#   20| exit M2
+
+#   20| exit M2 (normal)
+#-----|  -> exit M2
+
+#   21| {...}
+#-----|  -> access to parameter args
+
+#   22| foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+#-----| empty -> ;
+
+#   22| String arg
+#-----|  -> {...}
+
+#   22| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   23| {...}
+#-----|  -> try {...} ...
+
+#   24| try {...} ...
+#-----|  -> {...}
+
+#   25| {...}
+#-----|  -> if (...) ...
+
+#   26| if (...) ...
+#-----|  -> access to local variable arg
+
+#   26| ... == ...
+#-----| true -> break;
+#-----| false -> {...}
+
+#   26| access to local variable arg
+#-----|  -> null
+
+#   26| null
+#-----|  -> ... == ...
+
+#   27| break;
+#-----| break -> [finally: break] {...}
+
+#   30| {...}
+#-----|  -> if (...) ...
+
+#   30| [finally: break] {...}
+#-----|  -> [finally: break] if (...) ...
+
+#   31| if (...) ...
+#-----|  -> access to parameter args
+
+#   31| [finally: break] if (...) ...
+#-----|  -> [finally: break] access to parameter args
+
+#   31| ... == ...
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> ;
+
+#   31| [finally: break] ... == ...
+#-----| true -> [finally: break] ;
+#-----| false -> ;
+
+#   31| access to parameter args
+#-----|  -> null
+
+#   31| [finally: break] access to parameter args
+#-----|  -> [finally: break] null
+
+#   31| null
+#-----|  -> ... == ...
+
+#   31| [finally: break] null
+#-----|  -> [finally: break] ... == ...
+
+#   32| ;
+#-----|  -> foreach (... ... in ...) ...
+
+#   32| [finally: break] ;
+#-----| break -> ;
+
+#   35| ;
+#-----|  -> exit M2 (normal)
+
+#   38| enter M3
+#-----|  -> {...}
+
+#   38| exit M3
+
+#   38| exit M3 (normal)
+#-----|  -> exit M3
+
+#   39| {...}
+#-----|  -> try {...} ...
+
+#   40| try {...} ...
+#-----|  -> {...}
+
+#   41| {...}
+#-----|  -> if (...) ...
+
+#   42| if (...) ...
+#-----|  -> access to parameter args
+
+#   42| ... == ...
+#-----| true -> return ...;
+#-----| false -> {...}
+
+#   42| access to parameter args
+#-----|  -> null
+
+#   42| null
+#-----|  -> ... == ...
+
+#   43| return ...;
+#-----| return -> [finally: return] {...}
+
+#   46| {...}
+#-----|  -> access to parameter args
+
+#   46| [finally: return] {...}
+#-----|  -> [finally: return] access to parameter args
+
+#   47| foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+#-----| empty -> ;
+
+#   47| [finally: return] foreach (... ... in ...) ...
+#-----| non-empty -> [finally: return] String arg
+#-----| return -> exit M3 (normal)
+
+#   47| String arg
+#-----|  -> {...}
+
+#   47| [finally: return] String arg
+#-----|  -> [finally: return] {...}
+
+#   47| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   47| [finally: return] access to parameter args
+#-----|  -> [finally: return] foreach (... ... in ...) ...
+
+#   48| {...}
+#-----|  -> if (...) ...
+
+#   48| [finally: return] {...}
+#-----|  -> [finally: return] if (...) ...
+
+#   49| if (...) ...
+#-----|  -> access to local variable arg
+
+#   49| [finally: return] if (...) ...
+#-----|  -> [finally: return] access to local variable arg
+
+#   49| ... == ...
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> break;
+
+#   49| [finally: return] ... == ...
+#-----| false -> [finally: return] foreach (... ... in ...) ...
+#-----| true -> [finally: return] break;
+
+#   49| access to local variable arg
+#-----|  -> null
+
+#   49| [finally: return] access to local variable arg
+#-----|  -> [finally: return] null
+
+#   49| null
+#-----|  -> ... == ...
+
+#   49| [finally: return] null
+#-----|  -> [finally: return] ... == ...
+
+#   50| break;
+#-----| break -> ;
+
+#   50| [finally: return] break;
+#-----| return -> exit M3 (normal)
+
+#   53| ;
+#-----|  -> exit M3 (normal)
+
+#   56| enter M4
+#-----|  -> {...}
+
+#   56| exit M4
+
+#   56| exit M4 (normal)
+#-----|  -> exit M4
+
+#   57| {...}
+#-----|  -> try {...} ...
+
+#   58| try {...} ...
+#-----|  -> {...}
+
+#   59| {...}
+#-----|  -> if (...) ...
+
+#   60| if (...) ...
+#-----|  -> access to parameter args
+
+#   60| ... == ...
+#-----| true -> return ...;
+#-----| false -> {...}
+
+#   60| access to parameter args
+#-----|  -> null
+
+#   60| null
+#-----|  -> ... == ...
+
+#   61| return ...;
+#-----| return -> [finally: return] {...}
+
+#   64| {...}
+#-----|  -> access to parameter args
+
+#   64| [finally: return] {...}
+#-----|  -> [finally: return] access to parameter args
+
+#   65| foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+#-----| empty -> exit M4 (normal)
+
+#   65| [finally: return] foreach (... ... in ...) ...
+#-----| non-empty -> [finally: return] String arg
+#-----| return -> exit M4 (normal)
+
+#   65| String arg
+#-----|  -> {...}
+
+#   65| [finally: return] String arg
+#-----|  -> [finally: return] {...}
+
+#   65| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   65| [finally: return] access to parameter args
+#-----|  -> [finally: return] foreach (... ... in ...) ...
+
+#   66| {...}
+#-----|  -> if (...) ...
+
+#   66| [finally: return] {...}
+#-----|  -> [finally: return] if (...) ...
+
+#   67| if (...) ...
+#-----|  -> access to local variable arg
+
+#   67| [finally: return] if (...) ...
+#-----|  -> [finally: return] access to local variable arg
+
+#   67| ... == ...
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> break;
+
+#   67| [finally: return] ... == ...
+#-----| false -> [finally: return] foreach (... ... in ...) ...
+#-----| true -> [finally: return] break;
+
+#   67| access to local variable arg
+#-----|  -> null
+
+#   67| [finally: return] access to local variable arg
+#-----|  -> [finally: return] null
+
+#   67| null
+#-----|  -> ... == ...
+
+#   67| [finally: return] null
+#-----|  -> [finally: return] ... == ...
+
+#   68| break;
+#-----| break -> exit M4 (normal)
+
+#   68| [finally: return] break;
+#-----| return -> exit M4 (normal)
+
+CompileTimeOperators.cs:
+#    5| enter Default
+#-----|  -> {...}
+
+#    5| exit Default
+
+#    5| exit Default (normal)
+#-----|  -> exit Default
+
+#    6| {...}
+#-----|  -> default(...)
+
+#    7| return ...;
+#-----| return -> exit Default (normal)
+
+#    7| default(...)
+#-----|  -> return ...;
+
+#   10| enter Sizeof
+#-----|  -> {...}
+
+#   10| exit Sizeof
+
+#   10| exit Sizeof (normal)
+#-----|  -> exit Sizeof
+
+#   11| {...}
+#-----|  -> sizeof(..)
+
+#   12| return ...;
+#-----| return -> exit Sizeof (normal)
+
+#   12| sizeof(..)
+#-----|  -> return ...;
+
+#   15| enter Typeof
+#-----|  -> {...}
+
+#   15| exit Typeof
+
+#   15| exit Typeof (normal)
+#-----|  -> exit Typeof
+
+#   16| {...}
+#-----|  -> typeof(...)
+
+#   17| return ...;
+#-----| return -> exit Typeof (normal)
+
+#   17| typeof(...)
+#-----|  -> return ...;
+
+#   20| enter Nameof
+#-----|  -> {...}
+
+#   20| exit Nameof
+
+#   20| exit Nameof (normal)
+#-----|  -> exit Nameof
+
+#   21| {...}
+#-----|  -> nameof(...)
+
+#   22| return ...;
+#-----| return -> exit Nameof (normal)
+
+#   22| nameof(...)
+#-----|  -> return ...;
+
+#   28| enter M
+#-----|  -> {...}
+
+#   28| exit M
+
+#   28| exit M (normal)
+#-----|  -> exit M
+
+#   29| {...}
+#-----|  -> try {...} ...
+
+#   30| try {...} ...
+#-----|  -> {...}
+
+#   31| {...}
+#-----|  -> goto ...;
+
+#   32| goto ...;
+#-----| goto(End) -> [finally: goto(End)] {...}
+
+#   36| [finally: goto(End)] {...}
+#-----|  -> [finally: goto(End)] ...;
+
+#   37| [finally: goto(End)] ...;
+#-----|  -> [finally: goto(End)] "Finally"
+
+#   37| [finally: goto(End)] call to method WriteLine
+#-----| goto(End) -> End:
+
+#   37| [finally: goto(End)] "Finally"
+#-----|  -> [finally: goto(End)] call to method WriteLine
+
+#   40| End:
+#-----|  -> ...;
+
+#   40| ...;
+#-----|  -> "End"
+
+#   40| call to method WriteLine
+#-----|  -> exit M (normal)
+
+#   40| "End"
+#-----|  -> call to method WriteLine
+
+ConditionalAccess.cs:
+#    3| enter M1
+#-----|  -> access to parameter i
+
+#    3| exit M1
+
+#    3| exit M1 (normal)
+#-----|  -> exit M1
+
+#    3| access to parameter i
+#-----| non-null -> call to method ToString
+#-----| null -> exit M1 (normal)
+
+#    3| call to method ToString
+#-----| non-null -> call to method ToLower
+#-----| null -> exit M1 (normal)
+
+#    3| call to method ToLower
+#-----|  -> exit M1 (normal)
+
+#    5| enter M2
+#-----|  -> access to parameter s
+
+#    5| exit M2
+
+#    5| exit M2 (normal)
+#-----|  -> exit M2
+
+#    5| access to parameter s
+#-----| non-null -> access to property Length
+#-----| null -> exit M2 (normal)
+
+#    5| access to property Length
+#-----|  -> exit M2 (normal)
+
+#    7| enter M3
+#-----|  -> access to parameter s1
+
+#    7| exit M3
+
+#    7| exit M3 (normal)
+#-----|  -> exit M3
+
+#    7| ... ?? ...
+#-----| non-null -> access to property Length
+#-----| null -> exit M3 (normal)
+
+#    7| [non-null] ... ?? ...
+#-----| non-null -> access to property Length
+
+#    7| [null] ... ?? ...
+#-----| null -> exit M3 (normal)
+
+#    7| access to parameter s1
+#-----| non-null -> ... ?? ...
+#-----| null -> access to parameter s2
+
+#    7| access to parameter s2
+#-----| non-null -> [non-null] ... ?? ...
+#-----| null -> [null] ... ?? ...
+
+#    7| access to property Length
+#-----|  -> exit M3 (normal)
+
+#    9| enter M4
+#-----|  -> access to parameter s
+
+#    9| exit M4
+
+#    9| exit M4 (normal)
+#-----|  -> exit M4
+
+#    9| ... ?? ...
+#-----|  -> exit M4 (normal)
+
+#    9| access to parameter s
+#-----| non-null -> access to property Length
+#-----| null -> 0
+
+#    9| access to property Length
+#-----| non-null -> ... ?? ...
+#-----| null -> 0
+
+#    9| 0
+#-----|  -> ... ?? ...
+
+#   11| enter M5
+#-----|  -> {...}
+
+#   11| exit M5
+
+#   11| exit M5 (normal)
+#-----|  -> exit M5
+
+#   12| {...}
+#-----|  -> if (...) ...
+
+#   13| if (...) ...
+#-----|  -> access to parameter s
+
+#   13| ... > ...
+#-----| true -> 0
+#-----| false -> 1
+
+#   13| access to parameter s
+#-----| non-null -> access to property Length
+#-----| null -> 0
+
+#   13| access to property Length
+#-----|  -> 0
+
+#   13| (...) ...
+#-----|  -> ... > ...
+
+#   13| 0
+#-----|  -> (...) ...
+
+#   14| return ...;
+#-----| return -> exit M5 (normal)
+
+#   14| 0
+#-----|  -> return ...;
+
+#   16| return ...;
+#-----| return -> exit M5 (normal)
+
+#   16| 1
+#-----|  -> return ...;
+
+#   19| enter M6
+#-----|  -> access to parameter s1
+
+#   19| exit M6
+
+#   19| exit M6 (normal)
+#-----|  -> exit M6
+
+#   19| access to parameter s1
+#-----| non-null -> access to parameter s2
+#-----| null -> exit M6 (normal)
+
+#   19| call to method CommaJoinWith
+#-----|  -> exit M6 (normal)
+
+#   19| access to parameter s2
+#-----|  -> call to method CommaJoinWith
+
+#   21| enter M7
+#-----|  -> {...}
+
+#   21| exit M7
+
+#   21| exit M7 (normal)
+#-----|  -> exit M7
+
+#   22| {...}
+#-----|  -> ... ...;
+
+#   23| ... ...;
+#-----|  -> null
+
+#   23| Nullable<Int32> j = ...
+#-----|  -> ... ...;
+
+#   23| (...) ...
+#-----| null -> Nullable<Int32> j = ...
+
+#   23| null
+#-----|  -> (...) ...
+
+#   24| ... ...;
+#-----|  -> access to parameter i
+
+#   24| String s = ...
+#-----|  -> ...;
+
+#   24| (...) ...
+#-----| non-null -> call to method ToString
+
+#   24| access to parameter i
+#-----|  -> (...) ...
+
+#   24| call to method ToString
+#-----|  -> String s = ...
+
+#   25| ...;
+#-----|  -> ""
+
+#   25| ... = ...
+#-----|  -> exit M7 (normal)
+
+#   25| ""
+#-----| non-null -> access to local variable s
+
+#   25| call to method CommaJoinWith
+#-----|  -> ... = ...
+
+#   25| access to local variable s
+#-----|  -> call to method CommaJoinWith
+
+#   30| enter Out
+#-----|  -> 0
+
+#   30| exit Out
+
+#   30| exit Out (normal)
+#-----|  -> exit Out
+
+#   30| ... = ...
+#-----|  -> exit Out (normal)
+
+#   30| 0
+#-----|  -> ... = ...
+
+#   32| enter M8
+#-----|  -> {...}
+
+#   32| exit M8
+
+#   32| exit M8 (normal)
+#-----|  -> exit M8
+
+#   33| {...}
+#-----|  -> ...;
+
+#   34| ...;
+#-----|  -> 0
+
+#   34| ... = ...
+#-----|  -> ...;
+
+#   34| 0
+#-----|  -> ... = ...
+
+#   35| ...;
+#-----|  -> this access
+
+#   35| access to property Prop
+#-----| non-null -> call to method Out
+#-----| null -> exit M8 (normal)
+
+#   35| this access
+#-----|  -> access to property Prop
+
+#   35| call to method Out
+#-----|  -> exit M8 (normal)
+
+#   41| enter CommaJoinWith
+#-----|  -> access to parameter s1
+
+#   41| exit CommaJoinWith
+
+#   41| exit CommaJoinWith (normal)
+#-----|  -> exit CommaJoinWith
+
+#   41| ... + ...
+#-----|  -> exit CommaJoinWith (normal)
+
+#   41| ... + ...
+#-----|  -> access to parameter s2
+
+#   41| access to parameter s1
+#-----|  -> ", "
+
+#   41| ", "
+#-----|  -> ... + ...
+
+#   41| access to parameter s2
+#-----|  -> ... + ...
+
+Conditions.cs:
+#    3| enter IncrOrDecr
+#-----|  -> {...}
+
+#    3| exit IncrOrDecr
+
+#    3| exit IncrOrDecr (normal)
+#-----|  -> exit IncrOrDecr
+
+#    4| {...}
+#-----|  -> if (...) ...
+
+#    5| if (...) ...
+#-----|  -> access to parameter inc
+
+#    5| access to parameter inc
+#-----| true -> [inc (line 3): true] ...;
+#-----| false -> [inc (line 3): false] if (...) ...
+
+#    6| [inc (line 3): true] ...;
+#-----|  -> [inc (line 3): true] access to parameter x
+
+#    6| [inc (line 3): true] ...++
+#-----|  -> [inc (line 3): true] if (...) ...
+
+#    6| [inc (line 3): true] access to parameter x
+#-----|  -> [inc (line 3): true] ...++
+
+#    7| [inc (line 3): false] if (...) ...
+#-----|  -> [inc (line 3): false] access to parameter inc
+
+#    7| [inc (line 3): true] if (...) ...
+#-----|  -> [inc (line 3): true] access to parameter inc
+
+#    7| [false] !...
+#-----| false -> exit IncrOrDecr (normal)
+
+#    7| [true] !...
+#-----| true -> ...;
+
+#    7| [inc (line 3): false] access to parameter inc
+#-----| false -> [true] !...
+
+#    7| [inc (line 3): true] access to parameter inc
+#-----| true -> [false] !...
+
+#    8| ...;
+#-----|  -> access to parameter x
+
+#    8| ...--
+#-----|  -> exit IncrOrDecr (normal)
+
+#    8| access to parameter x
+#-----|  -> ...--
+
+#   11| enter M1
+#-----|  -> {...}
+
+#   11| exit M1
+
+#   11| exit M1 (normal)
+#-----|  -> exit M1
+
+#   12| {...}
+#-----|  -> ... ...;
+
+#   13| ... ...;
+#-----|  -> 0
+
+#   13| Int32 x = ...
+#-----|  -> if (...) ...
+
+#   13| 0
+#-----|  -> Int32 x = ...
+
+#   14| if (...) ...
+#-----|  -> access to parameter b
+
+#   14| access to parameter b
+#-----| true -> [b (line 11): true] ...;
+#-----| false -> [b (line 11): false] if (...) ...
+
+#   15| [b (line 11): true] ...;
+#-----|  -> [b (line 11): true] access to local variable x
+
+#   15| [b (line 11): true] ...++
+#-----|  -> [b (line 11): true] if (...) ...
+
+#   15| [b (line 11): true] access to local variable x
+#-----|  -> [b (line 11): true] ...++
+
+#   16| [b (line 11): false] if (...) ...
+#-----|  -> [b (line 11): false] access to local variable x
+
+#   16| [b (line 11): true] if (...) ...
+#-----|  -> [b (line 11): true] access to local variable x
+
+#   16| [b (line 11): false] ... > ...
+#-----| true -> [b (line 11): false] if (...) ...
+#-----| false -> access to local variable x
+
+#   16| [b (line 11): true] ... > ...
+#-----| true -> [b (line 11): true] if (...) ...
+#-----| false -> access to local variable x
+
+#   16| [b (line 11): false] access to local variable x
+#-----|  -> [b (line 11): false] 0
+
+#   16| [b (line 11): true] access to local variable x
+#-----|  -> [b (line 11): true] 0
+
+#   16| [b (line 11): false] 0
+#-----|  -> [b (line 11): false] ... > ...
+
+#   16| [b (line 11): true] 0
+#-----|  -> [b (line 11): true] ... > ...
+
+#   17| [b (line 11): false] if (...) ...
+#-----|  -> [b (line 11): false] access to parameter b
+
+#   17| [b (line 11): true] if (...) ...
+#-----|  -> [b (line 11): true] access to parameter b
+
+#   17| [false] !...
+#-----| false -> access to local variable x
+
+#   17| [true] !...
+#-----| true -> ...;
+
+#   17| [b (line 11): false] access to parameter b
+#-----| false -> [true] !...
+
+#   17| [b (line 11): true] access to parameter b
+#-----| true -> [false] !...
+
+#   18| ...;
+#-----|  -> access to local variable x
+
+#   18| ...--
+#-----|  -> access to local variable x
+
+#   18| access to local variable x
+#-----|  -> ...--
+
+#   19| return ...;
+#-----| return -> exit M1 (normal)
+
+#   19| access to local variable x
+#-----|  -> return ...;
+
+#   22| enter M2
+#-----|  -> {...}
+
+#   22| exit M2
+
+#   22| exit M2 (normal)
+#-----|  -> exit M2
+
+#   23| {...}
+#-----|  -> ... ...;
+
+#   24| ... ...;
+#-----|  -> 0
+
+#   24| Int32 x = ...
+#-----|  -> if (...) ...
+
+#   24| 0
+#-----|  -> Int32 x = ...
+
+#   25| if (...) ...
+#-----|  -> access to parameter b1
+
+#   25| access to parameter b1
+#-----| true -> if (...) ...
+#-----| false -> if (...) ...
+
+#   26| if (...) ...
+#-----|  -> access to parameter b2
+
+#   26| access to parameter b2
+#-----| true -> [b2 (line 22): true] ...;
+#-----| false -> [b2 (line 22): false] if (...) ...
+
+#   27| [b2 (line 22): true] ...;
+#-----|  -> [b2 (line 22): true] access to local variable x
+
+#   27| [b2 (line 22): true] ...++
+#-----|  -> [b2 (line 22): true] if (...) ...
+
+#   27| [b2 (line 22): true] access to local variable x
+#-----|  -> [b2 (line 22): true] ...++
+
+#   28| if (...) ...
+#-----|  -> access to parameter b2
+
+#   28| [b2 (line 22): false] if (...) ...
+#-----|  -> [b2 (line 22): false] access to parameter b2
+
+#   28| [b2 (line 22): true] if (...) ...
+#-----|  -> [b2 (line 22): true] access to parameter b2
+
+#   28| access to parameter b2
+#-----| true -> ...;
+#-----| false -> access to local variable x
+
+#   28| [b2 (line 22): false] access to parameter b2
+#-----| false -> access to local variable x
+
+#   28| [b2 (line 22): true] access to parameter b2
+#-----| true -> ...;
+
+#   29| ...;
+#-----|  -> access to local variable x
+
+#   29| ...++
+#-----|  -> access to local variable x
+
+#   29| access to local variable x
+#-----|  -> ...++
+
+#   30| return ...;
+#-----| return -> exit M2 (normal)
+
+#   30| access to local variable x
+#-----|  -> return ...;
+
+#   33| enter M3
+#-----|  -> {...}
+
+#   33| exit M3
+
+#   33| exit M3 (normal)
+#-----|  -> exit M3
+
+#   34| {...}
+#-----|  -> ... ...;
+
+#   35| ... ...;
+#-----|  -> 0
+
+#   35| Int32 x = ...
+#-----|  -> ... ...;
+
+#   35| 0
+#-----|  -> Int32 x = ...
+
+#   36| ... ...;
+#-----|  -> false
+
+#   36| Boolean b2 = ...
+#-----|  -> if (...) ...
+
+#   36| false
+#-----|  -> Boolean b2 = ...
+
+#   37| if (...) ...
+#-----|  -> access to parameter b1
+
+#   37| access to parameter b1
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   38| ...;
+#-----|  -> access to parameter b1
+
+#   38| ... = ...
+#-----|  -> if (...) ...
+
+#   38| access to parameter b1
+#-----|  -> ... = ...
+
+#   39| if (...) ...
+#-----|  -> access to local variable b2
+
+#   39| access to local variable b2
+#-----| true -> [b2 (line 39): true] ...;
+#-----| false -> [b2 (line 39): false] if (...) ...
+
+#   40| [b2 (line 39): true] ...;
+#-----|  -> [b2 (line 39): true] access to local variable x
+
+#   40| [b2 (line 39): true] ...++
+#-----|  -> [b2 (line 39): true] if (...) ...
+
+#   40| [b2 (line 39): true] access to local variable x
+#-----|  -> [b2 (line 39): true] ...++
+
+#   41| [b2 (line 39): false] if (...) ...
+#-----|  -> [b2 (line 39): false] access to local variable b2
+
+#   41| [b2 (line 39): true] if (...) ...
+#-----|  -> [b2 (line 39): true] access to local variable b2
+
+#   41| [b2 (line 39): false] access to local variable b2
+#-----| false -> access to local variable x
+
+#   41| [b2 (line 39): true] access to local variable b2
+#-----| true -> ...;
+
+#   42| ...;
+#-----|  -> access to local variable x
+
+#   42| ...++
+#-----|  -> access to local variable x
+
+#   42| access to local variable x
+#-----|  -> ...++
+
+#   43| return ...;
+#-----| return -> exit M3 (normal)
+
+#   43| access to local variable x
+#-----|  -> return ...;
+
+#   46| enter M4
+#-----|  -> {...}
+
+#   46| exit M4
+
+#   46| exit M4 (normal)
+#-----|  -> exit M4
+
+#   47| {...}
+#-----|  -> ... ...;
+
+#   48| ... ...;
+#-----|  -> 0
+
+#   48| Int32 y = ...
+#-----|  -> while (...) ...
+
+#   48| 0
+#-----|  -> Int32 y = ...
+
+#   49| while (...) ...
+#-----|  -> access to parameter x
+
+#   49| ... > ...
+#-----| true -> {...}
+#-----| false -> access to local variable y
+
+#   49| [b (line 46): false] ... > ...
+#-----| true -> [b (line 46): false] {...}
+#-----| false -> access to local variable y
+
+#   49| [b (line 46): true] ... > ...
+#-----| true -> [b (line 46): true] {...}
+#-----| false -> access to local variable y
+
+#   49| ...--
+#-----|  -> 0
+
+#   49| [b (line 46): false] ...--
+#-----|  -> [b (line 46): false] 0
+
+#   49| [b (line 46): true] ...--
+#-----|  -> [b (line 46): true] 0
+
+#   49| access to parameter x
+#-----|  -> ...--
+
+#   49| [b (line 46): false] access to parameter x
+#-----|  -> [b (line 46): false] ...--
+
+#   49| [b (line 46): true] access to parameter x
+#-----|  -> [b (line 46): true] ...--
+
+#   49| 0
+#-----|  -> ... > ...
+
+#   49| [b (line 46): false] 0
+#-----|  -> [b (line 46): false] ... > ...
+
+#   49| [b (line 46): true] 0
+#-----|  -> [b (line 46): true] ... > ...
+
+#   50| {...}
+#-----|  -> if (...) ...
+
+#   50| [b (line 46): false] {...}
+#-----|  -> [b (line 46): false] if (...) ...
+
+#   50| [b (line 46): true] {...}
+#-----|  -> [b (line 46): true] if (...) ...
+
+#   51| if (...) ...
+#-----|  -> access to parameter b
+
+#   51| [b (line 46): false] if (...) ...
+#-----|  -> [b (line 46): false] access to parameter b
+
+#   51| [b (line 46): true] if (...) ...
+#-----|  -> [b (line 46): true] access to parameter b
+
+#   51| access to parameter b
+#-----| true -> [b (line 46): true] ...;
+#-----| false -> [b (line 46): false] access to parameter x
+
+#   51| [b (line 46): false] access to parameter b
+#-----| false -> [b (line 46): false] access to parameter x
+
+#   51| [b (line 46): true] access to parameter b
+#-----| true -> [b (line 46): true] ...;
+
+#   52| [b (line 46): true] ...;
+#-----|  -> [b (line 46): true] access to local variable y
+
+#   52| [b (line 46): true] ...++
+#-----|  -> [b (line 46): true] access to parameter x
+
+#   52| [b (line 46): true] access to local variable y
+#-----|  -> [b (line 46): true] ...++
+
+#   54| return ...;
+#-----| return -> exit M4 (normal)
+
+#   54| access to local variable y
+#-----|  -> return ...;
+
+#   57| enter M5
+#-----|  -> {...}
+
+#   57| exit M5
+
+#   57| exit M5 (normal)
+#-----|  -> exit M5
+
+#   58| {...}
+#-----|  -> ... ...;
+
+#   59| ... ...;
+#-----|  -> 0
+
+#   59| Int32 y = ...
+#-----|  -> while (...) ...
+
+#   59| 0
+#-----|  -> Int32 y = ...
+
+#   60| while (...) ...
+#-----|  -> access to parameter x
+
+#   60| ... > ...
+#-----| true -> {...}
+#-----| false -> if (...) ...
+
+#   60| [b (line 57): false] ... > ...
+#-----| true -> [b (line 57): false] {...}
+#-----| false -> [b (line 57): false] if (...) ...
+
+#   60| [b (line 57): true] ... > ...
+#-----| true -> [b (line 57): true] {...}
+#-----| false -> [b (line 57): true] if (...) ...
+
+#   60| ...--
+#-----|  -> 0
+
+#   60| [b (line 57): false] ...--
+#-----|  -> [b (line 57): false] 0
+
+#   60| [b (line 57): true] ...--
+#-----|  -> [b (line 57): true] 0
+
+#   60| access to parameter x
+#-----|  -> ...--
+
+#   60| [b (line 57): false] access to parameter x
+#-----|  -> [b (line 57): false] ...--
+
+#   60| [b (line 57): true] access to parameter x
+#-----|  -> [b (line 57): true] ...--
+
+#   60| 0
+#-----|  -> ... > ...
+
+#   60| [b (line 57): false] 0
+#-----|  -> [b (line 57): false] ... > ...
+
+#   60| [b (line 57): true] 0
+#-----|  -> [b (line 57): true] ... > ...
+
+#   61| {...}
+#-----|  -> if (...) ...
+
+#   61| [b (line 57): false] {...}
+#-----|  -> [b (line 57): false] if (...) ...
+
+#   61| [b (line 57): true] {...}
+#-----|  -> [b (line 57): true] if (...) ...
+
+#   62| if (...) ...
+#-----|  -> access to parameter b
+
+#   62| [b (line 57): false] if (...) ...
+#-----|  -> [b (line 57): false] access to parameter b
+
+#   62| [b (line 57): true] if (...) ...
+#-----|  -> [b (line 57): true] access to parameter b
+
+#   62| access to parameter b
+#-----| true -> [b (line 57): true] ...;
+#-----| false -> [b (line 57): false] access to parameter x
+
+#   62| [b (line 57): false] access to parameter b
+#-----| false -> [b (line 57): false] access to parameter x
+
+#   62| [b (line 57): true] access to parameter b
+#-----| true -> [b (line 57): true] ...;
+
+#   63| [b (line 57): true] ...;
+#-----|  -> [b (line 57): true] access to local variable y
+
+#   63| [b (line 57): true] ...++
+#-----|  -> [b (line 57): true] access to parameter x
+
+#   63| [b (line 57): true] access to local variable y
+#-----|  -> [b (line 57): true] ...++
+
+#   65| if (...) ...
+#-----|  -> access to parameter b
+
+#   65| [b (line 57): false] if (...) ...
+#-----|  -> [b (line 57): false] access to parameter b
+
+#   65| [b (line 57): true] if (...) ...
+#-----|  -> [b (line 57): true] access to parameter b
+
+#   65| access to parameter b
+#-----| true -> ...;
+#-----| false -> access to local variable y
+
+#   65| [b (line 57): false] access to parameter b
+#-----| false -> access to local variable y
+
+#   65| [b (line 57): true] access to parameter b
+#-----| true -> ...;
+
+#   66| ...;
+#-----|  -> access to local variable y
+
+#   66| ...++
+#-----|  -> access to local variable y
+
+#   66| access to local variable y
+#-----|  -> ...++
+
+#   67| return ...;
+#-----| return -> exit M5 (normal)
+
+#   67| access to local variable y
+#-----|  -> return ...;
+
+#   70| enter M6
+#-----|  -> {...}
+
+#   70| exit M6
+
+#   70| exit M6 (normal)
+#-----|  -> exit M6
+
+#   71| {...}
+#-----|  -> ... ...;
+
+#   72| ... ...;
+#-----|  -> access to parameter ss
+
+#   72| Boolean b = ...
+#-----|  -> ... ...;
+
+#   72| ... > ...
+#-----|  -> Boolean b = ...
+
+#   72| access to property Length
+#-----|  -> 0
+
+#   72| access to parameter ss
+#-----|  -> access to property Length
+
+#   72| 0
+#-----|  -> ... > ...
+
+#   73| ... ...;
+#-----|  -> 0
+
+#   73| Int32 x = ...
+#-----|  -> access to parameter ss
+
+#   73| 0
+#-----|  -> Int32 x = ...
+
+#   74| foreach (... ... in ...) ...
+#-----| non-empty -> String _
+#-----| empty -> if (...) ...
+
+#   74| String _
+#-----|  -> {...}
+
+#   74| access to parameter ss
+#-----|  -> foreach (... ... in ...) ...
+
+#   75| {...}
+#-----|  -> if (...) ...
+
+#   76| if (...) ...
+#-----|  -> access to local variable b
+
+#   76| access to local variable b
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   77| ...;
+#-----|  -> access to local variable x
+
+#   77| ...++
+#-----|  -> if (...) ...
+
+#   77| access to local variable x
+#-----|  -> ...++
+
+#   78| if (...) ...
+#-----|  -> access to local variable x
+
+#   78| ... > ...
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> ...;
+
+#   78| access to local variable x
+#-----|  -> 0
+
+#   78| 0
+#-----|  -> ... > ...
+
+#   79| ...;
+#-----|  -> false
+
+#   79| ... = ...
+#-----|  -> foreach (... ... in ...) ...
+
+#   79| false
+#-----|  -> ... = ...
+
+#   81| if (...) ...
+#-----|  -> access to local variable b
+
+#   81| access to local variable b
+#-----| true -> ...;
+#-----| false -> access to local variable x
+
+#   82| ...;
+#-----|  -> access to local variable x
+
+#   82| ...++
+#-----|  -> access to local variable x
+
+#   82| access to local variable x
+#-----|  -> ...++
+
+#   83| return ...;
+#-----| return -> exit M6 (normal)
+
+#   83| access to local variable x
+#-----|  -> return ...;
+
+#   86| enter M7
+#-----|  -> {...}
+
+#   86| exit M7
+
+#   86| exit M7 (normal)
+#-----|  -> exit M7
+
+#   87| {...}
+#-----|  -> ... ...;
+
+#   88| ... ...;
+#-----|  -> access to parameter ss
+
+#   88| Boolean b = ...
+#-----|  -> ... ...;
+
+#   88| ... > ...
+#-----|  -> Boolean b = ...
+
+#   88| access to property Length
+#-----|  -> 0
+
+#   88| access to parameter ss
+#-----|  -> access to property Length
+
+#   88| 0
+#-----|  -> ... > ...
+
+#   89| ... ...;
+#-----|  -> 0
+
+#   89| Int32 x = ...
+#-----|  -> access to parameter ss
+
+#   89| 0
+#-----|  -> Int32 x = ...
+
+#   90| foreach (... ... in ...) ...
+#-----| non-empty -> String _
+#-----| empty -> access to local variable x
+
+#   90| String _
+#-----|  -> {...}
+
+#   90| access to parameter ss
+#-----|  -> foreach (... ... in ...) ...
+
+#   91| {...}
+#-----|  -> if (...) ...
+
+#   92| if (...) ...
+#-----|  -> access to local variable b
+
+#   92| access to local variable b
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   93| ...;
+#-----|  -> access to local variable x
+
+#   93| ...++
+#-----|  -> if (...) ...
+
+#   93| access to local variable x
+#-----|  -> ...++
+
+#   94| if (...) ...
+#-----|  -> access to local variable x
+
+#   94| ... > ...
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   94| access to local variable x
+#-----|  -> 0
+
+#   94| 0
+#-----|  -> ... > ...
+
+#   95| ...;
+#-----|  -> false
+
+#   95| ... = ...
+#-----|  -> if (...) ...
+
+#   95| false
+#-----|  -> ... = ...
+
+#   96| if (...) ...
+#-----|  -> access to local variable b
+
+#   96| access to local variable b
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> ...;
+
+#   97| ...;
+#-----|  -> access to local variable x
+
+#   97| ...++
+#-----|  -> foreach (... ... in ...) ...
+
+#   97| access to local variable x
+#-----|  -> ...++
+
+#   99| return ...;
+#-----| return -> exit M7 (normal)
+
+#   99| access to local variable x
+#-----|  -> return ...;
+
+#  102| enter M8
+#-----|  -> {...}
+
+#  102| exit M8
+
+#  102| exit M8 (normal)
+#-----|  -> exit M8
+
+#  103| {...}
+#-----|  -> ... ...;
+
+#  104| ... ...;
+#-----|  -> access to parameter b
+
+#  104| String x = ...
+#-----|  -> if (...) ...
+
+#  104| call to method ToString
+#-----|  -> String x = ...
+
+#  104| access to parameter b
+#-----|  -> call to method ToString
+
+#  105| if (...) ...
+#-----|  -> access to parameter b
+
+#  105| access to parameter b
+#-----| true -> [b (line 102): true] ...;
+#-----| false -> [b (line 102): false] if (...) ...
+
+#  106| [b (line 102): true] ...;
+#-----|  -> [b (line 102): true] access to local variable x
+
+#  106| [b (line 102): true] ... = ...
+#-----|  -> [b (line 102): true] if (...) ...
+
+#  106| [b (line 102): true] ... + ...
+#-----|  -> [b (line 102): true] ... = ...
+
+#  106| [b (line 102): true] access to local variable x
+#-----|  -> [b (line 102): true] ""
+
+#  106| [b (line 102): true] ""
+#-----|  -> [b (line 102): true] ... + ...
+
+#  107| [b (line 102): false] if (...) ...
+#-----|  -> [b (line 102): false] access to local variable x
+
+#  107| [b (line 102): true] if (...) ...
+#-----|  -> [b (line 102): true] access to local variable x
+
+#  107| [b (line 102): false] ... > ...
+#-----| true -> [b (line 102): false] if (...) ...
+#-----| false -> access to local variable x
+
+#  107| [b (line 102): true] ... > ...
+#-----| true -> [b (line 102): true] if (...) ...
+#-----| false -> access to local variable x
+
+#  107| [b (line 102): false] access to property Length
+#-----|  -> [b (line 102): false] 0
+
+#  107| [b (line 102): true] access to property Length
+#-----|  -> [b (line 102): true] 0
+
+#  107| [b (line 102): false] access to local variable x
+#-----|  -> [b (line 102): false] access to property Length
+
+#  107| [b (line 102): true] access to local variable x
+#-----|  -> [b (line 102): true] access to property Length
+
+#  107| [b (line 102): false] 0
+#-----|  -> [b (line 102): false] ... > ...
+
+#  107| [b (line 102): true] 0
+#-----|  -> [b (line 102): true] ... > ...
+
+#  108| [b (line 102): false] if (...) ...
+#-----|  -> [b (line 102): false] access to parameter b
+
+#  108| [b (line 102): true] if (...) ...
+#-----|  -> [b (line 102): true] access to parameter b
+
+#  108| [false] !...
+#-----| false -> access to local variable x
+
+#  108| [true] !...
+#-----| true -> ...;
+
+#  108| [b (line 102): false] access to parameter b
+#-----| false -> [true] !...
+
+#  108| [b (line 102): true] access to parameter b
+#-----| true -> [false] !...
+
+#  109| ...;
+#-----|  -> access to local variable x
+
+#  109| ... = ...
+#-----|  -> access to local variable x
+
+#  109| ... + ...
+#-----|  -> ... = ...
+
+#  109| access to local variable x
+#-----|  -> ""
+
+#  109| ""
+#-----|  -> ... + ...
+
+#  110| return ...;
+#-----| return -> exit M8 (normal)
+
+#  110| access to local variable x
+#-----|  -> return ...;
+
+#  113| enter M9
+#-----|  -> {...}
+
+#  113| exit M9
+
+#  113| exit M9 (normal)
+#-----|  -> exit M9
+
+#  114| {...}
+#-----|  -> ... ...;
+
+#  115| ... ...;
+#-----|  -> null
+
+#  115| String s = ...
+#-----|  -> for (...;...;...) ...
+
+#  115| null
+#-----|  -> String s = ...
+
+#  116| for (...;...;...) ...
+#-----|  -> 0
+
+#  116| Int32 i = ...
+#-----|  -> access to local variable i
+
+#  116| 0
+#-----|  -> Int32 i = ...
+
+#  116| ... < ...
+#-----| true -> {...}
+#-----| false -> exit M9 (normal)
+
+#  116| access to local variable i
+#-----|  -> access to parameter args
+
+#  116| access to property Length
+#-----|  -> ... < ...
+
+#  116| access to parameter args
+#-----|  -> access to property Length
+
+#  116| ...++
+#-----|  -> access to local variable i
+
+#  116| access to local variable i
+#-----|  -> ...++
+
+#  117| {...}
+#-----|  -> ... ...;
+
+#  118| ... ...;
+#-----|  -> access to local variable i
+
+#  118| Boolean last = ...
+#-----|  -> if (...) ...
+
+#  118| ... == ...
+#-----|  -> Boolean last = ...
+
+#  118| access to local variable i
+#-----|  -> access to parameter args
+
+#  118| ... - ...
+#-----|  -> ... == ...
+
+#  118| access to property Length
+#-----|  -> 1
+
+#  118| access to parameter args
+#-----|  -> access to property Length
+
+#  118| 1
+#-----|  -> ... - ...
+
+#  119| if (...) ...
+#-----|  -> access to local variable last
+
+#  119| [false, last (line 118): true] !...
+#-----| false -> [last (line 118): true] if (...) ...
+
+#  119| [true, last (line 118): false] !...
+#-----| true -> [last (line 118): false] ...;
+
+#  119| access to local variable last
+#-----| true -> [false, last (line 118): true] !...
+#-----| false -> [true, last (line 118): false] !...
+
+#  120| [last (line 118): false] ...;
+#-----|  -> [last (line 118): false] ""
+
+#  120| [last (line 118): false] ... = ...
+#-----|  -> [last (line 118): false] if (...) ...
+
+#  120| [last (line 118): false] ""
+#-----|  -> [last (line 118): false] ... = ...
+
+#  121| [last (line 118): false] if (...) ...
+#-----|  -> [last (line 118): false] access to local variable last
+
+#  121| [last (line 118): true] if (...) ...
+#-----|  -> [last (line 118): true] access to local variable last
+
+#  121| [last (line 118): false] access to local variable last
+#-----| false -> access to local variable i
+
+#  121| [last (line 118): true] access to local variable last
+#-----| true -> ...;
+
+#  122| ...;
+#-----|  -> null
+
+#  122| ... = ...
+#-----|  -> access to local variable i
+
+#  122| null
+#-----|  -> ... = ...
+
+#  129| enter M10
+#-----|  -> {...}
+
+#  130| {...}
+#-----|  -> while (...) ...
+
+#  131| while (...) ...
+#-----|  -> true
+
+#  131| true
+#-----| true -> {...}
+
+#  131| [Field1 (line 129): false] true
+#-----| true -> [Field1 (line 129): false] {...}
+
+#  131| [Field1 (line 129): true, Field2 (line 129): false] true
+#-----| true -> [Field1 (line 129): true, Field2 (line 129): false] {...}
+
+#  131| [Field1 (line 129): true, Field2 (line 129): true] true
+#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
+
+#  132| {...}
+#-----|  -> if (...) ...
+
+#  132| [Field1 (line 129): false] {...}
+#-----|  -> [Field1 (line 129): false] if (...) ...
+
+#  132| [Field1 (line 129): true, Field2 (line 129): false] {...}
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
+
+#  132| [Field1 (line 129): true, Field2 (line 129): true] {...}
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
+
+#  133| if (...) ...
+#-----|  -> this access
+
+#  133| [Field1 (line 129): false] if (...) ...
+#-----|  -> [Field1 (line 129): false] this access
+
+#  133| [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] this access
+
+#  133| [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] this access
+
+#  133| access to field Field1
+#-----| false -> [Field1 (line 129): false] true
+#-----| true -> [Field1 (line 129): true] {...}
+
+#  133| [Field1 (line 129): false] access to field Field1
+#-----| false -> [Field1 (line 129): false] true
+
+#  133| [Field1 (line 129): true, Field2 (line 129): false] access to field Field1
+#-----| true -> [Field1 (line 129): true, Field2 (line 129): false] {...}
+
+#  133| [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
+#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
+
+#  133| this access
+#-----|  -> access to field Field1
+
+#  133| [Field1 (line 129): false] this access
+#-----|  -> [Field1 (line 129): false] access to field Field1
+
+#  133| [Field1 (line 129): true, Field2 (line 129): false] this access
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] access to field Field1
+
+#  133| [Field1 (line 129): true, Field2 (line 129): true] this access
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
+
+#  134| [Field1 (line 129): true] {...}
+#-----|  -> [Field1 (line 129): true] if (...) ...
+
+#  134| [Field1 (line 129): true, Field2 (line 129): false] {...}
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
+
+#  134| [Field1 (line 129): true, Field2 (line 129): true] {...}
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
+
+#  135| [Field1 (line 129): true] if (...) ...
+#-----|  -> [Field1 (line 129): true] this access
+
+#  135| [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] this access
+
+#  135| [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] this access
+
+#  135| [Field1 (line 129): true] access to field Field2
+#-----| false -> [Field1 (line 129): true, Field2 (line 129): false] true
+#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
+
+#  135| [Field1 (line 129): true, Field2 (line 129): false] access to field Field2
+#-----| false -> [Field1 (line 129): true, Field2 (line 129): false] true
+
+#  135| [Field1 (line 129): true, Field2 (line 129): true] access to field Field2
+#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
+
+#  135| [Field1 (line 129): true] this access
+#-----|  -> [Field1 (line 129): true] access to field Field2
+
+#  135| [Field1 (line 129): true, Field2 (line 129): false] this access
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] access to field Field2
+
+#  135| [Field1 (line 129): true, Field2 (line 129): true] this access
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] access to field Field2
+
+#  136| [Field1 (line 129): true, Field2 (line 129): true] {...}
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] ...;
+
+#  137| [Field1 (line 129): true, Field2 (line 129): true] ...;
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] this access
+
+#  137| [Field1 (line 129): true, Field2 (line 129): true] call to method ToString
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] true
+
+#  137| [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] call to method ToString
+
+#  137| [Field1 (line 129): true, Field2 (line 129): true] this access
+#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
+
+#  143| enter M11
+#-----|  -> {...}
+
+#  143| exit M11
+
+#  143| exit M11 (normal)
+#-----|  -> exit M11
+
+#  144| {...}
+#-----|  -> ... ...;
+
+#  145| ... ...;
+#-----|  -> access to parameter b
+
+#  145| [b (line 143): false] String s = ...
+#-----|  -> [b (line 143): false] if (...) ...
+
+#  145| [b (line 143): true] String s = ...
+#-----|  -> [b (line 143): true] if (...) ...
+
+#  145| [b (line 143): false] ... ? ... : ...
+#-----|  -> [b (line 143): false] String s = ...
+
+#  145| [b (line 143): true] ... ? ... : ...
+#-----|  -> [b (line 143): true] String s = ...
+
+#  145| access to parameter b
+#-----| true -> [b (line 143): true] "a"
+#-----| false -> [b (line 143): false] "b"
+
+#  145| [b (line 143): true] "a"
+#-----|  -> [b (line 143): true] ... ? ... : ...
+
+#  145| [b (line 143): false] "b"
+#-----|  -> [b (line 143): false] ... ? ... : ...
+
+#  146| [b (line 143): false] if (...) ...
+#-----|  -> [b (line 143): false] access to parameter b
+
+#  146| [b (line 143): true] if (...) ...
+#-----|  -> [b (line 143): true] access to parameter b
+
+#  146| [b (line 143): false] access to parameter b
+#-----| false -> ...;
+
+#  146| [b (line 143): true] access to parameter b
+#-----| true -> ...;
+
+#  147| ...;
+#-----|  -> "a = "
+
+#  147| call to method WriteLine
+#-----|  -> exit M11 (normal)
+
+#  147| $"..."
+#-----|  -> call to method WriteLine
+
+#  147| "a = "
+#-----|  -> access to local variable s
+
+#  147| access to local variable s
+#-----|  -> $"..."
+
+#  149| ...;
+#-----|  -> "b = "
+
+#  149| call to method WriteLine
+#-----|  -> exit M11 (normal)
+
+#  149| $"..."
+#-----|  -> call to method WriteLine
+
+#  149| "b = "
+#-----|  -> access to local variable s
+
+#  149| access to local variable s
+#-----|  -> $"..."
+
+ExitMethods.cs:
+#    8| enter M1
+#-----|  -> {...}
+
+#    8| exit M1
+
+#    8| exit M1 (normal)
+#-----|  -> exit M1
+
+#    9| {...}
+#-----|  -> ...;
+
+#   10| ...;
+#-----|  -> true
+
+#   10| call to method ErrorMaybe
+#-----|  -> return ...;
+
+#   10| true
+#-----|  -> call to method ErrorMaybe
+
+#   11| return ...;
+#-----| return -> exit M1 (normal)
+
+#   14| enter M2
+#-----|  -> {...}
+
+#   14| exit M2
+
+#   14| exit M2 (normal)
+#-----|  -> exit M2
+
+#   15| {...}
+#-----|  -> ...;
+
+#   16| ...;
+#-----|  -> false
+
+#   16| call to method ErrorMaybe
+#-----|  -> return ...;
+
+#   16| false
+#-----|  -> call to method ErrorMaybe
+
+#   17| return ...;
+#-----| return -> exit M2 (normal)
+
+#   20| enter M3
+#-----|  -> {...}
+
+#   20| exit M3
+
+#   20| exit M3 (abnormal)
+#-----|  -> exit M3
+
+#   21| {...}
+#-----|  -> ...;
+
+#   22| ...;
+#-----|  -> true
+
+#   22| call to method ErrorAlways
+#-----| exception(Exception) -> exit M3 (abnormal)
+
+#   22| true
+#-----|  -> call to method ErrorAlways
+
+#   26| enter M4
+#-----|  -> {...}
+
+#   26| exit M4
+
+#   26| exit M4 (abnormal)
+#-----|  -> exit M4
+
+#   27| {...}
+#-----|  -> ...;
+
+#   28| ...;
+#-----|  -> this access
+
+#   28| call to method Exit
+#-----| exit -> exit M4 (abnormal)
+
+#   28| this access
+#-----|  -> call to method Exit
+
+#   32| enter M5
+#-----|  -> {...}
+
+#   32| exit M5
+
+#   32| exit M5 (abnormal)
+#-----|  -> exit M5
+
+#   33| {...}
+#-----|  -> ...;
+
+#   34| ...;
+#-----|  -> this access
+
+#   34| call to method ApplicationExit
+#-----| exit -> exit M5 (abnormal)
+
+#   34| this access
+#-----|  -> call to method ApplicationExit
+
+#   38| enter M6
+#-----|  -> {...}
+
+#   38| exit M6
+
+#   38| exit M6 (normal)
+#-----|  -> exit M6
+
+#   39| {...}
+#-----|  -> try {...} ...
+
+#   40| try {...} ...
+#-----|  -> {...}
+
+#   41| {...}
+#-----|  -> ...;
+
+#   42| ...;
+#-----|  -> false
+
+#   42| call to method ErrorAlways
+#-----| exception(ArgumentException) -> [exception: ArgumentException] catch (...) {...}
+#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
+
+#   42| false
+#-----|  -> call to method ErrorAlways
+
+#   44| [exception: ArgumentException] catch (...) {...}
+#-----| match -> {...}
+
+#   44| [exception: Exception] catch (...) {...}
+#-----| match -> {...}
+#-----| no-match -> [exception: Exception] catch (...) {...}
+
+#   45| {...}
+#-----|  -> return ...;
+
+#   46| return ...;
+#-----| return -> exit M6 (normal)
+
+#   48| [exception: Exception] catch (...) {...}
+#-----| match -> {...}
+
+#   49| {...}
+#-----|  -> return ...;
+
+#   50| return ...;
+#-----| return -> exit M6 (normal)
+
+#   54| enter M7
+#-----|  -> {...}
+
+#   54| exit M7
+
+#   54| exit M7 (abnormal)
+#-----|  -> exit M7
+
+#   55| {...}
+#-----|  -> ...;
+
+#   56| ...;
+#-----|  -> call to method ErrorAlways2
+
+#   56| call to method ErrorAlways2
+#-----| exception(Exception) -> exit M7 (abnormal)
+
+#   60| enter M8
+#-----|  -> {...}
+
+#   60| exit M8
+
+#   60| exit M8 (abnormal)
+#-----|  -> exit M8
+
+#   61| {...}
+#-----|  -> ...;
+
+#   62| ...;
+#-----|  -> call to method ErrorAlways3
+
+#   62| call to method ErrorAlways3
+#-----| exception(Exception) -> exit M8 (abnormal)
+
+#   66| enter ErrorMaybe
+#-----|  -> {...}
+
+#   66| exit ErrorMaybe
+
+#   66| exit ErrorMaybe (abnormal)
+#-----|  -> exit ErrorMaybe
+
+#   66| exit ErrorMaybe (normal)
+#-----|  -> exit ErrorMaybe
+
+#   67| {...}
+#-----|  -> if (...) ...
+
+#   68| if (...) ...
+#-----|  -> access to parameter b
+
+#   68| access to parameter b
+#-----| true -> object creation of type Exception
+#-----| false -> exit ErrorMaybe (normal)
+
+#   69| throw ...;
+#-----| exception(Exception) -> exit ErrorMaybe (abnormal)
+
+#   69| object creation of type Exception
+#-----|  -> throw ...;
+
+#   72| enter ErrorAlways
+#-----|  -> {...}
+
+#   72| exit ErrorAlways
+
+#   72| exit ErrorAlways (abnormal)
+#-----|  -> exit ErrorAlways
+
+#   73| {...}
+#-----|  -> if (...) ...
+
+#   74| if (...) ...
+#-----|  -> access to parameter b
+
+#   74| access to parameter b
+#-----| true -> object creation of type Exception
+#-----| false -> "b"
+
+#   75| throw ...;
+#-----| exception(Exception) -> exit ErrorAlways (abnormal)
+
+#   75| object creation of type Exception
+#-----|  -> throw ...;
+
+#   77| throw ...;
+#-----| exception(ArgumentException) -> exit ErrorAlways (abnormal)
+
+#   77| object creation of type ArgumentException
+#-----|  -> throw ...;
+
+#   77| "b"
+#-----|  -> object creation of type ArgumentException
+
+#   80| enter ErrorAlways2
+#-----|  -> {...}
+
+#   80| exit ErrorAlways2
+
+#   80| exit ErrorAlways2 (abnormal)
+#-----|  -> exit ErrorAlways2
+
+#   81| {...}
+#-----|  -> object creation of type Exception
+
+#   82| throw ...;
+#-----| exception(Exception) -> exit ErrorAlways2 (abnormal)
+
+#   82| object creation of type Exception
+#-----|  -> throw ...;
+
+#   85| enter ErrorAlways3
+#-----|  -> object creation of type Exception
+
+#   85| exit ErrorAlways3
+
+#   85| exit ErrorAlways3 (abnormal)
+#-----|  -> exit ErrorAlways3
+
+#   85| throw ...
+#-----| exception(Exception) -> exit ErrorAlways3 (abnormal)
+
+#   85| object creation of type Exception
+#-----|  -> throw ...
+
+#   87| enter Exit
+#-----|  -> {...}
+
+#   87| exit Exit
+
+#   87| exit Exit (abnormal)
+#-----|  -> exit Exit
+
+#   88| {...}
+#-----|  -> ...;
+
+#   89| ...;
+#-----|  -> 0
+
+#   89| call to method Exit
+#-----| exit -> exit Exit (abnormal)
+
+#   89| 0
+#-----|  -> call to method Exit
+
+#   92| enter ExitInTry
+#-----|  -> {...}
+
+#   92| exit ExitInTry
+
+#   92| exit ExitInTry (abnormal)
+#-----|  -> exit ExitInTry
+
+#   93| {...}
+#-----|  -> try {...} ...
+
+#   94| try {...} ...
+#-----|  -> {...}
+
+#   95| {...}
+#-----|  -> ...;
+
+#   96| ...;
+#-----|  -> this access
+
+#   96| call to method Exit
+#-----| exit -> exit ExitInTry (abnormal)
+
+#   96| this access
+#-----|  -> call to method Exit
+
+#  105| enter ApplicationExit
+#-----|  -> {...}
+
+#  105| exit ApplicationExit
+
+#  105| exit ApplicationExit (abnormal)
+#-----|  -> exit ApplicationExit
+
+#  106| {...}
+#-----|  -> ...;
+
+#  107| ...;
+#-----|  -> call to method Exit
+
+#  107| call to method Exit
+#-----| exit -> exit ApplicationExit (abnormal)
+
+#  110| enter ThrowExpr
+#-----|  -> {...}
+
+#  110| exit ThrowExpr
+
+#  110| exit ThrowExpr (abnormal)
+#-----|  -> exit ThrowExpr
+
+#  110| exit ThrowExpr (normal)
+#-----|  -> exit ThrowExpr
+
+#  111| {...}
+#-----|  -> access to parameter input
+
+#  112| return ...;
+#-----| return -> exit ThrowExpr (normal)
+
+#  112| ... ? ... : ...
+#-----|  -> return ...;
+
+#  112| ... != ...
+#-----| false -> "input"
+#-----| true -> 1
+
+#  112| access to parameter input
+#-----|  -> 0
+
+#  112| (...) ...
+#-----|  -> ... != ...
+
+#  112| 0
+#-----|  -> (...) ...
+
+#  112| ... / ...
+#-----|  -> ... ? ... : ...
+
+#  112| (...) ...
+#-----|  -> access to parameter input
+
+#  112| 1
+#-----|  -> (...) ...
+
+#  112| access to parameter input
+#-----|  -> ... / ...
+
+#  112| throw ...
+#-----| exception(ArgumentException) -> exit ThrowExpr (abnormal)
+
+#  112| object creation of type ArgumentException
+#-----|  -> throw ...
+
+#  112| "input"
+#-----|  -> object creation of type ArgumentException
+
+#  115| enter ExtensionMethodCall
+#-----|  -> {...}
+
+#  115| exit ExtensionMethodCall
+
+#  115| exit ExtensionMethodCall (normal)
+#-----|  -> exit ExtensionMethodCall
+
+#  116| {...}
+#-----|  -> access to parameter s
+
+#  117| return ...;
+#-----| return -> exit ExtensionMethodCall (normal)
+
+#  117| ... ? ... : ...
+#-----|  -> return ...;
+
+#  117| call to method Contains
+#-----| true -> 0
+#-----| false -> 1
+
+#  117| access to parameter s
+#-----|  -> -
+
+#  117| -
+#-----|  -> call to method Contains
+
+#  117| 0
+#-----|  -> ... ? ... : ...
+
+#  117| 1
+#-----|  -> ... ? ... : ...
+
+#  120| enter FailingAssertion
+#-----|  -> {...}
+
+#  120| exit FailingAssertion
+
+#  120| exit FailingAssertion (abnormal)
+#-----|  -> exit FailingAssertion
+
+#  121| {...}
+#-----|  -> ...;
+
+#  122| ...;
+#-----|  -> false
+
+#  122| [assertion failure] call to method IsTrue
+#-----| exception(AssertFailedException) -> exit FailingAssertion (abnormal)
+
+#  122| false
+#-----| false -> [assertion failure] call to method IsTrue
+
+#  126| enter FailingAssertion2
+#-----|  -> {...}
+
+#  126| exit FailingAssertion2
+
+#  126| exit FailingAssertion2 (abnormal)
+#-----|  -> exit FailingAssertion2
+
+#  127| {...}
+#-----|  -> ...;
+
+#  128| ...;
+#-----|  -> this access
+
+#  128| call to method FailingAssertion
+#-----| exception(AssertFailedException) -> exit FailingAssertion2 (abnormal)
+
+#  128| this access
+#-----|  -> call to method FailingAssertion
+
+#  132| enter AssertFalse
+#-----|  -> access to parameter b
+
+#  132| exit AssertFalse
+
+#  132| exit AssertFalse (abnormal)
+#-----|  -> exit AssertFalse
+
+#  132| exit AssertFalse (normal)
+#-----|  -> exit AssertFalse
+
+#  132| [assertion failure] call to method IsFalse
+#-----| exception(AssertFailedException) -> exit AssertFalse (abnormal)
+
+#  132| [assertion success] call to method IsFalse
+#-----|  -> exit AssertFalse (normal)
+
+#  132| access to parameter b
+#-----| true -> [assertion failure] call to method IsFalse
+#-----| false -> [assertion success] call to method IsFalse
+
+#  134| enter FailingAssertion3
+#-----|  -> {...}
+
+#  134| exit FailingAssertion3
+
+#  134| exit FailingAssertion3 (abnormal)
+#-----|  -> exit FailingAssertion3
+
+#  135| {...}
+#-----|  -> ...;
+
+#  136| ...;
+#-----|  -> this access
+
+#  136| [assertion failure] call to method AssertFalse
+#-----| exception(AssertFailedException) -> exit FailingAssertion3 (abnormal)
+
+#  136| this access
+#-----|  -> true
+
+#  136| true
+#-----| true -> [assertion failure] call to method AssertFalse
+
+#  140| enter ExceptionDispatchInfoThrow
+#-----|  -> {...}
+
+#  140| exit ExceptionDispatchInfoThrow
+
+#  140| exit ExceptionDispatchInfoThrow (abnormal)
+#-----|  -> exit ExceptionDispatchInfoThrow
+
+#  141| {...}
+#-----|  -> if (...) ...
+
+#  142| if (...) ...
+#-----|  -> access to parameter b
+
+#  142| access to parameter b
+#-----| true -> ...;
+#-----| false -> ...;
+
+#  143| ...;
+#-----|  -> access to parameter e
+
+#  143| call to method Throw
+#-----| exception(ArgumentException) -> exit ExceptionDispatchInfoThrow (abnormal)
+
+#  143| access to parameter e
+#-----|  -> call to method Throw
+
+#  145| ...;
+#-----|  -> access to parameter e
+
+#  145| call to method Throw
+#-----| exception(Exception) -> exit ExceptionDispatchInfoThrow (abnormal)
+
+#  145| call to method Capture
+#-----|  -> call to method Throw
+
+#  145| access to parameter e
+#-----|  -> call to method Capture
+
+Extensions.cs:
+#    5| enter ToInt32
+#-----|  -> {...}
+
+#    5| exit ToInt32
+
+#    5| exit ToInt32 (normal)
+#-----|  -> exit ToInt32
+
+#    6| {...}
+#-----|  -> access to parameter s
+
+#    7| return ...;
+#-----| return -> exit ToInt32 (normal)
+
+#    7| call to method Parse
+#-----|  -> return ...;
+
+#    7| access to parameter s
+#-----|  -> call to method Parse
+
+#   10| enter ToBool
+#-----|  -> {...}
+
+#   10| exit ToBool
+
+#   10| exit ToBool (normal)
+#-----|  -> exit ToBool
+
+#   11| {...}
+#-----|  -> access to parameter f
+
+#   12| return ...;
+#-----| return -> exit ToBool (normal)
+
+#   12| delegate call
+#-----|  -> return ...;
+
+#   12| access to parameter f
+#-----|  -> access to parameter s
+
+#   12| access to parameter s
+#-----|  -> delegate call
+
+#   15| enter CallToInt32
+#-----|  -> "0"
+
+#   15| exit CallToInt32
+
+#   15| exit CallToInt32 (normal)
+#-----|  -> exit CallToInt32
+
+#   15| call to method ToInt32
+#-----|  -> exit CallToInt32 (normal)
+
+#   15| "0"
+#-----|  -> call to method ToInt32
+
+#   20| enter Main
+#-----|  -> {...}
+
+#   20| exit Main
+
+#   20| exit Main (normal)
+#-----|  -> exit Main
+
+#   21| {...}
+#-----|  -> ...;
+
+#   22| ...;
+#-----|  -> access to parameter s
+
+#   22| call to method ToInt32
+#-----|  -> ...;
+
+#   22| access to parameter s
+#-----|  -> call to method ToInt32
+
+#   23| ...;
+#-----|  -> ""
+
+#   23| call to method ToInt32
+#-----|  -> ...;
+
+#   23| ""
+#-----|  -> call to method ToInt32
+
+#   24| ...;
+#-----|  -> "true"
+
+#   24| call to method ToBool
+#-----|  -> ...;
+
+#   24| "true"
+#-----|  -> access to method Parse
+
+#   24| delegate creation of type Func<String,Boolean>
+#-----|  -> call to method ToBool
+
+#   24| access to method Parse
+#-----|  -> delegate creation of type Func<String,Boolean>
+
+#   25| ...;
+#-----|  -> "true"
+
+#   25| call to method ToBool
+#-----|  -> exit Main (normal)
+
+#   25| "true"
+#-----|  -> access to method Parse
+
+#   25| delegate creation of type Func<String,Boolean>
+#-----|  -> call to method ToBool
+
+#   25| access to method Parse
+#-----|  -> delegate creation of type Func<String,Boolean>
+
+Finally.cs:
+#    7| enter M1
+#-----|  -> {...}
+
+#    7| exit M1
+
+#    7| exit M1 (abnormal)
+#-----|  -> exit M1
+
+#    7| exit M1 (normal)
+#-----|  -> exit M1
+
+#    8| {...}
+#-----|  -> try {...} ...
+
+#    9| try {...} ...
+#-----|  -> {...}
+
+#   10| {...}
+#-----|  -> ...;
+
+#   11| ...;
+#-----|  -> "Try1"
+
+#   11| call to method WriteLine
+#-----|  -> {...}
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#   11| "Try1"
+#-----|  -> call to method WriteLine
+
+#   14| {...}
+#-----|  -> ...;
+
+#   14| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#   15| ...;
+#-----|  -> "Finally"
+
+#   15| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] "Finally"
+
+#   15| call to method WriteLine
+#-----|  -> exit M1 (normal)
+
+#   15| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M1 (abnormal)
+
+#   15| "Finally"
+#-----|  -> call to method WriteLine
+
+#   15| [finally: exception(Exception)] "Finally"
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#   19| enter M2
+#-----|  -> {...}
+
+#   19| exit M2
+
+#   19| exit M2 (abnormal)
+#-----|  -> exit M2
+
+#   19| exit M2 (normal)
+#-----|  -> exit M2
+
+#   20| {...}
+#-----|  -> try {...} ...
+
+#   21| try {...} ...
+#-----|  -> {...}
+
+#   22| {...}
+#-----|  -> ...;
+
+#   23| ...;
+#-----|  -> "Try2"
+
+#   23| call to method WriteLine
+#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
+#-----|  -> return ...;
+
+#   23| "Try2"
+#-----|  -> call to method WriteLine
+
+#   24| return ...;
+#-----| return -> [finally: return] {...}
+
+#   26| [exception: Exception] catch (...) {...}
+#-----| match -> [exception: Exception] IOException ex
+#-----| no-match -> [exception: Exception] catch (...) {...}
+
+#   26| [exception: Exception] IOException ex
+#-----|  -> [exception: Exception] true
+
+#   26| [exception: Exception] true
+#-----| true -> {...}
+
+#   27| {...}
+#-----|  -> throw ...;
+
+#   28| throw ...;
+#-----| exception(IOException) -> [finally: exception(IOException)] {...}
+
+#   30| [exception: Exception] catch (...) {...}
+#-----| match -> [exception: Exception] ArgumentException ex
+#-----| no-match -> [exception: Exception] catch (...) {...}
+
+#   30| [exception: Exception] ArgumentException ex
+#-----|  -> {...}
+
+#   31| {...}
+#-----|  -> try {...} ...
+
+#   32| try {...} ...
+#-----|  -> {...}
+
+#   33| {...}
+#-----|  -> if (...) ...
+
+#   34| if (...) ...
+#-----|  -> true
+
+#   34| true
+#-----| true -> throw ...;
+
+#   34| throw ...;
+#-----| exception(ArgumentException) -> [finally: exception(ArgumentException)] {...}
+
+#   37| [finally: exception(ArgumentException)] {...}
+#-----|  -> [finally: exception(ArgumentException)] "Boo!"
+
+#   38| [finally: exception(ArgumentException)] throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#   38| [finally: exception(ArgumentException)] object creation of type Exception
+#-----|  -> [finally: exception(ArgumentException)] throw ...;
+
+#   38| [finally: exception(ArgumentException)] "Boo!"
+#-----|  -> [finally: exception(ArgumentException)] object creation of type Exception
+
+#   41| [exception: Exception] catch (...) {...}
+#-----| match -> {...}
+
+#   42| {...}
+#-----|  -> {...}
+
+#   49| {...}
+#-----|  -> ...;
+
+#   49| [finally: return] {...}
+#-----|  -> [finally: return] ...;
+
+#   49| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#   49| [finally: exception(IOException)] {...}
+#-----|  -> [finally: exception(IOException)] ...;
+
+#   50| ...;
+#-----|  -> "Finally"
+
+#   50| [finally: return] ...;
+#-----|  -> [finally: return] "Finally"
+
+#   50| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] "Finally"
+
+#   50| [finally: exception(IOException)] ...;
+#-----|  -> [finally: exception(IOException)] "Finally"
+
+#   50| call to method WriteLine
+#-----|  -> exit M2 (normal)
+
+#   50| [finally: return] call to method WriteLine
+#-----| return -> exit M2 (normal)
+
+#   50| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M2 (abnormal)
+
+#   50| [finally: exception(IOException)] call to method WriteLine
+#-----| exception(IOException) -> exit M2 (abnormal)
+
+#   50| "Finally"
+#-----|  -> call to method WriteLine
+
+#   50| [finally: return] "Finally"
+#-----|  -> [finally: return] call to method WriteLine
+
+#   50| [finally: exception(Exception)] "Finally"
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#   50| [finally: exception(IOException)] "Finally"
+#-----|  -> [finally: exception(IOException)] call to method WriteLine
+
+#   54| enter M3
+#-----|  -> {...}
+
+#   54| exit M3
+
+#   54| exit M3 (abnormal)
+#-----|  -> exit M3
+
+#   54| exit M3 (normal)
+#-----|  -> exit M3
+
+#   55| {...}
+#-----|  -> try {...} ...
+
+#   56| try {...} ...
+#-----|  -> {...}
+
+#   57| {...}
+#-----|  -> ...;
+
+#   58| ...;
+#-----|  -> "Try3"
+
+#   58| call to method WriteLine
+#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
+#-----|  -> return ...;
+
+#   58| "Try3"
+#-----|  -> call to method WriteLine
+
+#   59| return ...;
+#-----| return -> [finally: return] {...}
+
+#   61| [exception: Exception] catch (...) {...}
+#-----| match -> [exception: Exception] IOException ex
+#-----| no-match -> [exception: Exception] catch (...) {...}
+
+#   61| [exception: Exception] IOException ex
+#-----|  -> [exception: Exception] true
+
+#   61| [exception: Exception] true
+#-----| true -> {...}
+
+#   62| {...}
+#-----|  -> throw ...;
+
+#   63| throw ...;
+#-----| exception(IOException) -> [finally: exception(IOException)] {...}
+
+#   65| [exception: Exception] catch (...) {...}
+#-----| match -> [exception: Exception] Exception e
+
+#   65| [exception: Exception] Exception e
+#-----|  -> [exception: Exception] access to local variable e
+
+#   65| [exception: Exception] ... != ...
+#-----| true -> {...}
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#   65| [exception: Exception] access to property Message
+#-----|  -> [exception: Exception] null
+
+#   65| [exception: Exception] access to local variable e
+#-----|  -> [exception: Exception] access to property Message
+
+#   65| [exception: Exception] null
+#-----|  -> [exception: Exception] ... != ...
+
+#   66| {...}
+#-----|  -> {...}
+
+#   69| {...}
+#-----|  -> ...;
+
+#   69| [finally: return] {...}
+#-----|  -> [finally: return] ...;
+
+#   69| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#   69| [finally: exception(IOException)] {...}
+#-----|  -> [finally: exception(IOException)] ...;
+
+#   70| ...;
+#-----|  -> "Finally"
+
+#   70| [finally: return] ...;
+#-----|  -> [finally: return] "Finally"
+
+#   70| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] "Finally"
+
+#   70| [finally: exception(IOException)] ...;
+#-----|  -> [finally: exception(IOException)] "Finally"
+
+#   70| call to method WriteLine
+#-----|  -> exit M3 (normal)
+
+#   70| [finally: return] call to method WriteLine
+#-----| return -> exit M3 (normal)
+
+#   70| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M3 (abnormal)
+
+#   70| [finally: exception(IOException)] call to method WriteLine
+#-----| exception(IOException) -> exit M3 (abnormal)
+
+#   70| "Finally"
+#-----|  -> call to method WriteLine
+
+#   70| [finally: return] "Finally"
+#-----|  -> [finally: return] call to method WriteLine
+
+#   70| [finally: exception(Exception)] "Finally"
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#   70| [finally: exception(IOException)] "Finally"
+#-----|  -> [finally: exception(IOException)] call to method WriteLine
+
+#   74| enter M4
+#-----|  -> {...}
+
+#   74| exit M4
+
+#   74| exit M4 (abnormal)
+#-----|  -> exit M4
+
+#   74| exit M4 (normal)
+#-----|  -> exit M4
+
+#   75| {...}
+#-----|  -> ... ...;
+
+#   76| ... ...;
+#-----|  -> 10
+
+#   76| Int32 i = ...
+#-----|  -> while (...) ...
+
+#   76| 10
+#-----|  -> Int32 i = ...
+
+#   77| while (...) ...
+#-----|  -> access to local variable i
+
+#   77| ... > ...
+#-----| true -> {...}
+#-----| false -> exit M4 (normal)
+
+#   77| access to local variable i
+#-----|  -> 0
+
+#   77| 0
+#-----|  -> ... > ...
+
+#   78| {...}
+#-----|  -> try {...} ...
+
+#   79| try {...} ...
+#-----|  -> {...}
+
+#   80| {...}
+#-----|  -> if (...) ...
+
+#   81| if (...) ...
+#-----|  -> access to local variable i
+
+#   81| ... == ...
+#-----| true -> return ...;
+#-----| false -> if (...) ...
+
+#   81| access to local variable i
+#-----|  -> 0
+
+#   81| 0
+#-----|  -> ... == ...
+
+#   82| return ...;
+#-----| return -> [finally: return] {...}
+
+#   83| if (...) ...
+#-----|  -> access to local variable i
+
+#   83| ... == ...
+#-----| true -> continue;
+#-----| false -> if (...) ...
+
+#   83| access to local variable i
+#-----|  -> 1
+
+#   83| 1
+#-----|  -> ... == ...
+
+#   84| continue;
+#-----| continue -> [finally: continue] {...}
+
+#   85| if (...) ...
+#-----|  -> access to local variable i
+
+#   85| ... == ...
+#-----| true -> break;
+#-----| false -> {...}
+
+#   85| access to local variable i
+#-----|  -> 2
+
+#   85| 2
+#-----|  -> ... == ...
+
+#   86| break;
+#-----| break -> [finally: break] {...}
+
+#   89| {...}
+#-----|  -> try {...} ...
+
+#   89| [finally: return] {...}
+#-----|  -> [finally: return] try {...} ...
+
+#   89| [finally: break] {...}
+#-----|  -> [finally: break] try {...} ...
+
+#   89| [finally: continue] {...}
+#-----|  -> [finally: continue] try {...} ...
+
+#   90| try {...} ...
+#-----|  -> {...}
+
+#   90| [finally: return] try {...} ...
+#-----|  -> [finally: return] {...}
+
+#   90| [finally: break] try {...} ...
+#-----|  -> [finally: break] {...}
+
+#   90| [finally: continue] try {...} ...
+#-----|  -> [finally: continue] {...}
+
+#   91| {...}
+#-----|  -> if (...) ...
+
+#   91| [finally: return] {...}
+#-----|  -> [finally: return] if (...) ...
+
+#   91| [finally: break] {...}
+#-----|  -> [finally: break] if (...) ...
+
+#   91| [finally: continue] {...}
+#-----|  -> [finally: continue] if (...) ...
+
+#   92| if (...) ...
+#-----|  -> access to local variable i
+
+#   92| [finally: return] if (...) ...
+#-----|  -> [finally: return] access to local variable i
+
+#   92| [finally: break] if (...) ...
+#-----|  -> [finally: break] access to local variable i
+
+#   92| [finally: continue] if (...) ...
+#-----|  -> [finally: continue] access to local variable i
+
+#   92| ... == ...
+#-----| true -> object creation of type Exception
+#-----| false -> {...}
+
+#   92| [finally: return] ... == ...
+#-----| true -> [finally: return] object creation of type Exception
+#-----| false -> [finally: return] {...}
+
+#   92| [finally: break] ... == ...
+#-----| true -> [finally: break] object creation of type Exception
+#-----| false -> [finally: break] {...}
+
+#   92| [finally: continue] ... == ...
+#-----| true -> [finally: continue] object creation of type Exception
+#-----| false -> [finally: continue] {...}
+
+#   92| access to local variable i
+#-----|  -> 3
+
+#   92| [finally: return] access to local variable i
+#-----|  -> [finally: return] 3
+
+#   92| [finally: break] access to local variable i
+#-----|  -> [finally: break] 3
+
+#   92| [finally: continue] access to local variable i
+#-----|  -> [finally: continue] 3
+
+#   92| 3
+#-----|  -> ... == ...
+
+#   92| [finally: return] 3
+#-----|  -> [finally: return] ... == ...
+
+#   92| [finally: break] 3
+#-----|  -> [finally: break] ... == ...
+
+#   92| [finally: continue] 3
+#-----|  -> [finally: continue] ... == ...
+
+#   93| throw ...;
+#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
+
+#   93| [finally: return] throw ...;
+#-----| exception(Exception) -> [finally: return, finally(1): exception(Exception)] {...}
+
+#   93| [finally: break] throw ...;
+#-----| exception(Exception) -> [finally: break, finally(1): exception(Exception)] {...}
+
+#   93| [finally: continue] throw ...;
+#-----| exception(Exception) -> [finally: continue, finally(1): exception(Exception)] {...}
+
+#   93| object creation of type Exception
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
+
+#   93| [finally: return] object creation of type Exception
+#-----|  -> [finally: return] throw ...;
+#-----| exception(Exception) -> [finally: return, finally(1): exception(Exception)] {...}
+
+#   93| [finally: break] object creation of type Exception
+#-----|  -> [finally: break] throw ...;
+#-----| exception(Exception) -> [finally: break, finally(1): exception(Exception)] {...}
+
+#   93| [finally: continue] object creation of type Exception
+#-----|  -> [finally: continue] throw ...;
+#-----| exception(Exception) -> [finally: continue, finally(1): exception(Exception)] {...}
+
+#   96| {...}
+#-----|  -> ...;
+
+#   96| [finally(1): exception(Exception)] {...}
+#-----|  -> [finally(1): exception(Exception)] ...;
+
+#   96| [finally: return] {...}
+#-----|  -> [finally: return] ...;
+
+#   96| [finally: return, finally(1): exception(Exception)] {...}
+#-----|  -> [finally: return, finally(1): exception(Exception)] ...;
+
+#   96| [finally: break] {...}
+#-----|  -> [finally: break] ...;
+
+#   96| [finally: break, finally(1): exception(Exception)] {...}
+#-----|  -> [finally: break, finally(1): exception(Exception)] ...;
+
+#   96| [finally: continue] {...}
+#-----|  -> [finally: continue] ...;
+
+#   96| [finally: continue, finally(1): exception(Exception)] {...}
+#-----|  -> [finally: continue, finally(1): exception(Exception)] ...;
+
+#   97| ...;
+#-----|  -> access to local variable i
+
+#   97| [finally(1): exception(Exception)] ...;
+#-----|  -> [finally(1): exception(Exception)] access to local variable i
+
+#   97| [finally: return] ...;
+#-----|  -> [finally: return] access to local variable i
+
+#   97| [finally: return, finally(1): exception(Exception)] ...;
+#-----|  -> [finally: return, finally(1): exception(Exception)] access to local variable i
+
+#   97| [finally: break] ...;
+#-----|  -> [finally: break] access to local variable i
+
+#   97| [finally: break, finally(1): exception(Exception)] ...;
+#-----|  -> [finally: break, finally(1): exception(Exception)] access to local variable i
+
+#   97| [finally: continue] ...;
+#-----|  -> [finally: continue] access to local variable i
+
+#   97| [finally: continue, finally(1): exception(Exception)] ...;
+#-----|  -> [finally: continue, finally(1): exception(Exception)] access to local variable i
+
+#   97| ...--
+#-----|  -> access to local variable i
+
+#   97| [finally(1): exception(Exception)] ...--
+#-----| exception(Exception) -> exit M4 (abnormal)
+
+#   97| [finally: return] ...--
+#-----| return -> exit M4 (normal)
+
+#   97| [finally: return, finally(1): exception(Exception)] ...--
+#-----| exception(Exception) -> exit M4 (abnormal)
+
+#   97| [finally: break] ...--
+#-----| break -> exit M4 (normal)
+
+#   97| [finally: break, finally(1): exception(Exception)] ...--
+#-----| exception(Exception) -> exit M4 (abnormal)
+
+#   97| [finally: continue] ...--
+#-----| continue -> access to local variable i
+
+#   97| [finally: continue, finally(1): exception(Exception)] ...--
+#-----| exception(Exception) -> exit M4 (abnormal)
+
+#   97| access to local variable i
+#-----|  -> ...--
+
+#   97| [finally(1): exception(Exception)] access to local variable i
+#-----|  -> [finally(1): exception(Exception)] ...--
+
+#   97| [finally: return] access to local variable i
+#-----|  -> [finally: return] ...--
+
+#   97| [finally: return, finally(1): exception(Exception)] access to local variable i
+#-----|  -> [finally: return, finally(1): exception(Exception)] ...--
+
+#   97| [finally: break] access to local variable i
+#-----|  -> [finally: break] ...--
+
+#   97| [finally: break, finally(1): exception(Exception)] access to local variable i
+#-----|  -> [finally: break, finally(1): exception(Exception)] ...--
+
+#   97| [finally: continue] access to local variable i
+#-----|  -> [finally: continue] ...--
+
+#   97| [finally: continue, finally(1): exception(Exception)] access to local variable i
+#-----|  -> [finally: continue, finally(1): exception(Exception)] ...--
+
+#  103| enter M5
+#-----|  -> {...}
+
+#  103| exit M5
+
+#  103| exit M5 (abnormal)
+#-----|  -> exit M5
+
+#  103| exit M5 (normal)
+#-----|  -> exit M5
+
+#  104| {...}
+#-----|  -> try {...} ...
+
+#  105| try {...} ...
+#-----|  -> {...}
+
+#  106| {...}
+#-----|  -> if (...) ...
+
+#  107| if (...) ...
+#-----|  -> this access
+
+#  107| ... == ...
+#-----| true -> return ...;
+#-----| false -> if (...) ...
+
+#  107| access to property Length
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
+#-----|  -> 0
+
+#  107| access to field Field
+#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
+#-----|  -> access to property Length
+
+#  107| this access
+#-----|  -> access to field Field
+
+#  107| 0
+#-----|  -> ... == ...
+
+#  108| return ...;
+#-----| return -> [finally: return] {...}
+
+#  109| if (...) ...
+#-----|  -> this access
+
+#  109| ... == ...
+#-----| true -> object creation of type OutOfMemoryException
+#-----| false -> {...}
+
+#  109| access to property Length
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
+#-----|  -> 1
+
+#  109| access to field Field
+#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
+#-----|  -> access to property Length
+
+#  109| this access
+#-----|  -> access to field Field
+
+#  109| 1
+#-----|  -> ... == ...
+
+#  110| throw ...;
+#-----| exception(OutOfMemoryException) -> [finally: exception(OutOfMemoryException)] {...}
+
+#  110| object creation of type OutOfMemoryException
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  113| {...}
+#-----|  -> if (...) ...
+
+#  113| [finally: return] {...}
+#-----|  -> [finally: return] if (...) ...
+
+#  113| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] if (...) ...
+
+#  113| [finally: exception(OutOfMemoryException)] {...}
+#-----|  -> [finally: exception(OutOfMemoryException)] if (...) ...
+
+#  113| [finally: exception(NullReferenceException)] {...}
+#-----|  -> [finally: exception(NullReferenceException)] if (...) ...
+
+#  114| if (...) ...
+#-----|  -> this access
+
+#  114| [finally: return] if (...) ...
+#-----|  -> [finally: return] this access
+
+#  114| [finally: exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception)] this access
+
+#  114| [finally: exception(OutOfMemoryException)] if (...) ...
+#-----|  -> [finally: exception(OutOfMemoryException)] this access
+
+#  114| [finally: exception(NullReferenceException)] if (...) ...
+#-----|  -> [finally: exception(NullReferenceException)] this access
+
+#  114| [false] !...
+#-----| false -> if (...) ...
+
+#  114| [false, finally: return] !...
+#-----| false -> [finally: return] if (...) ...
+
+#  114| [false, finally: exception(Exception)] !...
+#-----| false -> [finally: exception(Exception)] if (...) ...
+
+#  114| [false, finally: exception(OutOfMemoryException)] !...
+#-----| false -> [finally: exception(OutOfMemoryException)] if (...) ...
+
+#  114| [false, finally: exception(NullReferenceException)] !...
+#-----| false -> [finally: exception(NullReferenceException)] if (...) ...
+
+#  114| [true] !...
+#-----| true -> ...;
+
+#  114| [true, finally: return] !...
+#-----| true -> [finally: return] ...;
+
+#  114| [true, finally: exception(Exception)] !...
+#-----| true -> [finally: exception(Exception)] ...;
+
+#  114| [true, finally: exception(OutOfMemoryException)] !...
+#-----| true -> [finally: exception(OutOfMemoryException)] ...;
+
+#  114| [true, finally: exception(NullReferenceException)] !...
+#-----| true -> [finally: exception(NullReferenceException)] ...;
+
+#  114| ... == ...
+#-----| true -> [false] !...
+#-----| false -> [true] !...
+
+#  114| [finally: return] ... == ...
+#-----| true -> [false, finally: return] !...
+#-----| false -> [true, finally: return] !...
+
+#  114| [finally: exception(Exception)] ... == ...
+#-----| true -> [false, finally: exception(Exception)] !...
+#-----| false -> [true, finally: exception(Exception)] !...
+
+#  114| [finally: exception(OutOfMemoryException)] ... == ...
+#-----| true -> [false, finally: exception(OutOfMemoryException)] !...
+#-----| false -> [true, finally: exception(OutOfMemoryException)] !...
+
+#  114| [finally: exception(NullReferenceException)] ... == ...
+#-----| true -> [false, finally: exception(NullReferenceException)] !...
+#-----| false -> [true, finally: exception(NullReferenceException)] !...
+
+#  114| access to property Length
+#-----|  -> 0
+
+#  114| [finally: return] access to property Length
+#-----|  -> [finally: return] 0
+
+#  114| [finally: exception(Exception)] access to property Length
+#-----|  -> [finally: exception(Exception)] 0
+
+#  114| [finally: exception(OutOfMemoryException)] access to property Length
+#-----|  -> [finally: exception(OutOfMemoryException)] 0
+
+#  114| [finally: exception(NullReferenceException)] access to property Length
+#-----|  -> [finally: exception(NullReferenceException)] 0
+
+#  114| access to field Field
+#-----|  -> access to property Length
+
+#  114| [finally: return] access to field Field
+#-----|  -> [finally: return] access to property Length
+
+#  114| [finally: exception(Exception)] access to field Field
+#-----|  -> [finally: exception(Exception)] access to property Length
+
+#  114| [finally: exception(OutOfMemoryException)] access to field Field
+#-----|  -> [finally: exception(OutOfMemoryException)] access to property Length
+
+#  114| [finally: exception(NullReferenceException)] access to field Field
+#-----|  -> [finally: exception(NullReferenceException)] access to property Length
+
+#  114| this access
+#-----|  -> access to field Field
+
+#  114| [finally: return] this access
+#-----|  -> [finally: return] access to field Field
+
+#  114| [finally: exception(Exception)] this access
+#-----|  -> [finally: exception(Exception)] access to field Field
+
+#  114| [finally: exception(OutOfMemoryException)] this access
+#-----|  -> [finally: exception(OutOfMemoryException)] access to field Field
+
+#  114| [finally: exception(NullReferenceException)] this access
+#-----|  -> [finally: exception(NullReferenceException)] access to field Field
+
+#  114| 0
+#-----|  -> ... == ...
+
+#  114| [finally: return] 0
+#-----|  -> [finally: return] ... == ...
+
+#  114| [finally: exception(Exception)] 0
+#-----|  -> [finally: exception(Exception)] ... == ...
+
+#  114| [finally: exception(OutOfMemoryException)] 0
+#-----|  -> [finally: exception(OutOfMemoryException)] ... == ...
+
+#  114| [finally: exception(NullReferenceException)] 0
+#-----|  -> [finally: exception(NullReferenceException)] ... == ...
+
+#  115| ...;
+#-----|  -> this access
+
+#  115| [finally: return] ...;
+#-----|  -> [finally: return] this access
+
+#  115| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] this access
+
+#  115| [finally: exception(OutOfMemoryException)] ...;
+#-----|  -> [finally: exception(OutOfMemoryException)] this access
+
+#  115| [finally: exception(NullReferenceException)] ...;
+#-----|  -> [finally: exception(NullReferenceException)] this access
+
+#  115| call to method WriteLine
+#-----|  -> if (...) ...
+
+#  115| [finally: return] call to method WriteLine
+#-----|  -> [finally: return] if (...) ...
+
+#  115| [finally: exception(Exception)] call to method WriteLine
+#-----|  -> [finally: exception(Exception)] if (...) ...
+
+#  115| [finally: exception(OutOfMemoryException)] call to method WriteLine
+#-----|  -> [finally: exception(OutOfMemoryException)] if (...) ...
+
+#  115| [finally: exception(NullReferenceException)] call to method WriteLine
+#-----|  -> [finally: exception(NullReferenceException)] if (...) ...
+
+#  115| access to field Field
+#-----|  -> call to method WriteLine
+
+#  115| [finally: return] access to field Field
+#-----|  -> [finally: return] call to method WriteLine
+
+#  115| [finally: exception(Exception)] access to field Field
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  115| [finally: exception(OutOfMemoryException)] access to field Field
+#-----|  -> [finally: exception(OutOfMemoryException)] call to method WriteLine
+
+#  115| [finally: exception(NullReferenceException)] access to field Field
+#-----|  -> [finally: exception(NullReferenceException)] call to method WriteLine
+
+#  115| this access
+#-----|  -> access to field Field
+
+#  115| [finally: return] this access
+#-----|  -> [finally: return] access to field Field
+
+#  115| [finally: exception(Exception)] this access
+#-----|  -> [finally: exception(Exception)] access to field Field
+
+#  115| [finally: exception(OutOfMemoryException)] this access
+#-----|  -> [finally: exception(OutOfMemoryException)] access to field Field
+
+#  115| [finally: exception(NullReferenceException)] this access
+#-----|  -> [finally: exception(NullReferenceException)] access to field Field
+
+#  116| if (...) ...
+#-----|  -> this access
+
+#  116| [finally: return] if (...) ...
+#-----|  -> [finally: return] this access
+
+#  116| [finally: exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception)] this access
+
+#  116| [finally: exception(OutOfMemoryException)] if (...) ...
+#-----|  -> [finally: exception(OutOfMemoryException)] this access
+
+#  116| [finally: exception(NullReferenceException)] if (...) ...
+#-----|  -> [finally: exception(NullReferenceException)] this access
+
+#  116| ... > ...
+#-----| true -> ...;
+#-----| false -> exit M5 (normal)
+
+#  116| [finally: return] ... > ...
+#-----| true -> [finally: return] ...;
+#-----| return -> exit M5 (normal)
+
+#  116| [finally: exception(Exception)] ... > ...
+#-----| true -> [finally: exception(Exception)] ...;
+#-----| exception(Exception) -> exit M5 (abnormal)
+
+#  116| [finally: exception(OutOfMemoryException)] ... > ...
+#-----| true -> [finally: exception(OutOfMemoryException)] ...;
+#-----| exception(OutOfMemoryException) -> exit M5 (abnormal)
+
+#  116| [finally: exception(NullReferenceException)] ... > ...
+#-----| true -> [finally: exception(NullReferenceException)] ...;
+#-----| exception(NullReferenceException) -> exit M5 (abnormal)
+
+#  116| access to property Length
+#-----|  -> 0
+
+#  116| [finally: return] access to property Length
+#-----|  -> [finally: return] 0
+
+#  116| [finally: exception(Exception)] access to property Length
+#-----|  -> [finally: exception(Exception)] 0
+
+#  116| [finally: exception(OutOfMemoryException)] access to property Length
+#-----|  -> [finally: exception(OutOfMemoryException)] 0
+
+#  116| [finally: exception(NullReferenceException)] access to property Length
+#-----|  -> [finally: exception(NullReferenceException)] 0
+
+#  116| access to field Field
+#-----|  -> access to property Length
+
+#  116| [finally: return] access to field Field
+#-----|  -> [finally: return] access to property Length
+
+#  116| [finally: exception(Exception)] access to field Field
+#-----|  -> [finally: exception(Exception)] access to property Length
+
+#  116| [finally: exception(OutOfMemoryException)] access to field Field
+#-----|  -> [finally: exception(OutOfMemoryException)] access to property Length
+
+#  116| [finally: exception(NullReferenceException)] access to field Field
+#-----|  -> [finally: exception(NullReferenceException)] access to property Length
+
+#  116| this access
+#-----|  -> access to field Field
+
+#  116| [finally: return] this access
+#-----|  -> [finally: return] access to field Field
+
+#  116| [finally: exception(Exception)] this access
+#-----|  -> [finally: exception(Exception)] access to field Field
+
+#  116| [finally: exception(OutOfMemoryException)] this access
+#-----|  -> [finally: exception(OutOfMemoryException)] access to field Field
+
+#  116| [finally: exception(NullReferenceException)] this access
+#-----|  -> [finally: exception(NullReferenceException)] access to field Field
+
+#  116| 0
+#-----|  -> ... > ...
+
+#  116| [finally: return] 0
+#-----|  -> [finally: return] ... > ...
+
+#  116| [finally: exception(Exception)] 0
+#-----|  -> [finally: exception(Exception)] ... > ...
+
+#  116| [finally: exception(OutOfMemoryException)] 0
+#-----|  -> [finally: exception(OutOfMemoryException)] ... > ...
+
+#  116| [finally: exception(NullReferenceException)] 0
+#-----|  -> [finally: exception(NullReferenceException)] ... > ...
+
+#  117| ...;
+#-----|  -> 1
+
+#  117| [finally: return] ...;
+#-----|  -> [finally: return] 1
+
+#  117| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] 1
+
+#  117| [finally: exception(OutOfMemoryException)] ...;
+#-----|  -> [finally: exception(OutOfMemoryException)] 1
+
+#  117| [finally: exception(NullReferenceException)] ...;
+#-----|  -> [finally: exception(NullReferenceException)] 1
+
+#  117| call to method WriteLine
+#-----|  -> exit M5 (normal)
+
+#  117| [finally: return] call to method WriteLine
+#-----| return -> exit M5 (normal)
+
+#  117| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M5 (abnormal)
+
+#  117| [finally: exception(OutOfMemoryException)] call to method WriteLine
+#-----| exception(OutOfMemoryException) -> exit M5 (abnormal)
+
+#  117| [finally: exception(NullReferenceException)] call to method WriteLine
+#-----| exception(NullReferenceException) -> exit M5 (abnormal)
+
+#  117| 1
+#-----|  -> call to method WriteLine
+
+#  117| [finally: return] 1
+#-----|  -> [finally: return] call to method WriteLine
+
+#  117| [finally: exception(Exception)] 1
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  117| [finally: exception(OutOfMemoryException)] 1
+#-----|  -> [finally: exception(OutOfMemoryException)] call to method WriteLine
+
+#  117| [finally: exception(NullReferenceException)] 1
+#-----|  -> [finally: exception(NullReferenceException)] call to method WriteLine
+
+#  121| enter M6
+#-----|  -> {...}
+
+#  121| exit M6
+
+#  121| exit M6 (normal)
+#-----|  -> exit M6
+
+#  122| {...}
+#-----|  -> try {...} ...
+
+#  123| try {...} ...
+#-----|  -> {...}
+
+#  124| {...}
+#-----|  -> ... ...;
+
+#  125| ... ...;
+#-----|  -> 0
+
+#  125| Double temp = ...
+#-----|  -> exit M6 (normal)
+
+#  125| ... / ...
+#-----|  -> Double temp = ...
+
+#  125| (...) ...
+#-----|  -> access to constant E
+
+#  125| 0
+#-----|  -> (...) ...
+
+#  125| access to constant E
+#-----|  -> ... / ...
+
+#  133| enter M7
+#-----|  -> {...}
+
+#  133| exit M7
+
+#  133| exit M7 (abnormal)
+#-----|  -> exit M7
+
+#  134| {...}
+#-----|  -> try {...} ...
+
+#  135| try {...} ...
+#-----|  -> {...}
+
+#  136| {...}
+#-----|  -> ...;
+
+#  137| ...;
+#-----|  -> "Try"
+
+#  137| call to method WriteLine
+#-----|  -> {...}
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  137| "Try"
+#-----|  -> call to method WriteLine
+
+#  140| {...}
+#-----|  -> ""
+
+#  140| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ""
+
+#  141| throw ...;
+#-----| exception(ArgumentException) -> exit M7 (abnormal)
+
+#  141| [finally: exception(Exception)] throw ...;
+#-----| exception(ArgumentException) -> exit M7 (abnormal)
+
+#  141| object creation of type ArgumentException
+#-----|  -> throw ...;
+
+#  141| [finally: exception(Exception)] object creation of type ArgumentException
+#-----|  -> [finally: exception(Exception)] throw ...;
+
+#  141| ""
+#-----|  -> object creation of type ArgumentException
+
+#  141| [finally: exception(Exception)] ""
+#-----|  -> [finally: exception(Exception)] object creation of type ArgumentException
+
+#  147| enter M8
+#-----|  -> {...}
+
+#  147| exit M8
+
+#  147| exit M8 (abnormal)
+#-----|  -> exit M8
+
+#  147| exit M8 (normal)
+#-----|  -> exit M8
+
+#  148| {...}
+#-----|  -> try {...} ...
+
+#  149| try {...} ...
+#-----|  -> {...}
+
+#  150| {...}
+#-----|  -> if (...) ...
+
+#  151| if (...) ...
+#-----|  -> access to parameter args
+
+#  151| ... == ...
+#-----| true -> object creation of type ArgumentNullException
+#-----| false -> {...}
+
+#  151| access to parameter args
+#-----|  -> null
+
+#  151| null
+#-----|  -> ... == ...
+
+#  152| throw ...;
+#-----| exception(ArgumentNullException) -> [finally: exception(ArgumentNullException)] {...}
+
+#  152| object creation of type ArgumentNullException
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  155| {...}
+#-----|  -> try {...} ...
+
+#  155| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] try {...} ...
+
+#  155| [finally: exception(ArgumentNullException)] {...}
+#-----|  -> [finally: exception(ArgumentNullException)] try {...} ...
+
+#  156| try {...} ...
+#-----|  -> {...}
+
+#  156| [finally: exception(Exception)] try {...} ...
+#-----|  -> [finally: exception(Exception)] {...}
+
+#  156| [finally: exception(ArgumentNullException)] try {...} ...
+#-----|  -> [finally: exception(ArgumentNullException)] {...}
+
+#  157| {...}
+#-----|  -> if (...) ...
+
+#  157| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] if (...) ...
+
+#  157| [finally: exception(ArgumentNullException)] {...}
+#-----|  -> [finally: exception(ArgumentNullException)] if (...) ...
+
+#  158| if (...) ...
+#-----|  -> access to parameter args
+
+#  158| [finally: exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception)] access to parameter args
+
+#  158| [finally: exception(ArgumentNullException)] if (...) ...
+#-----|  -> [finally: exception(ArgumentNullException)] access to parameter args
+
+#  158| ... == ...
+#-----| true -> "1"
+#-----| false -> exit M8 (normal)
+
+#  158| [finally: exception(Exception)] ... == ...
+#-----| true -> [finally: exception(Exception)] "1"
+#-----| exception(Exception) -> exit M8 (abnormal)
+
+#  158| [finally: exception(ArgumentNullException)] ... == ...
+#-----| true -> [finally: exception(ArgumentNullException)] "1"
+#-----| exception(ArgumentNullException) -> exit M8 (abnormal)
+
+#  158| access to property Length
+#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
+#-----| exception(NullReferenceException) -> [exception: NullReferenceException] catch (...) {...}
+#-----|  -> 1
+
+#  158| [finally: exception(Exception)] access to property Length
+#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception] catch (...) {...}
+#-----| exception(NullReferenceException) -> [finally: exception(Exception), exception: NullReferenceException] catch (...) {...}
+#-----|  -> [finally: exception(Exception)] 1
+
+#  158| [finally: exception(ArgumentNullException)] access to property Length
+#-----| exception(Exception) -> [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
+#-----| exception(NullReferenceException) -> [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...}
+#-----|  -> [finally: exception(ArgumentNullException)] 1
+
+#  158| access to parameter args
+#-----|  -> access to property Length
+
+#  158| [finally: exception(Exception)] access to parameter args
+#-----|  -> [finally: exception(Exception)] access to property Length
+
+#  158| [finally: exception(ArgumentNullException)] access to parameter args
+#-----|  -> [finally: exception(ArgumentNullException)] access to property Length
+
+#  158| 1
+#-----|  -> ... == ...
+
+#  158| [finally: exception(Exception)] 1
+#-----|  -> [finally: exception(Exception)] ... == ...
+
+#  158| [finally: exception(ArgumentNullException)] 1
+#-----|  -> [finally: exception(ArgumentNullException)] ... == ...
+
+#  159| throw ...;
+#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
+
+#  159| [finally: exception(Exception)] throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception] catch (...) {...}
+
+#  159| [finally: exception(ArgumentNullException)] throw ...;
+#-----| exception(Exception) -> [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
+
+#  159| object creation of type Exception
+#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
+#-----|  -> throw ...;
+
+#  159| [finally: exception(Exception)] object creation of type Exception
+#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception] catch (...) {...}
+#-----|  -> [finally: exception(Exception)] throw ...;
+
+#  159| [finally: exception(ArgumentNullException)] object creation of type Exception
+#-----| exception(Exception) -> [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
+#-----|  -> [finally: exception(ArgumentNullException)] throw ...;
+
+#  159| "1"
+#-----|  -> object creation of type Exception
+
+#  159| [finally: exception(Exception)] "1"
+#-----|  -> [finally: exception(Exception)] object creation of type Exception
+
+#  159| [finally: exception(ArgumentNullException)] "1"
+#-----|  -> [finally: exception(ArgumentNullException)] object creation of type Exception
+
+#  161| [exception: Exception] catch (...) {...}
+#-----| match -> [exception: Exception] Exception e
+
+#  161| [finally: exception(Exception), exception: Exception] catch (...) {...}
+#-----| match -> [finally: exception(Exception), exception: Exception] Exception e
+
+#  161| [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
+#-----| match -> [finally: exception(ArgumentNullException), exception: Exception] Exception e
+
+#  161| [exception: NullReferenceException] catch (...) {...}
+#-----| match -> [exception: NullReferenceException] Exception e
+
+#  161| [finally: exception(Exception), exception: NullReferenceException] catch (...) {...}
+#-----| match -> [finally: exception(Exception), exception: NullReferenceException] Exception e
+
+#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...}
+#-----| match -> [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e
+
+#  161| [exception: Exception] Exception e
+#-----|  -> [exception: Exception] access to local variable e
+
+#  161| [finally: exception(Exception), exception: Exception] Exception e
+#-----|  -> [finally: exception(Exception), exception: Exception] access to local variable e
+
+#  161| [finally: exception(ArgumentNullException), exception: Exception] Exception e
+#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] access to local variable e
+
+#  161| [exception: NullReferenceException] Exception e
+#-----|  -> [exception: NullReferenceException] access to local variable e
+
+#  161| [finally: exception(Exception), exception: NullReferenceException] Exception e
+#-----|  -> [finally: exception(Exception), exception: NullReferenceException] access to local variable e
+
+#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e
+#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e
+
+#  161| [exception: Exception] ... == ...
+#-----| true -> {...}
+#-----| false -> catch {...}
+
+#  161| [finally: exception(Exception), exception: Exception] ... == ...
+#-----| true -> [finally: exception(Exception)] {...}
+#-----| false -> [finally: exception(Exception)] catch {...}
+
+#  161| [finally: exception(ArgumentNullException), exception: Exception] ... == ...
+#-----| true -> [finally: exception(ArgumentNullException)] {...}
+#-----| false -> [finally: exception(ArgumentNullException)] catch {...}
+
+#  161| [exception: NullReferenceException] ... == ...
+#-----| true -> {...}
+#-----| false -> catch {...}
+
+#  161| [finally: exception(Exception), exception: NullReferenceException] ... == ...
+#-----| true -> [finally: exception(Exception)] {...}
+#-----| false -> [finally: exception(Exception)] catch {...}
+
+#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ...
+#-----| true -> [finally: exception(ArgumentNullException)] {...}
+#-----| false -> [finally: exception(ArgumentNullException)] catch {...}
+
+#  161| [exception: Exception] access to property Message
+#-----|  -> [exception: Exception] "1"
+
+#  161| [finally: exception(Exception), exception: Exception] access to property Message
+#-----|  -> [finally: exception(Exception), exception: Exception] "1"
+
+#  161| [finally: exception(ArgumentNullException), exception: Exception] access to property Message
+#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] "1"
+
+#  161| [exception: NullReferenceException] access to property Message
+#-----|  -> [exception: NullReferenceException] "1"
+
+#  161| [finally: exception(Exception), exception: NullReferenceException] access to property Message
+#-----|  -> [finally: exception(Exception), exception: NullReferenceException] "1"
+
+#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message
+#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] "1"
+
+#  161| [exception: Exception] access to local variable e
+#-----|  -> [exception: Exception] access to property Message
+
+#  161| [finally: exception(Exception), exception: Exception] access to local variable e
+#-----|  -> [finally: exception(Exception), exception: Exception] access to property Message
+
+#  161| [finally: exception(ArgumentNullException), exception: Exception] access to local variable e
+#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] access to property Message
+
+#  161| [exception: NullReferenceException] access to local variable e
+#-----|  -> [exception: NullReferenceException] access to property Message
+
+#  161| [finally: exception(Exception), exception: NullReferenceException] access to local variable e
+#-----|  -> [finally: exception(Exception), exception: NullReferenceException] access to property Message
+
+#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e
+#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message
+
+#  161| [exception: Exception] "1"
+#-----|  -> [exception: Exception] ... == ...
+
+#  161| [finally: exception(Exception), exception: Exception] "1"
+#-----|  -> [finally: exception(Exception), exception: Exception] ... == ...
+
+#  161| [finally: exception(ArgumentNullException), exception: Exception] "1"
+#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] ... == ...
+
+#  161| [exception: NullReferenceException] "1"
+#-----|  -> [exception: NullReferenceException] ... == ...
+
+#  161| [finally: exception(Exception), exception: NullReferenceException] "1"
+#-----|  -> [finally: exception(Exception), exception: NullReferenceException] ... == ...
+
+#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] "1"
+#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ...
+
+#  162| {...}
+#-----|  -> ...;
+
+#  162| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#  162| [finally: exception(ArgumentNullException)] {...}
+#-----|  -> [finally: exception(ArgumentNullException)] ...;
+
+#  163| ...;
+#-----|  -> access to parameter args
+
+#  163| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] access to parameter args
+
+#  163| [finally: exception(ArgumentNullException)] ...;
+#-----|  -> [finally: exception(ArgumentNullException)] access to parameter args
+
+#  163| call to method WriteLine
+#-----|  -> exit M8 (normal)
+
+#  163| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M8 (abnormal)
+
+#  163| [finally: exception(ArgumentNullException)] call to method WriteLine
+#-----| exception(ArgumentNullException) -> exit M8 (abnormal)
+
+#  163| access to array element
+#-----|  -> call to method WriteLine
+
+#  163| [finally: exception(Exception)] access to array element
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  163| [finally: exception(ArgumentNullException)] access to array element
+#-----|  -> [finally: exception(ArgumentNullException)] call to method WriteLine
+
+#  163| access to parameter args
+#-----|  -> 0
+
+#  163| [finally: exception(Exception)] access to parameter args
+#-----|  -> [finally: exception(Exception)] 0
+
+#  163| [finally: exception(ArgumentNullException)] access to parameter args
+#-----|  -> [finally: exception(ArgumentNullException)] 0
+
+#  163| 0
+#-----|  -> access to array element
+
+#  163| [finally: exception(Exception)] 0
+#-----|  -> [finally: exception(Exception)] access to array element
+
+#  163| [finally: exception(ArgumentNullException)] 0
+#-----|  -> [finally: exception(ArgumentNullException)] access to array element
+
+#  165| catch {...}
+#-----|  -> {...}
+
+#  165| [finally: exception(Exception)] catch {...}
+#-----|  -> [finally: exception(Exception)] {...}
+
+#  165| [finally: exception(ArgumentNullException)] catch {...}
+#-----|  -> [finally: exception(ArgumentNullException)] {...}
+
+#  166| {...}
+#-----|  -> ...;
+
+#  166| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#  166| [finally: exception(ArgumentNullException)] {...}
+#-----|  -> [finally: exception(ArgumentNullException)] ...;
+
+#  167| ...;
+#-----|  -> ""
+
+#  167| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] ""
+
+#  167| [finally: exception(ArgumentNullException)] ...;
+#-----|  -> [finally: exception(ArgumentNullException)] ""
+
+#  167| call to method WriteLine
+#-----|  -> exit M8 (normal)
+
+#  167| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M8 (abnormal)
+
+#  167| [finally: exception(ArgumentNullException)] call to method WriteLine
+#-----| exception(ArgumentNullException) -> exit M8 (abnormal)
+
+#  167| ""
+#-----|  -> call to method WriteLine
+
+#  167| [finally: exception(Exception)] ""
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  167| [finally: exception(ArgumentNullException)] ""
+#-----|  -> [finally: exception(ArgumentNullException)] call to method WriteLine
+
+#  176| enter M9
+#-----|  -> {...}
+
+#  176| exit M9
+
+#  176| exit M9 (abnormal)
+#-----|  -> exit M9
+
+#  176| exit M9 (normal)
+#-----|  -> exit M9
+
+#  177| {...}
+#-----|  -> try {...} ...
+
+#  178| try {...} ...
+#-----|  -> {...}
+
+#  179| {...}
+#-----|  -> if (...) ...
+
+#  180| if (...) ...
+#-----|  -> access to parameter b1
+
+#  180| access to parameter b1
+#-----| true -> [b1 (line 176): true] object creation of type ExceptionA
+#-----| false -> [b1 (line 176): false] {...}
+
+#  180| [b1 (line 176): true] throw ...;
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
+
+#  180| [b1 (line 176): true] object creation of type ExceptionA
+#-----|  -> [b1 (line 176): true] throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception), b1 (line 176): true] {...}
+
+#  183| [b1 (line 176): false] {...}
+#-----|  -> [b1 (line 176): false] try {...} ...
+
+#  183| [finally: exception(Exception), b1 (line 176): true] {...}
+#-----|  -> [finally: exception(Exception), b1 (line 176): true] try {...} ...
+
+#  183| [finally: exception(ExceptionA), b1 (line 176): true] {...}
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] try {...} ...
+
+#  184| [b1 (line 176): false] try {...} ...
+#-----|  -> [b1 (line 176): false] {...}
+
+#  184| [finally: exception(Exception), b1 (line 176): true] try {...} ...
+#-----|  -> [finally: exception(Exception), b1 (line 176): true] {...}
+
+#  184| [finally: exception(ExceptionA), b1 (line 176): true] try {...} ...
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
+
+#  185| [b1 (line 176): false] {...}
+#-----|  -> [b1 (line 176): false] if (...) ...
+
+#  185| [finally: exception(Exception), b1 (line 176): true] {...}
+#-----|  -> [finally: exception(Exception), b1 (line 176): true] if (...) ...
+
+#  185| [finally: exception(ExceptionA), b1 (line 176): true] {...}
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
+
+#  186| [b1 (line 176): false] if (...) ...
+#-----|  -> [b1 (line 176): false] access to parameter b2
+
+#  186| [finally: exception(Exception), b1 (line 176): true] if (...) ...
+#-----|  -> [finally: exception(Exception), b1 (line 176): true] access to parameter b2
+
+#  186| [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2
+
+#  186| [b1 (line 176): false] access to parameter b2
+#-----| true -> [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB
+#-----| false -> exit M9 (normal)
+
+#  186| [finally: exception(Exception), b1 (line 176): true] access to parameter b2
+#-----| true -> [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
+#-----| exception(Exception) -> exit M9 (abnormal)
+
+#  186| [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2
+#-----| true -> [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
+#-----| exception(ExceptionA) -> exit M9 (abnormal)
+
+#  186| [b1 (line 176): false, b2 (line 176): true] throw ...;
+#-----| exception(ExceptionB) -> [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
+
+#  186| [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...;
+#-----| exception(ExceptionB) -> [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+
+#  186| [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...;
+#-----| exception(ExceptionB) -> [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+
+#  186| [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB
+#-----| exception(Exception) -> [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
+#-----|  -> [b1 (line 176): false, b2 (line 176): true] throw ...;
+
+#  186| [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
+#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+#-----|  -> [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...;
+
+#  186| [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
+#-----| exception(Exception) -> [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...;
+
+#  188| [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
+#-----| match -> [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2
+#-----| exception(Exception) -> exit M9 (abnormal)
+
+#  188| [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
+#-----| match -> [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2
+
+#  188| [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+#-----| match -> [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+#-----| exception(Exception) -> exit M9 (abnormal)
+
+#  188| [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+#-----| match -> [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+
+#  188| [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+#-----| match -> [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+#-----| exception(Exception) -> exit M9 (abnormal)
+
+#  188| [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
+#-----| match -> [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+
+#  188| [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2
+#-----| true -> [b1 (line 176): false] {...}
+
+#  188| [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2
+#-----| true -> [b1 (line 176): false] {...}
+
+#  188| [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+#-----| true -> [finally: exception(Exception), b1 (line 176): true] {...}
+
+#  188| [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+#-----| true -> [finally: exception(Exception), b1 (line 176): true] {...}
+
+#  188| [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+#-----| true -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
+
+#  188| [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
+#-----| true -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
+
+#  189| [b1 (line 176): false] {...}
+#-----|  -> [b1 (line 176): false] if (...) ...
+
+#  189| [finally: exception(Exception), b1 (line 176): true] {...}
+#-----|  -> [finally: exception(Exception), b1 (line 176): true] if (...) ...
+
+#  189| [finally: exception(ExceptionA), b1 (line 176): true] {...}
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
+
+#  190| [b1 (line 176): false] if (...) ...
+#-----|  -> [b1 (line 176): false] access to parameter b1
+
+#  190| [finally: exception(Exception), b1 (line 176): true] if (...) ...
+#-----|  -> [finally: exception(Exception), b1 (line 176): true] access to parameter b1
+
+#  190| [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
+#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1
+
+#  190| [b1 (line 176): false] access to parameter b1
+#-----| false -> exit M9 (normal)
+
+#  190| [finally: exception(Exception), b1 (line 176): true] access to parameter b1
+#-----| true -> [finally: exception(Exception)] object creation of type ExceptionC
+
+#  190| [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1
+#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionC
+
+#  190| [finally: exception(Exception)] throw ...;
+#-----| exception(ExceptionC) -> exit M9 (abnormal)
+
+#  190| [finally: exception(ExceptionA)] throw ...;
+#-----| exception(ExceptionC) -> exit M9 (abnormal)
+
+#  190| [finally: exception(Exception)] object creation of type ExceptionC
+#-----|  -> [finally: exception(Exception)] throw ...;
+
+#  190| [finally: exception(ExceptionA)] object creation of type ExceptionC
+#-----|  -> [finally: exception(ExceptionA)] throw ...;
+
+#  195| enter M10
+#-----|  -> {...}
+
+#  195| exit M10
+
+#  195| exit M10 (abnormal)
+#-----|  -> exit M10
+
+#  195| exit M10 (normal)
+#-----|  -> exit M10
+
+#  196| {...}
+#-----|  -> try {...} ...
+
+#  197| try {...} ...
+#-----|  -> {...}
+
+#  198| {...}
+#-----|  -> if (...) ...
+
+#  199| if (...) ...
+#-----|  -> access to parameter b1
+
+#  199| access to parameter b1
+#-----| true -> object creation of type ExceptionA
+#-----| false -> {...}
+
+#  199| throw ...;
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
+
+#  199| object creation of type ExceptionA
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  202| {...}
+#-----|  -> try {...} ...
+
+#  202| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] try {...} ...
+
+#  202| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] try {...} ...
+
+#  203| try {...} ...
+#-----|  -> {...}
+
+#  203| [finally: exception(Exception)] try {...} ...
+#-----|  -> [finally: exception(Exception)] {...}
+
+#  203| [finally: exception(ExceptionA)] try {...} ...
+#-----|  -> [finally: exception(ExceptionA)] {...}
+
+#  204| {...}
+#-----|  -> if (...) ...
+
+#  204| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] if (...) ...
+
+#  204| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] if (...) ...
+
+#  205| if (...) ...
+#-----|  -> access to parameter b2
+
+#  205| [finally: exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception)] access to parameter b2
+
+#  205| [finally: exception(ExceptionA)] if (...) ...
+#-----|  -> [finally: exception(ExceptionA)] access to parameter b2
+
+#  205| access to parameter b2
+#-----| true -> object creation of type ExceptionB
+#-----| false -> {...}
+
+#  205| [finally: exception(Exception)] access to parameter b2
+#-----| true -> [finally: exception(Exception)] object creation of type ExceptionB
+#-----| false -> [finally: exception(Exception)] {...}
+
+#  205| [finally: exception(ExceptionA)] access to parameter b2
+#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionB
+#-----| false -> [finally: exception(ExceptionA)] {...}
+
+#  205| throw ...;
+#-----| exception(ExceptionB) -> [finally(1): exception(ExceptionB)] {...}
+
+#  205| [finally: exception(Exception)] throw ...;
+#-----| exception(ExceptionB) -> [finally: exception(Exception), finally(1): exception(ExceptionB)] {...}
+
+#  205| [finally: exception(ExceptionA)] throw ...;
+#-----| exception(ExceptionB) -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...}
+
+#  205| object creation of type ExceptionB
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
+
+#  205| [finally: exception(Exception)] object creation of type ExceptionB
+#-----|  -> [finally: exception(Exception)] throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception), finally(1): exception(Exception)] {...}
+
+#  205| [finally: exception(ExceptionA)] object creation of type ExceptionB
+#-----|  -> [finally: exception(ExceptionA)] throw ...;
+#-----| exception(Exception) -> [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
+
+#  208| {...}
+#-----|  -> if (...) ...
+
+#  208| [finally(1): exception(Exception)] {...}
+#-----|  -> [finally(1): exception(Exception)] if (...) ...
+
+#  208| [finally(1): exception(ExceptionB)] {...}
+#-----|  -> [finally(1): exception(ExceptionB)] if (...) ...
+
+#  208| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] if (...) ...
+
+#  208| [finally: exception(Exception), finally(1): exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] if (...) ...
+
+#  208| [finally: exception(Exception), finally(1): exception(ExceptionB)] {...}
+#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ...
+
+#  208| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] if (...) ...
+
+#  208| [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ...
+
+#  208| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...}
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ...
+
+#  209| if (...) ...
+#-----|  -> access to parameter b3
+
+#  209| [finally(1): exception(Exception)] if (...) ...
+#-----|  -> [finally(1): exception(Exception)] access to parameter b3
+
+#  209| [finally(1): exception(ExceptionB)] if (...) ...
+#-----|  -> [finally(1): exception(ExceptionB)] access to parameter b3
+
+#  209| [finally: exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception)] access to parameter b3
+
+#  209| [finally: exception(Exception), finally(1): exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3
+
+#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ...
+#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3
+
+#  209| [finally: exception(ExceptionA)] if (...) ...
+#-----|  -> [finally: exception(ExceptionA)] access to parameter b3
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ...
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3
+
+#  209| access to parameter b3
+#-----| true -> object creation of type ExceptionC
+#-----| false -> ...;
+
+#  209| [finally(1): exception(Exception)] access to parameter b3
+#-----| true -> [finally(1): exception(Exception)] object creation of type ExceptionC
+#-----| exception(Exception) -> exit M10 (abnormal)
+
+#  209| [finally(1): exception(ExceptionB)] access to parameter b3
+#-----| true -> [finally(1): exception(ExceptionB)] object creation of type ExceptionC
+#-----| exception(ExceptionB) -> exit M10 (abnormal)
+
+#  209| [finally: exception(Exception)] access to parameter b3
+#-----| true -> [finally: exception(Exception)] object creation of type ExceptionC
+#-----| false -> [finally: exception(Exception)] ...;
+
+#  209| [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3
+#-----| true -> [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC
+#-----| exception(Exception) -> exit M10 (abnormal)
+
+#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3
+#-----| true -> [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC
+#-----| exception(ExceptionB) -> exit M10 (abnormal)
+
+#  209| [finally: exception(ExceptionA)] access to parameter b3
+#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionC
+#-----| false -> [finally: exception(ExceptionA)] ...;
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3
+#-----| true -> [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC
+#-----| exception(Exception) -> exit M10 (abnormal)
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3
+#-----| true -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC
+#-----| exception(ExceptionB) -> exit M10 (abnormal)
+
+#  209| throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally(1): exception(Exception)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally(1): exception(ExceptionB)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally: exception(Exception)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally: exception(Exception), finally(1): exception(Exception)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally: exception(ExceptionA)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...;
+#-----| exception(ExceptionC) -> exit M10 (abnormal)
+
+#  209| object creation of type ExceptionC
+#-----|  -> throw ...;
+
+#  209| [finally(1): exception(Exception)] object creation of type ExceptionC
+#-----|  -> [finally(1): exception(Exception)] throw ...;
+
+#  209| [finally(1): exception(ExceptionB)] object creation of type ExceptionC
+#-----|  -> [finally(1): exception(ExceptionB)] throw ...;
+
+#  209| [finally: exception(Exception)] object creation of type ExceptionC
+#-----|  -> [finally: exception(Exception)] throw ...;
+
+#  209| [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC
+#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] throw ...;
+
+#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC
+#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...;
+
+#  209| [finally: exception(ExceptionA)] object creation of type ExceptionC
+#-----|  -> [finally: exception(ExceptionA)] throw ...;
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...;
+
+#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...;
+
+#  211| ...;
+#-----|  -> this access
+
+#  211| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] this access
+
+#  211| [finally: exception(ExceptionA)] ...;
+#-----|  -> [finally: exception(ExceptionA)] this access
+
+#  211| ... = ...
+#-----|  -> ...;
+
+#  211| [finally: exception(Exception)] ... = ...
+#-----| exception(Exception) -> exit M10 (abnormal)
+
+#  211| [finally: exception(ExceptionA)] ... = ...
+#-----| exception(ExceptionA) -> exit M10 (abnormal)
+
+#  211| this access
+#-----|  -> "0"
+
+#  211| [finally: exception(Exception)] this access
+#-----|  -> [finally: exception(Exception)] "0"
+
+#  211| [finally: exception(ExceptionA)] this access
+#-----|  -> [finally: exception(ExceptionA)] "0"
+
+#  211| "0"
+#-----|  -> ... = ...
+
+#  211| [finally: exception(Exception)] "0"
+#-----|  -> [finally: exception(Exception)] ... = ...
+
+#  211| [finally: exception(ExceptionA)] "0"
+#-----|  -> [finally: exception(ExceptionA)] ... = ...
+
+#  213| ...;
+#-----|  -> this access
+
+#  213| ... = ...
+#-----|  -> exit M10 (normal)
+
+#  213| this access
+#-----|  -> "1"
+
+#  213| "1"
+#-----|  -> ... = ...
+
+#  216| enter M11
+#-----|  -> {...}
+
+#  216| exit M11
+
+#  216| exit M11 (normal)
+#-----|  -> exit M11
+
+#  217| {...}
+#-----|  -> try {...} ...
+
+#  218| try {...} ...
+#-----|  -> {...}
+
+#  219| {...}
+#-----|  -> ...;
+
+#  220| ...;
+#-----|  -> "Try"
+
+#  220| call to method WriteLine
+#-----| exception(Exception) -> catch {...}
+#-----|  -> {...}
+
+#  220| "Try"
+#-----|  -> call to method WriteLine
+
+#  222| catch {...}
+#-----|  -> {...}
+
+#  223| {...}
+#-----|  -> ...;
+
+#  224| ...;
+#-----|  -> "Catch"
+
+#  224| call to method WriteLine
+#-----|  -> {...}
+
+#  224| "Catch"
+#-----|  -> call to method WriteLine
+
+#  227| {...}
+#-----|  -> ...;
+
+#  228| ...;
+#-----|  -> "Finally"
+
+#  228| call to method WriteLine
+#-----|  -> ...;
+
+#  228| "Finally"
+#-----|  -> call to method WriteLine
+
+#  230| ...;
+#-----|  -> "Done"
+
+#  230| call to method WriteLine
+#-----|  -> exit M11 (normal)
+
+#  230| "Done"
+#-----|  -> call to method WriteLine
+
+#  233| enter M12
+#-----|  -> {...}
+
+#  233| exit M12
+
+#  233| exit M12 (abnormal)
+#-----|  -> exit M12
+
+#  233| exit M12 (normal)
+#-----|  -> exit M12
+
+#  234| {...}
+#-----|  -> try {...} ...
+
+#  235| try {...} ...
+#-----|  -> {...}
+
+#  236| {...}
+#-----|  -> try {...} ...
+
+#  237| try {...} ...
+#-----|  -> {...}
+
+#  238| {...}
+#-----|  -> if (...) ...
+
+#  239| if (...) ...
+#-----|  -> access to parameter b1
+
+#  239| access to parameter b1
+#-----| true -> object creation of type ExceptionA
+#-----| false -> {...}
+
+#  240| throw ...;
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
+
+#  240| object creation of type ExceptionA
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  243| {...}
+#-----|  -> try {...} ...
+
+#  243| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] try {...} ...
+
+#  243| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] try {...} ...
+
+#  244| try {...} ...
+#-----|  -> {...}
+
+#  244| [finally: exception(Exception)] try {...} ...
+#-----|  -> [finally: exception(Exception)] {...}
+
+#  244| [finally: exception(ExceptionA)] try {...} ...
+#-----|  -> [finally: exception(ExceptionA)] {...}
+
+#  245| {...}
+#-----|  -> if (...) ...
+
+#  245| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] if (...) ...
+
+#  245| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] if (...) ...
+
+#  246| if (...) ...
+#-----|  -> access to parameter b2
+
+#  246| [finally: exception(Exception)] if (...) ...
+#-----|  -> [finally: exception(Exception)] access to parameter b2
+
+#  246| [finally: exception(ExceptionA)] if (...) ...
+#-----|  -> [finally: exception(ExceptionA)] access to parameter b2
+
+#  246| access to parameter b2
+#-----| true -> object creation of type ExceptionA
+#-----| false -> {...}
+
+#  246| [finally: exception(Exception)] access to parameter b2
+#-----| true -> [finally: exception(Exception)] object creation of type ExceptionA
+#-----| false -> [finally: exception(Exception)] {...}
+
+#  246| [finally: exception(ExceptionA)] access to parameter b2
+#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionA
+#-----| false -> [finally: exception(ExceptionA)] {...}
+
+#  247| throw ...;
+#-----| exception(ExceptionA) -> [finally(1): exception(ExceptionA)] {...}
+
+#  247| [finally: exception(Exception)] throw ...;
+#-----| exception(ExceptionA) -> [finally: exception(Exception), finally(1): exception(ExceptionA)] {...}
+
+#  247| [finally: exception(ExceptionA)] throw ...;
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...}
+
+#  247| object creation of type ExceptionA
+#-----|  -> throw ...;
+#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
+
+#  247| [finally: exception(Exception)] object creation of type ExceptionA
+#-----|  -> [finally: exception(Exception)] throw ...;
+#-----| exception(Exception) -> [finally: exception(Exception), finally(1): exception(Exception)] {...}
+
+#  247| [finally: exception(ExceptionA)] object creation of type ExceptionA
+#-----|  -> [finally: exception(ExceptionA)] throw ...;
+#-----| exception(Exception) -> [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
+
+#  250| {...}
+#-----|  -> ...;
+
+#  250| [finally(1): exception(Exception)] {...}
+#-----|  -> [finally(1): exception(Exception)] ...;
+
+#  250| [finally(1): exception(ExceptionA)] {...}
+#-----|  -> [finally(1): exception(ExceptionA)] ...;
+
+#  250| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#  250| [finally: exception(Exception), finally(1): exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] ...;
+
+#  250| [finally: exception(Exception), finally(1): exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionA)] ...;
+
+#  250| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] ...;
+
+#  250| [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] ...;
+
+#  250| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...;
+
+#  251| ...;
+#-----|  -> "Inner finally"
+
+#  251| [finally(1): exception(Exception)] ...;
+#-----|  -> [finally(1): exception(Exception)] "Inner finally"
+
+#  251| [finally(1): exception(ExceptionA)] ...;
+#-----|  -> [finally(1): exception(ExceptionA)] "Inner finally"
+
+#  251| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] "Inner finally"
+
+#  251| [finally: exception(Exception), finally(1): exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally"
+
+#  251| [finally: exception(Exception), finally(1): exception(ExceptionA)] ...;
+#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally"
+
+#  251| [finally: exception(ExceptionA)] ...;
+#-----|  -> [finally: exception(ExceptionA)] "Inner finally"
+
+#  251| [finally: exception(ExceptionA), finally(1): exception(Exception)] ...;
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally"
+
+#  251| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...;
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally"
+
+#  251| call to method WriteLine
+#-----|  -> ...;
+
+#  251| [finally(1): exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  251| [finally(1): exception(ExceptionA)] call to method WriteLine
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
+
+#  251| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  251| [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  251| [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
+
+#  251| [finally: exception(ExceptionA)] call to method WriteLine
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
+
+#  251| [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  251| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine
+#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
+
+#  251| "Inner finally"
+#-----|  -> call to method WriteLine
+
+#  251| [finally(1): exception(Exception)] "Inner finally"
+#-----|  -> [finally(1): exception(Exception)] call to method WriteLine
+
+#  251| [finally(1): exception(ExceptionA)] "Inner finally"
+#-----|  -> [finally(1): exception(ExceptionA)] call to method WriteLine
+
+#  251| [finally: exception(Exception)] "Inner finally"
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  251| [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally"
+#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine
+
+#  251| [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally"
+#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine
+
+#  251| [finally: exception(ExceptionA)] "Inner finally"
+#-----|  -> [finally: exception(ExceptionA)] call to method WriteLine
+
+#  251| [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally"
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine
+
+#  251| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally"
+#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine
+
+#  254| ...;
+#-----|  -> "Mid finally"
+
+#  254| call to method WriteLine
+#-----|  -> {...}
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  254| "Mid finally"
+#-----|  -> call to method WriteLine
+
+#  257| {...}
+#-----|  -> ...;
+
+#  257| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#  257| [finally: exception(ExceptionA)] {...}
+#-----|  -> [finally: exception(ExceptionA)] ...;
+
+#  258| ...;
+#-----|  -> "Outer finally"
+
+#  258| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] "Outer finally"
+
+#  258| [finally: exception(ExceptionA)] ...;
+#-----|  -> [finally: exception(ExceptionA)] "Outer finally"
+
+#  258| call to method WriteLine
+#-----|  -> ...;
+
+#  258| [finally: exception(Exception)] call to method WriteLine
+#-----| exception(Exception) -> exit M12 (abnormal)
+
+#  258| [finally: exception(ExceptionA)] call to method WriteLine
+#-----| exception(ExceptionA) -> exit M12 (abnormal)
+
+#  258| "Outer finally"
+#-----|  -> call to method WriteLine
+
+#  258| [finally: exception(Exception)] "Outer finally"
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  258| [finally: exception(ExceptionA)] "Outer finally"
+#-----|  -> [finally: exception(ExceptionA)] call to method WriteLine
+
+#  260| ...;
+#-----|  -> "Done"
+
+#  260| call to method WriteLine
+#-----|  -> exit M12 (normal)
+
+#  260| "Done"
+#-----|  -> call to method WriteLine
+
+#  263| enter M13
+#-----|  -> {...}
+
+#  263| exit M13
+
+#  263| exit M13 (abnormal)
+#-----|  -> exit M13
+
+#  263| exit M13 (normal)
+#-----|  -> exit M13
+
+#  264| {...}
+#-----|  -> try {...} ...
+
+#  265| try {...} ...
+#-----|  -> {...}
+
+#  266| {...}
+#-----|  -> ...;
+
+#  267| ...;
+#-----|  -> "1"
+
+#  267| call to method WriteLine
+#-----|  -> {...}
+#-----| exception(Exception) -> [finally: exception(Exception)] {...}
+
+#  267| "1"
+#-----|  -> call to method WriteLine
+
+#  270| {...}
+#-----|  -> ...;
+
+#  270| [finally: exception(Exception)] {...}
+#-----|  -> [finally: exception(Exception)] ...;
+
+#  271| ...;
+#-----|  -> "3"
+
+#  271| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] "3"
+
+#  271| call to method WriteLine
+#-----|  -> ...;
+
+#  271| [finally: exception(Exception)] call to method WriteLine
+#-----|  -> [finally: exception(Exception)] ...;
+
+#  271| "3"
+#-----|  -> call to method WriteLine
+
+#  271| [finally: exception(Exception)] "3"
+#-----|  -> [finally: exception(Exception)] call to method WriteLine
+
+#  272| ...;
+#-----|  -> access to parameter i
+
+#  272| [finally: exception(Exception)] ...;
+#-----|  -> [finally: exception(Exception)] access to parameter i
+
+#  272| ... = ...
+#-----|  -> exit M13 (normal)
+
+#  272| [finally: exception(Exception)] ... = ...
+#-----| exception(Exception) -> exit M13 (abnormal)
+
+#  272| ... + ...
+#-----|  -> ... = ...
+
+#  272| [finally: exception(Exception)] ... + ...
+#-----|  -> [finally: exception(Exception)] ... = ...
+
+#  272| access to parameter i
+#-----|  -> 3
+
+#  272| [finally: exception(Exception)] access to parameter i
+#-----|  -> [finally: exception(Exception)] 3
+
+#  272| 3
+#-----|  -> ... + ...
+
+#  272| [finally: exception(Exception)] 3
+#-----|  -> [finally: exception(Exception)] ... + ...
+
+Foreach.cs:
+#    6| enter M1
+#-----|  -> {...}
+
+#    6| exit M1
+
+#    6| exit M1 (normal)
+#-----|  -> exit M1
+
+#    7| {...}
+#-----|  -> access to parameter args
+
+#    8| foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+#-----| empty -> exit M1 (normal)
+
+#    8| String arg
+#-----|  -> ;
+
+#    8| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#    9| ;
+#-----|  -> foreach (... ... in ...) ...
+
+#   12| enter M2
+#-----|  -> {...}
+
+#   12| exit M2
+
+#   12| exit M2 (normal)
+#-----|  -> exit M2
+
+#   13| {...}
+#-----|  -> access to parameter args
+
+#   14| foreach (... ... in ...) ...
+#-----| non-empty -> String _
+#-----| empty -> exit M2 (normal)
+
+#   14| String _
+#-----|  -> ;
+
+#   14| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   15| ;
+#-----|  -> foreach (... ... in ...) ...
+
+#   18| enter M3
+#-----|  -> {...}
+
+#   18| exit M3
+
+#   18| exit M3 (normal)
+#-----|  -> exit M3
+
+#   19| {...}
+#-----|  -> access to parameter e
+
+#   20| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M3 (normal)
+
+#   20| String x
+#-----|  -> ;
+
+#   20| ... ?? ...
+#-----|  -> foreach (... ... in ...) ...
+
+#   20| access to parameter e
+#-----| non-null -> call to method ToArray
+#-----| null -> call to method Empty
+
+#   20| call to method ToArray
+#-----| non-null -> ... ?? ...
+#-----| null -> call to method Empty
+
+#   20| call to method Empty
+#-----|  -> ... ?? ...
+
+#   21| ;
+#-----|  -> foreach (... ... in ...) ...
+
+#   24| enter M4
+#-----|  -> {...}
+
+#   24| exit M4
+
+#   24| exit M4 (normal)
+#-----|  -> exit M4
+
+#   25| {...}
+#-----|  -> access to parameter args
+
+#   26| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M4 (normal)
+
+#   26| (..., ...)
+#-----|  -> ;
+
+#   26| String x
+#-----|  -> Int32 y
+
+#   26| Int32 y
+#-----|  -> (..., ...)
+
+#   26| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   27| ;
+#-----|  -> foreach (... ... in ...) ...
+
+#   30| enter M5
+#-----|  -> {...}
+
+#   30| exit M5
+
+#   30| exit M5 (normal)
+#-----|  -> exit M5
+
+#   31| {...}
+#-----|  -> access to parameter args
+
+#   32| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M5 (normal)
+
+#   32| (..., ...)
+#-----|  -> ;
+
+#   32| String x
+#-----|  -> Int32 y
+
+#   32| Int32 y
+#-----|  -> (..., ...)
+
+#   32| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   33| ;
+#-----|  -> foreach (... ... in ...) ...
+
+#   36| enter M6
+#-----|  -> {...}
+
+#   36| exit M6
+
+#   36| exit M6 (normal)
+#-----|  -> exit M6
+
+#   37| {...}
+#-----|  -> access to parameter args
+
+#   38| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M6 (normal)
+
+#   38| (..., ...)
+#-----|  -> ;
+
+#   38| String x
+#-----|  -> Int32 y
+
+#   38| Int32 y
+#-----|  -> (..., ...)
+
+#   38| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   39| ;
+#-----|  -> foreach (... ... in ...) ...
+
+Initializers.cs:
+#    5| ... = ...
+#-----|  -> this access
+
+#    5| ... = ...
+#-----|  -> this access
+
+#    5| this access
+#-----|  -> access to field H
+
+#    5| this access
+#-----|  -> access to field H
+
+#    5| ... + ...
+#-----|  -> ... = ...
+
+#    5| ... + ...
+#-----|  -> ... = ...
+
+#    5| access to field H
+#-----|  -> 1
+
+#    5| access to field H
+#-----|  -> 1
+
+#    5| 1
+#-----|  -> ... + ...
+
+#    5| 1
+#-----|  -> ... + ...
+
+#    6| access to property G
+#-----|  -> ... = ...
+
+#    6| access to property G
+#-----|  -> ... = ...
+
+#    6| this access
+#-----|  -> access to field H
+
+#    6| this access
+#-----|  -> access to field H
+
+#    6| ... = ...
+#-----|  -> {...}
+
+#    6| ... = ...
+#-----|  -> {...}
+
+#    6| ... + ...
+#-----|  -> access to property G
+
+#    6| ... + ...
+#-----|  -> access to property G
+
+#    6| access to field H
+#-----|  -> 2
+
+#    6| access to field H
+#-----|  -> 2
+
+#    6| 2
+#-----|  -> ... + ...
+
+#    6| 2
+#-----|  -> ... + ...
+
+#    8| enter Initializers
+#-----|  -> call to constructor Object
+
+#    8| call to constructor Object
+#-----|  -> this access
+
+#    8| exit Initializers
+
+#    8| exit Initializers (normal)
+#-----|  -> exit Initializers
+
+#    8| {...}
+#-----|  -> exit Initializers (normal)
+
+#   10| enter Initializers
+#-----|  -> call to constructor Object
+
+#   10| call to constructor Object
+#-----|  -> this access
+
+#   10| exit Initializers
+
+#   10| exit Initializers (normal)
+#-----|  -> exit Initializers
+
+#   10| {...}
+#-----|  -> exit Initializers (normal)
+
+#   12| enter M
+#-----|  -> {...}
+
+#   12| exit M
+
+#   12| exit M (normal)
+#-----|  -> exit M
+
+#   13| {...}
+#-----|  -> ... ...;
+
+#   14| ... ...;
+#-----|  -> ""
+
+#   14| Initializers i = ...
+#-----|  -> ... ...;
+
+#   14| object creation of type Initializers
+#-----|  -> 0
+
+#   14| ""
+#-----|  -> object creation of type Initializers
+
+#   14| { ..., ... }
+#-----|  -> Initializers i = ...
+
+#   14| ... = ...
+#-----|  -> 1
+
+#   14| 0
+#-----|  -> ... = ...
+
+#   14| ... = ...
+#-----|  -> { ..., ... }
+
+#   14| access to property G
+#-----|  -> ... = ...
+
+#   14| 1
+#-----|  -> access to property G
+
+#   15| ... ...;
+#-----|  -> 2
+
+#   15| Initializers[] iz = ...
+#-----|  -> exit M (normal)
+
+#   15| array creation of type Initializers[]
+#-----|  -> access to local variable i
+
+#   15| 2
+#-----|  -> array creation of type Initializers[]
+
+#   15| { ..., ... }
+#-----|  -> Initializers[] iz = ...
+
+#   15| access to local variable i
+#-----|  -> ""
+
+#   15| object creation of type Initializers
+#-----|  -> { ..., ... }
+
+#   15| ""
+#-----|  -> object creation of type Initializers
+
+#   18| enter H
+#-----|  -> 1
+
+#   18| ... = ...
+
+#   18| 1
+#-----|  -> ... = ...
+
+#   20| enter NoConstructor
+#-----|  -> this access
+
+#   20| exit NoConstructor
+
+#   20| exit NoConstructor (normal)
+#-----|  -> exit NoConstructor
+
+#   22| ... = ...
+#-----|  -> this access
+
+#   22| this access
+#-----|  -> 0
+
+#   22| 0
+#-----|  -> ... = ...
+
+#   23| ... = ...
+#-----|  -> exit NoConstructor (normal)
+
+#   23| this access
+#-----|  -> 1
+
+#   23| 1
+#-----|  -> ... = ...
+
+#   28| ... = ...
+#-----|  -> {...}
+
+#   28| ... = ...
+#-----|  -> {...}
+
+#   28| this access
+#-----|  -> 2
+
+#   28| this access
+#-----|  -> 2
+
+#   28| 2
+#-----|  -> ... = ...
+
+#   28| 2
+#-----|  -> ... = ...
+
+#   31| enter Sub
+#-----|  -> call to constructor NoConstructor
+
+#   31| exit Sub
+
+#   31| exit Sub (normal)
+#-----|  -> exit Sub
+
+#   31| call to constructor NoConstructor
+#-----|  -> this access
+
+#   31| {...}
+#-----|  -> ...;
+
+#   31| ...;
+#-----|  -> this access
+
+#   31| ... = ...
+#-----|  -> exit Sub (normal)
+
+#   31| this access
+#-----|  -> 3
+
+#   31| 3
+#-----|  -> ... = ...
+
+#   33| enter Sub
+#-----|  -> call to constructor Sub
+
+#   33| exit Sub
+
+#   33| exit Sub (normal)
+#-----|  -> exit Sub
+
+#   33| call to constructor Sub
+#-----|  -> {...}
+
+#   33| {...}
+#-----|  -> ...;
+
+#   33| ...;
+#-----|  -> this access
+
+#   33| ... = ...
+#-----|  -> exit Sub (normal)
+
+#   33| this access
+#-----|  -> access to parameter i
+
+#   33| access to parameter i
+#-----|  -> ... = ...
+
+#   35| enter Sub
+#-----|  -> call to constructor NoConstructor
+
+#   35| call to constructor NoConstructor
+#-----|  -> this access
+
+#   35| exit Sub
+
+#   35| exit Sub (normal)
+#-----|  -> exit Sub
+
+#   35| {...}
+#-----|  -> ...;
+
+#   35| ...;
+#-----|  -> this access
+
+#   35| ... = ...
+#-----|  -> exit Sub (normal)
+
+#   35| this access
+#-----|  -> access to parameter i
+
+#   35| ... + ...
+#-----|  -> ... = ...
+
+#   35| access to parameter i
+#-----|  -> access to parameter j
+
+#   35| access to parameter j
+#-----|  -> ... + ...
+
+#   51| enter Test
+#-----|  -> {...}
+
+#   51| exit Test
+
+#   51| exit Test (normal)
+#-----|  -> exit Test
+
+#   52| {...}
+#-----|  -> ... ...;
+
+#   54| ... ...;
+#-----|  -> object creation of type Dictionary<Int32,String>
+
+#   54| Dictionary<Int32,String> dict = ...
+#-----|  -> ... ...;
+
+#   54| object creation of type Dictionary<Int32,String>
+#-----|  -> 0
+
+#   54| { ..., ... }
+#-----|  -> Dictionary<Int32,String> dict = ...
+
+#   54| ... = ...
+#-----|  -> 1
+
+#   54| access to indexer
+#-----|  -> ... = ...
+
+#   54| 0
+#-----|  -> "Zero"
+
+#   54| "Zero"
+#-----|  -> access to indexer
+
+#   54| ... = ...
+#-----|  -> access to parameter i
+
+#   54| access to indexer
+#-----|  -> ... = ...
+
+#   54| 1
+#-----|  -> "One"
+
+#   54| "One"
+#-----|  -> access to indexer
+
+#   54| ... = ...
+#-----|  -> { ..., ... }
+
+#   54| access to indexer
+#-----|  -> ... = ...
+
+#   54| ... + ...
+#-----|  -> "Two"
+
+#   54| access to parameter i
+#-----|  -> 2
+
+#   54| 2
+#-----|  -> ... + ...
+
+#   54| "Two"
+#-----|  -> access to indexer
+
+#   57| ... ...;
+#-----|  -> object creation of type Compound
+
+#   57| Compound compound = ...
+#-----|  -> exit Test (normal)
+
+#   57| object creation of type Compound
+#-----|  -> 0
+
+#   58| { ..., ... }
+#-----|  -> Compound compound = ...
+
+#   59| ... = ...
+#-----|  -> 3
+
+#   59| { ..., ... }
+#-----|  -> ... = ...
+
+#   59| ... = ...
+#-----|  -> 1
+
+#   59| access to indexer
+#-----|  -> ... = ...
+
+#   59| 0
+#-----|  -> "Zero"
+
+#   59| "Zero"
+#-----|  -> access to indexer
+
+#   59| ... = ...
+#-----|  -> access to parameter i
+
+#   59| access to indexer
+#-----|  -> ... = ...
+
+#   59| 1
+#-----|  -> "One"
+
+#   59| "One"
+#-----|  -> access to indexer
+
+#   59| ... = ...
+#-----|  -> { ..., ... }
+
+#   59| access to indexer
+#-----|  -> ... = ...
+
+#   59| ... + ...
+#-----|  -> "Two"
+
+#   59| access to parameter i
+#-----|  -> 2
+
+#   59| 2
+#-----|  -> ... + ...
+
+#   59| "Two"
+#-----|  -> access to indexer
+
+#   60| ... = ...
+#-----|  -> 0
+
+#   60| access to property DictionaryProperty
+#-----|  -> ... = ...
+
+#   60| { ..., ... }
+#-----|  -> access to property DictionaryProperty
+
+#   60| ... = ...
+#-----|  -> 2
+
+#   60| access to indexer
+#-----|  -> ... = ...
+
+#   60| 3
+#-----|  -> "Three"
+
+#   60| "Three"
+#-----|  -> access to indexer
+
+#   60| ... = ...
+#-----|  -> access to parameter i
+
+#   60| access to indexer
+#-----|  -> ... = ...
+
+#   60| 2
+#-----|  -> "Two"
+
+#   60| "Two"
+#-----|  -> access to indexer
+
+#   60| ... = ...
+#-----|  -> { ..., ... }
+
+#   60| access to indexer
+#-----|  -> ... = ...
+
+#   60| ... + ...
+#-----|  -> "One"
+
+#   60| access to parameter i
+#-----|  -> 1
+
+#   60| 1
+#-----|  -> ... + ...
+
+#   60| "One"
+#-----|  -> access to indexer
+
+#   61| ... = ...
+#-----|  -> 0
+
+#   61| { ..., ... }
+#-----|  -> ... = ...
+
+#   61| ... = ...
+#-----|  -> access to parameter i
+
+#   61| 0
+#-----|  -> "Zero"
+
+#   61| "Zero"
+#-----|  -> ... = ...
+
+#   61| ... = ...
+#-----|  -> { ..., ... }
+
+#   61| ... + ...
+#-----|  -> "One"
+
+#   61| access to parameter i
+#-----|  -> 1
+
+#   61| 1
+#-----|  -> ... + ...
+
+#   61| "One"
+#-----|  -> ... = ...
+
+#   62| ... = ...
+#-----|  -> 1
+
+#   62| { ..., ... }
+#-----|  -> ... = ...
+
+#   62| ... = ...
+#-----|  -> 1
+
+#   62| 0
+#-----|  -> 1
+
+#   62| 1
+#-----|  -> "i"
+
+#   62| "i"
+#-----|  -> ... = ...
+
+#   62| ... = ...
+#-----|  -> { ..., ... }
+
+#   62| 1
+#-----|  -> access to parameter i
+
+#   62| ... + ...
+#-----|  -> "1"
+
+#   62| access to parameter i
+#-----|  -> 0
+
+#   62| 0
+#-----|  -> ... + ...
+
+#   62| "1"
+#-----|  -> ... = ...
+
+#   63| ... = ...
+#-----|  -> 0
+
+#   63| access to property ArrayProperty
+#-----|  -> ... = ...
+
+#   63| { ..., ... }
+#-----|  -> access to property ArrayProperty
+
+#   63| ... = ...
+#-----|  -> access to parameter i
+
+#   63| 1
+#-----|  -> "One"
+
+#   63| "One"
+#-----|  -> ... = ...
+
+#   63| ... = ...
+#-----|  -> { ..., ... }
+
+#   63| ... + ...
+#-----|  -> "Two"
+
+#   63| access to parameter i
+#-----|  -> 2
+
+#   63| 2
+#-----|  -> ... + ...
+
+#   63| "Two"
+#-----|  -> ... = ...
+
+#   64| ... = ...
+#-----|  -> { ..., ... }
+
+#   64| access to property ArrayProperty2
+#-----|  -> ... = ...
+
+#   64| { ..., ... }
+#-----|  -> access to property ArrayProperty2
+
+#   64| ... = ...
+#-----|  -> 1
+
+#   64| 0
+#-----|  -> 1
+
+#   64| 1
+#-----|  -> "i"
+
+#   64| "i"
+#-----|  -> ... = ...
+
+#   64| ... = ...
+#-----|  -> { ..., ... }
+
+#   64| 1
+#-----|  -> access to parameter i
+
+#   64| ... + ...
+#-----|  -> "1"
+
+#   64| access to parameter i
+#-----|  -> 0
+
+#   64| 0
+#-----|  -> ... + ...
+
+#   64| "1"
+#-----|  -> ... = ...
+
+LoopUnrolling.cs:
+#    7| enter M1
+#-----|  -> {...}
+
+#    7| exit M1
+
+#    7| exit M1 (normal)
+#-----|  -> exit M1
+
+#    8| {...}
+#-----|  -> if (...) ...
+
+#    9| if (...) ...
+#-----|  -> access to parameter args
+
+#    9| ... == ...
+#-----| true -> return ...;
+#-----| false -> access to parameter args
+
+#    9| access to property Length
+#-----|  -> 0
+
+#    9| access to parameter args
+#-----|  -> access to property Length
+
+#    9| 0
+#-----|  -> ... == ...
+
+#   10| return ...;
+#-----| return -> exit M1 (normal)
+
+#   11| foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+#-----| empty -> exit M1 (normal)
+
+#   11| [unroll (line 11)] foreach (... ... in ...) ...
+#-----| non-empty -> String arg
+
+#   11| String arg
+#-----|  -> ...;
+
+#   11| access to parameter args
+#-----|  -> [unroll (line 11)] foreach (... ... in ...) ...
+
+#   12| ...;
+#-----|  -> access to local variable arg
+
+#   12| call to method WriteLine
+#-----|  -> foreach (... ... in ...) ...
+
+#   12| access to local variable arg
+#-----|  -> call to method WriteLine
+
+#   15| enter M2
+#-----|  -> {...}
+
+#   15| exit M2
+
+#   15| exit M2 (normal)
+#-----|  -> exit M2
+
+#   16| {...}
+#-----|  -> ... ...;
+
+#   17| ... ...;
+#-----|  -> 3
+
+#   17| String[] xs = ...
+#-----|  -> access to local variable xs
+
+#   17| array creation of type String[]
+#-----|  -> "a"
+
+#   17| 3
+#-----|  -> array creation of type String[]
+
+#   17| { ..., ... }
+#-----|  -> String[] xs = ...
+
+#   17| "a"
+#-----|  -> "b"
+
+#   17| "b"
+#-----|  -> "c"
+
+#   17| "c"
+#-----|  -> { ..., ... }
+
+#   18| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M2 (normal)
+
+#   18| [unroll (line 18)] foreach (... ... in ...) ...
+#-----| non-empty -> String x
+
+#   18| String x
+#-----|  -> ...;
+
+#   18| access to local variable xs
+#-----|  -> [unroll (line 18)] foreach (... ... in ...) ...
+
+#   19| ...;
+#-----|  -> access to local variable x
+
+#   19| call to method WriteLine
+#-----|  -> foreach (... ... in ...) ...
+
+#   19| access to local variable x
+#-----|  -> call to method WriteLine
+
+#   22| enter M3
+#-----|  -> {...}
+
+#   22| exit M3
+
+#   22| exit M3 (normal)
+#-----|  -> exit M3
+
+#   23| {...}
+#-----|  -> access to parameter args
+
+#   24| foreach (... ... in ...) ...
+#-----| non-empty -> Char arg
+#-----| empty -> exit M3 (normal)
+
+#   24| Char arg
+#-----|  -> access to parameter args
+
+#   24| access to parameter args
+#-----|  -> foreach (... ... in ...) ...
+
+#   25| foreach (... ... in ...) ...
+#-----| empty -> foreach (... ... in ...) ...
+#-----| non-empty -> Char arg0
+
+#   25| [unroll (line 25)] foreach (... ... in ...) ...
+#-----| non-empty -> Char arg0
+
+#   25| Char arg0
+#-----|  -> ...;
+
+#   25| access to parameter args
+#-----|  -> [unroll (line 25)] foreach (... ... in ...) ...
+
+#   26| ...;
+#-----|  -> access to local variable arg0
+
+#   26| call to method WriteLine
+#-----|  -> foreach (... ... in ...) ...
+
+#   26| access to local variable arg0
+#-----|  -> call to method WriteLine
+
+#   29| enter M4
+#-----|  -> {...}
+
+#   29| exit M4
+
+#   29| exit M4 (normal)
+#-----|  -> exit M4
+
+#   30| {...}
+#-----|  -> ... ...;
+
+#   31| ... ...;
+#-----|  -> 0
+
+#   31| String[] xs = ...
+#-----|  -> access to local variable xs
+
+#   31| array creation of type String[]
+#-----|  -> String[] xs = ...
+
+#   31| 0
+#-----|  -> array creation of type String[]
+
+#   32| [skip (line 32)] foreach (... ... in ...) ...
+#-----| empty -> exit M4 (normal)
+
+#   32| access to local variable xs
+#-----|  -> [skip (line 32)] foreach (... ... in ...) ...
+
+#   36| enter M5
+#-----|  -> {...}
+
+#   36| exit M5
+
+#   36| exit M5 (normal)
+#-----|  -> exit M5
+
+#   37| {...}
+#-----|  -> ... ...;
+
+#   38| ... ...;
+#-----|  -> 3
+
+#   38| String[] xs = ...
+#-----|  -> ... ...;
+
+#   38| array creation of type String[]
+#-----|  -> "a"
+
+#   38| 3
+#-----|  -> array creation of type String[]
+
+#   38| { ..., ... }
+#-----|  -> String[] xs = ...
+
+#   38| "a"
+#-----|  -> "b"
+
+#   38| "b"
+#-----|  -> "c"
+
+#   38| "c"
+#-----|  -> { ..., ... }
+
+#   39| ... ...;
+#-----|  -> 3
+
+#   39| String[] ys = ...
+#-----|  -> access to local variable xs
+
+#   39| array creation of type String[]
+#-----|  -> "0"
+
+#   39| 3
+#-----|  -> array creation of type String[]
+
+#   39| { ..., ... }
+#-----|  -> String[] ys = ...
+
+#   39| "0"
+#-----|  -> "1"
+
+#   39| "1"
+#-----|  -> "2"
+
+#   39| "2"
+#-----|  -> { ..., ... }
+
+#   40| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M5 (normal)
+
+#   40| [unroll (line 40)] foreach (... ... in ...) ...
+#-----| non-empty -> String x
+
+#   40| String x
+#-----|  -> access to local variable ys
+
+#   40| access to local variable xs
+#-----|  -> [unroll (line 40)] foreach (... ... in ...) ...
+
+#   41| foreach (... ... in ...) ...
+#-----| empty -> foreach (... ... in ...) ...
+#-----| non-empty -> String y
+
+#   41| [unroll (line 41)] foreach (... ... in ...) ...
+#-----| non-empty -> String y
+
+#   41| String y
+#-----|  -> ...;
+
+#   41| access to local variable ys
+#-----|  -> [unroll (line 41)] foreach (... ... in ...) ...
+
+#   42| ...;
+#-----|  -> access to local variable x
+
+#   42| call to method WriteLine
+#-----|  -> foreach (... ... in ...) ...
+
+#   42| ... + ...
+#-----|  -> call to method WriteLine
+
+#   42| access to local variable x
+#-----|  -> access to local variable y
+
+#   42| access to local variable y
+#-----|  -> ... + ...
+
+#   45| enter M6
+#-----|  -> {...}
+
+#   46| {...}
+#-----|  -> ... ...;
+
+#   47| ... ...;
+#-----|  -> 3
+
+#   47| String[] xs = ...
+#-----|  -> access to local variable xs
+
+#   47| array creation of type String[]
+#-----|  -> "a"
+
+#   47| 3
+#-----|  -> array creation of type String[]
+
+#   47| { ..., ... }
+#-----|  -> String[] xs = ...
+
+#   47| "a"
+#-----|  -> "b"
+
+#   47| "b"
+#-----|  -> "c"
+
+#   47| "c"
+#-----|  -> { ..., ... }
+
+#   48| [unroll (line 48)] foreach (... ... in ...) ...
+#-----| non-empty -> String x
+
+#   48| String x
+#-----|  -> {...}
+
+#   48| access to local variable xs
+#-----|  -> [unroll (line 48)] foreach (... ... in ...) ...
+
+#   49| {...}
+#-----|  -> Label:
+
+#   50| Label:
+#-----|  -> ...;
+
+#   50| ...;
+#-----|  -> access to local variable x
+
+#   50| call to method WriteLine
+#-----|  -> goto ...;
+
+#   50| access to local variable x
+#-----|  -> call to method WriteLine
+
+#   51| goto ...;
+#-----| goto(Label) -> Label:
+
+#   55| enter M7
+#-----|  -> {...}
+
+#   55| exit M7
+
+#   55| exit M7 (normal)
+#-----|  -> exit M7
+
+#   56| {...}
+#-----|  -> ... ...;
+
+#   57| ... ...;
+#-----|  -> 3
+
+#   57| String[] xs = ...
+#-----|  -> access to local variable xs
+
+#   57| array creation of type String[]
+#-----|  -> "a"
+
+#   57| 3
+#-----|  -> array creation of type String[]
+
+#   57| { ..., ... }
+#-----|  -> String[] xs = ...
+
+#   57| "a"
+#-----|  -> "b"
+
+#   57| "b"
+#-----|  -> "c"
+
+#   57| "c"
+#-----|  -> { ..., ... }
+
+#   58| [unroll (line 58)] foreach (... ... in ...) ...
+#-----| non-empty -> String x
+
+#   58| [b (line 55): false] foreach (... ... in ...) ...
+#-----| non-empty -> [b (line 55): false] String x
+#-----| empty -> exit M7 (normal)
+
+#   58| [b (line 55): true] foreach (... ... in ...) ...
+#-----| non-empty -> [b (line 55): true] String x
+#-----| empty -> exit M7 (normal)
+
+#   58| String x
+#-----|  -> {...}
+
+#   58| [b (line 55): false] String x
+#-----|  -> [b (line 55): false] {...}
+
+#   58| [b (line 55): true] String x
+#-----|  -> [b (line 55): true] {...}
+
+#   58| access to local variable xs
+#-----|  -> [unroll (line 58)] foreach (... ... in ...) ...
+
+#   59| {...}
+#-----|  -> if (...) ...
+
+#   59| [b (line 55): false] {...}
+#-----|  -> [b (line 55): false] if (...) ...
+
+#   59| [b (line 55): true] {...}
+#-----|  -> [b (line 55): true] if (...) ...
+
+#   60| if (...) ...
+#-----|  -> access to parameter b
+
+#   60| [b (line 55): false] if (...) ...
+#-----|  -> [b (line 55): false] access to parameter b
+
+#   60| [b (line 55): true] if (...) ...
+#-----|  -> [b (line 55): true] access to parameter b
+
+#   60| access to parameter b
+#-----| true -> [b (line 55): true] ...;
+#-----| false -> [b (line 55): false] if (...) ...
+
+#   60| [b (line 55): false] access to parameter b
+#-----| false -> [b (line 55): false] if (...) ...
+
+#   60| [b (line 55): true] access to parameter b
+#-----| true -> [b (line 55): true] ...;
+
+#   61| [b (line 55): true] ...;
+#-----|  -> [b (line 55): true] access to local variable x
+
+#   61| [b (line 55): true] call to method WriteLine
+#-----|  -> [b (line 55): true] if (...) ...
+
+#   61| [b (line 55): true] access to local variable x
+#-----|  -> [b (line 55): true] call to method WriteLine
+
+#   62| [b (line 55): false] if (...) ...
+#-----|  -> [b (line 55): false] access to parameter b
+
+#   62| [b (line 55): true] if (...) ...
+#-----|  -> [b (line 55): true] access to parameter b
+
+#   62| [b (line 55): false] access to parameter b
+#-----| false -> [b (line 55): false] foreach (... ... in ...) ...
+
+#   62| [b (line 55): true] access to parameter b
+#-----| true -> [b (line 55): true] ...;
+
+#   63| [b (line 55): true] ...;
+#-----|  -> [b (line 55): true] access to local variable x
+
+#   63| [b (line 55): true] call to method WriteLine
+#-----|  -> [b (line 55): true] foreach (... ... in ...) ...
+
+#   63| [b (line 55): true] access to local variable x
+#-----|  -> [b (line 55): true] call to method WriteLine
+
+#   67| enter M8
+#-----|  -> {...}
+
+#   67| exit M8
+
+#   67| exit M8 (normal)
+#-----|  -> exit M8
+
+#   68| {...}
+#-----|  -> if (...) ...
+
+#   69| if (...) ...
+#-----|  -> access to parameter args
+
+#   69| [false] !...
+#-----| false -> ...;
+
+#   69| [true] !...
+#-----| true -> return ...;
+
+#   69| call to method Any
+#-----| true -> [false] !...
+#-----| false -> [true] !...
+
+#   69| access to parameter args
+#-----|  -> call to method Any
+
+#   70| return ...;
+#-----| return -> exit M8 (normal)
+
+#   71| ...;
+#-----|  -> access to parameter args
+
+#   71| call to method Clear
+#-----|  -> access to parameter args
+
+#   71| access to parameter args
+#-----|  -> call to method Clear
+
+#   72| [skip (line 72)] foreach (... ... in ...) ...
+#-----| empty -> exit M8 (normal)
+
+#   72| access to parameter args
+#-----|  -> [skip (line 72)] foreach (... ... in ...) ...
+
+#   76| enter M9
+#-----|  -> {...}
+
+#   76| exit M9
+
+#   76| exit M9 (normal)
+#-----|  -> exit M9
+
+#   77| {...}
+#-----|  -> ... ...;
+
+#   78| ... ...;
+#-----|  -> 2
+
+#   78| String[,] xs = ...
+#-----|  -> access to local variable xs
+
+#   78| array creation of type String[,]
+#-----|  -> String[,] xs = ...
+
+#   78| 2
+#-----|  -> 0
+
+#   78| 0
+#-----|  -> array creation of type String[,]
+
+#   79| [skip (line 79)] foreach (... ... in ...) ...
+#-----| empty -> exit M9 (normal)
+
+#   79| access to local variable xs
+#-----|  -> [skip (line 79)] foreach (... ... in ...) ...
+
+#   85| enter M10
+#-----|  -> {...}
+
+#   85| exit M10
+
+#   85| exit M10 (normal)
+#-----|  -> exit M10
+
+#   86| {...}
+#-----|  -> ... ...;
+
+#   87| ... ...;
+#-----|  -> 0
+
+#   87| String[,] xs = ...
+#-----|  -> access to local variable xs
+
+#   87| array creation of type String[,]
+#-----|  -> String[,] xs = ...
+
+#   87| 0
+#-----|  -> 2
+
+#   87| 2
+#-----|  -> array creation of type String[,]
+
+#   88| [skip (line 88)] foreach (... ... in ...) ...
+#-----| empty -> exit M10 (normal)
+
+#   88| access to local variable xs
+#-----|  -> [skip (line 88)] foreach (... ... in ...) ...
+
+#   94| enter M11
+#-----|  -> {...}
+
+#   94| exit M11
+
+#   94| exit M11 (normal)
+#-----|  -> exit M11
+
+#   95| {...}
+#-----|  -> ... ...;
+
+#   96| ... ...;
+#-----|  -> 2
+
+#   96| String[,] xs = ...
+#-----|  -> access to local variable xs
+
+#   96| array creation of type String[,]
+#-----|  -> String[,] xs = ...
+
+#   96| 2
+#-----|  -> 2
+
+#   96| 2
+#-----|  -> array creation of type String[,]
+
+#   97| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit M11 (normal)
+
+#   97| [unroll (line 97)] foreach (... ... in ...) ...
+#-----| non-empty -> String x
+
+#   97| String x
+#-----|  -> {...}
+
+#   97| access to local variable xs
+#-----|  -> [unroll (line 97)] foreach (... ... in ...) ...
+
+#   98| {...}
+#-----|  -> ...;
+
+#   99| ...;
+#-----|  -> access to local variable x
+
+#   99| call to method WriteLine
+#-----|  -> foreach (... ... in ...) ...
+
+#   99| access to local variable x
+#-----|  -> call to method WriteLine
+
+MultiImplementationA.cs:
+#    6| throw ...
+#-----| exception(NullReferenceException) -> exit get_P1 (abnormal)
+#-----| exception(NullReferenceException) -> exit get_P1 (abnormal)
+
+#    6| null
+#-----|  -> throw ...
+
+#    7| {...}
+#-----|  -> null
+
+#    7| throw ...;
+#-----| exception(NullReferenceException) -> exit get_P2 (abnormal)
+#-----| exception(NullReferenceException) -> exit get_P2 (abnormal)
+
+#    7| null
+#-----|  -> throw ...;
+
+#    7| {...}
+#-----|  -> null
+
+#    7| throw ...;
+#-----| exception(NullReferenceException) -> exit set_P2 (abnormal)
+#-----| exception(NullReferenceException) -> exit set_P2 (abnormal)
+
+#    7| null
+#-----|  -> throw ...;
+
+#    8| throw ...
+#-----| exception(NullReferenceException) -> exit M (abnormal)
+#-----| exception(NullReferenceException) -> exit M (abnormal)
+
+#    8| null
+#-----|  -> throw ...
+
+#   13| ... = ...
+#-----|  -> this access
+
+#   13| this access
+#-----|  -> 0
+
+#   13| 0
+#-----|  -> ... = ...
+
+#   14| access to parameter i
+#-----|  -> exit get_Item (normal)
+#-----|  -> exit get_Item (normal)
+
+#   15| {...}
+#-----|  -> access to parameter s
+
+#   15| return ...;
+#-----| return -> exit get_Item (normal)
+#-----| return -> exit get_Item (normal)
+
+#   15| access to parameter s
+#-----|  -> return ...;
+
+#   15| {...}
+#-----|  -> exit set_Item (normal)
+#-----|  -> exit set_Item (normal)
+
+#   17| {...}
+#-----|  -> M2(...)
+
+#   18| enter M2
+#-----|  -> 0
+
+#   18| M2(...)
+#-----|  -> exit M1 (normal)
+#-----|  -> exit M1 (normal)
+
+#   18| exit M2
+
+#   18| exit M2 (normal)
+#-----|  -> exit M2
+
+#   18| 0
+#-----|  -> exit M2 (normal)
+
+#   20| call to constructor Object
+#-----|  -> this access
+
+#   20| {...}
+#-----|  -> ...;
+
+#   20| ...;
+#-----|  -> this access
+
+#   20| ... = ...
+#-----|  -> exit C2 (normal)
+#-----|  -> exit C2 (normal)
+
+#   20| this access
+#-----|  -> access to parameter i
+
+#   20| access to parameter i
+#-----|  -> ... = ...
+
+#   21| call to constructor C2
+#-----|  -> {...}
+
+#   21| 0
+#-----|  -> call to constructor C2
+
+#   21| {...}
+#-----|  -> exit C2 (normal)
+#-----|  -> exit C2 (normal)
+
+#   22| {...}
+#-----|  -> exit ~C2 (normal)
+#-----|  -> exit ~C2 (normal)
+
+#   23| null
+#-----|  -> exit implicit conversion (normal)
+#-----|  -> exit implicit conversion (normal)
+
+#   24| access to property P
+#-----|  -> ... = ...
+
+#   24| this access
+#-----|  -> 0
+
+#   24| ... = ...
+#-----|  -> {...}
+
+#   24| 0
+#-----|  -> access to property P
+
+#   30| throw ...
+#-----| exception(NullReferenceException) -> exit get_P3 (abnormal)
+#-----| exception(NullReferenceException) -> exit get_P3 (abnormal)
+
+#   30| null
+#-----|  -> throw ...
+
+#   36| {...}
+#-----|  -> null
+
+#   36| throw ...;
+#-----| exception(NullReferenceException) -> exit M1 (abnormal)
+#-----| exception(NullReferenceException) -> exit M1 (abnormal)
+
+#   36| null
+#-----|  -> throw ...;
+
+#   37| enter M2
+#-----|  -> {...}
+
+#   37| exit M2
+
+#   37| exit M2 (abnormal)
+#-----|  -> exit M2
+
+#   37| {...}
+#-----|  -> null
+
+#   37| throw ...;
+#-----| exception(NullReferenceException) -> exit M2 (abnormal)
+
+#   37| null
+#-----|  -> throw ...;
+
+#    6| enter get_P1
+#-----|  -> null
+#-----|  -> 0
+
+MultiImplementationB.cs:
+#    3| enter get_P1
+#-----|  -> null
+#-----|  -> 0
+
+#    3| 0
+#-----|  -> exit get_P1 (normal)
+#-----|  -> exit get_P1 (normal)
+
+MultiImplementationA.cs:
+#    6| exit get_P1
+
+MultiImplementationB.cs:
+#    3| exit get_P1
+
+MultiImplementationA.cs:
+#    6| exit get_P1 (abnormal)
+#-----|  -> exit get_P1
+#-----|  -> exit get_P1
+
+MultiImplementationB.cs:
+#    3| exit get_P1 (abnormal)
+#-----|  -> exit get_P1
+#-----|  -> exit get_P1
+
+MultiImplementationA.cs:
+#    6| exit get_P1 (normal)
+#-----|  -> exit get_P1
+#-----|  -> exit get_P1
+
+MultiImplementationB.cs:
+#    3| exit get_P1 (normal)
+#-----|  -> exit get_P1
+#-----|  -> exit get_P1
+
+MultiImplementationA.cs:
+#    7| enter get_P2
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationB.cs:
+#    4| enter get_P2
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationA.cs:
+#    7| exit get_P2
+
+MultiImplementationB.cs:
+#    4| exit get_P2
+
+MultiImplementationA.cs:
+#    7| exit get_P2 (abnormal)
+#-----|  -> exit get_P2
+#-----|  -> exit get_P2
+
+MultiImplementationB.cs:
+#    4| exit get_P2 (abnormal)
+#-----|  -> exit get_P2
+#-----|  -> exit get_P2
+
+MultiImplementationA.cs:
+#    7| exit get_P2 (normal)
+#-----|  -> exit get_P2
+#-----|  -> exit get_P2
+
+MultiImplementationB.cs:
+#    4| exit get_P2 (normal)
+#-----|  -> exit get_P2
+#-----|  -> exit get_P2
+
+#    4| {...}
+#-----|  -> 1
+
+#    4| return ...;
+#-----| return -> exit get_P2 (normal)
+#-----| return -> exit get_P2 (normal)
+
+#    4| 1
+#-----|  -> return ...;
+
+MultiImplementationA.cs:
+#    7| enter set_P2
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationB.cs:
+#    4| enter set_P2
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationA.cs:
+#    7| exit set_P2
+
+MultiImplementationB.cs:
+#    4| exit set_P2
+
+MultiImplementationA.cs:
+#    7| exit set_P2 (abnormal)
+#-----|  -> exit set_P2
+#-----|  -> exit set_P2
+
+MultiImplementationB.cs:
+#    4| exit set_P2 (abnormal)
+#-----|  -> exit set_P2
+#-----|  -> exit set_P2
+
+MultiImplementationA.cs:
+#    7| exit set_P2 (normal)
+#-----|  -> exit set_P2
+#-----|  -> exit set_P2
+
+MultiImplementationB.cs:
+#    4| exit set_P2 (normal)
+#-----|  -> exit set_P2
+#-----|  -> exit set_P2
+
+#    4| {...}
+#-----|  -> exit set_P2 (normal)
+#-----|  -> exit set_P2 (normal)
+
+MultiImplementationA.cs:
+#    8| enter M
+#-----|  -> null
+#-----|  -> 2
+
+MultiImplementationB.cs:
+#    5| enter M
+#-----|  -> null
+#-----|  -> 2
+
+MultiImplementationA.cs:
+#    8| exit M
+
+MultiImplementationB.cs:
+#    5| exit M
+
+MultiImplementationA.cs:
+#    8| exit M (abnormal)
+#-----|  -> exit M
+#-----|  -> exit M
+
+MultiImplementationB.cs:
+#    5| exit M (abnormal)
+#-----|  -> exit M
+#-----|  -> exit M
+
+MultiImplementationA.cs:
+#    8| exit M (normal)
+#-----|  -> exit M
+#-----|  -> exit M
+
+MultiImplementationB.cs:
+#    5| exit M (normal)
+#-----|  -> exit M
+#-----|  -> exit M
+
+#    5| 2
+#-----|  -> exit M (normal)
+#-----|  -> exit M (normal)
+
+#   11| ... = ...
+#-----|  -> this access
+
+#   11| this access
+#-----|  -> 1
+
+#   11| 1
+#-----|  -> ... = ...
+
+MultiImplementationA.cs:
+#   14| enter get_Item
+#-----|  -> access to parameter i
+#-----|  -> null
+
+MultiImplementationB.cs:
+#   12| enter get_Item
+#-----|  -> access to parameter i
+#-----|  -> null
+
+#   12| throw ...
+#-----| exception(NullReferenceException) -> exit get_Item (abnormal)
+#-----| exception(NullReferenceException) -> exit get_Item (abnormal)
+
+MultiImplementationA.cs:
+#   14| exit get_Item
+
+MultiImplementationB.cs:
+#   12| exit get_Item
+
+MultiImplementationA.cs:
+#   14| exit get_Item (abnormal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+MultiImplementationB.cs:
+#   12| exit get_Item (abnormal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+MultiImplementationA.cs:
+#   14| exit get_Item (normal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+MultiImplementationB.cs:
+#   12| exit get_Item (normal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+#   12| null
+#-----|  -> throw ...
+
+MultiImplementationA.cs:
+#   15| enter get_Item
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationB.cs:
+#   13| enter get_Item
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationA.cs:
+#   15| exit get_Item
+
+MultiImplementationB.cs:
+#   13| exit get_Item
+
+MultiImplementationA.cs:
+#   15| exit get_Item (abnormal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+MultiImplementationB.cs:
+#   13| exit get_Item (abnormal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+MultiImplementationA.cs:
+#   15| exit get_Item (normal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+MultiImplementationB.cs:
+#   13| exit get_Item (normal)
+#-----|  -> exit get_Item
+#-----|  -> exit get_Item
+
+#   13| {...}
+#-----|  -> null
+
+#   13| throw ...;
+#-----| exception(NullReferenceException) -> exit get_Item (abnormal)
+#-----| exception(NullReferenceException) -> exit get_Item (abnormal)
+
+#   13| null
+#-----|  -> throw ...;
+
+MultiImplementationA.cs:
+#   15| enter set_Item
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationB.cs:
+#   13| enter set_Item
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationA.cs:
+#   15| exit set_Item
+
+MultiImplementationB.cs:
+#   13| exit set_Item
+
+MultiImplementationA.cs:
+#   15| exit set_Item (normal)
+#-----|  -> exit set_Item
+#-----|  -> exit set_Item
+
+MultiImplementationB.cs:
+#   13| exit set_Item (normal)
+#-----|  -> exit set_Item
+#-----|  -> exit set_Item
+
+#   13| {...}
+#-----|  -> exit set_Item (normal)
+#-----|  -> exit set_Item (normal)
+
+MultiImplementationA.cs:
+#   16| enter M1
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationB.cs:
+#   14| enter M1
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationA.cs:
+#   16| exit M1
+
+MultiImplementationB.cs:
+#   14| exit M1
+
+MultiImplementationA.cs:
+#   16| exit M1 (normal)
+#-----|  -> exit M1
+#-----|  -> exit M1
+
+MultiImplementationB.cs:
+#   14| exit M1 (normal)
+#-----|  -> exit M1
+#-----|  -> exit M1
+
+#   15| {...}
+#-----|  -> M2(...)
+
+#   16| enter M2
+#-----|  -> null
+
+#   16| M2(...)
+#-----|  -> exit M1 (normal)
+#-----|  -> exit M1 (normal)
+
+#   16| exit M2
+
+#   16| exit M2 (abnormal)
+#-----|  -> exit M2
+
+#   16| throw ...
+#-----| exception(NullReferenceException) -> exit M2 (abnormal)
+
+#   16| null
+#-----|  -> throw ...
+
+MultiImplementationA.cs:
+#   20| enter C2
+#-----|  -> call to constructor Object
+#-----|  -> call to constructor Object
+
+MultiImplementationB.cs:
+#   18| enter C2
+#-----|  -> call to constructor Object
+#-----|  -> call to constructor Object
+
+#   18| call to constructor Object
+#-----|  -> this access
+
+MultiImplementationA.cs:
+#   20| exit C2
+
+MultiImplementationB.cs:
+#   18| exit C2
+
+MultiImplementationA.cs:
+#   20| exit C2 (abnormal)
+#-----|  -> exit C2
+#-----|  -> exit C2
+
+MultiImplementationB.cs:
+#   18| exit C2 (abnormal)
+#-----|  -> exit C2
+#-----|  -> exit C2
+
+MultiImplementationA.cs:
+#   20| exit C2 (normal)
+#-----|  -> exit C2
+#-----|  -> exit C2
+
+MultiImplementationB.cs:
+#   18| exit C2 (normal)
+#-----|  -> exit C2
+#-----|  -> exit C2
+
+#   18| {...}
+#-----|  -> null
+
+#   18| throw ...;
+#-----| exception(NullReferenceException) -> exit C2 (abnormal)
+#-----| exception(NullReferenceException) -> exit C2 (abnormal)
+
+#   18| null
+#-----|  -> throw ...;
+
+MultiImplementationA.cs:
+#   21| enter C2
+#-----|  -> 0
+#-----|  -> 1
+
+MultiImplementationB.cs:
+#   19| enter C2
+#-----|  -> 0
+#-----|  -> 1
+
+MultiImplementationA.cs:
+#   21| exit C2
+
+MultiImplementationB.cs:
+#   19| exit C2
+
+MultiImplementationA.cs:
+#   21| exit C2 (normal)
+#-----|  -> exit C2
+#-----|  -> exit C2
+
+MultiImplementationB.cs:
+#   19| exit C2 (normal)
+#-----|  -> exit C2
+#-----|  -> exit C2
+
+#   19| call to constructor C2
+#-----|  -> {...}
+
+#   19| 1
+#-----|  -> call to constructor C2
+
+#   19| {...}
+#-----|  -> exit C2 (normal)
+#-----|  -> exit C2 (normal)
+
+MultiImplementationA.cs:
+#   22| enter ~C2
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationB.cs:
+#   20| enter ~C2
+#-----|  -> {...}
+#-----|  -> {...}
+
+MultiImplementationA.cs:
+#   22| exit ~C2
+
+MultiImplementationB.cs:
+#   20| exit ~C2
+
+MultiImplementationA.cs:
+#   22| exit ~C2 (abnormal)
+#-----|  -> exit ~C2
+#-----|  -> exit ~C2
+
+MultiImplementationB.cs:
+#   20| exit ~C2 (abnormal)
+#-----|  -> exit ~C2
+#-----|  -> exit ~C2
+
+MultiImplementationA.cs:
+#   22| exit ~C2 (normal)
+#-----|  -> exit ~C2
+#-----|  -> exit ~C2
+
+MultiImplementationB.cs:
+#   20| exit ~C2 (normal)
+#-----|  -> exit ~C2
+#-----|  -> exit ~C2
+
+#   20| {...}
+#-----|  -> null
+
+#   20| throw ...;
+#-----| exception(NullReferenceException) -> exit ~C2 (abnormal)
+#-----| exception(NullReferenceException) -> exit ~C2 (abnormal)
+
+#   20| null
+#-----|  -> throw ...;
+
+MultiImplementationA.cs:
+#   23| enter implicit conversion
+#-----|  -> null
+#-----|  -> null
+
+MultiImplementationB.cs:
+#   21| enter implicit conversion
+#-----|  -> null
+#-----|  -> null
+
+MultiImplementationA.cs:
+#   23| exit implicit conversion
+
+MultiImplementationB.cs:
+#   21| exit implicit conversion
+
+MultiImplementationA.cs:
+#   23| exit implicit conversion (abnormal)
+#-----|  -> exit implicit conversion
+#-----|  -> exit implicit conversion
+
+MultiImplementationB.cs:
+#   21| exit implicit conversion (abnormal)
+#-----|  -> exit implicit conversion
+#-----|  -> exit implicit conversion
+
+MultiImplementationA.cs:
+#   23| exit implicit conversion (normal)
+#-----|  -> exit implicit conversion
+#-----|  -> exit implicit conversion
+
+MultiImplementationB.cs:
+#   21| exit implicit conversion (normal)
+#-----|  -> exit implicit conversion
+#-----|  -> exit implicit conversion
+
+#   21| throw ...
+#-----| exception(NullReferenceException) -> exit implicit conversion (abnormal)
+#-----| exception(NullReferenceException) -> exit implicit conversion (abnormal)
+
+#   21| null
+#-----|  -> throw ...
+
+#   22| access to property P
+#-----|  -> ... = ...
+
+#   22| this access
+#-----|  -> 1
+
+#   22| ... = ...
+#-----|  -> {...}
+
+#   22| 1
+#-----|  -> access to property P
+
+MultiImplementationA.cs:
+#   30| enter get_P3
+#-----|  -> null
+
+MultiImplementationB.cs:
+#   27| enter get_P3
+#-----|  -> null
+
+MultiImplementationA.cs:
+#   30| exit get_P3
+
+MultiImplementationB.cs:
+#   27| exit get_P3
+
+MultiImplementationA.cs:
+#   30| exit get_P3 (abnormal)
+#-----|  -> exit get_P3
+#-----|  -> exit get_P3
+
+MultiImplementationB.cs:
+#   27| exit get_P3 (abnormal)
+#-----|  -> exit get_P3
+#-----|  -> exit get_P3
+
+MultiImplementationA.cs:
+#   36| enter M1
+#-----|  -> {...}
+#-----|  -> 0
+
+MultiImplementationB.cs:
+#   32| enter M1
+#-----|  -> {...}
+#-----|  -> 0
+
+MultiImplementationA.cs:
+#   36| exit M1
+
+MultiImplementationB.cs:
+#   32| exit M1
+
+MultiImplementationA.cs:
+#   36| exit M1 (abnormal)
+#-----|  -> exit M1
+#-----|  -> exit M1
+
+MultiImplementationB.cs:
+#   32| exit M1 (abnormal)
+#-----|  -> exit M1
+#-----|  -> exit M1
+
+MultiImplementationA.cs:
+#   36| exit M1 (normal)
+#-----|  -> exit M1
+#-----|  -> exit M1
+
+MultiImplementationB.cs:
+#   32| exit M1 (normal)
+#-----|  -> exit M1
+#-----|  -> exit M1
+
+#   32| 0
+#-----|  -> exit M1 (normal)
+#-----|  -> exit M1 (normal)
+
+NullCoalescing.cs:
+#    3| enter M1
+#-----|  -> access to parameter i
+
+#    3| exit M1
+
+#    3| exit M1 (normal)
+#-----|  -> exit M1
+
+#    3| ... ?? ...
+#-----|  -> exit M1 (normal)
+
+#    3| access to parameter i
+#-----| non-null -> ... ?? ...
+#-----| null -> 0
+
+#    3| 0
+#-----|  -> ... ?? ...
+
+#    5| enter M2
+#-----|  -> access to parameter b
+
+#    5| exit M2
+
+#    5| exit M2 (normal)
+#-----|  -> exit M2
+
+#    5| ... ? ... : ...
+#-----|  -> exit M2 (normal)
+
+#    5| [false] ... ?? ...
+#-----| false -> 1
+
+#    5| [true] ... ?? ...
+#-----| true -> 0
+
+#    5| access to parameter b
+#-----| false -> [false] ... ?? ...
+#-----| true -> [true] ... ?? ...
+#-----| null -> false
+
+#    5| false
+#-----| false -> [false] ... ?? ...
+
+#    5| 0
+#-----|  -> ... ? ... : ...
+
+#    5| 1
+#-----|  -> ... ? ... : ...
+
+#    7| enter M3
+#-----|  -> access to parameter s1
+
+#    7| exit M3
+
+#    7| exit M3 (normal)
+#-----|  -> exit M3
+
+#    7| ... ?? ...
+#-----|  -> exit M3 (normal)
+
+#    7| access to parameter s1
+#-----| non-null -> ... ?? ...
+#-----| null -> access to parameter s2
+
+#    7| ... ?? ...
+#-----|  -> ... ?? ...
+
+#    7| access to parameter s2
+#-----| non-null -> ... ?? ...
+#-----| null -> ""
+
+#    7| ""
+#-----|  -> ... ?? ...
+
+#    9| enter M4
+#-----|  -> access to parameter b
+
+#    9| exit M4
+
+#    9| exit M4 (normal)
+#-----|  -> exit M4
+
+#    9| ... ?? ...
+#-----|  -> exit M4 (normal)
+
+#    9| [non-null] ... ? ... : ...
+#-----| non-null -> ... ?? ...
+
+#    9| [null] ... ? ... : ...
+#-----| null -> ""
+
+#    9| access to parameter b
+#-----| true -> access to parameter s
+#-----| false -> access to parameter s
+
+#    9| access to parameter s
+#-----| non-null -> [non-null] ... ? ... : ...
+#-----| null -> [null] ... ? ... : ...
+
+#    9| access to parameter s
+#-----| non-null -> [non-null] ... ? ... : ...
+#-----| null -> [null] ... ? ... : ...
+
+#    9| ... ?? ...
+#-----|  -> ... ?? ...
+
+#    9| ""
+#-----| non-null -> ... ?? ...
+
+#   11| enter M5
+#-----|  -> access to parameter b1
+
+#   11| exit M5
+
+#   11| exit M5 (normal)
+#-----|  -> exit M5
+
+#   11| ... ? ... : ...
+#-----|  -> exit M5 (normal)
+
+#   11| [false] ... ?? ...
+#-----| false -> 1
+
+#   11| [true] ... ?? ...
+#-----| true -> 0
+
+#   11| access to parameter b1
+#-----| false -> [false] ... ?? ...
+#-----| true -> [true] ... ?? ...
+#-----| null -> access to parameter b2
+
+#   11| [false] ... && ...
+#-----| false -> [false] ... ?? ...
+
+#   11| [true] ... && ...
+#-----| true -> [true] ... ?? ...
+
+#   11| access to parameter b2
+#-----| false -> [false] ... && ...
+#-----| true -> access to parameter b3
+
+#   11| access to parameter b3
+#-----| false -> [false] ... && ...
+#-----| true -> [true] ... && ...
+
+#   11| 0
+#-----|  -> ... ? ... : ...
+
+#   11| 1
+#-----|  -> ... ? ... : ...
+
+#   13| enter M6
+#-----|  -> {...}
+
+#   13| exit M6
+
+#   13| exit M6 (normal)
+#-----|  -> exit M6
+
+#   14| {...}
+#-----|  -> ... ...;
+
+#   15| ... ...;
+#-----|  -> null
+
+#   15| Int32 j = ...
+#-----|  -> ... ...;
+
+#   15| ... ?? ...
+#-----|  -> Int32 j = ...
+
+#   15| (...) ...
+#-----| null -> 0
+
+#   15| null
+#-----|  -> (...) ...
+
+#   15| 0
+#-----|  -> ... ?? ...
+
+#   16| ... ...;
+#-----|  -> ""
+
+#   16| String s = ...
+#-----|  -> ...;
+
+#   16| ... ?? ...
+#-----|  -> String s = ...
+
+#   16| ""
+#-----| non-null -> ... ?? ...
+
+#   17| ...;
+#-----|  -> access to parameter i
+
+#   17| ... = ...
+#-----|  -> exit M6 (normal)
+
+#   17| ... ?? ...
+#-----|  -> ... = ...
+
+#   17| (...) ...
+#-----| non-null -> ... ?? ...
+
+#   17| access to parameter i
+#-----|  -> (...) ...
+
+PartialImplementationA.cs:
+#    3| enter Partial
+#-----|  -> call to constructor Object
+
+#    3| call to constructor Object
+#-----|  -> this access
+
+#    3| exit Partial
+
+#    3| exit Partial (normal)
+#-----|  -> exit Partial
+
+#    3| {...}
+#-----|  -> exit Partial (normal)
+
+PartialImplementationB.cs:
+#    3| ... = ...
+#-----|  -> this access
+
+#    3| ... = ...
+#-----|  -> this access
+
+#    3| this access
+#-----|  -> 0
+
+#    3| this access
+#-----|  -> 0
+
+#    3| 0
+#-----|  -> ... = ...
+
+#    3| 0
+#-----|  -> ... = ...
+
+#    4| enter Partial
+#-----|  -> call to constructor Object
+
+#    4| call to constructor Object
+#-----|  -> this access
+
+#    4| exit Partial
+
+#    4| exit Partial (normal)
+#-----|  -> exit Partial
+
+#    4| {...}
+#-----|  -> exit Partial (normal)
+
+#    5| access to property P
+#-----|  -> ... = ...
+
+#    5| access to property P
+#-----|  -> ... = ...
+
+#    5| this access
+#-----|  -> 0
+
+#    5| this access
+#-----|  -> 0
+
+#    5| ... = ...
+#-----|  -> {...}
+
+#    5| ... = ...
+#-----|  -> {...}
+
+#    5| 0
+#-----|  -> access to property P
+
+#    5| 0
+#-----|  -> access to property P
+
+Patterns.cs:
+#    5| enter M1
+#-----|  -> {...}
+
+#    5| exit M1
+
+#    5| exit M1 (normal)
+#-----|  -> exit M1
+
+#    6| {...}
+#-----|  -> ... ...;
+
+#    7| ... ...;
+#-----|  -> null
+
+#    7| Object o = ...
+#-----|  -> if (...) ...
+
+#    7| null
+#-----|  -> Object o = ...
+
+#    8| if (...) ...
+#-----|  -> access to local variable o
+
+#    8| [false] ... is ...
+#-----| false -> if (...) ...
+
+#    8| [true] ... is ...
+#-----| true -> {...}
+
+#    8| access to local variable o
+#-----|  -> Int32 i1
+
+#    8| Int32 i1
+#-----| no-match -> [false] ... is ...
+#-----| match -> [true] ... is ...
+
+#    9| {...}
+#-----|  -> ...;
+
+#   10| ...;
+#-----|  -> "int "
+
+#   10| call to method WriteLine
+#-----|  -> switch (...) {...}
+
+#   10| $"..."
+#-----|  -> call to method WriteLine
+
+#   10| "int "
+#-----|  -> access to local variable i1
+
+#   10| access to local variable i1
+#-----|  -> $"..."
+
+#   12| if (...) ...
+#-----|  -> access to local variable o
+
+#   12| [false] ... is ...
+#-----| false -> if (...) ...
+
+#   12| [true] ... is ...
+#-----| true -> {...}
+
+#   12| access to local variable o
+#-----|  -> String s1
+
+#   12| String s1
+#-----| no-match -> [false] ... is ...
+#-----| match -> [true] ... is ...
+
+#   13| {...}
+#-----|  -> ...;
+
+#   14| ...;
+#-----|  -> "string "
+
+#   14| call to method WriteLine
+#-----|  -> switch (...) {...}
+
+#   14| $"..."
+#-----|  -> call to method WriteLine
+
+#   14| "string "
+#-----|  -> access to local variable s1
+
+#   14| access to local variable s1
+#-----|  -> $"..."
+
+#   16| if (...) ...
+#-----|  -> access to local variable o
+
+#   16| [false] ... is ...
+#-----| false -> switch (...) {...}
+
+#   16| [true] ... is ...
+#-----| true -> {...}
+
+#   16| access to local variable o
+#-----|  -> Object v1
+
+#   16| Object v1
+#-----| no-match -> [false] ... is ...
+#-----| match -> [true] ... is ...
+
+#   17| {...}
+#-----|  -> switch (...) {...}
+
+#   20| switch (...) {...}
+#-----|  -> access to local variable o
+
+#   20| access to local variable o
+#-----|  -> case ...:
+
+#   22| case ...:
+#-----|  -> "xyz"
+
+#   22| "xyz"
+#-----| match -> break;
+#-----| no-match -> case ...:
+
+#   23| break;
+#-----| break -> switch (...) {...}
+
+#   24| case ...:
+#-----|  -> Int32 i2
+
+#   24| Int32 i2
+#-----| no-match -> case ...:
+#-----| match -> access to local variable i2
+
+#   24| ... > ...
+#-----| true -> ...;
+#-----| false -> case ...:
+
+#   24| access to local variable i2
+#-----|  -> 0
+
+#   24| 0
+#-----|  -> ... > ...
+
+#   25| ...;
+#-----|  -> "positive "
+
+#   25| call to method WriteLine
+#-----|  -> break;
+
+#   25| $"..."
+#-----|  -> call to method WriteLine
+
+#   25| "positive "
+#-----|  -> access to local variable i2
+
+#   25| access to local variable i2
+#-----|  -> $"..."
+
+#   26| break;
+#-----| break -> switch (...) {...}
+
+#   27| case ...:
+#-----|  -> Int32 i3
+
+#   27| Int32 i3
+#-----| match -> ...;
+#-----| no-match -> case ...:
+
+#   28| ...;
+#-----|  -> "int "
+
+#   28| call to method WriteLine
+#-----|  -> break;
+
+#   28| $"..."
+#-----|  -> call to method WriteLine
+
+#   28| "int "
+#-----|  -> access to local variable i3
+
+#   28| access to local variable i3
+#-----|  -> $"..."
+
+#   29| break;
+#-----| break -> switch (...) {...}
+
+#   30| case ...:
+#-----|  -> String s2
+
+#   30| String s2
+#-----| match -> ...;
+#-----| no-match -> case ...:
+
+#   31| ...;
+#-----|  -> "string "
+
+#   31| call to method WriteLine
+#-----|  -> break;
+
+#   31| $"..."
+#-----|  -> call to method WriteLine
+
+#   31| "string "
+#-----|  -> access to local variable s2
+
+#   31| access to local variable s2
+#-----|  -> $"..."
+
+#   32| break;
+#-----| break -> switch (...) {...}
+
+#   33| case ...:
+#-----|  -> Object v2
+
+#   33| Object v2
+#-----| match -> break;
+#-----| no-match -> default:
+
+#   34| break;
+#-----| break -> switch (...) {...}
+
+#   35| default:
+#-----|  -> ...;
+
+#   36| ...;
+#-----|  -> "Something else"
+
+#   36| call to method WriteLine
+#-----|  -> break;
+
+#   36| "Something else"
+#-----|  -> call to method WriteLine
+
+#   37| break;
+#-----| break -> switch (...) {...}
+
+#   40| switch (...) {...}
+#-----|  -> access to local variable o
+
+#   40| access to local variable o
+#-----|  -> exit M1 (normal)
+
+#   47| enter M2
+#-----|  -> access to parameter c
+
+#   47| exit M2
+
+#   47| exit M2 (normal)
+#-----|  -> exit M2
+
+#   48| ... is ...
+#-----|  -> exit M2 (normal)
+
+#   48| access to parameter c
+#-----|  -> a
+
+#   48| not ...
+#-----|  -> ... is ...
+
+#   48| a
+#-----|  -> not ...
+
+#   50| enter M3
+#-----|  -> access to parameter c
+
+#   50| exit M3
+
+#   50| exit M3 (normal)
+#-----|  -> exit M3
+
+#   51| ... ? ... : ...
+#-----|  -> exit M3 (normal)
+
+#   51| [false] ... is ...
+#-----| false -> access to parameter c
+
+#   51| [true] ... is ...
+#-----| true -> access to parameter c
+
+#   51| access to parameter c
+#-----|  -> null
+
+#   51| [no-match] not ...
+#-----| no-match -> [false] ... is ...
+
+#   51| [match] not ...
+#-----| match -> [true] ... is ...
+
+#   51| null
+#-----| match -> [no-match] not ...
+#-----| no-match -> [match] not ...
+
+#   51| ... is ...
+#-----|  -> ... ? ... : ...
+
+#   51| access to parameter c
+#-----|  -> 1
+
+#   51| 1
+#-----|  -> ... is ...
+
+#   51| ... is ...
+#-----|  -> ... ? ... : ...
+
+#   51| access to parameter c
+#-----|  -> 2
+
+#   51| 2
+#-----|  -> ... is ...
+
+#   53| enter M4
+#-----|  -> access to parameter c
+
+#   53| exit M4
+
+#   53| exit M4 (normal)
+#-----|  -> exit M4
+
+#   54| ... is ...
+#-----|  -> exit M4 (normal)
+
+#   54| access to parameter c
+#-----|  -> Patterns u
+
+#   54| not ...
+#-----|  -> ... is ...
+
+#   54| { ... }
+#-----|  -> not ...
+
+#   54| Patterns u
+#-----| no-match -> { ... }
+#-----| match -> 1
+
+#   54| [no-match] { ... }
+#-----| no-match -> { ... }
+
+#   54| [match] { ... }
+#-----| match -> { ... }
+
+#   54| 1
+#-----| no-match -> [no-match] { ... }
+#-----| match -> [match] { ... }
+
+#   56| enter M5
+#-----|  -> {...}
+
+#   56| exit M5
+
+#   56| exit M5 (normal)
+#-----|  -> exit M5
+
+#   57| {...}
+#-----|  -> access to parameter i
+
+#   58| return ...;
+#-----| return -> exit M5 (normal)
+
+#   58| ... switch { ... }
+#-----|  -> return ...;
+
+#   58| access to parameter i
+#-----|  -> 1
+
+#   60| ... => ...
+#-----|  -> ... switch { ... }
+
+#   60| [no-match] not ...
+#-----| no-match -> _
+
+#   60| [match] not ...
+#-----| match -> "not 1"
+
+#   60| 1
+#-----| match -> [no-match] not ...
+#-----| no-match -> [match] not ...
+
+#   60| "not 1"
+#-----|  -> ... => ...
+
+#   61| ... => ...
+#-----|  -> ... switch { ... }
+
+#   61| _
+#-----| match -> "other"
+
+#   61| "other"
+#-----|  -> ... => ...
+
+#   65| enter M6
+#-----|  -> {...}
+
+#   65| exit M6
+
+#   65| exit M6 (normal)
+#-----|  -> exit M6
+
+#   66| {...}
+#-----|  -> 2
+
+#   67| return ...;
+#-----| return -> exit M6 (normal)
+
+#   67| ... switch { ... }
+#-----|  -> return ...;
+
+#   67| 2
+#-----|  -> 2
+
+#   69| [no-match] not ...
+#-----| no-match -> 2
+
+#   69| 2
+#-----| match -> [no-match] not ...
+
+#   70| ... => ...
+#-----|  -> ... switch { ... }
+
+#   70| 2
+#-----| match -> "possible"
+
+#   70| "possible"
+#-----|  -> ... => ...
+
+#   74| enter M7
+#-----|  -> {...}
+
+#   74| exit M7
+
+#   74| exit M7 (normal)
+#-----|  -> exit M7
+
+#   75| {...}
+#-----|  -> access to parameter i
+
+#   76| return ...;
+#-----| return -> exit M7 (normal)
+
+#   76| ... switch { ... }
+#-----|  -> return ...;
+
+#   76| access to parameter i
+#-----|  -> 1
+
+#   78| ... => ...
+#-----|  -> ... switch { ... }
+
+#   78| > ...
+#-----| match -> "> 1"
+#-----| no-match -> 0
+
+#   78| 1
+#-----|  -> > ...
+
+#   78| "> 1"
+#-----|  -> ... => ...
+
+#   79| ... => ...
+#-----|  -> ... switch { ... }
+
+#   79| < ...
+#-----| match -> "< 0"
+#-----| no-match -> 1
+
+#   79| 0
+#-----|  -> < ...
+
+#   79| "< 0"
+#-----|  -> ... => ...
+
+#   80| ... => ...
+#-----|  -> ... switch { ... }
+
+#   80| 1
+#-----| match -> "1"
+#-----| no-match -> _
+
+#   80| "1"
+#-----|  -> ... => ...
+
+#   81| ... => ...
+#-----|  -> ... switch { ... }
+
+#   81| _
+#-----| match -> "0"
+
+#   81| "0"
+#-----|  -> ... => ...
+
+#   85| enter M8
+#-----|  -> access to parameter i
+
+#   85| exit M8
+
+#   85| exit M8 (normal)
+#-----|  -> exit M8
+
+#   85| ... ? ... : ...
+#-----|  -> exit M8 (normal)
+
+#   85| [false] ... is ...
+#-----| false -> "2"
+
+#   85| [true] ... is ...
+#-----| true -> "not 2"
+
+#   85| access to parameter i
+#-----|  -> 1
+
+#   85| [no-match] ... or ...
+#-----| no-match -> [false] ... is ...
+
+#   85| [match] ... or ...
+#-----| match -> [true] ... is ...
+
+#   85| 1
+#-----| match -> [match] ... or ...
+#-----| no-match -> 2
+
+#   85| [no-match] not ...
+#-----| no-match -> [no-match] ... or ...
+
+#   85| [match] not ...
+#-----| match -> [match] ... or ...
+
+#   85| 2
+#-----| match -> [no-match] not ...
+#-----| no-match -> [match] not ...
+
+#   85| "not 2"
+#-----|  -> ... ? ... : ...
+
+#   85| "2"
+#-----|  -> ... ? ... : ...
+
+#   87| enter M9
+#-----|  -> access to parameter i
+
+#   87| exit M9
+
+#   87| exit M9 (normal)
+#-----|  -> exit M9
+
+#   87| ... ? ... : ...
+#-----|  -> exit M9 (normal)
+
+#   87| [false] ... is ...
+#-----| false -> "not 1"
+
+#   87| [true] ... is ...
+#-----| true -> "1"
+
+#   87| access to parameter i
+#-----|  -> 1
+
+#   87| [no-match] ... and ...
+#-----| no-match -> [false] ... is ...
+
+#   87| [match] ... and ...
+#-----| match -> [true] ... is ...
+
+#   87| 1
+#-----| no-match -> [no-match] ... and ...
+#-----| match -> 2
+
+#   87| [no-match] not ...
+#-----| no-match -> [no-match] ... and ...
+
+#   87| [match] not ...
+#-----| match -> [match] ... and ...
+
+#   87| 2
+#-----| match -> [no-match] not ...
+#-----| no-match -> [match] not ...
+
+#   87| "1"
+#-----|  -> ... ? ... : ...
+
+#   87| "not 1"
+#-----|  -> ... ? ... : ...
+
+#   93| enter M10
+#-----|  -> {...}
+
+#   93| exit M10
+
+#   93| exit M10 (normal)
+#-----|  -> exit M10
+
+#   94| {...}
+#-----|  -> if (...) ...
+
+#   95| if (...) ...
+#-----|  -> this access
+
+#   95| [false] ... is ...
+#-----| false -> exit M10 (normal)
+
+#   95| [true] ... is ...
+#-----| true -> {...}
+
+#   95| this access
+#-----|  -> access to constant A
+
+#   95| [no-match] { ... }
+#-----| no-match -> [false] ... is ...
+
+#   95| [match] { ... }
+#-----| match -> [true] ... is ...
+
+#   95| [no-match] { ... }
+#-----| no-match -> [no-match] { ... }
+
+#   95| [match] { ... }
+#-----| match -> [match] { ... }
+
+#   95| [no-match] ... or ...
+#-----| no-match -> [no-match] { ... }
+
+#   95| [match] ... or ...
+#-----| match -> [match] { ... }
+
+#   95| access to constant A
+#-----| match -> [match] ... or ...
+#-----| no-match -> access to constant B
+
+#   95| access to constant B
+#-----| no-match -> [no-match] ... or ...
+#-----| match -> [match] ... or ...
+
+#   96| {...}
+#-----|  -> ...;
+
+#   97| ...;
+#-----|  -> "not C"
+
+#   97| call to method WriteLine
+#-----|  -> exit M10 (normal)
+
+#   97| "not C"
+#-----|  -> call to method WriteLine
+
+PostDominance.cs:
+#    5| enter M1
+#-----|  -> {...}
+
+#    5| exit M1
+
+#    5| exit M1 (normal)
+#-----|  -> exit M1
+
+#    6| {...}
+#-----|  -> ...;
+
+#    7| ...;
+#-----|  -> access to parameter s
+
+#    7| call to method WriteLine
+#-----|  -> exit M1 (normal)
+
+#    7| access to parameter s
+#-----|  -> call to method WriteLine
+
+#   10| enter M2
+#-----|  -> {...}
+
+#   10| exit M2
+
+#   10| exit M2 (normal)
+#-----|  -> exit M2
+
+#   11| {...}
+#-----|  -> if (...) ...
+
+#   12| if (...) ...
+#-----|  -> access to parameter s
+
+#   12| [false] ... is ...
+#-----| false -> ...;
+
+#   12| [true] ... is ...
+#-----| true -> return ...;
+
+#   12| access to parameter s
+#-----|  -> null
+
+#   12| null
+#-----| no-match -> [false] ... is ...
+#-----| match -> [true] ... is ...
+
+#   13| return ...;
+#-----| return -> exit M2 (normal)
+
+#   14| ...;
+#-----|  -> access to parameter s
+
+#   14| call to method WriteLine
+#-----|  -> exit M2 (normal)
+
+#   14| access to parameter s
+#-----|  -> call to method WriteLine
+
+#   17| enter M3
+#-----|  -> {...}
+
+#   17| exit M3
+
+#   17| exit M3 (abnormal)
+#-----|  -> exit M3
+
+#   17| exit M3 (normal)
+#-----|  -> exit M3
+
+#   18| {...}
+#-----|  -> if (...) ...
+
+#   19| if (...) ...
+#-----|  -> access to parameter s
+
+#   19| [false] ... is ...
+#-----| false -> ...;
+
+#   19| [true] ... is ...
+#-----| true -> nameof(...)
+
+#   19| access to parameter s
+#-----|  -> null
+
+#   19| null
+#-----| no-match -> [false] ... is ...
+#-----| match -> [true] ... is ...
+
+#   20| throw ...;
+#-----| exception(ArgumentNullException) -> exit M3 (abnormal)
+
+#   20| object creation of type ArgumentNullException
+#-----|  -> throw ...;
+
+#   20| nameof(...)
+#-----|  -> object creation of type ArgumentNullException
+
+#   21| ...;
+#-----|  -> access to parameter s
+
+#   21| call to method WriteLine
+#-----|  -> exit M3 (normal)
+
+#   21| access to parameter s
+#-----|  -> call to method WriteLine
+
+Qualifiers.cs:
+#    7| enter Method
+#-----|  -> null
+
+#    7| exit Method
+
+#    7| exit Method (normal)
+#-----|  -> exit Method
+
+#    7| null
+#-----|  -> exit Method (normal)
+
+#    8| enter StaticMethod
+#-----|  -> null
+
+#    8| exit StaticMethod
+
+#    8| exit StaticMethod (normal)
+#-----|  -> exit StaticMethod
+
+#    8| null
+#-----|  -> exit StaticMethod (normal)
+
+#   10| enter M
+#-----|  -> {...}
+
+#   10| exit M
+
+#   10| exit M (normal)
+#-----|  -> exit M
+
+#   11| {...}
+#-----|  -> ... ...;
+
+#   12| ... ...;
+#-----|  -> this access
+
+#   12| Qualifiers q = ...
+#-----|  -> ...;
+
+#   12| access to field Field
+#-----|  -> Qualifiers q = ...
+
+#   12| this access
+#-----|  -> access to field Field
+
+#   13| ...;
+#-----|  -> this access
+
+#   13| ... = ...
+#-----|  -> ...;
+
+#   13| access to property Property
+#-----|  -> ... = ...
+
+#   13| this access
+#-----|  -> access to property Property
+
+#   14| ...;
+#-----|  -> this access
+
+#   14| ... = ...
+#-----|  -> ...;
+
+#   14| call to method Method
+#-----|  -> ... = ...
+
+#   14| this access
+#-----|  -> call to method Method
+
+#   16| ...;
+#-----|  -> this access
+
+#   16| ... = ...
+#-----|  -> ...;
+
+#   16| access to field Field
+#-----|  -> ... = ...
+
+#   16| this access
+#-----|  -> access to field Field
+
+#   17| ...;
+#-----|  -> this access
+
+#   17| ... = ...
+#-----|  -> ...;
+
+#   17| access to property Property
+#-----|  -> ... = ...
+
+#   17| this access
+#-----|  -> access to property Property
+
+#   18| ...;
+#-----|  -> this access
+
+#   18| ... = ...
+#-----|  -> ...;
+
+#   18| call to method Method
+#-----|  -> ... = ...
+
+#   18| this access
+#-----|  -> call to method Method
+
+#   20| ...;
+#-----|  -> access to field StaticField
+
+#   20| ... = ...
+#-----|  -> ...;
+
+#   20| access to field StaticField
+#-----|  -> ... = ...
+
+#   21| ...;
+#-----|  -> access to property StaticProperty
+
+#   21| ... = ...
+#-----|  -> ...;
+
+#   21| access to property StaticProperty
+#-----|  -> ... = ...
+
+#   22| ...;
+#-----|  -> call to method StaticMethod
+
+#   22| ... = ...
+#-----|  -> ...;
+
+#   22| call to method StaticMethod
+#-----|  -> ... = ...
+
+#   24| ...;
+#-----|  -> access to field StaticField
+
+#   24| ... = ...
+#-----|  -> ...;
+
+#   24| access to field StaticField
+#-----|  -> ... = ...
+
+#   25| ...;
+#-----|  -> access to property StaticProperty
+
+#   25| ... = ...
+#-----|  -> ...;
+
+#   25| access to property StaticProperty
+#-----|  -> ... = ...
+
+#   26| ...;
+#-----|  -> call to method StaticMethod
+
+#   26| ... = ...
+#-----|  -> ...;
+
+#   26| call to method StaticMethod
+#-----|  -> ... = ...
+
+#   28| ...;
+#-----|  -> access to field StaticField
+
+#   28| ... = ...
+#-----|  -> ...;
+
+#   28| access to field Field
+#-----|  -> ... = ...
+
+#   28| access to field StaticField
+#-----|  -> access to field Field
+
+#   29| ...;
+#-----|  -> access to property StaticProperty
+
+#   29| ... = ...
+#-----|  -> ...;
+
+#   29| access to property Property
+#-----|  -> ... = ...
+
+#   29| access to property StaticProperty
+#-----|  -> access to property Property
+
+#   30| ...;
+#-----|  -> call to method StaticMethod
+
+#   30| ... = ...
+#-----|  -> exit M (normal)
+
+#   30| call to method Method
+#-----|  -> ... = ...
+
+#   30| call to method StaticMethod
+#-----|  -> call to method Method
+
+Switch.cs:
+#    5| enter M1
+#-----|  -> {...}
+
+#    5| exit M1
+
+#    5| exit M1 (normal)
+#-----|  -> exit M1
+
+#    6| {...}
+#-----|  -> switch (...) {...}
+
+#    7| switch (...) {...}
+#-----|  -> access to parameter o
+
+#    7| access to parameter o
+#-----|  -> exit M1 (normal)
+
+#   10| enter M2
+#-----|  -> {...}
+
+#   10| exit M2
+
+#   10| exit M2 (abnormal)
+#-----|  -> exit M2
+
+#   10| exit M2 (normal)
+#-----|  -> exit M2
+
+#   11| {...}
+#-----|  -> switch (...) {...}
+
+#   12| switch (...) {...}
+#-----|  -> access to parameter o
+
+#   12| access to parameter o
+#-----|  -> case ...:
+
+#   14| case ...:
+#-----|  -> "a"
+
+#   14| "a"
+#-----| match -> return ...;
+#-----| no-match -> case ...:
+
+#   15| return ...;
+#-----| return -> exit M2 (normal)
+
+#   16| case ...:
+#-----|  -> 0
+
+#   16| 0
+#-----| match -> object creation of type Exception
+#-----| no-match -> case ...:
+
+#   17| throw ...;
+#-----| exception(Exception) -> exit M2 (abnormal)
+
+#   17| object creation of type Exception
+#-----|  -> throw ...;
+
+#   18| case ...:
+#-----|  -> null
+
+#   18| null
+#-----| match -> goto default;
+#-----| no-match -> case ...:
+
+#   19| goto default;
+#-----| goto(default) -> default:
+
+#   20| case ...:
+#-----|  -> Int32 i
+
+#   20| Int32 i
+#-----| match -> if (...) ...
+#-----| no-match -> case ...:
+
+#   21| if (...) ...
+#-----|  -> access to parameter o
+
+#   21| ... == ...
+#-----| true -> return ...;
+#-----| false -> 0
+
+#   21| access to parameter o
+#-----|  -> null
+
+#   21| null
+#-----|  -> ... == ...
+
+#   22| return ...;
+#-----| return -> exit M2 (normal)
+
+#   23| goto case ...;
+#-----| goto(0) -> case ...:
+
+#   23| 0
+#-----|  -> goto case ...;
+
+#   24| case ...:
+#-----|  -> String s
+
+#   24| String s
+#-----| no-match -> case ...:
+#-----| match -> access to local variable s
+
+#   24| [false] ... && ...
+#-----| false -> case ...:
+
+#   24| [true] ... && ...
+#-----| true -> ...;
+
+#   24| ... > ...
+#-----| false -> [false] ... && ...
+#-----| true -> access to local variable s
+
+#   24| access to property Length
+#-----|  -> 0
+
+#   24| access to local variable s
+#-----|  -> access to property Length
+
+#   24| 0
+#-----|  -> ... > ...
+
+#   24| ... != ...
+#-----| false -> [false] ... && ...
+#-----| true -> [true] ... && ...
+
+#   24| access to local variable s
+#-----|  -> "a"
+
+#   24| "a"
+#-----|  -> ... != ...
+
+#   25| ...;
+#-----|  -> access to local variable s
+
+#   25| call to method WriteLine
+#-----|  -> return ...;
+
+#   25| access to local variable s
+#-----|  -> call to method WriteLine
+
+#   26| return ...;
+#-----| return -> exit M2 (normal)
+
+#   27| case ...:
+#-----|  -> Double d
+
+#   27| Double d
+#-----| match -> call to method Throw
+#-----| no-match -> default:
+
+#   27| call to method Throw
+#-----| exception(Exception) -> exit M2 (abnormal)
+
+#   28| Label:
+#-----|  -> return ...;
+
+#   29| return ...;
+#-----| return -> exit M2 (normal)
+
+#   30| default:
+#-----|  -> goto ...;
+
+#   31| goto ...;
+#-----| goto(Label) -> Label:
+
+#   35| enter M3
+#-----|  -> {...}
+
+#   35| exit M3
+
+#   35| exit M3 (abnormal)
+#-----|  -> exit M3
+
+#   36| {...}
+#-----|  -> switch (...) {...}
+
+#   37| switch (...) {...}
+#-----|  -> call to method Throw
+
+#   37| call to method Throw
+#-----| exception(Exception) -> exit M3 (abnormal)
+
+#   44| enter M4
+#-----|  -> {...}
+
+#   44| exit M4
+
+#   44| exit M4 (normal)
+#-----|  -> exit M4
+
+#   45| {...}
+#-----|  -> switch (...) {...}
+
+#   46| switch (...) {...}
+#-----|  -> access to parameter o
+
+#   46| access to parameter o
+#-----|  -> case ...:
+
+#   48| case ...:
+#-----|  -> access to type Int32
+
+#   48| access to type Int32
+#-----| match -> break;
+#-----| no-match -> case ...:
+
+#   49| break;
+#-----| break -> exit M4 (normal)
+
+#   50| case ...:
+#-----|  -> access to type Boolean
+
+#   50| access to type Boolean
+#-----| match -> access to parameter o
+#-----| no-match -> exit M4 (normal)
+
+#   50| ... != ...
+#-----| true -> break;
+#-----| false -> exit M4 (normal)
+
+#   50| access to parameter o
+#-----|  -> null
+
+#   50| null
+#-----|  -> ... != ...
+
+#   51| break;
+#-----| break -> exit M4 (normal)
+
+#   55| enter M5
+#-----|  -> {...}
+
+#   55| exit M5
+
+#   55| exit M5 (normal)
+#-----|  -> exit M5
+
+#   56| {...}
+#-----|  -> switch (...) {...}
+
+#   57| switch (...) {...}
+#-----|  -> 1
+
+#   57| ... + ...
+#-----|  -> case ...:
+
+#   57| 1
+#-----|  -> 2
+
+#   57| 2
+#-----|  -> ... + ...
+
+#   59| case ...:
+#-----|  -> 2
+
+#   59| 2
+#-----| no-match -> case ...:
+
+#   61| case ...:
+#-----|  -> 3
+
+#   61| 3
+#-----| match -> break;
+
+#   62| break;
+#-----| break -> exit M5 (normal)
+
+#   66| enter M6
+#-----|  -> {...}
+
+#   66| exit M6
+
+#   66| exit M6 (normal)
+#-----|  -> exit M6
+
+#   67| {...}
+#-----|  -> switch (...) {...}
+
+#   68| switch (...) {...}
+#-----|  -> access to parameter s
+
+#   68| (...) ...
+#-----|  -> case ...:
+
+#   68| access to parameter s
+#-----|  -> (...) ...
+
+#   70| case ...:
+#-----|  -> access to type Int32
+
+#   70| access to type Int32
+#-----| no-match -> case ...:
+
+#   72| case ...:
+#-----|  -> ""
+
+#   72| ""
+#-----| match -> break;
+#-----| no-match -> exit M6 (normal)
+
+#   73| break;
+#-----| break -> exit M6 (normal)
+
+#   77| enter M7
+#-----|  -> {...}
+
+#   77| exit M7
+
+#   77| exit M7 (normal)
+#-----|  -> exit M7
+
+#   78| {...}
+#-----|  -> switch (...) {...}
+
+#   79| switch (...) {...}
+#-----|  -> access to parameter i
+
+#   79| access to parameter i
+#-----|  -> case ...:
+
+#   81| case ...:
+#-----|  -> 1
+
+#   81| 1
+#-----| match -> true
+#-----| no-match -> case ...:
+
+#   82| return ...;
+#-----| return -> exit M7 (normal)
+
+#   82| true
+#-----|  -> return ...;
+
+#   83| case ...:
+#-----|  -> 2
+
+#   83| 2
+#-----| match -> if (...) ...
+#-----| no-match -> false
+
+#   84| if (...) ...
+#-----|  -> access to parameter j
+
+#   84| ... > ...
+#-----| true -> break;
+#-----| false -> true
+
+#   84| access to parameter j
+#-----|  -> 2
+
+#   84| 2
+#-----|  -> ... > ...
+
+#   85| break;
+#-----| break -> false
+
+#   86| return ...;
+#-----| return -> exit M7 (normal)
+
+#   86| true
+#-----|  -> return ...;
+
+#   88| return ...;
+#-----| return -> exit M7 (normal)
+
+#   88| false
+#-----|  -> return ...;
+
+#   91| enter M8
+#-----|  -> {...}
+
+#   91| exit M8
+
+#   91| exit M8 (normal)
+#-----|  -> exit M8
+
+#   92| {...}
+#-----|  -> switch (...) {...}
+
+#   93| switch (...) {...}
+#-----|  -> access to parameter o
+
+#   93| access to parameter o
+#-----|  -> case ...:
+
+#   95| case ...:
+#-----|  -> access to type Int32
+
+#   95| access to type Int32
+#-----| match -> true
+#-----| no-match -> false
+
+#   96| return ...;
+#-----| return -> exit M8 (normal)
+
+#   96| true
+#-----|  -> return ...;
+
+#   98| return ...;
+#-----| return -> exit M8 (normal)
+
+#   98| false
+#-----|  -> return ...;
+
+#  101| enter M9
+#-----|  -> {...}
+
+#  101| exit M9
+
+#  101| exit M9 (normal)
+#-----|  -> exit M9
+
+#  102| {...}
+#-----|  -> switch (...) {...}
+
+#  103| switch (...) {...}
+#-----|  -> access to parameter s
+
+#  103| access to parameter s
+#-----| non-null -> access to property Length
+#-----| null -> case ...:
+
+#  103| access to property Length
+#-----|  -> case ...:
+
+#  105| case ...:
+#-----|  -> 0
+
+#  105| 0
+#-----| match -> 0
+#-----| no-match -> case ...:
+
+#  105| return ...;
+#-----| return -> exit M9 (normal)
+
+#  105| 0
+#-----|  -> return ...;
+
+#  106| case ...:
+#-----|  -> 1
+
+#  106| 1
+#-----| match -> 1
+#-----| no-match -> 1
+
+#  106| return ...;
+#-----| return -> exit M9 (normal)
+
+#  106| 1
+#-----|  -> return ...;
+
+#  108| return ...;
+#-----| return -> exit M9 (normal)
+
+#  108| -...
+#-----|  -> return ...;
+
+#  108| 1
+#-----|  -> -...
+
+#  111| enter Throw
+#-----|  -> object creation of type Exception
+
+#  111| exit Throw
+
+#  111| exit Throw (abnormal)
+#-----|  -> exit Throw
+
+#  111| throw ...
+#-----| exception(Exception) -> exit Throw (abnormal)
+
+#  111| object creation of type Exception
+#-----|  -> throw ...
+
+#  113| enter M10
+#-----|  -> {...}
+
+#  113| exit M10
+
+#  113| exit M10 (normal)
+#-----|  -> exit M10
+
+#  114| {...}
+#-----|  -> switch (...) {...}
+
+#  115| switch (...) {...}
+#-----|  -> access to parameter s
+
+#  115| access to property Length
+#-----|  -> case ...:
+
+#  115| access to parameter s
+#-----|  -> access to property Length
+
+#  117| case ...:
+#-----|  -> 3
+
+#  117| 3
+#-----| no-match -> case ...:
+#-----| match -> access to parameter s
+
+#  117| ... == ...
+#-----| true -> 1
+#-----| false -> case ...:
+
+#  117| access to parameter s
+#-----|  -> "foo"
+
+#  117| "foo"
+#-----|  -> ... == ...
+
+#  117| return ...;
+#-----| return -> exit M10 (normal)
+
+#  117| 1
+#-----|  -> return ...;
+
+#  118| case ...:
+#-----|  -> 2
+
+#  118| 2
+#-----| no-match -> 1
+#-----| match -> access to parameter s
+
+#  118| ... == ...
+#-----| true -> 2
+#-----| false -> 1
+
+#  118| access to parameter s
+#-----|  -> "fu"
+
+#  118| "fu"
+#-----|  -> ... == ...
+
+#  118| return ...;
+#-----| return -> exit M10 (normal)
+
+#  118| 2
+#-----|  -> return ...;
+
+#  120| return ...;
+#-----| return -> exit M10 (normal)
+
+#  120| -...
+#-----|  -> return ...;
+
+#  120| 1
+#-----|  -> -...
+
+#  123| enter M11
+#-----|  -> {...}
+
+#  123| exit M11
+
+#  123| exit M11 (normal)
+#-----|  -> exit M11
+
+#  124| {...}
+#-----|  -> if (...) ...
+
+#  125| if (...) ...
+#-----|  -> access to parameter o
+
+#  125| [false] ... switch { ... }
+#-----| false -> exit M11 (normal)
+
+#  125| [true] ... switch { ... }
+#-----| true -> return ...;
+
+#  125| access to parameter o
+#-----|  -> Boolean b
+
+#  125| [false] ... => ...
+#-----| false -> [false] ... switch { ... }
+
+#  125| [true] ... => ...
+#-----| true -> [true] ... switch { ... }
+
+#  125| Boolean b
+#-----| match -> access to local variable b
+#-----| no-match -> _
+
+#  125| access to local variable b
+#-----| false -> [false] ... => ...
+#-----| true -> [true] ... => ...
+
+#  125| [false] ... => ...
+#-----| false -> [false] ... switch { ... }
+
+#  125| _
+#-----| match -> false
+
+#  125| false
+#-----| false -> [false] ... => ...
+
+#  126| return ...;
+#-----| return -> exit M11 (normal)
+
+#  129| enter M12
+#-----|  -> {...}
+
+#  129| exit M12
+
+#  129| exit M12 (normal)
+#-----|  -> exit M12
+
+#  130| {...}
+#-----|  -> access to parameter o
+
+#  131| return ...;
+#-----| return -> exit M12 (normal)
+
+#  131| [non-null] ... switch { ... }
+#-----| non-null -> call to method ToString
+
+#  131| [null] ... switch { ... }
+#-----| null -> return ...;
+
+#  131| access to parameter o
+#-----|  -> String s
+
+#  131| [non-null] ... => ...
+#-----| non-null -> [non-null] ... switch { ... }
+
+#  131| [null] ... => ...
+#-----| null -> [null] ... switch { ... }
+
+#  131| String s
+#-----| match -> access to local variable s
+#-----| no-match -> _
+
+#  131| access to local variable s
+#-----| non-null -> [non-null] ... => ...
+#-----| null -> [null] ... => ...
+
+#  131| [null] ... => ...
+#-----| null -> [null] ... switch { ... }
+
+#  131| _
+#-----| match -> null
+
+#  131| null
+#-----| null -> [null] ... => ...
+
+#  131| call to method ToString
+#-----|  -> return ...;
+
+#  134| enter M13
+#-----|  -> {...}
+
+#  134| exit M13
+
+#  134| exit M13 (normal)
+#-----|  -> exit M13
+
+#  135| {...}
+#-----|  -> switch (...) {...}
+
+#  136| switch (...) {...}
+#-----|  -> access to parameter i
+
+#  136| access to parameter i
+#-----|  -> case ...:
+
+#  138| default:
+#-----|  -> 1
+
+#  138| return ...;
+#-----| return -> exit M13 (normal)
+
+#  138| -...
+#-----|  -> return ...;
+
+#  138| 1
+#-----|  -> -...
+
+#  139| case ...:
+#-----|  -> 1
+
+#  139| 1
+#-----| match -> 1
+#-----| no-match -> case ...:
+
+#  139| return ...;
+#-----| return -> exit M13 (normal)
+
+#  139| 1
+#-----|  -> return ...;
+
+#  140| case ...:
+#-----|  -> 2
+
+#  140| 2
+#-----| no-match -> default:
+#-----| match -> 2
+
+#  140| return ...;
+#-----| return -> exit M13 (normal)
+
+#  140| 2
+#-----|  -> return ...;
+
+#  144| enter M14
+#-----|  -> {...}
+
+#  144| exit M14
+
+#  144| exit M14 (normal)
+#-----|  -> exit M14
+
+#  145| {...}
+#-----|  -> switch (...) {...}
+
+#  146| switch (...) {...}
+#-----|  -> access to parameter i
+
+#  146| access to parameter i
+#-----|  -> case ...:
+
+#  148| case ...:
+#-----|  -> 1
+
+#  148| 1
+#-----| match -> 1
+#-----| no-match -> case ...:
+
+#  148| return ...;
+#-----| return -> exit M14 (normal)
+
+#  148| 1
+#-----|  -> return ...;
+
+#  149| default:
+#-----|  -> 1
+
+#  149| return ...;
+#-----| return -> exit M14 (normal)
+
+#  149| -...
+#-----|  -> return ...;
+
+#  149| 1
+#-----|  -> -...
+
+#  150| case ...:
+#-----|  -> 2
+
+#  150| 2
+#-----| no-match -> default:
+#-----| match -> 2
+
+#  150| return ...;
+#-----| return -> exit M14 (normal)
+
+#  150| 2
+#-----|  -> return ...;
+
+#  154| enter M15
+#-----|  -> {...}
+
+#  154| exit M15
+
+#  154| exit M15 (abnormal)
+#-----|  -> exit M15
+
+#  154| exit M15 (normal)
+#-----|  -> exit M15
+
+#  155| {...}
+#-----|  -> ... ...;
+
+#  156| ... ...;
+#-----|  -> access to parameter b
+
+#  156| String s = ...
+#-----|  -> if (...) ...
+
+#  156| ... switch { ... }
+#-----|  -> String s = ...
+
+#  156| access to parameter b
+#-----|  -> true
+
+#  156| ... => ...
+#-----|  -> ... switch { ... }
+
+#  156| true
+#-----| match -> "a"
+#-----| no-match -> false
+
+#  156| "a"
+#-----|  -> ... => ...
+
+#  156| ... => ...
+#-----|  -> ... switch { ... }
+
+#  156| false
+#-----| match -> "b"
+#-----| exception(InvalidOperationException) -> exit M15 (abnormal)
+
+#  156| "b"
+#-----|  -> ... => ...
+
+#  157| if (...) ...
+#-----|  -> access to parameter b
+
+#  157| access to parameter b
+#-----| true -> ...;
+#-----| false -> ...;
+
+#  158| ...;
+#-----|  -> "a = "
+
+#  158| call to method WriteLine
+#-----|  -> exit M15 (normal)
+
+#  158| $"..."
+#-----|  -> call to method WriteLine
+
+#  158| "a = "
+#-----|  -> access to local variable s
+
+#  158| access to local variable s
+#-----|  -> $"..."
+
+#  160| ...;
+#-----|  -> "b = "
+
+#  160| call to method WriteLine
+#-----|  -> exit M15 (normal)
+
+#  160| $"..."
+#-----|  -> call to method WriteLine
+
+#  160| "b = "
+#-----|  -> access to local variable s
+
+#  160| access to local variable s
+#-----|  -> $"..."
+
+TypeAccesses.cs:
+#    3| enter M
+#-----|  -> {...}
+
+#    3| exit M
+
+#    3| exit M (normal)
+#-----|  -> exit M
+
+#    4| {...}
+#-----|  -> ... ...;
+
+#    5| ... ...;
+#-----|  -> access to parameter o
+
+#    5| String s = ...
+#-----|  -> ...;
+
+#    5| (...) ...
+#-----|  -> String s = ...
+
+#    5| access to parameter o
+#-----|  -> (...) ...
+
+#    6| ...;
+#-----|  -> access to parameter o
+
+#    6| ... = ...
+#-----|  -> if (...) ...
+
+#    6| ... as ...
+#-----|  -> ... = ...
+
+#    6| access to parameter o
+#-----|  -> ... as ...
+
+#    7| if (...) ...
+#-----|  -> access to parameter o
+
+#    7| [false] ... is ...
+#-----| false -> ... ...;
+
+#    7| [true] ... is ...
+#-----| true -> ;
+
+#    7| access to parameter o
+#-----|  -> Int32 j
+
+#    7| Int32 j
+#-----| no-match -> [false] ... is ...
+#-----| match -> [true] ... is ...
+
+#    7| ;
+#-----|  -> ... ...;
+
+#    8| ... ...;
+#-----|  -> typeof(...)
+
+#    8| Type t = ...
+#-----|  -> exit M (normal)
+
+#    8| typeof(...)
+#-----|  -> Type t = ...
+
+VarDecls.cs:
+#    5| enter M1
+#-----|  -> {...}
+
+#    5| exit M1
+
+#    5| exit M1 (normal)
+#-----|  -> exit M1
+
+#    6| {...}
+#-----|  -> fixed(...) { ... }
+
+#    7| fixed(...) { ... }
+#-----|  -> access to parameter strings
+
+#    7| Char* c1 = ...
+#-----|  -> access to parameter strings
+
+#    7| (...) ...
+#-----|  -> Char* c1 = ...
+
+#    7| access to array element
+#-----|  -> (...) ...
+
+#    7| access to parameter strings
+#-----|  -> 0
+
+#    7| 0
+#-----|  -> access to array element
+
+#    7| Char* c2 = ...
+#-----|  -> {...}
+
+#    7| (...) ...
+#-----|  -> Char* c2 = ...
+
+#    7| access to array element
+#-----|  -> (...) ...
+
+#    7| access to parameter strings
+#-----|  -> 1
+
+#    7| 1
+#-----|  -> access to array element
+
+#    8| {...}
+#-----|  -> access to local variable c1
+
+#    9| return ...;
+#-----| return -> exit M1 (normal)
+
+#    9| (...) ...
+#-----|  -> return ...;
+
+#    9| access to local variable c1
+#-----|  -> (...) ...
+
+#   13| enter M2
+#-----|  -> {...}
+
+#   13| exit M2
+
+#   13| exit M2 (normal)
+#-----|  -> exit M2
+
+#   14| {...}
+#-----|  -> ... ...;
+
+#   15| ... ...;
+#-----|  -> access to parameter s
+
+#   15| String s1 = ...
+#-----|  -> access to parameter s
+
+#   15| access to parameter s
+#-----|  -> String s1 = ...
+
+#   15| String s2 = ...
+#-----|  -> access to local variable s1
+
+#   15| access to parameter s
+#-----|  -> String s2 = ...
+
+#   16| return ...;
+#-----| return -> exit M2 (normal)
+
+#   16| ... + ...
+#-----|  -> return ...;
+
+#   16| access to local variable s1
+#-----|  -> access to local variable s2
+
+#   16| access to local variable s2
+#-----|  -> ... + ...
+
+#   19| enter M3
+#-----|  -> {...}
+
+#   19| exit M3
+
+#   19| exit M3 (normal)
+#-----|  -> exit M3
+
+#   20| {...}
+#-----|  -> using (...) {...}
+
+#   21| using (...) {...}
+#-----|  -> object creation of type C
+
+#   21| object creation of type C
+#-----|  -> ;
+
+#   22| ;
+#-----|  -> using (...) {...}
+
+#   24| using (...) {...}
+#-----|  -> object creation of type C
+
+#   24| C x = ...
+#-----|  -> object creation of type C
+
+#   24| object creation of type C
+#-----|  -> C x = ...
+
+#   24| C y = ...
+#-----|  -> access to parameter b
+
+#   24| object creation of type C
+#-----|  -> C y = ...
+
+#   25| return ...;
+#-----| return -> exit M3 (normal)
+
+#   25| ... ? ... : ...
+#-----|  -> return ...;
+
+#   25| access to parameter b
+#-----| true -> access to local variable x
+#-----| false -> access to local variable y
+
+#   25| access to local variable x
+#-----|  -> ... ? ... : ...
+
+#   25| access to local variable y
+#-----|  -> ... ? ... : ...
+
+#   28| enter Dispose
+#-----|  -> {...}
+
+#   28| exit Dispose
+
+#   28| exit Dispose (normal)
+#-----|  -> exit Dispose
+
+#   28| {...}
+#-----|  -> exit Dispose (normal)
+
+cflow.cs:
+#    5| enter Main
+#-----|  -> {...}
+
+#    5| exit Main
+
+#    5| exit Main (normal)
+#-----|  -> exit Main
+
+#    6| {...}
+#-----|  -> ... ...;
+
+#    7| ... ...;
+#-----|  -> access to parameter args
+
+#    7| Int32 a = ...
+#-----|  -> ...;
+
+#    7| access to property Length
+#-----|  -> Int32 a = ...
+
+#    7| access to parameter args
+#-----|  -> access to property Length
+
+#    9| ...;
+#-----|  -> object creation of type ControlFlow
+
+#    9| ... = ...
+#-----|  -> if (...) ...
+
+#    9| call to method Switch
+#-----|  -> ... = ...
+
+#    9| object creation of type ControlFlow
+#-----|  -> access to local variable a
+
+#    9| access to local variable a
+#-----|  -> call to method Switch
+
+#   11| if (...) ...
+#-----|  -> access to local variable a
+
+#   11| ... > ...
+#-----| true -> ...;
+#-----| false -> while (...) ...
+
+#   11| access to local variable a
+#-----|  -> 3
+
+#   11| 3
+#-----|  -> ... > ...
+
+#   12| ...;
+#-----|  -> "more than a few"
+
+#   12| call to method WriteLine
+#-----|  -> while (...) ...
+
+#   12| "more than a few"
+#-----|  -> call to method WriteLine
+
+#   14| while (...) ...
+#-----|  -> access to local variable a
+
+#   14| ... > ...
+#-----| true -> {...}
+#-----| false -> do ... while (...);
+
+#   14| access to local variable a
+#-----|  -> 0
+
+#   14| 0
+#-----|  -> ... > ...
+
+#   15| {...}
+#-----|  -> ...;
+
+#   16| ...;
+#-----|  -> access to local variable a
+
+#   16| call to method WriteLine
+#-----|  -> access to local variable a
+
+#   16| ... * ...
+#-----|  -> call to method WriteLine
+
+#   16| ...--
+#-----|  -> 100
+
+#   16| access to local variable a
+#-----|  -> ...--
+
+#   16| 100
+#-----|  -> ... * ...
+
+#   19| do ... while (...);
+#-----|  -> {...}
+
+#   20| {...}
+#-----|  -> ...;
+
+#   21| ...;
+#-----|  -> access to local variable a
+
+#   21| call to method WriteLine
+#-----|  -> access to local variable a
+
+#   21| -...
+#-----|  -> call to method WriteLine
+
+#   21| ...++
+#-----|  -> -...
+
+#   21| access to local variable a
+#-----|  -> ...++
+
+#   22| ... < ...
+#-----| true -> {...}
+#-----| false -> for (...;...;...) ...
+
+#   22| access to local variable a
+#-----|  -> 10
+
+#   22| 10
+#-----|  -> ... < ...
+
+#   24| for (...;...;...) ...
+#-----|  -> 1
+
+#   24| Int32 i = ...
+#-----|  -> access to local variable i
+
+#   24| 1
+#-----|  -> Int32 i = ...
+
+#   24| ... <= ...
+#-----| true -> {...}
+#-----| false -> exit Main (normal)
+
+#   24| access to local variable i
+#-----|  -> 20
+
+#   24| 20
+#-----|  -> ... <= ...
+
+#   24| ...++
+#-----|  -> access to local variable i
+
+#   24| access to local variable i
+#-----|  -> ...++
+
+#   25| {...}
+#-----|  -> if (...) ...
+
+#   26| if (...) ...
+#-----|  -> access to local variable i
+
+#   26| [false] ... && ...
+#-----| false -> if (...) ...
+
+#   26| [true] ... && ...
+#-----| true -> ...;
+
+#   26| ... == ...
+#-----| false -> [false] ... && ...
+#-----| true -> access to local variable i
+
+#   26| ... % ...
+#-----|  -> 0
+
+#   26| access to local variable i
+#-----|  -> 3
+
+#   26| 3
+#-----|  -> ... % ...
+
+#   26| 0
+#-----|  -> ... == ...
+
+#   26| ... == ...
+#-----| false -> [false] ... && ...
+#-----| true -> [true] ... && ...
+
+#   26| ... % ...
+#-----|  -> 0
+
+#   26| access to local variable i
+#-----|  -> 5
+
+#   26| 5
+#-----|  -> ... % ...
+
+#   26| 0
+#-----|  -> ... == ...
+
+#   27| ...;
+#-----|  -> "FizzBuzz"
+
+#   27| call to method WriteLine
+#-----|  -> access to local variable i
+
+#   27| "FizzBuzz"
+#-----|  -> call to method WriteLine
+
+#   28| if (...) ...
+#-----|  -> access to local variable i
+
+#   28| ... == ...
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   28| ... % ...
+#-----|  -> 0
+
+#   28| access to local variable i
+#-----|  -> 3
+
+#   28| 3
+#-----|  -> ... % ...
+
+#   28| 0
+#-----|  -> ... == ...
+
+#   29| ...;
+#-----|  -> "Fizz"
+
+#   29| call to method WriteLine
+#-----|  -> access to local variable i
+
+#   29| "Fizz"
+#-----|  -> call to method WriteLine
+
+#   30| if (...) ...
+#-----|  -> access to local variable i
+
+#   30| ... == ...
+#-----| true -> ...;
+#-----| false -> ...;
+
+#   30| ... % ...
+#-----|  -> 0
+
+#   30| access to local variable i
+#-----|  -> 5
+
+#   30| 5
+#-----|  -> ... % ...
+
+#   30| 0
+#-----|  -> ... == ...
+
+#   31| ...;
+#-----|  -> "Buzz"
+
+#   31| call to method WriteLine
+#-----|  -> access to local variable i
+
+#   31| "Buzz"
+#-----|  -> call to method WriteLine
+
+#   33| ...;
+#-----|  -> access to local variable i
+
+#   33| call to method WriteLine
+#-----|  -> access to local variable i
+
+#   33| access to local variable i
+#-----|  -> call to method WriteLine
+
+#   37| enter Switch
+#-----|  -> {...}
+
+#   37| exit Switch
+
+#   37| exit Switch (abnormal)
+#-----|  -> exit Switch
+
+#   37| exit Switch (normal)
+#-----|  -> exit Switch
+
+#   38| {...}
+#-----|  -> switch (...) {...}
+
+#   39| switch (...) {...}
+#-----|  -> access to parameter a
+
+#   39| access to parameter a
+#-----|  -> case ...:
+
+#   41| case ...:
+#-----|  -> 1
+
+#   41| 1
+#-----| match -> ...;
+#-----| no-match -> case ...:
+
+#   42| ...;
+#-----|  -> "1"
+
+#   42| call to method WriteLine
+#-----|  -> 2
+
+#   42| "1"
+#-----|  -> call to method WriteLine
+
+#   43| goto case ...;
+#-----| goto(2) -> case ...:
+
+#   43| 2
+#-----|  -> goto case ...;
+
+#   44| case ...:
+#-----|  -> 2
+
+#   44| 2
+#-----| match -> ...;
+#-----| no-match -> case ...:
+
+#   45| ...;
+#-----|  -> "2"
+
+#   45| call to method WriteLine
+#-----|  -> 1
+
+#   45| "2"
+#-----|  -> call to method WriteLine
+
+#   46| goto case ...;
+#-----| goto(1) -> case ...:
+
+#   46| 1
+#-----|  -> goto case ...;
+
+#   47| case ...:
+#-----|  -> 3
+
+#   47| 3
+#-----| match -> ...;
+#-----| no-match -> switch (...) {...}
+
+#   48| ...;
+#-----|  -> "3"
+
+#   48| call to method WriteLine
+#-----|  -> break;
+
+#   48| "3"
+#-----|  -> call to method WriteLine
+
+#   49| break;
+#-----| break -> switch (...) {...}
+
+#   51| switch (...) {...}
+#-----|  -> access to parameter a
+
+#   51| access to parameter a
+#-----|  -> case ...:
+
+#   53| case ...:
+#-----|  -> 42
+
+#   53| 42
+#-----| match -> ...;
+#-----| no-match -> default:
+
+#   54| ...;
+#-----|  -> "The answer"
+
+#   54| call to method WriteLine
+#-----|  -> break;
+
+#   54| "The answer"
+#-----|  -> call to method WriteLine
+
+#   55| break;
+#-----| break -> switch (...) {...}
+
+#   56| default:
+#-----|  -> ...;
+
+#   57| ...;
+#-----|  -> "Not the answer"
+
+#   57| call to method WriteLine
+#-----|  -> break;
+
+#   57| "Not the answer"
+#-----|  -> call to method WriteLine
+
+#   58| break;
+#-----| break -> switch (...) {...}
+
+#   60| switch (...) {...}
+#-----|  -> this access
+
+#   60| call to method Parse
+#-----|  -> case ...:
+
+#   60| access to field Field
+#-----|  -> call to method Parse
+
+#   60| this access
+#-----|  -> access to field Field
+
+#   62| case ...:
+#-----|  -> 0
+
+#   62| 0
+#-----| match -> if (...) ...
+#-----| no-match -> access to parameter a
+
+#   63| if (...) ...
+#-----|  -> this access
+
+#   63| [false] !...
+#-----| false -> break;
+
+#   63| [true] !...
+#-----| true -> object creation of type NullReferenceException
+
+#   63| ... == ...
+#-----| true -> [false] !...
+#-----| false -> [true] !...
+
+#   63| access to field Field
+#-----|  -> ""
+
+#   63| this access
+#-----|  -> access to field Field
+
+#   63| ""
+#-----|  -> ... == ...
+
+#   64| throw ...;
+#-----| exception(NullReferenceException) -> exit Switch (abnormal)
+
+#   64| object creation of type NullReferenceException
+#-----|  -> throw ...;
+
+#   65| break;
+#-----| break -> access to parameter a
+
+#   67| return ...;
+#-----| return -> exit Switch (normal)
+
+#   67| access to parameter a
+#-----|  -> return ...;
+
+#   70| enter M
+#-----|  -> {...}
+
+#   70| exit M
+
+#   70| exit M (normal)
+#-----|  -> exit M
+
+#   71| {...}
+#-----|  -> if (...) ...
+
+#   72| if (...) ...
+#-----|  -> access to parameter s
+
+#   72| ... == ...
+#-----| true -> return ...;
+#-----| false -> if (...) ...
+
+#   72| access to parameter s
+#-----|  -> null
+
+#   72| null
+#-----|  -> ... == ...
+
+#   73| return ...;
+#-----| return -> exit M (normal)
+
+#   74| if (...) ...
+#-----|  -> access to parameter s
+
+#   74| ... > ...
+#-----| true -> {...}
+#-----| false -> {...}
+
+#   74| access to property Length
+#-----|  -> 0
+
+#   74| access to parameter s
+#-----|  -> access to property Length
+
+#   74| 0
+#-----|  -> ... > ...
+
+#   75| {...}
+#-----|  -> ...;
+
+#   76| ...;
+#-----|  -> access to parameter s
+
+#   76| call to method WriteLine
+#-----|  -> exit M (normal)
+
+#   76| access to parameter s
+#-----|  -> call to method WriteLine
+
+#   79| {...}
+#-----|  -> ...;
+
+#   80| ...;
+#-----|  -> "<empty string>"
+
+#   80| call to method WriteLine
+#-----|  -> exit M (normal)
+
+#   80| "<empty string>"
+#-----|  -> call to method WriteLine
+
+#   84| enter M2
+#-----|  -> {...}
+
+#   84| exit M2
+
+#   84| exit M2 (normal)
+#-----|  -> exit M2
+
+#   85| {...}
+#-----|  -> if (...) ...
+
+#   86| if (...) ...
+#-----|  -> access to parameter s
+
+#   86| [false] ... && ...
+#-----| false -> exit M2 (normal)
+
+#   86| [true] ... && ...
+#-----| true -> ...;
+
+#   86| ... != ...
+#-----| false -> [false] ... && ...
+#-----| true -> access to parameter s
+
+#   86| access to parameter s
+#-----|  -> null
+
+#   86| null
+#-----|  -> ... != ...
+
+#   86| ... > ...
+#-----| false -> [false] ... && ...
+#-----| true -> [true] ... && ...
+
+#   86| access to property Length
+#-----|  -> 0
+
+#   86| access to parameter s
+#-----|  -> access to property Length
+
+#   86| 0
+#-----|  -> ... > ...
+
+#   87| ...;
+#-----|  -> access to parameter s
+
+#   87| call to method WriteLine
+#-----|  -> exit M2 (normal)
+
+#   87| access to parameter s
+#-----|  -> call to method WriteLine
+
+#   90| enter M3
+#-----|  -> {...}
+
+#   90| exit M3
+
+#   90| exit M3 (abnormal)
+#-----|  -> exit M3
+
+#   90| exit M3 (normal)
+#-----|  -> exit M3
+
+#   91| {...}
+#-----|  -> if (...) ...
+
+#   92| if (...) ...
+#-----|  -> access to parameter s
+
+#   92| call to method Equals
+#-----| true -> "s"
+#-----| false -> ...;
+
+#   92| access to parameter s
+#-----|  -> null
+
+#   92| null
+#-----|  -> call to method Equals
+
+#   93| throw ...;
+#-----| exception(ArgumentNullException) -> exit M3 (abnormal)
+
+#   93| object creation of type ArgumentNullException
+#-----|  -> throw ...;
+
+#   93| "s"
+#-----|  -> object creation of type ArgumentNullException
+
+#   94| ...;
+#-----|  -> access to parameter s
+
+#   94| call to method WriteLine
+#-----|  -> if (...) ...
+
+#   94| access to parameter s
+#-----|  -> call to method WriteLine
+
+#   96| if (...) ...
+#-----|  -> this access
+
+#   96| ... != ...
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   96| access to field Field
+#-----|  -> null
+
+#   96| this access
+#-----|  -> access to field Field
+
+#   96| null
+#-----|  -> ... != ...
+
+#   97| ...;
+#-----|  -> object creation of type ControlFlow
+
+#   97| call to method WriteLine
+#-----|  -> if (...) ...
+
+#   97| access to field Field
+#-----|  -> call to method WriteLine
+
+#   97| object creation of type ControlFlow
+#-----|  -> access to field Field
+
+#   99| if (...) ...
+#-----|  -> this access
+
+#   99| ... != ...
+#-----| true -> ...;
+#-----| false -> if (...) ...
+
+#   99| access to field Field
+#-----|  -> null
+
+#   99| this access
+#-----|  -> access to field Field
+
+#   99| null
+#-----|  -> ... != ...
+
+#  100| ...;
+#-----|  -> this access
+
+#  100| call to method WriteLine
+#-----|  -> if (...) ...
+
+#  100| access to field Field
+#-----|  -> call to method WriteLine
+
+#  100| this access
+#-----|  -> access to field Field
+
+#  102| if (...) ...
+#-----|  -> this access
+
+#  102| ... != ...
+#-----| true -> ...;
+#-----| false -> exit M3 (normal)
+
+#  102| access to property Prop
+#-----|  -> null
+
+#  102| this access
+#-----|  -> access to property Prop
+
+#  102| null
+#-----|  -> ... != ...
+
+#  103| ...;
+#-----|  -> this access
+
+#  103| call to method WriteLine
+#-----|  -> exit M3 (normal)
+
+#  103| access to property Prop
+#-----|  -> call to method WriteLine
+
+#  103| this access
+#-----|  -> access to property Prop
+
+#  106| enter M4
+#-----|  -> {...}
+
+#  106| exit M4
+
+#  106| exit M4 (normal)
+#-----|  -> exit M4
+
+#  107| {...}
+#-----|  -> if (...) ...
+
+#  108| if (...) ...
+#-----|  -> access to parameter s
+
+#  108| ... != ...
+#-----| true -> {...}
+#-----| false -> ...;
+
+#  108| access to parameter s
+#-----|  -> null
+
+#  108| null
+#-----|  -> ... != ...
+
+#  109| {...}
+#-----|  -> while (...) ...
+
+#  110| while (...) ...
+#-----|  -> true
+
+#  110| true
+#-----| true -> {...}
+
+#  111| {...}
+#-----|  -> ...;
+
+#  112| ...;
+#-----|  -> access to parameter s
+
+#  112| call to method WriteLine
+#-----|  -> true
+
+#  112| access to parameter s
+#-----|  -> call to method WriteLine
+
+#  116| ...;
+#-----|  -> access to parameter s
+
+#  116| call to method WriteLine
+#-----|  -> exit M4 (normal)
+
+#  116| access to parameter s
+#-----|  -> call to method WriteLine
+
+#  119| enter M5
+#-----|  -> {...}
+
+#  119| exit M5
+
+#  119| exit M5 (normal)
+#-----|  -> exit M5
+
+#  120| {...}
+#-----|  -> ... ...;
+
+#  121| ... ...;
+#-----|  -> access to parameter s
+
+#  121| String x = ...
+#-----|  -> ...;
+
+#  121| access to parameter s
+#-----|  -> String x = ...
+
+#  122| ...;
+#-----|  -> access to local variable x
+
+#  122| ... = ...
+#-----|  -> access to local variable x
+
+#  122| ... + ...
+#-----|  -> ... = ...
+
+#  122| access to local variable x
+#-----|  -> " "
+
+#  122| " "
+#-----|  -> ... + ...
+
+#  123| return ...;
+#-----| return -> exit M5 (normal)
+
+#  123| access to local variable x
+#-----|  -> return ...;
+
+#  127| enter get_Prop
+#-----|  -> {...}
+
+#  127| exit get_Prop
+
+#  127| exit get_Prop (normal)
+#-----|  -> exit get_Prop
+
+#  127| {...}
+#-----|  -> this access
+
+#  127| return ...;
+#-----| return -> exit get_Prop (normal)
+
+#  127| ... ? ... : ...
+#-----|  -> return ...;
+
+#  127| ... == ...
+#-----| true -> ""
+#-----| false -> this access
+
+#  127| access to field Field
+#-----|  -> null
+
+#  127| this access
+#-----|  -> access to field Field
+
+#  127| null
+#-----|  -> ... == ...
+
+#  127| ""
+#-----|  -> ... ? ... : ...
+
+#  127| access to field Field
+#-----|  -> ... ? ... : ...
+
+#  127| this access
+#-----|  -> access to field Field
+
+#  127| enter set_Prop
+#-----|  -> {...}
+
+#  127| exit set_Prop
+
+#  127| exit set_Prop (normal)
+#-----|  -> exit set_Prop
+
+#  127| {...}
+#-----|  -> ...;
+
+#  127| ...;
+#-----|  -> this access
+
+#  127| ... = ...
+#-----|  -> exit set_Prop (normal)
+
+#  127| this access
+#-----|  -> access to parameter value
+
+#  127| access to parameter value
+#-----|  -> ... = ...
+
+#  129| enter ControlFlow
+#-----|  -> call to constructor Object
+
+#  129| call to constructor Object
+#-----|  -> {...}
+
+#  129| exit ControlFlow
+
+#  129| exit ControlFlow (normal)
+#-----|  -> exit ControlFlow
+
+#  130| {...}
+#-----|  -> ...;
+
+#  131| ...;
+#-----|  -> this access
+
+#  131| ... = ...
+#-----|  -> exit ControlFlow (normal)
+
+#  131| this access
+#-----|  -> access to parameter s
+
+#  131| access to parameter s
+#-----|  -> ... = ...
+
+#  134| enter ControlFlow
+#-----|  -> access to parameter i
+
+#  134| exit ControlFlow
+
+#  134| exit ControlFlow (normal)
+#-----|  -> exit ControlFlow
+
+#  134| call to constructor ControlFlow
+#-----|  -> {...}
+
+#  134| ... + ...
+#-----|  -> call to constructor ControlFlow
+
+#  134| (...) ...
+#-----|  -> ""
+
+#  134| access to parameter i
+#-----|  -> (...) ...
+
+#  134| ""
+#-----|  -> ... + ...
+
+#  134| {...}
+#-----|  -> exit ControlFlow (normal)
+
+#  136| enter ControlFlow
+#-----|  -> 0
+
+#  136| exit ControlFlow
+
+#  136| exit ControlFlow (normal)
+#-----|  -> exit ControlFlow
+
+#  136| call to constructor ControlFlow
+#-----|  -> {...}
+
+#  136| ... + ...
+#-----|  -> call to constructor ControlFlow
+
+#  136| 0
+#-----|  -> 1
+
+#  136| 1
+#-----|  -> ... + ...
+
+#  136| {...}
+#-----|  -> exit ControlFlow (normal)
+
+#  138| enter +
+#-----|  -> {...}
+
+#  138| exit +
+
+#  138| exit + (normal)
+#-----|  -> exit +
+
+#  139| {...}
+#-----|  -> ...;
+
+#  140| ...;
+#-----|  -> access to parameter x
+
+#  140| call to method WriteLine
+#-----|  -> access to parameter y
+
+#  140| access to parameter x
+#-----|  -> call to method WriteLine
+
+#  141| return ...;
+#-----| return -> exit + (normal)
+
+#  141| access to parameter y
+#-----|  -> return ...;
+
+#  144| enter get_Item
+#-----|  -> {...}
+
+#  144| exit get_Item
+
+#  144| exit get_Item (normal)
+#-----|  -> exit get_Item
+
+#  144| {...}
+#-----|  -> access to parameter i
+
+#  144| return ...;
+#-----| return -> exit get_Item (normal)
+
+#  144| ... + ...
+#-----|  -> return ...;
+
+#  144| (...) ...
+#-----|  -> ""
+
+#  144| access to parameter i
+#-----|  -> (...) ...
+
+#  144| ""
+#-----|  -> ... + ...
+
+#  144| enter set_Item
+#-----|  -> {...}
+
+#  144| exit set_Item
+
+#  144| exit set_Item (normal)
+#-----|  -> exit set_Item
+
+#  144| {...}
+#-----|  -> exit set_Item (normal)
+
+#  146| enter For
+#-----|  -> {...}
+
+#  146| exit For
+
+#  146| exit For (normal)
+#-----|  -> exit For
+
+#  147| {...}
+#-----|  -> ... ...;
+
+#  148| ... ...;
+#-----|  -> 0
+
+#  148| Int32 x = ...
+#-----|  -> for (...;...;...) ...
+
+#  148| 0
+#-----|  -> Int32 x = ...
+
+#  149| for (...;...;...) ...
+#-----|  -> access to local variable x
+
+#  149| ... < ...
+#-----| true -> ...;
+#-----| false -> for (...;...;...) ...
+
+#  149| access to local variable x
+#-----|  -> 10
+
+#  149| 10
+#-----|  -> ... < ...
+
+#  149| ++...
+#-----|  -> access to local variable x
+
+#  149| access to local variable x
+#-----|  -> ++...
+
+#  150| ...;
+#-----|  -> access to local variable x
+
+#  150| call to method WriteLine
+#-----|  -> access to local variable x
+
+#  150| access to local variable x
+#-----|  -> call to method WriteLine
+
+#  152| for (...;...;...) ...
+#-----|  -> {...}
+
+#  152| ...++
+#-----|  -> {...}
+
+#  152| access to local variable x
+#-----|  -> ...++
+
+#  153| {...}
+#-----|  -> ...;
+
+#  154| ...;
+#-----|  -> access to local variable x
+
+#  154| call to method WriteLine
+#-----|  -> if (...) ...
+
+#  154| access to local variable x
+#-----|  -> call to method WriteLine
+
+#  155| if (...) ...
+#-----|  -> access to local variable x
+
+#  155| ... > ...
+#-----| false -> access to local variable x
+#-----| true -> break;
+
+#  155| access to local variable x
+#-----|  -> 20
+
+#  155| 20
+#-----|  -> ... > ...
+
+#  156| break;
+#-----| break -> for (...;...;...) ...
+
+#  159| for (...;...;...) ...
+#-----|  -> {...}
+
+#  160| {...}
+#-----|  -> ...;
+
+#  161| ...;
+#-----|  -> access to local variable x
+
+#  161| call to method WriteLine
+#-----|  -> ...;
+
+#  161| access to local variable x
+#-----|  -> call to method WriteLine
+
+#  162| ...;
+#-----|  -> access to local variable x
+
+#  162| ...++
+#-----|  -> if (...) ...
+
+#  162| access to local variable x
+#-----|  -> ...++
+
+#  163| if (...) ...
+#-----|  -> access to local variable x
+
+#  163| ... > ...
+#-----| false -> {...}
+#-----| true -> break;
+
+#  163| access to local variable x
+#-----|  -> 30
+
+#  163| 30
+#-----|  -> ... > ...
+
+#  164| break;
+#-----| break -> for (...;...;...) ...
+
+#  167| for (...;...;...) ...
+#-----|  -> access to local variable x
+
+#  167| ... < ...
+#-----| true -> {...}
+#-----| false -> for (...;...;...) ...
+
+#  167| access to local variable x
+#-----|  -> 40
+
+#  167| 40
+#-----|  -> ... < ...
+
+#  168| {...}
+#-----|  -> ...;
+
+#  169| ...;
+#-----|  -> access to local variable x
+
+#  169| call to method WriteLine
+#-----|  -> ...;
+
+#  169| access to local variable x
+#-----|  -> call to method WriteLine
+
+#  170| ...;
+#-----|  -> access to local variable x
+
+#  170| ...++
+#-----|  -> access to local variable x
+
+#  170| access to local variable x
+#-----|  -> ...++
+
+#  173| for (...;...;...) ...
+#-----|  -> 0
+
+#  173| Int32 i = ...
+#-----|  -> 0
+
+#  173| 0
+#-----|  -> Int32 i = ...
+
+#  173| Int32 j = ...
+#-----|  -> access to local variable i
+
+#  173| 0
+#-----|  -> Int32 j = ...
+
+#  173| ... < ...
+#-----| true -> {...}
+#-----| false -> exit For (normal)
+
+#  173| ... + ...
+#-----|  -> 10
+
+#  173| access to local variable i
+#-----|  -> access to local variable j
+
+#  173| access to local variable j
+#-----|  -> ... + ...
+
+#  173| 10
+#-----|  -> ... < ...
+
+#  173| ...++
+#-----|  -> access to local variable j
+
+#  173| access to local variable i
+#-----|  -> ...++
+
+#  173| ...++
+#-----|  -> access to local variable i
+
+#  173| access to local variable j
+#-----|  -> ...++
+
+#  174| {...}
+#-----|  -> ...;
+
+#  175| ...;
+#-----|  -> access to local variable i
+
+#  175| call to method WriteLine
+#-----|  -> access to local variable i
+
+#  175| ... + ...
+#-----|  -> call to method WriteLine
+
+#  175| access to local variable i
+#-----|  -> access to local variable j
+
+#  175| access to local variable j
+#-----|  -> ... + ...
+
+#  179| enter Lambdas
+#-----|  -> {...}
+
+#  179| exit Lambdas
+
+#  179| exit Lambdas (normal)
+#-----|  -> exit Lambdas
+
+#  180| {...}
+#-----|  -> ... ...;
+
+#  181| ... ...;
+#-----|  -> (...) => ...
+
+#  181| Func<Int32,Int32> y = ...
+#-----|  -> ... ...;
+
+#  181| enter (...) => ...
+#-----|  -> access to parameter x
+
+#  181| (...) => ...
+#-----|  -> Func<Int32,Int32> y = ...
+
+#  181| exit (...) => ...
+
+#  181| exit (...) => ... (normal)
+#-----|  -> exit (...) => ...
+
+#  181| ... + ...
+#-----|  -> exit (...) => ... (normal)
+
+#  181| access to parameter x
+#-----|  -> 1
+
+#  181| 1
+#-----|  -> ... + ...
+
+#  182| ... ...;
+#-----|  -> delegate(...) { ... }
+
+#  182| Func<Int32,Int32> z = ...
+#-----|  -> exit Lambdas (normal)
+
+#  182| enter delegate(...) { ... }
+#-----|  -> {...}
+
+#  182| delegate(...) { ... }
+#-----|  -> Func<Int32,Int32> z = ...
+
+#  182| exit delegate(...) { ... }
+
+#  182| exit delegate(...) { ... } (normal)
+#-----|  -> exit delegate(...) { ... }
+
+#  182| {...}
+#-----|  -> access to parameter x
+
+#  182| return ...;
+#-----| return -> exit delegate(...) { ... } (normal)
+
+#  182| ... + ...
+#-----|  -> return ...;
+
+#  182| access to parameter x
+#-----|  -> 1
+
+#  182| 1
+#-----|  -> ... + ...
+
+#  185| enter LogicalOr
+#-----|  -> {...}
+
+#  185| exit LogicalOr
+
+#  185| exit LogicalOr (normal)
+#-----|  -> exit LogicalOr
+
+#  186| {...}
+#-----|  -> if (...) ...
+
+#  187| if (...) ...
+#-----|  -> 1
+
+#  187| [false] ... || ...
+#-----| false -> ...;
+
+#  187| [false] ... || ...
+#-----| false -> 1
+
+#  187| ... == ...
+#-----| false -> 2
+
+#  187| 1
+#-----|  -> 2
+
+#  187| 2
+#-----|  -> ... == ...
+
+#  187| ... == ...
+#-----| false -> [false] ... || ...
+
+#  187| 2
+#-----|  -> 3
+
+#  187| 3
+#-----|  -> ... == ...
+
+#  187| [false] ... && ...
+#-----| false -> [false] ... || ...
+
+#  187| ... == ...
+#-----| false -> [false] ... && ...
+
+#  187| 1
+#-----|  -> 3
+
+#  187| 3
+#-----|  -> ... == ...
+
+#  190| ...;
+#-----|  -> "This should happen"
+
+#  190| call to method WriteLine
+#-----|  -> exit LogicalOr (normal)
+
+#  190| "This should happen"
+#-----|  -> call to method WriteLine
+
+#  193| enter Booleans
+#-----|  -> {...}
+
+#  193| exit Booleans
+
+#  193| exit Booleans (abnormal)
+#-----|  -> exit Booleans
+
+#  193| exit Booleans (normal)
+#-----|  -> exit Booleans
+
+#  194| {...}
+#-----|  -> ... ...;
+
+#  195| ... ...;
+#-----|  -> this access
+
+#  195| Boolean b = ...
+#-----|  -> if (...) ...
+
+#  195| ... && ...
+#-----|  -> Boolean b = ...
+
+#  195| ... > ...
+#-----| false -> ... && ...
+#-----| true -> this access
+
+#  195| access to property Length
+#-----|  -> 0
+
+#  195| access to field Field
+#-----|  -> access to property Length
+
+#  195| this access
+#-----|  -> access to field Field
+
+#  195| 0
+#-----|  -> ... > ...
+
+#  195| !...
+#-----|  -> ... && ...
+
+#  195| ... == ...
+#-----|  -> !...
+
+#  195| access to property Length
+#-----|  -> 1
+
+#  195| access to field Field
+#-----|  -> access to property Length
+
+#  195| this access
+#-----|  -> access to field Field
+
+#  195| 1
+#-----|  -> ... == ...
+
+#  197| if (...) ...
+#-----|  -> this access
+
+#  197| [false] !...
+#-----| false -> if (...) ...
+
+#  197| [true] !...
+#-----| true -> ...;
+
+#  197| [false] ... ? ... : ...
+#-----| false -> [true] !...
+
+#  197| [true] ... ? ... : ...
+#-----| true -> [false] !...
+
+#  197| ... == ...
+#-----| true -> false
+#-----| false -> true
+
+#  197| access to property Length
+#-----|  -> 0
+
+#  197| access to field Field
+#-----|  -> access to property Length
+
+#  197| this access
+#-----|  -> access to field Field
+
+#  197| 0
+#-----|  -> ... == ...
+
+#  197| false
+#-----| false -> [false] ... ? ... : ...
+
+#  197| true
+#-----| true -> [true] ... ? ... : ...
+
+#  198| ...;
+#-----|  -> this access
+
+#  198| ... = ...
+#-----|  -> if (...) ...
+
+#  198| ... ? ... : ...
+#-----|  -> ... = ...
+
+#  198| ... == ...
+#-----| true -> false
+#-----| false -> true
+
+#  198| access to property Length
+#-----|  -> 0
+
+#  198| access to field Field
+#-----|  -> access to property Length
+
+#  198| this access
+#-----|  -> access to field Field
+
+#  198| 0
+#-----|  -> ... == ...
+
+#  198| false
+#-----|  -> ... ? ... : ...
+
+#  198| true
+#-----|  -> ... ? ... : ...
+
+#  200| if (...) ...
+#-----|  -> this access
+
+#  200| [false] ... || ...
+#-----| false -> exit Booleans (normal)
+
+#  200| [true] ... || ...
+#-----| true -> {...}
+
+#  200| [false] !...
+#-----| false -> this access
+
+#  200| [true] !...
+#-----| true -> [true] ... || ...
+
+#  200| ... == ...
+#-----| true -> [false] !...
+#-----| false -> [true] !...
+
+#  200| access to property Length
+#-----|  -> 0
+
+#  200| access to field Field
+#-----|  -> access to property Length
+
+#  200| this access
+#-----|  -> access to field Field
+
+#  200| 0
+#-----|  -> ... == ...
+
+#  200| [false] !...
+#-----| false -> [false] ... || ...
+
+#  200| [true] !...
+#-----| true -> [true] ... || ...
+
+#  200| [false] !...
+#-----| false -> [true] !...
+
+#  200| [true] !...
+#-----| true -> [false] !...
+
+#  200| [false] ... && ...
+#-----| false -> [true] !...
+
+#  200| [true] ... && ...
+#-----| true -> [false] !...
+
+#  200| ... == ...
+#-----| false -> [false] ... && ...
+#-----| true -> access to local variable b
+
+#  200| access to property Length
+#-----|  -> 1
+
+#  200| access to field Field
+#-----|  -> access to property Length
+
+#  200| this access
+#-----|  -> access to field Field
+
+#  200| 1
+#-----|  -> ... == ...
+
+#  200| access to local variable b
+#-----| false -> [false] ... && ...
+#-----| true -> [true] ... && ...
+
+#  201| {...}
+#-----|  -> {...}
+
+#  202| {...}
+#-----|  -> object creation of type Exception
+
+#  203| throw ...;
+#-----| exception(Exception) -> exit Booleans (abnormal)
+
+#  203| object creation of type Exception
+#-----|  -> throw ...;
+
+#  208| enter Do
+#-----|  -> {...}
+
+#  208| exit Do
+
+#  208| exit Do (normal)
+#-----|  -> exit Do
+
+#  209| {...}
+#-----|  -> do ... while (...);
+
+#  210| do ... while (...);
+#-----|  -> {...}
+
+#  211| {...}
+#-----|  -> ...;
+
+#  212| ...;
+#-----|  -> this access
+
+#  212| ... = ...
+#-----|  -> if (...) ...
+
+#  212| this access
+#-----|  -> this access
+
+#  212| ... + ...
+#-----|  -> ... = ...
+
+#  212| access to field Field
+#-----|  -> "a"
+
+#  212| this access
+#-----|  -> access to field Field
+
+#  212| "a"
+#-----|  -> ... + ...
+
+#  213| if (...) ...
+#-----|  -> this access
+
+#  213| ... > ...
+#-----| true -> {...}
+#-----| false -> if (...) ...
+
+#  213| access to property Length
+#-----|  -> 0
+
+#  213| access to field Field
+#-----|  -> access to property Length
+
+#  213| this access
+#-----|  -> access to field Field
+
+#  213| 0
+#-----|  -> ... > ...
+
+#  214| {...}
+#-----|  -> continue;
+
+#  215| continue;
+#-----| continue -> this access
+
+#  217| if (...) ...
+#-----|  -> this access
+
+#  217| ... < ...
+#-----| true -> {...}
+#-----| false -> this access
+
+#  217| access to property Length
+#-----|  -> 0
+
+#  217| access to field Field
+#-----|  -> access to property Length
+
+#  217| this access
+#-----|  -> access to field Field
+
+#  217| 0
+#-----|  -> ... < ...
+
+#  218| {...}
+#-----|  -> break;
+
+#  219| break;
+#-----| break -> exit Do (normal)
+
+#  221| ... < ...
+#-----| true -> {...}
+#-----| false -> exit Do (normal)
+
+#  221| access to property Length
+#-----|  -> 10
+
+#  221| access to field Field
+#-----|  -> access to property Length
+
+#  221| this access
+#-----|  -> access to field Field
+
+#  221| 10
+#-----|  -> ... < ...
+
+#  224| enter Foreach
+#-----|  -> {...}
+
+#  224| exit Foreach
+
+#  224| exit Foreach (normal)
+#-----|  -> exit Foreach
+
+#  225| {...}
+#-----|  -> "a"
+
+#  226| foreach (... ... in ...) ...
+#-----| non-empty -> String x
+#-----| empty -> exit Foreach (normal)
+
+#  226| String x
+#-----|  -> {...}
+
+#  226| call to method Repeat
+#-----|  -> foreach (... ... in ...) ...
+
+#  226| "a"
+#-----|  -> 10
+
+#  226| 10
+#-----|  -> call to method Repeat
+
+#  227| {...}
+#-----|  -> ...;
+
+#  228| ...;
+#-----|  -> this access
+
+#  228| ... = ...
+#-----|  -> if (...) ...
+
+#  228| this access
+#-----|  -> this access
+
+#  228| ... + ...
+#-----|  -> ... = ...
+
+#  228| access to field Field
+#-----|  -> access to local variable x
+
+#  228| this access
+#-----|  -> access to field Field
+
+#  228| access to local variable x
+#-----|  -> ... + ...
+
+#  229| if (...) ...
+#-----|  -> this access
+
+#  229| ... > ...
+#-----| true -> {...}
+#-----| false -> if (...) ...
+
+#  229| access to property Length
+#-----|  -> 0
+
+#  229| access to field Field
+#-----|  -> access to property Length
+
+#  229| this access
+#-----|  -> access to field Field
+
+#  229| 0
+#-----|  -> ... > ...
+
+#  230| {...}
+#-----|  -> continue;
+
+#  231| continue;
+#-----| continue -> foreach (... ... in ...) ...
+
+#  233| if (...) ...
+#-----|  -> this access
+
+#  233| ... < ...
+#-----| false -> foreach (... ... in ...) ...
+#-----| true -> {...}
+
+#  233| access to property Length
+#-----|  -> 0
+
+#  233| access to field Field
+#-----|  -> access to property Length
+
+#  233| this access
+#-----|  -> access to field Field
+
+#  233| 0
+#-----|  -> ... < ...
+
+#  234| {...}
+#-----|  -> break;
+
+#  235| break;
+#-----| break -> exit Foreach (normal)
+
+#  240| enter Goto
+#-----|  -> {...}
+
+#  240| exit Goto
+
+#  240| exit Goto (normal)
+#-----|  -> exit Goto
+
+#  241| {...}
+#-----|  -> Label:
+
+#  242| Label:
+#-----|  -> if (...) ...
+
+#  242| if (...) ...
+#-----|  -> this access
+
+#  242| [false] !...
+#-----| false -> if (...) ...
+
+#  242| [true] !...
+#-----| true -> {...}
+
+#  242| [false] !...
+#-----| false -> [true] !...
+
+#  242| [true] !...
+#-----| true -> [false] !...
+
+#  242| ... == ...
+#-----| true -> [false] !...
+#-----| false -> [true] !...
+
+#  242| access to property Length
+#-----|  -> 0
+
+#  242| access to field Field
+#-----|  -> access to property Length
+
+#  242| this access
+#-----|  -> access to field Field
+
+#  242| 0
+#-----|  -> ... == ...
+
+#  242| {...}
+#-----|  -> if (...) ...
+
+#  244| if (...) ...
+#-----|  -> this access
+
+#  244| ... > ...
+#-----| true -> goto ...;
+#-----| false -> switch (...) {...}
+
+#  244| access to property Length
+#-----|  -> 0
+
+#  244| access to field Field
+#-----|  -> access to property Length
+
+#  244| this access
+#-----|  -> access to field Field
+
+#  244| 0
+#-----|  -> ... > ...
+
+#  244| goto ...;
+#-----| goto(Label) -> Label:
+
+#  246| switch (...) {...}
+#-----|  -> this access
+
+#  246| ... + ...
+#-----|  -> case ...:
+
+#  246| access to property Length
+#-----|  -> 3
+
+#  246| access to field Field
+#-----|  -> access to property Length
+
+#  246| this access
+#-----|  -> access to field Field
+
+#  246| 3
+#-----|  -> ... + ...
+
+#  248| case ...:
+#-----|  -> 0
+
+#  248| 0
+#-----| match -> goto default;
+#-----| no-match -> case ...:
+
+#  249| goto default;
+#-----| goto(default) -> default:
+
+#  250| case ...:
+#-----|  -> 1
+
+#  250| 1
+#-----| match -> ...;
+#-----| no-match -> case ...:
+
+#  251| ...;
+#-----|  -> 1
+
+#  251| call to method WriteLine
+#-----|  -> break;
+
+#  251| 1
+#-----|  -> call to method WriteLine
+
+#  252| break;
+#-----| break -> exit Goto (normal)
+
+#  253| case ...:
+#-----|  -> 2
+
+#  253| 2
+#-----| match -> goto ...;
+#-----| no-match -> default:
+
+#  254| goto ...;
+#-----| goto(Label) -> Label:
+
+#  255| default:
+#-----|  -> ...;
+
+#  256| ...;
+#-----|  -> 0
+
+#  256| call to method WriteLine
+#-----|  -> break;
+
+#  256| 0
+#-----|  -> call to method WriteLine
+
+#  257| break;
+#-----| break -> exit Goto (normal)
+
+#  261| enter Yield
+#-----|  -> {...}
+
+#  261| exit Yield
+
+#  261| exit Yield (normal)
+#-----|  -> exit Yield
+
+#  262| {...}
+#-----|  -> 0
+
+#  263| yield return ...;
+#-----|  -> for (...;...;...) ...
+
+#  263| 0
+#-----|  -> yield return ...;
+
+#  264| for (...;...;...) ...
+#-----|  -> 1
+
+#  264| Int32 i = ...
+#-----|  -> access to local variable i
+
+#  264| 1
+#-----|  -> Int32 i = ...
+
+#  264| ... < ...
+#-----| true -> {...}
+#-----| false -> try {...} ...
+
+#  264| access to local variable i
+#-----|  -> 10
+
+#  264| 10
+#-----|  -> ... < ...
+
+#  264| ...++
+#-----|  -> access to local variable i
+
+#  264| access to local variable i
+#-----|  -> ...++
+
+#  265| {...}
+#-----|  -> access to local variable i
+
+#  266| yield return ...;
+#-----|  -> access to local variable i
+
+#  266| access to local variable i
+#-----|  -> yield return ...;
+
+#  268| try {...} ...
+#-----|  -> {...}
+
+#  269| {...}
+#-----|  -> yield break;
+
+#  270| yield break;
+#-----| return -> [finally: return] {...}
+
+#  274| [finally: return] {...}
+#-----|  -> [finally: return] ...;
+
+#  275| [finally: return] ...;
+#-----|  -> [finally: return] "not dead"
+
+#  275| [finally: return] call to method WriteLine
+#-----| return -> exit Yield (normal)
+
+#  275| [finally: return] "not dead"
+#-----|  -> [finally: return] call to method WriteLine
+
+#  282| enter ControlFlowSub
+#-----|  -> call to constructor ControlFlow
+
+#  282| exit ControlFlowSub
+
+#  282| exit ControlFlowSub (normal)
+#-----|  -> exit ControlFlowSub
+
+#  282| call to constructor ControlFlow
+#-----|  -> {...}
+
+#  282| {...}
+#-----|  -> exit ControlFlowSub (normal)
+
+#  284| enter ControlFlowSub
+#-----|  -> call to constructor ControlFlowSub
+
+#  284| exit ControlFlowSub
+
+#  284| exit ControlFlowSub (normal)
+#-----|  -> exit ControlFlowSub
+
+#  284| call to constructor ControlFlowSub
+#-----|  -> {...}
+
+#  284| {...}
+#-----|  -> exit ControlFlowSub (normal)
+
+#  286| enter ControlFlowSub
+#-----|  -> access to parameter i
+
+#  286| exit ControlFlowSub
+
+#  286| exit ControlFlowSub (normal)
+#-----|  -> exit ControlFlowSub
+
+#  286| call to constructor ControlFlowSub
+#-----|  -> {...}
+
+#  286| call to method ToString
+#-----|  -> call to constructor ControlFlowSub
+
+#  286| access to parameter i
+#-----|  -> call to method ToString
+
+#  286| {...}
+#-----|  -> exit ControlFlowSub (normal)
+
+#  291| enter M
+#-----|  -> access to parameter f
+
+#  291| exit M
+
+#  291| exit M (normal)
+#-----|  -> exit M
+
+#  291| delegate call
+#-----|  -> exit M (normal)
+
+#  291| access to parameter f
+#-----|  -> 0
+
+#  291| 0
+#-----|  -> delegate call
+
+#  296| enter NegationInConstructor
+#-----|  -> call to constructor Object
+
+#  296| call to constructor Object
+#-----|  -> {...}
+
+#  296| exit NegationInConstructor
+
+#  296| exit NegationInConstructor (normal)
+#-----|  -> exit NegationInConstructor
+
+#  296| {...}
+#-----|  -> exit NegationInConstructor (normal)
+
+#  298| enter M
+#-----|  -> {...}
+
+#  298| exit M
+
+#  298| exit M (normal)
+#-----|  -> exit M
+
+#  299| {...}
+#-----|  -> ...;
+
+#  300| ...;
+#-----|  -> 0
+
+#  300| object creation of type NegationInConstructor
+#-----|  -> exit M (normal)
+
+#  300| 0
+#-----|  -> access to parameter i
+
+#  300| ... && ...
+#-----|  -> ""
+
+#  300| [false] !...
+#-----| false -> ... && ...
+
+#  300| [true] !...
+#-----| true -> access to parameter s
+
+#  300| ... > ...
+#-----| true -> [false] !...
+#-----| false -> [true] !...
+
+#  300| access to parameter i
+#-----|  -> 0
+
+#  300| 0
+#-----|  -> ... > ...
+
+#  300| ... != ...
+#-----|  -> ... && ...
+
+#  300| access to parameter s
+#-----|  -> null
+
+#  300| null
+#-----|  -> ... != ...
+
+#  300| ""
+#-----|  -> object creation of type NegationInConstructor

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2821,6 +2821,7 @@
 | Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:59:15:60 | "" | semmle.label | successor |
 | Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:37:15:63 | { ..., ... } | semmle.label | successor |
 | Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers | semmle.label | successor |
+| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:20:18:20 | 1 | semmle.label | successor |
 | Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | semmle.label | successor |
 | Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
 | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.ql
@@ -1,11 +1,9 @@
+/**
+ * @kind graph
+ */
+
 import csharp
 import Common
+import semmle.code.csharp.controlflow.internal.ControlFlowGraphImplShared::TestOutput
 
-query predicate edges(
-  SourceControlFlowNode node, SourceControlFlowNode successor, string attr, string val
-) {
-  exists(ControlFlow::SuccessorType t | successor = node.getASuccessorByType(t) |
-    attr = "semmle.label" and
-    val = t.toString()
-  )
-}
+private class MyRelevantNode extends RelevantNode, SourceControlFlowNode { }


### PR DESCRIPTION
The PR moves the language agnostic features of `ControlFlowGraphImpl.qll` (as well as consistency tests) into a sharable `ControlFlowGraphImplShared.qll`. It contains an interface for constructing a simple CFG (`first`, `last`, and `succ`), as well as optional functionality for adding CFG splitting.

The two commits should be reviewed individually.

~https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1272/~
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1288/