### PR TITLE
Update qldoc for the Access class

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -9,7 +9,7 @@ import semmle.code.cpp.Enum
 private import semmle.code.cpp.dataflow.EscapesTree
 
 /**
- * A C/C++ access expression. This refers to a function, variable, or enum constant.
+ * A C/C++ access expression. This refers to a function (excluding function references in function call expressions), variable, or enum constant.
  */
 class Access extends Expr, NameQualifiableElement, @access {
   // As `@access` is a union type containing `@routineexpr` (which describes function accesses

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -350,6 +350,15 @@ class PointerToFieldLiteral extends ImplicitThisFieldAccess {
  *   int (*myFunctionPointer)(int) = &myFunctionTarget;
  * }
  * ```
+ * This excludes function accesses in function call expressions.
+ * For example the access `myFunctionTarget` in `myFunction` in the following code:
+ * ```
+ * int myFunctionTarget(int);
+ *
+ * void myFunction() {
+ *   myFunctionTarget(1);
+ * }
+ * ```
  */
 class FunctionAccess extends Access, @routineexpr {
   FunctionAccess() { not iscall(underlyingElement(this), _) }


### PR DESCRIPTION
The class `Access` and `FunctionAccess` do not capture function accesses that are part of a function call expression.
This update makes that explicit.