### PR TITLE
JS: Add support for TypeScript 4.4

### DIFF
--- a/docs/codeql/support/reusables/versions-compilers.rst
+++ b/docs/codeql/support/reusables/versions-compilers.rst
@@ -22,7 +22,7 @@
    Eclipse compiler for Java (ECJ) [5]_",``.java``
    JavaScript,ECMAScript 2021 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhm``, ``.xhtml``, ``.vue``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [6]_"
    Python,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9",Not applicable,``.py``
-   TypeScript [7]_,"2.6-4.2",Standard TypeScript compiler,"``.ts``, ``.tsx``"
+   TypeScript [7]_,"2.6-4.4",Standard TypeScript compiler,"``.ts``, ``.tsx``"
 
 .. container:: footnote-group
 

--- a/javascript/change-notes/2021-09-01-typescript-4.4.md
+++ b/javascript/change-notes/2021-09-01-typescript-4.4.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* TypeScript 4.4 is now supported.

--- a/javascript/change-notes/2021-09-07-static-initializer.md
+++ b/javascript/change-notes/2021-09-07-static-initializer.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Support for the ECMAScript proposed feature "class static initialization blocks" has been added.

--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "4.3.5"
+        "typescript": "4.4.2"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json",

--- a/javascript/extractor/lib/typescript/yarn.lock
+++ b/javascript/extractor/lib/typescript/yarn.lock
@@ -6,7 +6,7 @@
   version "12.7.11"
   resolved node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==

--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -3219,7 +3219,7 @@ public class Parser {
     Expression superClass = this.parseClassSuper();
     Position bodyStartLoc = this.startLoc;
     boolean hadConstructor = false;
-    List<Node> body = new ArrayList<>(); // TODO: The JS parser doesn't support static initializer blocks.
+    List<Node> body = new ArrayList<>();
     this.expect(TokenType.braceL);
     while (!this.eat(TokenType.braceR)) {
       if (this.eat(TokenType.semi)) continue;

--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -3219,7 +3219,7 @@ public class Parser {
     Expression superClass = this.parseClassSuper();
     Position bodyStartLoc = this.startLoc;
     boolean hadConstructor = false;
-    List<MemberDefinition<?>> body = new ArrayList<>();
+    List<MemberDefinition<?>> body = new ArrayList<MemberDefinition<?>>();
     this.expect(TokenType.braceL);
     while (!this.eat(TokenType.braceR)) {
       if (this.eat(TokenType.semi)) continue;

--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -3219,7 +3219,7 @@ public class Parser {
     Expression superClass = this.parseClassSuper();
     Position bodyStartLoc = this.startLoc;
     boolean hadConstructor = false;
-    List<MemberDefinition<?>> body = new ArrayList<MemberDefinition<?>>();
+    List<Node> body = new ArrayList<>(); // TODO: The JS parser doesn't support static initializer blocks.
     this.expect(TokenType.braceL);
     while (!this.eat(TokenType.braceR)) {
       if (this.eat(TokenType.semi)) continue;

--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -83,6 +83,7 @@ import com.semmle.js.ast.SequenceExpression;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.SpreadElement;
 import com.semmle.js.ast.Statement;
+import com.semmle.js.ast.StaticInitializer;
 import com.semmle.js.ast.Super;
 import com.semmle.js.ast.SwitchCase;
 import com.semmle.js.ast.SwitchStatement;
@@ -3244,6 +3245,10 @@ public class Parser {
     PropertyInfo pi = new PropertyInfo(false, isGenerator, methodStartLoc);
     this.parsePropertyName(pi);
     boolean isStatic = isMaybeStatic && this.type != TokenType.parenL;
+    if (isStatic && this.type == TokenType.braceL) {
+      BlockStatement block = parseBlock(false);
+      return new StaticInitializer(block.getLoc(), block);
+    }
     if (isStatic) {
       if (isGenerator) this.unexpected();
       isGenerator = this.eat(TokenType.star);

--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -3219,7 +3219,7 @@ public class Parser {
     Expression superClass = this.parseClassSuper();
     Position bodyStartLoc = this.startLoc;
     boolean hadConstructor = false;
-    List<Node> body = new ArrayList<>();
+    List<MemberDefinition<?>> body = new ArrayList<>();
     this.expect(TokenType.braceL);
     while (!this.eat(TokenType.braceR)) {
       if (this.eat(TokenType.semi)) continue;

--- a/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
+++ b/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /** The body of a {@linkplain ClassDeclaration} or {@linkplain ClassExpression}. */
 public class ClassBody extends Node {
-  private final List<Node> body; // either MemberDefintion or BlockStatement (static initialization blocks)
+  private final List<Node> body; // either MemberDefinition or BlockStatement (static initialization blocks)
 
   public ClassBody(SourceLocation loc, List<Node> body) {
     super("ClassBody", loc);

--- a/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
+++ b/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
@@ -20,7 +20,7 @@ public class ClassBody extends Node {
   }
 
   public MethodDefinition getConstructor() {
-    for (Node md : body) if (md instanceof MethodDefinition && ((MethodDefinition)md).isConstructor()) return (MethodDefinition) md;
+    for (MemberDefinition<?> md : body) if (md.isConstructor()) return (MethodDefinition) md;
     return null;
   }
 

--- a/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
+++ b/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
@@ -4,18 +4,18 @@ import java.util.List;
 
 /** The body of a {@linkplain ClassDeclaration} or {@linkplain ClassExpression}. */
 public class ClassBody extends Node {
-  private final List<Node> body; // either MemberDefinition or BlockStatement (static initialization blocks)
+  private final List<MemberDefinition<?>> body;
 
-  public ClassBody(SourceLocation loc, List<Node> body) {
+  public ClassBody(SourceLocation loc, List<MemberDefinition<?>> body) {
     super("ClassBody", loc);
     this.body = body;
   }
 
-  public List<Node> getBody() {
+  public List<MemberDefinition<?>> getBody() {
     return body;
   }
 
-  public void addMember(Node md) {
+  public void addMember(MemberDefinition<?> md) {
     body.add(md);
   }
 

--- a/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
+++ b/javascript/extractor/src/com/semmle/js/ast/ClassBody.java
@@ -4,23 +4,23 @@ import java.util.List;
 
 /** The body of a {@linkplain ClassDeclaration} or {@linkplain ClassExpression}. */
 public class ClassBody extends Node {
-  private final List<MemberDefinition<?>> body;
+  private final List<Node> body; // either MemberDefintion or BlockStatement (static initialization blocks)
 
-  public ClassBody(SourceLocation loc, List<MemberDefinition<?>> body) {
+  public ClassBody(SourceLocation loc, List<Node> body) {
     super("ClassBody", loc);
     this.body = body;
   }
 
-  public List<MemberDefinition<?>> getBody() {
+  public List<Node> getBody() {
     return body;
   }
 
-  public void addMember(MemberDefinition<?> md) {
+  public void addMember(Node md) {
     body.add(md);
   }
 
   public MethodDefinition getConstructor() {
-    for (MemberDefinition<?> md : body) if (md.isConstructor()) return (MethodDefinition) md;
+    for (Node md : body) if (md instanceof MethodDefinition && ((MethodDefinition)md).isConstructor()) return (MethodDefinition) md;
     return null;
   }
 

--- a/javascript/extractor/src/com/semmle/js/ast/DefaultVisitor.java
+++ b/javascript/extractor/src/com/semmle/js/ast/DefaultVisitor.java
@@ -782,4 +782,9 @@ public class DefaultVisitor<C, R> implements Visitor<C, R> {
   public R visit(GeneratedCodeExpr nd, C c) {
     return visit((Expression) nd, c);
   }
+
+  @Override
+  public R visit(StaticInitializer nd, C c) {
+    return visit((MemberDefinition<Expression>) nd, c);
+  }
 }

--- a/javascript/extractor/src/com/semmle/js/ast/DefaultVisitor.java
+++ b/javascript/extractor/src/com/semmle/js/ast/DefaultVisitor.java
@@ -785,6 +785,6 @@ public class DefaultVisitor<C, R> implements Visitor<C, R> {
 
   @Override
   public R visit(StaticInitializer nd, C c) {
-    return visit((MemberDefinition<Expression>) nd, c);
+    return visit((MemberDefinition<BlockStatement>) nd, c);
   }
 }

--- a/javascript/extractor/src/com/semmle/js/ast/MemberDefinition.java
+++ b/javascript/extractor/src/com/semmle/js/ast/MemberDefinition.java
@@ -9,7 +9,7 @@ import java.util.List;
  * <p>A member definition has a name and an optional initial value, whose type is given by the type
  * parameter {@code V}.
  */
-public abstract class MemberDefinition<V extends Expression> extends Node {
+public abstract class MemberDefinition<V extends Node> extends Node {
   /** A bitmask of flags defined in {@linkplain DeclarationFlags}. */
   private final int flags;
 
@@ -21,7 +21,7 @@ public abstract class MemberDefinition<V extends Expression> extends Node {
    */
   private final Expression key;
 
-  /** The initial value of the member. */
+  /** The initial value / initializer of the member. */
   private final V value;
 
   /** The decorators applied to this member, if any. */

--- a/javascript/extractor/src/com/semmle/js/ast/NodeCopier.java
+++ b/javascript/extractor/src/com/semmle/js/ast/NodeCopier.java
@@ -902,6 +902,6 @@ public class NodeCopier implements Visitor<Void, INode> {
 
   @Override
   public INode visit(StaticInitializer nd, Void c) {
-    return new StaticInitializer(visit(nd.getLoc()), copy(nd.getBody()));
+    return new StaticInitializer(visit(nd.getLoc()), copy(nd.getValue()));
   }
 }

--- a/javascript/extractor/src/com/semmle/js/ast/NodeCopier.java
+++ b/javascript/extractor/src/com/semmle/js/ast/NodeCopier.java
@@ -897,6 +897,11 @@ public class NodeCopier implements Visitor<Void, INode> {
 
   @Override
   public INode visit(GeneratedCodeExpr nd, Void c) {
-  return new GeneratedCodeExpr(visit(nd.getLoc()), nd.getOpeningDelimiter(), nd.getClosingDelimiter(), nd.getBody());
+    return new GeneratedCodeExpr(visit(nd.getLoc()), nd.getOpeningDelimiter(), nd.getClosingDelimiter(), nd.getBody());
+  }
+
+  @Override
+  public INode visit(StaticInitializer nd, Void c) {
+    return new StaticInitializer(visit(nd.getLoc()), copy(nd.getBody()));
   }
 }

--- a/javascript/extractor/src/com/semmle/js/ast/StaticInitializer.java
+++ b/javascript/extractor/src/com/semmle/js/ast/StaticInitializer.java
@@ -1,37 +1,18 @@
 package com.semmle.js.ast;
 
 /**
- * A static initializer block in a class.
- * E.g. 
- * ```TypeScript
- * class Foo {
- *  static bar : number;
- *  static {
- *   Foo.bar = 42;
- *  }
- * }
+ * A static initializer block in a class. E.g. ```TypeScript class Foo { static
+ * bar : number; static { Foo.bar = 42; } }
  */
-public class StaticInitializer extends MemberDefinition<Expression> {
-  private final BlockStatement body;
-
+public class StaticInitializer extends MemberDefinition<BlockStatement> {
   public StaticInitializer(SourceLocation loc, BlockStatement body) {
-    super("StaticInitializer", loc, DeclarationFlags.static_, null, null);
-    this.body = body;
-  }
-
-  /**
-   * Gets the body of this static initializer.
-   * @return The body of this static initializer.
-   */
-  public BlockStatement getBody() {
-    return body;
+    super("StaticInitializer", loc, DeclarationFlags.static_, null, body);
   }
 
   @Override
   public boolean isConcrete() {
     return false;
   }
-
 
   @Override
   public <C, R> R accept(Visitor<C, R> v, C c) {

--- a/javascript/extractor/src/com/semmle/js/ast/StaticInitializer.java
+++ b/javascript/extractor/src/com/semmle/js/ast/StaticInitializer.java
@@ -1,0 +1,40 @@
+package com.semmle.js.ast;
+
+/**
+ * A static initializer block in a class.
+ * E.g. 
+ * ```TypeScript
+ * class Foo {
+ *  static bar : number;
+ *  static {
+ *   Foo.bar = 42;
+ *  }
+ * }
+ */
+public class StaticInitializer extends MemberDefinition<Expression> {
+  private final BlockStatement body;
+
+  public StaticInitializer(SourceLocation loc, BlockStatement body) {
+    super("StaticInitializer", loc, DeclarationFlags.static_, null, null);
+    this.body = body;
+  }
+
+  /**
+   * Gets the body of this static initializer.
+   * @return The body of this static initializer.
+   */
+  public BlockStatement getBody() {
+    return body;
+  }
+
+  @Override
+  public boolean isConcrete() {
+    return false;
+  }
+
+
+  @Override
+  public <C, R> R accept(Visitor<C, R> v, C c) {
+    return v.visit(this, c);
+  }
+}

--- a/javascript/extractor/src/com/semmle/js/ast/Visitor.java
+++ b/javascript/extractor/src/com/semmle/js/ast/Visitor.java
@@ -315,4 +315,6 @@ public interface Visitor<C, R> {
   public R visit(XMLDotDotExpression nd, C c);
 
   public R visit(GeneratedCodeExpr generatedCodeExpr, C c);
+
+  public R visit(StaticInitializer nd, C c);
 }

--- a/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
@@ -80,6 +80,7 @@ import com.semmle.js.ast.SourceElement;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.SpreadElement;
 import com.semmle.js.ast.Statement;
+import com.semmle.js.ast.StaticInitializer;
 import com.semmle.js.ast.Super;
 import com.semmle.js.ast.SwitchCase;
 import com.semmle.js.ast.SwitchStatement;
@@ -1613,6 +1614,8 @@ public class ASTExtractor {
       int kind;
       if (nd instanceof MethodDefinition) {
         kind = getMethodKind((MethodDefinition) nd);
+      } else if (nd instanceof StaticInitializer) {
+        kind = 10;
       } else {
         kind = getFieldKind((FieldDefinition) nd);
       }
@@ -1641,6 +1644,11 @@ public class ASTExtractor {
         if (DeclarationFlags.hasNthFlag(nd.getFlags(), i)) {
           trapwriter.addTuple(DeclarationFlags.relationNames.get(i), methkey);
         }
+      }
+
+      if (nd instanceof StaticInitializer) {
+        StaticInitializer si = (StaticInitializer) nd;
+        visit(si.getBody(), methkey, 3, IdContext.VAR_BIND);
       }
 
       if (nd instanceof FieldDefinition) {

--- a/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
@@ -1646,11 +1646,6 @@ public class ASTExtractor {
         }
       }
 
-      if (nd instanceof StaticInitializer) {
-        StaticInitializer si = (StaticInitializer) nd;
-        visit(si.getBody(), methkey, 3, IdContext.VAR_BIND);
-      }
-
       if (nd instanceof FieldDefinition) {
         FieldDefinition field = (FieldDefinition) nd;
         if (field.isParameterField() && constructorKey != null) {

--- a/javascript/extractor/src/com/semmle/js/extractor/CFGExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/CFGExtractor.java
@@ -1165,7 +1165,7 @@ public class CFGExtractor {
 
     private Void visit(Node nd, AClass ac, SuccessorInfo i) {
       for (MemberDefinition<?> md : ac.getBody().getBody()) {
-        if (md.isConstructor() && md.isConcrete()) constructor2Class.put(md.getValue(), ac);
+        if (md.isConstructor() && md.isConcrete()) constructor2Class.put((Expression)md.getValue(), ac);
       }
       visitSequence(ac.getId(), ac.getSuperClass(), ac.getBody(), nd);
       writeSuccessors(nd, visitSequence(getStaticInitializers(ac.getBody()), getDecoratorsOfClass(ac), i.getAllSuccessors()));
@@ -1627,7 +1627,7 @@ public class CFGExtractor {
       List<Node> nodes = new ArrayList<>();
       for (MemberDefinition<?> node : nd.getBody()) {
         if (node instanceof FieldDefinition && ((FieldDefinition)node).isStatic()) nodes.add(node);
-        if (node instanceof StaticInitializer) nodes.add(((StaticInitializer)node).getBody());
+        if (node instanceof StaticInitializer) nodes.add(node.getValue());
       }
       return nodes;
     }

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -43,7 +43,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2021-07-28";
+  public static final String EXTRACTOR_VERSION = "2021-09-01";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
@@ -632,6 +632,8 @@ public class TypeScriptASTConverter {
         return convertWithStatement(node, loc);
       case "YieldExpression":
         return convertYieldExpression(node, loc);
+      case "ClassStaticBlockDeclaration":
+        return convertStaticInitializerBlock(node, loc);
       default:
         throw new ParseError(
             "Unsupported TypeScript syntax " + kind, getSourceLocation(node).getStart());
@@ -864,6 +866,10 @@ public class TypeScriptASTConverter {
       default:
         return new BinaryExpression(loc, operator, left, right);
     }
+  }
+
+  private Node convertStaticInitializerBlock(JsonObject node, SourceLocation loc) throws ParseError {
+    return new BlockStatement(loc, convertChildren(node.get("body").getAsJsonObject(), "statements"));
   }
 
   private Node convertBlock(JsonObject node, SourceLocation loc) throws ParseError {

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
@@ -82,6 +82,7 @@ import com.semmle.js.ast.SequenceExpression;
 import com.semmle.js.ast.SourceLocation;
 import com.semmle.js.ast.SpreadElement;
 import com.semmle.js.ast.Statement;
+import com.semmle.js.ast.StaticInitializer;
 import com.semmle.js.ast.Super;
 import com.semmle.js.ast.SwitchCase;
 import com.semmle.js.ast.SwitchStatement;
@@ -154,6 +155,8 @@ import com.semmle.ts.ast.UnaryTypeExpr;
 import com.semmle.ts.ast.UnionTypeExpr;
 import com.semmle.util.collections.CollectionUtil;
 import com.semmle.util.data.IntList;
+
+import jdk.internal.org.objectweb.asm.commons.StaticInitMerger;
 
 /**
  * Utility class for converting a <a
@@ -869,7 +872,8 @@ public class TypeScriptASTConverter {
   }
 
   private Node convertStaticInitializerBlock(JsonObject node, SourceLocation loc) throws ParseError {
-    return new BlockStatement(loc, convertChildren(node.get("body").getAsJsonObject(), "statements"));
+    BlockStatement body = new BlockStatement(loc, convertChildren(node.get("body").getAsJsonObject(), "statements"));
+    return new StaticInitializer(loc, body);
   }
 
   private Node convertBlock(JsonObject node, SourceLocation loc) throws ParseError {

--- a/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/ts/extractor/TypeScriptASTConverter.java
@@ -156,8 +156,6 @@ import com.semmle.ts.ast.UnionTypeExpr;
 import com.semmle.util.collections.CollectionUtil;
 import com.semmle.util.data.IntList;
 
-import jdk.internal.org.objectweb.asm.commons.StaticInitMerger;
-
 /**
  * Utility class for converting a <a
  * href="https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API">TypeScript AST

--- a/javascript/ql/lib/semmle/javascript/Classes.qll
+++ b/javascript/ql/lib/semmle/javascript/Classes.qll
@@ -262,7 +262,9 @@ class ClassDefinition extends @class_definition, ClassOrInterface, AST::ValueNod
   /**
    * Gets a static initializer of this class, if any.
    */
-  BlockStmt getAStaticInitializerBlock() { result.getParent() = this }
+  BlockStmt getAStaticInitializerBlock() {
+    exists(StaticInitializer init | init.getDeclaringClass() = this | result = init.getBody())
+  }
 }
 
 /**
@@ -1137,6 +1139,15 @@ class ParameterField extends FieldDeclaration, @parameter_field {
   override Expr getNameExpr() { result = getParameter() }
 
   override TypeAnnotation getTypeAnnotation() { result = getParameter().getTypeAnnotation() }
+}
+
+/**
+ * A static initializer in a class.
+ */
+class StaticInitializer extends MemberDefinition, @static_initializer {
+  BlockStmt getBody() { result.getParent() = this }
+
+  override Expr getNameExpr() { none() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/Classes.qll
+++ b/javascript/ql/lib/semmle/javascript/Classes.qll
@@ -1145,6 +1145,9 @@ class ParameterField extends FieldDeclaration, @parameter_field {
  * A static initializer in a class.
  */
 class StaticInitializer extends MemberDefinition, @static_initializer {
+  /**
+   * Gets the body of the static initializer.
+   */
   BlockStmt getBody() { result.getParent() = this }
 
   override Expr getNameExpr() { none() }

--- a/javascript/ql/lib/semmle/javascript/Classes.qll
+++ b/javascript/ql/lib/semmle/javascript/Classes.qll
@@ -258,6 +258,11 @@ class ClassDefinition extends @class_definition, ClassOrInterface, AST::ValueNod
   }
 
   override string getAPrimaryQlClass() { result = "ClassDefinition" }
+
+  /**
+   * Gets a static initializer of this class, if any.
+   */
+  BlockStmt getAStaticInitializerBlock() { result.getParent() = this }
 }
 
 /**

--- a/javascript/ql/lib/semmlecode.javascript.dbscheme
+++ b/javascript/ql/lib/semmlecode.javascript.dbscheme
@@ -146,7 +146,7 @@ stmt_containers (unique int stmt: @stmt ref,
 jump_targets (unique int jump: @stmt ref,
        int target: @stmt ref);
 
-@stmt_parent = @stmt | @toplevel | @function_expr | @arrow_function_expr;
+@stmt_parent = @stmt | @toplevel | @function_expr | @arrow_function_expr | @static_initializer;
 @stmt_container = @toplevel | @function | @namespace_declaration | @external_module_declaration | @global_augmentation_declaration;
 
 case @stmt.kind of

--- a/javascript/ql/lib/semmlecode.javascript.dbscheme
+++ b/javascript/ql/lib/semmlecode.javascript.dbscheme
@@ -521,6 +521,7 @@ case @property.kind of
 | 7 = @enum_member
 | 8 = @proper_field
 | 9 = @parameter_field
+| 10 = @static_initializer
 ;
 
 @property_parent = @obj_expr | @object_pattern | @class_definition | @jsx_element | @interface_definition | @enum_declaration;

--- a/javascript/ql/lib/semmlecode.javascript.dbscheme.stats
+++ b/javascript/ql/lib/semmlecode.javascript.dbscheme.stats
@@ -774,6 +774,10 @@
 <v>2693</v>
 </e>
 <e>
+<k>@static_initializer</k>
+<v>100</v>
+</e>
+<e>
 <k>@local_type_access</k>
 <v>25491</v>
 </e>

--- a/javascript/ql/lib/upgrade.properties
+++ b/javascript/ql/lib/upgrade.properties
@@ -1,0 +1,2 @@
+description: add @static_initializer property kind
+compatibility: backwards

--- a/javascript/ql/test/library-tests/CFG/CFG.expected
+++ b/javascript/ql/test/library-tests/CFG/CFG.expected
@@ -770,7 +770,37 @@
 | staticFieldsTS | 6 | D | 6 | new D() |
 | staticFieldsTS | 6 | instance | 6 | D |
 | staticFieldsTS | 6 | new D() | 6 | static  ... ew D(); |
-| staticFieldsTS | 6 | static  ... ew D(); | 8 | exit node of <toplevel> |
+| staticFieldsTS | 6 | static  ... ew D(); | 9 | export  ... ;\\n  }\\n} |
+| staticFieldsTS | 9 | E | 9 | constructor |
+| staticFieldsTS | 9 | class E ... ;\\n  }\\n} | 10 | f |
+| staticFieldsTS | 9 | constructor | 9 | function in constructor() {} |
+| staticFieldsTS | 9 | constructor() {} | 9 | class E ... ;\\n  }\\n} |
+| staticFieldsTS | 9 | entry node of () {} | 9 | {} |
+| staticFieldsTS | 9 | export  ... ;\\n  }\\n} | 9 | E |
+| staticFieldsTS | 9 | function in constructor() {} | 9 | constructor() {} |
+| staticFieldsTS | 9 | {} | 9 | exit node of () {} |
+| staticFieldsTS | 10 | f | 10 | false |
+| staticFieldsTS | 10 | false | 10 | static  ...  false; |
+| staticFieldsTS | 10 | static  ...  false; | 11 | static  ... ();\\n  } |
+| staticFieldsTS | 11 | static  ... ();\\n  } | 12 | E.f = new C(); |
+| staticFieldsTS | 12 | C | 12 | new C() |
+| staticFieldsTS | 12 | E | 12 | f |
+| staticFieldsTS | 12 | E.f | 12 | C |
+| staticFieldsTS | 12 | E.f = new C() | 14 | g |
+| staticFieldsTS | 12 | E.f = new C(); | 12 | E |
+| staticFieldsTS | 12 | f | 12 | E.f |
+| staticFieldsTS | 12 | new C() | 12 | E.f = new C() |
+| staticFieldsTS | 14 | 1337 | 14 | static  ... = 1337; |
+| staticFieldsTS | 14 | g | 14 | 1337 |
+| staticFieldsTS | 14 | static  ... = 1337; | 15 | static  ... ();\\n  } |
+| staticFieldsTS | 15 | static  ... ();\\n  } | 16 | E.g = new D(); |
+| staticFieldsTS | 16 | D | 16 | new D() |
+| staticFieldsTS | 16 | E | 16 | g |
+| staticFieldsTS | 16 | E.g | 16 | D |
+| staticFieldsTS | 16 | E.g = new D() | 18 | exit node of <toplevel> |
+| staticFieldsTS | 16 | E.g = new D(); | 16 | E |
+| staticFieldsTS | 16 | g | 16 | E.g |
+| staticFieldsTS | 16 | new D() | 16 | E.g = new D() |
 | switch | 1 | entry node of <toplevel> | 14 | f |
 | switch | 1 | switch  ...   19;\\n} | 2 | x |
 | switch | 2 | x | 6 | case\\n   ...     19; |

--- a/javascript/ql/test/library-tests/CFG/StaticInit.expected
+++ b/javascript/ql/test/library-tests/CFG/StaticInit.expected
@@ -14,3 +14,5 @@
 | staticFields.js:2:3:2:28 | static  ... ew C(); | Field initializer occurs after its class is created |
 | staticFieldsTS.ts:2:3:2:31 | static  ... ew C(); | Field initializer occurs after its class is created |
 | staticFieldsTS.ts:6:3:6:31 | static  ... ew D(); | Field initializer occurs after its class is created |
+| staticFieldsTS.ts:10:3:10:32 | static  ...  false; | Field initializer occurs after its class is created |
+| staticFieldsTS.ts:14:3:14:30 | static  ... = 1337; | Field initializer occurs after its class is created |

--- a/javascript/ql/test/library-tests/CFG/staticFieldsTS.ts
+++ b/javascript/ql/test/library-tests/CFG/staticFieldsTS.ts
@@ -5,3 +5,14 @@ class C {
 export class D {
   static instance: D = new D();
 }
+
+export class E {
+  static f: C | boolean = false;
+  static {
+    E.f = new C();
+  }
+  static g: D | number = 1337;
+  static {
+    E.g = new D();
+  }
+}

--- a/javascript/ql/test/library-tests/Classes/staticInitializer.js
+++ b/javascript/ql/test/library-tests/Classes/staticInitializer.js
@@ -1,0 +1,18 @@
+class MyClass {
+  static x = 1;
+  constructor() {
+    this.y = 2;
+  }
+  static {
+    MyClass.z = 3;
+  }
+  foo() {
+    this.t = 4;
+  }
+  static bar() {
+    this.u = 5;
+  }
+  static {
+    this.v = 6;
+  }
+}

--- a/javascript/ql/test/library-tests/Classes/tests.expected
+++ b/javascript/ql/test/library-tests/Classes/tests.expected
@@ -4,6 +4,7 @@ test_FieldInits
 | privateFields.js:2:2:2:15 | #privDecl = 3; | privateFields.js:2:14:2:14 | 3 |
 | privateFields.js:3:2:3:12 | #if = "if"; | privateFields.js:3:8:3:11 | "if" |
 | privateFields.js:21:2:21:22 | ["#publ ... "] = 6; | privateFields.js:21:21:21:21 | 6 |
+| staticInitializer.js:2:3:2:15 | static x = 1; | staticInitializer.js:2:14:2:14 | 1 |
 test_ComputedMethods
 | tst.js:3:3:3:56 | ["const ... r. */ } |
 | tst.js:13:3:13:10 | [m]() {} |
@@ -11,6 +12,7 @@ test_StaticMethods
 | points.js:15:3:17:3 | static  ... t";\\n  } |
 | points.js:30:3:32:3 | static  ... t";\\n  } |
 | staticConstructor.js:2:3:2:59 | static  ... tor"; } |
+| staticInitializer.js:12:3:14:3 | static  ...  5;\\n  } |
 test_ClassDefinition_getSuperClass
 | points.js:20:1:33:1 | class C ... ;\\n  }\\n} | points.js:20:29:20:33 | Point |
 | tst.js:6:1:8:1 | class B ... t); }\\n} | tst.js:6:17:6:17 | A |
@@ -18,6 +20,7 @@ test_ClassNodeStaticMethod
 | points.js:1:1:18:1 | class P ... ;\\n  }\\n} | className | points.js:15:19:17:3 | () {\\n   ... t";\\n  } |
 | points.js:20:1:33:1 | class C ... ;\\n  }\\n} | className | points.js:30:19:32:3 | () {\\n   ... t";\\n  } |
 | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} | constructor | staticConstructor.js:2:21:2:59 | () { re ... tor"; } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | bar | staticInitializer.js:12:13:14:3 | () {\\n   ...  5;\\n  } |
 test_ClassDefinitions
 | dataflow.js:4:2:13:2 | class F ... \\n\\t\\t}\\n\\t} |
 | fields.js:1:1:4:1 | class C ...  = 42\\n} |
@@ -25,6 +28,7 @@ test_ClassDefinitions
 | points.js:20:1:33:1 | class C ... ;\\n  }\\n} |
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} |
 | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} |
 | tst.js:1:9:4:1 | class { ...  */ }\\n} |
 | tst.js:6:1:8:1 | class B ... t); }\\n} |
 | tst.js:11:1:14:1 | class C ... () {}\\n} |
@@ -38,6 +42,7 @@ test_Fields
 | privateFields.js:3:2:3:12 | #if = "if"; | privateFields.js:3:2:3:4 | #if |
 | privateFields.js:19:2:19:13 | #privSecond; | privateFields.js:19:2:19:12 | #privSecond |
 | privateFields.js:21:2:21:22 | ["#publ ... "] = 6; | privateFields.js:21:3:21:16 | "#publicField" |
+| staticInitializer.js:2:3:2:15 | static x = 1; | staticInitializer.js:2:10:2:10 | x |
 test_ClassDefinition_getName
 | dataflow.js:4:2:13:2 | class F ... \\n\\t\\t}\\n\\t} | Foo |
 | fields.js:1:1:4:1 | class C ...  = 42\\n} | C |
@@ -45,6 +50,7 @@ test_ClassDefinition_getName
 | points.js:20:1:33:1 | class C ... ;\\n  }\\n} | ColouredPoint |
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} | Foo |
 | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} | MyClass |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | MyClass |
 | tst.js:1:9:4:1 | class { ...  */ }\\n} | A |
 | tst.js:6:1:8:1 | class B ... t); }\\n} | B |
 | tst.js:11:1:14:1 | class C ... () {}\\n} | C |
