### PR TITLE
JS: add jQuery writes to `href`/`src` as sinks in `js/client-side-unvaledated-url-redirection`

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/TaintedUrlSuffix.qll
+++ b/javascript/ql/lib/semmle/javascript/security/TaintedUrlSuffix.qll
@@ -26,6 +26,17 @@ module TaintedUrlSuffix {
    */
   FlowLabel label() { result instanceof TaintedUrlSuffixLabel }
 
+  /**
+   * Gets a remote flow source that is a tainted URL query or fragment part.
+   */
+  ClientSideRemoteFlowSource source() {
+    result.getKind().isFragment()
+    or
+    result.getKind().isQuery()
+    or
+    result.getKind().isUrl()
+  }
+
   /** Holds for `pred -> succ` is a step of form `x -> x.p` */
   private predicate isSafeLocationProp(DataFlow::PropRead read) {
     // Ignore properties that refer to the scheme, domain, port, auth, or path.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -19,7 +19,12 @@ module ClientSideUrlRedirect {
   /**
    * A data flow sink for unvalidated URL redirect vulnerabilities.
    */
-  abstract class Sink extends DataFlow::Node { }
+  abstract class Sink extends DataFlow::Node {
+    /** Holds if the sink can execute JavaScript code in the current context. */
+    predicate isXSSSink() {
+      none() // overwritten in subclasses
+    }
+  }
 
   /**
    * A sanitizer for unvalidated URL redirect vulnerabilities.
@@ -84,11 +89,14 @@ module ClientSideUrlRedirect {
    * A sink which is used to set the window location.
    */
   class LocationSink extends Sink, DataFlow::ValueNode {
+    boolean xss;
+
     LocationSink() {
       // A call to a `window.navigate` or `window.open`
       exists(string name | name = ["navigate", "open", "openDialog", "showModalDialog"] |
         this = DataFlow::globalVarRef(name).getACall().getArgument(0)
-      )
+      ) and
+      xss = false
       or
       // A call to `location.replace` or `location.assign`
       exists(DataFlow::MethodCallNode locationCall, string name |
@@ -96,25 +104,31 @@ module ClientSideUrlRedirect {
         this = locationCall.getArgument(0)
       |
         name = ["replace", "assign"]
-      )
+      ) and
+      xss = true
       or
       // An assignment to `location`
-      exists(Assignment assgn | isLocation(assgn.getTarget()) and astNode = assgn.getRhs())
+      exists(Assignment assgn | isLocation(assgn.getTarget()) and astNode = assgn.getRhs()) and
+      xss = true
       or
       // An assignment to `location.href`, `location.protocol` or `location.hostname`
       exists(DataFlow::PropWrite pw, string propName |
         pw = DOM::locationRef().getAPropertyWrite(propName) and
         this = pw.getRhs()
       |
-        propName = ["href", "protocol", "hostname"]
+        propName = ["href", "protocol", "hostname"] and
+        (if propName = "href" then xss = true else xss = false)
       )
       or
       // A redirection using the AngularJS `$location` service
       exists(AngularJS::ServiceReference service |
         service.getName() = "$location" and
         this.asExpr() = service.getAMethodCall("url").getArgument(0)
-      )
+      ) and
+      xss = false
     }
+
+    override predicate isXSSSink() { xss = true }
   }
 
   /**
@@ -157,6 +171,8 @@ module ClientSideUrlRedirect {
       // e.g. node.setAttribute("href", sink)
       any(DomMethodCallExpr call).interpretsArgumentsAsURL(this.asExpr())
     }
+
+    override predicate isXSSSink() { any() }
   }
 
   /**
@@ -170,6 +186,8 @@ module ClientSideUrlRedirect {
         this = DataFlow::valueNode(pw.getRhs())
       )
     }
+
+    override predicate isXSSSink() { any() }
   }
 
   /**
@@ -186,6 +204,8 @@ module ClientSideUrlRedirect {
         this = attr.getValue().flow()
       )
     }
+
+    override predicate isXSSSink() { any() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -144,15 +144,20 @@ module ClientSideUrlRedirect {
   }
 
   /**
-   * A script or iframe `src` attribute, viewed as a `ScriptUrlSink`.
+   * A write to a `href` or similar attribute viewed as a `ScriptUrlSink`.
    */
