### PR TITLE
JS: recognize that checking for `(constructor || prototype) && __proto__)` is enough to prevent prototype pollution

### DIFF
--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingFunction.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingFunction.ql
@@ -302,13 +302,18 @@ class DenyListEqualityGuard extends DataFlow::LabeledBarrierGuardNode, ValueNode
 
   DenyListEqualityGuard() {
     astNode.getAnOperand().getStringValue() = propName and
-    propName = unsafePropName()
+    propName = [unsafePropName(), "prototype"]
   }
 
   override predicate blocks(boolean outcome, Expr e, FlowLabel label) {
     e = astNode.getAnOperand() and
     outcome = astNode.getPolarity().booleanNot() and
-    label = propName
+    (
+      label = propName
+      or
+      propName = "prototype" and
+      label = "constructor"
+    )
   }
 }
 

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingFunction/PrototypePollutingFunction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingFunction/PrototypePollutingFunction.expected
@@ -1320,6 +1320,12 @@ nodes
 | tests.js:502:24:502:28 | value |
 | tests.js:502:24:502:28 | value |
 | tests.js:502:24:502:28 | value |
+| tests.js:508:18:508:22 | value |
+| tests.js:508:18:508:22 | value |
+| tests.js:508:18:508:22 | value |
+| tests.js:515:24:515:28 | value |
+| tests.js:515:24:515:28 | value |
+| tests.js:515:24:515:28 | value |
 edges
 | examples/PrototypePollutingFunction.js:1:16:1:18 | dst | examples/PrototypePollutingFunction.js:5:19:5:21 | dst |
 | examples/PrototypePollutingFunction.js:1:16:1:18 | dst | examples/PrototypePollutingFunction.js:5:19:5:21 | dst |
@@ -2982,6 +2988,13 @@ edges
 | tests.js:498:25:498:27 | key | tests.js:498:21:498:28 | src[key] |
 | tests.js:500:38:500:42 | value | tests.js:494:32:494:34 | src |
 | tests.js:500:38:500:42 | value | tests.js:494:32:494:34 | src |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
+| tests.js:508:18:508:22 | value | tests.js:515:24:515:28 | value |
 #select
 | examples/PrototypePollutingFunction.js:7:13:7:15 | dst | examples/PrototypePollutingFunction.js:2:14:2:16 | key | examples/PrototypePollutingFunction.js:7:13:7:15 | dst | Properties are copied from $@ to $@ without guarding against prototype pollution. | examples/PrototypePollutingFunction.js:2:21:2:23 | src | src | examples/PrototypePollutingFunction.js:7:13:7:15 | dst | dst |
 | path-assignment.js:15:13:15:18 | target | path-assignment.js:8:19:8:25 | keys[i] | path-assignment.js:15:13:15:18 | target | The property chain $@ is recursively assigned to $@ without guarding against prototype pollution. | path-assignment.js:8:19:8:25 | keys[i] | here | path-assignment.js:15:13:15:18 | target | target |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingFunction/tests.js
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingFunction/tests.js
@@ -503,3 +503,16 @@ function copyPlainObject2(dst, src) {
         }
     }
 }
+
+function doubleGuarded2(dst, src) {
+    _.each(src, (value, key, o) => {
+        if (key === "__proto__" || key === "prototype") { 
+            return;
+        }
+        if (dst[key]) {
+            doubleGuarded2(dst[key], src[key]);
+        } else {
+            dst[key] = value; // OK
+        }
+    });
+}


### PR DESCRIPTION
I haven't been able to craft a prototype-pollution exploit using just the `constructor` or `prototype` property, I need both.  

This PR makes sure we recognize that a `key === "__proto__" || key === "prototype"` check is sufficient to protect against prototype-pollution. 

Gets a TN for CVE-2020-7722

[Evaluation was uneventful](https://github.com/dsp-testing/erik-krogh-dca/tree/run/protoTN-eval__nightly__CustomSuite/reports). 