@@ -67,6 +73,9 @@ test_MethodDefinitions
 | privateFields.js:23:2:26:2 | calls() ... l();\\n\\t} | privateFields.js:23:2:23:6 | calls | privateFields.js:23:7:26:2 | () {\\n\\t\\t ... l();\\n\\t} | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} |
 | staticConstructor.js:1:15:1:14 | constructor() {} | staticConstructor.js:1:15:1:14 | constructor | staticConstructor.js:1:15:1:14 | () {} | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} |
 | staticConstructor.js:2:3:2:59 | static  ... tor"; } | staticConstructor.js:2:10:2:20 | constructor | staticConstructor.js:2:21:2:59 | () { re ... tor"; } | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} |
+| staticInitializer.js:3:3:5:3 | constru ...  2;\\n  } | staticInitializer.js:3:3:3:13 | constructor | staticInitializer.js:3:14:5:3 | () {\\n   ...  2;\\n  } | staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} |
+| staticInitializer.js:9:3:11:3 | foo() { ...  4;\\n  } | staticInitializer.js:9:3:9:5 | foo | staticInitializer.js:9:6:11:3 | () {\\n   ...  4;\\n  } | staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} |
+| staticInitializer.js:12:3:14:3 | static  ...  5;\\n  } | staticInitializer.js:12:10:12:12 | bar | staticInitializer.js:12:13:14:3 | () {\\n   ...  5;\\n  } | staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} |
 | tst.js:2:3:2:50 | "constr ... r. */ } | tst.js:2:3:2:15 | "constructor" | tst.js:2:16:2:50 | () { /* ... r. */ } | tst.js:1:9:4:1 | class { ...  */ }\\n} |
 | tst.js:3:3:3:56 | ["const ... r. */ } | tst.js:3:4:3:16 | "constructor" | tst.js:3:18:3:56 | () { /* ... r. */ } | tst.js:1:9:4:1 | class { ...  */ }\\n} |
 | tst.js:7:3:7:38 | constru ... get); } | tst.js:7:3:7:13 | constructor | tst.js:7:14:7:38 | () { su ... get); } | tst.js:6:1:8:1 | class B ... t); }\\n} |
@@ -99,6 +108,12 @@ test_getAMember
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} | privateFields.js:23:2:26:2 | calls() ... l();\\n\\t} |
 | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} | staticConstructor.js:1:15:1:14 | constructor() {} |
 | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} | staticConstructor.js:2:3:2:59 | static  ... tor"; } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:2:3:2:15 | static x = 1; |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:3:3:5:3 | constru ...  2;\\n  } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:6:10:8:3 | {\\n    M ...  3;\\n  } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:9:3:11:3 | foo() { ...  4;\\n  } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:12:3:14:3 | static  ...  5;\\n  } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:15:10:17:3 | {\\n    t ...  6;\\n  } |
 | tst.js:1:9:4:1 | class { ...  */ }\\n} | tst.js:2:3:2:50 | "constr ... r. */ } |
 | tst.js:1:9:4:1 | class { ...  */ }\\n} | tst.js:3:3:3:56 | ["const ... r. */ } |
 | tst.js:6:1:8:1 | class B ... t); }\\n} | tst.js:7:3:7:38 | constru ... get); } |
@@ -124,6 +139,9 @@ test_MethodNames
 | privateFields.js:23:2:26:2 | calls() ... l();\\n\\t} | calls |
 | staticConstructor.js:1:15:1:14 | constructor() {} | constructor |
 | staticConstructor.js:2:3:2:59 | static  ... tor"; } | constructor |
+| staticInitializer.js:3:3:5:3 | constru ...  2;\\n  } | constructor |
+| staticInitializer.js:9:3:11:3 | foo() { ...  4;\\n  } | foo |
+| staticInitializer.js:12:3:14:3 | static  ...  5;\\n  } | bar |
 | tst.js:2:3:2:50 | "constr ... r. */ } | constructor |
 | tst.js:3:3:3:56 | ["const ... r. */ } | constructor |
 | tst.js:7:3:7:38 | constru ... get); } | constructor |
@@ -148,6 +166,7 @@ test_ConstructorDefinitions
 | points.js:21:3:24:3 | constru ...  c;\\n  } |
 | privateFields.js:1:11:1:10 | constructor() {} |
 | staticConstructor.js:1:15:1:14 | constructor() {} |
+| staticInitializer.js:3:3:5:3 | constru ...  2;\\n  } |
 | tst.js:2:3:2:50 | "constr ... r. */ } |
 | tst.js:7:3:7:38 | constru ... get); } |
 | tst.js:11:9:11:8 | constructor() {} |
@@ -158,6 +177,7 @@ test_ClassNodeConstructor
 | points.js:20:1:33:1 | class C ... ;\\n  }\\n} | points.js:21:14:24:3 | (x, y,  ...  c;\\n  } |
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} | privateFields.js:1:11:1:10 | () {} |
 | staticConstructor.js:1:1:3:1 | class M ... r"; }\\n} | staticConstructor.js:1:15:1:14 | () {} |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:3:14:5:3 | () {\\n   ...  2;\\n  } |
 | tst.js:1:9:4:1 | class { ...  */ }\\n} | tst.js:2:16:2:50 | () { /* ... r. */ } |
 | tst.js:6:1:8:1 | class B ... t); }\\n} | tst.js:7:14:7:38 | () { su ... get); } |
 | tst.js:11:1:14:1 | class C ... () {}\\n} | tst.js:11:9:11:8 | () {} |
@@ -170,6 +190,7 @@ test_ClassNodeInstanceMethod
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} | equals | privateFields.js:10:8:12:2 | (o) {\\n\\t ... ecl;\\n\\t} |
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} | reads | privateFields.js:4:7:8:2 | () {\\n\\t\\t ... #if;\\n\\t} |
 | privateFields.js:1:1:27:1 | class F ... );\\n\\t}\\n} | writes | privateFields.js:14:8:17:2 | () {\\n\\t\\t ... = 5;\\n\\t} |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | foo | staticInitializer.js:9:6:11:3 | () {\\n   ...  4;\\n  } |
 | tst.js:1:9:4:1 | class { ...  */ }\\n} | constructor | tst.js:3:18:3:56 | () { /* ... r. */ } |
 | tst.js:11:1:14:1 | class C ... () {}\\n} | m | tst.js:12:4:12:8 | () {} |
 getAccessModifier
@@ -223,6 +244,15 @@ getAccessModifier
 | staticConstructor.js:2:3:2:59 | static  ... tor"; } | staticConstructor.js:2:10:2:20 | constructor | Public |
 | staticConstructor.js:4:1:4:11 | console.log | staticConstructor.js:4:9:4:11 | log | Public |
 | staticConstructor.js:4:13:4:31 | MyClass.constructor | staticConstructor.js:4:21:4:31 | constructor | Public |
+| staticInitializer.js:2:3:2:15 | static x = 1; | staticInitializer.js:2:10:2:10 | x | Public |
+| staticInitializer.js:3:3:5:3 | constru ...  2;\\n  } | staticInitializer.js:3:3:3:13 | constructor | Public |
+| staticInitializer.js:4:5:4:10 | this.y | staticInitializer.js:4:10:4:10 | y | Public |
+| staticInitializer.js:7:5:7:13 | MyClass.z | staticInitializer.js:7:13:7:13 | z | Public |
+| staticInitializer.js:9:3:11:3 | foo() { ...  4;\\n  } | staticInitializer.js:9:3:9:5 | foo | Public |
+| staticInitializer.js:10:5:10:10 | this.t | staticInitializer.js:10:10:10:10 | t | Public |
+| staticInitializer.js:12:3:14:3 | static  ...  5;\\n  } | staticInitializer.js:12:10:12:12 | bar | Public |
+| staticInitializer.js:13:5:13:10 | this.u | staticInitializer.js:13:10:13:10 | u | Public |
+| staticInitializer.js:16:5:16:10 | this.v | staticInitializer.js:16:10:16:10 | v | Public |
 | tst.js:2:3:2:50 | "constr ... r. */ } | tst.js:2:3:2:15 | "constructor" | Public |
 | tst.js:3:3:3:56 | ["const ... r. */ } | tst.js:3:4:3:16 | "constructor" | Public |
 | tst.js:7:3:7:38 | constru ... get); } | tst.js:7:3:7:13 | constructor | Public |
@@ -233,3 +263,6 @@ getAccessModifier
 dataflow
 | dataflow.js:2:15:2:22 | "source" | dataflow.js:14:7:14:25 | new Foo().getPriv() |
 | dataflow.js:2:15:2:22 | "source" | dataflow.js:16:7:16:33 | new Foo ... ivate() |
+staticInitializer
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:6:10:8:3 | {\\n    M ...  3;\\n  } |
+| staticInitializer.js:1:1:18:1 | class M ... ;\\n  }\\n} | staticInitializer.js:15:10:17:3 | {\\n    t ...  6;\\n  } |

--- a/javascript/ql/test/library-tests/Classes/tests.ql
+++ b/javascript/ql/test/library-tests/Classes/tests.ql
@@ -1,20 +1,76 @@
-import FieldInits
-import ComputedMethods
-import StaticMethods
-import ClassDefinition_getSuperClass
-import ClassNodeStaticMethod
-import ClassDefinitions
-import AccessorMethods
-import Fields
-import ClassDefinition_getName
-import MethodDefinitions
-import getAMember
-import MethodNames
-import NewTargetExpr
-import SuperExpr
-import SyntheticConstructors
-import ConstructorDefinitions
-import ClassNodeConstructor
-import ClassNodeInstanceMethod
-import PrivateField
-import ClassFlow
+import javascript
+
+query predicate test_FieldInits(FieldDefinition field, Expr res) { res = field.getInit() }
+
+query predicate test_ComputedMethods(MethodDefinition md) { md.isComputed() }
+
+query predicate test_StaticMethods(MethodDefinition md) { md.isStatic() }
+
+query predicate test_ClassDefinition_getSuperClass(ClassDefinition cd, Expr res) {
+  res = cd.getSuperClass()
+}
+
+query predicate test_ClassNodeStaticMethod(
+  DataFlow::ClassNode class_, string name, DataFlow::FunctionNode res
+) {
+  res = class_.getStaticMethod(name)
+}
+
+query predicate test_ClassDefinitions(ClassDefinition cd) { any() }
+
+query predicate test_AccessorMethods(AccessorMethodDefinition amd) { any() }
+
+query predicate test_Fields(FieldDefinition field, Expr res) { res = field.getNameExpr() }
+
+query predicate test_ClassDefinition_getName(ClassDefinition cd, string res) { res = cd.getName() }
+
+query predicate test_MethodDefinitions(
+  MethodDefinition md, Expr res0, FunctionExpr res1, ClassDefinition res2
+) {
+  res0 = md.getNameExpr() and res1 = md.getBody() and res2 = md.getDeclaringClass()
+}
+
+query predicate test_getAMember(ClassDefinition c, MemberDeclaration res) { res = c.getAMember() }
+
+query predicate test_MethodNames(MethodDefinition md, string res) { res = md.getName() }
+
+query predicate test_NewTargetExpr(NewTargetExpr e) { any() }
+
+query predicate test_SuperExpr(SuperExpr s) { any() }
+
+query predicate test_SyntheticConstructors(ConstructorDefinition cd) { cd.isSynthetic() }
+
+query predicate test_ConstructorDefinitions(ConstructorDefinition cd) { any() }
+
+query predicate test_ClassNodeConstructor(DataFlow::ClassNode class_, DataFlow::FunctionNode res) {
+  res = class_.getConstructor()
+}
+
+query predicate test_ClassNodeInstanceMethod(
+  DataFlow::ClassNode class_, string name, DataFlow::FunctionNode res
+) {
+  res = class_.getInstanceMethod(name)
+}
+
+query string getAccessModifier(DataFlow::PropRef ref, Expr prop) {
+  prop = ref.getPropertyNameExpr() and
+  if ref.isPrivateField() then result = "Private" else result = "Public"
+}
+
+class Configuration extends DataFlow::Configuration {
+  Configuration() { this = "ClassDataFlowTestingConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.getEnclosingExpr().(StringLiteral).getValue().toLowerCase() = "source"
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    any(DataFlow::CallNode call | call.getCalleeName() = "sink").getAnArgument() = sink
+  }
+}
+
+query predicate dataflow(DataFlow::Node pred, DataFlow::Node succ) {
+  any(Configuration c).hasFlow(pred, succ)
+}
+
+query BlockStmt staticInitializer(ClassDefinition cd) { result = cd.getAStaticInitializerBlock() }

--- a/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
@@ -775,6 +775,7 @@ nodes
 | tst.ts:183:16:183:25 | [DotExpr] Foo.#count | semmle.label | [DotExpr] Foo.#count |
 | tst.ts:183:20:183:25 | [Label] #count | semmle.label | [Label] #count |
 | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.label | [BlockStmt] static ... ; } |
+| tst.ts:185:5:187:5 | [ClassInitializedMember] static ... ; } | semmle.label | [ClassInitializedMember] static ... ; } |
 | tst.ts:186:7:186:9 | [VarRef] Foo | semmle.label | [VarRef] Foo |
 | tst.ts:186:7:186:16 | [DotExpr] Foo.#count | semmle.label | [DotExpr] Foo.#count |
 | tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | semmle.label | [CompoundAssignExpr] Foo.#count += 3 |
@@ -782,6 +783,7 @@ nodes
 | tst.ts:186:11:186:16 | [Label] #count | semmle.label | [Label] #count |
 | tst.ts:186:21:186:21 | [Literal] 3 | semmle.label | [Literal] 3 |
 | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.label | [BlockStmt] static ... ; } |
+| tst.ts:188:5:190:5 | [ClassInitializedMember] static ... ; } | semmle.label | [ClassInitializedMember] static ... ; } |
 | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | semmle.label | [DeclStmt] var count = ... |
 | tst.ts:189:11:189:15 | [VarDecl] count | semmle.label | [VarDecl] count |
 | tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | semmle.label | [VariableDeclarator] count = Foo.#count |
@@ -2295,10 +2297,10 @@ edges
 | tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | semmle.order | 3 |
 | tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | semmle.label | 4 |
 | tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | semmle.order | 4 |
-| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.label | 5 |
-| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.order | 5 |
-| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.label | 6 |
-| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.order | 6 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:185:5:187:5 | [ClassInitializedMember] static ... ; } | semmle.label | 5 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:185:5:187:5 | [ClassInitializedMember] static ... ; } | semmle.order | 5 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:188:5:190:5 | [ClassInitializedMember] static ... ; } | semmle.label | 6 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:188:5:190:5 | [ClassInitializedMember] static ... ; } | semmle.order | 6 |
 | tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [FunctionExpr] () {} | semmle.label | 2 |
 | tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [FunctionExpr] () {} | semmle.order | 2 |
 | tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [Label] constructor | semmle.label | 1 |
@@ -2325,6 +2327,8 @@ edges
 | tst.ts:183:16:183:25 | [DotExpr] Foo.#count | tst.ts:183:20:183:25 | [Label] #count | semmle.order | 2 |
 | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | semmle.label | 1 |
 | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | semmle.order | 1 |
+| tst.ts:185:5:187:5 | [ClassInitializedMember] static ... ; } | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.label | 1 |
+| tst.ts:185:5:187:5 | [ClassInitializedMember] static ... ; } | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.order | 1 |
 | tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:7:186:9 | [VarRef] Foo | semmle.label | 1 |
 | tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:7:186:9 | [VarRef] Foo | semmle.order | 1 |
 | tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:11:186:16 | [Label] #count | semmle.label | 2 |
@@ -2337,6 +2341,8 @@ edges
 | tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | semmle.order | 1 |
 | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | semmle.label | 1 |
 | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | semmle.order | 1 |
+| tst.ts:188:5:190:5 | [ClassInitializedMember] static ... ; } | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.label | 1 |
+| tst.ts:188:5:190:5 | [ClassInitializedMember] static ... ; } | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.order | 1 |
 | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | semmle.label | 1 |
 | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | semmle.order | 1 |
 | tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | tst.ts:189:11:189:15 | [VarDecl] count | semmle.label | 1 |

--- a/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
@@ -87,6 +87,14 @@ nodes
 | dummy.ts:4:22:4:22 | [RegExpNormalConstant] c | semmle.label | [RegExpNormalConstant] c |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
@@ -591,17 +599,175 @@ nodes
 | tst.ts:127:14:127:17 | [ThisExpr] this | semmle.label | [ThisExpr] this |
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | semmle.label | [DotExpr] this.#someValue |
 | tst.ts:127:19:127:28 | [Label] #someValue | semmle.label | [Label] #someValue |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | semmle.label | [NamespaceDeclaration] module ... ; } } |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | semmle.order | 56 |
+| tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.label | [VarDecl] TS44 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.label | [FunctionDeclStmt] functio ... } } |
+| tst.ts:133:12:133:14 | [VarDecl] foo | semmle.label | [VarDecl] foo |
+| tst.ts:133:16:133:18 | [SimpleParameter] arg | semmle.label | [SimpleParameter] arg |
+| tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.label | [KeywordTypeExpr] unknown |
+| tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | semmle.label | [BlockStmt] { c ... } } |
+| tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | semmle.label | [DeclStmt] const argIsString = ... |
+| tst.ts:134:11:134:21 | [VarDecl] argIsString | semmle.label | [VarDecl] argIsString |
+| tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | semmle.label | [VariableDeclarator] argIsSt ... string" |
+| tst.ts:134:25:134:34 | [UnaryExpr] typeof arg | semmle.label | [UnaryExpr] typeof arg |
+| tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | semmle.label | [BinaryExpr] typeof ... string" |
+| tst.ts:134:32:134:34 | [VarRef] arg | semmle.label | [VarRef] arg |
+| tst.ts:134:40:134:47 | [Literal] "string" | semmle.label | [Literal] "string" |
+| tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | semmle.label | [IfStmt] if (arg ... ; } |
+| tst.ts:135:9:135:19 | [VarRef] argIsString | semmle.label | [VarRef] argIsString |
+| tst.ts:135:22:137:5 | [BlockStmt] { ... ; } | semmle.label | [BlockStmt] { ... ; } |
+| tst.ts:136:9:136:40 | [DeclStmt] const upper = ... | semmle.label | [DeclStmt] const upper = ... |
+| tst.ts:136:15:136:19 | [VarDecl] upper | semmle.label | [VarDecl] upper |
+| tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | semmle.label | [VariableDeclarator] upper = ... rCase() |
+| tst.ts:136:23:136:25 | [VarRef] arg | semmle.label | [VarRef] arg |
+| tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | semmle.label | [DotExpr] arg.toUpperCase |
+| tst.ts:136:23:136:39 | [MethodCallExpr] arg.toUpperCase() | semmle.label | [MethodCallExpr] arg.toUpperCase() |
+| tst.ts:136:27:136:37 | [Label] toUpperCase | semmle.label | [Label] toUpperCase |
+| tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; |
+| tst.ts:140:8:140:12 | [Identifier] Shape | semmle.label | [Identifier] Shape |
+| tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | semmle.label | [UnionTypeExpr] \| { kin ... umber } |
+| tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | semmle.label | [InterfaceTypeExpr] { kind: ... umber } |
+| tst.ts:141:11:141:14 | [Label] kind | semmle.label | [Label] kind |
+| tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | semmle.label | [FieldDeclaration] kind: "circle", |
+| tst.ts:141:17:141:24 | [LiteralTypeExpr] "circle" | semmle.label | [LiteralTypeExpr] "circle" |
+| tst.ts:141:27:141:32 | [Label] radius | semmle.label | [Label] radius |
+| tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | semmle.label | [FieldDeclaration] radius: number |
+| tst.ts:141:35:141:40 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | semmle.label | [InterfaceTypeExpr] { kind: ... umber } |
+| tst.ts:142:11:142:14 | [Label] kind | semmle.label | [Label] kind |
+| tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | semmle.label | [FieldDeclaration] kind: "square", |
+| tst.ts:142:17:142:24 | [LiteralTypeExpr] "square" | semmle.label | [LiteralTypeExpr] "square" |
+| tst.ts:142:27:142:36 | [Label] sideLength | semmle.label | [Label] sideLength |
+| tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | semmle.label | [FieldDeclaration] sideLength: number |
+| tst.ts:142:39:142:44 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.label | [FunctionDeclStmt] functio ... ; } } |
+| tst.ts:144:12:144:15 | [VarDecl] side | semmle.label | [VarDecl] side |
+| tst.ts:144:17:144:21 | [SimpleParameter] shape | semmle.label | [SimpleParameter] shape |
+| tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.label | [LocalTypeAccess] Shape |
+| tst.ts:144:32:144:37 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | semmle.label | [BlockStmt] { ... ; } } |
+| tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | semmle.label | [DeclStmt] const { ... shape; |
+| tst.ts:145:13:145:20 | [ObjectPattern] { kind } | semmle.label | [ObjectPattern] { kind } |
+| tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | semmle.label | [VariableDeclarator] { kind } = shape |
+| tst.ts:145:15:145:18 | [Label] kind | semmle.label | [Label] kind |
+| tst.ts:145:15:145:18 | [PropertyPattern] kind | semmle.label | [PropertyPattern] kind |
+| tst.ts:145:15:145:18 | [VarDecl] kind | semmle.label | [VarDecl] kind |
+| tst.ts:145:24:145:28 | [VarRef] shape | semmle.label | [VarRef] shape |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | semmle.label | [IfStmt] if (kin ... ngth; } |
+| tst.ts:147:11:147:14 | [VarRef] kind | semmle.label | [VarRef] kind |
+| tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | semmle.label | [BinaryExpr] kind === "circle" |
+| tst.ts:147:20:147:27 | [Literal] "circle" | semmle.label | [Literal] "circle" |
+| tst.ts:147:30:147:52 | [BlockStmt] { retur ... adius;} | semmle.label | [BlockStmt] { retur ... adius;} |
+| tst.ts:147:32:147:51 | [ReturnStmt] return shape.radius; | semmle.label | [ReturnStmt] return shape.radius; |
+| tst.ts:147:39:147:43 | [VarRef] shape | semmle.label | [VarRef] shape |
+| tst.ts:147:39:147:50 | [DotExpr] shape.radius | semmle.label | [DotExpr] shape.radius |
+| tst.ts:147:45:147:50 | [Label] radius | semmle.label | [Label] radius |
+| tst.ts:148:12:148:39 | [BlockStmt] { retur ... ngth; } | semmle.label | [BlockStmt] { retur ... ngth; } |
+| tst.ts:148:14:148:37 | [ReturnStmt] return ... Length; | semmle.label | [ReturnStmt] return ... Length; |
+| tst.ts:148:21:148:25 | [VarRef] shape | semmle.label | [VarRef] shape |
+| tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | semmle.label | [DotExpr] shape.sideLength |
+| tst.ts:148:27:148:36 | [Label] sideLength | semmle.label | [Label] sideLength |
+| tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.label | [FunctionDeclStmt] functio ... 2]; } |
+| tst.ts:151:12:151:22 | [VarDecl] symbolIndex | semmle.label | [VarDecl] symbolIndex |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | semmle.label | [BlockStmt] { i ... 2]; } |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.label | [InterfaceDeclaration,TypeDefinition] interfa ... ; } |
+| tst.ts:152:15:152:20 | [Identifier] Colors | semmle.label | [Identifier] Colors |
+| tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | semmle.label | [FunctionExpr] [sym: s ... number; |
+| tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | semmle.label | [IndexSignature] [sym: s ... number; |
+| tst.ts:153:8:153:10 | [SimpleParameter] sym | semmle.label | [SimpleParameter] sym |
+| tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.label | [KeywordTypeExpr] symbol |
+| tst.ts:153:22:153:27 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | semmle.label | [FunctionExpr] [key: s ... string; |
+| tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | semmle.label | [IndexSignature] [key: s ... string; |
+| tst.ts:154:8:154:10 | [SimpleParameter] key | semmle.label | [SimpleParameter] key |
+| tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
+| tst.ts:154:22:154:27 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
+| tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | semmle.label | [FunctionExpr] [num: n ... oolean; |
+| tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | semmle.label | [IndexSignature] [num: n ... oolean; |
+| tst.ts:155:8:155:10 | [SimpleParameter] num | semmle.label | [SimpleParameter] num |
+| tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:155:22:155:28 | [KeywordTypeExpr] boolean | semmle.label | [KeywordTypeExpr] boolean |
+| tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | semmle.label | [DeclStmt] let colors = ... |
+| tst.ts:158:9:158:14 | [VarDecl] colors | semmle.label | [VarDecl] colors |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | semmle.label | [VariableDeclarator] colors: Colors = {} |
+| tst.ts:158:17:158:22 | [LocalTypeAccess] Colors | semmle.label | [LocalTypeAccess] Colors |
+| tst.ts:158:26:158:27 | [ObjectExpr] {} | semmle.label | [ObjectExpr] {} |
+| tst.ts:159:5:159:38 | [DeclStmt] const red = ... | semmle.label | [DeclStmt] const red = ... |
+| tst.ts:159:11:159:13 | [VarDecl] red | semmle.label | [VarDecl] red |
+| tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | semmle.label | [VariableDeclarator] red = c ... "red")] |
+| tst.ts:159:17:159:22 | [VarRef] colors | semmle.label | [VarRef] colors |
+| tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | semmle.label | [IndexExpr] colors[ ... "red")] |
+| tst.ts:159:24:159:29 | [VarRef] Symbol | semmle.label | [VarRef] Symbol |
+| tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | semmle.label | [CallExpr] Symbol("red") |
+| tst.ts:159:31:159:35 | [Literal] "red" | semmle.label | [Literal] "red" |
+| tst.ts:160:5:160:34 | [DeclStmt] const green = ... | semmle.label | [DeclStmt] const green = ... |
+| tst.ts:160:11:160:15 | [VarDecl] green | semmle.label | [VarDecl] green |
+| tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | semmle.label | [VariableDeclarator] green = ... green"] |
+| tst.ts:160:19:160:24 | [VarRef] colors | semmle.label | [VarRef] colors |
+| tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | semmle.label | [IndexExpr] colors["green"] |
+| tst.ts:160:26:160:32 | [Literal] "green" | semmle.label | [Literal] "green" |
+| tst.ts:161:5:161:27 | [DeclStmt] const blue = ... | semmle.label | [DeclStmt] const blue = ... |
+| tst.ts:161:11:161:14 | [VarDecl] blue | semmle.label | [VarDecl] blue |
+| tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | semmle.label | [VariableDeclarator] blue = colors[2] |
+| tst.ts:161:18:161:23 | [VarRef] colors | semmle.label | [VarRef] colors |
+| tst.ts:161:18:161:26 | [IndexExpr] colors[2] | semmle.label | [IndexExpr] colors[2] |
+| tst.ts:161:25:161:25 | [Literal] 2 | semmle.label | [Literal] 2 |
+| tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.label | [FunctionDeclStmt] functio ... "]; } |
+| tst.ts:164:12:164:29 | [VarDecl] stringPatternIndex | semmle.label | [VarDecl] stringPatternIndex |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | semmle.label | [BlockStmt] { i ... "]; } |
+| tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.label | [InterfaceDeclaration,TypeDefinition] interfa ... ; } |
+| tst.ts:165:15:165:17 | [Identifier] Foo | semmle.label | [Identifier] Foo |
+| tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | semmle.label | [FunctionExpr] [key: ` ... number; |
+| tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | semmle.label | [IndexSignature] [key: ` ... number; |
+| tst.ts:166:8:166:10 | [SimpleParameter] key | semmle.label | [SimpleParameter] key |
+| tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.label | [TemplateLiteralTypeExpr] `foo-${number}` |
+| tst.ts:166:14:166:17 | [LiteralTypeExpr] foo- | semmle.label | [LiteralTypeExpr] foo- |
+| tst.ts:166:20:166:25 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:166:31:166:36 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
+| tst.ts:168:5:168:23 | [DeclStmt] var bla = ... | semmle.label | [DeclStmt] var bla = ... |
+| tst.ts:168:9:168:11 | [VarDecl] bla | semmle.label | [VarDecl] bla |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | semmle.label | [VariableDeclarator] bla : Foo = {} |
+| tst.ts:168:15:168:17 | [LocalTypeAccess] Foo | semmle.label | [LocalTypeAccess] Foo |
+| tst.ts:168:21:168:22 | [ObjectExpr] {} | semmle.label | [ObjectExpr] {} |
+| tst.ts:169:5:169:29 | [DeclStmt] const bar = ... | semmle.label | [DeclStmt] const bar = ... |
+| tst.ts:169:11:169:13 | [VarDecl] bar | semmle.label | [VarDecl] bar |
+| tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | semmle.label | [VariableDeclarator] bar = bla[`foo-1`] |
+| tst.ts:169:17:169:19 | [VarRef] bla | semmle.label | [VarRef] bla |
+| tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | semmle.label | [IndexExpr] bla[`foo-1`] |
+| tst.ts:169:21:169:27 | [TemplateElement] `foo-1` | semmle.label | [TemplateElement] `foo-1` |
+| tst.ts:169:21:169:27 | [TemplateLiteral] `foo-1` | semmle.label | [TemplateLiteral] `foo-1` |
+| tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.label | [InterfaceDeclaration,TypeDefinition] interfa ... ; } |
+| tst.ts:171:15:171:18 | [Identifier] Data | semmle.label | [Identifier] Data |
+| tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | semmle.label | [FunctionExpr] [optNam ... oolean; |
+| tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | semmle.label | [IndexSignature] [optNam ... oolean; |
+| tst.ts:172:8:172:14 | [SimpleParameter] optName | semmle.label | [SimpleParameter] optName |
+| tst.ts:172:17:172:22 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
+| tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.label | [UnionTypeExpr] string \| symbol |
+| tst.ts:172:26:172:31 | [KeywordTypeExpr] symbol | semmle.label | [KeywordTypeExpr] symbol |
+| tst.ts:172:35:172:41 | [KeywordTypeExpr] boolean | semmle.label | [KeywordTypeExpr] boolean |
+| tst.ts:175:5:175:26 | [DeclStmt] const data = ... | semmle.label | [DeclStmt] const data = ... |
+| tst.ts:175:11:175:14 | [VarDecl] data | semmle.label | [VarDecl] data |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | semmle.label | [VariableDeclarator] data: Data = {} |
+| tst.ts:175:17:175:20 | [LocalTypeAccess] Data | semmle.label | [LocalTypeAccess] Data |
+| tst.ts:175:24:175:25 | [ObjectExpr] {} | semmle.label | [ObjectExpr] {} |
+| tst.ts:176:5:176:28 | [DeclStmt] const baz = ... | semmle.label | [DeclStmt] const baz = ... |
+| tst.ts:176:11:176:13 | [VarDecl] baz | semmle.label | [VarDecl] baz |
+| tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | semmle.label | [VariableDeclarator] baz = data["foo"] |
+| tst.ts:176:17:176:20 | [VarRef] data | semmle.label | [VarRef] data |
+| tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | semmle.label | [IndexExpr] data["foo"] |
+| tst.ts:176:22:176:26 | [Literal] "foo" | semmle.label | [Literal] "foo" |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type B = boolean; |
-| type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.order | 56 |
+| type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.order | 57 |
 | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.label | [Identifier] B |
 | type_alias.ts:1:10:1:16 | [KeywordTypeExpr] boolean | semmle.label | [KeywordTypeExpr] boolean |
 | type_alias.ts:3:1:3:9 | [DeclStmt] var b = ... | semmle.label | [DeclStmt] var b = ... |
-| type_alias.ts:3:1:3:9 | [DeclStmt] var b = ... | semmle.order | 57 |
+| type_alias.ts:3:1:3:9 | [DeclStmt] var b = ... | semmle.order | 58 |
 | type_alias.ts:3:5:3:5 | [VarDecl] b | semmle.label | [VarDecl] b |
 | type_alias.ts:3:5:3:8 | [VariableDeclarator] b: B | semmle.label | [VariableDeclarator] b: B |
 | type_alias.ts:3:8:3:8 | [LocalTypeAccess] B | semmle.label | [LocalTypeAccess] B |
 | type_alias.ts:5:1:5:50 | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; |
-| type_alias.ts:5:1:5:50 | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; | semmle.order | 58 |
+| type_alias.ts:5:1:5:50 | [TypeAliasDeclaration,TypeDefinition] type Va ... ay<T>>; | semmle.order | 59 |
 | type_alias.ts:5:6:5:17 | [Identifier] ValueOrArray | semmle.label | [Identifier] ValueOrArray |
 | type_alias.ts:5:19:5:19 | [Identifier] T | semmle.label | [Identifier] T |
 | type_alias.ts:5:19:5:19 | [TypeParameter] T | semmle.label | [TypeParameter] T |
@@ -613,14 +779,14 @@ nodes
 | type_alias.ts:5:34:5:48 | [GenericTypeExpr] ValueOrArray<T> | semmle.label | [GenericTypeExpr] ValueOrArray<T> |
 | type_alias.ts:5:47:5:47 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
 | type_alias.ts:7:1:7:28 | [DeclStmt] var c = ... | semmle.label | [DeclStmt] var c = ... |
-| type_alias.ts:7:1:7:28 | [DeclStmt] var c = ... | semmle.order | 59 |
+| type_alias.ts:7:1:7:28 | [DeclStmt] var c = ... | semmle.order | 60 |
 | type_alias.ts:7:5:7:5 | [VarDecl] c | semmle.label | [VarDecl] c |
 | type_alias.ts:7:5:7:27 | [VariableDeclarator] c: Valu ... number> | semmle.label | [VariableDeclarator] c: Valu ... number> |
 | type_alias.ts:7:8:7:19 | [LocalTypeAccess] ValueOrArray | semmle.label | [LocalTypeAccess] ValueOrArray |
 | type_alias.ts:7:8:7:27 | [GenericTypeExpr] ValueOrArray<number> | semmle.label | [GenericTypeExpr] ValueOrArray<number> |
 | type_alias.ts:7:21:7:26 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
 | type_alias.ts:9:1:15:13 | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; |
-| type_alias.ts:9:1:15:13 | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; | semmle.order | 60 |
+| type_alias.ts:9:1:15:13 | [TypeAliasDeclaration,TypeDefinition] type Js ... Json[]; | semmle.order | 61 |
 | type_alias.ts:9:6:9:9 | [Identifier] Json | semmle.label | [Identifier] Json |
 | type_alias.ts:10:5:15:12 | [UnionTypeExpr] \| strin ... Json[] | semmle.label | [UnionTypeExpr] \| strin ... Json[] |
 | type_alias.ts:10:7:10:12 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
@@ -636,12 +802,12 @@ nodes
 | type_alias.ts:15:7:15:10 | [LocalTypeAccess] Json | semmle.label | [LocalTypeAccess] Json |
 | type_alias.ts:15:7:15:12 | [ArrayTypeExpr] Json[] | semmle.label | [ArrayTypeExpr] Json[] |
 | type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | semmle.label | [DeclStmt] var json = ... |
-| type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | semmle.order | 61 |
+| type_alias.ts:17:1:17:15 | [DeclStmt] var json = ... | semmle.order | 62 |
 | type_alias.ts:17:5:17:8 | [VarDecl] json | semmle.label | [VarDecl] json |
 | type_alias.ts:17:5:17:14 | [VariableDeclarator] json: Json | semmle.label | [VariableDeclarator] json: Json |
 | type_alias.ts:17:11:17:14 | [LocalTypeAccess] Json | semmle.label | [LocalTypeAccess] Json |
 | type_alias.ts:19:1:21:57 | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; |
-| type_alias.ts:19:1:21:57 | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; | semmle.order | 62 |
+| type_alias.ts:19:1:21:57 | [TypeAliasDeclaration,TypeDefinition] type Vi ... ode[]]; | semmle.order | 63 |
 | type_alias.ts:19:6:19:16 | [Identifier] VirtualNode | semmle.label | [Identifier] VirtualNode |
 | type_alias.ts:20:5:21:56 | [UnionTypeExpr] \| strin ... Node[]] | semmle.label | [UnionTypeExpr] \| strin ... Node[]] |
 | type_alias.ts:20:7:20:12 | [KeywordTypeExpr] string | semmle.label | [KeywordTypeExpr] string |
@@ -657,7 +823,7 @@ nodes
 | type_alias.ts:21:43:21:53 | [LocalTypeAccess] VirtualNode | semmle.label | [LocalTypeAccess] VirtualNode |
 | type_alias.ts:21:43:21:55 | [ArrayTypeExpr] VirtualNode[] | semmle.label | [ArrayTypeExpr] VirtualNode[] |
 | type_alias.ts:23:1:27:6 | [DeclStmt] const myNode = ... | semmle.label | [DeclStmt] const myNode = ... |
-| type_alias.ts:23:1:27:6 | [DeclStmt] const myNode = ... | semmle.order | 63 |
+| type_alias.ts:23:1:27:6 | [DeclStmt] const myNode = ... | semmle.order | 64 |
 | type_alias.ts:23:7:23:12 | [VarDecl] myNode | semmle.label | [VarDecl] myNode |
 | type_alias.ts:23:7:27:5 | [VariableDeclarator] myNode: ... ] ] | semmle.label | [VariableDeclarator] myNode: ... ] ] |
 | type_alias.ts:23:15:23:25 | [LocalTypeAccess] VirtualNode | semmle.label | [LocalTypeAccess] VirtualNode |
@@ -682,12 +848,12 @@ nodes
 | type_alias.ts:26:23:26:36 | [Literal] "second-child" | semmle.label | [Literal] "second-child" |
 | type_alias.ts:26:41:26:62 | [Literal] "I'm the second child" | semmle.label | [Literal] "I'm the second child" |
 | type_definition_objects.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.label | [ImportDeclaration] import ... dummy"; |
-| type_definition_objects.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 64 |
+| type_definition_objects.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 65 |
 | type_definition_objects.ts:1:8:1:17 | [ImportSpecifier] * as dummy | semmle.label | [ImportSpecifier] * as dummy |
 | type_definition_objects.ts:1:13:1:17 | [VarDecl] dummy | semmle.label | [VarDecl] dummy |
 | type_definition_objects.ts:1:24:1:32 | [Literal] "./dummy" | semmle.label | [Literal] "./dummy" |
 | type_definition_objects.ts:3:1:3:17 | [ExportDeclaration] export class C {} | semmle.label | [ExportDeclaration] export class C {} |
-| type_definition_objects.ts:3:1:3:17 | [ExportDeclaration] export class C {} | semmle.order | 65 |
+| type_definition_objects.ts:3:1:3:17 | [ExportDeclaration] export class C {} | semmle.order | 66 |
 | type_definition_objects.ts:3:8:3:17 | [ClassDefinition,TypeDefinition] class C {} | semmle.label | [ClassDefinition,TypeDefinition] class C {} |
 | type_definition_objects.ts:3:14:3:14 | [VarDecl] C | semmle.label | [VarDecl] C |
 | type_definition_objects.ts:3:16:3:15 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
@@ -695,36 +861,36 @@ nodes
 | type_definition_objects.ts:3:16:3:15 | [FunctionExpr] () {} | semmle.label | [FunctionExpr] () {} |
 | type_definition_objects.ts:3:16:3:15 | [Label] constructor | semmle.label | [Label] constructor |
 | type_definition_objects.ts:4:1:4:17 | [DeclStmt] let classObj = ... | semmle.label | [DeclStmt] let classObj = ... |
-| type_definition_objects.ts:4:1:4:17 | [DeclStmt] let classObj = ... | semmle.order | 66 |
+| type_definition_objects.ts:4:1:4:17 | [DeclStmt] let classObj = ... | semmle.order | 67 |
 | type_definition_objects.ts:4:5:4:12 | [VarDecl] classObj | semmle.label | [VarDecl] classObj |
 | type_definition_objects.ts:4:5:4:16 | [VariableDeclarator] classObj = C | semmle.label | [VariableDeclarator] classObj = C |
 | type_definition_objects.ts:4:16:4:16 | [VarRef] C | semmle.label | [VarRef] C |
 | type_definition_objects.ts:6:1:6:16 | [ExportDeclaration] export enum E {} | semmle.label | [ExportDeclaration] export enum E {} |
-| type_definition_objects.ts:6:1:6:16 | [ExportDeclaration] export enum E {} | semmle.order | 67 |
+| type_definition_objects.ts:6:1:6:16 | [ExportDeclaration] export enum E {} | semmle.order | 68 |
 | type_definition_objects.ts:6:8:6:16 | [EnumDeclaration,TypeDefinition] enum E {} | semmle.label | [EnumDeclaration,TypeDefinition] enum E {} |
 | type_definition_objects.ts:6:13:6:13 | [VarDecl] E | semmle.label | [VarDecl] E |
 | type_definition_objects.ts:7:1:7:16 | [DeclStmt] let enumObj = ... | semmle.label | [DeclStmt] let enumObj = ... |
-| type_definition_objects.ts:7:1:7:16 | [DeclStmt] let enumObj = ... | semmle.order | 68 |
+| type_definition_objects.ts:7:1:7:16 | [DeclStmt] let enumObj = ... | semmle.order | 69 |
 | type_definition_objects.ts:7:5:7:11 | [VarDecl] enumObj | semmle.label | [VarDecl] enumObj |
 | type_definition_objects.ts:7:5:7:15 | [VariableDeclarator] enumObj = E | semmle.label | [VariableDeclarator] enumObj = E |
 | type_definition_objects.ts:7:15:7:15 | [VarRef] E | semmle.label | [VarRef] E |
 | type_definition_objects.ts:9:1:9:22 | [ExportDeclaration] export ... e N {;} | semmle.label | [ExportDeclaration] export ... e N {;} |
-| type_definition_objects.ts:9:1:9:22 | [ExportDeclaration] export ... e N {;} | semmle.order | 69 |
+| type_definition_objects.ts:9:1:9:22 | [ExportDeclaration] export ... e N {;} | semmle.order | 70 |
 | type_definition_objects.ts:9:8:9:22 | [NamespaceDeclaration] namespace N {;} | semmle.label | [NamespaceDeclaration] namespace N {;} |
 | type_definition_objects.ts:9:18:9:18 | [VarDecl] N | semmle.label | [VarDecl] N |
 | type_definition_objects.ts:9:21:9:21 | [EmptyStmt] ; | semmle.label | [EmptyStmt] ; |
 | type_definition_objects.ts:10:1:10:21 | [DeclStmt] let namespaceObj = ... | semmle.label | [DeclStmt] let namespaceObj = ... |
-| type_definition_objects.ts:10:1:10:21 | [DeclStmt] let namespaceObj = ... | semmle.order | 70 |
+| type_definition_objects.ts:10:1:10:21 | [DeclStmt] let namespaceObj = ... | semmle.order | 71 |
 | type_definition_objects.ts:10:5:10:16 | [VarDecl] namespaceObj | semmle.label | [VarDecl] namespaceObj |
 | type_definition_objects.ts:10:5:10:20 | [VariableDeclarator] namespaceObj = N | semmle.label | [VariableDeclarator] namespaceObj = N |
 | type_definition_objects.ts:10:20:10:20 | [VarRef] N | semmle.label | [VarRef] N |
 | type_definitions.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.label | [ImportDeclaration] import ... dummy"; |
-| type_definitions.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 71 |
+| type_definitions.ts:1:1:1:33 | [ImportDeclaration] import ... dummy"; | semmle.order | 72 |
 | type_definitions.ts:1:8:1:17 | [ImportSpecifier] * as dummy | semmle.label | [ImportSpecifier] * as dummy |
 | type_definitions.ts:1:13:1:17 | [VarDecl] dummy | semmle.label | [VarDecl] dummy |
 | type_definitions.ts:1:24:1:32 | [Literal] "./dummy" | semmle.label | [Literal] "./dummy" |
 | type_definitions.ts:3:1:5:1 | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } | semmle.label | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } |
-| type_definitions.ts:3:1:5:1 | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } | semmle.order | 72 |
+| type_definitions.ts:3:1:5:1 | [InterfaceDeclaration,TypeDefinition] interfa ... x: S; } | semmle.order | 73 |
 | type_definitions.ts:3:11:3:11 | [Identifier] I | semmle.label | [Identifier] I |
 | type_definitions.ts:3:13:3:13 | [Identifier] S | semmle.label | [Identifier] S |
 | type_definitions.ts:3:13:3:13 | [TypeParameter] S | semmle.label | [TypeParameter] S |
@@ -732,14 +898,14 @@ nodes
 | type_definitions.ts:4:3:4:7 | [FieldDeclaration] x: S; | semmle.label | [FieldDeclaration] x: S; |
 | type_definitions.ts:4:6:4:6 | [LocalTypeAccess] S | semmle.label | [LocalTypeAccess] S |
 | type_definitions.ts:6:1:6:16 | [DeclStmt] let i = ... | semmle.label | [DeclStmt] let i = ... |
-| type_definitions.ts:6:1:6:16 | [DeclStmt] let i = ... | semmle.order | 73 |
+| type_definitions.ts:6:1:6:16 | [DeclStmt] let i = ... | semmle.order | 74 |
 | type_definitions.ts:6:5:6:5 | [VarDecl] i | semmle.label | [VarDecl] i |
 | type_definitions.ts:6:5:6:16 | [VariableDeclarator] i: I<number> | semmle.label | [VariableDeclarator] i: I<number> |
 | type_definitions.ts:6:8:6:8 | [LocalTypeAccess] I | semmle.label | [LocalTypeAccess] I |
 | type_definitions.ts:6:8:6:16 | [GenericTypeExpr] I<number> | semmle.label | [GenericTypeExpr] I<number> |
 | type_definitions.ts:6:10:6:15 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
 | type_definitions.ts:8:1:10:1 | [ClassDefinition,TypeDefinition] class C ... x: T } | semmle.label | [ClassDefinition,TypeDefinition] class C ... x: T } |
-| type_definitions.ts:8:1:10:1 | [ClassDefinition,TypeDefinition] class C ... x: T } | semmle.order | 74 |
+| type_definitions.ts:8:1:10:1 | [ClassDefinition,TypeDefinition] class C ... x: T } | semmle.order | 75 |
 | type_definitions.ts:8:7:8:7 | [VarDecl] C | semmle.label | [VarDecl] C |
 | type_definitions.ts:8:8:8:7 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
 | type_definitions.ts:8:8:8:7 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.label | [ClassInitializedMember,ConstructorDefinition] constructor() {} |
@@ -751,14 +917,14 @@ nodes
 | type_definitions.ts:9:3:9:6 | [FieldDeclaration] x: T | semmle.label | [FieldDeclaration] x: T |
 | type_definitions.ts:9:6:9:6 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
 | type_definitions.ts:11:1:11:17 | [DeclStmt] let c = ... | semmle.label | [DeclStmt] let c = ... |
-| type_definitions.ts:11:1:11:17 | [DeclStmt] let c = ... | semmle.order | 75 |
+| type_definitions.ts:11:1:11:17 | [DeclStmt] let c = ... | semmle.order | 76 |
 | type_definitions.ts:11:5:11:5 | [VarDecl] c | semmle.label | [VarDecl] c |
 | type_definitions.ts:11:5:11:16 | [VariableDeclarator] c: C<number> | semmle.label | [VariableDeclarator] c: C<number> |
 | type_definitions.ts:11:8:11:8 | [LocalTypeAccess] C | semmle.label | [LocalTypeAccess] C |
 | type_definitions.ts:11:8:11:16 | [GenericTypeExpr] C<number> | semmle.label | [GenericTypeExpr] C<number> |
 | type_definitions.ts:11:10:11:15 | [KeywordTypeExpr] number | semmle.label | [KeywordTypeExpr] number |
 | type_definitions.ts:13:1:15:1 | [EnumDeclaration,TypeDefinition] enum Co ... blue } | semmle.label | [EnumDeclaration,TypeDefinition] enum Co ... blue } |
-| type_definitions.ts:13:1:15:1 | [EnumDeclaration,TypeDefinition] enum Co ... blue } | semmle.order | 76 |
+| type_definitions.ts:13:1:15:1 | [EnumDeclaration,TypeDefinition] enum Co ... blue } | semmle.order | 77 |
 | type_definitions.ts:13:6:13:10 | [VarDecl] Color | semmle.label | [VarDecl] Color |
 | type_definitions.ts:14:3:14:5 | [EnumMember,TypeDefinition] red | semmle.label | [EnumMember,TypeDefinition] red |
 | type_definitions.ts:14:3:14:5 | [VarDecl] red | semmle.label | [VarDecl] red |
@@ -767,29 +933,29 @@ nodes
 | type_definitions.ts:14:15:14:18 | [EnumMember,TypeDefinition] blue | semmle.label | [EnumMember,TypeDefinition] blue |
 | type_definitions.ts:14:15:14:18 | [VarDecl] blue | semmle.label | [VarDecl] blue |
 | type_definitions.ts:16:1:16:17 | [DeclStmt] let color = ... | semmle.label | [DeclStmt] let color = ... |
-| type_definitions.ts:16:1:16:17 | [DeclStmt] let color = ... | semmle.order | 77 |
+| type_definitions.ts:16:1:16:17 | [DeclStmt] let color = ... | semmle.order | 78 |
 | type_definitions.ts:16:5:16:9 | [VarDecl] color | semmle.label | [VarDecl] color |
 | type_definitions.ts:16:5:16:16 | [VariableDeclarator] color: Color | semmle.label | [VariableDeclarator] color: Color |
 | type_definitions.ts:16:12:16:16 | [LocalTypeAccess] Color | semmle.label | [LocalTypeAccess] Color |
 | type_definitions.ts:18:1:18:33 | [EnumDeclaration,TypeDefinition] enum En ... ember } | semmle.label | [EnumDeclaration,TypeDefinition] enum En ... ember } |
-| type_definitions.ts:18:1:18:33 | [EnumDeclaration,TypeDefinition] enum En ... ember } | semmle.order | 78 |
+| type_definitions.ts:18:1:18:33 | [EnumDeclaration,TypeDefinition] enum En ... ember } | semmle.order | 79 |
 | type_definitions.ts:18:6:18:22 | [VarDecl] EnumWithOneMember | semmle.label | [VarDecl] EnumWithOneMember |
 | type_definitions.ts:18:26:18:31 | [EnumMember,TypeDefinition] member | semmle.label | [EnumMember,TypeDefinition] member |
 | type_definitions.ts:18:26:18:31 | [VarDecl] member | semmle.label | [VarDecl] member |
 | type_definitions.ts:19:1:19:25 | [DeclStmt] let e = ... | semmle.label | [DeclStmt] let e = ... |
-| type_definitions.ts:19:1:19:25 | [DeclStmt] let e = ... | semmle.order | 79 |
+| type_definitions.ts:19:1:19:25 | [DeclStmt] let e = ... | semmle.order | 80 |
 | type_definitions.ts:19:5:19:5 | [VarDecl] e | semmle.label | [VarDecl] e |
 | type_definitions.ts:19:5:19:24 | [VariableDeclarator] e: EnumWithOneMember | semmle.label | [VariableDeclarator] e: EnumWithOneMember |
 | type_definitions.ts:19:8:19:24 | [LocalTypeAccess] EnumWithOneMember | semmle.label | [LocalTypeAccess] EnumWithOneMember |
 | type_definitions.ts:21:1:21:20 | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; |
-| type_definitions.ts:21:1:21:20 | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; | semmle.order | 80 |
+| type_definitions.ts:21:1:21:20 | [TypeAliasDeclaration,TypeDefinition] type Alias<T> = T[]; | semmle.order | 81 |
 | type_definitions.ts:21:6:21:10 | [Identifier] Alias | semmle.label | [Identifier] Alias |
 | type_definitions.ts:21:12:21:12 | [Identifier] T | semmle.label | [Identifier] T |
 | type_definitions.ts:21:12:21:12 | [TypeParameter] T | semmle.label | [TypeParameter] T |
 | type_definitions.ts:21:17:21:17 | [LocalTypeAccess] T | semmle.label | [LocalTypeAccess] T |
 | type_definitions.ts:21:17:21:19 | [ArrayTypeExpr] T[] | semmle.label | [ArrayTypeExpr] T[] |
 | type_definitions.ts:22:1:22:39 | [DeclStmt] let aliasForNumberArray = ... | semmle.label | [DeclStmt] let aliasForNumberArray = ... |
-| type_definitions.ts:22:1:22:39 | [DeclStmt] let aliasForNumberArray = ... | semmle.order | 81 |
+| type_definitions.ts:22:1:22:39 | [DeclStmt] let aliasForNumberArray = ... | semmle.order | 82 |
 | type_definitions.ts:22:5:22:23 | [VarDecl] aliasForNumberArray | semmle.label | [VarDecl] aliasForNumberArray |
 | type_definitions.ts:22:5:22:38 | [VariableDeclarator] aliasFo ... number> | semmle.label | [VariableDeclarator] aliasFo ... number> |
 | type_definitions.ts:22:26:22:30 | [LocalTypeAccess] Alias | semmle.label | [LocalTypeAccess] Alias |
@@ -920,6 +1086,8 @@ edges
 | file://:0:0:0:0 | (Arguments) | tst.ts:86:27:86:31 | [VarRef] value | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | tst.ts:97:27:97:26 | [SpreadElement] ...args | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | tst.ts:97:27:97:26 | [SpreadElement] ...args | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:159:31:159:35 | [Literal] "red" | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | tst.ts:159:31:159:35 | [Literal] "red" | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:14:17:14:17 | [SimpleParameter] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:14:17:14:17 | [SimpleParameter] x | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:14:28:14:28 | [SimpleParameter] y | semmle.label | 1 |
@@ -944,6 +1112,20 @@ edges
 | file://:0:0:0:0 | (Parameters) | tst.ts:97:27:97:26 | [SimpleParameter] args | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:104:16:104:16 | [SimpleParameter] s | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | tst.ts:104:16:104:16 | [SimpleParameter] s | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:133:16:133:18 | [SimpleParameter] arg | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:133:16:133:18 | [SimpleParameter] arg | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:144:17:144:21 | [SimpleParameter] shape | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:144:17:144:21 | [SimpleParameter] shape | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:153:8:153:10 | [SimpleParameter] sym | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:153:8:153:10 | [SimpleParameter] sym | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:154:8:154:10 | [SimpleParameter] key | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:154:8:154:10 | [SimpleParameter] key | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:155:8:155:10 | [SimpleParameter] num | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:155:8:155:10 | [SimpleParameter] num | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:166:8:166:10 | [SimpleParameter] key | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:166:8:166:10 | [SimpleParameter] key | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:172:8:172:14 | [SimpleParameter] optName | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | tst.ts:172:8:172:14 | [SimpleParameter] optName | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | type_alias.ts:14:10:14:17 | [SimpleParameter] property | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | type_alias.ts:14:10:14:17 | [SimpleParameter] property | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | type_alias.ts:21:19:21:21 | [SimpleParameter] key | semmle.label | 0 |
