### PR TITLE
Java: Add tests for static and final modifiers relating to record classes

### DIFF
--- a/java/ql/test/library-tests/record-classes/MyFinalRecord.java
+++ b/java/ql/test/library-tests/record-classes/MyFinalRecord.java
@@ -1,0 +1,1 @@
+final record MyFinalRecord() { }

--- a/java/ql/test/library-tests/record-classes/MyRecord.java
+++ b/java/ql/test/library-tests/record-classes/MyRecord.java
@@ -1,0 +1,2 @@
+// Records are implicitly final
+record MyRecord() { }

--- a/java/ql/test/library-tests/record-classes/RecordClasses.expected
+++ b/java/ql/test/library-tests/record-classes/RecordClasses.expected
@@ -1,0 +1,6 @@
+| MyFinalRecord.java:1:14:1:26 | MyFinalRecord | final=true | static=false | Record |
+| MyRecord.java:2:8:2:15 | MyRecord | final=true | static=false | Record |
+| Test.java:3:12:3:13 | R1 | final=true | static=true | Record |
+| Test.java:4:25:4:26 | R2 | final=true | static=true | Record |
+| Test.java:8:12:8:13 | R3 | final=true | static=true | Record,SuperInterface |
+| Test.java:12:16:12:26 | LocalRecord | final=true | static=true | Record |

--- a/java/ql/test/library-tests/record-classes/RecordClasses.ql
+++ b/java/ql/test/library-tests/record-classes/RecordClasses.ql
@@ -1,0 +1,8 @@
+import java
+
+from Record r, boolean isFinal, boolean isStatic, string superTypes
+where
+  (if r.isFinal() then isFinal = true else isFinal = false) and
+  (if r.isStatic() then isStatic = true else isStatic = false) and
+  superTypes = concat(RefType superType | superType = r.getASupertype() | superType.toString(), ",")
+select r, "final=" + isFinal, "static=" + isStatic, superTypes

--- a/java/ql/test/library-tests/record-classes/Test.java
+++ b/java/ql/test/library-tests/record-classes/Test.java
@@ -1,0 +1,14 @@
+class Test {
+    // Nested records are implicitly static
+    record R1() { }
+    static final record R2() { }
+
+    interface SuperInterface { }
+
+    record R3() implements SuperInterface { }
+
+    void test() {
+        // Nested records are implicitly static
+        record LocalRecord() { }
+    }
+}

--- a/java/ql/test/library-tests/record-classes/options
+++ b/java/ql/test/library-tests/record-classes/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -source 16 -target 16


### PR DESCRIPTION
This is https://github.com/github/codeql/pull/5473 without the CodeQL changes, as the extractor turns out to be populating the modifiers as required already.