### PR TITLE
C#: Fix CWE tag for `cs/insufficient-key-size`

### DIFF
--- a/csharp/ql/src/Security Features/InsufficientKeySize.ql
+++ b/csharp/ql/src/Security Features/InsufficientKeySize.ql
@@ -7,7 +7,7 @@
  * @precision high
  * @id cs/insufficient-key-size
  * @tags security
- *       external/cwe/cwe-327
+ *       external/cwe/cwe-326
  */
 
 import csharp


### PR DESCRIPTION
Since this targets

CWE-326 Inadequate Encryption Strength

> The software stores or transmits sensitive data using an encryption scheme that is theoretically sound, but is not strong enough for the level of protection required.
> \- https://cwe.mitre.org/data/definitions/326.html

and not

CWE-327: Use of a Broken or Risky Cryptographic Algorithm

> The use of a broken or risky cryptographic algorithm is an unnecessary risk that may result in the exposure of sensitive information.
> \- https://cwe.mitre.org/data/definitions/327.html

This matches what we do for similar query in Python: https://github.com/github/codeql/blob/main/python/ql/src/Security/CWE-326/WeakCryptoKey.ql