@@ -1760,6 +1942,318 @@ edges
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | tst.ts:127:14:127:17 | [ThisExpr] this | semmle.order | 1 |
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | tst.ts:127:19:127:28 | [Label] #someValue | semmle.label | 2 |
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | tst.ts:127:19:127:28 | [Label] #someValue | semmle.order | 2 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.label | 1 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.order | 1 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.label | 2 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.order | 2 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.label | 3 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.order | 3 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.label | 4 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.order | 4 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.label | 5 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.order | 5 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.label | 6 |
+| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.order | 6 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:12:133:14 | [VarDecl] foo | semmle.label | 0 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:12:133:14 | [VarDecl] foo | semmle.order | 0 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | semmle.label | 5 |
+| tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | semmle.order | 5 |
+| tst.ts:133:16:133:18 | [SimpleParameter] arg | tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.label | 0 |
+| tst.ts:133:16:133:18 | [SimpleParameter] arg | tst.ts:133:21:133:27 | [KeywordTypeExpr] unknown | semmle.order | 0 |
+| tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | semmle.label | 1 |
+| tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | semmle.order | 1 |
+| tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | semmle.label | 2 |
+| tst.ts:133:30:138:3 | [BlockStmt] { c ... } } | tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | semmle.order | 2 |
+| tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | semmle.label | 1 |
+| tst.ts:134:5:134:48 | [DeclStmt] const argIsString = ... | tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | semmle.order | 1 |
+| tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | tst.ts:134:11:134:21 | [VarDecl] argIsString | semmle.label | 1 |
+| tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | tst.ts:134:11:134:21 | [VarDecl] argIsString | semmle.order | 1 |
+| tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | semmle.label | 2 |
+| tst.ts:134:11:134:47 | [VariableDeclarator] argIsSt ... string" | tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | semmle.order | 2 |
+| tst.ts:134:25:134:34 | [UnaryExpr] typeof arg | tst.ts:134:32:134:34 | [VarRef] arg | semmle.label | 1 |
+| tst.ts:134:25:134:34 | [UnaryExpr] typeof arg | tst.ts:134:32:134:34 | [VarRef] arg | semmle.order | 1 |
+| tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | tst.ts:134:25:134:34 | [UnaryExpr] typeof arg | semmle.label | 1 |
+| tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | tst.ts:134:25:134:34 | [UnaryExpr] typeof arg | semmle.order | 1 |
+| tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | tst.ts:134:40:134:47 | [Literal] "string" | semmle.label | 2 |
+| tst.ts:134:25:134:47 | [BinaryExpr] typeof ... string" | tst.ts:134:40:134:47 | [Literal] "string" | semmle.order | 2 |
+| tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | tst.ts:135:9:135:19 | [VarRef] argIsString | semmle.label | 1 |
+| tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | tst.ts:135:9:135:19 | [VarRef] argIsString | semmle.order | 1 |
+| tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | tst.ts:135:22:137:5 | [BlockStmt] { ... ; } | semmle.label | 2 |
+| tst.ts:135:5:137:5 | [IfStmt] if (arg ... ; } | tst.ts:135:22:137:5 | [BlockStmt] { ... ; } | semmle.order | 2 |
+| tst.ts:135:22:137:5 | [BlockStmt] { ... ; } | tst.ts:136:9:136:40 | [DeclStmt] const upper = ... | semmle.label | 1 |
+| tst.ts:135:22:137:5 | [BlockStmt] { ... ; } | tst.ts:136:9:136:40 | [DeclStmt] const upper = ... | semmle.order | 1 |
+| tst.ts:136:9:136:40 | [DeclStmt] const upper = ... | tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | semmle.label | 1 |
+| tst.ts:136:9:136:40 | [DeclStmt] const upper = ... | tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | semmle.order | 1 |
+| tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | tst.ts:136:15:136:19 | [VarDecl] upper | semmle.label | 1 |
+| tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | tst.ts:136:15:136:19 | [VarDecl] upper | semmle.order | 1 |
+| tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | tst.ts:136:23:136:39 | [MethodCallExpr] arg.toUpperCase() | semmle.label | 2 |
+| tst.ts:136:15:136:39 | [VariableDeclarator] upper = ... rCase() | tst.ts:136:23:136:39 | [MethodCallExpr] arg.toUpperCase() | semmle.order | 2 |
+| tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | tst.ts:136:23:136:25 | [VarRef] arg | semmle.label | 1 |
+| tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | tst.ts:136:23:136:25 | [VarRef] arg | semmle.order | 1 |
+| tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | tst.ts:136:27:136:37 | [Label] toUpperCase | semmle.label | 2 |
+| tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | tst.ts:136:27:136:37 | [Label] toUpperCase | semmle.order | 2 |
+| tst.ts:136:23:136:39 | [MethodCallExpr] arg.toUpperCase() | tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | semmle.label | 0 |
+| tst.ts:136:23:136:39 | [MethodCallExpr] arg.toUpperCase() | tst.ts:136:23:136:37 | [DotExpr] arg.toUpperCase | semmle.order | 0 |
+| tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | tst.ts:140:8:140:12 | [Identifier] Shape | semmle.label | 1 |
+| tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | tst.ts:140:8:140:12 | [Identifier] Shape | semmle.order | 1 |
+| tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | semmle.label | 2 |
+| tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | semmle.order | 2 |
+| tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | semmle.label | 1 |
+| tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | semmle.order | 1 |
+| tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | semmle.label | 2 |
+| tst.ts:141:7:142:46 | [UnionTypeExpr] \| { kin ... umber } | tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | semmle.order | 2 |
+| tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | semmle.label | 1 |
+| tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | semmle.order | 1 |
+| tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | semmle.label | 2 |
+| tst.ts:141:9:141:42 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | semmle.order | 2 |
+| tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | tst.ts:141:11:141:14 | [Label] kind | semmle.label | 1 |
+| tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | tst.ts:141:11:141:14 | [Label] kind | semmle.order | 1 |
+| tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | tst.ts:141:17:141:24 | [LiteralTypeExpr] "circle" | semmle.label | 2 |
+| tst.ts:141:11:141:25 | [FieldDeclaration] kind: "circle", | tst.ts:141:17:141:24 | [LiteralTypeExpr] "circle" | semmle.order | 2 |
+| tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | tst.ts:141:27:141:32 | [Label] radius | semmle.label | 1 |
+| tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | tst.ts:141:27:141:32 | [Label] radius | semmle.order | 1 |
+| tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | tst.ts:141:35:141:40 | [KeywordTypeExpr] number | semmle.label | 2 |
+| tst.ts:141:27:141:40 | [FieldDeclaration] radius: number | tst.ts:141:35:141:40 | [KeywordTypeExpr] number | semmle.order | 2 |
+| tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | semmle.label | 1 |
+| tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | semmle.order | 1 |
+| tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | semmle.label | 2 |
+| tst.ts:142:9:142:46 | [InterfaceTypeExpr] { kind: ... umber } | tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | semmle.order | 2 |
+| tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | tst.ts:142:11:142:14 | [Label] kind | semmle.label | 1 |
+| tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | tst.ts:142:11:142:14 | [Label] kind | semmle.order | 1 |
+| tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | tst.ts:142:17:142:24 | [LiteralTypeExpr] "square" | semmle.label | 2 |
+| tst.ts:142:11:142:25 | [FieldDeclaration] kind: "square", | tst.ts:142:17:142:24 | [LiteralTypeExpr] "square" | semmle.order | 2 |
+| tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | tst.ts:142:27:142:36 | [Label] sideLength | semmle.label | 1 |
+| tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | tst.ts:142:27:142:36 | [Label] sideLength | semmle.order | 1 |
+| tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | tst.ts:142:39:142:44 | [KeywordTypeExpr] number | semmle.label | 2 |
+| tst.ts:142:27:142:44 | [FieldDeclaration] sideLength: number | tst.ts:142:39:142:44 | [KeywordTypeExpr] number | semmle.order | 2 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:12:144:15 | [VarDecl] side | semmle.label | 0 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:12:144:15 | [VarDecl] side | semmle.order | 0 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:32:144:37 | [KeywordTypeExpr] number | semmle.label | 4 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:32:144:37 | [KeywordTypeExpr] number | semmle.order | 4 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | semmle.label | 5 |
+| tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | semmle.order | 5 |
+| tst.ts:144:17:144:21 | [SimpleParameter] shape | tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.label | 0 |
+| tst.ts:144:17:144:21 | [SimpleParameter] shape | tst.ts:144:24:144:28 | [LocalTypeAccess] Shape | semmle.order | 0 |
+| tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | semmle.label | 1 |
+| tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | semmle.order | 1 |
+| tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | semmle.label | 2 |
+| tst.ts:144:39:149:3 | [BlockStmt] { ... ; } } | tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | semmle.order | 2 |
+| tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | semmle.label | 1 |
+| tst.ts:145:7:145:29 | [DeclStmt] const { ... shape; | tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | semmle.order | 1 |
+| tst.ts:145:13:145:20 | [ObjectPattern] { kind } | tst.ts:145:15:145:18 | [PropertyPattern] kind | semmle.label | 1 |
+| tst.ts:145:13:145:20 | [ObjectPattern] { kind } | tst.ts:145:15:145:18 | [PropertyPattern] kind | semmle.order | 1 |
+| tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | tst.ts:145:13:145:20 | [ObjectPattern] { kind } | semmle.label | 1 |
+| tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | tst.ts:145:13:145:20 | [ObjectPattern] { kind } | semmle.order | 1 |
+| tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | tst.ts:145:24:145:28 | [VarRef] shape | semmle.label | 2 |
+| tst.ts:145:13:145:28 | [VariableDeclarator] { kind } = shape | tst.ts:145:24:145:28 | [VarRef] shape | semmle.order | 2 |
+| tst.ts:145:15:145:18 | [PropertyPattern] kind | tst.ts:145:15:145:18 | [Label] kind | semmle.label | 1 |
+| tst.ts:145:15:145:18 | [PropertyPattern] kind | tst.ts:145:15:145:18 | [Label] kind | semmle.order | 1 |
+| tst.ts:145:15:145:18 | [PropertyPattern] kind | tst.ts:145:15:145:18 | [VarDecl] kind | semmle.label | 2 |
+| tst.ts:145:15:145:18 | [PropertyPattern] kind | tst.ts:145:15:145:18 | [VarDecl] kind | semmle.order | 2 |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | semmle.label | 1 |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | semmle.order | 1 |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | tst.ts:147:30:147:52 | [BlockStmt] { retur ... adius;} | semmle.label | 2 |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | tst.ts:147:30:147:52 | [BlockStmt] { retur ... adius;} | semmle.order | 2 |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | tst.ts:148:12:148:39 | [BlockStmt] { retur ... ngth; } | semmle.label | 3 |
+| tst.ts:147:7:148:39 | [IfStmt] if (kin ... ngth; } | tst.ts:148:12:148:39 | [BlockStmt] { retur ... ngth; } | semmle.order | 3 |
+| tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | tst.ts:147:11:147:14 | [VarRef] kind | semmle.label | 1 |
+| tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | tst.ts:147:11:147:14 | [VarRef] kind | semmle.order | 1 |
+| tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | tst.ts:147:20:147:27 | [Literal] "circle" | semmle.label | 2 |
+| tst.ts:147:11:147:27 | [BinaryExpr] kind === "circle" | tst.ts:147:20:147:27 | [Literal] "circle" | semmle.order | 2 |
+| tst.ts:147:30:147:52 | [BlockStmt] { retur ... adius;} | tst.ts:147:32:147:51 | [ReturnStmt] return shape.radius; | semmle.label | 1 |
+| tst.ts:147:30:147:52 | [BlockStmt] { retur ... adius;} | tst.ts:147:32:147:51 | [ReturnStmt] return shape.radius; | semmle.order | 1 |
+| tst.ts:147:32:147:51 | [ReturnStmt] return shape.radius; | tst.ts:147:39:147:50 | [DotExpr] shape.radius | semmle.label | 1 |
+| tst.ts:147:32:147:51 | [ReturnStmt] return shape.radius; | tst.ts:147:39:147:50 | [DotExpr] shape.radius | semmle.order | 1 |
+| tst.ts:147:39:147:50 | [DotExpr] shape.radius | tst.ts:147:39:147:43 | [VarRef] shape | semmle.label | 1 |
+| tst.ts:147:39:147:50 | [DotExpr] shape.radius | tst.ts:147:39:147:43 | [VarRef] shape | semmle.order | 1 |
+| tst.ts:147:39:147:50 | [DotExpr] shape.radius | tst.ts:147:45:147:50 | [Label] radius | semmle.label | 2 |
+| tst.ts:147:39:147:50 | [DotExpr] shape.radius | tst.ts:147:45:147:50 | [Label] radius | semmle.order | 2 |
+| tst.ts:148:12:148:39 | [BlockStmt] { retur ... ngth; } | tst.ts:148:14:148:37 | [ReturnStmt] return ... Length; | semmle.label | 1 |
+| tst.ts:148:12:148:39 | [BlockStmt] { retur ... ngth; } | tst.ts:148:14:148:37 | [ReturnStmt] return ... Length; | semmle.order | 1 |
+| tst.ts:148:14:148:37 | [ReturnStmt] return ... Length; | tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | semmle.label | 1 |
+| tst.ts:148:14:148:37 | [ReturnStmt] return ... Length; | tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | semmle.order | 1 |
+| tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | tst.ts:148:21:148:25 | [VarRef] shape | semmle.label | 1 |
+| tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | tst.ts:148:21:148:25 | [VarRef] shape | semmle.order | 1 |
+| tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | tst.ts:148:27:148:36 | [Label] sideLength | semmle.label | 2 |
+| tst.ts:148:21:148:36 | [DotExpr] shape.sideLength | tst.ts:148:27:148:36 | [Label] sideLength | semmle.order | 2 |
+| tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | tst.ts:151:12:151:22 | [VarDecl] symbolIndex | semmle.label | 0 |
+| tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | tst.ts:151:12:151:22 | [VarDecl] symbolIndex | semmle.order | 0 |
+| tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | semmle.label | 5 |
+| tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | semmle.order | 5 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.label | 1 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.order | 1 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | semmle.label | 2 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | semmle.order | 2 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:159:5:159:38 | [DeclStmt] const red = ... | semmle.label | 3 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:159:5:159:38 | [DeclStmt] const red = ... | semmle.order | 3 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:160:5:160:34 | [DeclStmt] const green = ... | semmle.label | 4 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:160:5:160:34 | [DeclStmt] const green = ... | semmle.order | 4 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:161:5:161:27 | [DeclStmt] const blue = ... | semmle.label | 5 |
+| tst.ts:151:26:162:3 | [BlockStmt] { i ... 2]; } | tst.ts:161:5:161:27 | [DeclStmt] const blue = ... | semmle.order | 5 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:152:15:152:20 | [Identifier] Colors | semmle.label | 1 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:152:15:152:20 | [Identifier] Colors | semmle.order | 1 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | semmle.label | 2 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | semmle.order | 2 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | semmle.label | 3 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | semmle.order | 3 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | semmle.label | 4 |
+| tst.ts:152:5:156:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | semmle.order | 4 |
+| tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | tst.ts:153:22:153:27 | [KeywordTypeExpr] number | semmle.label | 4 |
+| tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | tst.ts:153:22:153:27 | [KeywordTypeExpr] number | semmle.order | 4 |
+| tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | semmle.label | 1 |
+| tst.ts:153:7:153:28 | [IndexSignature] [sym: s ... number; | tst.ts:153:7:153:28 | [FunctionExpr] [sym: s ... number; | semmle.order | 1 |
+| tst.ts:153:8:153:10 | [SimpleParameter] sym | tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.label | 0 |
+| tst.ts:153:8:153:10 | [SimpleParameter] sym | tst.ts:153:13:153:18 | [KeywordTypeExpr] symbol | semmle.order | 0 |
+| tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | tst.ts:154:22:154:27 | [KeywordTypeExpr] string | semmle.label | 4 |
+| tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | tst.ts:154:22:154:27 | [KeywordTypeExpr] string | semmle.order | 4 |
+| tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | semmle.label | 1 |
+| tst.ts:154:7:154:28 | [IndexSignature] [key: s ... string; | tst.ts:154:7:154:28 | [FunctionExpr] [key: s ... string; | semmle.order | 1 |
+| tst.ts:154:8:154:10 | [SimpleParameter] key | tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.label | 0 |
+| tst.ts:154:8:154:10 | [SimpleParameter] key | tst.ts:154:13:154:18 | [KeywordTypeExpr] string | semmle.order | 0 |
+| tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | tst.ts:155:22:155:28 | [KeywordTypeExpr] boolean | semmle.label | 4 |
+| tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | tst.ts:155:22:155:28 | [KeywordTypeExpr] boolean | semmle.order | 4 |
+| tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | semmle.label | 1 |
+| tst.ts:155:7:155:29 | [IndexSignature] [num: n ... oolean; | tst.ts:155:7:155:29 | [FunctionExpr] [num: n ... oolean; | semmle.order | 1 |
+| tst.ts:155:8:155:10 | [SimpleParameter] num | tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.label | 0 |
+| tst.ts:155:8:155:10 | [SimpleParameter] num | tst.ts:155:13:155:18 | [KeywordTypeExpr] number | semmle.order | 0 |
+| tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | semmle.label | 1 |
+| tst.ts:158:5:158:28 | [DeclStmt] let colors = ... | tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | semmle.order | 1 |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:9:158:14 | [VarDecl] colors | semmle.label | 1 |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:9:158:14 | [VarDecl] colors | semmle.order | 1 |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:17:158:22 | [LocalTypeAccess] Colors | semmle.label | 2 |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:17:158:22 | [LocalTypeAccess] Colors | semmle.order | 2 |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:26:158:27 | [ObjectExpr] {} | semmle.label | 3 |
+| tst.ts:158:9:158:27 | [VariableDeclarator] colors: Colors = {} | tst.ts:158:26:158:27 | [ObjectExpr] {} | semmle.order | 3 |
+| tst.ts:159:5:159:38 | [DeclStmt] const red = ... | tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | semmle.label | 1 |
+| tst.ts:159:5:159:38 | [DeclStmt] const red = ... | tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | semmle.order | 1 |
+| tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | tst.ts:159:11:159:13 | [VarDecl] red | semmle.label | 1 |
+| tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | tst.ts:159:11:159:13 | [VarDecl] red | semmle.order | 1 |
+| tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | semmle.label | 2 |
+| tst.ts:159:11:159:37 | [VariableDeclarator] red = c ... "red")] | tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | semmle.order | 2 |
+| tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | tst.ts:159:17:159:22 | [VarRef] colors | semmle.label | 1 |
+| tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | tst.ts:159:17:159:22 | [VarRef] colors | semmle.order | 1 |
+| tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | semmle.label | 2 |
+| tst.ts:159:17:159:37 | [IndexExpr] colors[ ... "red")] | tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | semmle.order | 2 |
+| tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | tst.ts:159:24:159:29 | [VarRef] Symbol | semmle.label | 0 |
+| tst.ts:159:24:159:36 | [CallExpr] Symbol("red") | tst.ts:159:24:159:29 | [VarRef] Symbol | semmle.order | 0 |
+| tst.ts:160:5:160:34 | [DeclStmt] const green = ... | tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | semmle.label | 1 |
+| tst.ts:160:5:160:34 | [DeclStmt] const green = ... | tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | semmle.order | 1 |
+| tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | tst.ts:160:11:160:15 | [VarDecl] green | semmle.label | 1 |
+| tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | tst.ts:160:11:160:15 | [VarDecl] green | semmle.order | 1 |
+| tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | semmle.label | 2 |
+| tst.ts:160:11:160:33 | [VariableDeclarator] green = ... green"] | tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | semmle.order | 2 |
+| tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | tst.ts:160:19:160:24 | [VarRef] colors | semmle.label | 1 |
+| tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | tst.ts:160:19:160:24 | [VarRef] colors | semmle.order | 1 |
+| tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | tst.ts:160:26:160:32 | [Literal] "green" | semmle.label | 2 |
+| tst.ts:160:19:160:33 | [IndexExpr] colors["green"] | tst.ts:160:26:160:32 | [Literal] "green" | semmle.order | 2 |
+| tst.ts:161:5:161:27 | [DeclStmt] const blue = ... | tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | semmle.label | 1 |
+| tst.ts:161:5:161:27 | [DeclStmt] const blue = ... | tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | semmle.order | 1 |
+| tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | tst.ts:161:11:161:14 | [VarDecl] blue | semmle.label | 1 |
+| tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | tst.ts:161:11:161:14 | [VarDecl] blue | semmle.order | 1 |
+| tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | tst.ts:161:18:161:26 | [IndexExpr] colors[2] | semmle.label | 2 |
+| tst.ts:161:11:161:26 | [VariableDeclarator] blue = colors[2] | tst.ts:161:18:161:26 | [IndexExpr] colors[2] | semmle.order | 2 |
+| tst.ts:161:18:161:26 | [IndexExpr] colors[2] | tst.ts:161:18:161:23 | [VarRef] colors | semmle.label | 1 |
+| tst.ts:161:18:161:26 | [IndexExpr] colors[2] | tst.ts:161:18:161:23 | [VarRef] colors | semmle.order | 1 |
+| tst.ts:161:18:161:26 | [IndexExpr] colors[2] | tst.ts:161:25:161:25 | [Literal] 2 | semmle.label | 2 |
+| tst.ts:161:18:161:26 | [IndexExpr] colors[2] | tst.ts:161:25:161:25 | [Literal] 2 | semmle.order | 2 |
+| tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | tst.ts:164:12:164:29 | [VarDecl] stringPatternIndex | semmle.label | 0 |
+| tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | tst.ts:164:12:164:29 | [VarDecl] stringPatternIndex | semmle.order | 0 |
+| tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | semmle.label | 5 |
+| tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | semmle.order | 5 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.label | 1 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.order | 1 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:168:5:168:23 | [DeclStmt] var bla = ... | semmle.label | 2 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:168:5:168:23 | [DeclStmt] var bla = ... | semmle.order | 2 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:169:5:169:29 | [DeclStmt] const bar = ... | semmle.label | 3 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:169:5:169:29 | [DeclStmt] const bar = ... | semmle.order | 3 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.label | 4 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | semmle.order | 4 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:175:5:175:26 | [DeclStmt] const data = ... | semmle.label | 5 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:175:5:175:26 | [DeclStmt] const data = ... | semmle.order | 5 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:176:5:176:28 | [DeclStmt] const baz = ... | semmle.label | 6 |
+| tst.ts:164:33:177:3 | [BlockStmt] { i ... "]; } | tst.ts:176:5:176:28 | [DeclStmt] const baz = ... | semmle.order | 6 |
+| tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:165:15:165:17 | [Identifier] Foo | semmle.label | 1 |
+| tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:165:15:165:17 | [Identifier] Foo | semmle.order | 1 |
+| tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | semmle.label | 2 |
+| tst.ts:165:5:167:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | semmle.order | 2 |
+| tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | tst.ts:166:31:166:36 | [KeywordTypeExpr] number | semmle.label | 4 |
+| tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | tst.ts:166:31:166:36 | [KeywordTypeExpr] number | semmle.order | 4 |
+| tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | semmle.label | 1 |
+| tst.ts:166:7:166:37 | [IndexSignature] [key: ` ... number; | tst.ts:166:7:166:37 | [FunctionExpr] [key: ` ... number; | semmle.order | 1 |
+| tst.ts:166:8:166:10 | [SimpleParameter] key | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.label | 0 |
+| tst.ts:166:8:166:10 | [SimpleParameter] key | tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | semmle.order | 0 |
+| tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:14:166:17 | [LiteralTypeExpr] foo- | semmle.label | 1 |
+| tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:14:166:17 | [LiteralTypeExpr] foo- | semmle.order | 1 |
+| tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:20:166:25 | [KeywordTypeExpr] number | semmle.label | 2 |
+| tst.ts:166:13:166:27 | [TemplateLiteralTypeExpr] `foo-${number}` | tst.ts:166:20:166:25 | [KeywordTypeExpr] number | semmle.order | 2 |
+| tst.ts:168:5:168:23 | [DeclStmt] var bla = ... | tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | semmle.label | 1 |
+| tst.ts:168:5:168:23 | [DeclStmt] var bla = ... | tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | semmle.order | 1 |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | tst.ts:168:9:168:11 | [VarDecl] bla | semmle.label | 1 |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | tst.ts:168:9:168:11 | [VarDecl] bla | semmle.order | 1 |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | tst.ts:168:15:168:17 | [LocalTypeAccess] Foo | semmle.label | 2 |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | tst.ts:168:15:168:17 | [LocalTypeAccess] Foo | semmle.order | 2 |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | tst.ts:168:21:168:22 | [ObjectExpr] {} | semmle.label | 3 |
+| tst.ts:168:9:168:22 | [VariableDeclarator] bla : Foo = {} | tst.ts:168:21:168:22 | [ObjectExpr] {} | semmle.order | 3 |
+| tst.ts:169:5:169:29 | [DeclStmt] const bar = ... | tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | semmle.label | 1 |
+| tst.ts:169:5:169:29 | [DeclStmt] const bar = ... | tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | semmle.order | 1 |
+| tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | tst.ts:169:11:169:13 | [VarDecl] bar | semmle.label | 1 |
+| tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | tst.ts:169:11:169:13 | [VarDecl] bar | semmle.order | 1 |
+| tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | semmle.label | 2 |
+| tst.ts:169:11:169:28 | [VariableDeclarator] bar = bla[`foo-1`] | tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | semmle.order | 2 |
+| tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | tst.ts:169:17:169:19 | [VarRef] bla | semmle.label | 1 |
+| tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | tst.ts:169:17:169:19 | [VarRef] bla | semmle.order | 1 |
+| tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | tst.ts:169:21:169:27 | [TemplateLiteral] `foo-1` | semmle.label | 2 |
+| tst.ts:169:17:169:28 | [IndexExpr] bla[`foo-1`] | tst.ts:169:21:169:27 | [TemplateLiteral] `foo-1` | semmle.order | 2 |
+| tst.ts:169:21:169:27 | [TemplateLiteral] `foo-1` | tst.ts:169:21:169:27 | [TemplateElement] `foo-1` | semmle.label | 1 |
+| tst.ts:169:21:169:27 | [TemplateLiteral] `foo-1` | tst.ts:169:21:169:27 | [TemplateElement] `foo-1` | semmle.order | 1 |
+| tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:171:15:171:18 | [Identifier] Data | semmle.label | 1 |
+| tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:171:15:171:18 | [Identifier] Data | semmle.order | 1 |
+| tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | semmle.label | 2 |
+| tst.ts:171:5:173:5 | [InterfaceDeclaration,TypeDefinition] interfa ... ; } | tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | semmle.order | 2 |
+| tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | tst.ts:172:35:172:41 | [KeywordTypeExpr] boolean | semmle.label | 4 |
+| tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | tst.ts:172:35:172:41 | [KeywordTypeExpr] boolean | semmle.order | 4 |
+| tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | semmle.label | 1 |
+| tst.ts:172:7:172:42 | [IndexSignature] [optNam ... oolean; | tst.ts:172:7:172:42 | [FunctionExpr] [optNam ... oolean; | semmle.order | 1 |
+| tst.ts:172:8:172:14 | [SimpleParameter] optName | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.label | 0 |
+| tst.ts:172:8:172:14 | [SimpleParameter] optName | tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | semmle.order | 0 |
+| tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:17:172:22 | [KeywordTypeExpr] string | semmle.label | 1 |
+| tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:17:172:22 | [KeywordTypeExpr] string | semmle.order | 1 |
+| tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:26:172:31 | [KeywordTypeExpr] symbol | semmle.label | 2 |
+| tst.ts:172:17:172:31 | [UnionTypeExpr] string \| symbol | tst.ts:172:26:172:31 | [KeywordTypeExpr] symbol | semmle.order | 2 |
+| tst.ts:175:5:175:26 | [DeclStmt] const data = ... | tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | semmle.label | 1 |
+| tst.ts:175:5:175:26 | [DeclStmt] const data = ... | tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | semmle.order | 1 |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | tst.ts:175:11:175:14 | [VarDecl] data | semmle.label | 1 |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | tst.ts:175:11:175:14 | [VarDecl] data | semmle.order | 1 |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | tst.ts:175:17:175:20 | [LocalTypeAccess] Data | semmle.label | 2 |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | tst.ts:175:17:175:20 | [LocalTypeAccess] Data | semmle.order | 2 |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | tst.ts:175:24:175:25 | [ObjectExpr] {} | semmle.label | 3 |
+| tst.ts:175:11:175:25 | [VariableDeclarator] data: Data = {} | tst.ts:175:24:175:25 | [ObjectExpr] {} | semmle.order | 3 |
+| tst.ts:176:5:176:28 | [DeclStmt] const baz = ... | tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | semmle.label | 1 |
+| tst.ts:176:5:176:28 | [DeclStmt] const baz = ... | tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | semmle.order | 1 |
+| tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | tst.ts:176:11:176:13 | [VarDecl] baz | semmle.label | 1 |
+| tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | tst.ts:176:11:176:13 | [VarDecl] baz | semmle.order | 1 |
+| tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | semmle.label | 2 |
+| tst.ts:176:11:176:27 | [VariableDeclarator] baz = data["foo"] | tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | semmle.order | 2 |
+| tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:17:176:20 | [VarRef] data | semmle.label | 1 |
+| tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:17:176:20 | [VarRef] data | semmle.order | 1 |
+| tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:22:176:26 | [Literal] "foo" | semmle.label | 2 |
+| tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:22:176:26 | [Literal] "foo" | semmle.order | 2 |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.label | 1 |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.order | 1 |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | type_alias.ts:1:10:1:16 | [KeywordTypeExpr] boolean | semmle.label | 2 |

--- a/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/printAst.expected
@@ -599,8 +599,8 @@ nodes
 | tst.ts:127:14:127:17 | [ThisExpr] this | semmle.label | [ThisExpr] this |
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | semmle.label | [DotExpr] this.#someValue |
 | tst.ts:127:19:127:28 | [Label] #someValue | semmle.label | [Label] #someValue |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | semmle.label | [NamespaceDeclaration] module ... ; } } |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | semmle.order | 56 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | semmle.label | [NamespaceDeclaration] module ... } } |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | semmle.order | 56 |
 | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.label | [VarDecl] TS44 |
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.label | [FunctionDeclStmt] functio ... } } |
 | tst.ts:133:12:133:14 | [VarDecl] foo | semmle.label | [VarDecl] foo |
@@ -757,6 +757,37 @@ nodes
 | tst.ts:176:17:176:20 | [VarRef] data | semmle.label | [VarRef] data |
 | tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | semmle.label | [IndexExpr] data["foo"] |
 | tst.ts:176:22:176:26 | [Literal] "foo" | semmle.label | [Literal] "foo" |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | semmle.label | [ClassDefinition,TypeDefinition] class F ... } |
+| tst.ts:179:9:179:11 | [VarDecl] Foo | semmle.label | [VarDecl] Foo |
+| tst.ts:179:13:179:12 | [BlockStmt] {} | semmle.label | [BlockStmt] {} |
+| tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.label | [ClassInitializedMember,ConstructorDefinition] constructor() {} |
+| tst.ts:179:13:179:12 | [FunctionExpr] () {} | semmle.label | [FunctionExpr] () {} |
+| tst.ts:179:13:179:12 | [Label] constructor | semmle.label | [Label] constructor |
+| tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | semmle.label | [ClassInitializedMember,FieldDeclaration] static #count = 0; |
+| tst.ts:180:12:180:17 | [Label] #count | semmle.label | [Label] #count |
+| tst.ts:180:21:180:21 | [Literal] 0 | semmle.label | [Literal] 0 |
+| tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | semmle.label | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } |
+| tst.ts:182:5:184:5 | [FunctionExpr] get cou ... ; } | semmle.label | [FunctionExpr] get cou ... ; } |
+| tst.ts:182:9:182:13 | [Label] count | semmle.label | [Label] count |
+| tst.ts:182:17:184:5 | [BlockStmt] { ... ; } | semmle.label | [BlockStmt] { ... ; } |
+| tst.ts:183:9:183:26 | [ReturnStmt] return Foo.#count; | semmle.label | [ReturnStmt] return Foo.#count; |
+| tst.ts:183:16:183:18 | [VarRef] Foo | semmle.label | [VarRef] Foo |
+| tst.ts:183:16:183:25 | [DotExpr] Foo.#count | semmle.label | [DotExpr] Foo.#count |
+| tst.ts:183:20:183:25 | [Label] #count | semmle.label | [Label] #count |
+| tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.label | [BlockStmt] static ... ; } |
+| tst.ts:186:7:186:9 | [VarRef] Foo | semmle.label | [VarRef] Foo |
+| tst.ts:186:7:186:16 | [DotExpr] Foo.#count | semmle.label | [DotExpr] Foo.#count |
+| tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | semmle.label | [CompoundAssignExpr] Foo.#count += 3 |
+| tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | semmle.label | [ExprStmt] Foo.#count += 3; |
+| tst.ts:186:11:186:16 | [Label] #count | semmle.label | [Label] #count |
+| tst.ts:186:21:186:21 | [Literal] 3 | semmle.label | [Literal] 3 |
+| tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.label | [BlockStmt] static ... ; } |
+| tst.ts:189:7:189:29 | [DeclStmt] var count = ... | semmle.label | [DeclStmt] var count = ... |
+| tst.ts:189:11:189:15 | [VarDecl] count | semmle.label | [VarDecl] count |
+| tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | semmle.label | [VariableDeclarator] count = Foo.#count |
+| tst.ts:189:19:189:21 | [VarRef] Foo | semmle.label | [VarRef] Foo |
+| tst.ts:189:19:189:28 | [DotExpr] Foo.#count | semmle.label | [DotExpr] Foo.#count |
+| tst.ts:189:23:189:28 | [Label] #count | semmle.label | [Label] #count |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.label | [TypeAliasDeclaration,TypeDefinition] type B = boolean; |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | semmle.order | 57 |
 | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.label | [Identifier] B |
