### PR TITLE
Java: Hide diff for generated files by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -48,3 +48,5 @@
 *.gif -text
 *.dll -text
 *.pdb -text
+
+java/ql/test/stubs/**/*.java linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -50,3 +50,4 @@
 *.pdb -text
 
 java/ql/test/stubs/**/*.java linguist-generated=true
+java/ql/test/experimental/stubs/**/*.java linguist-generated=true


### PR DESCRIPTION
Given the stubs are mostly generated, hide them by default in diff and PR views to make reviewing easier.

* [Example PR with change](https://github.com/github/codeql/compare/main...bmuskalla:linguistExclude?expand=1)
* [Example PR without change](https://github.com/github/codeql/compare/main...bmuskalla:someChanges?expand=1)

See [Customizing how changed files appear on GitHub](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/customizing-how-changed-files-appear-on-github) for more information
