### PR TITLE
C++: Clarify difference between 'Initializer' and 'Assignment'.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Initializer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Initializer.qll
@@ -18,6 +18,12 @@ import semmle.code.cpp.controlflow.ControlFlowGraph
  *   ...
  * }
  * ```
+ * But _not_ `4` in the following code:
+ * ```
+ * int myUninitializedVariable;
+ * myUninitializedVariable = 4;
+ * ```
+ * Instead, this is an `Assignment`.
  */
 class Initializer extends ControlFlowNode, @initialiser {
   override Location getLocation() { initialisers(underlyingElement(this), _, _, result) }

--- a/cpp/ql/lib/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Variable.qll
@@ -140,7 +140,8 @@ class Variable extends Declaration, @variable {
    * This does _not_ include the initialization of the variable. Use
    * `Variable.getInitializer()` to get the variable's initializer,
    * or use `Variable.getAnAssignedValue()` to get an expression that
-   * is assigned to this variable somewhere in the program.
+   * is the right-hand side of an assignment or an initialization of
+   * the varible.
    */
   Assignment getAnAssignment() { result.getLValue() = this.getAnAccess() }
 

--- a/cpp/ql/lib/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Variable.qll
@@ -138,7 +138,9 @@ class Variable extends Declaration, @variable {
    * For example: `x=...` or `x+=...`.
    *
    * This does _not_ include the initialization of the variable. Use
-   * `Variable.getInitializer()` to get the variable's initializer.
+   * `Variable.getInitializer()` to get the variable's initializer,
+   * or use `Variable.getAnAssignedValue()` to get an expression that
+   * is assigned to this variable somewhere in the program.
    */
   Assignment getAnAssignment() { result.getLValue() = this.getAnAccess() }
 

--- a/cpp/ql/lib/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Variable.qll
@@ -136,6 +136,9 @@ class Variable extends Declaration, @variable {
   /**
    * Gets an assignment expression that assigns to this variable.
    * For example: `x=...` or `x+=...`.
+   *
+   * This does _not_ include the initialization of the variable. Use
+   * `Variable.getInitializer()` to get the variable's initializer.
    */
   Assignment getAnAssignment() { result.getLValue() = this.getAnAccess() }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Assignment.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Assignment.qll
@@ -5,7 +5,8 @@ import semmle.code.cpp.exprs.BitwiseOperation
 /**
  * A non-overloaded binary assignment operation, including `=`, `+=`, `&=`,
  * etc. A C++ overloaded assignment operation looks syntactically identical but is instead
- * a `FunctionCall`.
+ * a `FunctionCall`. This class does _not_ include variable initializers. To get a variable
+ * initializer, use `Initializer` instead.
  *
  * This is a QL base class for all (non-overloaded) assignments.
  */
@@ -34,6 +35,8 @@ class Assignment extends Operation, @assign_expr {
  * ```
  * a = b;
  * ```
+ * Note that `int a = b;` _not_ an `AssignExpr`. It is a `Variable`,
+ * and `b` can be obtained using `Variable.getInitializer()`.
  */
 class AssignExpr extends Assignment, @assignexpr {
   override string getOperator() { result = "=" }
@@ -46,6 +49,9 @@ class AssignExpr extends Assignment, @assignexpr {
 
 /**
  * A non-overloaded binary assignment operation other than `=`.
+ *
+ * This class does _not_ include variable initializers. To get a variable
+ * initializer, use `Initializer` instead.
  */
 class AssignOperation extends Assignment, @assign_op_expr {
   override string toString() { result = "... " + this.getOperator() + " ..." }

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Assignment.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Assignment.qll
@@ -35,7 +35,7 @@ class Assignment extends Operation, @assign_expr {
  * ```
  * a = b;
  * ```
- * Note that `int a = b;` _not_ an `AssignExpr`. It is a `Variable`,
+ * Note that `int a = b;` is _not_ an `AssignExpr`. It is a `Variable`,
  * and `b` can be obtained using `Variable.getInitializer()`.
  */
 class AssignExpr extends Assignment, @assignexpr {


### PR DESCRIPTION
https://github.com/github/codeql/issues/6510 mentioned that our distinction between a variable _assignment_, and a variable _initialization_ isn't obvious to new users. This PR addresses part of this problem by clarifying this distinction in the QLDoc for those classes.

The issue also suggests making a common class that captures both assignments and initializers. I haven't done that yet, but if this is something we want to do I'd be happy to do this as a follow-up to this PR.