### PR TITLE
Fix incompatibility with release CLI

### DIFF
--- a/misc/suite-helpers/qlpack.yml
+++ b/misc/suite-helpers/qlpack.yml
@@ -1,3 +1,2 @@
 name: codeql/suite-helpers
 version: 0.0.2
-library: true


### PR DESCRIPTION
This fixes #6563, in which a customer reports being unable to run a query suite despite following the "Getting Started with the CodeQL CLI" instructions. The problem is that the released versions of the CodeQL CLI incorrectly disallow any reference to a library pack from within a .qls file. This is a CLI bug that will be fixed in the next CLI release, but since our policy is to make `github/codeql`'s `main` branch compatible with the latest released CLI, we need to work around this for now by pretending `codeql/suite-helpers` is a query pack.