### PR TITLE
JS: Release new version of library and upgrade pack

### DIFF
--- a/javascript/ql/lib/qlpack.yml
+++ b/javascript/ql/lib/qlpack.yml
@@ -1,7 +1,7 @@
 name: codeql/javascript-all
-version: 0.0.2
+version: 0.0.3
 dbscheme: semmlecode.javascript.dbscheme
 extractor: javascript
 library: true
 dependencies:
-    codeql/javascript-upgrades: 0.0.2
+    codeql/javascript-upgrades: 0.0.3

--- a/javascript/upgrades/qlpack.yml
+++ b/javascript/upgrades/qlpack.yml
@@ -1,2 +1,4 @@
-name: codeql-javascript-upgrades
+name: codeql/javascript-upgrades
 upgrades: .
+library: true
+version: 0.0.3


### PR DESCRIPTION
This PR bumps the versions of the `codeql/javascript-all` and `codeql/javascript-upgrades` packs following a new release I did earlier today to get a pack with the latest DB scheme.