-  class SrcAttributeUrlSink extends ScriptUrlSink, DataFlow::ValueNode {
-    SrcAttributeUrlSink() {
+  class AttributeUrlSink extends ScriptUrlSink {
+    AttributeUrlSink() {
+      // e.g. `$("<a>", {href: sink}).appendTo("body")`
       exists(DOM::AttributeDefinition attr |
-        attr.getElement().getName() = ["script", "iframe"] and
-        attr.getName() = "src" and
+        not attr instanceof JSXAttribute and // handled more precisely in `ReactAttributeWriteUrlSink`.
+        attr.getName() = DOM::getAPropertyNameInterpretedAsJavaScriptUrl()
+      |
         this = attr.getValueNode()
       )
+      or
+      // e.g. node.setAttribute("href", sink)
+      any(DomMethodCallExpr call).interpretsArgumentsAsURL(this.asExpr())
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -216,4 +216,15 @@ module ClientSideUrlRedirect {
       this = NextJS::nextRouter().getAMemberCall(["push", "replace"]).getArgument(0)
     }
   }
+
+  /**
+   * Improper use of openExternal can be leveraged to compromise the user's host.
+   * When openExternal is used with untrusted content, it can be leveraged to execute arbitrary commands.
+   */
+  class ElectronShellOpenExternalSink extends Sink {
+    ElectronShellOpenExternalSink() {
+      this =
+        DataFlow::moduleMember("electron", "shell").getAMemberCall("openExternal").getArgument(0)
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -120,24 +120,6 @@ module ClientSideUrlRedirect {
   }
 
   /**
-   * A call to `$("<a>", { href: sink })` or `$(...).attr("href", sink)`.
-   */
-  class JQueryHrefSink extends Sink {
-    JQueryHrefSink() {
-      exists(string prop | prop = DOM::getAPropertyNameInterpretedAsJavaScriptUrl() |
-        this = JQuery::dollarCall().getOptionArgument(1, prop)
-        or
-        exists(DataFlow::MethodCallNode call | call = JQuery::objectRef().getAMethodCall("attr") |
-          call.getArgument(0).mayHaveStringValue(prop) and
-          this = call.getArgument(1)
-          or
-          this = call.getOptionArgument(0, prop)
-        )
-      )
-    }
-  }
-
-  /**
    * An expression that may be interpreted as the URL of a script.
    */
   abstract class ScriptUrlSink extends Sink { }
@@ -199,6 +181,20 @@ module ClientSideUrlRedirect {
         DataFlow::moduleImport("next/link").flowsToExpr(attr.getElement().getNameExpr())
       |
         this = attr.getValue().flow()
+      )
+    }
+  }
+
+  /**
+   * A write to a HTML attribute which may execute JavaScript code.
+   */
+  class DOMAttributeWriteUrlSink extends Sink {
+    DOMAttributeWriteUrlSink() {
+      exists(DOM::AttributeDefinition attr |
+        not attr instanceof JSXAttribute and // handled more precisely in `ReactAttributeWriteUrlSink`
+        attr.getName() = DOM::getAPropertyNameInterpretedAsJavaScriptUrl()
+      |
+        this = attr.getValueNode()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -8,8 +8,6 @@ import javascript
 import semmle.javascript.security.dataflow.RemoteFlowSources
 
 module ClientSideUrlRedirect {
-  private import Xss::DomBasedXss as DomBasedXss
-
   /**
    * A data flow source for unvalidated URL redirect vulnerabilities.
    */
@@ -186,20 +184,6 @@ module ClientSideUrlRedirect {
         DataFlow::moduleImport("next/link").flowsToExpr(attr.getElement().getNameExpr())
       |
         this = attr.getValue().flow()
-      )
-    }
-  }
-
-  /**
-   * A write to a HTML attribute which may execute JavaScript code.
-   */
-  class DOMAttributeWriteUrlSink extends Sink {
-    DOMAttributeWriteUrlSink() {
-      exists(DOM::AttributeDefinition attr |
-        not attr instanceof JSXAttribute and // handled more precisely in `ReactAttributeWriteUrlSink`
-        attr.getName() = DOM::getAPropertyNameInterpretedAsJavaScriptUrl()
-      |
-        this = attr.getValueNode()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -120,6 +120,24 @@ module ClientSideUrlRedirect {
   }
 
   /**
+   * A call to `$("<a>", { href: sink })` or `$(...).attr("href", sink)`.
+   */
+  class JQueryHrefSink extends Sink {
+    JQueryHrefSink() {
+      exists(string prop | prop = DOM::getAPropertyNameInterpretedAsJavaScriptUrl() |
+        this = JQuery::dollarCall().getOptionArgument(1, prop)
+        or
+        exists(DataFlow::MethodCallNode call | call = JQuery::objectRef().getAMethodCall("attr") |
+          call.getArgument(0).mayHaveStringValue(prop) and
+          this = call.getArgument(1)
+          or
+          this = call.getOptionArgument(0, prop)
+        )
+      )
+    }
+  }
+
+  /**
    * An expression that may be interpreted as the URL of a script.
    */
   abstract class ScriptUrlSink extends Sink { }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectQuery.qll
@@ -55,13 +55,3 @@ class Configuration extends TaintTracking::Configuration {
     guard instanceof HostnameSanitizerGuard
   }
 }
-
-/**
- * Improper use of openExternal can be leveraged to compromise the user's host.
- * When openExternal is used with untrusted content, it can be leveraged to execute arbitrary commands.
- */
-class ElectronShellOpenExternalSink extends Sink {
-  ElectronShellOpenExternalSink() {
-    this = DataFlow::moduleMember("electron", "shell").getAMemberCall("openExternal").getArgument(0)
-  }
-}

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -84,6 +84,9 @@ class DomMethodCallExpr extends MethodCallExpr {
     )
   }
 
+  /**
+   * Holds if `arg` is an argument that is used as an URL.
+   */
   predicate interpretsArgumentsAsURL(Expr arg) {
     exists(int argPos, string name |
       arg = this.getArgument(argPos) and

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -81,7 +81,14 @@ class DomMethodCallExpr extends MethodCallExpr {
       name = "createElement" and argPos = 0
       or
       name = "appendChild" and argPos = 0
-      or
+    )
+  }
+
+  predicate interpretsArgumentsAsURL(Expr arg) {
+    exists(int argPos, string name |
+      arg = this.getArgument(argPos) and
+      name = this.getMethodName()
+    |
       (
         name = "setAttribute" and argPos = 1
         or
@@ -250,7 +257,7 @@ private class WindowLocationFlowSource extends ClientSideRemoteFlowSource {
   ClientSideRemoteFlowKind kind;
 
   WindowLocationFlowSource() {
-    this = DOM::locationSource() and kind.isUrl()
+    this = DOM::locationRef() and kind.isUrl()
     or
     // Add separate sources for the properties of window.location as they are excluded
     // from the default taint steps.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -12,4 +12,29 @@ module DomBasedXss {
   class RemoteFlowSourceAsSource extends Source {
     RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
   }
+
+  /**
+   * A flow-label representing tainted values where the prefix is attacker controlled.
+   */
+  class PrefixString extends DataFlow::FlowLabel {
+    PrefixString() { this = "PrefixString" }
+  }
+
+  /** Gets the flow-label representing tainted values where the prefix is attacker controlled. */
+  PrefixString prefixLabel() { any() }
+
+  /**
+   * A sanitizer that blocks the `PrefixString` label when the start of the string is being tested as being of a particular prefix.
+   */
+  class PrefixStringSanitizer extends SanitizerGuard instanceof StringOps::StartsWith {
+    override predicate sanitizes(boolean outcome, Expr e) { none() }
+
+    override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
+      super.blocks(outcome, e, label)
+      or
+      e = super.getBaseString().asExpr() and
+      label = prefixLabel() and
+      outcome = super.getPolarity()
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
@@ -8,64 +8,60 @@ private import semmle.javascript.security.TaintedUrlSuffix
 import DomBasedXssCustomizations::DomBasedXss
 
 /**
- * DEPRECATED. Use `HtmlInjectionConfiguration` or `JQueryHtmlOrSelectorInjectionConfiguration`.
- */
-deprecated class Configuration = HtmlInjectionConfiguration;
-
-/**
  * DEPRECATED. Use `Vue::VHtmlSourceWrite` instead.
  */
 deprecated class VHtmlSourceWrite = Vue::VHtmlSourceWrite;
 
+/** DEPRECATED. Use `Configuration`. */
+deprecated class HtmlInjectionConfiguration = Configuration;
+
+/** DEPRECATED. Use `Configuration`. */
+deprecated class JQueryHtmlOrSelectorInjectionConfiguration = Configuration;
+
 /**
- * A taint-tracking configuration for reasoning about XSS.
+ * A sink that is not a URL write or a JQuery selector,
+ * assumed to be a value that is interpreted as HTML.
  */
-class HtmlInjectionConfiguration extends TaintTracking::Configuration {
-  HtmlInjectionConfiguration() { this = "HtmlInjection" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
-
-  override predicate isSink(DataFlow::Node sink) {
-    sink instanceof Sink and
-    not sink instanceof JQueryHtmlOrSelectorSink // Handled by JQueryHtmlOrSelectorInjectionConfiguration below
-  }
-
-  override predicate isSanitizer(DataFlow::Node node) {
-    super.isSanitizer(node)
-    or
-    node instanceof Sanitizer
-  }
-
-  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
-    guard instanceof SanitizerGuard
-  }
-
-  override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ) {
-    isOptionallySanitizedEdge(pred, succ)
+class HTMLSink extends DataFlow::Node instanceof Sink {
+  HTMLSink() {
+    not this instanceof WriteURLSink and
+    not this instanceof JQueryHtmlOrSelectorSink
   }
 }
 
 /**
- * A taint-tracking configuration for reasoning about injection into the jQuery `$` function
- * or similar, where the interpretation of the input string depends on its first character.
+ * A taint-tracking configuration for reasoning about XSS.
+ * Both ordinary HTML sinks, URL sinks, and JQuery selector based sinks.
+ * - HTML sinks are sinks for any tainted value
+ * - URL sinks are only sinks when the scheme is user controlled
+ * - JQuery selector sinks are sinks when the tainted value can start with `<`.
  *
- * Values are only considered tainted if they can start with the `<` character.
+ * The above is achieved using three flow labels:
+ * - TaintedUrlSuffix: a URL where the attacker only controls a suffix.
+ * - Taint: a tainted value where the attacker controls part of the value.
+ * - PrefixLabel: a tainted value where the attacker controls the prefix
  */
-class JQueryHtmlOrSelectorInjectionConfiguration extends TaintTracking::Configuration {
-  JQueryHtmlOrSelectorInjectionConfiguration() { this = "JQueryHtmlOrSelectorInjection" }
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "HtmlInjection" }
 
   override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel label) {
-    // Reuse any source not derived from location
     source instanceof Source and
-    not source = [DOM::locationRef(), DOM::locationRef().getAPropertyRead()] and
-    label.isTaint()
+    (label.isTaint() or label = prefixLabel()) and
+    not source = TaintedUrlSuffix::source()
     or
-    source = [DOM::locationSource(), DOM::locationRef().getAPropertyRead(["hash", "search"])] and
+    source = TaintedUrlSuffix::source() and
     label = TaintedUrlSuffix::label()
   }
 
   override predicate isSink(DataFlow::Node sink, DataFlow::FlowLabel label) {
-    sink instanceof JQueryHtmlOrSelectorSink and label.isTaint()
+    sink instanceof HTMLSink and
+    label = [TaintedUrlSuffix::label(), prefixLabel(), DataFlow::FlowLabel::taint()]
+    or
+    sink instanceof JQueryHtmlOrSelectorSink and
+    label = [DataFlow::FlowLabel::taint(), prefixLabel()]
+    or
+    sink instanceof WriteURLSink and
+    label = prefixLabel()
   }
 
   override predicate isSanitizer(DataFlow::Node node) {
@@ -76,6 +72,32 @@ class JQueryHtmlOrSelectorInjectionConfiguration extends TaintTracking::Configur
 
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
     guard instanceof SanitizerGuard
+  }
+
+  override predicate isLabeledBarrier(DataFlow::Node node, DataFlow::FlowLabel lbl) {
+    super.isLabeledBarrier(node, lbl)
+    or
+    // copy all taint barriers to the TaintedUrlSuffix/PrefixLabel label. This copies both the ordinary sanitizers and the sanitizer-guards.
+    super.isLabeledBarrier(node, DataFlow::FlowLabel::taint()) and
+    lbl = [TaintedUrlSuffix::label(), prefixLabel()]
+    or
+    // any non-first string-concatenation leaf is a barrier for the prefix label.
+    exists(StringOps::ConcatenationRoot root |
+      node = root.getALeaf() and
+      not node = root.getFirstLeaf() and
+      lbl = prefixLabel()
+    )
+    or
+    // we assume that `.join()` calls have a prefix, and thus block the prefix label.
+    node = any(DataFlow::MethodCallNode call | call.getMethodName() = "join") and
+    lbl = prefixLabel()
+  }
+
+  override predicate isSanitizerEdge(
+    DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel label
+  ) {
+    isOptionallySanitizedEdge(pred, succ) and
+    label = [DataFlow::FlowLabel::taint(), prefixLabel(), TaintedUrlSuffix::label()]
   }
 
   override predicate isAdditionalFlowStep(
@@ -89,5 +111,15 @@ class JQueryHtmlOrSelectorInjectionConfiguration extends TaintTracking::Configur
       inlbl = TaintedUrlSuffix::label() and
       outlbl.isTaint()
     )
+    or
+    // inherit all ordinary taint steps for prefixLabel
+    inlbl = prefixLabel() and
+    outlbl = prefixLabel() and
+    TaintTracking::sharedTaintStep(src, trg)
+    or
+    // steps out of taintedSuffixlabel to taint-label, are also a steps to prefixLabel.
+    TaintedUrlSuffix::step(src, trg, TaintedUrlSuffix::label(), DataFlow::FlowLabel::taint()) and
+    inlbl = TaintedUrlSuffix::label() and
+    outlbl = prefixLabel()
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -250,6 +250,13 @@ module DomBasedXss {
     }
   }
 
+  import ClientSideUrlRedirectCustomizations::ClientSideUrlRedirect as ClientSideUrlRedirect
+
+  /**
+   * A write to a URL which may execute JavaScript code.
+   */
+  class WriteURLSink extends Sink instanceof ClientSideUrlRedirect::Sink { }
+
   /**
    * An expression whose value is interpreted as HTML or CSS
    * and may be inserted into the DOM.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -255,7 +255,9 @@ module DomBasedXss {
   /**
    * A write to a URL which may execute JavaScript code.
    */
-  class WriteURLSink extends Sink instanceof ClientSideUrlRedirect::Sink { }
+  class WriteURLSink extends Sink instanceof ClientSideUrlRedirect::Sink {
+    WriteURLSink() { super.isXSSSink() }
+  }
 
   /**
    * An expression whose value is interpreted as HTML or CSS

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -351,7 +351,7 @@ module DomBasedXss {
   /**
    * A write to the `template` option of a Vue instance, viewed as an XSS sink.
    */
-  class VueTemplateSink extends DomBasedXss::Sink {
+  class VueTemplateSink extends Sink {
     VueTemplateSink() {
       // Note: don't use Vue::Component#getTemplate as it includes an unwanted getALocalSource() step
       this = any(Vue::Component c).getOption("template")
@@ -362,7 +362,7 @@ module DomBasedXss {
    * The tag name argument to the `createElement` parameter of the
    * `render` method of a Vue instance, viewed as an XSS sink.
    */
-  class VueCreateElementSink extends DomBasedXss::Sink {
+  class VueCreateElementSink extends Sink {
     VueCreateElementSink() {
       exists(Vue::Component c, DataFlow::FunctionNode f |
         f.flowsTo(c.getRender()) and
@@ -374,12 +374,12 @@ module DomBasedXss {
   /**
    * A Vue `v-html` attribute, viewed as an XSS sink.
    */
-  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink { }
+  class VHtmlSink extends Vue::VHtmlAttribute, Sink { }
 
   /**
    * A raw interpolation tag in a template file, viewed as an XSS sink.
    */
-  class TemplateSink extends DomBasedXss::Sink {
+  class TemplateSink extends Sink {
     TemplateSink() {
       exists(Templating::TemplatePlaceholderTag tag |
         tag.isRawInterpolation() and
@@ -392,7 +392,7 @@ module DomBasedXss {
    * A value being piped into the `safe` pipe in a template file,
    * disabling subsequent HTML escaping.
    */
-  class SafePipe extends DomBasedXss::Sink {
+  class SafePipe extends Sink {
     SafePipe() { this = Templating::getAPipeCall("safe").getArgument(0) }
   }
 

--- a/javascript/ql/src/Security/CWE-079/Xss.ql
+++ b/javascript/ql/src/Security/CWE-079/Xss.ql
@@ -17,12 +17,7 @@ import semmle.javascript.security.dataflow.DomBasedXssQuery
 import DataFlow::PathGraph
 
 from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where
-  (
-    cfg instanceof HtmlInjectionConfiguration or
-    cfg instanceof JQueryHtmlOrSelectorInjectionConfiguration
-  ) and
-  cfg.hasFlowPath(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink,
   sink.getNode().(Sink).getVulnerabilityKind() + " vulnerability due to $@.", source.getNode(),
   "user-provided value"

--- a/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
@@ -1,166 +1,274 @@
 nodes
 | app.js:8:18:8:34 | req.query.rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml |
+| app.js:11:26:11:46 | req.que ... tmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp |
 | app.js:14:33:14:64 | req.que ... eralRaw |
 | app.js:14:33:14:64 | req.que ... eralRaw |
+| app.js:14:33:14:64 | req.que ... eralRaw |
+| app.js:16:33:16:64 | req.que ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw |
+| app.js:20:38:20:74 | req.que ... ringRaw |
+| app.js:27:18:27:34 | req.query.rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml |
 | app.js:30:26:30:46 | req.que ... tmlProp |
 | app.js:30:26:30:46 | req.que ... tmlProp |
+| app.js:30:26:30:46 | req.que ... tmlProp |
+| app.js:33:33:33:64 | req.que ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw |
 | app.js:46:18:46:34 | req.query.rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml |
+| app.js:49:26:49:46 | req.que ... tmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp |
 | app.js:52:33:52:64 | req.que ... eralRaw |
 | app.js:52:33:52:64 | req.que ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw |
+| app.js:55:37:55:72 | req.que ... JsonRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:66:18:66:34 | req.query.rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml |
+| projectA/src/index.js:7:16:7:30 | req.query.sinkA |
 | projectA/src/index.js:7:16:7:30 | req.query.sinkA |
 | projectA/src/index.js:7:16:7:30 | req.query.sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
+| projectA/src/index.js:12:16:12:30 | req.query.sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:32:16:32:30 | req.query.sinkA |
 | projectA/src/index.js:32:16:32:30 | req.query.sinkA |
+| projectA/src/index.js:32:16:32:30 | req.query.sinkA |
+| projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA |
+| projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectB/src/index.js:8:16:8:30 | req.query.sinkB |
 | projectB/src/index.js:8:16:8:30 | req.query.sinkB |
 | projectB/src/index.js:8:16:8:30 | req.query.sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
+| projectB/src/index.js:13:16:13:30 | req.query.sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:33:16:33:30 | req.query.sinkB |
 | projectB/src/index.js:33:16:33:30 | req.query.sinkB |
+| projectB/src/index.js:33:16:33:30 | req.query.sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB |
+| projectB/src/index.js:38:16:38:30 | req.query.sinkB |
+| projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
+| views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
+| views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
+| views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
+| views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
 | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
 | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
 | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
 | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
 | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
 | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
 | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
 | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
 | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
 | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
 | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
 | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
 | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
 | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
 | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
+| views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
+| views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 edges
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
+| app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
+| app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
 | app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
 | app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
+| app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
 | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
 | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
+| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
+| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
+| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
+| app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
+| app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
@@ -169,85 +277,167 @@ edges
 | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
 | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
 | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
+| projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
+| views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
+| views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
+| views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
+| views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
+| views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
+| views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
+| views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
+| views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
+| views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
+| views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
+| views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
+| views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
+| views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
+| views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:24:44:24:50 | rawHtml | views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/ejs_sinks.ejs:24:44:24:50 | rawHtml | views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/hbs_sinks.hbs:4:13:4:19 | rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:4:13:4:19 | rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:4:13:4:19 | rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:4:13:4:19 | rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
 | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
 | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
 | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
 | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
+| views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 #select

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -1,18 +1,28 @@
 nodes
 | addEventListener.js:1:43:1:47 | event |
 | addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | {data} |
 | addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
@@ -20,6 +30,8 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
@@ -32,32 +44,41 @@ nodes
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
@@ -92,124 +113,194 @@ nodes
 | classnames.js:15:52:15:62 | window.name |
 | classnames.js:15:52:15:62 | window.name |
 | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | d3.js:4:12:4:22 | window.name |
 | d3.js:4:12:4:22 | window.name |
+| d3.js:4:12:4:22 | window.name |
+| d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
+| d3.js:12:20:12:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
+| d3.js:14:20:14:29 | getTaint() |
+| d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint |
+| dates.js:9:9:9:69 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:63:11:67 | taint |
 | dates.js:11:63:11:67 | taint |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:66:12:70 | taint |
 | dates.js:12:66:12:70 | taint |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:59:13:63 | taint |
 | dates.js:13:59:13:63 | taint |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:62:16:66 | taint |
 | dates.js:16:62:16:66 | taint |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:59:18:63 | taint |
 | dates.js:18:59:18:63 | taint |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint |
+| dates.js:21:61:21:65 | taint |
 | dates.js:30:9:30:69 | taint |
+| dates.js:30:9:30:69 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:77:37:81 | taint |
 | dates.js:37:77:37:81 | taint |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:77:38:81 | taint |
 | dates.js:38:77:38:81 | taint |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:79:39:83 | taint |
 | dates.js:39:79:39:83 | taint |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint |
+| dates.js:40:77:40:81 | taint |
 | dates.js:46:9:46:69 | taint |
+| dates.js:46:9:46:69 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:83:48:87 | taint |
 | dates.js:48:83:48:87 | taint |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:82:49:86 | taint |
 | dates.js:49:82:49:86 | taint |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint |
+| dates.js:50:97:50:101 | taint |
 | dates.js:54:9:54:69 | taint |
+| dates.js:54:9:54:69 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:94:57:98 | taint |
 | dates.js:57:94:57:98 | taint |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:80:59:84 | taint |
 | dates.js:59:80:59:84 | taint |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
+| express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search |
-| jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -242,31 +333,43 @@ nodes
 | jquery.js:21:5:21:8 | hash |
 | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:22:5:22:8 | hash |
+| jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash |
 | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:24:5:24:8 | hash |
+| jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:28:5:28:26 | window. ... .search |
 | jquery.js:28:5:28:26 | window. ... .search |
+| jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash |
 | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:9:55:9:61 | decoded |
 | jwt-server.js:9:55:9:61 | decoded |
 | jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:29 | decoded.foo |
 | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -313,43 +416,67 @@ nodes
 | optionalSanitizer.js:45:41:45:46 | target |
 | optionalSanitizer.js:45:51:45:56 | target |
 | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:8:18:8:24 | tainted |
 | react-native.js:8:18:8:24 | tainted |
+| react-native.js:8:18:8:24 | tainted |
 | react-native.js:9:27:9:33 | tainted |
 | react-native.js:9:27:9:33 | tainted |
+| react-native.js:9:27:9:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name |
 | react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name |
 | react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name |
 | react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -368,6 +495,8 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search |
@@ -380,6 +509,7 @@ nodes
 | stored-xss.js:8:20:8:48 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') |
+| stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href |
@@ -414,17 +544,28 @@ nodes
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
+| translate.js:7:7:7:61 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:47 | target |
 | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:9:27:9:38 | searchParams |
+| translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
@@ -448,27 +589,38 @@ nodes
 | tst3.js:10:38:10:43 | data.p |
 | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
-| tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search |
-| tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:5:18:5:23 | target |
 | tst.js:5:18:5:23 | target |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target |
+| tst.js:17:7:17:56 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location |
 | tst.js:17:25:17:41 | document.location |
+| tst.js:18:18:18:23 | params |
 | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:47 | target |
 | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:21:18:21:29 | searchParams |
+| tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target |
@@ -486,18 +638,25 @@ nodes
 | tst.js:40:20:40:43 | documen ... .search |
 | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search |
 | tst.js:46:21:46:44 | documen ... .search |
+| tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() |
 | tst.js:60:34:60:34 | s |
@@ -540,11 +699,19 @@ nodes
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:110:18:110:18 | v |
 | tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:136:18:136:18 | v |
+| tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:148:29:148:50 | window. ... .search |
@@ -614,9 +781,12 @@ nodes
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
+| tst.js:259:7:259:17 | window.name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
+| tst.js:260:7:260:10 | name |
+| tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
@@ -624,8 +794,11 @@ nodes
 | tst.js:280:22:280:29 | location |
 | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted |
+| tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name |
 | tst.js:285:19:285:29 | window.name |
+| tst.js:285:19:285:29 | window.name |
+| tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:301:9:301:16 | location |
@@ -643,11 +816,17 @@ nodes
 | tst.js:316:35:316:42 | location |
 | tst.js:327:18:327:34 | document.location |
 | tst.js:327:18:327:34 | document.location |
+| tst.js:331:7:331:43 | params |
+| tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:332:18:332:23 | params |
+| tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target |
@@ -692,9 +871,15 @@ nodes
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:417:18:417:24 | payload |
+| tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:419:7:419:55 | match |
@@ -707,6 +892,10 @@ nodes
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target |
@@ -747,6 +936,20 @@ nodes
 | tst.js:465:19:465:24 | source |
 | tst.js:467:20:467:25 | source |
 | tst.js:467:20:467:25 | source |
+| tst.js:471:7:471:46 | url |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:473:19:473:21 | url |
+| tst.js:473:19:473:21 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:486:22:486:24 | url |
+| tst.js:486:22:486:24 | url |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:45 | documen ... .search |
@@ -800,28 +1003,52 @@ nodes
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:3:43:3:49 | tainted |
 | winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 edges
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
+| addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
@@ -839,7 +1066,13 @@ edges
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
@@ -873,6 +1106,10 @@ edges
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
@@ -882,6 +1119,12 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
@@ -890,90 +1133,178 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -981,8 +1312,6 @@ edges
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:7:20:7:26 | tainted | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -1015,14 +1344,21 @@ edges
 | jquery.js:18:14:18:33 | window.location.hash | jquery.js:18:7:18:33 | hash |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
@@ -1030,10 +1366,17 @@ edges
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
 | jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -1085,30 +1428,56 @@ edges
 | optionalSanitizer.js:45:51:45:56 | target | optionalSanitizer.js:45:18:45:56 | sanitiz ...  target |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
+| react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:23:29:23:35 | tainted |
@@ -1117,6 +1486,9 @@ edges
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -1129,6 +1501,8 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -1143,6 +1517,7 @@ edges
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href | stored-xss.js:12:35:12:38 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') | stored-xss.js:10:9:10:44 | href |
+| stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location |
@@ -1173,16 +1548,34 @@ edges
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
+| translate.js:7:7:7:61 | searchParams | translate.js:9:27:9:38 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) | translate.js:7:7:7:61 | searchParams |
 | translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
@@ -1208,21 +1601,43 @@ edges
 | tst.js:2:7:2:39 | target | tst.js:20:42:20:47 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
+| tst.js:17:7:17:56 | params | tst.js:18:18:18:23 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams | tst.js:17:7:17:56 | params |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams | tst.js:21:18:21:29 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) | tst.js:20:7:20:61 | searchParams |
 | tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
@@ -1245,16 +1660,30 @@ edges
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
@@ -1279,10 +1708,24 @@ edges
 | tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
@@ -1350,6 +1793,10 @@ edges
 | tst.js:280:22:280:29 | location | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:301:9:301:16 | location | tst.js:302:10:302:10 | e |
@@ -1361,12 +1808,20 @@ edges
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:316:35:316:42 | location | tst.js:316:35:316:42 | location |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:331:7:331:43 | params | tst.js:332:18:332:23 | params |
+| tst.js:331:16:331:43 | getTain ... hParams | tst.js:331:7:331:43 | params |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
@@ -1409,8 +1864,18 @@ edges
 | tst.js:408:19:408:31 | target.taint8 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:419:7:419:55 | match | tst.js:421:20:421:24 | match |
 | tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
@@ -1420,6 +1885,14 @@ edges
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
@@ -1456,6 +1929,19 @@ edges
 | tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
@@ -1506,10 +1992,24 @@ edges
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 #select
 | addEventListener.js:2:20:2:29 | event.data | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
@@ -1699,6 +2199,11 @@ edges
 | tst.js:463:21:463:26 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:463:21:463:26 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
 | tst.js:465:19:465:24 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:465:19:465:24 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
 | tst.js:467:20:467:25 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:467:20:467:25 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
+| tst.js:473:19:473:21 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:473:19:473:21 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:474:26:474:28 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:474:26:474:28 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:475:25:475:27 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:475:25:475:27 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:476:20:476:22 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:476:20:476:22 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:486:22:486:24 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:486:22:486:24 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:45 | documen ... .search | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -1,18 +1,28 @@
 nodes
 | addEventListener.js:1:43:1:47 | event |
 | addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | {data} |
 | addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
@@ -20,6 +30,8 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
@@ -32,32 +44,41 @@ nodes
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
@@ -92,124 +113,194 @@ nodes
 | classnames.js:15:52:15:62 | window.name |
 | classnames.js:15:52:15:62 | window.name |
 | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | d3.js:4:12:4:22 | window.name |
 | d3.js:4:12:4:22 | window.name |
+| d3.js:4:12:4:22 | window.name |
+| d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
+| d3.js:12:20:12:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
+| d3.js:14:20:14:29 | getTaint() |
+| d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint |
+| dates.js:9:9:9:69 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:63:11:67 | taint |
 | dates.js:11:63:11:67 | taint |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:66:12:70 | taint |
 | dates.js:12:66:12:70 | taint |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:59:13:63 | taint |
 | dates.js:13:59:13:63 | taint |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:62:16:66 | taint |
 | dates.js:16:62:16:66 | taint |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:59:18:63 | taint |
 | dates.js:18:59:18:63 | taint |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint |
+| dates.js:21:61:21:65 | taint |
 | dates.js:30:9:30:69 | taint |
+| dates.js:30:9:30:69 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:77:37:81 | taint |
 | dates.js:37:77:37:81 | taint |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:77:38:81 | taint |
 | dates.js:38:77:38:81 | taint |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:79:39:83 | taint |
 | dates.js:39:79:39:83 | taint |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint |
+| dates.js:40:77:40:81 | taint |
 | dates.js:46:9:46:69 | taint |
+| dates.js:46:9:46:69 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:83:48:87 | taint |
 | dates.js:48:83:48:87 | taint |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:82:49:86 | taint |
 | dates.js:49:82:49:86 | taint |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint |
+| dates.js:50:97:50:101 | taint |
 | dates.js:54:9:54:69 | taint |
+| dates.js:54:9:54:69 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:94:57:98 | taint |
 | dates.js:57:94:57:98 | taint |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:80:59:84 | taint |
 | dates.js:59:80:59:84 | taint |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
+| express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search |
-| jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -242,38 +333,55 @@ nodes
 | jquery.js:21:5:21:8 | hash |
 | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:22:5:22:8 | hash |
+| jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash |
 | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:24:5:24:8 | hash |
+| jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:28:5:28:26 | window. ... .search |
 | jquery.js:28:5:28:26 | window. ... .search |
+| jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash |
 | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:9:16:9:20 | taint |
 | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt.js:4:36:4:39 | data |
 | jwt.js:4:36:4:39 | data |
 | jwt.js:4:36:4:39 | data |
 | jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:19:5:34 | jwt_decode(data) |
 | jwt.js:5:19:5:34 | jwt_decode(data) |
 | jwt.js:5:30:5:33 | data |
+| jwt.js:5:30:5:33 | data |
+| jwt.js:6:14:6:20 | decoded |
 | jwt.js:6:14:6:20 | decoded |
 | jwt.js:6:14:6:20 | decoded |
 | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -320,43 +428,67 @@ nodes
 | optionalSanitizer.js:45:41:45:46 | target |
 | optionalSanitizer.js:45:51:45:56 | target |
 | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:8:18:8:24 | tainted |
 | react-native.js:8:18:8:24 | tainted |
+| react-native.js:8:18:8:24 | tainted |
 | react-native.js:9:27:9:33 | tainted |
 | react-native.js:9:27:9:33 | tainted |
+| react-native.js:9:27:9:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name |
 | react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name |
 | react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name |
 | react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -375,6 +507,8 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search |
@@ -387,6 +521,7 @@ nodes
 | stored-xss.js:8:20:8:48 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') |
+| stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href |
@@ -421,17 +556,28 @@ nodes
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
+| translate.js:7:7:7:61 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:47 | target |
 | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:9:27:9:38 | searchParams |
+| translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
@@ -455,27 +601,38 @@ nodes
 | tst3.js:10:38:10:43 | data.p |
 | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
-| tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search |
-| tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:5:18:5:23 | target |
 | tst.js:5:18:5:23 | target |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target |
+| tst.js:17:7:17:56 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location |
 | tst.js:17:25:17:41 | document.location |
+| tst.js:18:18:18:23 | params |
 | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:47 | target |
 | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:21:18:21:29 | searchParams |
+| tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target |
@@ -493,18 +650,25 @@ nodes
 | tst.js:40:20:40:43 | documen ... .search |
 | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search |
 | tst.js:46:21:46:44 | documen ... .search |
+| tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() |
 | tst.js:60:34:60:34 | s |
@@ -547,11 +711,19 @@ nodes
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:110:18:110:18 | v |
 | tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:136:18:136:18 | v |
+| tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:148:29:148:50 | window. ... .search |
@@ -621,9 +793,12 @@ nodes
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
+| tst.js:259:7:259:17 | window.name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
+| tst.js:260:7:260:10 | name |
+| tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
@@ -631,8 +806,11 @@ nodes
 | tst.js:280:22:280:29 | location |
 | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted |
+| tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name |
 | tst.js:285:19:285:29 | window.name |
+| tst.js:285:19:285:29 | window.name |
+| tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:301:9:301:16 | location |
@@ -650,11 +828,17 @@ nodes
 | tst.js:316:35:316:42 | location |
 | tst.js:327:18:327:34 | document.location |
 | tst.js:327:18:327:34 | document.location |
+| tst.js:331:7:331:43 | params |
+| tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:332:18:332:23 | params |
+| tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target |
@@ -699,9 +883,15 @@ nodes
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:417:18:417:24 | payload |
+| tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:419:7:419:55 | match |
@@ -714,6 +904,10 @@ nodes
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target |
@@ -754,8 +948,24 @@ nodes
 | tst.js:465:19:465:24 | source |
 | tst.js:467:20:467:25 | source |
 | tst.js:467:20:467:25 | source |
+| tst.js:471:7:471:46 | url |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:473:19:473:21 | url |
+| tst.js:473:19:473:21 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:486:22:486:24 | url |
+| tst.js:486:22:486:24 | url |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
+| typeahead.js:9:28:9:30 | loc |
+| typeahead.js:10:16:10:18 | loc |
 | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:20:13:20:45 | target |
@@ -811,46 +1021,84 @@ nodes
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:3:43:3:49 | tainted |
 | winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 | xmlRequest.js:8:13:8:47 | json |
+| xmlRequest.js:8:13:8:47 | json |
+| xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
 | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
 | xmlRequest.js:8:31:8:46 | xhr.responseText |
 | xmlRequest.js:8:31:8:46 | xhr.responseText |
+| xmlRequest.js:8:31:8:46 | xhr.responseText |
+| xmlRequest.js:9:28:9:31 | json |
 | xmlRequest.js:9:28:9:31 | json |
 | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:9:28:9:39 | json.message |
+| xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:20:11:20:48 | resp |
+| xmlRequest.js:20:11:20:48 | resp |
+| xmlRequest.js:20:18:20:48 | await g ... rl }}") |
 | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") |
+| xmlRequest.js:20:24:20:48 | got.get ... rl }}") |
+| xmlRequest.js:21:11:21:38 | json |
 | xmlRequest.js:21:11:21:38 | json |
 | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:21:29:21:32 | resp |
 | xmlRequest.js:21:29:21:32 | resp |
 | xmlRequest.js:21:29:21:37 | resp.body |
+| xmlRequest.js:21:29:21:37 | resp.body |
 | xmlRequest.js:22:24:22:27 | json |
+| xmlRequest.js:22:24:22:27 | json |
+| xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:35 | json.message |
 edges
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
+| addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
@@ -868,7 +1116,13 @@ edges
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
@@ -902,6 +1156,10 @@ edges
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
@@ -911,6 +1169,12 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
@@ -919,90 +1183,178 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1010,8 +1362,6 @@ edges
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:7:20:7:26 | tainted | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -1044,14 +1394,21 @@ edges
 | jquery.js:18:14:18:33 | window.location.hash | jquery.js:18:7:18:33 | hash |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
@@ -1059,17 +1416,30 @@ edges
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
 | jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
+| jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
+| jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
+| jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
+| jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
 | jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
 | jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
 | jwt.js:5:19:5:34 | jwt_decode(data) | jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:19:5:34 | jwt_decode(data) | jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:30:5:33 | data | jwt.js:5:19:5:34 | jwt_decode(data) |
 | jwt.js:5:30:5:33 | data | jwt.js:5:19:5:34 | jwt_decode(data) |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -1120,30 +1490,56 @@ edges
 | optionalSanitizer.js:45:51:45:56 | target | optionalSanitizer.js:45:18:45:56 | sanitiz ...  target |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
+| react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:23:29:23:35 | tainted |
@@ -1152,6 +1548,9 @@ edges
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -1164,6 +1563,8 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -1178,6 +1579,7 @@ edges
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href | stored-xss.js:12:35:12:38 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') | stored-xss.js:10:9:10:44 | href |
+| stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location |
@@ -1208,16 +1610,34 @@ edges
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
+| translate.js:7:7:7:61 | searchParams | translate.js:9:27:9:38 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) | translate.js:7:7:7:61 | searchParams |
 | translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
@@ -1243,21 +1663,43 @@ edges
 | tst.js:2:7:2:39 | target | tst.js:20:42:20:47 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
+| tst.js:17:7:17:56 | params | tst.js:18:18:18:23 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams | tst.js:17:7:17:56 | params |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams | tst.js:21:18:21:29 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) | tst.js:20:7:20:61 | searchParams |
 | tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
@@ -1280,16 +1722,30 @@ edges
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
@@ -1314,10 +1770,24 @@ edges
 | tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
@@ -1385,6 +1855,10 @@ edges
 | tst.js:280:22:280:29 | location | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:301:9:301:16 | location | tst.js:302:10:302:10 | e |
@@ -1396,12 +1870,20 @@ edges
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:316:35:316:42 | location | tst.js:316:35:316:42 | location |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:331:7:331:43 | params | tst.js:332:18:332:23 | params |
+| tst.js:331:16:331:43 | getTain ... hParams | tst.js:331:7:331:43 | params |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
@@ -1444,8 +1926,18 @@ edges
 | tst.js:408:19:408:31 | target.taint8 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:419:7:419:55 | match | tst.js:421:20:421:24 | match |
 | tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
@@ -1455,6 +1947,14 @@ edges
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
@@ -1491,6 +1991,22 @@ edges
 | tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
+| typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
+| typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
+| typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
@@ -1545,25 +2061,55 @@ edges
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 | xmlRequest.js:8:13:8:47 | json | xmlRequest.js:9:28:9:31 | json |
+| xmlRequest.js:8:13:8:47 | json | xmlRequest.js:9:28:9:31 | json |
+| xmlRequest.js:8:20:8:47 | JSON.pa ... seText) | xmlRequest.js:8:13:8:47 | json |
 | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) | xmlRequest.js:8:13:8:47 | json |
 | xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
 | xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
+| xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
+| xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
+| xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
+| xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:20:11:20:48 | resp | xmlRequest.js:21:29:21:32 | resp |
+| xmlRequest.js:20:11:20:48 | resp | xmlRequest.js:21:29:21:32 | resp |
+| xmlRequest.js:20:18:20:48 | await g ... rl }}") | xmlRequest.js:20:11:20:48 | resp |
 | xmlRequest.js:20:18:20:48 | await g ... rl }}") | xmlRequest.js:20:11:20:48 | resp |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
+| xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
+| xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
+| xmlRequest.js:21:11:21:38 | json | xmlRequest.js:22:24:22:27 | json |
 | xmlRequest.js:21:11:21:38 | json | xmlRequest.js:22:24:22:27 | json |
 | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) | xmlRequest.js:21:11:21:38 | json |
+| xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) | xmlRequest.js:21:11:21:38 | json |
+| xmlRequest.js:21:29:21:32 | resp | xmlRequest.js:21:29:21:37 | resp.body |
 | xmlRequest.js:21:29:21:32 | resp | xmlRequest.js:21:29:21:37 | resp.body |
 | xmlRequest.js:21:29:21:37 | resp.body | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:21:29:21:37 | resp.body | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
+| xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
 #select

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -466,3 +466,23 @@ function domMethods() {
   let cell = row.insertCell();
   cell.innerHTML = source; // NOT OK
 }
+
+function urlStuff() {
+  var url = document.location.search.substr(1);
+
+  $("<a>", {href: url}).appendTo("body"); // NOT OK
+  $("#foo").attr("href", url); // NOT OK
+  $("#foo").attr({href: url}); // NOT OK
+  $("<img>", {src: url}).appendTo("body"); // NOT OK
+  $("<a>", {href: win.location.href}).appendTo("body"); // OK
+
+  $("<img>", {src: "http://google.com/" + url}).appendTo("body"); // OK
+
+  $("<img>", {src: ["http://google.com", url].join("/")}).appendTo("body"); // OK
+
+  if (url.startsWith("https://")) {
+    $("<img>", {src: url}).appendTo("body"); // OK
+  } else {
+    $("<img>", {src: url}).appendTo("body"); // NOT OK
+  }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -485,4 +485,6 @@ function urlStuff() {
   } else {
     $("<img>", {src: url}).appendTo("body"); // NOT OK
   }
+
+  window.open(location.hash.substr(1)); // OK - any JavaScript is executed in another context
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/ExceptionXss/ExceptionXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ExceptionXss/ExceptionXss.expected
@@ -8,13 +8,19 @@ nodes
 | exception-xss.js:2:6:2:28 | foo |
 | exception-xss.js:2:12:2:28 | document.location |
 | exception-xss.js:2:12:2:28 | document.location |
+| exception-xss.js:4:17:4:17 | x |
+| exception-xss.js:4:17:4:17 | x |
+| exception-xss.js:5:11:5:11 | x |
 | exception-xss.js:9:11:9:13 | foo |
 | exception-xss.js:10:11:10:11 | e |
 | exception-xss.js:11:18:11:18 | e |
 | exception-xss.js:11:18:11:18 | e |
 | exception-xss.js:15:3:15:12 | exceptional return of inner(foo) |
+| exception-xss.js:15:3:15:12 | exceptional return of inner(foo) |
 | exception-xss.js:15:9:15:11 | foo |
 | exception-xss.js:16:11:16:11 | e |
+| exception-xss.js:16:11:16:11 | e |
+| exception-xss.js:17:18:17:18 | e |
 | exception-xss.js:17:18:17:18 | e |
 | exception-xss.js:17:18:17:18 | e |
 | exception-xss.js:21:11:21:13 | foo |
@@ -27,15 +33,28 @@ nodes
 | exception-xss.js:34:11:34:11 | e |
 | exception-xss.js:35:18:35:18 | e |
 | exception-xss.js:35:18:35:18 | e |
+| exception-xss.js:39:3:39:10 | exceptional return of deep2(x) |
+| exception-xss.js:42:3:42:10 | exceptional return of inner(x) |
+| exception-xss.js:46:3:46:19 | exceptional return of deep("bar" + foo) |
 | exception-xss.js:46:3:46:19 | exceptional return of deep("bar" + foo) |
 | exception-xss.js:46:8:46:18 | "bar" + foo |
 | exception-xss.js:46:16:46:18 | foo |
 | exception-xss.js:47:11:47:11 | e |
+| exception-xss.js:47:11:47:11 | e |
 | exception-xss.js:48:18:48:18 | e |
 | exception-xss.js:48:18:48:18 | e |
+| exception-xss.js:48:18:48:18 | e |
+| exception-xss.js:74:28:74:28 | x |
+| exception-xss.js:74:28:74:28 | x |
+| exception-xss.js:75:4:75:11 | exceptional return of inner(x) |
+| exception-xss.js:75:4:75:11 | exceptional return of inner(x) |
+| exception-xss.js:75:10:75:10 | x |
+| exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) |
 | exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) |
 | exception-xss.js:81:16:81:18 | foo |
 | exception-xss.js:82:11:82:11 | e |
+| exception-xss.js:82:11:82:11 | e |
+| exception-xss.js:83:18:83:18 | e |
 | exception-xss.js:83:18:83:18 | e |
 | exception-xss.js:83:18:83:18 | e |
 | exception-xss.js:89:11:89:13 | foo |
@@ -104,11 +123,19 @@ edges
 | exception-xss.js:2:6:2:28 | foo | exception-xss.js:102:12:102:14 | foo |
 | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:2:6:2:28 | foo |
 | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:2:6:2:28 | foo |
+| exception-xss.js:4:17:4:17 | x | exception-xss.js:5:11:5:11 | x |
+| exception-xss.js:4:17:4:17 | x | exception-xss.js:5:11:5:11 | x |
+| exception-xss.js:5:11:5:11 | x | exception-xss.js:15:3:15:12 | exceptional return of inner(foo) |
+| exception-xss.js:5:11:5:11 | x | exception-xss.js:42:3:42:10 | exceptional return of inner(x) |
+| exception-xss.js:5:11:5:11 | x | exception-xss.js:75:4:75:11 | exceptional return of inner(x) |
 | exception-xss.js:9:11:9:13 | foo | exception-xss.js:10:11:10:11 | e |
 | exception-xss.js:10:11:10:11 | e | exception-xss.js:11:18:11:18 | e |
 | exception-xss.js:10:11:10:11 | e | exception-xss.js:11:18:11:18 | e |
 | exception-xss.js:15:3:15:12 | exceptional return of inner(foo) | exception-xss.js:16:11:16:11 | e |
+| exception-xss.js:15:3:15:12 | exceptional return of inner(foo) | exception-xss.js:16:11:16:11 | e |
 | exception-xss.js:15:9:15:11 | foo | exception-xss.js:15:3:15:12 | exceptional return of inner(foo) |
+| exception-xss.js:16:11:16:11 | e | exception-xss.js:17:18:17:18 | e |
+| exception-xss.js:16:11:16:11 | e | exception-xss.js:17:18:17:18 | e |
 | exception-xss.js:16:11:16:11 | e | exception-xss.js:17:18:17:18 | e |
 | exception-xss.js:16:11:16:11 | e | exception-xss.js:17:18:17:18 | e |
 | exception-xss.js:21:11:21:13 | foo | exception-xss.js:21:11:21:21 | foo + "bar" |
@@ -119,13 +146,26 @@ edges
 | exception-xss.js:33:19:33:21 | foo | exception-xss.js:33:11:33:22 | ["bar", foo] |
 | exception-xss.js:34:11:34:11 | e | exception-xss.js:35:18:35:18 | e |
 | exception-xss.js:34:11:34:11 | e | exception-xss.js:35:18:35:18 | e |
+| exception-xss.js:39:3:39:10 | exceptional return of deep2(x) | exception-xss.js:46:3:46:19 | exceptional return of deep("bar" + foo) |
+| exception-xss.js:42:3:42:10 | exceptional return of inner(x) | exception-xss.js:39:3:39:10 | exceptional return of deep2(x) |
+| exception-xss.js:46:3:46:19 | exceptional return of deep("bar" + foo) | exception-xss.js:47:11:47:11 | e |
 | exception-xss.js:46:3:46:19 | exceptional return of deep("bar" + foo) | exception-xss.js:47:11:47:11 | e |
 | exception-xss.js:46:8:46:18 | "bar" + foo | exception-xss.js:46:3:46:19 | exceptional return of deep("bar" + foo) |
 | exception-xss.js:46:16:46:18 | foo | exception-xss.js:46:8:46:18 | "bar" + foo |
 | exception-xss.js:47:11:47:11 | e | exception-xss.js:48:18:48:18 | e |
 | exception-xss.js:47:11:47:11 | e | exception-xss.js:48:18:48:18 | e |
+| exception-xss.js:47:11:47:11 | e | exception-xss.js:48:18:48:18 | e |
+| exception-xss.js:47:11:47:11 | e | exception-xss.js:48:18:48:18 | e |
+| exception-xss.js:74:28:74:28 | x | exception-xss.js:75:10:75:10 | x |
+| exception-xss.js:74:28:74:28 | x | exception-xss.js:75:10:75:10 | x |
+| exception-xss.js:75:4:75:11 | exceptional return of inner(x) | exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) |
+| exception-xss.js:75:4:75:11 | exceptional return of inner(x) | exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) |
+| exception-xss.js:75:10:75:10 | x | exception-xss.js:75:4:75:11 | exceptional return of inner(x) |
+| exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) | exception-xss.js:82:11:82:11 | e |
 | exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) | exception-xss.js:82:11:82:11 | e |
 | exception-xss.js:81:16:81:18 | foo | exception-xss.js:81:3:81:19 | exceptional return of myWeirdInner(foo) |
+| exception-xss.js:82:11:82:11 | e | exception-xss.js:83:18:83:18 | e |
+| exception-xss.js:82:11:82:11 | e | exception-xss.js:83:18:83:18 | e |
 | exception-xss.js:82:11:82:11 | e | exception-xss.js:83:18:83:18 | e |
 | exception-xss.js:82:11:82:11 | e | exception-xss.js:83:18:83:18 | e |
 | exception-xss.js:89:11:89:13 | foo | exception-xss.js:89:11:89:26 | foo.match(/foo/) |
@@ -177,10 +217,14 @@ edges
 | ajv.js:24:18:24:26 | val.error | ajv.js:24:18:24:26 | val.error | ajv.js:24:18:24:26 | val.error | $@ is reinterpreted as HTML without escaping meta-characters. | ajv.js:24:18:24:26 | val.error | JSON schema validation error |
 | exception-xss.js:11:18:11:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:11:18:11:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:17:18:17:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:17:18:17:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
+| exception-xss.js:17:18:17:18 | e | exception-xss.js:4:17:4:17 | x | exception-xss.js:17:18:17:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:4:17:4:17 | x | Exception text |
 | exception-xss.js:23:18:23:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:23:18:23:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:35:18:35:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:35:18:35:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:48:18:48:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:48:18:48:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
+| exception-xss.js:48:18:48:18 | e | exception-xss.js:4:17:4:17 | x | exception-xss.js:48:18:48:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:4:17:4:17 | x | Exception text |
 | exception-xss.js:83:18:83:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:83:18:83:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
+| exception-xss.js:83:18:83:18 | e | exception-xss.js:4:17:4:17 | x | exception-xss.js:83:18:83:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:4:17:4:17 | x | Exception text |
+| exception-xss.js:83:18:83:18 | e | exception-xss.js:74:28:74:28 | x | exception-xss.js:83:18:83:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:74:28:74:28 | x | Exception text |
 | exception-xss.js:91:18:91:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:91:18:91:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:97:18:97:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:97:18:97:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |
 | exception-xss.js:107:18:107:18 | e | exception-xss.js:2:12:2:28 | document.location | exception-xss.js:107:18:107:18 | e | $@ is reinterpreted as HTML without escaping meta-characters. | exception-xss.js:2:12:2:28 | document.location | Exception text |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
@@ -147,6 +147,18 @@ nodes
 | tst13.js:72:19:72:49 | history ... bstr(1) |
 | tst13.js:74:21:74:27 | payload |
 | tst13.js:74:21:74:27 | payload |
+| tst13.js:78:9:78:48 | url |
+| tst13.js:78:15:78:38 | documen ... .search |
+| tst13.js:78:15:78:38 | documen ... .search |
+| tst13.js:78:15:78:48 | documen ... bstr(1) |
+| tst13.js:80:21:80:23 | url |
+| tst13.js:80:21:80:23 | url |
+| tst13.js:81:28:81:30 | url |
+| tst13.js:81:28:81:30 | url |
+| tst13.js:82:27:82:29 | url |
+| tst13.js:82:27:82:29 | url |
+| tst13.js:83:22:83:24 | url |
+| tst13.js:83:22:83:24 | url |
 | tst.js:2:19:2:69 | /.*redi ... n.href) |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
@@ -339,6 +351,17 @@ edges
 | tst13.js:72:19:72:39 | history ... on.hash | tst13.js:72:19:72:49 | history ... bstr(1) |
 | tst13.js:72:19:72:39 | history ... on.hash | tst13.js:72:19:72:49 | history ... bstr(1) |
 | tst13.js:72:19:72:49 | history ... bstr(1) | tst13.js:72:9:72:49 | payload |
+| tst13.js:78:9:78:48 | url | tst13.js:80:21:80:23 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:80:21:80:23 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:81:28:81:30 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:81:28:81:30 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:82:27:82:29 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:82:27:82:29 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:83:22:83:24 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:83:22:83:24 | url |
+| tst13.js:78:15:78:38 | documen ... .search | tst13.js:78:15:78:48 | documen ... bstr(1) |
+| tst13.js:78:15:78:38 | documen ... .search | tst13.js:78:15:78:48 | documen ... bstr(1) |
+| tst13.js:78:15:78:48 | documen ... bstr(1) | tst13.js:78:9:78:48 | url |
 | tst.js:2:19:2:69 | /.*redi ... n.href) | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
 | tst.js:2:19:2:69 | /.*redi ... n.href) | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
 | tst.js:2:47:2:63 | document.location | tst.js:2:47:2:68 | documen ... on.href |
@@ -433,6 +456,10 @@ edges
 | tst13.js:61:18:61:24 | payload | tst13.js:59:19:59:42 | documen ... .search | tst13.js:61:18:61:24 | payload | Untrusted URL redirection due to $@. | tst13.js:59:19:59:42 | documen ... .search | user-provided value |
 | tst13.js:67:21:67:27 | payload | tst13.js:65:19:65:39 | history ... on.hash | tst13.js:67:21:67:27 | payload | Untrusted URL redirection due to $@. | tst13.js:65:19:65:39 | history ... on.hash | user-provided value |
 | tst13.js:74:21:74:27 | payload | tst13.js:72:19:72:39 | history ... on.hash | tst13.js:74:21:74:27 | payload | Untrusted URL redirection due to $@. | tst13.js:72:19:72:39 | history ... on.hash | user-provided value |
+| tst13.js:80:21:80:23 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:80:21:80:23 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
+| tst13.js:81:28:81:30 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:81:28:81:30 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
+| tst13.js:82:27:82:29 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:82:27:82:29 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
+| tst13.js:83:22:83:24 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:83:22:83:24 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] | tst.js:2:47:2:63 | document.location | tst.js:2:19:2:72 | /.*redi ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:2:47:2:63 | document.location | user-provided value |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] | tst.js:2:47:2:68 | documen ... on.href | tst.js:2:19:2:72 | /.*redi ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:2:47:2:68 | documen ... on.href | user-provided value |
 | tst.js:6:20:6:59 | indirec ... ref)[1] | tst.js:6:34:6:50 | document.location | tst.js:6:20:6:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:6:34:6:50 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
@@ -204,6 +204,8 @@ nodes
 | tst.js:26:22:26:79 | new Reg ... n.href) |
 | tst.js:26:22:26:82 | new Reg ... ref)[1] |
 | tst.js:26:22:26:82 | new Reg ... ref)[1] |
