### PR TITLE
C++:Lower potentially-dangerous-function precision

### DIFF
--- a/cpp/change-notes/2021-08-23-ctime-weaken-claims.md
+++ b/cpp/change-notes/2021-08-23-ctime-weaken-claims.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Lowered the precision of `cpp/potentially-dangerous-function` so it is run but not displayed on LGTM by default and so it's only run and displayed on Code Scanning if a broader suite like `cpp-security-extended` is opted into.

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.qhelp
@@ -26,7 +26,7 @@ can use their own storage.</p>
 <p>Similarly replace calls to <code>localtime</code> with
 <code>localtime_r</code>, calls to <code>ctime</code> with
 <code>ctime_r</code> and calls to <code>asctime</code> with
-<code>asctime_r</code>.</p>
+<code>asctime_r</code> (if those functions exist on your platform).</p>
 
 </recommendation>
 <example>

--- a/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
+++ b/cpp/ql/src/Security/CWE/CWE-676/PotentiallyDangerousFunction.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @security-severity 10.0
- * @precision high
+ * @precision medium
  * @id cpp/potentially-dangerous-function
  * @tags reliability
  *       security


### PR DESCRIPTION
Fixes #6451.

There have been multiple reports of false positives from this query over time. Now that it has `@security-severity 10.0`, these false positives look even worse.

The query looks purely for calls to functions with certain names, not at whether the calls happen in a dangerous context. To justify a higher precision, the query should only flag calls that happen in a thread or another non-reentrant context.