### PR TITLE
C++: Add uninterpreted query for obtaining frontend and extraction time

### DIFF
--- a/cpp/ql/src/Metrics/Internal/DiagnosticsSumElapsedTimes.ql
+++ b/cpp/ql/src/Metrics/Internal/DiagnosticsSumElapsedTimes.ql
@@ -1,0 +1,9 @@
+/**
+ * @name Sum of frontend and extractor time
+ * @description The sum of elapsed frontend time, and the sum of elapsed extractor time.
+ * @kind table
+ * @id cpp/frontend-and-extractor-time
+ */
+
+select sum(@compilation c, float seconds | compilation_time(c, _, 2, seconds) | seconds) as sum_frontend_elapsed_seconds,
+  sum(@compilation c, float seconds | compilation_time(c, _, 4, seconds) | seconds) as sum_extractor_elapsed_seconds

--- a/cpp/ql/src/Metrics/Internal/DiagnosticsSumElapsedTimes.ql
+++ b/cpp/ql/src/Metrics/Internal/DiagnosticsSumElapsedTimes.ql
@@ -1,9 +1,12 @@
 /**
  * @name Sum of frontend and extractor time
  * @description The sum of elapsed frontend time, and the sum of elapsed extractor time.
+ *              This query is for internal use only and may change without notice.
  * @kind table
  * @id cpp/frontend-and-extractor-time
  */
 
-select sum(@compilation c, float seconds | compilation_time(c, _, 2, seconds) | seconds) as sum_frontend_elapsed_seconds,
-  sum(@compilation c, float seconds | compilation_time(c, _, 4, seconds) | seconds) as sum_extractor_elapsed_seconds
+import cpp
+
+select sum(Compilation c, float seconds | compilation_time(c, _, 2, seconds) | seconds) as sum_frontend_elapsed_seconds,
+  sum(Compilation c, float seconds | compilation_time(c, _, 4, seconds) | seconds) as sum_extractor_elapsed_seconds


### PR DESCRIPTION
This is needed to get frontend and extraction time in DCA reports. There will be a corresponding DCA PR later for consuming this file.