@@ -1942,18 +1973,20 @@ edges
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | tst.ts:127:14:127:17 | [ThisExpr] this | semmle.order | 1 |
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | tst.ts:127:19:127:28 | [Label] #someValue | semmle.label | 2 |
 | tst.ts:127:14:127:28 | [DotExpr] this.#someValue | tst.ts:127:19:127:28 | [Label] #someValue | semmle.order | 2 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.label | 1 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.order | 1 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.label | 2 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.order | 2 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.label | 3 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.order | 3 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.label | 4 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.order | 4 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.label | 5 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.order | 5 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.label | 6 |
-| tst.ts:132:1:178:1 | [NamespaceDeclaration] module ... ; } } | tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.order | 6 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.label | 1 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:132:8:132:11 | [VarDecl] TS44 | semmle.order | 1 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.label | 2 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | semmle.order | 2 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.label | 3 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:140:3:142:47 | [TypeAliasDeclaration,TypeDefinition] type Sh ... mber }; | semmle.order | 3 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.label | 4 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:144:3:149:3 | [FunctionDeclStmt] functio ... ; } } | semmle.order | 4 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.label | 5 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:151:3:162:3 | [FunctionDeclStmt] functio ... 2]; } | semmle.order | 5 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.label | 6 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:164:3:177:3 | [FunctionDeclStmt] functio ... "]; } | semmle.order | 6 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | semmle.label | 7 |
+| tst.ts:132:1:193:1 | [NamespaceDeclaration] module ... } } | tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | semmle.order | 7 |
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
 | tst.ts:133:3:138:3 | [FunctionDeclStmt] functio ... } } | tst.ts:133:12:133:14 | [VarDecl] foo | semmle.label | 0 |
@@ -2254,6 +2287,66 @@ edges
 | tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:17:176:20 | [VarRef] data | semmle.order | 1 |
 | tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:22:176:26 | [Literal] "foo" | semmle.label | 2 |
 | tst.ts:176:17:176:27 | [IndexExpr] data["foo"] | tst.ts:176:22:176:26 | [Literal] "foo" | semmle.order | 2 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:179:9:179:11 | [VarDecl] Foo | semmle.label | 1 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:179:9:179:11 | [VarDecl] Foo | semmle.order | 1 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.label | 2 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | semmle.order | 2 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | semmle.label | 3 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | semmle.order | 3 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | semmle.label | 4 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | semmle.order | 4 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.label | 5 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | semmle.order | 5 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.label | 6 |
+| tst.ts:179:3:192:3 | [ClassDefinition,TypeDefinition] class F ... } | tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | semmle.order | 6 |
+| tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [FunctionExpr] () {} | semmle.label | 2 |
+| tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [FunctionExpr] () {} | semmle.order | 2 |
+| tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [Label] constructor | semmle.label | 1 |
+| tst.ts:179:13:179:12 | [ClassInitializedMember,ConstructorDefinition] constructor() {} | tst.ts:179:13:179:12 | [Label] constructor | semmle.order | 1 |
+| tst.ts:179:13:179:12 | [FunctionExpr] () {} | tst.ts:179:13:179:12 | [BlockStmt] {} | semmle.label | 5 |
+| tst.ts:179:13:179:12 | [FunctionExpr] () {} | tst.ts:179:13:179:12 | [BlockStmt] {} | semmle.order | 5 |
+| tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | tst.ts:180:12:180:17 | [Label] #count | semmle.label | 1 |
+| tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | tst.ts:180:12:180:17 | [Label] #count | semmle.order | 1 |
+| tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | tst.ts:180:21:180:21 | [Literal] 0 | semmle.label | 2 |
+| tst.ts:180:5:180:22 | [ClassInitializedMember,FieldDeclaration] static #count = 0; | tst.ts:180:21:180:21 | [Literal] 0 | semmle.order | 2 |
+| tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | tst.ts:182:5:184:5 | [FunctionExpr] get cou ... ; } | semmle.label | 1 |
+| tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | tst.ts:182:5:184:5 | [FunctionExpr] get cou ... ; } | semmle.order | 1 |
+| tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | tst.ts:182:9:182:13 | [Label] count | semmle.label | 2 |
+| tst.ts:182:5:184:5 | [ClassInitializedMember,GetterMethodDefinition] get cou ... ; } | tst.ts:182:9:182:13 | [Label] count | semmle.order | 2 |
+| tst.ts:182:5:184:5 | [FunctionExpr] get cou ... ; } | tst.ts:182:17:184:5 | [BlockStmt] { ... ; } | semmle.label | 5 |
+| tst.ts:182:5:184:5 | [FunctionExpr] get cou ... ; } | tst.ts:182:17:184:5 | [BlockStmt] { ... ; } | semmle.order | 5 |
+| tst.ts:182:17:184:5 | [BlockStmt] { ... ; } | tst.ts:183:9:183:26 | [ReturnStmt] return Foo.#count; | semmle.label | 1 |
+| tst.ts:182:17:184:5 | [BlockStmt] { ... ; } | tst.ts:183:9:183:26 | [ReturnStmt] return Foo.#count; | semmle.order | 1 |
+| tst.ts:183:9:183:26 | [ReturnStmt] return Foo.#count; | tst.ts:183:16:183:25 | [DotExpr] Foo.#count | semmle.label | 1 |
+| tst.ts:183:9:183:26 | [ReturnStmt] return Foo.#count; | tst.ts:183:16:183:25 | [DotExpr] Foo.#count | semmle.order | 1 |
+| tst.ts:183:16:183:25 | [DotExpr] Foo.#count | tst.ts:183:16:183:18 | [VarRef] Foo | semmle.label | 1 |
+| tst.ts:183:16:183:25 | [DotExpr] Foo.#count | tst.ts:183:16:183:18 | [VarRef] Foo | semmle.order | 1 |
+| tst.ts:183:16:183:25 | [DotExpr] Foo.#count | tst.ts:183:20:183:25 | [Label] #count | semmle.label | 2 |
+| tst.ts:183:16:183:25 | [DotExpr] Foo.#count | tst.ts:183:20:183:25 | [Label] #count | semmle.order | 2 |
+| tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | semmle.label | 1 |
+| tst.ts:185:5:187:5 | [BlockStmt] static ... ; } | tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | semmle.order | 1 |
+| tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:7:186:9 | [VarRef] Foo | semmle.label | 1 |
+| tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:7:186:9 | [VarRef] Foo | semmle.order | 1 |
+| tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:11:186:16 | [Label] #count | semmle.label | 2 |
+| tst.ts:186:7:186:16 | [DotExpr] Foo.#count | tst.ts:186:11:186:16 | [Label] #count | semmle.order | 2 |
+| tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | tst.ts:186:7:186:16 | [DotExpr] Foo.#count | semmle.label | 1 |
+| tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | tst.ts:186:7:186:16 | [DotExpr] Foo.#count | semmle.order | 1 |
+| tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | tst.ts:186:21:186:21 | [Literal] 3 | semmle.label | 2 |
+| tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | tst.ts:186:21:186:21 | [Literal] 3 | semmle.order | 2 |
+| tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | semmle.label | 1 |
+| tst.ts:186:7:186:22 | [ExprStmt] Foo.#count += 3; | tst.ts:186:7:186:21 | [CompoundAssignExpr] Foo.#count += 3 | semmle.order | 1 |
+| tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | semmle.label | 1 |
+| tst.ts:188:5:190:5 | [BlockStmt] static ... ; } | tst.ts:189:7:189:29 | [DeclStmt] var count = ... | semmle.order | 1 |
+| tst.ts:189:7:189:29 | [DeclStmt] var count = ... | tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | semmle.label | 1 |
+| tst.ts:189:7:189:29 | [DeclStmt] var count = ... | tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | semmle.order | 1 |
+| tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | tst.ts:189:11:189:15 | [VarDecl] count | semmle.label | 1 |
+| tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | tst.ts:189:11:189:15 | [VarDecl] count | semmle.order | 1 |
+| tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | tst.ts:189:19:189:28 | [DotExpr] Foo.#count | semmle.label | 2 |
+| tst.ts:189:11:189:28 | [VariableDeclarator] count = Foo.#count | tst.ts:189:19:189:28 | [DotExpr] Foo.#count | semmle.order | 2 |
+| tst.ts:189:19:189:28 | [DotExpr] Foo.#count | tst.ts:189:19:189:21 | [VarRef] Foo | semmle.label | 1 |
+| tst.ts:189:19:189:28 | [DotExpr] Foo.#count | tst.ts:189:19:189:21 | [VarRef] Foo | semmle.order | 1 |
+| tst.ts:189:19:189:28 | [DotExpr] Foo.#count | tst.ts:189:23:189:28 | [Label] #count | semmle.label | 2 |
+| tst.ts:189:19:189:28 | [DotExpr] Foo.#count | tst.ts:189:23:189:28 | [Label] #count | semmle.order | 2 |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.label | 1 |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | type_alias.ts:1:6:1:6 | [Identifier] B | semmle.order | 1 |
 | type_alias.ts:1:1:1:17 | [TypeAliasDeclaration,TypeDefinition] type B = boolean; | type_alias.ts:1:10:1:16 | [KeywordTypeExpr] boolean | semmle.label | 2 |

--- a/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
@@ -670,3 +670,6 @@ unionIndex
 | { stillMyUnion: true; } | 1 | MyUnion \| { yetAnotherType: true; } |
 | { stillMyUnion: true; } | 1 | { myUnion: true; } \| { stillMyUnion: true; } |
 | { yetAnotherType: true; } | 2 | MyUnion \| { yetAnotherType: true; } |
+getAStaticInitializerBlock
+| tst.ts:179:3:192:3 | class F ...    \\n  } | tst.ts:185:5:187:5 | static  ... ;\\n    } |
+| tst.ts:179:3:192:3 | class F ...    \\n  } | tst.ts:188:5:190:5 | static  ... ;\\n    } |

--- a/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
@@ -247,6 +247,19 @@ getExprType
 | tst.ts:176:17:176:20 | data | Data |
 | tst.ts:176:17:176:27 | data["foo"] | boolean |
 | tst.ts:176:22:176:26 | "foo" | "foo" |
+| tst.ts:179:9:179:11 | Foo | Foo |
+| tst.ts:180:21:180:21 | 0 | 0 |
+| tst.ts:182:5:184:5 | get cou ... ;\\n    } | number |
+| tst.ts:182:9:182:13 | count | number |
+| tst.ts:183:16:183:18 | Foo | typeof Foo in tst.ts:132 |
+| tst.ts:183:16:183:25 | Foo.#count | number |
+| tst.ts:186:7:186:9 | Foo | typeof Foo in tst.ts:132 |
+| tst.ts:186:7:186:16 | Foo.#count | number |
+| tst.ts:186:7:186:21 | Foo.#count += 3 | number |
+| tst.ts:186:21:186:21 | 3 | 3 |
+| tst.ts:189:11:189:15 | count | number |
+| tst.ts:189:19:189:21 | Foo | typeof Foo in tst.ts:132 |
+| tst.ts:189:19:189:28 | Foo.#count | number |
 | type_alias.ts:3:5:3:5 | b | boolean |
 | type_alias.ts:7:5:7:5 | c | ValueOrArray<number> |
 | type_alias.ts:14:9:14:32 | [proper ... ]: Json | any |
@@ -309,6 +322,7 @@ getTypeDefinitionType
 | tst.ts:152:5:156:5 | interfa ... ;\\n    } | Colors |
 | tst.ts:165:5:167:5 | interfa ... ;\\n    } | Foo |
 | tst.ts:171:5:173:5 | interfa ... ;\\n    } | Data |
+| tst.ts:179:3:192:3 | class F ...    \\n  } | Foo |
 | type_alias.ts:1:1:1:17 | type B = boolean; | boolean |
 | type_alias.ts:5:1:5:50 | type Va ... ay<T>>; | ValueOrArray<T> |
 | type_alias.ts:9:1:15:13 | type Js ... Json[]; | Json |
@@ -551,6 +565,7 @@ referenceDefinition
 | EnumWithOneMember | type_definitions.ts:18:26:18:31 | member |
 | Foo | tst.ts:116:3:129:3 | class F ...   }\\n  } |
 | Foo | tst.ts:165:5:167:5 | interfa ... ;\\n    } |
+| Foo | tst.ts:179:3:192:3 | class F ...    \\n  } |
 | HasArea | tst.ts:58:1:60:1 | interfa ... mber;\\n} |
 | I<S> | type_definitions.ts:3:1:5:1 | interfa ... x: S;\\n} |
 | I<number> | type_definitions.ts:3:1:5:1 | interfa ... x: S;\\n} |

--- a/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tests.expected
@@ -175,6 +175,78 @@ getExprType
 | tst.ts:126:7:126:22 | this.#someMethod | () => number |
 | tst.ts:126:7:126:24 | this.#someMethod() | number |
 | tst.ts:127:14:127:28 | this.#someValue | number |
