### PR TITLE
C#: Fix dispatch library to handle summarized callables with no runti…

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -8,6 +8,7 @@ private import FlowSummaryImpl as FlowSummaryImpl
 private import semmle.code.csharp.dataflow.FlowSummary
 private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dispatch.Dispatch
+private import semmle.code.csharp.dispatch.RuntimeCallable
 private import semmle.code.csharp.frameworks.system.Collections
 private import semmle.code.csharp.frameworks.system.collections.Generic
 
@@ -275,6 +276,10 @@ class NonDelegateDataFlowCall extends DataFlowCall, TNonDelegateCall {
 
   override DataFlowCallable getARuntimeTarget() {
     result = getCallableForDataFlow(dc.getADynamicTarget())
+    or
+    result = dc.getAStaticTarget().getUnboundDeclaration() and
+    summarizedCallable(result) and
+    not result instanceof RuntimeCallable
   }
 
   override ControlFlow::Nodes::ElementNode getControlFlowNode() { result = cfn }


### PR DESCRIPTION
…me target

This PR changes the dispatch logic to return summarized callables in `NonDelegateDataFlowCall::getARuntimeTarget` even if there's no method that's known to implement the given abstract or interface member. This allows writing tests that only rely on interface members without having stubs for their concrete implementation.

[Diff job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1314/)