### PR TITLE
Implicit downcast involving references

### DIFF
--- a/cpp/change-notes/2021-08-24-implicit-downcast-from-bitfield.md
+++ b/cpp/change-notes/2021-08-24-implicit-downcast-from-bitfield.md
@@ -1,3 +1,2 @@
 lgtm,codescanning
-* Extend query `ImplicitDowncastFromBitfield` to detect implicit
-  downcast on references
+* The query `cpp/implicit-bitfield-downcast` now accounts for C++ reference types, which leads to more true positive results.

--- a/cpp/change-notes/2021-08-24-implicit-downcast-from-bitfield.md
+++ b/cpp/change-notes/2021-08-24-implicit-downcast-from-bitfield.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Extend query `ImplicitDowncastFromBitfield` to detect implicit
+  downcast on references

--- a/cpp/ql/src/Likely Bugs/Conversion/ImplicitDowncastFromBitfield.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/ImplicitDowncastFromBitfield.ql
@@ -13,10 +13,16 @@
 
 import cpp
 
-from BitField fi, VariableAccess va
+from BitField fi, VariableAccess va, Type fct
 where
-  fi.getNumBits() > va.getFullyConverted().getType().getSize() * 8 and
-  va.getExplicitlyConverted().getType().getSize() > va.getFullyConverted().getType().getSize() and
+  (
+    if va.getFullyConverted().getType() instanceof ReferenceType
+    then fct = va.getFullyConverted().getType().(ReferenceType).getBaseType()
+    else fct = va.getFullyConverted().getType()
+  ) and
+  fi.getNumBits() > fct.getSize() * 8 and
+  va.getExplicitlyConverted().getType().getSize() > fct.getSize() and
   va.getTarget() = fi and
-  not va.getActualType() instanceof BoolType
+  not fct.getUnspecifiedType() instanceof BoolType and
+  any()
 select va, "Implicit downcast of bitfield $@", fi, fi.toString()

--- a/cpp/ql/src/Likely Bugs/Conversion/ImplicitDowncastFromBitfield.ql
+++ b/cpp/ql/src/Likely Bugs/Conversion/ImplicitDowncastFromBitfield.ql
@@ -23,6 +23,5 @@ where
   fi.getNumBits() > fct.getSize() * 8 and
   va.getExplicitlyConverted().getType().getSize() > fct.getSize() and
   va.getTarget() = fi and
-  not fct.getUnspecifiedType() instanceof BoolType and
-  any()
+  not fct.getUnspecifiedType() instanceof BoolType
 select va, "Implicit downcast of bitfield $@", fi, fi.toString()

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/ImplicitDowncastFromBitfield.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/ImplicitDowncastFromBitfield.expected
@@ -1,1 +1,2 @@
 | test.cpp:10:11:10:11 | x | Implicit downcast of bitfield $@ | test.cpp:2:6:2:6 | x | x |
+| test.cpp:26:25:26:25 | x | Implicit downcast of bitfield $@ | test.cpp:2:6:2:6 | x | x |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/test.cpp
@@ -2,22 +2,42 @@ typedef struct {
 	int x : 24;
 } my_struct;
 
-int getX1(my_struct m) {
+unsigned int getX1(my_struct m) {
 	return m.x;
 }
 
 short getX2(my_struct m) {
-	return m.x;
+	return m.x; // BAD
 }
 
 short getX3(my_struct m) {
-	return (short) m.x;
+	return (short) m.x; // GOOD
 }
 
 bool getX4(my_struct m) {
-	return m.x;
+	return m.x; // GOOD
 }
 
 short getX5(my_struct m) {
-	return (char) m.x;
+	return (char) m.x; // GOOD
+}
+
+const char& getx6(my_struct& m) {
+	const char& result = m.x; // BAD [NOT DETECTED]
+	return result;
+}
+
+const short& getx7(my_struct& m) {
+	const short& result = (short) m.x; // GOOD
+	return result;
+}
+
+const int& getx8(my_struct& m) {
+	const int& result = m.x; // GOOD
+	return result;
+}
+
+const bool& getx9(my_struct& m) {
+	const bool& result = m.x; // GOOD
+	return result;
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/test.cpp
@@ -2,8 +2,8 @@ typedef struct {
 	int x : 24;
 } my_struct;
 
-unsigned int getX1(my_struct m) {
-	return m.x;
+int getX1(my_struct m) {
+	return m.x; // GOOD
 }
 
 short getX2(my_struct m) {

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/ImplicitDowncastFromBitfield/test.cpp
@@ -23,7 +23,7 @@ short getX5(my_struct m) {
 }
 
 const char& getx6(my_struct& m) {
-	const char& result = m.x; // BAD [NOT DETECTED]
+	const char& result = m.x; // BAD
 	return result;
 }
 


### PR DESCRIPTION
Add tests for implict downcast when using references, and fix the test to detect implicit downcasts when using references, which was not previously not detected. 