+| tst.js:26:62:26:73 | win.location |
+| tst.js:26:62:26:73 | win.location |
 | tst.js:26:62:26:78 | win.location.href |
 | tst.js:26:62:26:78 | win.location.href |
 | typed.ts:4:13:4:36 | params |
@@ -400,6 +402,8 @@ edges
 | tst.js:22:34:22:55 | documen ... on.href | tst.js:22:20:22:56 | indirec ... n.href) |
 | tst.js:26:22:26:79 | new Reg ... n.href) | tst.js:26:22:26:82 | new Reg ... ref)[1] |
 | tst.js:26:22:26:79 | new Reg ... n.href) | tst.js:26:22:26:82 | new Reg ... ref)[1] |
+| tst.js:26:62:26:73 | win.location | tst.js:26:62:26:78 | win.location.href |
+| tst.js:26:62:26:73 | win.location | tst.js:26:62:26:78 | win.location.href |
 | tst.js:26:62:26:78 | win.location.href | tst.js:26:22:26:79 | new Reg ... n.href) |
 | tst.js:26:62:26:78 | win.location.href | tst.js:26:22:26:79 | new Reg ... n.href) |
 | typed.ts:4:13:4:36 | params | typed.ts:5:25:5:30 | params |
@@ -472,6 +476,7 @@ edges
 | tst.js:18:19:18:84 | new Reg ... ref)[1] | tst.js:18:59:18:80 | documen ... on.href | tst.js:18:19:18:84 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:18:59:18:80 | documen ... on.href | user-provided value |
 | tst.js:22:20:22:59 | indirec ... ref)[1] | tst.js:22:34:22:50 | document.location | tst.js:22:20:22:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:22:34:22:50 | document.location | user-provided value |
 | tst.js:22:20:22:59 | indirec ... ref)[1] | tst.js:22:34:22:55 | documen ... on.href | tst.js:22:20:22:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:22:34:22:55 | documen ... on.href | user-provided value |
