### PR TITLE
Data flow: Add precise call contexts to stage 2

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -786,13 +786,18 @@ private module Cached {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   * Holds if the call context `call` improves virtual dispatch in `callable`.
    */
   cached
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
-    or
+  }
+
+  /**
+   * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
     exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
   }
 
@@ -844,6 +849,15 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+}
+
+/**
+ * Holds if the call context `call` either improves virtual dispatch in
+ * `callable` or if it allows us to prune unreachable nodes in `callable`.
+ */
+predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  recordDataFlowCallSiteDispatch(call, callable) or
+  recordDataFlowCallSiteUnreachable(call, callable)
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -786,13 +786,18 @@ private module Cached {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   * Holds if the call context `call` improves virtual dispatch in `callable`.
    */
   cached
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
-    or
+  }
+
+  /**
+   * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
     exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
   }
 
@@ -844,6 +849,15 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+}
+
+/**
+ * Holds if the call context `call` either improves virtual dispatch in
+ * `callable` or if it allows us to prune unreachable nodes in `callable`.
+ */
+predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  recordDataFlowCallSiteDispatch(call, callable) or
+  recordDataFlowCallSiteUnreachable(call, callable)
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -923,28 +923,29 @@ private module Stage2 {
 
   ApOption apSome(Ap ap) { result = TBooleanSome(ap) }
 
-  class Cc = boolean;
+  class Cc = CallContext;
 
-  class CcCall extends Cc {
-    CcCall() { this = true }
+  class CcCall = CallContextCall;
 
-    /** Holds if this call context may be `call`. */
-    predicate matchesCall(DataFlowCall call) { any() }
-  }
+  class CcNoCall = CallContextNoCall;
 
-  class CcNoCall extends Cc {
-    CcNoCall() { this = false }
-  }
-
-  Cc ccNone() { result = false }
+  Cc ccNone() { result instanceof CallContextAny }
 
   private class LocalCc = Unit;
 
   bindingset[call, c, outercc]
-  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) { any() }
+  private CcCall getCallContextCall(DataFlowCall call, DataFlowCallable c, Cc outercc) {
+    checkCallContextCall(outercc, call, c) and
+    if recordDataFlowCallSiteDispatch(call, c)
+    then result = TSpecificCall(call)
+    else result = TSomeCall()
+  }
 
   bindingset[call, c, innercc]
-  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) { any() }
+  private CcNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call, Cc innercc) {
+    checkCallContextReturn(innercc, c, call) and
+    if reducedViableImplInReturn(c, call) then result = TReturn(c, call) else result = ccNone()
+  }
 
   bindingset[node, cc, config]
   private LocalCc getLocalCc(NodeEx node, Cc cc, Configuration config) { any() }
@@ -2117,7 +2118,7 @@ private module Stage3 {
 private predicate flowCandSummaryCtx(NodeEx node, AccessPathFront argApf, Configuration config) {
   exists(AccessPathFront apf |
     Stage3::revFlow(node, true, _, apf, config) and
-    Stage3::fwdFlow(node, true, TAccessPathFrontSome(argApf), apf, config)
+    Stage3::fwdFlow(node, any(Stage3::CcCall ccc), TAccessPathFrontSome(argApf), apf, config)
   )
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1170,11 +1170,10 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
+      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
+        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), argAp0,
-        pragma[only_bind_into](config))
+      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
     )
   }
 
@@ -1858,11 +1857,10 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
+      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
+        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), argAp0,
-        pragma[only_bind_into](config))
+      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
     )
   }
 
