### PR TITLE
Java: Adapt test generator to new qlpack name

### DIFF
--- a/java/ql/src/utils/GenerateFlowTestCase.py
+++ b/java/ql/src/utils/GenerateFlowTestCase.py
@@ -127,7 +127,7 @@ queryDir = os.path.join(workDir, "query")
 os.makedirs(queryDir)
 qlFile = os.path.join(queryDir, "gen.ql")
 with open(os.path.join(queryDir, "qlpack.yml"), "w") as f:
-    f.write("name: test-generation-query\nversion: 0.0.0\nlibraryPathDependencies: codeql-java")
+    f.write("name: test-generation-query\nversion: 0.0.0\nlibraryPathDependencies: codeql/java-queries")
 with open(qlFile, "w") as f:
     f.write(
         "import java\nimport utils.GenerateFlowTestCase\n\nclass GenRow extends TargetSummaryModelCsv {\n\n\toverride predicate row(string r) {\n\t\tr = [\n")


### PR DESCRIPTION
Use the qlpack `codeql/java-queries` instead of `codeql-java` for the `GenerateFlowTestCase` query.