### PR TITLE
Python: Add CWE-328 to `py/weak-sensitive-data-hashing`

### DIFF
--- a/python/ql/src/Security/CWE-327/WeakSensitiveDataHashing.ql
+++ b/python/ql/src/Security/CWE-327/WeakSensitiveDataHashing.ql
@@ -8,6 +8,7 @@
  * @id py/weak-sensitive-data-hashing
  * @tags security
  *       external/cwe/cwe-327
+ *       external/cwe/cwe-328
  *       external/cwe/cwe-916
  */
 


### PR DESCRIPTION
Reading over the description at https://cwe.mitre.org/data/definitions/328.html:

> The product uses a hashing algorithm that produces a hash value that can be used to determine the original input, or to find an input that can produce the same hash, more efficiently than brute force techniques.

For the data that does not require computationally expensive hashing, that will be the exactly problems that this query finds :+1: (that is, MD5, SHA1)