+| tst.ts:132:8:132:11 | TS44 | typeof TS44 in library-tests/TypeScript/Types/tst.ts |
+| tst.ts:133:12:133:14 | foo | (arg: unknown) => void |
+| tst.ts:133:16:133:18 | arg | unknown |
+| tst.ts:134:11:134:21 | argIsString | boolean |
+| tst.ts:134:25:134:34 | typeof arg | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
+| tst.ts:134:25:134:47 | typeof  ... string" | boolean |
+| tst.ts:134:32:134:34 | arg | unknown |
+| tst.ts:134:40:134:47 | "string" | "string" |
+| tst.ts:135:9:135:19 | argIsString | boolean |
+| tst.ts:136:15:136:19 | upper | string |
+| tst.ts:136:23:136:25 | arg | string |
+| tst.ts:136:23:136:37 | arg.toUpperCase | () => string |
+| tst.ts:136:23:136:39 | arg.toUpperCase() | string |
+| tst.ts:136:27:136:37 | toUpperCase | () => string |
+| tst.ts:141:11:141:14 | kind | "circle" |
+| tst.ts:141:27:141:32 | radius | number |
+| tst.ts:142:11:142:14 | kind | "square" |
+| tst.ts:142:27:142:36 | sideLength | number |
+| tst.ts:144:12:144:15 | side | (shape: Shape) => number |
+| tst.ts:144:17:144:21 | shape | Shape |
+| tst.ts:145:15:145:18 | kind | "circle" \| "square" |
+| tst.ts:145:15:145:18 | kind | "circle" \| "square" |
+| tst.ts:145:24:145:28 | shape | Shape |
+| tst.ts:147:11:147:14 | kind | "circle" \| "square" |
+| tst.ts:147:11:147:27 | kind === "circle" | boolean |
+| tst.ts:147:20:147:27 | "circle" | "circle" |
+| tst.ts:147:39:147:43 | shape | { kind: "circle"; radius: number; } |
+| tst.ts:147:39:147:50 | shape.radius | number |
+| tst.ts:147:45:147:50 | radius | number |
+| tst.ts:148:21:148:25 | shape | { kind: "square"; sideLength: number; } |
+| tst.ts:148:21:148:36 | shape.sideLength | number |
+| tst.ts:148:27:148:36 | sideLength | number |
+| tst.ts:151:12:151:22 | symbolIndex | () => void |
+| tst.ts:153:7:153:28 | [sym: s ... number; | any |
+| tst.ts:153:8:153:10 | sym | symbol |
+| tst.ts:154:7:154:28 | [key: s ... string; | any |
+| tst.ts:154:8:154:10 | key | string |
+| tst.ts:155:7:155:29 | [num: n ... oolean; | any |
+| tst.ts:155:8:155:10 | num | number |
+| tst.ts:158:9:158:14 | colors | Colors |
+| tst.ts:158:26:158:27 | {} | Colors |
+| tst.ts:159:11:159:13 | red | number |
+| tst.ts:159:17:159:22 | colors | Colors |
+| tst.ts:159:17:159:37 | colors[ ... "red")] | number |
+| tst.ts:159:24:159:29 | Symbol | SymbolConstructor |
+| tst.ts:159:24:159:36 | Symbol("red") | symbol |
+| tst.ts:159:31:159:35 | "red" | "red" |
+| tst.ts:160:11:160:15 | green | string |
+| tst.ts:160:19:160:24 | colors | Colors |
+| tst.ts:160:19:160:33 | colors["green"] | string |
+| tst.ts:160:26:160:32 | "green" | "green" |
+| tst.ts:161:11:161:14 | blue | boolean |
+| tst.ts:161:18:161:23 | colors | Colors |
+| tst.ts:161:18:161:26 | colors[2] | boolean |
+| tst.ts:161:25:161:25 | 2 | 2 |
+| tst.ts:164:12:164:29 | stringPatternIndex | () => void |
+| tst.ts:166:7:166:37 | [key: ` ... number; | any |
+| tst.ts:168:9:168:11 | bla | Foo |
+| tst.ts:168:21:168:22 | {} | Foo |
+| tst.ts:169:11:169:13 | bar | number |
+| tst.ts:169:17:169:19 | bla | Foo |
+| tst.ts:169:17:169:28 | bla[`foo-1`] | number |
+| tst.ts:169:21:169:27 | `foo-1` | "foo-1" |
+| tst.ts:169:21:169:27 | `foo-1` | "foo-1" |
+| tst.ts:172:7:172:42 | [optNam ... oolean; | any |
+| tst.ts:172:8:172:14 | optName | string \| symbol |
+| tst.ts:175:11:175:14 | data | Data |
+| tst.ts:175:24:175:25 | {} | Data |
+| tst.ts:176:11:176:13 | baz | boolean |
+| tst.ts:176:17:176:20 | data | Data |
+| tst.ts:176:17:176:27 | data["foo"] | boolean |
+| tst.ts:176:22:176:26 | "foo" | "foo" |
 | type_alias.ts:3:5:3:5 | b | boolean |
 | type_alias.ts:7:5:7:5 | c | ValueOrArray<number> |
 | type_alias.ts:14:9:14:32 | [proper ... ]: Json | any |
@@ -233,6 +305,10 @@ getTypeDefinitionType
 | tst.ts:91:3:95:3 | class S ...   }\\n  } | Super |
 | tst.ts:97:3:101:3 | class S ...   }\\n  } | Sub |
 | tst.ts:116:3:129:3 | class F ...   }\\n  } | Foo |
+| tst.ts:140:3:142:47 | type Sh ... mber }; | Shape |
+| tst.ts:152:5:156:5 | interfa ... ;\\n    } | Colors |
+| tst.ts:165:5:167:5 | interfa ... ;\\n    } | Foo |
+| tst.ts:171:5:173:5 | interfa ... ;\\n    } | Data |
 | type_alias.ts:1:1:1:17 | type B = boolean; | boolean |
 | type_alias.ts:5:1:5:50 | type Va ... ay<T>>; | ValueOrArray<T> |
 | type_alias.ts:9:1:15:13 | type Js ... Json[]; | Json |
@@ -369,6 +445,36 @@ getTypeExprType
 | tst.ts:111:29:111:32 | -2-3 | any |
 | tst.ts:117:20:117:25 | number | number |
 | tst.ts:121:23:121:28 | number | number |
+| tst.ts:133:21:133:27 | unknown | unknown |
+| tst.ts:140:8:140:12 | Shape | Shape |
+| tst.ts:141:7:142:46 | \| { kin ... umber } | { kind: "circle"; radius: number; } \| { kind: "... |
+| tst.ts:141:9:141:42 | { kind: ... umber } | { kind: "circle"; radius: number; } |
+| tst.ts:141:17:141:24 | "circle" | "circle" |
+| tst.ts:141:35:141:40 | number | number |
+| tst.ts:142:9:142:46 | { kind: ... umber } | { kind: "square"; sideLength: number; } |
+| tst.ts:142:17:142:24 | "square" | "square" |
+| tst.ts:142:39:142:44 | number | number |
+| tst.ts:144:24:144:28 | Shape | Shape |
+| tst.ts:144:32:144:37 | number | number |
+| tst.ts:152:15:152:20 | Colors | Colors |
+| tst.ts:153:13:153:18 | symbol | symbol |
+| tst.ts:153:22:153:27 | number | number |
+| tst.ts:154:13:154:18 | string | string |
+| tst.ts:154:22:154:27 | string | string |
+| tst.ts:155:13:155:18 | number | number |
+| tst.ts:155:22:155:28 | boolean | boolean |
+| tst.ts:158:17:158:22 | Colors | Colors |
+| tst.ts:165:15:165:17 | Foo | Foo |
+| tst.ts:166:14:166:17 | foo- | any |
+| tst.ts:166:20:166:25 | number | number |
+| tst.ts:166:31:166:36 | number | number |
+| tst.ts:168:15:168:17 | Foo | Foo |
+| tst.ts:171:15:171:18 | Data | Data |
+| tst.ts:172:17:172:22 | string | string |
+| tst.ts:172:17:172:31 | string \| symbol | string \| symbol |
+| tst.ts:172:26:172:31 | symbol | symbol |
+| tst.ts:172:35:172:41 | boolean | boolean |
+| tst.ts:175:17:175:20 | Data | Data |
 | type_alias.ts:1:6:1:6 | B | boolean |
 | type_alias.ts:1:10:1:16 | boolean | boolean |
 | type_alias.ts:3:8:3:8 | B | boolean |
@@ -439,9 +545,12 @@ referenceDefinition
 | Color.blue | type_definitions.ts:14:15:14:18 | blue |
 | Color.green | type_definitions.ts:14:8:14:12 | green |
 | Color.red | type_definitions.ts:14:3:14:5 | red |
+| Colors | tst.ts:152:5:156:5 | interfa ... ;\\n    } |
+| Data | tst.ts:171:5:173:5 | interfa ... ;\\n    } |
 | E | type_definition_objects.ts:6:8:6:16 | enum E {} |
 | EnumWithOneMember | type_definitions.ts:18:26:18:31 | member |
 | Foo | tst.ts:116:3:129:3 | class F ...   }\\n  } |
+| Foo | tst.ts:165:5:167:5 | interfa ... ;\\n    } |
 | HasArea | tst.ts:58:1:60:1 | interfa ... mber;\\n} |
 | I<S> | type_definitions.ts:3:1:5:1 | interfa ... x: S;\\n} |
 | I<number> | type_definitions.ts:3:1:5:1 | interfa ... x: S;\\n} |
@@ -449,6 +558,7 @@ referenceDefinition
 | MyUnion | tst.ts:65:1:65:54 | type My ...  true}; |
 | MyUnion2 | tst.ts:68:1:68:49 | type My ...  true}; |
 | NonAbstractDummy | tst.ts:54:1:56:1 | interfa ... mber;\\n} |
+| Shape | tst.ts:140:3:142:47 | type Sh ... mber }; |
 | Sub | tst.ts:97:3:101:3 | class S ...   }\\n  } |
 | Super | tst.ts:91:3:95:3 | class S ...   }\\n  } |
 | Super | tst.ts:91:3:95:3 | class S ...   }\\n  } |
@@ -490,6 +600,8 @@ unknownType
 | tst.ts:40:5:40:15 | unknownType | unknown |
 | tst.ts:47:8:47:8 | e | unknown |
 | tst.ts:48:14:48:14 | e | unknown |
+| tst.ts:133:16:133:18 | arg | unknown |
+| tst.ts:134:32:134:34 | arg | unknown |
 abstractSignature
 | (): HasArea |
 | new (): HasArea |
@@ -498,9 +610,11 @@ unionIndex
 | 2 | 1 | 1 \| 2 |
 | "bigint" | 2 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
 | "boolean" | 3 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
+| "circle" | 0 | "circle" \| "square" |
 | "function" | 7 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
 | "number" | 1 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
 | "object" | 6 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
+| "square" | 1 | "circle" \| "square" |
 | "string" | 0 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
 | "symbol" | 4 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
 | "undefined" | 5 | "string" \| "number" \| "bigint" \| "boolean" \| "s... |
@@ -524,7 +638,9 @@ unionIndex
 | string | 0 | string \| number \| boolean |
 | string | 0 | string \| number \| boolean \| { [property: string... |
 | string | 0 | string \| number \| true |
+| string | 0 | string \| symbol |
 | string | 0 | string \| { [key: string]: any; } |
+| symbol | 1 | string \| symbol |
 | true | 1 | boolean |
 | true | 2 | string \| number \| true |
 | true | 3 | string \| number \| boolean |
@@ -532,6 +648,8 @@ unionIndex
 | { [key: string]: any; } | 1 | string \| { [key: string]: any; } |
 | { [key: string]: any; } | 2 | VirtualNode \| { [key: string]: any; } |
 | { [property: string]: Json; } | 4 | string \| number \| boolean \| { [property: string... |
+| { kind: "circle"; radius: number; } | 0 | { kind: "circle"; radius: number; } \| { kind: "... |
+| { kind: "square"; sideLength: number; } | 1 | { kind: "circle"; radius: number; } \| { kind: "... |
 | { myUnion: true; } | 0 | MyUnion \| { yetAnotherType: true; } |
 | { myUnion: true; } | 0 | { myUnion: true; } \| { stillMyUnion: true; } |
 | { stillMyUnion: true; } | 1 | MyUnion \| { yetAnotherType: true; } |

--- a/javascript/ql/test/library-tests/TypeScript/Types/tests.ql
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tests.ql
@@ -39,3 +39,7 @@ query predicate unknownType(Expr e, Type type) {
 query CallSignatureType abstractSignature() { result.isAbstract() }
 
 query UnionType unionIndex(Type element, int i) { result.getElementType(i) = element }
+
+query BlockStmt getAStaticInitializerBlock(ClassDefinition cls) {
+  result = cls.getAStaticInitializerBlock()
+}

--- a/javascript/ql/test/library-tests/TypeScript/Types/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tst.ts
@@ -175,4 +175,19 @@ module TS44 {
     const data: Data = {};
     const baz = data["foo"];
   }
+
+  class Foo {
+    static #count = 0;
+
+    get count() {
+        return Foo.#count;
+    }
+    static {
+      Foo.#count += 3;
+    }
+    static {
+      var count = Foo.#count;
+    }
+    
+  }
 }

--- a/javascript/ql/test/library-tests/TypeScript/Types/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/Types/tst.ts
@@ -128,3 +128,51 @@ module TS43 {
     }
   } 
 }
+
+module TS44 {
+  function foo(arg: unknown) {
+    const argIsString = typeof arg === "string";
+    if (argIsString) {
+        const upper = arg.toUpperCase();
+    }
+  }
+
+  type Shape =
+      | { kind: "circle", radius: number }
+      | { kind: "square", sideLength: number };
+
+  function side(shape: Shape): number {
+      const { kind } = shape;
+
+      if (kind === "circle") { return shape.radius;}
+      else { return shape.sideLength; }
+  }
+
+  function symbolIndex() {
+    interface Colors {
+      [sym: symbol]: number;
+      [key: string]: string;
+      [num: number]: boolean;
+    }
+    
+    let colors: Colors = {};
+    const red = colors[Symbol("red")];
+    const green = colors["green"];
+    const blue = colors[2];
+  }
+
+  function stringPatternIndex() {
+    interface Foo {
+      [key: `foo-${number}`]: number;
+    }
+    var bla : Foo = {};
+    const bar = bla[`foo-1`];
+
+    interface Data {
+      [optName: string | symbol]: boolean;
+    }
+
+    const data: Data = {};
+    const baz = data["foo"];
+  }
+}

--- a/javascript/upgrades/e34b3e16dba5d11961119818c9beeff334f20a90/old.dbscheme
+++ b/javascript/upgrades/e34b3e16dba5d11961119818c9beeff334f20a90/old.dbscheme
@@ -1,0 +1,1216 @@
+/*** Standard fragments ***/
+
+/** Files and folders **/
+
+@location = @location_default;
+ 
+locations_default(unique int id: @location_default,
+          int file: @file ref,
+          int beginLine: int ref,
+          int beginColumn: int ref,
+          int endLine: int ref,
+          int endColumn: int ref
+         );
+ 
+@sourceline = @locatable;
+ 
+numlines(int element_id: @sourceline ref,
+         int num_lines: int ref,
+         int num_code: int ref,
+         int num_comment: int ref
+        );
+ 
+files(unique int id: @file,
+      varchar(900) name: string ref);
+ 
+folders(unique int id: @folder,
+        varchar(900) name: string ref);
+ 
+ 
+@container = @folder | @file ;
+ 
+ 
+containerparent(int parent: @container ref,
+                unique int child: @container ref);
+
+/** Duplicate code **/
+
+duplicateCode(
+  unique int id : @duplication,
+  varchar(900) relativePath : string ref,
+  int equivClass : int ref);
+ 
+similarCode(
+  unique int id : @similarity,
+  varchar(900) relativePath : string ref,
+  int equivClass : int ref);
+ 
+@duplication_or_similarity = @duplication | @similarity;
+ 
+tokens(
+  int id : @duplication_or_similarity ref,
+  int offset : int ref,
+  int beginLine : int ref,
+  int beginColumn : int ref,
+  int endLine : int ref,
+  int endColumn : int ref);
+
+/** External data **/
+
+externalData(
+  int id : @externalDataElement,
+  varchar(900) path : string ref,
+  int column: int ref,
+  varchar(900) value : string ref
+);
+ 
+snapshotDate(unique date snapshotDate : date ref);
+ 
+sourceLocationPrefix(varchar(900) prefix : string ref);
+
+/** Version control data **/
+
+svnentries(
+  int id : @svnentry,
+  varchar(500) revision : string ref,
+  varchar(500) author : string ref,
+  date revisionDate : date ref,
+  int changeSize : int ref
+);
+ 
+svnaffectedfiles(
+  int id : @svnentry ref,
+  int file : @file ref,
+  varchar(500) action : string ref
+);
+ 
+svnentrymsg(
+  int id : @svnentry ref,
+  varchar(500) message : string ref
+);
+ 
+svnchurn(
+  int commit : @svnentry ref,
+  int file : @file ref,
+  int addedLines : int ref,
+  int deletedLines : int ref
+);
+
+
+/*** JavaScript-specific part ***/
+
+filetype(
+  int file: @file ref,
+  string filetype: string ref
+)
+
+// top-level code fragments
+toplevels (unique int id: @toplevel,
+           int kind: int ref);
+
+is_externs (int toplevel: @toplevel ref);
+
+case @toplevel.kind of
+   0 = @script
+|  1 = @inline_script
+|  2 = @event_handler
+|  3 = @javascript_url
+|  4 = @template_toplevel;
+
+is_module (int tl: @toplevel ref);
+is_nodejs (int tl: @toplevel ref);
+is_es2015_module (int tl: @toplevel ref);
+is_closure_module (int tl: @toplevel ref);
+
+@xml_node_with_code = @xmlelement | @xmlattribute | @template_placeholder_tag;
+toplevel_parent_xml_node(
+  unique int toplevel: @toplevel ref,
+  int xmlnode: @xml_node_with_code ref);
+
+xml_element_parent_expression(
+  unique int xmlnode: @xmlelement ref,
+  int expression: @expr ref,
+  int index: int ref);
+
+// statements
+#keyset[parent, idx]
+stmts (unique int id: @stmt, 
+       int kind: int ref,
+       int parent: @stmt_parent ref, 
+       int idx: int ref,
+       varchar(900) tostring: string ref);
+
+stmt_containers (unique int stmt: @stmt ref,
+       int container: @stmt_container ref);
+       
+jump_targets (unique int jump: @stmt ref,
+       int target: @stmt ref);
+
+@stmt_parent = @stmt | @toplevel | @function_expr | @arrow_function_expr;
+@stmt_container = @toplevel | @function | @namespace_declaration | @external_module_declaration | @global_augmentation_declaration;
+
+case @stmt.kind of
+   0 = @empty_stmt
+|  1 = @block_stmt
+|  2 = @expr_stmt
+|  3 = @if_stmt
+|  4 = @labeled_stmt
+|  5 = @break_stmt
+|  6 = @continue_stmt
+|  7 = @with_stmt
+|  8 = @switch_stmt
+|  9 = @return_stmt
+| 10 = @throw_stmt
+| 11 = @try_stmt
+| 12 = @while_stmt
+| 13 = @do_while_stmt
+| 14 = @for_stmt
+| 15 = @for_in_stmt
+| 16 = @debugger_stmt
+| 17 = @function_decl_stmt
+| 18 = @var_decl_stmt
+| 19 = @case
+| 20 = @catch_clause
+| 21 = @for_of_stmt
+| 22 = @const_decl_stmt
+| 23 = @let_stmt
+| 24 = @legacy_let_stmt
+| 25 = @for_each_stmt
+| 26 = @class_decl_stmt
+| 27 = @import_declaration
+| 28 = @export_all_declaration
+| 29 = @export_default_declaration
+| 30 = @export_named_declaration
+| 31 = @namespace_declaration
+| 32 = @import_equals_declaration
+| 33 = @export_assign_declaration
+| 34 = @interface_declaration
+| 35 = @type_alias_declaration
+| 36 = @enum_declaration
+| 37 = @external_module_declaration
+| 38 = @export_as_namespace_declaration
+| 39 = @global_augmentation_declaration
+;
+
+@decl_stmt = @var_decl_stmt | @const_decl_stmt | @let_stmt | @legacy_let_stmt;
+
+@export_declaration = @export_all_declaration | @export_default_declaration | @export_named_declaration;
+
+@namespace_definition = @namespace_declaration | @enum_declaration;
+@type_definition = @class_definition | @interface_declaration | @enum_declaration | @type_alias_declaration | @enum_member;
+
+is_instantiated(unique int decl: @namespace_declaration ref);
+
+@declarable_node = @decl_stmt | @namespace_declaration | @class_decl_stmt | @function_decl_stmt | @enum_declaration | @external_module_declaration | @global_augmentation_declaration | @field;
+has_declare_keyword(unique int stmt: @declarable_node ref);
+
+is_for_await_of(unique int forof: @for_of_stmt ref);
+
+// expressions
+#keyset[parent, idx]
+exprs (unique int id: @expr,
+       int kind: int ref,
+       int parent: @expr_parent ref,
+       int idx: int ref,
+       varchar(900) tostring: string ref);
+
+literals (varchar(900) value: string ref,
+       varchar(900) raw: string ref,
+       unique int expr: @expr_or_type ref);
+       
+enclosing_stmt (unique int expr: @expr_or_type ref,
+       int stmt: @stmt ref);
+
+expr_containers (unique int expr: @expr_or_type ref,
+       int container: @stmt_container ref);
+
+array_size (unique int ae: @arraylike ref,
+       int sz: int ref);
+
+is_delegating (int yield: @yield_expr ref);
+
+@expr_or_stmt = @expr | @stmt;
+@expr_or_type = @expr | @typeexpr;
+@expr_parent = @expr_or_stmt | @property | @function_typeexpr;
+@arraylike = @array_expr | @array_pattern;
+@type_annotation = @typeexpr | @jsdoc_type_expr;
+@node_in_stmt_container = @cfg_node | @type_annotation | @toplevel;
+
+case @expr.kind of
+   0 = @label
+|  1 = @null_literal
+|  2 = @boolean_literal
+|  3 = @number_literal
+|  4 = @string_literal
+|  5 = @regexp_literal
+|  6 = @this_expr
+|  7 = @array_expr
+|  8 = @obj_expr
+|  9 = @function_expr
+| 10 = @seq_expr
+| 11 = @conditional_expr
+| 12 = @new_expr
+| 13 = @call_expr
+| 14 = @dot_expr
+| 15 = @index_expr
+| 16 = @neg_expr
+| 17 = @plus_expr
+| 18 = @log_not_expr
+| 19 = @bit_not_expr
+| 20 = @typeof_expr
+| 21 = @void_expr
+| 22 = @delete_expr
+| 23 = @eq_expr
+| 24 = @neq_expr
+| 25 = @eqq_expr
+| 26 = @neqq_expr
+| 27 = @lt_expr
+| 28 = @le_expr
+| 29 = @gt_expr
+| 30 = @ge_expr
+| 31 = @lshift_expr
+| 32 = @rshift_expr
+| 33 = @urshift_expr
+| 34 = @add_expr
+| 35 = @sub_expr
+| 36 = @mul_expr
+| 37 = @div_expr
+| 38 = @mod_expr
+| 39 = @bitor_expr
+| 40 = @xor_expr
+| 41 = @bitand_expr
+| 42 = @in_expr
+| 43 = @instanceof_expr
+| 44 = @logand_expr
+| 45 = @logor_expr
+| 47 = @assign_expr
+| 48 = @assign_add_expr
+| 49 = @assign_sub_expr
+| 50 = @assign_mul_expr
+| 51 = @assign_div_expr
+| 52 = @assign_mod_expr
+| 53 = @assign_lshift_expr
+| 54 = @assign_rshift_expr
+| 55 = @assign_urshift_expr
+| 56 = @assign_or_expr
+| 57 = @assign_xor_expr
+| 58 = @assign_and_expr
+| 59 = @preinc_expr
+| 60 = @postinc_expr
+| 61 = @predec_expr
+| 62 = @postdec_expr
+| 63 = @par_expr
+| 64 = @var_declarator
+| 65 = @arrow_function_expr
+| 66 = @spread_element
+| 67 = @array_pattern
+| 68 = @object_pattern
+| 69 = @yield_expr
+| 70 = @tagged_template_expr
+| 71 = @template_literal
+| 72 = @template_element
+| 73 = @array_comprehension_expr
+| 74 = @generator_expr
+| 75 = @for_in_comprehension_block
+| 76 = @for_of_comprehension_block
+| 77 = @legacy_letexpr
+| 78 = @var_decl
+| 79 = @proper_varaccess
+| 80 = @class_expr
+| 81 = @super_expr
+| 82 = @newtarget_expr
+| 83 = @named_import_specifier
+| 84 = @import_default_specifier
+| 85 = @import_namespace_specifier
+| 86 = @named_export_specifier
+| 87 = @exp_expr
+| 88 = @assign_exp_expr
+| 89 = @jsx_element
+| 90 = @jsx_qualified_name
+| 91 = @jsx_empty_expr
+| 92 = @await_expr
+| 93 = @function_sent_expr
+| 94 = @decorator
+| 95 = @export_default_specifier
+| 96 = @export_namespace_specifier
+| 97 = @bind_expr
+| 98 = @external_module_reference
+| 99 = @dynamic_import
+| 100 = @expression_with_type_arguments
+| 101 = @prefix_type_assertion
+| 102 = @as_type_assertion
+| 103 = @export_varaccess
+| 104 = @decorator_list
+| 105 = @non_null_assertion
+| 106 = @bigint_literal
+| 107 = @nullishcoalescing_expr
+| 108 = @e4x_xml_anyname
+| 109 = @e4x_xml_static_attribute_selector
+| 110 = @e4x_xml_dynamic_attribute_selector
+| 111 = @e4x_xml_filter_expression
+| 112 = @e4x_xml_static_qualident
+| 113 = @e4x_xml_dynamic_qualident
+| 114 = @e4x_xml_dotdotexpr
+| 115 = @import_meta_expr
+| 116 = @assignlogandexpr
+| 117 = @assignlogorexpr
+| 118 = @assignnullishcoalescingexpr
+| 119 = @template_pipe_ref
+| 120 = @generated_code_expr
+;
+
+@varaccess = @proper_varaccess | @export_varaccess;
+@varref = @var_decl | @varaccess;
+
+@identifier = @label | @varref | @type_identifier;
+
+@literal = @null_literal | @boolean_literal | @number_literal | @string_literal | @regexp_literal | @bigint_literal;
+
+@propaccess = @dot_expr | @index_expr;
+
+@invokeexpr = @new_expr | @call_expr;
+
+@unaryexpr = @neg_expr | @plus_expr | @log_not_expr | @bit_not_expr | @typeof_expr | @void_expr | @delete_expr | @spread_element;
+
+@equality_test = @eq_expr | @neq_expr | @eqq_expr | @neqq_expr;
+
+@comparison = @equality_test | @lt_expr | @le_expr | @gt_expr | @ge_expr;
+
+@binaryexpr = @comparison | @lshift_expr | @rshift_expr | @urshift_expr | @add_expr | @sub_expr | @mul_expr | @div_expr | @mod_expr | @exp_expr | @bitor_expr | @xor_expr | @bitand_expr | @in_expr | @instanceof_expr | @logand_expr | @logor_expr | @nullishcoalescing_expr;
+
+@assignment = @assign_expr | @assign_add_expr | @assign_sub_expr | @assign_mul_expr | @assign_div_expr | @assign_mod_expr | @assign_exp_expr | @assign_lshift_expr | @assign_rshift_expr | @assign_urshift_expr | @assign_or_expr | @assign_xor_expr | @assign_and_expr | @assignlogandexpr | @assignlogorexpr | @assignnullishcoalescingexpr;
+
+@updateexpr = @preinc_expr | @postinc_expr | @predec_expr | @postdec_expr;
+
+@pattern = @varref | @array_pattern | @object_pattern;
+
+@comprehension_expr = @array_comprehension_expr | @generator_expr;
+
+@comprehension_block = @for_in_comprehension_block | @for_of_comprehension_block;
+
+@import_specifier = @named_import_specifier | @import_default_specifier | @import_namespace_specifier;
+
+@exportspecifier = @named_export_specifier | @export_default_specifier | @export_namespace_specifier;
+
+@import_or_export_declaration = @import_declaration | @export_declaration;
+
+@type_assertion = @as_type_assertion | @prefix_type_assertion;
+
+@class_definition = @class_decl_stmt | @class_expr;
+@interface_definition = @interface_declaration | @interface_typeexpr;
+@class_or_interface = @class_definition | @interface_definition;
+
+@lexical_decl = @var_decl | @type_decl;
+@lexical_access = @varaccess | @local_type_access | @local_var_type_access | @local_namespace_access;
+@lexical_ref = @lexical_decl | @lexical_access;
+
+@e4x_xml_attribute_selector = @e4x_xml_static_attribute_selector | @e4x_xml_dynamic_attribute_selector;
+@e4x_xml_qualident = @e4x_xml_static_qualident | @e4x_xml_dynamic_qualident;
+
+expr_contains_template_tag_location(
+  int expr: @expr ref,
+  int location: @location ref
+);
+
+@template_placeholder_tag_parent = @xmlelement | @xmlattribute | @file;
+
+template_placeholder_tag_info(
+  unique int node: @template_placeholder_tag,
+  int parentNode: @template_placeholder_tag_parent ref,
+  varchar(900) raw: string ref
+);
+
+// scopes
+scopes (unique int id: @scope,
+        int kind: int ref);
+
+case @scope.kind of
+   0 = @global_scope
+|  1 = @function_scope
+|  2 = @catch_scope
+|  3 = @module_scope
+|  4 = @block_scope
+|  5 = @for_scope
+|  6 = @for_in_scope // for-of scopes work the same as for-in scopes
+|  7 = @comprehension_block_scope
+|  8 = @class_expr_scope
+|  9 = @namespace_scope
+| 10 = @class_decl_scope
+| 11 = @interface_scope
+| 12 = @type_alias_scope
+| 13 = @mapped_type_scope
+| 14 = @enum_scope
+| 15 = @external_module_scope
+| 16 = @conditional_type_scope;
+
+scopenodes (unique int node: @ast_node ref,
+            int scope: @scope ref);
+            
+scopenesting (unique int inner: @scope ref,
+              int outer: @scope ref);
+
+// functions
+@function = @function_decl_stmt | @function_expr | @arrow_function_expr;
+
+@parameterized = @function | @catch_clause;
+@type_parameterized = @function | @class_or_interface | @type_alias_declaration | @mapped_typeexpr | @infer_typeexpr;
+
+is_generator (int fun: @function ref);
+has_rest_parameter (int fun: @function ref);
+is_async (int fun: @function ref);
+
+// variables and lexically scoped type names
+#keyset[scope, name]
+variables (unique int id: @variable,
+           varchar(900) name: string ref,
+           int scope: @scope ref);
+
+#keyset[scope, name]
+local_type_names (unique int id: @local_type_name,
+                  varchar(900) name: string ref,
+                  int scope: @scope ref);
+
+#keyset[scope, name]
+local_namespace_names (unique int id: @local_namespace_name,
+                       varchar(900) name: string ref,
+                       int scope: @scope ref);
+
+is_arguments_object (int id: @variable ref);
+
+@lexical_name = @variable | @local_type_name | @local_namespace_name;
+
+@bind_id = @varaccess | @local_var_type_access;
+bind (unique int id: @bind_id ref,
+      int decl: @variable ref);
+
+decl (unique int id: @var_decl ref,
+      int decl: @variable ref);
+
+@typebind_id = @local_type_access | @export_varaccess;
+typebind (unique int id: @typebind_id ref,
+          int decl: @local_type_name ref);
+
+@typedecl_id = @type_decl | @var_decl;
+typedecl (unique int id: @typedecl_id ref,
+          int decl: @local_type_name ref);
+
+namespacedecl (unique int id: @var_decl ref,
+               int decl: @local_namespace_name ref);
+
+@namespacebind_id = @local_namespace_access | @export_varaccess;
+namespacebind (unique int id: @namespacebind_id ref,
+               int decl: @local_namespace_name ref);
+
+
+// properties in object literals, property patterns in object patterns, and method declarations in classes
+#keyset[parent, index]
+properties (unique int id: @property,
+            int parent: @property_parent ref,
+            int index: int ref,
+            int kind: int ref,
+            varchar(900) tostring: string ref);
+
+case @property.kind of
+  0 = @value_property
+| 1 = @property_getter
+| 2 = @property_setter
+| 3 = @jsx_attribute
+| 4 = @function_call_signature
+| 5 = @constructor_call_signature
+| 6 = @index_signature
+| 7 = @enum_member
+| 8 = @proper_field
+| 9 = @parameter_field
+;
+
+@property_parent = @obj_expr | @object_pattern | @class_definition | @jsx_element | @interface_definition | @enum_declaration;
+@property_accessor = @property_getter | @property_setter;
+@call_signature = @function_call_signature | @constructor_call_signature;
+@field = @proper_field | @parameter_field;
+@field_or_vardeclarator = @field | @var_declarator;
+
+is_computed (int id: @property ref);
+is_method   (int id: @property ref);
+is_static   (int id: @property ref);
+is_abstract_member (int id: @property ref);
+is_const_enum (int id: @enum_declaration ref);
+is_abstract_class (int id: @class_decl_stmt ref);
+
+has_public_keyword (int id: @property ref);
+has_private_keyword (int id: @property ref);
+has_protected_keyword (int id: @property ref);
+has_readonly_keyword (int id: @property ref);
+has_type_keyword (int id: @import_or_export_declaration ref);
+is_optional_member (int id: @property ref);
+has_definite_assignment_assertion (int id: @field_or_vardeclarator ref);
+is_optional_parameter_declaration (unique int parameter: @pattern ref);
+
+#keyset[constructor, param_index]
+parameter_fields(
+  unique int field: @parameter_field ref,
+  int constructor: @function_expr ref,
+  int param_index: int ref
+);
+
+// types
+#keyset[parent, idx]
+typeexprs (
+  unique int id: @typeexpr,
+  int kind: int ref,
+  int parent: @typeexpr_parent ref,
+  int idx: int ref,
+  varchar(900) tostring: string ref
+);
+
+case @typeexpr.kind of
+  0 = @local_type_access
+| 1 = @type_decl
+| 2 = @keyword_typeexpr
+| 3 = @string_literal_typeexpr
+| 4 = @number_literal_typeexpr
+| 5 = @boolean_literal_typeexpr
+| 6 = @array_typeexpr
+| 7 = @union_typeexpr
+| 8 = @indexed_access_typeexpr
+| 9 = @intersection_typeexpr
+| 10 = @parenthesized_typeexpr
+| 11 = @tuple_typeexpr
+| 12 = @keyof_typeexpr
+| 13 = @qualified_type_access
+| 14 = @generic_typeexpr
+| 15 = @type_label
+| 16 = @typeof_typeexpr
+| 17 = @local_var_type_access
+| 18 = @qualified_var_type_access
+| 19 = @this_var_type_access
+| 20 = @predicate_typeexpr
+| 21 = @interface_typeexpr
+| 22 = @type_parameter
+| 23 = @plain_function_typeexpr
+| 24 = @constructor_typeexpr
+| 25 = @local_namespace_access
+| 26 = @qualified_namespace_access
+| 27 = @mapped_typeexpr
+| 28 = @conditional_typeexpr
+| 29 = @infer_typeexpr
+| 30 = @import_type_access
+| 31 = @import_namespace_access
+| 32 = @import_var_type_access
+| 33 = @optional_typeexpr
+| 34 = @rest_typeexpr
+| 35 = @bigint_literal_typeexpr
+| 36 = @readonly_typeexpr
+| 37 = @template_literal_typeexpr
+;
+
+@typeref = @typeaccess | @type_decl;
+@type_identifier = @type_decl | @local_type_access | @type_label | @local_var_type_access | @local_namespace_access;
+@typeexpr_parent = @expr | @stmt | @property | @typeexpr;
+@literal_typeexpr = @string_literal_typeexpr | @number_literal_typeexpr | @boolean_literal_typeexpr | @bigint_literal_typeexpr;
+@typeaccess = @local_type_access | @qualified_type_access | @import_type_access;
+@vartypeaccess = @local_var_type_access | @qualified_var_type_access | @this_var_type_access | @import_var_type_access;
+@namespace_access = @local_namespace_access | @qualified_namespace_access | @import_namespace_access;
+@import_typeexpr = @import_type_access | @import_namespace_access | @import_var_type_access;
+
+@function_typeexpr = @plain_function_typeexpr | @constructor_typeexpr;
+
+// types
+types (
+  unique int id: @type,
+  int kind: int ref,
+  varchar(900) tostring: string ref
+);
+
+#keyset[parent, idx]
+type_child (
+  int child: @type ref,
+  int parent: @type ref,
+  int idx: int ref
+);
+
+case @type.kind of
+  0 = @any_type
+| 1 = @string_type
+| 2 = @number_type
+| 3 = @union_type
+| 4 = @true_type
+| 5 = @false_type
+| 6 = @type_reference
+| 7 = @object_type
+| 8 = @canonical_type_variable_type
+| 9 = @typeof_type
+| 10 = @void_type
+| 11 = @undefined_type
+| 12 = @null_type
+| 13 = @never_type
+| 14 = @plain_symbol_type
+| 15 = @unique_symbol_type
+| 16 = @objectkeyword_type
+| 17 = @intersection_type
+| 18 = @tuple_type
+| 19 = @lexical_type_variable_type
+| 20 = @this_type
+| 21 = @number_literal_type
+| 22 = @string_literal_type
+| 23 = @unknown_type
+| 24 = @bigint_type
+| 25 = @bigint_literal_type
+;
+
+@boolean_literal_type = @true_type | @false_type;
+@symbol_type = @plain_symbol_type | @unique_symbol_type;
+@union_or_intersection_type = @union_type | @intersection_type;
+@typevariable_type = @canonical_type_variable_type | @lexical_type_variable_type;
+
+has_asserts_keyword(int node: @predicate_typeexpr ref);
+
+@typed_ast_node = @expr | @typeexpr | @function;
+ast_node_type(
+  unique int node: @typed_ast_node ref, 
+  int typ: @type ref);
+
+declared_function_signature(
+  unique int node: @function ref,
+  int sig: @signature_type ref
+);
+
+invoke_expr_signature(
+  unique int node: @invokeexpr ref,
+  int sig: @signature_type ref
+);
+
+invoke_expr_overload_index(
+  unique int node: @invokeexpr ref,
+  int index: int ref
+);
+
+symbols (
+  unique int id: @symbol,
+  int kind: int ref,
+  varchar(900) name: string ref
+);
+
+symbol_parent (
+  unique int symbol: @symbol ref,
+  int parent: @symbol ref
+);
+
+symbol_module (
+  int symbol: @symbol ref,
+  varchar(900) moduleName: string ref
+);
+
+symbol_global (
+  int symbol: @symbol ref,
+  varchar(900) globalName: string ref
+);
+
+case @symbol.kind of
+  0 = @root_symbol
+| 1 = @member_symbol
+| 2 = @other_symbol
+;
+
+@type_with_symbol = @type_reference | @typevariable_type | @typeof_type | @unique_symbol_type;
+@ast_node_with_symbol = @type_definition | @namespace_definition | @toplevel | @typeaccess | @namespace_access | @var_decl | @function | @invokeexpr | @import_declaration | @external_module_reference;
+
+ast_node_symbol(
+  unique int node: @ast_node_with_symbol ref,
+  int symbol: @symbol ref);
+
+type_symbol(
+  unique int typ: @type_with_symbol ref,
+  int symbol: @symbol ref);
+
+#keyset[typ, name]
+type_property(
+  int typ: @type ref,
+  varchar(900) name: string ref,
+  int propertyType: @type ref);
+
+type_alias(
+  unique int aliasType: @type ref,
+  int underlyingType: @type ref);
+
+@literal_type = @string_literal_type | @number_literal_type | @boolean_literal_type | @bigint_literal_type;
+@type_with_literal_value = @string_literal_type | @number_literal_type | @bigint_literal_type;
+type_literal_value(
+  unique int typ: @type_with_literal_value ref,
+  varchar(900) value: string ref);
+
+signature_types (
+  unique int id: @signature_type,
+  int kind: int ref,
+  varchar(900) tostring: string ref,
+  int type_parameters: int ref,
+  int required_params: int ref
+);
+
+is_abstract_signature(
+  unique int sig: @signature_type ref
+);
+
+signature_rest_parameter(
+  unique int sig: @signature_type ref,
+  int rest_param_arra_type: @type ref
+);
+
+case @signature_type.kind of
+  0 = @function_signature_type
+| 1 = @constructor_signature_type
+;
+
+#keyset[typ, kind, index]
+type_contains_signature (
+  int typ: @type ref,
+  int kind: int ref,  // constructor/call/index
+  int index: int ref, // ordering of overloaded signatures
+  int sig: @signature_type ref
+);
+
+#keyset[parent, index]
+signature_contains_type (
+  int child: @type ref,
+  int parent: @signature_type ref,
+  int index: int ref
+);
+
+#keyset[sig, index]
+signature_parameter_name (
+  int sig: @signature_type ref,
+  int index: int ref,
+  varchar(900) name: string ref
+);
+
+number_index_type (
+  unique int baseType: @type ref,
+  int propertyType: @type ref
+);
+
+string_index_type (
+  unique int baseType: @type ref,
+  int propertyType: @type ref
+);
+
+base_type_names(
+  int typeName: @symbol ref,
+  int baseTypeName: @symbol ref
+);
+
+self_types(
+  int typeName: @symbol ref,
+  int selfType: @type_reference ref
+);
+
+tuple_type_min_length(
+  unique int typ: @type ref,
+  int minLength: int ref
+);
+
+tuple_type_rest_index(
+  unique int typ: @type ref,
+  int index: int ref
+);
+
+// comments
+comments (unique int id: @comment,
+          int kind: int ref,
+          int toplevel: @toplevel ref,
+          varchar(900) text: string ref,
+          varchar(900) tostring: string ref);
+
+case @comment.kind of
+  0 = @slashslash_comment
+| 1 = @slashstar_comment
+| 2 = @doc_comment
+| 3 = @html_comment_start
+| 4 = @htmlcommentend;
+
+@html_comment = @html_comment_start | @htmlcommentend;
+@line_comment = @slashslash_comment | @html_comment;
+@block_comment = @slashstar_comment | @doc_comment;
+
+// source lines
+lines (unique int id: @line,
+       int toplevel: @toplevel ref,
+       varchar(900) text: string ref,
+       varchar(2) terminator: string ref);
+indentation (int file: @file ref,
+            int lineno: int ref,
+            varchar(1) indentChar: string ref,
+            int indentDepth: int ref);
+
+// JavaScript parse errors
+js_parse_errors (unique int id: @js_parse_error,
+        int toplevel: @toplevel ref,
+        varchar(900) message: string ref,
+        varchar(900) line: string ref);
+  
+// regular expressions
+#keyset[parent, idx]
+regexpterm (unique int id: @regexpterm,
+        int kind: int ref,
+        int parent: @regexpparent ref,
+        int idx: int ref,
+        varchar(900) tostring: string ref);
+        
+@regexpparent = @regexpterm | @regexp_literal | @string_literal;
+
+case @regexpterm.kind of
+   0 = @regexp_alt
+|  1 = @regexp_seq
+|  2 = @regexp_caret
+|  3 = @regexp_dollar
+|  4 = @regexp_wordboundary
+|  5 = @regexp_nonwordboundary
+|  6 = @regexp_positive_lookahead
+|  7 = @regexp_negative_lookahead
+|  8 = @regexp_star
+|  9 = @regexp_plus
+| 10 = @regexp_opt
+| 11 = @regexp_range
+| 12 = @regexp_dot
+| 13 = @regexp_group
+| 14 = @regexp_normal_constant
+| 15 = @regexp_hex_escape
+| 16 = @regexp_unicode_escape
+| 17 = @regexp_dec_escape
+| 18 = @regexp_oct_escape
+| 19 = @regexp_ctrl_escape
+| 20 = @regexp_char_class_escape
+| 21 = @regexp_id_escape
+| 22 = @regexp_backref
+| 23 = @regexp_char_class
+| 24 = @regexp_char_range
+| 25 = @regexp_positive_lookbehind
+| 26 = @regexp_negative_lookbehind
+| 27 = @regexp_unicode_property_escape;
+
+regexp_parse_errors (unique int id: @regexp_parse_error,
+    int regexp: @regexpterm ref,
+    varchar(900) message: string ref);
+
+@regexp_quantifier = @regexp_star | @regexp_plus | @regexp_opt | @regexp_range;
+@regexp_escape = @regexp_char_escape | @regexp_char_class_escape | @regexp_unicode_property_escape;
+@regexp_char_escape = @regexp_hex_escape | @regexp_unicode_escape | @regexp_dec_escape | @regexp_oct_escape | @regexp_ctrl_escape | @regexp_id_escape;
+@regexp_constant = @regexp_normal_constant | @regexp_char_escape;
+@regexp_lookahead = @regexp_positive_lookahead | @regexp_negative_lookahead;
+@regexp_lookbehind = @regexp_positive_lookbehind | @regexp_negative_lookbehind;
+@regexp_subpattern = @regexp_lookahead | @regexp_lookbehind;
+@regexp_anchor = @regexp_dollar | @regexp_caret;
+
+is_greedy (int id: @regexp_quantifier ref);
+range_quantifier_lower_bound (unique int id: @regexp_range ref, int lo: int ref);
+range_quantifier_upper_bound (unique int id: @regexp_range ref, int hi: int ref);
+is_capture (unique int id: @regexp_group ref, int number: int ref);
+is_named_capture (unique int id: @regexp_group ref, string name: string ref);
+is_inverted (int id: @regexp_char_class ref);
+regexp_const_value (unique int id: @regexp_constant ref, varchar(1) value: string ref);
+char_class_escape (unique int id: @regexp_char_class_escape ref, varchar(1) value: string ref);
+backref (unique int id: @regexp_backref ref, int value: int ref);
+named_backref (unique int id: @regexp_backref ref, string name: string ref);
+unicode_property_escapename (unique int id: @regexp_unicode_property_escape ref, string name: string ref);
+unicode_property_escapevalue (unique int id: @regexp_unicode_property_escape ref, string value: string ref);
+
+// tokens
+#keyset[toplevel, idx]
+tokeninfo (unique int id: @token,
+    int kind: int ref,
+    int toplevel: @toplevel ref,
+    int idx: int ref,
+    varchar(900) value: string ref);
+
+case @token.kind of
+  0 = @token_eof
+| 1 = @token_null_literal
+| 2 = @token_boolean_literal
+| 3 = @token_numeric_literal
+| 4 = @token_string_literal
+| 5 = @token_regular_expression
+| 6 = @token_identifier
+| 7 = @token_keyword
+| 8 = @token_punctuator;
+
+// associate comments with the token immediately following them (which may be EOF)
+next_token (int comment: @comment ref, int token: @token ref);
+
+// JSON
+#keyset[parent, idx]
+json (unique int id: @json_value,
+      int kind: int ref,
+      int parent: @json_parent ref,
+      int idx: int ref,
+      varchar(900) tostring: string ref);
+
+json_literals (varchar(900) value: string ref,
+      varchar(900) raw: string ref,
+      unique int expr: @json_value ref);
+
+json_properties (int obj: @json_object ref,
+      varchar(900) property: string ref,
+      int value: @json_value ref);
+
+json_errors (unique int id: @json_parse_error,
+      varchar(900) message: string ref);
+
+json_locations(unique int locatable: @json_locatable ref,
+      int location: @location_default ref);
+
+case @json_value.kind of
+  0 = @json_null
+| 1 = @json_boolean
+| 2 = @json_number
+| 3 = @json_string
+| 4 = @json_array
+| 5 = @json_object;
+
+@json_parent = @json_object | @json_array | @file;
+
+@json_locatable = @json_value | @json_parse_error;
+
+// locations
+@ast_node = @toplevel | @stmt | @expr | @property | @typeexpr;
+
+@locatable = @file 
+    | @ast_node
+    | @comment
+    | @line
+    | @js_parse_error | @regexp_parse_error
+    | @regexpterm
+    | @json_locatable
+    | @token
+    | @cfg_node
+    | @jsdoc | @jsdoc_type_expr | @jsdoc_tag
+    | @yaml_locatable
+    | @xmllocatable
+    | @configLocatable
+    | @template_placeholder_tag;
+
+hasLocation (unique int locatable: @locatable ref,
+    int location: @location ref);
+
+// CFG
+entry_cfg_node (unique int id: @entry_node, int container: @stmt_container ref);
+exit_cfg_node (unique int id: @exit_node, int container: @stmt_container ref);
+guard_node (unique int id: @guard_node, int kind: int ref, int test: @expr ref);
+case @guard_node.kind of
+  0 = @falsy_guard
+| 1 = @truthy_guard;
+@condition_guard = @falsy_guard | @truthy_guard;
+
+@synthetic_cfg_node = @entry_node | @exit_node | @guard_node;
+@cfg_node = @synthetic_cfg_node | @expr_parent;
+
+successor (int pred: @cfg_node ref, int succ: @cfg_node ref);
+
+// JSDoc comments
+jsdoc (unique int id: @jsdoc, varchar(900) description: string ref, int comment: @comment ref);
+#keyset[parent, idx]
+jsdoc_tags (unique int id: @jsdoc_tag, varchar(900) title: string ref,
+            int parent: @jsdoc ref, int idx: int ref, varchar(900) tostring: string ref);
+jsdoc_tag_descriptions (unique int tag: @jsdoc_tag ref, varchar(900) text: string ref);
+jsdoc_tag_names (unique int tag: @jsdoc_tag ref, varchar(900) text: string ref);
+
+#keyset[parent, idx]
+jsdoc_type_exprs (unique int id: @jsdoc_type_expr,
+                  int kind: int ref,
+                  int parent: @jsdoc_type_expr_parent ref,
+                  int idx: int ref,
+                  varchar(900) tostring: string ref);
+case @jsdoc_type_expr.kind of
+    0 = @jsdoc_any_type_expr
+|   1 = @jsdoc_null_type_expr
+|   2 = @jsdoc_undefined_type_expr
+|   3 = @jsdoc_unknown_type_expr
+|   4 = @jsdoc_void_type_expr
+|   5 = @jsdoc_named_type_expr
+|   6 = @jsdoc_applied_type_expr
+|   7 = @jsdoc_nullable_type_expr
+|   8 = @jsdoc_non_nullable_type_expr
+|   9 = @jsdoc_record_type_expr
+|  10 = @jsdoc_array_type_expr
+|  11 = @jsdoc_union_type_expr
+|  12 = @jsdoc_function_type_expr
+|  13 = @jsdoc_optional_type_expr
+|  14 = @jsdoc_rest_type_expr
+;
+
+#keyset[id, idx]
+jsdoc_record_field_name (int id: @jsdoc_record_type_expr ref, int idx: int ref, varchar(900) name: string ref);
+jsdoc_prefix_qualifier (int id: @jsdoc_type_expr ref);
+jsdoc_has_new_parameter (int fn: @jsdoc_function_type_expr ref);
+
+@jsdoc_type_expr_parent = @jsdoc_type_expr | @jsdoc_tag;
+
+jsdoc_errors (unique int id: @jsdoc_error, int tag: @jsdoc_tag ref, varchar(900) message: string ref, varchar(900) tostring: string ref);
+
+// YAML
+#keyset[parent, idx]
+yaml (unique int id: @yaml_node,
+      int kind: int ref,
+      int parent: @yaml_node_parent ref,
+      int idx: int ref,
+      varchar(900) tag: string ref,
+      varchar(900) tostring: string ref);
+
+case @yaml_node.kind of
+  0 = @yaml_scalar_node
+| 1 = @yaml_mapping_node
+| 2 = @yaml_sequence_node
+| 3 = @yaml_alias_node
+;
+
+@yaml_collection_node = @yaml_mapping_node | @yaml_sequence_node;
+
+@yaml_node_parent = @yaml_collection_node | @file;
+
+yaml_anchors (unique int node: @yaml_node ref,
+              varchar(900) anchor: string ref);
+
+yaml_aliases (unique int alias: @yaml_alias_node ref,
+              varchar(900) target: string ref);
+
+yaml_scalars (unique int scalar: @yaml_scalar_node ref,
+              int style: int ref,
+              varchar(900) value: string ref);
+
+yaml_errors (unique int id: @yaml_error,
+             varchar(900) message: string ref);
+
+yaml_locations(unique int locatable: @yaml_locatable ref,
+             int location: @location_default ref);
+
+@yaml_locatable = @yaml_node | @yaml_error;
+
+/* XML Files */
+
+xmlEncoding(
+  unique int id: @file ref,
+  varchar(900) encoding: string ref
+);
+
+xmlDTDs(
+  unique int id: @xmldtd,
+  varchar(900) root: string ref,
+  varchar(900) publicId: string ref,
+  varchar(900) systemId: string ref,
+  int fileid: @file ref
+);
+
+xmlElements(
+  unique int id: @xmlelement,
+  varchar(900) name: string ref,
+  int parentid: @xmlparent ref,
+  int idx: int ref,
+  int fileid: @file ref
+);
+
+xmlAttrs(
+  unique int id: @xmlattribute,
+  int elementid: @xmlelement ref,
+  varchar(900) name: string ref,
+  varchar(3600) value: string ref,
+  int idx: int ref,
+  int fileid: @file ref
+);
+
+xmlNs(
+  int id: @xmlnamespace,
+  varchar(900) prefixName: string ref,
+  varchar(900) URI: string ref,
+  int fileid: @file ref
+);
+
+xmlHasNs(
+  int elementId: @xmlnamespaceable ref,
+  int nsId: @xmlnamespace ref,
+  int fileid: @file ref
+);
+
+xmlComments(
+  unique int id: @xmlcomment,
+  varchar(3600) text: string ref,
+  int parentid: @xmlparent ref,
+  int fileid: @file ref
+);
+
+xmlChars(
+  unique int id: @xmlcharacters,
+  varchar(3600) text: string ref,
+  int parentid: @xmlparent ref,
+  int idx: int ref,
+  int isCDATA: int ref,
+  int fileid: @file ref
+);
+
+@xmlparent = @file | @xmlelement;
+@xmlnamespaceable = @xmlelement | @xmlattribute;
+
+xmllocations(
+  int xmlElement: @xmllocatable ref,
+  int location: @location_default ref
+);
+
+@xmllocatable = @xmlcharacters | @xmlelement | @xmlcomment | @xmlattribute | @xmldtd | @file | @xmlnamespace;
+
+@dataflownode = @expr | @function_decl_stmt | @class_decl_stmt | @namespace_declaration | @enum_declaration | @property;
+
+@optionalchainable = @call_expr | @propaccess;
+
+isOptionalChaining(int id: @optionalchainable ref);
+
+/*
+ * configuration files with key value pairs
+ */
+
+configs(
+  unique int id: @config
+);
+
+configNames(
+  unique int id: @configName,
+  int config: @config ref,
+  string name: string ref
+);
+
+configValues(
+  unique int id: @configValue,
+  int config: @config ref,
+  string value: string ref
+);
+
+configLocations(
+  int locatable: @configLocatable ref,
+  int location: @location_default ref
+);
+
+@configLocatable = @config | @configName | @configValue;
+
+/**
+ * The time taken for the extraction of a file.
+ * This table contains non-deterministic content.
+ *
+ * The sum of the `time` column for each (`file`, `timerKind`) pair
+ * is the total time taken for extraction of `file`.  The `extractionPhase`
+ * column provides a granular view of the extraction time of the file.
+ */
+extraction_time(
+   int file : @file ref,
+   // see `com.semmle.js.extractor.ExtractionMetrics.ExtractionPhase`.
+   int extractionPhase: int ref,
+   // 0 for the elapsed CPU time in nanoseconds, 1 for the elapsed wallclock time in nanoseconds
+   int timerKind: int ref,
+   float time: float ref
+)
+
+/**
+ * Non-timing related data for the extraction of a single file.
+ * This table contains non-deterministic content.
+ */
+extraction_data(
+   int file : @file ref,
+   // the absolute path to the cache file
+   varchar(900) cacheFile: string ref,
+   boolean fromCache: boolean ref,
+   int length: int ref
+)

--- a/javascript/upgrades/e34b3e16dba5d11961119818c9beeff334f20a90/semmlecode.javascript.dbscheme
+++ b/javascript/upgrades/e34b3e16dba5d11961119818c9beeff334f20a90/semmlecode.javascript.dbscheme
@@ -1,0 +1,1217 @@
+/*** Standard fragments ***/
+
+/** Files and folders **/
+
+@location = @location_default;
+ 
+locations_default(unique int id: @location_default,
+          int file: @file ref,
+          int beginLine: int ref,
+          int beginColumn: int ref,
+          int endLine: int ref,
+          int endColumn: int ref
+         );
+ 
+@sourceline = @locatable;
+ 
+numlines(int element_id: @sourceline ref,
+         int num_lines: int ref,
+         int num_code: int ref,
+         int num_comment: int ref
+        );
+ 
+files(unique int id: @file,
+      varchar(900) name: string ref);
+ 
+folders(unique int id: @folder,
+        varchar(900) name: string ref);
+ 
+ 
+@container = @folder | @file ;
+ 
+ 
+containerparent(int parent: @container ref,
+                unique int child: @container ref);
+
+/** Duplicate code **/
+
+duplicateCode(
+  unique int id : @duplication,
+  varchar(900) relativePath : string ref,
+  int equivClass : int ref);
+ 
+similarCode(
+  unique int id : @similarity,
+  varchar(900) relativePath : string ref,
+  int equivClass : int ref);
+ 
+@duplication_or_similarity = @duplication | @similarity;
+ 
+tokens(
+  int id : @duplication_or_similarity ref,
+  int offset : int ref,
+  int beginLine : int ref,
+  int beginColumn : int ref,
+  int endLine : int ref,
+  int endColumn : int ref);
+
+/** External data **/
+
+externalData(
+  int id : @externalDataElement,
+  varchar(900) path : string ref,
+  int column: int ref,
+  varchar(900) value : string ref
+);
+ 
+snapshotDate(unique date snapshotDate : date ref);
+ 
+sourceLocationPrefix(varchar(900) prefix : string ref);
+
+/** Version control data **/
+
+svnentries(
+  int id : @svnentry,
+  varchar(500) revision : string ref,
+  varchar(500) author : string ref,
+  date revisionDate : date ref,
+  int changeSize : int ref
+);
+ 
+svnaffectedfiles(
+  int id : @svnentry ref,
+  int file : @file ref,
+  varchar(500) action : string ref
+);
+ 
+svnentrymsg(
+  int id : @svnentry ref,
+  varchar(500) message : string ref
+);
+ 
+svnchurn(
+  int commit : @svnentry ref,
+  int file : @file ref,
+  int addedLines : int ref,
+  int deletedLines : int ref
+);
+
+
+/*** JavaScript-specific part ***/
+
+filetype(
+  int file: @file ref,
+  string filetype: string ref
+)
+
+// top-level code fragments
+toplevels (unique int id: @toplevel,
+           int kind: int ref);
+
+is_externs (int toplevel: @toplevel ref);
+
+case @toplevel.kind of
+   0 = @script
+|  1 = @inline_script
+|  2 = @event_handler
+|  3 = @javascript_url
+|  4 = @template_toplevel;
+
+is_module (int tl: @toplevel ref);
+is_nodejs (int tl: @toplevel ref);
+is_es2015_module (int tl: @toplevel ref);
+is_closure_module (int tl: @toplevel ref);
+
+@xml_node_with_code = @xmlelement | @xmlattribute | @template_placeholder_tag;
+toplevel_parent_xml_node(
+  unique int toplevel: @toplevel ref,
+  int xmlnode: @xml_node_with_code ref);
+
+xml_element_parent_expression(
+  unique int xmlnode: @xmlelement ref,
+  int expression: @expr ref,
+  int index: int ref);
+
+// statements
+#keyset[parent, idx]
+stmts (unique int id: @stmt, 
+       int kind: int ref,
+       int parent: @stmt_parent ref, 
+       int idx: int ref,
+       varchar(900) tostring: string ref);
+
+stmt_containers (unique int stmt: @stmt ref,
+       int container: @stmt_container ref);
+       
+jump_targets (unique int jump: @stmt ref,
+       int target: @stmt ref);
+
+@stmt_parent = @stmt | @toplevel | @function_expr | @arrow_function_expr;
+@stmt_container = @toplevel | @function | @namespace_declaration | @external_module_declaration | @global_augmentation_declaration;
+
+case @stmt.kind of
+   0 = @empty_stmt
+|  1 = @block_stmt
+|  2 = @expr_stmt
+|  3 = @if_stmt
+|  4 = @labeled_stmt
+|  5 = @break_stmt
+|  6 = @continue_stmt
+|  7 = @with_stmt
+|  8 = @switch_stmt
+|  9 = @return_stmt
+| 10 = @throw_stmt
+| 11 = @try_stmt
+| 12 = @while_stmt
+| 13 = @do_while_stmt
+| 14 = @for_stmt
+| 15 = @for_in_stmt
+| 16 = @debugger_stmt
+| 17 = @function_decl_stmt
+| 18 = @var_decl_stmt
+| 19 = @case
+| 20 = @catch_clause
+| 21 = @for_of_stmt
+| 22 = @const_decl_stmt
+| 23 = @let_stmt
+| 24 = @legacy_let_stmt
+| 25 = @for_each_stmt
+| 26 = @class_decl_stmt
+| 27 = @import_declaration
+| 28 = @export_all_declaration
+| 29 = @export_default_declaration
+| 30 = @export_named_declaration
+| 31 = @namespace_declaration
+| 32 = @import_equals_declaration
+| 33 = @export_assign_declaration
+| 34 = @interface_declaration
+| 35 = @type_alias_declaration
+| 36 = @enum_declaration
+| 37 = @external_module_declaration
+| 38 = @export_as_namespace_declaration
+| 39 = @global_augmentation_declaration
+;
+
+@decl_stmt = @var_decl_stmt | @const_decl_stmt | @let_stmt | @legacy_let_stmt;
+
+@export_declaration = @export_all_declaration | @export_default_declaration | @export_named_declaration;
+
+@namespace_definition = @namespace_declaration | @enum_declaration;
+@type_definition = @class_definition | @interface_declaration | @enum_declaration | @type_alias_declaration | @enum_member;
+
+is_instantiated(unique int decl: @namespace_declaration ref);
+
+@declarable_node = @decl_stmt | @namespace_declaration | @class_decl_stmt | @function_decl_stmt | @enum_declaration | @external_module_declaration | @global_augmentation_declaration | @field;
+has_declare_keyword(unique int stmt: @declarable_node ref);
+
+is_for_await_of(unique int forof: @for_of_stmt ref);
+
+// expressions
+#keyset[parent, idx]
+exprs (unique int id: @expr,
+       int kind: int ref,
+       int parent: @expr_parent ref,
+       int idx: int ref,
+       varchar(900) tostring: string ref);
+
+literals (varchar(900) value: string ref,
+       varchar(900) raw: string ref,
+       unique int expr: @expr_or_type ref);
+       
+enclosing_stmt (unique int expr: @expr_or_type ref,
+       int stmt: @stmt ref);
+
+expr_containers (unique int expr: @expr_or_type ref,
+       int container: @stmt_container ref);
+
+array_size (unique int ae: @arraylike ref,
+       int sz: int ref);
+
+is_delegating (int yield: @yield_expr ref);
+
+@expr_or_stmt = @expr | @stmt;
+@expr_or_type = @expr | @typeexpr;
+@expr_parent = @expr_or_stmt | @property | @function_typeexpr;
+@arraylike = @array_expr | @array_pattern;
+@type_annotation = @typeexpr | @jsdoc_type_expr;
+@node_in_stmt_container = @cfg_node | @type_annotation | @toplevel;
+
+case @expr.kind of
+   0 = @label
+|  1 = @null_literal
+|  2 = @boolean_literal
+|  3 = @number_literal
+|  4 = @string_literal
+|  5 = @regexp_literal
+|  6 = @this_expr
+|  7 = @array_expr
+|  8 = @obj_expr
+|  9 = @function_expr
+| 10 = @seq_expr
+| 11 = @conditional_expr
+| 12 = @new_expr
+| 13 = @call_expr
+| 14 = @dot_expr
+| 15 = @index_expr
+| 16 = @neg_expr
+| 17 = @plus_expr
+| 18 = @log_not_expr
+| 19 = @bit_not_expr
+| 20 = @typeof_expr
+| 21 = @void_expr
+| 22 = @delete_expr
+| 23 = @eq_expr
+| 24 = @neq_expr
+| 25 = @eqq_expr
+| 26 = @neqq_expr
+| 27 = @lt_expr
+| 28 = @le_expr
+| 29 = @gt_expr
+| 30 = @ge_expr
+| 31 = @lshift_expr
+| 32 = @rshift_expr
+| 33 = @urshift_expr
+| 34 = @add_expr
+| 35 = @sub_expr
+| 36 = @mul_expr
+| 37 = @div_expr
+| 38 = @mod_expr
+| 39 = @bitor_expr
+| 40 = @xor_expr
+| 41 = @bitand_expr
+| 42 = @in_expr
+| 43 = @instanceof_expr
+| 44 = @logand_expr
+| 45 = @logor_expr
+| 47 = @assign_expr
+| 48 = @assign_add_expr
+| 49 = @assign_sub_expr
+| 50 = @assign_mul_expr
+| 51 = @assign_div_expr
+| 52 = @assign_mod_expr
+| 53 = @assign_lshift_expr
+| 54 = @assign_rshift_expr
+| 55 = @assign_urshift_expr
+| 56 = @assign_or_expr
+| 57 = @assign_xor_expr
+| 58 = @assign_and_expr
+| 59 = @preinc_expr
+| 60 = @postinc_expr
+| 61 = @predec_expr
+| 62 = @postdec_expr
+| 63 = @par_expr
+| 64 = @var_declarator
+| 65 = @arrow_function_expr
+| 66 = @spread_element
+| 67 = @array_pattern
+| 68 = @object_pattern
+| 69 = @yield_expr
+| 70 = @tagged_template_expr
+| 71 = @template_literal
+| 72 = @template_element
+| 73 = @array_comprehension_expr
+| 74 = @generator_expr
+| 75 = @for_in_comprehension_block
+| 76 = @for_of_comprehension_block
+| 77 = @legacy_letexpr
+| 78 = @var_decl
+| 79 = @proper_varaccess
+| 80 = @class_expr
+| 81 = @super_expr
+| 82 = @newtarget_expr
+| 83 = @named_import_specifier
+| 84 = @import_default_specifier
+| 85 = @import_namespace_specifier
+| 86 = @named_export_specifier
+| 87 = @exp_expr
+| 88 = @assign_exp_expr
+| 89 = @jsx_element
+| 90 = @jsx_qualified_name
+| 91 = @jsx_empty_expr
+| 92 = @await_expr
+| 93 = @function_sent_expr
+| 94 = @decorator
+| 95 = @export_default_specifier
+| 96 = @export_namespace_specifier
+| 97 = @bind_expr
+| 98 = @external_module_reference
+| 99 = @dynamic_import
+| 100 = @expression_with_type_arguments
+| 101 = @prefix_type_assertion
+| 102 = @as_type_assertion
+| 103 = @export_varaccess
+| 104 = @decorator_list
+| 105 = @non_null_assertion
+| 106 = @bigint_literal
+| 107 = @nullishcoalescing_expr
+| 108 = @e4x_xml_anyname
+| 109 = @e4x_xml_static_attribute_selector
+| 110 = @e4x_xml_dynamic_attribute_selector
+| 111 = @e4x_xml_filter_expression
+| 112 = @e4x_xml_static_qualident
+| 113 = @e4x_xml_dynamic_qualident
+| 114 = @e4x_xml_dotdotexpr
+| 115 = @import_meta_expr
+| 116 = @assignlogandexpr
+| 117 = @assignlogorexpr
+| 118 = @assignnullishcoalescingexpr
+| 119 = @template_pipe_ref
+| 120 = @generated_code_expr
+;
+
+@varaccess = @proper_varaccess | @export_varaccess;
+@varref = @var_decl | @varaccess;
+
+@identifier = @label | @varref | @type_identifier;
+
+@literal = @null_literal | @boolean_literal | @number_literal | @string_literal | @regexp_literal | @bigint_literal;
+
+@propaccess = @dot_expr | @index_expr;
+
+@invokeexpr = @new_expr | @call_expr;
+
+@unaryexpr = @neg_expr | @plus_expr | @log_not_expr | @bit_not_expr | @typeof_expr | @void_expr | @delete_expr | @spread_element;
+
+@equality_test = @eq_expr | @neq_expr | @eqq_expr | @neqq_expr;
+
+@comparison = @equality_test | @lt_expr | @le_expr | @gt_expr | @ge_expr;
+
+@binaryexpr = @comparison | @lshift_expr | @rshift_expr | @urshift_expr | @add_expr | @sub_expr | @mul_expr | @div_expr | @mod_expr | @exp_expr | @bitor_expr | @xor_expr | @bitand_expr | @in_expr | @instanceof_expr | @logand_expr | @logor_expr | @nullishcoalescing_expr;
+
+@assignment = @assign_expr | @assign_add_expr | @assign_sub_expr | @assign_mul_expr | @assign_div_expr | @assign_mod_expr | @assign_exp_expr | @assign_lshift_expr | @assign_rshift_expr | @assign_urshift_expr | @assign_or_expr | @assign_xor_expr | @assign_and_expr | @assignlogandexpr | @assignlogorexpr | @assignnullishcoalescingexpr;
+
+@updateexpr = @preinc_expr | @postinc_expr | @predec_expr | @postdec_expr;
+
+@pattern = @varref | @array_pattern | @object_pattern;
+
+@comprehension_expr = @array_comprehension_expr | @generator_expr;
+
+@comprehension_block = @for_in_comprehension_block | @for_of_comprehension_block;
+
+@import_specifier = @named_import_specifier | @import_default_specifier | @import_namespace_specifier;
+
+@exportspecifier = @named_export_specifier | @export_default_specifier | @export_namespace_specifier;
+
+@import_or_export_declaration = @import_declaration | @export_declaration;
+
+@type_assertion = @as_type_assertion | @prefix_type_assertion;
+
+@class_definition = @class_decl_stmt | @class_expr;
+@interface_definition = @interface_declaration | @interface_typeexpr;
+@class_or_interface = @class_definition | @interface_definition;
+
+@lexical_decl = @var_decl | @type_decl;
+@lexical_access = @varaccess | @local_type_access | @local_var_type_access | @local_namespace_access;
+@lexical_ref = @lexical_decl | @lexical_access;
+
+@e4x_xml_attribute_selector = @e4x_xml_static_attribute_selector | @e4x_xml_dynamic_attribute_selector;
+@e4x_xml_qualident = @e4x_xml_static_qualident | @e4x_xml_dynamic_qualident;
+
+expr_contains_template_tag_location(
+  int expr: @expr ref,
+  int location: @location ref
+);
+
+@template_placeholder_tag_parent = @xmlelement | @xmlattribute | @file;
+
+template_placeholder_tag_info(
+  unique int node: @template_placeholder_tag,
+  int parentNode: @template_placeholder_tag_parent ref,
+  varchar(900) raw: string ref
+);
+
+// scopes
+scopes (unique int id: @scope,
+        int kind: int ref);
+
+case @scope.kind of
+   0 = @global_scope
+|  1 = @function_scope
+|  2 = @catch_scope
+|  3 = @module_scope
+|  4 = @block_scope
+|  5 = @for_scope
+|  6 = @for_in_scope // for-of scopes work the same as for-in scopes
+|  7 = @comprehension_block_scope
+|  8 = @class_expr_scope
+|  9 = @namespace_scope
+| 10 = @class_decl_scope
+| 11 = @interface_scope
+| 12 = @type_alias_scope
+| 13 = @mapped_type_scope
+| 14 = @enum_scope
+| 15 = @external_module_scope
+| 16 = @conditional_type_scope;
+
+scopenodes (unique int node: @ast_node ref,
+            int scope: @scope ref);
+            
+scopenesting (unique int inner: @scope ref,
+              int outer: @scope ref);
+
+// functions
+@function = @function_decl_stmt | @function_expr | @arrow_function_expr;
+
+@parameterized = @function | @catch_clause;
+@type_parameterized = @function | @class_or_interface | @type_alias_declaration | @mapped_typeexpr | @infer_typeexpr;
+
+is_generator (int fun: @function ref);
+has_rest_parameter (int fun: @function ref);
+is_async (int fun: @function ref);
+
+// variables and lexically scoped type names
+#keyset[scope, name]
+variables (unique int id: @variable,
+           varchar(900) name: string ref,
+           int scope: @scope ref);
+
+#keyset[scope, name]
+local_type_names (unique int id: @local_type_name,
+                  varchar(900) name: string ref,
+                  int scope: @scope ref);
+
+#keyset[scope, name]
+local_namespace_names (unique int id: @local_namespace_name,
+                       varchar(900) name: string ref,
+                       int scope: @scope ref);
+
+is_arguments_object (int id: @variable ref);
+
+@lexical_name = @variable | @local_type_name | @local_namespace_name;
+
+@bind_id = @varaccess | @local_var_type_access;
+bind (unique int id: @bind_id ref,
+      int decl: @variable ref);
+
+decl (unique int id: @var_decl ref,
+      int decl: @variable ref);
+
+@typebind_id = @local_type_access | @export_varaccess;
+typebind (unique int id: @typebind_id ref,
+          int decl: @local_type_name ref);
+
+@typedecl_id = @type_decl | @var_decl;
+typedecl (unique int id: @typedecl_id ref,
+          int decl: @local_type_name ref);
+
+namespacedecl (unique int id: @var_decl ref,
+               int decl: @local_namespace_name ref);
+
+@namespacebind_id = @local_namespace_access | @export_varaccess;
+namespacebind (unique int id: @namespacebind_id ref,
+               int decl: @local_namespace_name ref);
+
+
+// properties in object literals, property patterns in object patterns, and method declarations in classes
+#keyset[parent, index]
+properties (unique int id: @property,
+            int parent: @property_parent ref,
+            int index: int ref,
+            int kind: int ref,
+            varchar(900) tostring: string ref);
+
+case @property.kind of
+  0 = @value_property
+| 1 = @property_getter
+| 2 = @property_setter
+| 3 = @jsx_attribute
+| 4 = @function_call_signature
+| 5 = @constructor_call_signature
+| 6 = @index_signature
+| 7 = @enum_member
+| 8 = @proper_field
+| 9 = @parameter_field
+| 10 = @static_initializer
+;
+
+@property_parent = @obj_expr | @object_pattern | @class_definition | @jsx_element | @interface_definition | @enum_declaration;
+@property_accessor = @property_getter | @property_setter;
+@call_signature = @function_call_signature | @constructor_call_signature;
+@field = @proper_field | @parameter_field;
+@field_or_vardeclarator = @field | @var_declarator;
+
+is_computed (int id: @property ref);
+is_method   (int id: @property ref);
+is_static   (int id: @property ref);
+is_abstract_member (int id: @property ref);
+is_const_enum (int id: @enum_declaration ref);
+is_abstract_class (int id: @class_decl_stmt ref);
+
+has_public_keyword (int id: @property ref);
+has_private_keyword (int id: @property ref);
+has_protected_keyword (int id: @property ref);
+has_readonly_keyword (int id: @property ref);
+has_type_keyword (int id: @import_or_export_declaration ref);
+is_optional_member (int id: @property ref);
+has_definite_assignment_assertion (int id: @field_or_vardeclarator ref);
+is_optional_parameter_declaration (unique int parameter: @pattern ref);
+
+#keyset[constructor, param_index]
+parameter_fields(
+  unique int field: @parameter_field ref,
+  int constructor: @function_expr ref,
+  int param_index: int ref
+);
+
+// types
+#keyset[parent, idx]
+typeexprs (
+  unique int id: @typeexpr,
+  int kind: int ref,
+  int parent: @typeexpr_parent ref,
+  int idx: int ref,
+  varchar(900) tostring: string ref
+);
+
+case @typeexpr.kind of
+  0 = @local_type_access
+| 1 = @type_decl
+| 2 = @keyword_typeexpr
+| 3 = @string_literal_typeexpr
+| 4 = @number_literal_typeexpr
+| 5 = @boolean_literal_typeexpr
+| 6 = @array_typeexpr
+| 7 = @union_typeexpr
+| 8 = @indexed_access_typeexpr
+| 9 = @intersection_typeexpr
+| 10 = @parenthesized_typeexpr
+| 11 = @tuple_typeexpr
+| 12 = @keyof_typeexpr
+| 13 = @qualified_type_access
+| 14 = @generic_typeexpr
+| 15 = @type_label
+| 16 = @typeof_typeexpr
+| 17 = @local_var_type_access
+| 18 = @qualified_var_type_access
+| 19 = @this_var_type_access
+| 20 = @predicate_typeexpr
+| 21 = @interface_typeexpr
+| 22 = @type_parameter
+| 23 = @plain_function_typeexpr
+| 24 = @constructor_typeexpr
+| 25 = @local_namespace_access
+| 26 = @qualified_namespace_access
+| 27 = @mapped_typeexpr
+| 28 = @conditional_typeexpr
+| 29 = @infer_typeexpr
+| 30 = @import_type_access
+| 31 = @import_namespace_access
+| 32 = @import_var_type_access
+| 33 = @optional_typeexpr
+| 34 = @rest_typeexpr
+| 35 = @bigint_literal_typeexpr
+| 36 = @readonly_typeexpr
+| 37 = @template_literal_typeexpr
+;
+
+@typeref = @typeaccess | @type_decl;
+@type_identifier = @type_decl | @local_type_access | @type_label | @local_var_type_access | @local_namespace_access;
+@typeexpr_parent = @expr | @stmt | @property | @typeexpr;
+@literal_typeexpr = @string_literal_typeexpr | @number_literal_typeexpr | @boolean_literal_typeexpr | @bigint_literal_typeexpr;
+@typeaccess = @local_type_access | @qualified_type_access | @import_type_access;
+@vartypeaccess = @local_var_type_access | @qualified_var_type_access | @this_var_type_access | @import_var_type_access;
+@namespace_access = @local_namespace_access | @qualified_namespace_access | @import_namespace_access;
+@import_typeexpr = @import_type_access | @import_namespace_access | @import_var_type_access;
+
+@function_typeexpr = @plain_function_typeexpr | @constructor_typeexpr;
+
+// types
+types (
+  unique int id: @type,
+  int kind: int ref,
+  varchar(900) tostring: string ref
+);
+
+#keyset[parent, idx]
+type_child (
+  int child: @type ref,
+  int parent: @type ref,
+  int idx: int ref
+);
+
+case @type.kind of
+  0 = @any_type
+| 1 = @string_type
+| 2 = @number_type
+| 3 = @union_type
+| 4 = @true_type
+| 5 = @false_type
+| 6 = @type_reference
+| 7 = @object_type
+| 8 = @canonical_type_variable_type
+| 9 = @typeof_type
+| 10 = @void_type
+| 11 = @undefined_type
+| 12 = @null_type
+| 13 = @never_type
+| 14 = @plain_symbol_type
+| 15 = @unique_symbol_type
+| 16 = @objectkeyword_type
+| 17 = @intersection_type
+| 18 = @tuple_type
+| 19 = @lexical_type_variable_type
+| 20 = @this_type
+| 21 = @number_literal_type
+| 22 = @string_literal_type
+| 23 = @unknown_type
+| 24 = @bigint_type
+| 25 = @bigint_literal_type
+;
+
+@boolean_literal_type = @true_type | @false_type;
+@symbol_type = @plain_symbol_type | @unique_symbol_type;
+@union_or_intersection_type = @union_type | @intersection_type;
+@typevariable_type = @canonical_type_variable_type | @lexical_type_variable_type;
+
+has_asserts_keyword(int node: @predicate_typeexpr ref);
+
+@typed_ast_node = @expr | @typeexpr | @function;
+ast_node_type(
+  unique int node: @typed_ast_node ref, 
+  int typ: @type ref);
+
+declared_function_signature(
+  unique int node: @function ref,
+  int sig: @signature_type ref
+);
+
+invoke_expr_signature(
+  unique int node: @invokeexpr ref,
+  int sig: @signature_type ref
+);
+
+invoke_expr_overload_index(
+  unique int node: @invokeexpr ref,
+  int index: int ref
+);
+
+symbols (
+  unique int id: @symbol,
+  int kind: int ref,
+  varchar(900) name: string ref
+);
+
+symbol_parent (
+  unique int symbol: @symbol ref,
+  int parent: @symbol ref
+);
+
+symbol_module (
+  int symbol: @symbol ref,
+  varchar(900) moduleName: string ref
+);
+
+symbol_global (
+  int symbol: @symbol ref,
+  varchar(900) globalName: string ref
+);
+
+case @symbol.kind of
+  0 = @root_symbol
+| 1 = @member_symbol
+| 2 = @other_symbol
+;
+
+@type_with_symbol = @type_reference | @typevariable_type | @typeof_type | @unique_symbol_type;
+@ast_node_with_symbol = @type_definition | @namespace_definition | @toplevel | @typeaccess | @namespace_access | @var_decl | @function | @invokeexpr | @import_declaration | @external_module_reference;
+
+ast_node_symbol(
+  unique int node: @ast_node_with_symbol ref,
+  int symbol: @symbol ref);
+
+type_symbol(
+  unique int typ: @type_with_symbol ref,
+  int symbol: @symbol ref);
+
+#keyset[typ, name]
+type_property(
+  int typ: @type ref,
+  varchar(900) name: string ref,
+  int propertyType: @type ref);
+
+type_alias(
+  unique int aliasType: @type ref,
+  int underlyingType: @type ref);
+
+@literal_type = @string_literal_type | @number_literal_type | @boolean_literal_type | @bigint_literal_type;
+@type_with_literal_value = @string_literal_type | @number_literal_type | @bigint_literal_type;
+type_literal_value(
+  unique int typ: @type_with_literal_value ref,
+  varchar(900) value: string ref);
+
+signature_types (
+  unique int id: @signature_type,
+  int kind: int ref,
+  varchar(900) tostring: string ref,
+  int type_parameters: int ref,
+  int required_params: int ref
+);
+
+is_abstract_signature(
+  unique int sig: @signature_type ref
+);
+
+signature_rest_parameter(
+  unique int sig: @signature_type ref,
+  int rest_param_arra_type: @type ref
+);
+
+case @signature_type.kind of
+  0 = @function_signature_type
+| 1 = @constructor_signature_type
+;
+
+#keyset[typ, kind, index]
+type_contains_signature (
+  int typ: @type ref,
+  int kind: int ref,  // constructor/call/index
+  int index: int ref, // ordering of overloaded signatures
+  int sig: @signature_type ref
+);
+
+#keyset[parent, index]
+signature_contains_type (
+  int child: @type ref,
+  int parent: @signature_type ref,
+  int index: int ref
+);
+
+#keyset[sig, index]
+signature_parameter_name (
+  int sig: @signature_type ref,
+  int index: int ref,
+  varchar(900) name: string ref
+);
+
+number_index_type (
+  unique int baseType: @type ref,
+  int propertyType: @type ref
+);
+
+string_index_type (
+  unique int baseType: @type ref,
+  int propertyType: @type ref
+);
+
+base_type_names(
+  int typeName: @symbol ref,
+  int baseTypeName: @symbol ref
+);
+
+self_types(
+  int typeName: @symbol ref,
+  int selfType: @type_reference ref
+);
+
+tuple_type_min_length(
+  unique int typ: @type ref,
+  int minLength: int ref
+);
+
+tuple_type_rest_index(
+  unique int typ: @type ref,
+  int index: int ref
+);
+
+// comments
+comments (unique int id: @comment,
+          int kind: int ref,
+          int toplevel: @toplevel ref,
+          varchar(900) text: string ref,
+          varchar(900) tostring: string ref);
+
+case @comment.kind of
+  0 = @slashslash_comment
+| 1 = @slashstar_comment
+| 2 = @doc_comment
+| 3 = @html_comment_start
+| 4 = @htmlcommentend;
+
+@html_comment = @html_comment_start | @htmlcommentend;
+@line_comment = @slashslash_comment | @html_comment;
+@block_comment = @slashstar_comment | @doc_comment;
+
+// source lines
+lines (unique int id: @line,
+       int toplevel: @toplevel ref,
+       varchar(900) text: string ref,
+       varchar(2) terminator: string ref);
+indentation (int file: @file ref,
+            int lineno: int ref,
+            varchar(1) indentChar: string ref,
+            int indentDepth: int ref);
+
+// JavaScript parse errors
+js_parse_errors (unique int id: @js_parse_error,
+        int toplevel: @toplevel ref,
+        varchar(900) message: string ref,
+        varchar(900) line: string ref);
+  
+// regular expressions
+#keyset[parent, idx]
+regexpterm (unique int id: @regexpterm,
+        int kind: int ref,
+        int parent: @regexpparent ref,
+        int idx: int ref,
+        varchar(900) tostring: string ref);
+        
+@regexpparent = @regexpterm | @regexp_literal | @string_literal;
+
+case @regexpterm.kind of
+   0 = @regexp_alt
+|  1 = @regexp_seq
+|  2 = @regexp_caret
+|  3 = @regexp_dollar
+|  4 = @regexp_wordboundary
+|  5 = @regexp_nonwordboundary
+|  6 = @regexp_positive_lookahead
+|  7 = @regexp_negative_lookahead
+|  8 = @regexp_star
+|  9 = @regexp_plus
+| 10 = @regexp_opt
+| 11 = @regexp_range
+| 12 = @regexp_dot
+| 13 = @regexp_group
+| 14 = @regexp_normal_constant
+| 15 = @regexp_hex_escape
+| 16 = @regexp_unicode_escape
+| 17 = @regexp_dec_escape
+| 18 = @regexp_oct_escape
+| 19 = @regexp_ctrl_escape
+| 20 = @regexp_char_class_escape
+| 21 = @regexp_id_escape
+| 22 = @regexp_backref
+| 23 = @regexp_char_class
+| 24 = @regexp_char_range
+| 25 = @regexp_positive_lookbehind
+| 26 = @regexp_negative_lookbehind
+| 27 = @regexp_unicode_property_escape;
+
+regexp_parse_errors (unique int id: @regexp_parse_error,
+    int regexp: @regexpterm ref,
+    varchar(900) message: string ref);
+
+@regexp_quantifier = @regexp_star | @regexp_plus | @regexp_opt | @regexp_range;
+@regexp_escape = @regexp_char_escape | @regexp_char_class_escape | @regexp_unicode_property_escape;
+@regexp_char_escape = @regexp_hex_escape | @regexp_unicode_escape | @regexp_dec_escape | @regexp_oct_escape | @regexp_ctrl_escape | @regexp_id_escape;
+@regexp_constant = @regexp_normal_constant | @regexp_char_escape;
+@regexp_lookahead = @regexp_positive_lookahead | @regexp_negative_lookahead;
+@regexp_lookbehind = @regexp_positive_lookbehind | @regexp_negative_lookbehind;
+@regexp_subpattern = @regexp_lookahead | @regexp_lookbehind;
+@regexp_anchor = @regexp_dollar | @regexp_caret;
+
+is_greedy (int id: @regexp_quantifier ref);
+range_quantifier_lower_bound (unique int id: @regexp_range ref, int lo: int ref);
+range_quantifier_upper_bound (unique int id: @regexp_range ref, int hi: int ref);
+is_capture (unique int id: @regexp_group ref, int number: int ref);
+is_named_capture (unique int id: @regexp_group ref, string name: string ref);
+is_inverted (int id: @regexp_char_class ref);
+regexp_const_value (unique int id: @regexp_constant ref, varchar(1) value: string ref);
+char_class_escape (unique int id: @regexp_char_class_escape ref, varchar(1) value: string ref);
+backref (unique int id: @regexp_backref ref, int value: int ref);
+named_backref (unique int id: @regexp_backref ref, string name: string ref);
+unicode_property_escapename (unique int id: @regexp_unicode_property_escape ref, string name: string ref);
+unicode_property_escapevalue (unique int id: @regexp_unicode_property_escape ref, string value: string ref);
+
+// tokens
+#keyset[toplevel, idx]
+tokeninfo (unique int id: @token,
+    int kind: int ref,
+    int toplevel: @toplevel ref,
+    int idx: int ref,
+    varchar(900) value: string ref);
+
+case @token.kind of
+  0 = @token_eof
+| 1 = @token_null_literal
+| 2 = @token_boolean_literal
+| 3 = @token_numeric_literal
+| 4 = @token_string_literal
+| 5 = @token_regular_expression
+| 6 = @token_identifier
+| 7 = @token_keyword
+| 8 = @token_punctuator;
+
+// associate comments with the token immediately following them (which may be EOF)
+next_token (int comment: @comment ref, int token: @token ref);
+
+// JSON
+#keyset[parent, idx]
+json (unique int id: @json_value,
+      int kind: int ref,
+      int parent: @json_parent ref,
+      int idx: int ref,
+      varchar(900) tostring: string ref);
+
+json_literals (varchar(900) value: string ref,
+      varchar(900) raw: string ref,
+      unique int expr: @json_value ref);
+
+json_properties (int obj: @json_object ref,
+      varchar(900) property: string ref,
+      int value: @json_value ref);
+
+json_errors (unique int id: @json_parse_error,
+      varchar(900) message: string ref);
+
+json_locations(unique int locatable: @json_locatable ref,
+      int location: @location_default ref);
+
+case @json_value.kind of
+  0 = @json_null
+| 1 = @json_boolean
+| 2 = @json_number
+| 3 = @json_string
+| 4 = @json_array
+| 5 = @json_object;
+
+@json_parent = @json_object | @json_array | @file;
+
+@json_locatable = @json_value | @json_parse_error;
+
+// locations
+@ast_node = @toplevel | @stmt | @expr | @property | @typeexpr;
+
+@locatable = @file 
+    | @ast_node
+    | @comment
+    | @line
+    | @js_parse_error | @regexp_parse_error
+    | @regexpterm
+    | @json_locatable
+    | @token
+    | @cfg_node
+    | @jsdoc | @jsdoc_type_expr | @jsdoc_tag
+    | @yaml_locatable
+    | @xmllocatable
+    | @configLocatable
+    | @template_placeholder_tag;
+
+hasLocation (unique int locatable: @locatable ref,
+    int location: @location ref);
+
+// CFG
+entry_cfg_node (unique int id: @entry_node, int container: @stmt_container ref);
+exit_cfg_node (unique int id: @exit_node, int container: @stmt_container ref);
+guard_node (unique int id: @guard_node, int kind: int ref, int test: @expr ref);
+case @guard_node.kind of
+  0 = @falsy_guard
+| 1 = @truthy_guard;
+@condition_guard = @falsy_guard | @truthy_guard;
+
+@synthetic_cfg_node = @entry_node | @exit_node | @guard_node;
+@cfg_node = @synthetic_cfg_node | @expr_parent;
+
+successor (int pred: @cfg_node ref, int succ: @cfg_node ref);
+
+// JSDoc comments
+jsdoc (unique int id: @jsdoc, varchar(900) description: string ref, int comment: @comment ref);
+#keyset[parent, idx]
+jsdoc_tags (unique int id: @jsdoc_tag, varchar(900) title: string ref,
+            int parent: @jsdoc ref, int idx: int ref, varchar(900) tostring: string ref);
+jsdoc_tag_descriptions (unique int tag: @jsdoc_tag ref, varchar(900) text: string ref);
+jsdoc_tag_names (unique int tag: @jsdoc_tag ref, varchar(900) text: string ref);
+
+#keyset[parent, idx]
+jsdoc_type_exprs (unique int id: @jsdoc_type_expr,
+                  int kind: int ref,
+                  int parent: @jsdoc_type_expr_parent ref,
+                  int idx: int ref,
+                  varchar(900) tostring: string ref);
+case @jsdoc_type_expr.kind of
+    0 = @jsdoc_any_type_expr
+|   1 = @jsdoc_null_type_expr
+|   2 = @jsdoc_undefined_type_expr
+|   3 = @jsdoc_unknown_type_expr
+|   4 = @jsdoc_void_type_expr
+|   5 = @jsdoc_named_type_expr
+|   6 = @jsdoc_applied_type_expr
+|   7 = @jsdoc_nullable_type_expr
+|   8 = @jsdoc_non_nullable_type_expr
+|   9 = @jsdoc_record_type_expr
+|  10 = @jsdoc_array_type_expr
+|  11 = @jsdoc_union_type_expr
+|  12 = @jsdoc_function_type_expr
+|  13 = @jsdoc_optional_type_expr
+|  14 = @jsdoc_rest_type_expr
+;
+
+#keyset[id, idx]
+jsdoc_record_field_name (int id: @jsdoc_record_type_expr ref, int idx: int ref, varchar(900) name: string ref);
+jsdoc_prefix_qualifier (int id: @jsdoc_type_expr ref);
+jsdoc_has_new_parameter (int fn: @jsdoc_function_type_expr ref);
+
+@jsdoc_type_expr_parent = @jsdoc_type_expr | @jsdoc_tag;
+
+jsdoc_errors (unique int id: @jsdoc_error, int tag: @jsdoc_tag ref, varchar(900) message: string ref, varchar(900) tostring: string ref);
+
+// YAML
+#keyset[parent, idx]
+yaml (unique int id: @yaml_node,
+      int kind: int ref,
+      int parent: @yaml_node_parent ref,
+      int idx: int ref,
+      varchar(900) tag: string ref,
+      varchar(900) tostring: string ref);
+
+case @yaml_node.kind of
+  0 = @yaml_scalar_node
+| 1 = @yaml_mapping_node
+| 2 = @yaml_sequence_node
+| 3 = @yaml_alias_node
+;
+
+@yaml_collection_node = @yaml_mapping_node | @yaml_sequence_node;
+
+@yaml_node_parent = @yaml_collection_node | @file;
+
+yaml_anchors (unique int node: @yaml_node ref,
+              varchar(900) anchor: string ref);
+
+yaml_aliases (unique int alias: @yaml_alias_node ref,
+              varchar(900) target: string ref);
+
+yaml_scalars (unique int scalar: @yaml_scalar_node ref,
+              int style: int ref,
+              varchar(900) value: string ref);
+
+yaml_errors (unique int id: @yaml_error,
+             varchar(900) message: string ref);
+
+yaml_locations(unique int locatable: @yaml_locatable ref,
+             int location: @location_default ref);
+
+@yaml_locatable = @yaml_node | @yaml_error;
+
+/* XML Files */
+
+xmlEncoding(
+  unique int id: @file ref,
+  varchar(900) encoding: string ref
+);
+
+xmlDTDs(
+  unique int id: @xmldtd,
+  varchar(900) root: string ref,
+  varchar(900) publicId: string ref,
+  varchar(900) systemId: string ref,
+  int fileid: @file ref
+);
+
+xmlElements(
+  unique int id: @xmlelement,
+  varchar(900) name: string ref,
+  int parentid: @xmlparent ref,
+  int idx: int ref,
+  int fileid: @file ref
+);
+
+xmlAttrs(
+  unique int id: @xmlattribute,
+  int elementid: @xmlelement ref,
+  varchar(900) name: string ref,
+  varchar(3600) value: string ref,
+  int idx: int ref,
+  int fileid: @file ref
+);
+
+xmlNs(
+  int id: @xmlnamespace,
+  varchar(900) prefixName: string ref,
+  varchar(900) URI: string ref,
+  int fileid: @file ref
+);
+
+xmlHasNs(
+  int elementId: @xmlnamespaceable ref,
+  int nsId: @xmlnamespace ref,
+  int fileid: @file ref
+);
+
+xmlComments(
+  unique int id: @xmlcomment,
+  varchar(3600) text: string ref,
+  int parentid: @xmlparent ref,
+  int fileid: @file ref
+);
+
+xmlChars(
+  unique int id: @xmlcharacters,
+  varchar(3600) text: string ref,
+  int parentid: @xmlparent ref,
+  int idx: int ref,
+  int isCDATA: int ref,
+  int fileid: @file ref
+);
+
+@xmlparent = @file | @xmlelement;
+@xmlnamespaceable = @xmlelement | @xmlattribute;
+
+xmllocations(
+  int xmlElement: @xmllocatable ref,
+  int location: @location_default ref
+);
+
+@xmllocatable = @xmlcharacters | @xmlelement | @xmlcomment | @xmlattribute | @xmldtd | @file | @xmlnamespace;
+
+@dataflownode = @expr | @function_decl_stmt | @class_decl_stmt | @namespace_declaration | @enum_declaration | @property;
+
+@optionalchainable = @call_expr | @propaccess;
+
+isOptionalChaining(int id: @optionalchainable ref);
+
+/*
+ * configuration files with key value pairs
+ */
+
+configs(
+  unique int id: @config
+);
+
+configNames(
+  unique int id: @configName,
+  int config: @config ref,
+  string name: string ref
+);
+
+configValues(
+  unique int id: @configValue,
+  int config: @config ref,
+  string value: string ref
+);
+
+configLocations(
+  int locatable: @configLocatable ref,
+  int location: @location_default ref
+);
+
+@configLocatable = @config | @configName | @configValue;
+
+/**
+ * The time taken for the extraction of a file.
+ * This table contains non-deterministic content.
+ *
+ * The sum of the `time` column for each (`file`, `timerKind`) pair
+ * is the total time taken for extraction of `file`.  The `extractionPhase`
+ * column provides a granular view of the extraction time of the file.
+ */
+extraction_time(
+   int file : @file ref,
+   // see `com.semmle.js.extractor.ExtractionMetrics.ExtractionPhase`.
+   int extractionPhase: int ref,
+   // 0 for the elapsed CPU time in nanoseconds, 1 for the elapsed wallclock time in nanoseconds
+   int timerKind: int ref,
+   float time: float ref
+)
+
+/**
+ * Non-timing related data for the extraction of a single file.
+ * This table contains non-deterministic content.
+ */
+extraction_data(
+   int file : @file ref,
+   // the absolute path to the cache file
+   varchar(900) cacheFile: string ref,
+   boolean fromCache: boolean ref,
+   int length: int ref
+)


### PR DESCRIPTION
Adds support for TypeScript 4.4.  
Adding support for TypeScript 4.4 was completely straight-forward, except for [static initializer blocks](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#static-blocks). 

It looks like [static initializer blocks is making it's way into ECMAScript](https://github.com/tc39/ecma262/pull/2440). So we should look into that later.  
(I'll check it out after this PR is merged). 

The `List<Node> body;` type in `ClassBody` is not the prettiest type.  
But we need an ordered list that contains a mix of member-declarations and block-statements, so I think the only way to do better is to create an entirely new interface. 

I haven't added getters for [the new index signatures](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#symbol-template-signatures), because the [available API still only exposes string/number index signatures](https://github.com/microsoft/TypeScript/blob/6f7f3b1775911a6e857a5699b767cb5a8868f980/lib/typescript.d.ts#L5440-L5441).  

No evaluation planned. 