### PR TITLE
Java: Fix performance issues with future versions of codeql.

### DIFF
--- a/java/ql/lib/semmle/code/java/Annotation.qll
+++ b/java/ql/lib/semmle/code/java/Annotation.qll
@@ -110,6 +110,7 @@ class Annotatable extends Element {
   }
 
   /** Gets an annotation that applies to this element. */
+  cached
   Annotation getAnAnnotation() { result.getAnnotatedElement() = this }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -616,16 +616,21 @@ private predicate elementSpec(
   summaryModel(namespace, type, subtypes, name, signature, ext, _, _, _)
 }
 
+private predicate relevantCallable(Callable c) { elementSpec(_, _, _, c.getName(), _, _) }
+
 private string paramsStringPart(Callable c, int i) {
-  i = -1 and result = "("
-  or
-  exists(int n, string p | c.getParameterType(n).getErasure().toString() = p |
-    i = 2 * n and result = p
+  relevantCallable(c) and
+  (
+    i = -1 and result = "("
     or
-    i = 2 * n - 1 and result = "," and n != 0
+    exists(int n, string p | c.getParameterType(n).getErasure().toString() = p |
+      i = 2 * n and result = p
+      or
+      i = 2 * n - 1 and result = "," and n != 0
+    )
+    or
+    i = 2 * c.getNumberOfParameters() and result = ")"
   )
-  or
-  i = 2 * c.getNumberOfParameters() and result = ")"
 }
 
 private string paramsString(Callable c) {

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -11,11 +11,13 @@ import semmle.code.xml.AndroidManifest
  */
 class AndroidComponent extends Class {
   AndroidComponent() {
-    this.getASupertype*().hasQualifiedName("android.app", "Activity") or
-    this.getASupertype*().hasQualifiedName("android.app", "Service") or
-    this.getASupertype*().hasQualifiedName("android.content", "BroadcastReceiver") or
-    this.getASupertype*().hasQualifiedName("android.content", "ContentProvider") or
-    this.getASupertype*().hasQualifiedName("android.content", "ContentResolver")
+    // The casts here are due to misoptimisation if they are missing
+    // but are not needed semantically.
+    this.(Class).getASupertype*().hasQualifiedName("android.app", "Activity") or
+    this.(Class).getASupertype*().hasQualifiedName("android.app", "Service") or
+    this.(Class).getASupertype*().hasQualifiedName("android.content", "BroadcastReceiver") or
+    this.(Class).getASupertype*().hasQualifiedName("android.content", "ContentProvider") or
+    this.(Class).getASupertype*().hasQualifiedName("android.content", "ContentResolver")
   }
 
   /** The XML element corresponding to this Android component. */


### PR DESCRIPTION
There are three changes

- The first is the most awkward. Lots of optimisation and inlining happens here and fixing it directly requires multiple pragma and changes. Simply reversing the optimiser change directly fixes it simplest so I went for that even though that adds pointless casts.
- The second is simplest, magic doesn't happen anymore so we do it manually and only construct parameter strings for matching names in CSV summaries. I don't think this is actually significant but I found it when looking into the main regression and it does fix a regression.
- The last has a simple fix but is most complex. Reevaluation already happens due to wierd type spec interations. However it gets worse due to not optimising quite the same. The simplest fix is to use cached to eliminate all cases both currently and with the caches.
