### PR TITLE
Don't report the 'byte' in `new byte[] { 0 }` or `new byte[10]` as if it is part of an array initializer

### DIFF
--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -454,10 +454,10 @@ class ArrayInit extends Expr, @arrayinit {
    * expression representing an element of the array,
    * depending on the level of nesting.
    */
-  Expr getAnInit() { result.getParent() = this }
+  Expr getAnInit() { result.getParent() = this and not result.isNthChildOf(this, -1) }
 
   /** Gets the initializer occurring at the specified (zero-based) position. */
-  Expr getInit(int index) { result = this.getAnInit() and result.getIndex() = index }
+  Expr getInit(int index) { result = this.getAnInit() and result.getIndex() = index and index >= 0 }
 
   /**
    * Gets the number of expressions in this initializer, that is, the size the


### PR DESCRIPTION
This is a partial fix for our misreporting of array inits like `byte[][] bs = { new byte[5], new byte[] { 0 } }`, where we currently mistake the typename `byte` of the inner expressions for initializer elements.

An extractor fix is needed to remedy mistaking the dimension `5` for an initializer; see the extractor PR for alternative solutions to this.