@@ -2616,11 +2614,10 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
-        pragma[only_bind_into](config)) and
+      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
+        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), argAp0,
-        pragma[only_bind_into](config))
+      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -786,13 +786,18 @@ private module Cached {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   * Holds if the call context `call` improves virtual dispatch in `callable`.
    */
   cached
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
-    or
+  }
+
+  /**
+   * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
     exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
   }
 
@@ -844,6 +849,15 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+}
+
+/**
+ * Holds if the call context `call` either improves virtual dispatch in
+ * `callable` or if it allows us to prune unreachable nodes in `callable`.
+ */
+predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  recordDataFlowCallSiteDispatch(call, callable) or
+  recordDataFlowCallSiteUnreachable(call, callable)
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -508,7 +508,7 @@ private module Internal {
     override RuntimeCallable getADynamicTarget() {
       result = getAViableInherited()
       or
-      result = getAViableOverrider() and strictcount(getAViableOverrider()) < 1000
+      result = getAViableOverrider()
       or
       // Simple case: target method cannot be overridden
       result = getAStaticTarget() and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -786,13 +786,18 @@ private module Cached {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   * Holds if the call context `call` improves virtual dispatch in `callable`.
    */
   cached
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
-    or
+  }
+
+  /**
+   * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
     exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
   }
 
@@ -844,6 +849,15 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+}
+
+/**
+ * Holds if the call context `call` either improves virtual dispatch in
+ * `callable` or if it allows us to prune unreachable nodes in `callable`.
+ */
+predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  recordDataFlowCallSiteDispatch(call, callable) or
+  recordDataFlowCallSiteUnreachable(call, callable)
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -1170,10 +1170,12 @@ private module Stage2 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -1857,10 +1859,12 @@ private module Stage3 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 
@@ -2614,10 +2618,12 @@ private module Stage4 {
   pragma[nomagic]
   private predicate callMayFlowThroughFwd(DataFlowCall call, Configuration config) {
     exists(Ap argAp0, NodeEx out, Cc cc, ApOption argAp, Ap ap |
-      fwdFlow(pragma[only_bind_out](out), pragma[only_bind_out](cc), pragma[only_bind_out](argAp),
-        pragma[only_bind_out](ap), pragma[only_bind_out](config)) and
+      fwdFlow(out, pragma[only_bind_into](cc), pragma[only_bind_into](argAp), ap,
+        pragma[only_bind_into](config)) and
       fwdFlowOutFromArg(call, out, argAp0, ap, config) and
-      fwdFlowIsEntered(call, cc, argAp, argAp0, config)
+      fwdFlowIsEntered(pragma[only_bind_into](call), pragma[only_bind_into](cc),
+        pragma[only_bind_into](argAp), pragma[only_bind_into](argAp0),
+        pragma[only_bind_into](config))
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -786,13 +786,18 @@ private module Cached {
   }
 
   /**
-   * Holds if the call context `call` either improves virtual dispatch in
-   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   * Holds if the call context `call` improves virtual dispatch in `callable`.
    */
   cached
-  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
     reducedViableImplInCallContext(_, callable, call)
-    or
+  }
+
+  /**
+   * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
     exists(Node n | getNodeEnclosingCallable(n) = callable | isUnreachableInCallCached(n, call))
   }
 
@@ -844,6 +849,15 @@ private module Cached {
   newtype TAccessPathFrontOption =
     TAccessPathFrontNone() or
     TAccessPathFrontSome(AccessPathFront apf)
+}
+
+/**
+ * Holds if the call context `call` either improves virtual dispatch in
+ * `callable` or if it allows us to prune unreachable nodes in `callable`.
+ */
+predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+  recordDataFlowCallSiteDispatch(call, callable) or
+  recordDataFlowCallSiteUnreachable(call, callable)
 }
 
 /**


### PR DESCRIPTION
The motivation for this PR is to revert the [temporary virtual dispatch cap](https://github.com/github/codeql/pull/6394) put in place for C#. The change mostly makes a difference for DBs with huge virtual dispatch fan-out. The timings below are for a proprietary C# database.

<details>
 <summary>Before this PR:</summary>

```
	XSS.ql-33:DataFlowImpl2::additionalJumpStep#fff#shared ....................................................................................... 1m10s
	XSS.ql-33:DataFlowPrivate::NodeImpl::getTypeImpl_dispred#ff_10#join_rhs ...................................................................... 54.6s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ............................................................................................... 54.3s (1756 evaluations with max 1.4s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i95#d1de60)
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ................................................................................................ 50.1s
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff .................................................................................................. 44.1s
	XSS.ql-33:num#DataFlowImpl2::TNil#ff ......................................................................................................... 43.9s
	XSS.ql-33:num#DataFlowImpl2::TSummaryCtxNone#f ............................................................................................... 41.1s
	XSS.ql-33:locations_default_102345#join_rhs .................................................................................................. 37.9s
	XSS.ql-33:DataFlowImpl2::localFlowStep#fff ................................................................................................... 35.4s
	XSS.ql-33:#Type::ValueOrRefType::getBaseClass_dispredPlus#ff ................................................................................. 33.1s
	XSS.ql-33:Location::Location::hasLocationInfo_dispred#ffffff ................................................................................. 32s
	XSS.ql-33:DataFlowImpl2::jumpStep#fff#shared ................................................................................................. 27.5s
	XSS.ql-33:DataFlowImpl2::NodeEx::getDataFlowType0#ff ......................................................................................... 25.8s
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ........................................................................................ 24.7s
	XSS.ql-33:DataFlowImpl2::NodeEx::getEnclosingCallable0#ff .................................................................................... 24.2s
	XSS.ql-33:ControlFlowGraph::ControlFlow::Node::getEnclosingCallable_dispred#ff ............................................................... 23.2s
	XSS.ql-33:DataFlowImpl2::Stage1::revFlow0#fff ................................................................................................ 22.2s (797 evaluations with max 385ms in DataFlowImpl2::Stage1::revFlow0#fff/3@i243#09cb13)
	XSS.ql-33:XSSSinks::HtmlSinkSink#class#f ..................................................................................................... 21.6s
	XSS.ql-33:DataFlowPublic::Content::toString_dispred#ff ....................................................................................... 18.9s
	XSS.ql-33:m#Assignable::nameOfChild#fb ....................................................................................................... 16.9s (240 evaluations with max 7.5s in m#Assignable::nameOfChild#fb/1@i3#e5ba6w)
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ........................................................................ 16.3s
```
</details>


<details>
 <summary>First commit of this PR (revert https://github.com/github/codeql/pull/6394):</summary>

```
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIn#fffffff ........................................ 192m53s (366 evaluations with max 13m37s in DataFlowImpl2::Stage3::fwdFlowIn#fffffff/7@i174#0675c0)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow0#fffff ........................................... 46m40s (369 evaluations with max 2m45s in DataFlowImpl2::Stage3::fwdFlow0#fffff/5@i181#0675c4)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3 ................ 35m46s (365 evaluations with max 2m11s in DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3/5@i174#0675cy)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow#fffff ............................................ 33m23s (367 evaluations with max 40.5s in DataFlowImpl2::Stage3::fwdFlow#fffff/5@i168#0675c3)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2 ................. 16m28s (360 evaluations with max 1m16s in DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2/5@i181#0675cx)
	XSS.ql-33:DataFlowImpl2::Stage3::revFlowInToReturn#fffff#reorder_0_2_4_1_3 ................ 9m23s (362 evaluations with max 52.8s in DataFlowImpl2::Stage3::revFlowInToReturn#fffff#reorder_0_2_4_1_3/5@i28#6b414z)
	XSS.ql-33:DataFlowImpl2::Stage3::callMayFlowThroughFwd#ff ................................. 3m53s
	XSS.ql-33:DataFlowImpl2::Stage4::fwdFlowIn#fffffff ........................................ 3m32s (403 evaluations with max 29.8s in DataFlowImpl2::Stage4::fwdFlowIn#fffffff/7@i113#b7163z)
	XSS.ql-33:DataFlowImpl2::Stage3::revFlow0#fffff ........................................... 2m49s (380 evaluations with max 6.4s in DataFlowImpl2::Stage3::revFlow0#fffff/5@i19#6b4143)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutNotFromArg#fffff ............................... 2m44s (364 evaluations with max 1.9s in DataFlowImpl2::Stage3::fwdFlowOutNotFromArg#fffff/5@i136#0675c2)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowStore#fffffff ..................................... 2m35s (366 evaluations with max 8.2s in DataFlowImpl2::Stage3::fwdFlowStore#fffffff/7@i205#0675c1)
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ............................................. 2m18s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff ......................................... 1m59s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ............................................ 1m37s (1753 evaluations with max 2.9s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i30#d93cc0)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5#join_rhs ....... 1m34s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff_102#join_rhs ............................ 1m21s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5 ................ 1m17s (363 evaluations with max 5.3s in DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5/7@i137#0675cz)
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff ............................................... 1m8s
	XSS.ql-33:DataFlowImpl2::Stage3::revFlowOut#ffffff ........................................ 57.7s (361 evaluations with max 7.7s in DataFlowImpl2::Stage3::revFlowOut#ffffff/6@i18#6b4140)
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlowOut#ffff .......................................... 52.4s (1735 evaluations with max 3.3s in DataFlowImpl2::Stage1::fwdFlowOut#ffff/4@i23#d93cc2)
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ..................................... 48.4s
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ..................... 46.2s
```

</details>


<details>
 <summary>This PR:</summary>

```
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIn#fffffff .................................. 3m31s (429 evaluations with max 13.6s in DataFlowImpl2::Stage3::fwdFlowIn#fffffff/7@i148#a26e80)
	XSS.ql-33:DataFlowImpl2::viableParamArgEx#fff ....................................... 3m6s
	XSS.ql-33:DataFlowImpl2::additionalJumpStep#fff#shared .............................. 2m33s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff ................................... 2m32s
	XSS.ql-33:DataFlowImpl2::viableReturnPosOutEx#fff_102#join_rhs ...................... 2m29s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow0#fffff ..................................... 2m7s (439 evaluations with max 6.6s in DataFlowImpl2::Stage3::fwdFlow0#fffff/5@i149#a26e84)
	XSS.ql-33:DataFlowImplCommon::Cached::nodeEnclosingCallable#ff ...................... 1m59s
	XSS.ql-33:DataFlowImplCommon::viableCallableExt#ff_10#join_rhs ...................... 1m33s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlow#2#fff ...................................... 1m33s (1753 evaluations with max 3s in DataFlowImpl2::Stage1::fwdFlow#2#fff/3@i30#d93cc0)
	XSS.ql-33:project#DataFlowImpl2::viableParamArgEx#fff ............................... 1m22s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlow#fffff ...................................... 1m10s (436 evaluations with max 3.2s in DataFlowImpl2::Stage3::fwdFlow#fffff/5@i130#a26e83)
	XSS.ql-33:DataFlowPrivate::NodeImpl::getTypeImpl_dispred#ff_10#join_rhs ............. 1m9s
	XSS.ql-33:DataFlowImpl2::Stage1::fwdFlowOut#ffff .................................... 1m8s (1735 evaluations with max 5.3s in DataFlowImpl2::Stage1::fwdFlowOut#ffff/4@i23#d93cc2)
	XSS.ql-33:num#DataFlowImpl2::TNodeNormal#ff ......................................... 1m1s
	XSS.ql-33:DataFlowImpl2::Stage2::fwdFlowIn#fffffff .................................. 58.3s (1502 evaluations with max 2s in DataFlowImpl2::Stage2::fwdFlowIn#fffffff/7@i71#63d620)
	XSS.ql-33:DataFlowImplCommon::Cached::viableParamArg#fff_102#join_rhs ............... 57.6s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2 ........... 56.6s (412 evaluations with max 3.4s in DataFlowImpl2::Stage3::fwdFlowIsEntered#fffff#reorder_0_3_4_1_2/5@i149#a26e8x)
	XSS.ql-33:#Type::ValueOrRefType::getBaseClass_dispredPlus#ff ........................ 54.2s
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3 .......... 52.8s (432 evaluations with max 1.6s in DataFlowImpl2::Stage3::fwdFlowOutFromArg#fffff#reorder_0_2_4_1_3/5@i146#a26e8y)
	XSS.ql-33:DataFlowImpl2::Stage3::fwdFlowRead#fffffff#reorder_0_1_6_2_3_4_5#join_rhs . 51.6s
```

</details>

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1299/ (first commit against base)
https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1312/ (PR against first commit)
https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/2235/
https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/1579/
https://jenkins.internal.semmle.com/job/Changes/job/Python-Differences/682/