### PR TITLE
JS: Add `src` as an unsafe DOM property for `js/xss-through-dom`.

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -1591,7 +1591,7 @@ module DataFlow {
    */
   predicate localFieldStep(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ClassNode cls, string prop |
-      pred = cls.getAReceiverNode().getAPropertyWrite(prop).getRhs() or
+      pred = cls.getADirectSuperClass*().getAReceiverNode().getAPropertyWrite(prop).getRhs() or
       pred = cls.getInstanceMethod(prop)
     |
       succ = cls.getAReceiverNode().getAPropertyRead(prop)

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -30,7 +30,7 @@ module XssThroughDom {
   /**
    * Gets a DOM property name that could store user-controlled data.
    */
-  string unsafeDomPropertyName() { result = ["innerText", "textContent", "value", "name"] }
+  string unsafeDomPropertyName() { result = ["innerText", "textContent", "value", "name", "src"] }
 
   /**
    * A source for text from the DOM from a JQuery method call.

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -118,6 +118,10 @@ nodes
 | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value |
 | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value |
 | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value |
+| xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" |
+| xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" |
+| xss-through-dom.js:109:45:109:55 | this.el.src |
+| xss-through-dom.js:109:45:109:55 | this.el.src |
 edges
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
@@ -186,6 +190,10 @@ edges
 | xss-through-dom.js:87:36:87:39 | text | xss-through-dom.js:87:16:87:40 | new ans ... s(text) |
 | xss-through-dom.js:93:16:93:46 | $("#foo ... ].value | xss-through-dom.js:93:16:93:46 | $("#foo ... ].value |
 | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value |
+| xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" |
+| xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" |
+| xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" |
+| xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" |
 #select
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
@@ -219,3 +227,4 @@ edges
 | xss-through-dom.js:87:16:87:40 | new ans ... s(text) | xss-through-dom.js:84:15:84:30 | $("text").text() | xss-through-dom.js:87:16:87:40 | new ans ... s(text) | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:84:15:84:30 | $("text").text() | DOM text |
 | xss-through-dom.js:93:16:93:46 | $("#foo ... ].value | xss-through-dom.js:93:16:93:46 | $("#foo ... ].value | xss-through-dom.js:93:16:93:46 | $("#foo ... ].value | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:93:16:93:46 | $("#foo ... ].value | DOM text |
 | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | DOM text |
+| xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" | xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:109:45:109:55 | this.el.src | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -96,3 +96,16 @@
 		$("#id").html($("#foo").find(".bla")[i].value); // NOT OK.
 	}
 })();
+
+class Super {
+	constructor() {
+		this.el = $("#id").get(0);
+	}
+}
+
+class Sub extends Super {
+	constructor() {
+		super();
+		$("#id").get(0).innerHTML = "<a src=\"" + this.el.src + "\">foo</a>"; // NOT OK. Attack: `<mytag id="id" src="x:&quot;&gt;&lt;img src=1 onerror=&quot;alert(1)&quot;&gt;" />`
+	}
+}


### PR DESCRIPTION
And propagate field-flow from writes in a super-class to reads in a sub-class. 

Gets a TP/TN for CVE-2021-23414. 

[Evaluation looks OK-ish in terms of performance](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreDom-eval__nightly__security-extend/reports).  
There is a few new results. 
The bootstrap result is an FP (failed to recognize sanitizer). 
And another result is flow from one `src` attribute to another `src` attribute, which is safe.  
I'll look at fixing those FPs in a followup PR. 

I wasn't sure about the performance from the above evaluation, so I [ran another one](https://github.com/dsp-testing/erik-krogh-dca/tree/run/moreDom__default__smoke-test/reports).  
And performance looks fine there. 
