### PR TITLE
JS: Detect untrusted inputs in 'discussion' and 'discussion_comment' payloads

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-094/ExpressionInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-094/ExpressionInjection.ql
@@ -65,6 +65,12 @@ private predicate isExternalUserControlledCommit(string context) {
   context.regexpMatch("\\bgithub\\s*\\.\\s*head_ref\\b")
 }
 
+bindingset[context]
+private predicate isExternalUserControlledDiscussion(string context) {
+  context.regexpMatch("\\bgithub\\s*\\.\\s*event\\s*\\.\\s*discussion\\s*\\.\\s*title\\b") or
+  context.regexpMatch("\\bgithub\\s*\\.\\s*event\\s*\\.\\s*discussion\\s*\\.\\s*body\\b")
+}
+
 from Actions::Run run, string context, Actions::On on
 where
   run.getAReferencedExpression() = context and
@@ -87,6 +93,9 @@ where
     or
     exists(on.getNode("pull_request_target")) and
     isExternalUserControlledCommit(context)
+    or
+    (exists(on.getNode("discussion")) or exists(on.getNode("discussion_comment"))) and
+    isExternalUserControlledDiscussion(context)
   )
 select run,
   "Potential injection from the " + context +


### PR DESCRIPTION
GitHub Actions introduced [`discussion`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#discussion) and [`discussion_comment`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#discussion_comment) webhook events support. Both events' payloads have [discussion](https://docs.github.com/en/graphql/guides/using-the-graphql-api-for-discussions#discussion) object and its `title` and `body` are from external users.

- `github.event.discussion.title`
- `github.event.discussion.body`

This PR adds detection for the untrusted inputs to CWE-094.