### PR TITLE
Docs: Minor tweaks to VS Code docs (query history + viewing results)

### DIFF
--- a/docs/codeql/codeql-for-visual-studio-code/analyzing-your-projects.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/analyzing-your-projects.rst
@@ -129,12 +129,14 @@ To remove queries from the Query History view, select all the queries you want t
 Viewing query results
 -----------------------
 
-#. Click a query in the Query History view to display its results in the Results view. Alternatively, right-click the result to select a different view:
+#. Click a query in the Query History view to display its results in the Results view.
 
-   - To view the results in :ref:`SARIF format <sarif-output>`, right-click and select **View SARIF**.
-   - To view the results in :ref:`DIL format <dil>`, right-click and select **View DIL**.
+   .. pull-quote:: Note
 
-#. Use the dropdown menu in the Results view to choose which results to display, and in what form to display them, such as a formatted alert message or a table of raw results. The available output forms are specified by the format of the query and the metadata. For more information, see ":ref:`CodeQL queries <codeql-queries>`."
+      Depending on the query, you can also choose different views such as CSV, :ref:`SARIF <sarif-output>`, or :ref:`DIL format <dil>`. For example, to view the DIL format, right-click a result and select **View DIL**.
+      The available output views are determined by the format of the query and the metadata. For more information, see ":ref:`CodeQL queries <codeql-queries>`."
+
+#. Use the dropdown menu in the Results view to choose which results to display, and in what form to display them, such as a formatted alert message or a table of raw results.
 
 #. To sort the results by the entries in a particular column, click the column header.
 

--- a/docs/codeql/codeql-for-visual-studio-code/analyzing-your-projects.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/analyzing-your-projects.rst
@@ -134,7 +134,7 @@ Viewing query results
    .. pull-quote:: Note
 
       Depending on the query, you can also choose different views such as CSV, :ref:`SARIF <sarif-output>`, or :ref:`DIL format <dil>`. For example, to view the DIL format, right-click a result and select **View DIL**.
-      The available output views are determined by the format of the query and the metadata. For more information, see ":ref:`CodeQL queries <codeql-queries>`."
+      The available output views are determined by the format and the metadata of the query. For more information, see ":ref:`CodeQL queries <codeql-queries>`."
 
 #. Use the dropdown menu in the Results view to choose which results to display, and in what form to display them, such as a formatted alert message or a table of raw results.
 

--- a/docs/codeql/codeql-for-visual-studio-code/customizing-settings.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/customizing-settings.rst
@@ -37,12 +37,13 @@ Changing the labels of query history items
 
 The query history **Format** setting controls how the extension lists queries in the query history. By default, each item has a label with the following format::
     
-    [%t] %q on %d - %s
-  
-- ``%t`` is the time the query was run
+    %q on %d - %s, %r result count [%t]
+
 - ``%q`` is the query name
 - ``%d`` is the database name
 - ``%s`` is a status string
+- ``%r`` is the number of results
+- ``%t`` is the time the query was run
 
 To override the default label, you can specify a different format for the query history items.
 


### PR DESCRIPTION
I noticed a few areas where the docs were outdated:

- In "[Customizing settings](https://codeql.github.com/docs/codeql-for-visual-studio-code/customizing-settings/)", the [default](https://github.com/github/vscode-codeql/blob/089b23f0aa31a23706ad3b2d3430b67615f3f749/extensions/ql-vscode/package.json#L208) query history label was changed a while ago.
- In "[Viewing query results](https://codeql.github.com/docs/codeql-for-visual-studio-code/analyzing-your-projects/#viewing-query-results)", the command for viewing SARIF has changed name and there's also an option to view CSV. (I've been deliberately vague about the command name for CSV, since it could be **View Alerts** or **View Results**, depending on how the query is structured. (Which should also help future-proof the docs if the command names change again!)
I've also pulled this info about different views into a **Note** (in an attempt to declutter the actual steps), but other suggestions are welcome 😅 
![image](https://user-images.githubusercontent.com/42641846/130122357-98b525f2-32b1-4746-aef2-2d4c90633527.png)

PS: This can ship any time. I noticed these changes because of recent PRs in this general area (https://github.com/github/vscode-codeql/pull/930 and https://github.com/github/vscode-codeql/pull/929), but the docs change is valid now already!