### PR TITLE
C# Extend runtime callables to cover interface members with default implementation

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dispatch/RuntimeCallable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/RuntimeCallable.qll
@@ -15,7 +15,10 @@ private import dotnet
 class RuntimeCallable extends DotNet::Callable {
   RuntimeCallable() {
     not this.(Modifiable).isAbstract() and
-    not getDeclaringType() instanceof Interface
+    (
+      not getDeclaringType() instanceof Interface or
+      this.(Virtualizable).isVirtual()
+    )
   }
 }
 

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -236,3 +236,5 @@
 | ViableCallable.cs:452:10:452:14 | M4<> | ViableCallable.cs:444:23:444:27 | M2<> |
 | ViableCallable.cs:458:10:458:14 | M5<> | ViableCallable.cs:430:22:430:26 | M2<> |
 | ViableCallable.cs:458:10:458:14 | M5<> | ViableCallable.cs:444:23:444:27 | M2<> |
+| ViableCallable.cs:475:10:475:12 | Run | ViableCallable.cs:468:10:468:11 | M2 |
+| ViableCallable.cs:475:10:475:12 | Run | ViableCallable.cs:473:17:473:18 | M1 |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -469,3 +469,5 @@
 | ViableCallable.cs:455:9:455:30 | call to method M2<T> | C17.M2<T>(Func<T>) |
 | ViableCallable.cs:461:9:461:30 | call to method M2<T> | C16<T,System.Int32>.M2<T>(Func<T>) |
 | ViableCallable.cs:461:9:461:30 | call to method M2<T> | C17.M2<T>(Func<T>) |
+| ViableCallable.cs:478:9:478:14 | call to method M1 | C18.M1() |
+| ViableCallable.cs:481:9:481:14 | call to method M2 | I2.M2() |

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -461,3 +461,23 @@ class C17 : C16<string, int>
         c.M2(() => default(T));
     }
 }
+
+interface I2
+{
+    void M1();
+    void M2() => throw null;
+}
+
+class C18 : I2
+{
+    public void M1() { }
+
+    void Run(I2 i)
+    {
+        // Viable callables: C18.M1()
+        i.M1();
+
+        // Viable callables: I2.M2()
+        i.M2();
+    }
+}

--- a/csharp/ql/test/library-tests/dispatch/viableCallable.expected
+++ b/csharp/ql/test/library-tests/dispatch/viableCallable.expected
@@ -251,3 +251,5 @@
 | ViableCallable.cs:419:9:419:21 | call to method M<String> | M<> | A4 |
 | ViableCallable.cs:423:9:423:21 | call to method M<String> | M<> | A4 |
 | ViableCallable.cs:423:9:423:21 | call to method M<String> | M<> | A5 |
+| ViableCallable.cs:478:9:478:14 | call to method M1 | M1 | C18 |
+| ViableCallable.cs:481:9:481:14 | call to method M2 | M2 | I2 |


### PR DESCRIPTION
This PR makes an interface member with default implementation a `RuntimeCallable`.

~~[Diff job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1313/)~~ [Diff job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/1316/)