### PR TITLE
Python: Broaden noqa regex to allow comments

### DIFF
--- a/python/ql/src/analysis/AlertSuppression.ql
+++ b/python/ql/src/analysis/AlertSuppression.ql
@@ -72,7 +72,7 @@ class LgtmSuppressionComment extends LineSuppressionComment {
  * A noqa suppression comment. Both pylint and pyflakes respect this, so lgtm ought to too.
  */
 class NoqaSuppressionComment extends LineSuppressionComment {
-  NoqaSuppressionComment() { this.getContents().toLowerCase().regexpMatch("\\s*noqa\\s*") }
+  NoqaSuppressionComment() { this.getContents().toLowerCase().regexpMatch("\\s*noqa([^:].*)?") }
 
   override string getAnnotation() { result = "lgtm" }
 }

--- a/python/ql/src/analysis/AlertSuppression.ql
+++ b/python/ql/src/analysis/AlertSuppression.ql
@@ -72,7 +72,7 @@ class LgtmSuppressionComment extends LineSuppressionComment {
  * A noqa suppression comment. Both pylint and pyflakes respect this, so lgtm ought to too.
  */
 class NoqaSuppressionComment extends LineSuppressionComment {
-  NoqaSuppressionComment() { this.getContents().toLowerCase().regexpMatch("\\s*noqa([^:].*)?") }
+  NoqaSuppressionComment() { this.getContents().toLowerCase().regexpMatch("\\s*noqa\\s*([^:].*)?") }
 
   override string getAnnotation() { result = "lgtm" }
 }

--- a/python/ql/test/query-tests/analysis/suppression/AlertSuppression.expected
+++ b/python/ql/test/query-tests/analysis/suppression/AlertSuppression.expected
@@ -21,6 +21,7 @@
 | test.py:36:21:36:33 | Comment # lgtm method |  lgtm method | lgtm | test.py:36:1:36:33 | suppression range |
 | test.py:39:4:39:8 | Comment #noqa | noqa | lgtm | test.py:39:1:39:8 | suppression range |
 | test.py:40:4:40:9 | Comment # noqa |  noqa | lgtm | test.py:40:1:40:9 | suppression range |
+| test.py:45:4:45:31 | Comment # noqa -- Some extra detail. |  noqa -- Some extra detail. | lgtm | test.py:45:1:45:31 | suppression range |
 | test.py:50:34:50:117 | Comment # noqa: E501; (line too long) pylint: disable=invalid-name; lgtm [py/missing-equals] |  noqa: E501; (line too long) pylint: disable=invalid-name; lgtm [py/missing-equals] | lgtm [py/missing-equals] | test.py:50:1:50:117 | suppression range |
 | test.py:52:4:52:67 | Comment # noqa: E501; (line too long) pylint: disable=invalid-name; lgtm |  noqa: E501; (line too long) pylint: disable=invalid-name; lgtm | lgtm | test.py:52:1:52:67 | suppression range |
 | test.py:53:4:53:78 | Comment # random nonsense lgtm [py/missing-equals] and then some more commentary... |  random nonsense lgtm [py/missing-equals] and then some more commentary... | lgtm [py/missing-equals] | test.py:53:1:53:78 | suppression range |


### PR DESCRIPTION
Fixes issue mentioned [here](https://github.com/github/codeql/pull/6528#issuecomment-906494399).

In the code
```
from schemacode import macros  # noqa   (used in "eval" call later on)
```
the `noqa` annotation is ignored because of the comment.