### PR TITLE
JS: add the cwd option to shell executions as a sink to js/path-injection

### DIFF
--- a/javascript/change-notes/2021-08-24-tainted-path-cwd.md
+++ b/javascript/change-notes/2021-08-24-tainted-path-cwd.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The `js/tainted-path` query now recognizes the `cwd` option to shell invocations as a sink.

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -697,6 +697,18 @@ module TaintedPath {
   }
 
   /**
+   * The `cwd` option to a shell execution.
+   */
+  private class ShellCwdSink extends TaintedPath::Sink {
+    ShellCwdSink() {
+      exists(SystemCommandExecution sys, API::Node opts |
+        opts.getARhs() = sys.getOptionsArg() and // assuming that an API::Node exists here.
+        this = opts.getMember("cwd").getARhs()
+      )
+    }
+  }
+
+  /**
    * Holds if there is a step `src -> dst` mapping `srclabel` to `dstlabel` relevant for path traversal vulnerabilities.
    */
   predicate isAdditionalTaintedPathFlowStep(

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1415,6 +1415,126 @@ nodes
 | TaintedPath.js:206:44:206:50 | req.url |
 | TaintedPath.js:206:44:206:50 | req.url |
 | TaintedPath.js:206:44:206:50 | req.url |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:24:211:30 | req.url |
+| TaintedPath.js:211:24:211:30 | req.url |
+| TaintedPath.js:211:24:211:30 | req.url |
+| TaintedPath.js:211:24:211:30 | req.url |
+| TaintedPath.js:211:24:211:30 | req.url |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:214:35:214:38 | path |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
@@ -6012,6 +6132,182 @@ edges
 | TaintedPath.js:206:44:206:50 | req.url | TaintedPath.js:206:29:206:51 | parseqs ... eq.url) |
 | TaintedPath.js:206:44:206:50 | req.url | TaintedPath.js:206:29:206:51 | parseqs ... eq.url) |
 | TaintedPath.js:206:44:206:50 | req.url | TaintedPath.js:206:29:206:51 | parseqs ... eq.url) |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:212:31:212:34 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:213:45:213:48 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:7:211:48 | path | TaintedPath.js:214:35:214:38 | path |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:37 | url.par ... , true) | TaintedPath.js:211:14:211:43 | url.par ... ).query |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:43 | url.par ... ).query | TaintedPath.js:211:14:211:48 | url.par ... ry.path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:14:211:48 | url.par ... ry.path | TaintedPath.js:211:7:211:48 | path |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
+| TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:211:14:211:37 | url.par ... , true) |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
@@ -9312,6 +9608,9 @@ edges
 | TaintedPath.js:203:29:203:49 | qs.pars ... rl).foo | TaintedPath.js:203:38:203:44 | req.url | TaintedPath.js:203:29:203:49 | qs.pars ... rl).foo | This path depends on $@. | TaintedPath.js:203:38:203:44 | req.url | a user-provided value |
 | TaintedPath.js:204:29:204:63 | qs.pars ... l)).foo | TaintedPath.js:204:51:204:57 | req.url | TaintedPath.js:204:29:204:63 | qs.pars ... l)).foo | This path depends on $@. | TaintedPath.js:204:51:204:57 | req.url | a user-provided value |
 | TaintedPath.js:206:29:206:55 | parseqs ... rl).foo | TaintedPath.js:206:44:206:50 | req.url | TaintedPath.js:206:29:206:55 | parseqs ... rl).foo | This path depends on $@. | TaintedPath.js:206:44:206:50 | req.url | a user-provided value |
+| TaintedPath.js:212:31:212:34 | path | TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:212:31:212:34 | path | This path depends on $@. | TaintedPath.js:211:24:211:30 | req.url | a user-provided value |
+| TaintedPath.js:213:45:213:48 | path | TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:213:45:213:48 | path | This path depends on $@. | TaintedPath.js:211:24:211:30 | req.url | a user-provided value |
+| TaintedPath.js:214:35:214:38 | path | TaintedPath.js:211:24:211:30 | req.url | TaintedPath.js:214:35:214:38 | path | This path depends on $@. | TaintedPath.js:211:24:211:30 | req.url | a user-provided value |
 | normalizedPaths.js:13:19:13:22 | path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:13:19:13:22 | path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:14:19:14:29 | './' + path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:14:19:14:29 | './' + path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:15:19:15:38 | path + '/index.html' | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:15:19:15:38 | path + '/index.html' | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
@@ -205,3 +205,11 @@ var server = http.createServer(function(req, res) {
   const parseqs = require("parseqs");
   res.write(fs.readFileSync(parseqs.decode(req.url).foo)); // NOT OK
 });
+
+const cp = require("child_process");
+var server = http.createServer(function(req, res) {
+  let path = url.parse(req.url, true).query.path;
+  cp.execSync("foobar", {cwd: path}); // NOT OK
+  cp.execFileSync("foobar", ["args"], {cwd: path}); // NOT OK
+  cp.execFileSync("foobar", {cwd: path}); // NOT OK
+});


### PR DESCRIPTION
Recognizes the sink for CVE-2021-32662

[Evaluation looks clean](https://github.com/dsp-testing/erik-krogh-dca/tree/run/pr-6533-32ac877__nightly__CustomSuite/reports). 