### PR TITLE
JS: Add model for `live-server`

### DIFF
--- a/javascript/change-notes/2021-08-30-live-server.md
+++ b/javascript/change-notes/2021-08-30-live-server.md
@@ -1,0 +1,6 @@
+lgtm,codescanning
+* The dataflow libraries now model sources and sinks from the `live-server` library.
+  The model for `connect` has improved to recognize more sources and sinks.
+  Affected packages are
+    [live-server](https://www.npmjs.com/package/live-server),
+    [connect](https://www.npmjs.com/package/connect)

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -24,7 +24,8 @@ module Connect {
    * but support for other kinds of route handlers can be added by implementing
    * additional subclasses of this class.
    */
-  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::ValueNode {
+  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, NodeJSLib::RouteHandler,
+    DataFlow::ValueNode {
     /**
      * Gets the parameter of kind `kind` of this route handler.
      *
@@ -35,12 +36,12 @@ module Connect {
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
-    Parameter getRequestParameter() { result = getRouteHandlerParameter("request") }
+    override Parameter getRequestParameter() { result = getRouteHandlerParameter("request") }
 
     /**
      * Gets the parameter of the route handler that contains the response object.
      */
-    Parameter getResponseParameter() { result = getRouteHandlerParameter("response") }
+    override Parameter getResponseParameter() { result = getRouteHandlerParameter("response") }
   }
 
   /**
@@ -54,50 +55,6 @@ module Connect {
     override Parameter getRouteHandlerParameter(string kind) {
       result = getRouteHandlerParameter(astNode, kind)
     }
-  }
-
-  /**
-   * A Connect response source, that is, the response parameter of a
-   * route handler.
-   */
-  private class ResponseSource extends HTTP::Servers::ResponseSource {
-    RouteHandler rh;
-
-    ResponseSource() { this = DataFlow::parameterNode(rh.getResponseParameter()) }
-
-    /**
-     * Gets the route handler that provides this response.
-     */
-    override RouteHandler getRouteHandler() { result = rh }
-  }
-
-  /**
-   * A Connect request source, that is, the request parameter of a
-   * route handler.
-   */
-  private class RequestSource extends HTTP::Servers::RequestSource {
-    RouteHandler rh;
-
-    RequestSource() { this = DataFlow::parameterNode(rh.getRequestParameter()) }
-
-    /**
-     * Gets the route handler that handles this request.
-     */
-    override RouteHandler getRouteHandler() { result = rh }
-  }
-
-  /**
-   * A Node.js HTTP response provided by Connect.
-   */
-  class ResponseExpr extends NodeJSLib::ResponseExpr {
-    ResponseExpr() { src instanceof ResponseSource }
-  }
-
-  /**
-   * A Node.js HTTP request provided by Connect.
-   */
-  class RequestExpr extends NodeJSLib::RequestExpr {
-    RequestExpr() { src instanceof RequestSource }
   }
 
   /**
@@ -156,10 +113,11 @@ module Connect {
    * An access to a user-controlled Connect request input.
    */
   private class RequestInputAccess extends HTTP::RequestInputAccess {
-    RequestExpr request;
+    NodeJSLib::RequestExpr request;
     string kind;
 
     RequestInputAccess() {
+      request.getRouteHandler() instanceof StandardRouteHandler and
       exists(PropAccess cookies |
         // `req.cookies.get(<name>)`
         kind = "cookie" and
@@ -171,34 +129,5 @@ module Connect {
     override RouteHandler getRouteHandler() { result = request.getRouteHandler() }
 
     override string getKind() { result = kind }
-  }
-
-  /**
-   * A function that flows to a route setup.
-   */
-  private class TrackedRouteHandlerCandidateWithSetup extends RouteHandler,
-    HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
-    TrackedRouteHandlerCandidateWithSetup() { this = any(RouteSetup s).getARouteHandler() }
-
-    override Parameter getRouteHandlerParameter(string kind) {
-      result = getRouteHandlerParameter(astNode, kind)
-    }
-  }
-
-  /**
-   * A call that looks like a route setup on a Connect server.
-   *
-   * For example, this could be the call `router.use(handler)` where
-   * it is unknown if `router` is a Connect router.
-   */
-  class RouteSetupCandidate extends HTTP::RouteSetupCandidate, DataFlow::MethodCallNode {
-    DataFlow::ValueNode routeHandlerArg;
-
-    RouteSetupCandidate() {
-      getMethodName() = "use" and
-      routeHandlerArg = getAnArgument()
-    }
-
-    override DataFlow::ValueNode getARouteHandlerArg() { result = routeHandlerArg }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -24,8 +24,7 @@ module Connect {
    * but support for other kinds of route handlers can be added by implementing
    * additional subclasses of this class.
    */
-  abstract class RouteHandler extends NodeJSLib::RouteHandler,
-    DataFlow::ValueNode {
+  abstract class RouteHandler extends NodeJSLib::RouteHandler, DataFlow::ValueNode {
     /**
      * Gets the parameter of kind `kind` of this route handler.
      *
@@ -109,11 +108,13 @@ module Connect {
     override string getCredentialsKind() { result = kind }
   }
 
+  class RequestExpr = NodeJSLib::RequestExpr;
+
   /**
    * An access to a user-controlled Connect request input.
    */
   private class RequestInputAccess extends HTTP::RequestInputAccess {
-    NodeJSLib::RequestExpr request;
+    RequestExpr request;
     string kind;
 
     RequestInputAccess() {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -24,7 +24,7 @@ module Connect {
    * but support for other kinds of route handlers can be added by implementing
    * additional subclasses of this class.
    */
-  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, NodeJSLib::RouteHandler,
+  abstract class RouteHandler extends NodeJSLib::RouteHandler,
     DataFlow::ValueNode {
     /**
      * Gets the parameter of kind `kind` of this route handler.

--- a/javascript/ql/lib/semmle/javascript/frameworks/HttpFrameworks.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HttpFrameworks.qll
@@ -1,6 +1,7 @@
 import semmle.javascript.frameworks.Express
 import semmle.javascript.frameworks.Hapi
 import semmle.javascript.frameworks.Koa
+import semmle.javascript.frameworks.LiveServer
 import semmle.javascript.frameworks.NodeJSLib
 import semmle.javascript.frameworks.Micro
 import semmle.javascript.frameworks.Restify

--- a/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
@@ -1,0 +1,59 @@
+/**
+ * Provides classes modelling the [live-server](https://npmjs.com/package/live-server) package.
+ */
+
+import javascript
+private import semmle.javascript.frameworks.ConnectExpressShared::ConnectExpressShared as ConnectExpressShared
+
+private module LiveServer {
+  /**
+   * An expression that imports the live-server package, seen as a server-definition.
+   */
+  class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
+    API::Node imp;
+
+    ServerDefinition() {
+      imp = API::moduleImport("live-server") and
+      this = imp.getAnImmediateUse().asExpr()
+    }
+
+    API::Node getImportNode() { result = imp }
+  }
+
+  /**
+   * A live-server middleware definition.
+   * `live-server` uses the `connect` library under the hood, so the model is based on the `connect` model.
+   */
+  class RouteHandler extends Connect::RouteHandler, DataFlow::FunctionNode {
+    RouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
+
+    override Parameter getRouteHandlerParameter(string kind) {
+      result = ConnectExpressShared::getRouteHandlerParameter(astNode, kind)
+    }
+  }
+
+  /**
+   * The call to `require("live-server").start()`, seen as a route setup.
+   */
+  class RouteSetup extends MethodCallExpr, HTTP::Servers::StandardRouteSetup {
+    ServerDefinition server;
+    API::CallNode call;
+
+    RouteSetup() {
+      call = server.getImportNode().getMember("start").getACall() and
+      this = call.asExpr()
+    }
+
+    override DataFlow::SourceNode getARouteHandler() {
+      exists(DataFlow::SourceNode middleware |
+        middleware = call.getParameter(0).getMember("middleware").getAValueReachingRhs()
+      |
+        result = middleware.getAMemberCall(["push", "unshift"]).getArgument(0).getAFunctionValue()
+        or
+        result = middleware.(DataFlow::ArrayCreationNode).getAnElement().getAFunctionValue()
+      )
+    }
+
+    override Expr getServer() { result = server }
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
@@ -29,7 +29,7 @@ private import semmle.javascript.frameworks.ConnectExpressShared::ConnectExpress
 /**
  * A route handler that should be rate-limited.
  */
-abstract class ExpensiveRouteHandler extends HTTP::RouteHandler {
+abstract class ExpensiveRouteHandler extends DataFlow::Node {
   Express::RouteHandler impl;
 
   ExpensiveRouteHandler() { this = impl }
@@ -42,10 +42,6 @@ abstract class ExpensiveRouteHandler extends HTTP::RouteHandler {
    * `referenceLabel` are ignored and should be bound to dummy values.
    */
   abstract predicate explain(string explanation, DataFlow::Node reference, string referenceLabel);
-
-  override HTTP::HeaderDefinition getAResponseHeader(string name) {
-    result = impl.getAResponseHeader(name)
-  }
 }
 
 /**

--- a/javascript/ql/test/library-tests/frameworks/connect/Credentials.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/Credentials.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_Credentials(Connect::Credentials cr, string res) {
-  res = cr.getCredentialsKind()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/HeaderDefinition.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Connect::RouteHandler rh) {
-  rh = hd.getRouteHandler()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/HeaderDefinition_defines.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
-  hd.defines(name, value) and hd.getRouteHandler() instanceof Connect::RouteHandler
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/HeaderDefinition_getAHeaderName.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
-  hd.getRouteHandler() instanceof Connect::RouteHandler and res = hd.getAHeaderName()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Connect::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(HTTP::RequestExpr e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/connect/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RequestExpr.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_RequestExpr(HTTP::RequestExpr e, HTTP::RouteHandler res) {
-  res = e.getRouteHandler()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RequestInputAccess.qll
@@ -1,7 +1,0 @@
-import javascript
-
-query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Connect::RouteHandler rh
-) {
-  ria.getRouteHandler() = rh and res = ria.getKind()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Connect::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(HTTP::ResponseExpr e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/connect/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/ResponseExpr.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_ResponseExpr(HTTP::ResponseExpr e, HTTP::RouteHandler res) {
-  res = e.getRouteHandler()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteHandler.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_RouteHandler(Connect::RouteHandler rh, Expr res) { res = rh.getServer() }

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,0 @@
-import semmle.javascript.frameworks.Express
-
-query predicate test_RouteHandler_getARequestExpr(Connect::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,0 @@
-import semmle.javascript.frameworks.Express
-
-query predicate test_RouteHandler_getAResponseExpr(Connect::RouteHandler rh, HTTP::ResponseExpr res) {
-  res = rh.getAResponseExpr()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteHandler_getAResponseHeader.qll
@@ -1,7 +1,0 @@
-import semmle.javascript.frameworks.Express
-
-query predicate test_RouteHandler_getAResponseHeader(
-  Connect::RouteHandler rh, string name, HTTP::HeaderDefinition res
-) {
-  res = rh.getAResponseHeader(name)
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteSetup.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteSetup.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_RouteSetup(Connect::RouteSetup rs) { any() }

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteSetup_getARouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteSetup_getARouteHandler.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_RouteSetup_getARouteHandler(Connect::RouteSetup r, DataFlow::SourceNode res) {
-  res = r.getARouteHandler()
-}

--- a/javascript/ql/test/library-tests/frameworks/connect/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/RouteSetup_getServer.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_RouteSetup_getServer(Connect::RouteSetup rs, Expr res) { res = rs.getServer() }

--- a/javascript/ql/test/library-tests/frameworks/connect/ServerDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/connect/ServerDefinition.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_ServerDefinition(Connect::ServerDefinition s) { any() }

--- a/javascript/ql/test/library-tests/frameworks/connect/src/test.js
+++ b/javascript/ql/test/library-tests/frameworks/connect/src/test.js
@@ -28,3 +28,8 @@ app.use(function (error, req, res, next){
 app.use(function ({url, query, cookies}, res){
     cookies.get(query.foobar);
 });
+
+app.use(function (req, res){
+    var url = req.url;
+    res.end(url);
+});

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.expected
@@ -6,8 +6,10 @@ test_RouteSetup
 | src/test.js:19:1:20:29 | app.use ... res){}) |
 | src/test.js:24:1:26:2 | app.use ... '');\\n}) |
 | src/test.js:28:1:30:2 | app.use ... ar);\\n}) |
+| src/test.js:32:1:35:2 | app.use ... rl);\\n}) |
 test_RequestInputAccess
 | src/test.js:8:5:8:26 | req.coo ... ('foo') | cookie | src/test.js:6:9:9:1 | functio ... oo');\\n} |
+| src/test.js:33:15:33:21 | req.url | url | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_RouteHandler_getAResponseHeader
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | header1 | src/test.js:7:5:7:32 | res.set ... 1', '') |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | header2 | src/test.js:25:5:25:32 | res.set ... 2', '') |
@@ -23,6 +25,8 @@ test_ResponseExpr
 | src/test.js:24:31:24:33 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:25:5:25:7 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:28:42:28:44 | res | src/test.js:28:9:30:1 | functio ... bar);\\n} |
+| src/test.js:32:24:32:26 | res | src/test.js:32:9:35:1 | functio ... url);\\n} |
+| src/test.js:34:5:34:7 | res | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_HeaderDefinition
 | src/test.js:7:5:7:32 | res.set ... 1', '') | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:25:5:25:32 | res.set ... 2', '') | src/test.js:24:9:26:1 | functio ...  '');\\n} |
@@ -34,6 +38,7 @@ test_RouteSetup_getServer
 | src/test.js:19:1:20:29 | app.use ... res){}) | src/test.js:4:11:4:19 | connect() |
 | src/test.js:24:1:26:2 | app.use ... '');\\n}) | src/test.js:4:11:4:19 | connect() |
 | src/test.js:28:1:30:2 | app.use ... ar);\\n}) | src/test.js:4:11:4:19 | connect() |
+| src/test.js:32:1:35:2 | app.use ... rl);\\n}) | src/test.js:4:11:4:19 | connect() |
 test_HeaderDefinition_getAHeaderName
 | src/test.js:7:5:7:32 | res.set ... 1', '') | header1 |
 | src/test.js:25:5:25:32 | res.set ... 2', '') | header2 |
@@ -48,6 +53,8 @@ test_RouteHandler_getAResponseExpr
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:31:24:33 | res |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:25:5:25:7 | res |
 | src/test.js:28:9:30:1 | functio ... bar);\\n} | src/test.js:28:42:28:44 | res |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:32:24:32:26 | res |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:34:5:34:7 | res |
 test_RouteSetup_getARouteHandler
 | src/test.js:6:1:9:2 | app.use ... o');\\n}) | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:12:1:12:42 | app.use ... word')) | src/test.js:12:9:12:41 | basicAu ... sword') |
@@ -58,6 +65,7 @@ test_RouteSetup_getARouteHandler
 | src/test.js:19:1:20:29 | app.use ... res){}) | src/test.js:20:10:20:28 | function(req,res){} |
 | src/test.js:24:1:26:2 | app.use ... '');\\n}) | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:28:1:30:2 | app.use ... ar);\\n}) | src/test.js:28:9:30:1 | functio ... bar);\\n} |
+| src/test.js:32:1:35:2 | app.use ... rl);\\n}) | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_RouteHandler
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:4:11:4:19 | connect() |
 | src/test.js:15:12:15:32 | functio ...  res){} | src/test.js:4:11:4:19 | connect() |
@@ -65,6 +73,7 @@ test_RouteHandler
 | src/test.js:20:10:20:28 | function(req,res){} | src/test.js:4:11:4:19 | connect() |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:4:11:4:19 | connect() |
 | src/test.js:28:9:30:1 | functio ... bar);\\n} | src/test.js:4:11:4:19 | connect() |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:4:11:4:19 | connect() |
 test_RequestExpr
 | src/test.js:6:27:6:29 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:8:5:8:7 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
@@ -73,6 +82,8 @@ test_RequestExpr
 | src/test.js:20:19:20:21 | req | src/test.js:20:10:20:28 | function(req,res){} |
 | src/test.js:24:26:24:28 | req | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:28:19:28:39 | {url, q ... ookies} | src/test.js:28:9:30:1 | functio ... bar);\\n} |
+| src/test.js:32:19:32:21 | req | src/test.js:32:9:35:1 | functio ... url);\\n} |
+| src/test.js:33:15:33:17 | req | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_Credentials
 | src/test.js:12:19:12:28 | 'username' | user name |
 | src/test.js:12:31:12:40 | 'password' | password |
@@ -84,3 +95,5 @@ test_RouteHandler_getARequestExpr
 | src/test.js:20:10:20:28 | function(req,res){} | src/test.js:20:19:20:21 | req |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:26:24:28 | req |
 | src/test.js:28:9:30:1 | functio ... bar);\\n} | src/test.js:28:19:28:39 | {url, q ... ookies} |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:32:19:32:21 | req |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:33:15:33:17 | req |

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.ql
@@ -1,15 +1,57 @@
-import RouteSetup
-import RequestInputAccess
-import RouteHandler_getAResponseHeader
-import HeaderDefinition_defines
-import ResponseExpr
-import HeaderDefinition
-import RouteSetup_getServer
-import HeaderDefinition_getAHeaderName
-import ServerDefinition
-import RouteHandler_getAResponseExpr
-import RouteSetup_getARouteHandler
-import RouteHandler
-import RequestExpr
-import Credentials
-import RouteHandler_getARequestExpr
+import javascript
+
+query predicate test_RouteSetup(Connect::RouteSetup rs) { any() }
+
+query predicate test_RequestInputAccess(
+  HTTP::RequestInputAccess ria, string res, Connect::RouteHandler rh
+) {
+  ria.getRouteHandler() = rh and res = ria.getKind()
+}
+
+query predicate test_RouteHandler_getAResponseHeader(
+  Connect::RouteHandler rh, string name, HTTP::HeaderDefinition res
+) {
+  res = rh.getAResponseHeader(name)
+}
+
+query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+  hd.defines(name, value) and hd.getRouteHandler() instanceof Connect::RouteHandler
+}
+
+query predicate test_ResponseExpr(HTTP::ResponseExpr e, HTTP::RouteHandler res) {
+  res = e.getRouteHandler()
+}
+
+query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Connect::RouteHandler rh) {
+  rh = hd.getRouteHandler()
+}
+
+query predicate test_RouteSetup_getServer(Connect::RouteSetup rs, Expr res) { res = rs.getServer() }
+
+query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+  hd.getRouteHandler() instanceof Connect::RouteHandler and res = hd.getAHeaderName()
+}
+
+query predicate test_ServerDefinition(Connect::ServerDefinition s) { any() }
+
+query predicate test_RouteHandler_getAResponseExpr(Connect::RouteHandler rh, HTTP::ResponseExpr res) {
+  res = rh.getAResponseExpr()
+}
+
+query predicate test_RouteSetup_getARouteHandler(Connect::RouteSetup r, DataFlow::SourceNode res) {
+  res = r.getARouteHandler()
+}
+
+query predicate test_RouteHandler(Connect::RouteHandler rh, Expr res) { res = rh.getServer() }
+
+query predicate test_RequestExpr(HTTP::RequestExpr e, HTTP::RouteHandler res) {
+  res = e.getRouteHandler()
+}
+
+query predicate test_Credentials(Connect::Credentials cr, string res) {
+  res = cr.getCredentialsKind()
+}
+
+query predicate test_RouteHandler_getARequestExpr(Connect::RouteHandler rh, HTTP::RequestExpr res) {
+  res = rh.getARequestExpr()
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -118,6 +118,18 @@ nodes
 | formatting.js:7:14:7:53 | require ... , evil) |
 | formatting.js:7:14:7:53 | require ... , evil) |
 | formatting.js:7:49:7:52 | evil |
+| live-server.js:4:11:4:27 | tainted |
+| live-server.js:4:21:4:27 | req.url |
+| live-server.js:4:21:4:27 | req.url |
+| live-server.js:6:13:6:50 | `<html> ... /html>` |
+| live-server.js:6:13:6:50 | `<html> ... /html>` |
+| live-server.js:6:28:6:34 | tainted |
+| live-server.js:10:11:10:27 | tainted |
+| live-server.js:10:21:10:27 | req.url |
+| live-server.js:10:21:10:27 | req.url |
+| live-server.js:12:13:12:50 | `<html> ... /html>` |
+| live-server.js:12:13:12:50 | `<html> ... /html>` |
+| live-server.js:12:28:12:34 | tainted |
 | pages/Next.jsx:8:13:8:19 | req.url |
 | pages/Next.jsx:8:13:8:19 | req.url |
 | pages/Next.jsx:8:13:8:19 | req.url |
@@ -325,6 +337,16 @@ edges
 | formatting.js:6:43:6:46 | evil | formatting.js:6:14:6:47 | util.fo ... , evil) |
 | formatting.js:7:49:7:52 | evil | formatting.js:7:14:7:53 | require ... , evil) |
 | formatting.js:7:49:7:52 | evil | formatting.js:7:14:7:53 | require ... , evil) |
+| live-server.js:4:11:4:27 | tainted | live-server.js:6:28:6:34 | tainted |
+| live-server.js:4:21:4:27 | req.url | live-server.js:4:11:4:27 | tainted |
+| live-server.js:4:21:4:27 | req.url | live-server.js:4:11:4:27 | tainted |
+| live-server.js:6:28:6:34 | tainted | live-server.js:6:13:6:50 | `<html> ... /html>` |
+| live-server.js:6:28:6:34 | tainted | live-server.js:6:13:6:50 | `<html> ... /html>` |
+| live-server.js:10:11:10:27 | tainted | live-server.js:12:28:12:34 | tainted |
+| live-server.js:10:21:10:27 | req.url | live-server.js:10:11:10:27 | tainted |
+| live-server.js:10:21:10:27 | req.url | live-server.js:10:11:10:27 | tainted |
+| live-server.js:12:28:12:34 | tainted | live-server.js:12:13:12:50 | `<html> ... /html>` |
+| live-server.js:12:28:12:34 | tainted | live-server.js:12:13:12:50 | `<html> ... /html>` |
 | pages/Next.jsx:8:13:8:19 | req.url | pages/Next.jsx:8:13:8:19 | req.url |
 | pages/Next.jsx:15:13:15:19 | req.url | pages/Next.jsx:15:13:15:19 | req.url |
 | pages/api/myapi.js:2:14:2:20 | req.url | pages/api/myapi.js:2:14:2:20 | req.url |
@@ -442,6 +464,8 @@ edges
 | etherpad.js:11:12:11:19 | response | etherpad.js:9:16:9:30 | req.query.jsonp | etherpad.js:11:12:11:19 | response | Cross-site scripting vulnerability due to $@. | etherpad.js:9:16:9:30 | req.query.jsonp | user-provided value |
 | formatting.js:6:14:6:47 | util.fo ... , evil) | formatting.js:4:16:4:29 | req.query.evil | formatting.js:6:14:6:47 | util.fo ... , evil) | Cross-site scripting vulnerability due to $@. | formatting.js:4:16:4:29 | req.query.evil | user-provided value |
 | formatting.js:7:14:7:53 | require ... , evil) | formatting.js:4:16:4:29 | req.query.evil | formatting.js:7:14:7:53 | require ... , evil) | Cross-site scripting vulnerability due to $@. | formatting.js:4:16:4:29 | req.query.evil | user-provided value |
+| live-server.js:6:13:6:50 | `<html> ... /html>` | live-server.js:4:21:4:27 | req.url | live-server.js:6:13:6:50 | `<html> ... /html>` | Cross-site scripting vulnerability due to $@. | live-server.js:4:21:4:27 | req.url | user-provided value |
+| live-server.js:12:13:12:50 | `<html> ... /html>` | live-server.js:10:21:10:27 | req.url | live-server.js:12:13:12:50 | `<html> ... /html>` | Cross-site scripting vulnerability due to $@. | live-server.js:10:21:10:27 | req.url | user-provided value |
 | pages/Next.jsx:8:13:8:19 | req.url | pages/Next.jsx:8:13:8:19 | req.url | pages/Next.jsx:8:13:8:19 | req.url | Cross-site scripting vulnerability due to $@. | pages/Next.jsx:8:13:8:19 | req.url | user-provided value |
 | pages/Next.jsx:15:13:15:19 | req.url | pages/Next.jsx:15:13:15:19 | req.url | pages/Next.jsx:15:13:15:19 | req.url | Cross-site scripting vulnerability due to $@. | pages/Next.jsx:15:13:15:19 | req.url | user-provided value |
 | pages/api/myapi.js:2:14:2:20 | req.url | pages/api/myapi.js:2:14:2:20 | req.url | pages/api/myapi.js:2:14:2:20 | req.url | Cross-site scripting vulnerability due to $@. | pages/api/myapi.js:2:14:2:20 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXssWithCustomSanitizer.expected
@@ -25,6 +25,8 @@
 | ReflectedXssGood3.js:139:12:139:27 | escapeHtml3(url) | Cross-site scripting vulnerability due to $@. | ReflectedXssGood3.js:135:15:135:27 | req.params.id | user-provided value |
 | formatting.js:6:14:6:47 | util.fo ... , evil) | Cross-site scripting vulnerability due to $@. | formatting.js:4:16:4:29 | req.query.evil | user-provided value |
 | formatting.js:7:14:7:53 | require ... , evil) | Cross-site scripting vulnerability due to $@. | formatting.js:4:16:4:29 | req.query.evil | user-provided value |
+| live-server.js:6:13:6:50 | `<html> ... /html>` | Cross-site scripting vulnerability due to $@. | live-server.js:4:21:4:27 | req.url | user-provided value |
+| live-server.js:12:13:12:50 | `<html> ... /html>` | Cross-site scripting vulnerability due to $@. | live-server.js:10:21:10:27 | req.url | user-provided value |
 | pages/Next.jsx:8:13:8:19 | req.url | Cross-site scripting vulnerability due to $@. | pages/Next.jsx:8:13:8:19 | req.url | user-provided value |
 | pages/Next.jsx:15:13:15:19 | req.url | Cross-site scripting vulnerability due to $@. | pages/Next.jsx:15:13:15:19 | req.url | user-provided value |
 | pages/api/myapi.js:2:14:2:20 | req.url | Cross-site scripting vulnerability due to $@. | pages/api/myapi.js:2:14:2:20 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/live-server.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/live-server.js
@@ -1,0 +1,18 @@
+var liveServer = require("live-server");
+ 
+const middleware = [function(req, res, next) {
+    const tainted = req.url;    
+
+    res.end(`<html><body>${tainted}</body></html>`); // NOT OK
+}];
+
+middleware.push(function(req, res, next) {
+    const tainted = req.url;
+
+    res.end(`<html><body>${tainted}</body></html>`); // NOT OK
+});
+
+var params = {
+    middleware
+};
+liveServer.start(params);


### PR DESCRIPTION
And improve+simplify the model for `connect` by basing it off the `NodeJS` model. 

Adds source+sink for CVE-2020-7680. 

[Evaluation was uneventful](https://github.com/dsp-testing/erik-krogh-dca/tree/run/live-server__nightly__security-extend__2/reports). 