+| tst.js:26:22:26:82 | new Reg ... ref)[1] | tst.js:26:62:26:73 | win.location | tst.js:26:22:26:82 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:26:62:26:73 | win.location | user-provided value |
 | tst.js:26:22:26:82 | new Reg ... ref)[1] | tst.js:26:62:26:78 | win.location.href | tst.js:26:22:26:82 | new Reg ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:26:62:26:78 | win.location.href | user-provided value |
 | typed.ts:8:33:8:43 | redirectUri | typed.ts:4:22:4:36 | location.search | typed.ts:8:33:8:43 | redirectUri | Untrusted URL redirection due to $@. | typed.ts:4:22:4:36 | location.search | user-provided value |
 | typed.ts:29:33:29:43 | redirectUri | typed.ts:25:25:25:34 | loc.search | typed.ts:29:33:29:43 | redirectUri | Untrusted URL redirection due to $@. | typed.ts:25:25:25:34 | loc.search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/tst13.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/tst13.js
@@ -73,3 +73,12 @@ function quz() {
 
     history.replace(payload); // NOT OK
 }
+
+function bar() {
+    var url = document.location.search.substr(1);
+
+    $("<a>", {href: url}).appendTo("body"); // NOT OK
+    $("#foo").attr("href", url); // NOT OK
+    $("#foo").attr({href: url}); // NOT OK
+    $("<img>", {src: url}).appendTo("body"); // NOT OK
+}


### PR DESCRIPTION
Inspired by a question on the Security lab Slack. 

[A quick run on LGTM](https://lgtm.com/query/5867827528990886707/) shows that the sink is somewhat common. 

[An evaluation looks fine](https://github.com/github/codeql-dca-main/tree/run/erik-krogh/buildJqueryHref__nightly__CustomSuite/reports).  
Two new results that look like TPs. 