### PR TITLE
Docs: Auto-update copyright year

### DIFF
--- a/docs/codeql/_templates/layout.html
+++ b/docs/codeql/_templates/layout.html
@@ -165,7 +165,8 @@
             </li>
         </ul>
         <ul class="list-style-none d-flex text-gray">
-            <li class="mr-3">&copy; 2021 GitHub, Inc.</li>
+            <li class="mr-3">&copy; 
+                <script type="text/javascript">document.write(new Date().getFullYear());</script> GitHub, Inc.</li>
             <li class="mr-3"><a
                     href="https://docs.github.com/github/site-policy/github-terms-of-service"
                     class="link-gray">Terms </a></li>

--- a/docs/codeql/index.html
+++ b/docs/codeql/index.html
@@ -349,11 +349,12 @@
                     </li>
                 </ul>
                 <ul class="list-style-none d-flex text-gray">
-                    <li class="mr-3">&copy; 2021 GitHub, Inc.</li>
+                    <li class="mr-3">&copy; 
+                        <script type="text/javascript">document.write(new Date().getFullYear());</script> GitHub, Inc.</li>
                     <li class="mr-3"><a
-                            href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service"
+                            href="https://docs.github.com/github/site-policy/github-terms-of-service"
                             class="link-gray">Terms </a></li>
-                    <li><a href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-privacy-statement"
+                    <li><a href="https://docs.github.com/github/site-policy/github-privacy-statement"
                             class="link-gray">Privacy </a></li>
                 </ul>
             </div>


### PR DESCRIPTION
See internal linked issue. It would be nice if we could avoid updating the date manually every year (e.g. https://github.com/github/codeql/pull/5028), since this is likely to get overlooked... 📆 

I've checked this in the Sphinx build (both locally and in the actions run 🖼️ )