### PR TITLE
Packaging: Normalize all qlpack.yml files for all languages

### DIFF
--- a/cpp/ql/examples/qlpack.lock.yml
+++ b/cpp/ql/examples/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/cpp/ql/examples/qlpack.yml
+++ b/cpp/ql/examples/qlpack.yml
@@ -1,3 +1,4 @@
-name: codeql-cpp-examples
-version: 0.0.0
-libraryPathDependencies: codeql/cpp-all
+name: codeql/cpp-examples
+version: 0.0.2
+dependencies:
+  codeql/cpp-all: "*"

--- a/cpp/ql/lib/qlpack.yml
+++ b/cpp/ql/lib/qlpack.yml
@@ -3,3 +3,5 @@ version: 0.0.2
 dbscheme: semmlecode.cpp.dbscheme
 extractor: cpp
 library: true
+dependencies:
+  codeql/cpp-upgrades: 0.0.2

--- a/cpp/ql/src/codeql-suites/cpp-code-scanning.qls
+++ b/cpp/ql/src/codeql-suites/cpp-code-scanning.qls
@@ -3,4 +3,4 @@
 - apply: code-scanning-selectors.yml
   from: codeql/suite-helpers
 - apply: codeql-suites/exclude-slow-queries.yml
-  from: codeql-cpp
+  from: codeql/cpp-queries

--- a/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
+++ b/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
@@ -3,7 +3,7 @@
 - apply: lgtm-selectors.yml
   from: codeql/suite-helpers
 - apply: codeql-suites/exclude-slow-queries.yml
-  from: codeql-cpp
+  from: codeql/cpp-queries
 # These are only for IDE use.
 - exclude:
     tags contain:

--- a/cpp/ql/src/codeql-suites/cpp-security-and-quality.qls
+++ b/cpp/ql/src/codeql-suites/cpp-security-and-quality.qls
@@ -3,4 +3,4 @@
 - apply: security-and-quality-selectors.yml
   from: codeql/suite-helpers
 - apply: codeql-suites/exclude-slow-queries.yml
-  from: codeql-cpp
+  from: codeql/cpp-queries

--- a/cpp/ql/src/codeql-suites/cpp-security-extended.qls
+++ b/cpp/ql/src/codeql-suites/cpp-security-extended.qls
@@ -3,4 +3,4 @@
 - apply: security-extended-selectors.yml
   from: codeql/suite-helpers
 - apply: codeql-suites/exclude-slow-queries.yml
-  from: codeql-cpp
+  from: codeql/cpp-queries

--- a/cpp/ql/src/qlpack.yml
+++ b/cpp/ql/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: codeql/cpp-queries
 version: 0.0.2
 dependencies:
-    codeql/cpp-all: ^0.0.2
-    codeql/suite-helpers: ^0.0.2
+    codeql/cpp-all: "*"
+    codeql/suite-helpers: "*"
 suites: codeql-suites
 extractor: cpp
 defaultSuiteFile: codeql-suites/cpp-code-scanning.qls

--- a/cpp/ql/test/qlpack.lock.yml
+++ b/cpp/ql/test/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/cpp/ql/test/qlpack.yml
+++ b/cpp/ql/test/qlpack.yml
@@ -1,5 +1,5 @@
-name: codeql-cpp-tests
-version: 0.0.0
+name: codeql/cpp-tests
+version: 0.0.2
 dependencies:
   codeql/cpp-all: "*"
   codeql/cpp-queries: "*"

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml
@@ -1,6 +1,6 @@
 # This directory has its own qlpack for reasons detailed in commit 2550788598010fa2117274607c9d58f64f997f34
-name: codeql-cpp-tests-cwe-190-tainted
-version: 0.0.0
+name: codeql/cpp-tests-cwe-190-tainted
+version: 0.0.2
 dependencies:
   codeql/cpp-all: "*"
   codeql/cpp-queries: "*"

--- a/cpp/upgrades/qlpack.lock.yml
+++ b/cpp/upgrades/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/cpp/upgrades/qlpack.yml
+++ b/cpp/upgrades/qlpack.yml
@@ -1,2 +1,3 @@
-name: codeql-cpp-upgrades
+name: codeql/cpp-upgrades
 upgrades: .
+version: 0.0.2

--- a/csharp/ql/examples/qlpack.lock.yml
+++ b/csharp/ql/examples/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/csharp/ql/examples/qlpack.yml
+++ b/csharp/ql/examples/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql-csharp-examples
-version: 0.0.0
+version: 0.0.2
 dependencies:
-  codeql/csharp-all: ^0.0.1
+  codeql/csharp-all: "*"

--- a/csharp/ql/lib/qlpack.lock.yml
+++ b/csharp/ql/lib/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/csharp/ql/lib/qlpack.yml
+++ b/csharp/ql/lib/qlpack.yml
@@ -4,3 +4,5 @@ dbscheme: semmlecode.csharp.dbscheme
 suites: codeql-suites
 extractor: csharp
 library: true
+dependencies:
+  codeql/csharp-upgrades: 0.0.2

--- a/csharp/ql/src/qlpack.lock.yml
+++ b/csharp/ql/src/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/csharp/ql/src/qlpack.yml
+++ b/csharp/ql/src/qlpack.yml
@@ -3,5 +3,5 @@ version: 0.0.2
 suites: codeql-suites
 extractor: csharp
 dependencies:
-  codeql/csharp-all: ^0.0.2
-  codeql/suite-helpers: ^0.0.2
+  codeql/csharp-all: "*"
+  codeql/suite-helpers: "*"

--- a/csharp/ql/test/qlpack.lock.yml
+++ b/csharp/ql/test/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/csharp/ql/test/qlpack.yml
+++ b/csharp/ql/test/qlpack.yml
@@ -1,7 +1,7 @@
 name: codeql-csharp-tests
-version: 0.0.0
+version: 0.0.2
 dependencies:
-  codeql/csharp-all: ^0.0.2
-  codeql/csharp-queries: ^0.0.2
+  codeql/csharp-all: "*"
+  codeql/csharp-queries: "*"
 extractor: csharp
 tests: .

--- a/csharp/upgrades/qlpack.yml
+++ b/csharp/upgrades/qlpack.yml
@@ -1,2 +1,3 @@
-name: codeql-csharp-upgrades
+name: codeql/csharp-upgrades
 upgrades: .
+version: 0.0.2

--- a/java/ql/examples/qlpack.lock.yml
+++ b/java/ql/examples/qlpack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/java/ql/examples/qlpack.yml
+++ b/java/ql/examples/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-java-examples
-version: 0.0.0
-libraryPathDependencies: codeql/java-all
+version: 0.0.2
+dependencies:
+    codeql/java-all: "*"

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -3,5 +3,5 @@ version: 0.0.2
 suites: codeql-suites
 extractor: java
 dependencies:
-    codeql/java-all: ^0.0.2
-    codeql/suite-helpers: ^0.0.2
+    codeql/java-all: "*"
+    codeql/suite-helpers: "*"

--- a/java/ql/test/qlpack.yml
+++ b/java/ql/test/qlpack.yml
@@ -1,7 +1,7 @@
 name: codeql/java-tests
-version: 0.0.0
+version: 0.0.2
 dependencies:
-    codeql/java-all: ^0.0.1
-    codeql/java-queries: ^0.0.1
+    codeql/java-all: "*"
+    codeql/java-queries: "*"
 extractor: java
 tests: .

--- a/javascript/ql/examples/qlpack.yml
+++ b/javascript/ql/examples/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-javascript-examples
-version: 0.0.0
-libraryPathDependencies: codeql/javascript-all
+version: 0.0.3
+dependencies:
+  codeql/javascript-all: "*"

--- a/javascript/ql/src/qlpack.yml
+++ b/javascript/ql/src/qlpack.yml
@@ -1,7 +1,7 @@
 name: codeql/javascript-queries
-version: 0.0.2
+version: 0.0.3
 suites: codeql-suites
 extractor: javascript
 dependencies:
-    codeql/javascript-all: ^0.0.2
-    codeql/suite-helpers: ^0.0.2
+    codeql/javascript-all: "*"
+    codeql/suite-helpers: "*"

--- a/javascript/ql/test/qlpack.yml
+++ b/javascript/ql/test/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/javascript-tests
-version: 0.0.0
+version: 0.0.3
 dependencies:
   codeql/javascript-all: "*"
   codeql/javascript-queries: "*"

--- a/python/ql/examples/qlpack.yml
+++ b/python/ql/examples/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/python-examples
-version: 0.0.0
-libraryPathDependencies: codeql/python-all
+version: 0.0.2
+dependencies:
+    codeql/python-all: "*"

--- a/python/ql/lib/qlpack.yml
+++ b/python/ql/lib/qlpack.yml
@@ -4,4 +4,4 @@ dbscheme: semmlecode.python.dbscheme
 extractor: python
 library: true
 dependencies:
-    codeql/python-upgrades: ~0.0.2
+    codeql/python-upgrades: 0.0.2

--- a/python/ql/src/qlpack.yml
+++ b/python/ql/src/qlpack.yml
@@ -1,8 +1,8 @@
 name: codeql/python-queries
 version: 0.0.2
 dependencies:
-    codeql/python-all: ^0.0.2
-    codeql/suite-helpers: ^0.0.2
+    codeql/python-all: "*"
+    codeql/suite-helpers: "*"
 suites: codeql-suites
 extractor: python
 defaultSuiteFile: codeql-suites/python-code-scanning.qls

--- a/python/ql/test/qlpack.yml
+++ b/python/ql/test/qlpack.yml
@@ -1,7 +1,7 @@
 name: codeql/python-tests
-version: 0.0.0
+version: 0.0.2
 dependencies:
-    codeql/python-all: ^0.0.1
-    codeql/python-queries: ^0.0.1
+    codeql/python-all: "*"
+    codeql/python-queries: "*"
 extractor: python
 tests: .


### PR DESCRIPTION
This commit ensures consistency among all of our qlpacks. Here are the
changes:

1. Ensure only modern references are used (codeql-{lang} is converted to
   codeql/{lang}-all or codeql/{lang}-queries where appropriate).
2. Use consistent version numbers. All languages are at 0.0.2 except
   javascript, which is 0.0.3.
3. Convert all `libraryPathDependencies` to `dependencies` with version
   constraints
4. Dependencies from query packs to other packs are always `"*"` since
   these dependencies are always from source and we should get the
   latest.
5. Dependencies from codeql/{lang}-lib to codeql/{lang}-upgrades must
   be strict since there is a tight connection between the libary
   and its relevant upgrades.

See also #6598.