### PR TITLE
All languages: Add getPrimaryQlClasses()

### DIFF
--- a/cpp/change-notes/2021-08-23-getPrimaryQlClasses.md
+++ b/cpp/change-notes/2021-08-23-getPrimaryQlClasses.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* Added `ElementBase.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
+* Added `Element.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.

--- a/cpp/change-notes/2021-08-23-getPrimaryQlClasses.md
+++ b/cpp/change-notes/2021-08-23-getPrimaryQlClasses.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added `ElementBase.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.

--- a/cpp/ql/lib/semmle/code/cpp/Element.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Element.qll
@@ -59,6 +59,11 @@ class ElementBase extends @element {
   deprecated string getCanonicalQLClass() { result = this.getAPrimaryQlClass() }
 
   /**
+   * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
+   */
+  final string getPrimaryQlClasses() { result = concat(getAPrimaryQlClass(), ",") }
+
+  /**
    * Gets the name of a primary CodeQL class to which this element belongs.
    *
    * For most elements, this is simply the most precise syntactic category to

--- a/csharp/change-notes/2021-08-23-getPrimaryQlClasses.md
+++ b/csharp/change-notes/2021-08-23-getPrimaryQlClasses.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added `Element.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.

--- a/csharp/ql/lib/semmle/code/cil/ConsistencyChecks.qll
+++ b/csharp/ql/lib/semmle/code/cil/ConsistencyChecks.qll
@@ -670,7 +670,7 @@ class MissingCilDeclaration extends ConsistencyViolation, MissingCSharpCheck {
   override string getMessage() {
     result =
       "Cannot locate CIL for " + getDeclaration().toStringWithTypes() + " of class " +
-        getDeclaration().getAPrimaryQlClass()
+        getDeclaration().getPrimaryQlClasses()
   }
 
   override string toString() { result = getDeclaration().toStringWithTypes() }

--- a/csharp/ql/lib/semmle/code/csharp/PrintAst.qll
+++ b/csharp/ql/lib/semmle/code/csharp/PrintAst.qll
@@ -61,7 +61,7 @@ private predicate isNotNeeded(Element e) {
  * Retrieves the canonical QL class(es) for entity `el`
  */
 private string getQlClass(Element el) {
-  result = "[" + concat(el.getAPrimaryQlClass(), ",") + "] "
+  result = "[" + el.getPrimaryQlClasses() + "] "
   // Alternative implementation -- do not delete. It is useful for QL class discovery.
   // result = "["+ concat(el.getAQlClass(), ",") + "] "
 }

--- a/csharp/ql/lib/semmle/code/dotnet/Element.qll
+++ b/csharp/ql/lib/semmle/code/dotnet/Element.qll
@@ -41,6 +41,11 @@ class Element extends @dotnet_element {
   string toStringWithTypes() { result = this.toString() }
 
   /**
+   * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
+   */
+  final string getPrimaryQlClasses() { result = concat(getAPrimaryQlClass(), ",") }
+
+  /**
    * Gets the name of a primary CodeQL class to which this element belongs.
    *
    * For most elements, this is simply the most precise syntactic category to

--- a/csharp/ql/test/library-tests/generics/ConsistencyChecks.ql
+++ b/csharp/ql/test/library-tests/generics/ConsistencyChecks.ql
@@ -6,4 +6,4 @@ import semmle.code.csharp.commons.ConsistencyChecks
 
 from Element e, string m
 where consistencyFailure(e, m)
-select e, "Element class " + e.getAPrimaryQlClass() + " has consistency check failed: " + m
+select e, "Element class " + e.getPrimaryQlClasses() + " has consistency check failed: " + m

--- a/java/change-notes/2021-08-23-getPrimaryQlClasses.md
+++ b/java/change-notes/2021-08-23-getPrimaryQlClasses.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added `Top.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.

--- a/java/ql/lib/semmle/code/Location.qll
+++ b/java/ql/lib/semmle/code/Location.qll
@@ -101,6 +101,11 @@ class Top extends @top {
   string toString() { hasName(this, result) }
 
   /**
+   * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
+   */
+  final string getPrimaryQlClasses() { result = concat(getAPrimaryQlClass(), ",") }
+
+  /**
    * Gets the name of a primary CodeQL class to which this element belongs.
    *
    * For most elements, this is simply the most precise syntactic category to

--- a/java/ql/lib/semmle/code/java/PrintAst.qll
+++ b/java/ql/lib/semmle/code/java/PrintAst.qll
@@ -89,7 +89,7 @@ private predicate duplicateMetadata(Field f) {
  * Retrieves the canonical QL class(es) for entity `el`
  */
 private string getQlClass(Top el) {
-  result = "[" + concat(el.getAPrimaryQlClass(), ",") + "] "
+  result = "[" + el.getPrimaryQlClasses() + "] "
   // Alternative implementation -- do not delete. It is useful for QL class discovery.
   // result = "[" + concat(el.getAQlClass(), ",") + "] "
 }

--- a/javascript/change-notes/2021-08-23-getPrimaryQlClasses.md
+++ b/javascript/change-notes/2021-08-23-getPrimaryQlClasses.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added `Locatable.getPrimaryQlClasses()` predicate, which gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.

--- a/javascript/ql/src/semmle/javascript/Locations.qll
+++ b/javascript/ql/src/semmle/javascript/Locations.qll
@@ -133,6 +133,11 @@ class Locatable extends @locatable {
   }
 
   /**
+   * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
+   */
+  final string getPrimaryQlClasses() { result = concat(getAPrimaryQlClass(), ",") }
+
+  /**
    * Gets the primary QL class for the Locatable.
    */
   string getAPrimaryQlClass() { result = "???" }

--- a/javascript/ql/src/semmle/javascript/PrintAst.qll
+++ b/javascript/ql/src/semmle/javascript/PrintAst.qll
@@ -44,9 +44,9 @@ private predicate isNotNeeded(Locatable el) {
  * Retrieves the canonical QL class(es) for entity `el`
  */
 private string getQlClass(Locatable el) {
-  result = "[" + concat(el.getAPrimaryQlClass(), ",") + "] "
+  result = "[" + el.getPrimaryQlClasses() + "] "
   // Alternative implementation -- do not delete. It is useful for QL class discovery.
-  // not el.getAPrimaryQlClass() = "???" and result = "[" + concat(el.getAPrimaryQlClass(), ",") + "] " or el.getAPrimaryQlClass() = "???" and result = "??[" + concat(el.getAQlClass(), ",") + "] "
+  // not el.getAPrimaryQlClass() = "???" and result = "[" + getPrimaryQlClasses() + "] " or el.getAPrimaryQlClass() = "???" and result = "??[" + concat(el.getAQlClass(), ",") + "] "
 }
 
 /**


### PR DESCRIPTION
This is a non-overridable predicate that concatenates all the `getAPrimaryQlClass()` results into a comma-separated string.