### PR TITLE
Java: Initial CSV model generator

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -889,10 +889,17 @@ module Private {
      * model.
      */
     predicate isSourceNode(InterpretNode node, string kind) {
-      exists(InterpretNode ref, string output |
-        sourceElementRef(ref, output, kind) and
-        interpretOutput(output, 0, ref, node)
-      )
+      exists(InterpretNode ref, string output | isSourceNode(ref, node, output, kind))
+    }
+
+    // TODO: I wonder if this is actually the interface we want to expose.
+    predicate isSourceNode(InterpretNode node, string output, string kind) {
+      exists(InterpretNode ref | isSourceNode(ref, node, output, kind))
+    }
+
+    predicate isSourceNode(InterpretNode ref, InterpretNode node, string output, string kind) {
+      sourceElementRef(ref, output, kind) and
+      interpretOutput(output, 0, ref, node)
     }
 
     /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -889,17 +889,10 @@ module Private {
      * model.
      */
     predicate isSourceNode(InterpretNode node, string kind) {
-      exists(InterpretNode ref, string output | isSourceNode(ref, node, output, kind))
-    }
-
-    // TODO: I wonder if this is actually the interface we want to expose.
-    predicate isSourceNode(InterpretNode node, string output, string kind) {
-      exists(InterpretNode ref | isSourceNode(ref, node, output, kind))
-    }
-
-    predicate isSourceNode(InterpretNode ref, InterpretNode node, string output, string kind) {
-      sourceElementRef(ref, output, kind) and
-      interpretOutput(output, 0, ref, node)
+      exists(InterpretNode ref, string output |
+        sourceElementRef(ref, output, kind) and
+        interpretOutput(output, 0, ref, node)
+      )
     }
 
     /**

--- a/java/ql/lib/semmle/code/java/frameworks/Strings.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Strings.qll
@@ -54,7 +54,8 @@ private class StringSummaryCsv extends SummaryModelCsv {
         "java.lang;StringBuffer;true;StringBuffer;(CharSequence);;Argument[0];Argument[-1];taint",
         "java.lang;StringBuffer;true;StringBuffer;(String);;Argument[0];Argument[-1];taint",
         "java.lang;StringBuilder;true;StringBuilder;;;Argument[0];Argument[-1];taint",
-        "java.lang;CharSequence;true;subSequence;;;Argument[-1];ReturnValue;taint"
+        "java.lang;CharSequence;true;subSequence;;;Argument[-1];ReturnValue;taint",
+        "java.lang;CharSequence;true;toString;;;Argument[-1];ReturnValue;taint"
       ]
   }
 }

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -12,10 +12,10 @@ import semmle.code.java.dataflow.ExternalFlow
 import ModelGeneratorUtils
 
 class PropagateToSinkConfiguration extends TaintTracking::Configuration {
-  PropagateToSinkConfiguration() { this = "public methods calling sinks" }
+  PropagateToSinkConfiguration() { this = "parameters on public api flowing into sinks" }
 
   override predicate isSource(DataFlow::Node source) {
-    source.asParameter().getCallable().isPublic()
+    source instanceof DataFlow::ParameterNode and source.asParameter().getCallable().isPublic() and source.asParameter().getCallable().getDeclaringType().isPublic()
   }
 
   override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
@@ -29,7 +29,7 @@ string captureSink(Callable api) {
   exists(DataFlow::Node src, DataFlow::Node sink, PropagateToSinkConfiguration config, string kind |
     config.hasFlow(src, sink) and
     sinkNode(sink, kind) and
-    api = src.asParameter().getCallable() and
+    api = src.getEnclosingCallable() and
     result = asSinkModel(api, asInputArgument(src), kind)
   )
 }

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -15,7 +15,9 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
   PropagateToSinkConfiguration() { this = "parameters on public api flowing into sinks" }
 
   override predicate isSource(DataFlow::Node source) {
-    source instanceof DataFlow::ParameterNode and source.asParameter().getCallable().isPublic() and source.asParameter().getCallable().getDeclaringType().isPublic()
+    source instanceof DataFlow::ParameterNode and
+    source.asParameter().getCallable().isPublic() and
+    source.asParameter().getCallable().getDeclaringType().isPublic()
   }
 
   override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -16,7 +16,7 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node source) {
     exists(MethodAccess ma |
-      ma = source.asExpr() and
+      ma.getAChildExpr() = source.asExpr() and
       ma.getAnEnclosingStmt().getEnclosingCallable().isPublic() and
       ma.getAnEnclosingStmt().getEnclosingCallable().fromSource()
     )
@@ -25,7 +25,11 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
 }
 
-string asInputArgument(Expr source) { result = "Argument[" + source.(Argument).getPosition() + "]" }
+string asInputArgument(Expr source) {
+  result = "Argument[" + source.(Argument).getPosition() + "]"
+  or
+  result = source.(VarAccess).getVariable().toString()
+}
 
 string captureSink(Callable api) {
   exists(DataFlow::Node src, DataFlow::Node sink, PropagateToSinkConfiguration config, string kind |

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -17,10 +17,11 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) {
     source instanceof DataFlow::ParameterNode and
     source.asParameter().getCallable().isPublic() and
-    source.asParameter().getCallable().getDeclaringType().isPublic()
+    source.asParameter().getCallable().getDeclaringType().isPublic() and
+    isRelevantForModels(source.getEnclosingCallable())
   }
 
-  override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
+  override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _)}
 }
 
 string asInputArgument(DataFlow::Node source) {
@@ -36,8 +37,7 @@ string captureSink(Callable api) {
   )
 }
 
-from Callable api, string sink
+from TargetAPI api, string sink
 where
-  sink = captureSink(api) and
-  not isInTestFile(api)
+  sink = captureSink(api)
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -27,6 +27,10 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
+
+  override DataFlow::FlowFeature getAFeature() {
+    result instanceof DataFlow::FeatureHasSourceCallContext
+  }
 }
 
 string asInputArgument(DataFlow::Node source) {
@@ -50,6 +54,4 @@ string captureSink(Callable api) {
 
 from TargetAPI api, string sink
 where sink = captureSink(api)
-// and
-// api.hasName("openStream")
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -33,5 +33,5 @@ string captureSink(Callable api) {
 from Callable api, string sink
 where
   sink = captureSink(api) and
-  not api.getCompilationUnit().getFile().getAbsolutePath().matches("%src/test/%")
+  not isInTestFile(api)
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -1,3 +1,9 @@
+/**
+ * @name Capture sink models.
+ * @description Finds public methods that act as sinks as they flow into a a known sink.
+ * @id java/utils/model-generator/sink-models
+ */
+
 import java
 import Telemetry.ExternalAPI
 import semmle.code.java.dataflow.DataFlow
@@ -5,8 +11,8 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.ExternalFlow
 import ModelGeneratorUtils
 
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "public methods calling sinks" }
+class PropagateToSinkConfiguration extends TaintTracking::Configuration {
+  PropagateToSinkConfiguration() { this = "public methods calling sinks" }
 
   override predicate isSource(DataFlow::Node source) {
     exists(MethodAccess ma |
@@ -22,7 +28,7 @@ class Configuration extends TaintTracking::Configuration {
 string asInputArgument(Expr source) { result = "Argument[" + source.(Argument).getPosition() + "]" }
 
 string captureSink(Callable api) {
-  exists(DataFlow::Node src, DataFlow::Node sink, Configuration config, string kind |
+  exists(DataFlow::Node src, DataFlow::Node sink, PropagateToSinkConfiguration config, string kind |
     config.hasFlow(src, sink) and
     sinkNode(sink, kind) and
     api = src.asExpr().getEnclosingCallable() and

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -1,0 +1,37 @@
+import java
+import Telemetry.ExternalAPI
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.ExternalFlow
+import ModelGeneratorUtils
+
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "public methods calling sinks" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(MethodAccess ma |
+      ma = source.asExpr() and
+      ma.getAnEnclosingStmt().getEnclosingCallable().isPublic() and
+      ma.getAnEnclosingStmt().getEnclosingCallable().fromSource()
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
+}
+
+string asInputArgument(Expr source) { result = "Argument[" + source.(Argument).getPosition() + "]" }
+
+string captureSink(Callable api) {
+  exists(DataFlow::Node src, DataFlow::Node sink, Configuration config, string kind |
+    config.hasFlow(src, sink) and
+    sinkNode(sink, kind) and
+    api = src.asExpr().getEnclosingCallable() and
+    result = asSinkModel(api, asInputArgument(src.asExpr()), kind)
+  )
+}
+
+from Callable api, string sink
+where
+  sink = captureSink(api) and
+  not api.getCompilationUnit().getFile().getAbsolutePath().matches("%src/test/%")
+select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -15,28 +15,22 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
   PropagateToSinkConfiguration() { this = "public methods calling sinks" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(MethodAccess ma |
-      ma.getAChildExpr() = source.asExpr() and
-      ma.getAnEnclosingStmt().getEnclosingCallable().isPublic() and
-      ma.getAnEnclosingStmt().getEnclosingCallable().fromSource()
-    )
+    source.asParameter().getCallable().isPublic()
   }
 
   override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
 }
 
-string asInputArgument(Expr source) {
-  result = "Argument[" + source.(Argument).getPosition() + "]"
-  or
-  result = "Argument[" + source.(VarAccess).getVariable().(Parameter).getPosition() + "]"
+string asInputArgument(DataFlow::Node source) {
+  result = "Argument[" + source.asParameter().getPosition() + "]"
 }
 
 string captureSink(Callable api) {
   exists(DataFlow::Node src, DataFlow::Node sink, PropagateToSinkConfiguration config, string kind |
     config.hasFlow(src, sink) and
     sinkNode(sink, kind) and
-    api = src.asExpr().getEnclosingCallable() and
-    result = asSinkModel(api, asInputArgument(src.asExpr()), kind)
+    api = src.asParameter().getCallable() and
+    result = asSinkModel(api, asInputArgument(src), kind)
   )
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -28,7 +28,7 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
 string asInputArgument(Expr source) {
   result = "Argument[" + source.(Argument).getPosition() + "]"
   or
-  result = source.(VarAccess).getVariable().toString()
+  result = "Argument[" + source.(VarAccess).getVariable().(Parameter).getPosition() + "]"
 }
 
 string captureSink(Callable api) {

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -16,7 +16,7 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
   PropagateToSinkConfiguration() { this = "parameters or  flowing into sinks" }
 
   override predicate isSource(DataFlow::Node source) {
-    (source.asExpr() instanceof FieldAccess or source instanceof DataFlow::ParameterNode) and
+    (source.asExpr().(FieldAccess).isOwnFieldAccess() or source instanceof DataFlow::ParameterNode) and
     source.getEnclosingCallable().isPublic() and
     exists(RefType t |
       t = source.getEnclosingCallable().getDeclaringType().getAnAncestor() and

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -21,7 +21,7 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
     isRelevantForModels(source.getEnclosingCallable())
   }
 
-  override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _)}
+  override predicate isSink(DataFlow::Node sink) { sinkNode(sink, _) }
 }
 
 string asInputArgument(DataFlow::Node source) {
@@ -38,6 +38,5 @@ string captureSink(Callable api) {
 }
 
 from TargetAPI api, string sink
-where
-  sink = captureSink(api)
+where sink = captureSink(api)
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -16,8 +16,8 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node source) {
     source instanceof DataFlow::ParameterNode and
-    source.asParameter().getCallable().isPublic() and
-    source.asParameter().getCallable().getDeclaringType().isPublic() and
+    source.getEnclosingCallable().isPublic() and
+    source.getEnclosingCallable().getDeclaringType().isPublic() and
     isRelevantForModels(source.getEnclosingCallable())
   }
 
@@ -25,7 +25,10 @@ class PropagateToSinkConfiguration extends TaintTracking::Configuration {
 }
 
 string asInputArgument(DataFlow::Node source) {
-  result = "Argument[" + source.asParameter().getPosition() + "]"
+  exists(int pos |
+    source.(DataFlow::ParameterNode).isParameterOf(_, pos) and
+    result = "Argument[" + pos + "]"
+  )
 }
 
 string captureSink(Callable api) {

--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -43,7 +43,7 @@ string asInputArgument(DataFlow::Node source) {
   result = "Argument[-1]"
 }
 
-string captureSink(Callable api) {
+string captureSink(TargetAPI api) {
   exists(DataFlow::Node src, DataFlow::Node sink, PropagateToSinkConfiguration config, string kind |
     config.hasFlow(src, sink) and
     sinkNode(sink, kind) and

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -47,8 +47,7 @@ string captureSource(Callable api) {
   )
 }
 
-from Callable api, string sink
+from TargetAPI api, string sink
 where
-  sink = captureSource(api) and
-  not isInTestFile(api)
+  sink = captureSource(api) 
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -48,6 +48,5 @@ string captureSource(Callable api) {
 }
 
 from TargetAPI api, string sink
-where
-  sink = captureSource(api) 
+where sink = captureSource(api)
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -32,7 +32,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   }
 
   override DataFlow::FlowFeature getAFeature() {
-    result instanceof DataFlow::FeatureHasSourceCallContext
+    result instanceof DataFlow::FeatureHasSinkCallContext
   }
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -35,19 +35,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    exists(DataFlow::Content f |
-      readStep(node1, f, node2) and
-      if f instanceof DataFlow::FieldContent
-      then isRelevantType(f.(DataFlow::FieldContent).getField().getType())
-      else any()
-    )
-    or
-    exists(DataFlow::Content f | storeStep(node1, f, node2) |
-      f instanceof DataFlow::ArrayContent or
-      f instanceof DataFlow::CollectionContent or
-      f instanceof DataFlow::MapKeyContent or
-      f instanceof DataFlow::MapValueContent
-    )
+    isRelevantTaintStep(node1, node2)
   }
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -1,14 +1,20 @@
+/**
+ * @name Capture source models.
+ * @description Finds APIs that act as sources as they expose already known sources.
+ * @id java/utils/model-generator/sink-models
+ */
+
 import java
-import Telemetry.ExternalAPI
-import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.TaintTracking
-import semmle.code.java.dataflow.ExternalFlow
-import ModelGeneratorUtils
+private import Telemetry.ExternalAPI
+private import semmle.code.java.dataflow.DataFlow
+private import semmle.code.java.dataflow.TaintTracking
+private import semmle.code.java.dataflow.ExternalFlow
+private import ModelGeneratorUtils
 private import semmle.code.java.dataflow.internal.FlowSummaryImplSpecific
 private import semmle.code.java.dataflow.internal.FlowSummaryImpl
 
-class Configuration extends TaintTracking::Configuration {
-  Configuration() { this = "Configuration" }
+class FromSourceConfiguration extends TaintTracking::Configuration {
+  FromSourceConfiguration() { this = "FromSourceConfiguration" }
 
   override predicate isSource(DataFlow::Node source) { sourceNode(source, _) }
 
@@ -21,14 +27,17 @@ class Configuration extends TaintTracking::Configuration {
   }
 }
 
-// TODO: internals
+// TODO: better way than rely on internals?
 cached
 predicate specificSourceNode(DataFlow::Node node, string output, string kind) {
   exists(InterpretNode n | Private::External::isSourceNode(n, output, kind) and n.asNode() = node)
 }
 
 string captureSink(Callable api) {
-  exists(DataFlow::Node src, DataFlow::Node sink, Configuration config, string kind, string output |
+  exists(
+    DataFlow::Node src, DataFlow::Node sink, FromSourceConfiguration config, string kind,
+    string output
+  |
     config.hasFlow(src, sink) and
     specificSourceNode(sink, output, kind) and
     api = src.asExpr().getEnclosingCallable() and

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -1,0 +1,43 @@
+import java
+import Telemetry.ExternalAPI
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.ExternalFlow
+import ModelGeneratorUtils
+private import semmle.code.java.dataflow.internal.FlowSummaryImplSpecific
+private import semmle.code.java.dataflow.internal.FlowSummaryImpl
+
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "Configuration" }
+
+  override predicate isSource(DataFlow::Node source) { sourceNode(source, _) }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(Callable c |
+      sink.asExpr().getEnclosingCallable() = c and
+      c.isPublic() and
+      c.fromSource()
+    )
+  }
+}
+
+// TODO: internals
+cached
+predicate specificSourceNode(DataFlow::Node node, string output, string kind) {
+  exists(InterpretNode n | Private::External::isSourceNode(n, output, kind) and n.asNode() = node)
+}
+
+string captureSink(Callable api) {
+  exists(DataFlow::Node src, DataFlow::Node sink, Configuration config, string kind, string output |
+    config.hasFlow(src, sink) and
+    specificSourceNode(sink, output, kind) and
+    api = src.asExpr().getEnclosingCallable() and
+    result = asSourceModel(api, output, kind)
+  )
+}
+
+from Callable api, string sink
+where
+  sink = captureSink(api) and
+  not isInTestFile(api)
+select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -13,7 +13,7 @@ private import ModelGeneratorUtils
 private import semmle.code.java.dataflow.internal.FlowSummaryImplSpecific
 private import semmle.code.java.dataflow.internal.FlowSummaryImpl
 private import semmle.code.java.dataflow.internal.DataFlowImplCommon
-import semmle.code.java.dataflow.internal.DataFlowNodes::Private
+private import semmle.code.java.dataflow.internal.DataFlowNodes::Private
 
 class FromSourceConfiguration extends TaintTracking::Configuration {
   FromSourceConfiguration() { this = "FromSourceConfiguration" }

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -33,7 +33,7 @@ predicate specificSourceNode(DataFlow::Node node, string output, string kind) {
   exists(InterpretNode n | Private::External::isSourceNode(n, output, kind) and n.asNode() = node)
 }
 
-string captureSink(Callable api) {
+string captureSource(Callable api) {
   exists(
     DataFlow::Node src, DataFlow::Node sink, FromSourceConfiguration config, string kind,
     string output
@@ -47,6 +47,6 @@ string captureSink(Callable api) {
 
 from Callable api, string sink
 where
-  sink = captureSink(api) and
+  sink = captureSource(api) and
   not isInTestFile(api)
 select sink order by sink

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -49,10 +49,10 @@ string asOutput(DataFlow::Node node) {
 }
 
 string captureSource(Callable api) {
-  exists(DataFlow::Node src, DataFlow::Node sink, FromSourceConfiguration config, string kind |
-    config.hasFlow(src, sink) and
-    sourceNode(sink, kind) and
-    api = src.getEnclosingCallable() and
+  exists(DataFlow::Node source, DataFlow::Node sink, FromSourceConfiguration config, string kind |
+    config.hasFlow(source, sink) and
+    sourceNode(source, kind) and
+    api = source.getEnclosingCallable() and
     result = asSourceModel(api, asOutput(sink), kind)
   )
 }

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -22,13 +22,11 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
 
   override predicate isSink(DataFlow::Node sink) {
     exists(Callable c |
-      sink instanceof ReturnNodeExt and
+      sink instanceof ReturnNode and
       sink.getEnclosingCallable() = c and
       c.isPublic() and
       c.fromSource()
     )
-    or
-    exists(MethodAccess c | sink.asExpr() = c.getAnArgument())
   }
 
   override DataFlow::FlowFeature getAFeature() {
@@ -36,28 +34,12 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   }
 }
 
-string asOutput(DataFlow::Node node) {
-  if node instanceof ReturnNodeExt
-  then result = "ReturnValue"
-  else
-    result =
-      "Parameter[" +
-        node.(ArgumentNode)
-            .getCall()
-            .asCall()
-            .getQualifier()
-            .(VarAccess)
-            .getVariable()
-            .(Parameter)
-            .getPosition() + "]"
-}
-
 string captureSource(Callable api) {
   exists(DataFlow::Node source, DataFlow::Node sink, FromSourceConfiguration config, string kind |
     config.hasFlow(source, sink) and
     sourceNode(source, kind) and
     api = source.getEnclosingCallable() and
-    result = asSourceModel(api, asOutput(sink), kind)
+    result = asSourceModel(api, "ReturnValue", kind)
   )
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -22,7 +22,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) {
     exists(Callable c |
       sink instanceof ReturnNodeExt and
-      sink.asExpr().getEnclosingCallable() = c and
+      sink.getEnclosingCallable() = c and
       c.isPublic() and
       c.fromSource()
     )
@@ -42,7 +42,7 @@ string captureSource(Callable api) {
   |
     config.hasFlow(src, sink) and
     specificSourceNode(sink, output, kind) and
-    api = src.asExpr().getEnclosingCallable() and
+    api = src.getEnclosingCallable() and
     result = asSourceModel(api, output, kind)
   )
 }

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -29,7 +29,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   }
 }
 
-// TODO: better way than rely on internals?
+// TODO: better way than rely on internals to capture kind?
 cached
 predicate specificSourceNode(DataFlow::Node node, string output, string kind) {
   exists(InterpretNode n | Private::External::isSourceNode(n, output, kind) and n.asNode() = node)

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -30,6 +30,10 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
     or
     exists(MethodAccess c | sink.asExpr() = c.getAnArgument())
   }
+
+  override DataFlow::FlowFeature getAFeature() {
+    result instanceof DataFlow::FeatureHasSourceCallContext
+  }
 }
 
 string asOutput(DataFlow::Node node) {

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -12,6 +12,7 @@ private import semmle.code.java.dataflow.ExternalFlow
 private import ModelGeneratorUtils
 private import semmle.code.java.dataflow.internal.FlowSummaryImplSpecific
 private import semmle.code.java.dataflow.internal.FlowSummaryImpl
+private import semmle.code.java.dataflow.internal.DataFlowImplCommon
 
 class FromSourceConfiguration extends TaintTracking::Configuration {
   FromSourceConfiguration() { this = "FromSourceConfiguration" }
@@ -20,6 +21,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
 
   override predicate isSink(DataFlow::Node sink) {
     exists(Callable c |
+      sink instanceof ReturnNodeExt and
       sink.asExpr().getEnclosingCallable() = c and
       c.isPublic() and
       c.fromSource()

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -21,7 +21,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { sourceNode(source, _) }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(Callable c |
+    exists(TargetAPI c |
       sink instanceof ReturnNode and
       sink.getEnclosingCallable() = c and
       c.isPublic() and
@@ -34,7 +34,7 @@ class FromSourceConfiguration extends TaintTracking::Configuration {
   }
 }
 
-string captureSource(Callable api) {
+string captureSource(TargetAPI api) {
   exists(DataFlow::Node source, DataFlow::Node sink, FromSourceConfiguration config, string kind |
     config.hasFlow(source, sink) and
     sourceNode(source, kind) and

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -58,7 +58,7 @@ class ParameterToFieldConfig extends TaintTracking::Configuration {
 
   override predicate isSink(DataFlow::Node sink) {
     exists(FieldAssignment a |
-      a.getSource().getAChildExpr() = sink.asExpr() or a.getSource() = sink.asExpr()
+      a.getSource() = sink.asExpr()
     )
   }
 }

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -54,19 +54,7 @@ class FieldToReturnConfig extends TaintTracking::Configuration {
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    exists(DataFlow::Content f |
-      readStep(node1, f, node2) and
-      if f instanceof DataFlow::FieldContent
-      then isRelevantType(f.(DataFlow::FieldContent).getField().getType())
-      else any()
-    )
-    or
-    exists(DataFlow::Content f | storeStep(node1, f, node2) |
-      f instanceof DataFlow::ArrayContent or
-      f instanceof DataFlow::CollectionContent or
-      f instanceof DataFlow::MapKeyContent or
-      f instanceof DataFlow::MapValueContent
-    )
+    isRelevantTaintStep(node1, node2)
   }
 
   override DataFlow::FlowFeature getAFeature() {

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -103,15 +103,8 @@ string captureFieldFlow(TargetAPI api) {
     not api.getDeclaringType() instanceof EnumType and
     isRelevantType(returnNodeExt.getType())
   |
-    result = asTaintModel(api, "Argument[-1]", asOutput(api, returnNodeExt))
+    result = asTaintModel(api, "Argument[-1]", returnNodeAsOutput(api, returnNodeExt))
   )
-}
-
-string asOutput(TargetAPI api, ReturnNodeExt node) {
-  if node.getKind() instanceof ValueReturnKind
-  then result = "ReturnValue"
-  else
-    result = parameterAccess(api.getParameter(node.getKind().(ParamUpdateReturnKind).getPosition()))
 }
 
 class FieldAssignment extends AssignExpr {
@@ -166,7 +159,6 @@ private predicate thisAccess(DataFlow::Node n) {
  */
 string captureFieldFlowIn(TargetAPI api) {
   exists(DataFlow::Node source, ParameterToFieldConfig config |
-    not api.isStatic() and
     config.hasFlow(source, _) and
     source.asParameter().getCallable() = api
   |
@@ -254,27 +246,6 @@ string captureParameterToParameterFlow(TargetAPI api) {
     result =
       asTaintModel(api, parameterAccess(source.asParameter()),
         parameterAccess(sink.getPreUpdateNode().asExpr().(VarAccess).getVariable().(Parameter)))
-  )
-}
-
-predicate isRelevantType(Type t) {
-  not t instanceof TypeClass and
-  not t instanceof EnumType and
-  not t instanceof PrimitiveType and
-  not t instanceof BoxedType and
-  not t.(RefType).getAnAncestor().hasQualifiedName("java.lang", "Number") and
-  not t.(RefType).getAnAncestor().hasQualifiedName("java.nio.charset", "Charset") and
-  (
-    not t.(Array).getElementType() instanceof PrimitiveType or
-    isPrimitiveTypeUsedForBulkData(t.(Array).getElementType())
-  ) and
-  (
-    not t.(Array).getElementType() instanceof BoxedType or
-    isPrimitiveTypeUsedForBulkData(t.(Array).getElementType())
-  ) and
-  (
-    not t.(CollectionType).getElementType() instanceof BoxedType or
-    isPrimitiveTypeUsedForBulkData(t.(CollectionType).getElementType())
   )
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -158,9 +158,9 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof ReturnNode }
 
-  // track taint across objects so we consider factory methods returning newly tainted objects
+  // consider store steps to track taint across objects to model factory methods returning tainted objects
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    node2.asExpr().(ConstructorCall).getAnArgument() = node1.asExpr()
+    store(node1, _, node2, _)
   }
 
   override DataFlow::FlowFeature getAFeature() {

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -96,8 +96,8 @@ class ParameterToFieldConfig extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) {
     exists(FieldAssignment a |
       a.getSource() = sink.asExpr() and
-      a.getDest().(VarAccess).getVariable().getCompilationUnit() =
-        sink.getEnclosingCallable().getCompilationUnit()
+      a.getDest().(FieldAccess).getField().getDeclaringType() =
+        sink.getEnclosingCallable().getDeclaringType()
     )
   }
 }

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -22,7 +22,7 @@ string captureFlow(Callable api) {
 string captureQualifierFlow(Callable api) {
   exists(ReturnStmt rtn |
     rtn.getEnclosingCallable() = api and
-    rtn.getResult() instanceof ThisAccess
+    rtn.getResult().(ThisAccess).isOwnInstanceAccess()
   ) and
   result = asValueModel(api, "Argument[-1]", "ReturnValue")
 }

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -190,8 +190,7 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
   override predicate isSink(DataFlow::Node sink) { sink instanceof ReturnNodeExt }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    node2.asExpr().(ConstructorCall).getAnArgument() = node1.asExpr() and
-    node1.asExpr().(Argument).getCall().getCallee().fromSource()
+    node2.asExpr().(ConstructorCall).getAnArgument() = node1.asExpr()
   }
 }
 
@@ -261,6 +260,7 @@ predicate isRelevantType(Type t) {
   not t instanceof PrimitiveType and
   not t instanceof BoxedType and
   not t.(RefType).getAnAncestor().hasQualifiedName("java.lang", "Number") and
+  not t.(RefType).getAnAncestor().hasQualifiedName("java.nio.charset", "Charset") and
   (
     not t.(Array).getElementType() instanceof PrimitiveType or
     isPrimitiveTypeUsedForBulkData(t.(Array).getElementType())

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -64,8 +64,8 @@ string captureQualifierFlow(Callable api) {
 string captureFieldFlow(Callable api) {
   exists(FieldAccess fa, ReturnNodeExt returnNode |
     not (fa.getField().isStatic() and fa.getField().isFinal()) and
+    fa.getField().getDeclaringType() = api.getDeclaringType() and
     returnNode.getEnclosingCallable() = api and
-    fa.getCompilationUnit() = api.getCompilationUnit() and
     isRelevantType(api.getReturnType()) and
     not api.getDeclaringType() instanceof EnumType and
     TaintTracking::localTaint(DataFlow::exprNode(fa), returnNode)

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -4,3 +4,33 @@
  * @id TBD
  */
 
+import java
+import ModelGeneratorUtils
+
+string captureFlow(Callable api) { result = captureQualifierFlow(api) }
+
+string captureQualifierFlow(Callable api) {
+  exists(ReturnStmt rtn |
+    rtn.getEnclosingCallable() = api and
+    rtn.getResult() instanceof ThisAccess
+  ) and
+  result = asValueModel(api, "Argument[-1]", "ReturnValue")
+}
+
+// TODO: handle cases like Ticker
+// TODO: "com.google.common.base;Converter;true;convertAll;(Iterable);;Element of Argument[0];Element of ReturnValue;taint",
+// TODO: infer interface from multiple implementations? e.g. UriComponentsContributor
+// TODO: distinguish between taint and value flows. If we find a value flow, omit the taint flow
+class TargetAPI extends Callable {
+  TargetAPI() {
+    this.isPublic() and
+    this.fromSource() and
+    this.getDeclaringType().isPublic() and
+    not this.getCompilationUnit().getFile().getAbsolutePath().matches("%src/test/%") and
+    not this.getCompilationUnit().getFile().getAbsolutePath().matches("%src/guava-tests/%")
+  }
+}
+
+from TargetAPI api, string flow
+where flow = captureFlow(api)
+select flow order by flow

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -259,7 +259,7 @@ predicate isRelevantType(Type t) {
   not t instanceof EnumType and
   not t instanceof PrimitiveType and
   not t instanceof BoxedType and
-  not t.(RefType).hasQualifiedName("java.math", "BigInteger") and
+  not t.(RefType).getAnAncestor().hasQualifiedName("java.lang", "Number") and
   (
     not t.(Array).getElementType() instanceof PrimitiveType or
     isPrimitiveTypeUsedForBulkData(t.(Array).getElementType())

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -95,10 +95,6 @@ string captureFieldFlow(TargetAPI api) {
   )
 }
 
-class FieldAssignment extends AssignExpr {
-  FieldAssignment() { exists(Field f | f.getAnAccess() = this.getDest()) }
-}
-
 class ParameterToFieldConfig extends TaintTracking::Configuration {
   ParameterToFieldConfig() { this = "ParameterToFieldConfig" }
 
@@ -112,11 +108,7 @@ class ParameterToFieldConfig extends TaintTracking::Configuration {
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    exists(FieldAssignment a |
-      a.getSource() = node1.asExpr() and
-      DataFlow::getFieldQualifier(a.getDest()) = node2.(DataFlow::PostUpdateNode).getPreUpdateNode() and
-      isRelevantType(a.getDest().(FieldAccess).getField().getType())
-    )
+    store(node1, _, node2, _)
   }
 
   override DataFlow::FlowFeature getAFeature() {
@@ -128,8 +120,6 @@ private predicate thisAccess(DataFlow::Node n) {
   n.asExpr().(InstanceAccess).isOwnInstanceAccess()
   or
   n.(DataFlow::ImplicitInstanceAccess).getInstanceAccess() instanceof OwnInstanceAccess
-  or
-  n.asExpr().(FieldAccess).isOwnFieldAccess()
 }
 
 /**

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -57,9 +57,7 @@ class ParameterToFieldConfig extends TaintTracking::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(FieldAssignment a |
-      a.getSource() = sink.asExpr()
-    )
+    exists(FieldAssignment a | a.getSource() = sink.asExpr())
   }
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -9,6 +9,7 @@ import ModelGeneratorUtils
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.internal.DataFlowImplCommon
 import semmle.code.java.dataflow.internal.DataFlowNodes
+import ModelGeneratorUtils
 
 string captureFlow(Callable api) {
   result = captureQualifierFlow(api) or
@@ -123,15 +124,6 @@ string captureParameterToParameterFlow(Callable api) {
 // TODO: infer interface from multiple implementations? e.g. UriComponentsContributor
 // TODO: distinguish between taint and value flows. If we find a value flow, omit the taint flow
 // TODO: merge param->return value with param->parameter flow?
-class TargetAPI extends Callable {
-  TargetAPI() {
-    this.isPublic() and
-    this.fromSource() and
-    this.getDeclaringType().isPublic() and
-    not isInTestFile(this)
-  }
-}
-
 from TargetAPI api, string flow
 where flow = captureFlow(api)
 select flow order by flow

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -130,10 +130,6 @@ predicate isRelevantType(Type t) {
   not t.(CollectionType).getElementType() instanceof BoxedType
 }
 
-// TODO: "com.google.common.base;Converter;true;convertAll;(Iterable);;Element of Argument[0];Element of ReturnValue;taint",
-// TODO: infer interface from multiple implementations? e.g. UriComponentsContributor
-// TODO: distinguish between taint and value flows. If we find a value flow, omit the taint flow
-// TODO: merge param->return value with param->parameter flow?
 from TargetAPI api, string flow
 where flow = captureFlow(api)
 select flow order by flow

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -1,0 +1,6 @@
+/**
+ * @name TBD
+ * @description TBD
+ * @id TBD
+ */
+

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -186,8 +186,9 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
     )
   }
 
-  override predicate isSink(DataFlow::Node sink) { sink instanceof ReturnNodeExt }
+  override predicate isSink(DataFlow::Node sink) { sink instanceof ReturnNode }
 
+  // track taint across objects so we consider factory methods returning newly tainted objects
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
     node2.asExpr().(ConstructorCall).getAnArgument() = node1.asExpr()
   }

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -12,7 +12,7 @@ import semmle.code.java.dataflow.internal.DataFlowPrivate
 import semmle.code.java.dataflow.InstanceAccess
 import ModelGeneratorUtils
 
-string captureFlow(Callable api) {
+string captureFlow(TargetAPI api) {
   result = captureQualifierFlow(api) or
   result = captureParameterFlowToReturnValue(api) or
   result = captureFieldFlowIn(api) or
@@ -32,7 +32,7 @@ string captureFlow(Callable api) {
  * }
  * ```
  */
-string captureQualifierFlow(Callable api) {
+string captureQualifierFlow(TargetAPI api) {
   exists(ReturnStmt rtn |
     rtn.getEnclosingCallable() = api and
     rtn.getResult().(ThisAccess).isOwnInstanceAccess()
@@ -92,7 +92,7 @@ class FieldToReturnConfig extends TaintTracking::Configuration {
  * p;Foo;true;putsTaintIntoParameter;(List);Argument[-1];Argument[0];taint
  * ```
  */
-string captureFieldFlow(Callable api) {
+string captureFieldFlow(TargetAPI api) {
   exists(FieldToReturnConfig config, ReturnNodeExt returnNodeExt |
     config.hasFlow(_, returnNodeExt) and
     returnNodeExt.getEnclosingCallable() = api and
@@ -107,7 +107,7 @@ string captureFieldFlow(Callable api) {
   )
 }
 
-string asOutput(Callable api, ReturnNodeExt node) {
+string asOutput(TargetAPI api, ReturnNodeExt node) {
   if node.getKind() instanceof ValueReturnKind
   then result = "ReturnValue"
   else
@@ -164,7 +164,7 @@ private predicate thisAccess(DataFlow::Node n) {
  * Captured Model:
  * `p;Foo;true;doSomething;(String);Argument[0];Argument[-1];taint`
  */
-string captureFieldFlowIn(Callable api) {
+string captureFieldFlowIn(TargetAPI api) {
   exists(DataFlow::Node source, ParameterToFieldConfig config |
     not api.isStatic() and
     config.hasFlow(source, _) and
@@ -179,7 +179,7 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
   ParameterToReturnValueTaintConfig() { this = "ParameterToReturnValueTaintConfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(Callable api |
+    exists(TargetAPI api |
       source instanceof DataFlow::ParameterNode and
       api = source.asParameter().getCallable() and
       isRelevantType(api.getReturnType()) and
@@ -221,7 +221,7 @@ predicate paramFlowToReturnValueExists(Parameter p) {
  * p;Foo;true;returnData;;Argument[0];ReturnValue;taint
  * ```
  */
-string captureParameterFlowToReturnValue(Callable api) {
+string captureParameterFlowToReturnValue(TargetAPI api) {
   exists(Parameter p |
     p = api.getAParameter() and
     paramFlowToReturnValueExists(p)
@@ -246,7 +246,7 @@ string captureParameterFlowToReturnValue(Callable api) {
  * p;Foo;true;addToList;;Argument[0];Argument[1];taint
  * ```
  */
-string captureParameterToParameterFlow(Callable api) {
+string captureParameterToParameterFlow(TargetAPI api) {
   exists(DataFlow::ParameterNode source, DataFlow::PostUpdateNode sink |
     source.getEnclosingCallable() = api and
     sink.getPreUpdateNode().asExpr() = api.getAParameter().getAnAccess() and

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -41,7 +41,8 @@ string captureFieldFlow(Callable api) {
 string asOutput(Callable api, ReturnNodeExt node) {
   if node.getKind() instanceof ValueReturnKind
   then result = "ReturnValue"
-  else result = parameterAccess(api.getParameter(node.getKind().(ParamUpdateReturnKind).getPosition()))
+  else
+    result = parameterAccess(api.getParameter(node.getKind().(ParamUpdateReturnKind).getPosition()))
 }
 
 class FieldAssignment extends AssignExpr {

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -140,8 +140,7 @@ class TargetAPI extends Callable {
     this.isPublic() and
     this.fromSource() and
     this.getDeclaringType().isPublic() and
-    not this.getCompilationUnit().getFile().getAbsolutePath().matches("%src/test/%") and
-    not this.getCompilationUnit().getFile().getAbsolutePath().matches("%src/guava-tests/%")
+    not isInTestFile(this)
   }
 }
 

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -53,7 +53,8 @@ class ParameterToFieldConfig extends TaintTracking::Configuration {
   ParameterToFieldConfig() { this = "ParameterToFieldConfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    not source.asParameter().getType() instanceof PrimitiveType
+    source instanceof DataFlow::ParameterNode and
+    not source.getType() instanceof PrimitiveType
   }
 
   override predicate isSink(DataFlow::Node sink) {
@@ -77,17 +78,13 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
   ParameterToReturnValueTaintConfig() { this = "ParameterToReturnValueTaintConfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(Parameter p, Callable api |
-      p = source.asParameter() and
-      api = p.getCallable() and
-      (
-        not api.getReturnType() instanceof PrimitiveType and
-        not p.getType() instanceof PrimitiveType
-      ) and
-      (
-        not api.getReturnType() instanceof TypeClass and
-        not p.getType() instanceof TypeClass
-      )
+    exists(Callable api |
+      source instanceof DataFlow::ParameterNode and
+      api = source.asParameter().getCallable() and
+      not api.getReturnType() instanceof PrimitiveType and
+      not api.getReturnType() instanceof TypeClass and
+      not source.asParameter().getType() instanceof PrimitiveType and
+      not source.asParameter().getType() instanceof TypeClass
     )
   }
 

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -131,10 +131,20 @@ predicate isRelevantType(Type t) {
   not t.(RefType).hasQualifiedName("java.math", "BigInteger") and
   (
     not t.(Array).getElementType() instanceof PrimitiveType or
-    t.(Array).getElementType().(PrimitiveType).getName().regexpMatch("byte|char")
+    isPrimitiveTypeUsedForBulkData(t.(Array).getElementType())
   ) and
-  not t.(Array).getElementType() instanceof BoxedType and
-  not t.(CollectionType).getElementType() instanceof BoxedType
+  (
+    not t.(Array).getElementType() instanceof BoxedType or
+    isPrimitiveTypeUsedForBulkData(t.(Array).getElementType())
+  ) and
+  (
+    not t.(CollectionType).getElementType() instanceof BoxedType or
+    isPrimitiveTypeUsedForBulkData(t.(CollectionType).getElementType())
+  )
+}
+
+predicate isPrimitiveTypeUsedForBulkData(Type t) {
+  t.getName().regexpMatch("byte|char|Byte|Character")
 }
 
 from TargetAPI api, string flow

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -6,8 +6,13 @@
 
 import java
 import ModelGeneratorUtils
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.internal.DataFlowImplCommon
 
-string captureFlow(Callable api) { result = captureQualifierFlow(api) }
+string captureFlow(Callable api) {
+  result = captureQualifierFlow(api) or
+  result = captureParameterFlowToReturnValue(api)
+}
 
 string captureQualifierFlow(Callable api) {
   exists(ReturnStmt rtn |
@@ -15,6 +20,44 @@ string captureQualifierFlow(Callable api) {
     rtn.getResult() instanceof ThisAccess
   ) and
   result = asValueModel(api, "Argument[-1]", "ReturnValue")
+}
+
+class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
+  ParameterToReturnValueTaintConfig() { this = "ParameterToReturnValueTaintConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(Parameter p, Callable api |
+      p = source.asParameter() and
+      api = p.getCallable() and
+      (
+        not api.getReturnType() instanceof PrimitiveType and
+        not p.getType() instanceof PrimitiveType
+      ) and
+      (
+        not api.getReturnType() instanceof TypeClass and
+        not p.getType() instanceof TypeClass
+      )
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof ReturnNodeExt }
+}
+
+// TODO: rtn -> Node as ReturnNodeExt is also PostUpdateNode, might be able to merge with p2p flow
+predicate paramFlowToReturnValueExists(Parameter p) {
+  exists(ParameterToReturnValueTaintConfig config, ReturnStmt rtn |
+    rtn.getEnclosingCallable() = p.getCallable() and
+    config.hasFlow(DataFlow::parameterNode(p), DataFlow::exprNode(rtn.getResult()))
+  )
+}
+
+string captureParameterFlowToReturnValue(Callable api) {
+  exists(Parameter p |
+    p = api.getAParameter() and
+    paramFlowToReturnValueExists(p)
+  |
+    result = asTaintModel(api, parameterAccess(p), "ReturnValue")
+  )
 }
 
 // TODO: handle cases like Ticker

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -119,6 +119,7 @@ string captureFieldFlowIn(Callable api) {
   exists(DataFlow::ParameterNode source, DataFlow::ExprNode sink, ParameterToFieldConfig config |
     sink.asExpr().getEnclosingCallable().getDeclaringType() =
       source.asParameter().getCallable().getDeclaringType() and
+    not api.isStatic() and
     config.hasFlow(source, sink) and
     source.asParameter().getCallable() = api
   |
@@ -140,6 +141,11 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof ReturnNodeExt }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    node2.asExpr().(ConstructorCall).getAnArgument() = node1.asExpr() and
+    node1.asExpr().(Argument).getCall().getCallee().fromSource()
+  }
 }
 
 predicate paramFlowToReturnValueExists(Parameter p) {

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -199,7 +199,6 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
 
 predicate paramFlowToReturnValueExists(Parameter p) {
   exists(ParameterToReturnValueTaintConfig config, ReturnStmt rtn |
-    rtn.getEnclosingCallable() = p.getCallable() and
     config.hasFlow(DataFlow::parameterNode(p), DataFlow::exprNode(rtn.getResult()))
   )
 }

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -129,8 +129,10 @@ predicate isRelevantType(Type t) {
   not t instanceof PrimitiveType and
   not t instanceof BoxedType and
   not t.(RefType).hasQualifiedName("java.math", "BigInteger") and
-  not t.(Array).getElementType() instanceof PrimitiveType and
-  not t.(Array).getElementType().(PrimitiveType).getName().regexpMatch("byte|char") and
+  (
+    not t.(Array).getElementType() instanceof PrimitiveType or
+    t.(Array).getElementType().(PrimitiveType).getName().regexpMatch("byte|char")
+  ) and
   not t.(Array).getElementType() instanceof BoxedType and
   not t.(CollectionType).getElementType() instanceof BoxedType
 }

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -228,10 +228,6 @@ predicate isRelevantType(Type t) {
   )
 }
 
-predicate isPrimitiveTypeUsedForBulkData(Type t) {
-  t.getName().regexpMatch("byte|char|Byte|Character")
-}
-
 from TargetAPI api, string flow
 where flow = captureFlow(api)
 select flow order by flow

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -58,7 +58,7 @@ string captureQualifierFlow(Callable api) {
  * Captured Model:
  * ```
  * p;Foo;true;returnsTainted;;Argument[-1];ReturnValue;taint
- * p;Foo;true;putsTaintIntoParameter;(List);Argument[-1];ReturnValue;taint
+ * p;Foo;true;putsTaintIntoParameter;(List);Argument[-1];Argument[0];taint
  * ```
  */
 string captureFieldFlow(Callable api) {

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -180,7 +180,6 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node source) {
     exists(TargetAPI api |
-      source instanceof DataFlow::ParameterNode and
       api = source.asParameter().getCallable() and
       isRelevantType(api.getReturnType()) and
       isRelevantType(source.asParameter().getType())

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -5,7 +5,6 @@
  */
 
 import java
-import ModelGeneratorUtils
 import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.dataflow.internal.DataFlowImplCommon
 import semmle.code.java.dataflow.internal.DataFlowNodes
@@ -148,6 +147,8 @@ private predicate thisAccess(DataFlow::Node n) {
   n.asExpr().(InstanceAccess).isOwnInstanceAccess()
   or
   n.(DataFlow::ImplicitInstanceAccess).getInstanceAccess() instanceof OwnInstanceAccess
+  or
+  n.asExpr().(FieldAccess).isOwnFieldAccess()
 }
 
 /**

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -192,6 +192,10 @@ class ParameterToReturnValueTaintConfig extends TaintTracking::Configuration {
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
     node2.asExpr().(ConstructorCall).getAnArgument() = node1.asExpr()
   }
+
+  override DataFlow::FlowFeature getAFeature() {
+    result instanceof DataFlow::FeatureEqualSourceSinkCallContext
+  }
 }
 
 predicate paramFlowToReturnValueExists(Parameter p) {

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -104,7 +104,7 @@ private class {0}{1}Csv extends {2} {{
 """
     if rows.strip() == "":
         return ""
-    return classTemplate.format(shortname.capitalize(), kind.capitalize(), superclass, rows)
+    return classTemplate.format(shortname[0].upper() + shortname[1:], kind.capitalize(), superclass, rows)
 
 
 summaryRows = runQuery("summary models", "CaptureSummaryModels.ql")

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -80,7 +80,7 @@ def runQuery(infoMessage, query):
         __file__), query)
     resultBqrs = os.path.join(workDir, "out.bqrs")
     cmd = ['codeql', 'query', 'run', queryFile, '--database',
-           database, '--output', resultBqrs]
+           database, '--output', resultBqrs, '--threads', '8']
 
     ret = subprocess.call(cmd)
     if ret != 0:

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+
+import errno
+import json
+import os
+import os.path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def printHelp():
+    print("""Usage:
+GenerateFlowModel.py <library-database> "simpleName"
+
+This generates summary, source and sink models for the code in the database.
+The files will be placed in `java/ql/lib/semmle/code/java/frameworks/generated/<simpleName>/`
+
+A simple name is used for the generated target files (e.g. `simpleName.qll`).
+
+Requirements: `codeql` should both appear on your path.
+""")
+
+
+if any(s == "--help" for s in sys.argv):
+    printHelp()
+    sys.exit(0)
+
+withTests = False
+if "--with-tests" in sys.argv:
+    sys.argv.remove("--with-tests")
+    withTests = True
+
+if len(sys.argv) != 3:
+    printHelp()
+    sys.exit(1)
+
+codeQlRoot = subprocess.check_output(
+    ["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
+shortname = sys.argv[2]
+generatedFrameworks = os.path.join(
+    codeQlRoot, "java/ql/lib/semmle/code/java/frameworks/generated/")
+frameworkTarget = os.path.join(generatedFrameworks, shortname + ".qll")
+
+workDir = tempfile.mkdtemp()
+os.makedirs(generatedFrameworks, exist_ok=True)
+
+
+def runQuery(infoMessage, query):
+    print("########## Querying " + infoMessage + "...")
+    database = sys.argv[1]
+    queryFile = os.path.join(os.path.dirname(
+        __file__), query)
+    resultBqrs = os.path.join(workDir, "out.bqrs")
+    cmd = ['codeql', 'query', 'run', queryFile, '--database',
+           database, '--output', resultBqrs]
+
+    ret = subprocess.call(cmd)
+    if ret != 0:
+        print("Failed to generate " + infoMessage +
+              ". Failed command was: " + shlex.join(cmd))
+        sys.exit(1)
+    return readRows(resultBqrs)
+
+
+def readRows(bqrsFile):
+    generatedJson = os.path.join(workDir, "out.json")
+    cmd = ['codeql', 'bqrs', 'decode', bqrsFile,
+           '--format=json', '--output', generatedJson]
+    ret = subprocess.call(cmd)
+    if ret != 0:
+        print("Failed to decode BQRS. Failed command was: " + shlex.join(cmd))
+        sys.exit(1)
+
+    with open(generatedJson) as f:
+        results = json.load(f)
+
+    try:
+        results['#select']['tuples']
+    except KeyError:
+        print('Unexpected JSON output - no tuples found')
+        exit(1)
+
+    rows = ""
+    for (row) in results['#select']['tuples']:
+        rows += "            \"" + row[0] + "\",\n"
+
+    return rows[:-2]
+
+
+def asCsvModel(superclass, kind, rows):
+    classTemplate = """
+private class {0}{1}Csv extends {2} {{
+    override predicate row(string row) {{
+        row =
+            [
+{3}
+            ]
+    }}
+}}
+"""
+    return classTemplate.format(shortname.capitalize(), kind.capitalize(), superclass, rows)
+
+
+summaryRows = runQuery("summary models", "CaptureSummaryModels.ql")
+summaryCsv = asCsvModel("SummaryModelCsv", "summary", summaryRows)
+
+sinkRows = runQuery("sink models", "CaptureSinkModels.ql")
+sinkCsv = asCsvModel("SinkModelCsv", "sinks", sinkRows)
+
+
+qllTemplate = """
+/** Definitions of taint steps in the {0} framework */
+
+import java
+private import semmle.code.java.dataflow.ExternalFlow
+
+{1}
+{2}
+
+"""
+
+
+qllContents = qllTemplate.format(shortname, summaryCsv, sinkCsv)
+
+
+with open(frameworkTarget, "w") as frameworkQll:
+    frameworkQll.write(qllContents)

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -11,7 +11,7 @@ import tempfile
 
 def printHelp():
     print("""Usage:
-GenerateFlowModel.py <library-database> "simpleName" [--with-sinks] [--with-sources] [--with-summaries]
+GenerateFlowModel.py <library-database> <simpleName> [--with-sinks] [--with-sources] [--with-summaries]
 
 This generates summary, source and sink models for the code in the database.
 The files will be placed in `java/ql/lib/semmle/code/java/frameworks/generated/<simpleName>/`
@@ -158,6 +158,12 @@ qllContents = qllTemplate.format(shortname, sinkCsv, sourceCsv, summaryCsv)
 
 with open(frameworkTarget, "w") as frameworkQll:
     frameworkQll.write(qllContents)
+
+cmd = ['codeql', 'query', 'format', '--in-place', frameworkTarget]
+ret = subprocess.call(cmd)
+if ret != 0:
+    print("Failed to format query. Failed command was: " + shlex.join(cmd))
+    sys.exit(1)
 
 print("")
 print("CSV model written to " + frameworkTarget)

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -126,7 +126,7 @@ private import semmle.code.java.dataflow.ExternalFlow
 """
 
 
-qllContents = qllTemplate.format(shortname, summaryCsv, sinkCsv, sourceCsv)
+qllContents = qllTemplate.format(shortname, sinkCsv, sourceCsv, summaryCsv)
 
 
 with open(frameworkTarget, "w") as frameworkQll:

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -102,6 +102,8 @@ private class {0}{1}Csv extends {2} {{
     }}
 }}
 """
+    if rows.strip() == "":
+        return ""
     return classTemplate.format(shortname.capitalize(), kind.capitalize(), superclass, rows)
 
 
@@ -111,6 +113,8 @@ summaryCsv = asCsvModel("SummaryModelCsv", "summary", summaryRows)
 sinkRows = runQuery("sink models", "CaptureSinkModels.ql")
 sinkCsv = asCsvModel("SinkModelCsv", "sinks", sinkRows)
 
+sourceRows = runQuery("source models", "CaptureSourceModels.ql")
+sourceCsv = asCsvModel("SourceModelCsv", "sources", sourceRows)
 
 qllTemplate = """
 /** Definitions of taint steps in the {0} framework */
@@ -120,12 +124,16 @@ private import semmle.code.java.dataflow.ExternalFlow
 
 {1}
 {2}
+{3}
 
 """
 
 
-qllContents = qllTemplate.format(shortname, summaryCsv, sinkCsv)
+qllContents = qllTemplate.format(shortname, summaryCsv, sinkCsv, sourceCsv)
 
 
 with open(frameworkTarget, "w") as frameworkQll:
     frameworkQll.write(qllContents)
+
+print("")
+print("CSV model written to " + frameworkTarget)

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -1,12 +1,9 @@
 #!/usr/bin/python3
 
-import errno
 import json
 import os
 import os.path
-import re
 import shlex
-import shutil
 import subprocess
 import sys
 import tempfile

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -60,10 +60,14 @@ if len(sys.argv) != 3:
 
 codeQlRoot = subprocess.check_output(
     ["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip()
-shortname = sys.argv[2]
+targetQll = sys.argv[2]
+if not targetQll.endswith(".qll"):
+    targetQll += ".qll"
+filename = os.path.basename(targetQll)
+shortname = filename[:-4]
 generatedFrameworks = os.path.join(
-    codeQlRoot, "java/ql/lib/semmle/code/java/frameworks/generated/")
-frameworkTarget = os.path.join(generatedFrameworks, shortname + ".qll")
+    codeQlRoot, "java/ql/lib/semmle/code/java/frameworks/")
+frameworkTarget = os.path.join(generatedFrameworks, targetQll)
 
 workDir = tempfile.mkdtemp()
 os.makedirs(generatedFrameworks, exist_ok=True)

--- a/java/ql/src/utils/model-generator/GenerateFlowModel.py
+++ b/java/ql/src/utils/model-generator/GenerateFlowModel.py
@@ -11,17 +11,22 @@ import tempfile
 
 def printHelp():
     print("""Usage:
-GenerateFlowModel.py <library-database> <simpleName> [--with-sinks] [--with-sources] [--with-summaries]
+GenerateFlowModel.py <library-database> <outputQll> [--with-sinks] [--with-sources] [--with-summaries]
 
 This generates summary, source and sink models for the code in the database.
-The files will be placed in `java/ql/lib/semmle/code/java/frameworks/generated/<simpleName>/`
+The files will be placed in `java/ql/lib/semmle/code/java/frameworks/<outputQll>` where
+outputQll is the name (and path) of the output QLL file. Usually, models are grouped by their
+respective frameworks.
 
-A simple name is used for the generated target files (e.g. `simpleName.qll`).
 Which models are generated is controlled by the flags:
     --with-sinks
     --with-sources
     --with-summaries
 If none of these flags are specified, all models are generated.
+
+Example invocations:
+$ GenerateFlowModel.py /tmp/dbs/apache_commons-codec_45649c8 "apache/Codec.qll"
+$ GenerateFlowModel.py /tmp/dbs/jdk15_db "javase/jdk_sinks.qll" --with-sinks
 
 Requirements: `codeql` should both appear on your path.
 """)

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -29,6 +29,13 @@ string asSinkModel(Callable api, string input, string kind) {
       + kind + ";" //
 }
 
+bindingset[output, kind]
+string asSourceModel(Callable api, string output, string kind) {
+  result =
+    asPartialModel(api) + output + ";" //
+      + kind + ";" //
+}
+
 /**
  * Computes the first 6 columns for CSV rows.
  */
@@ -49,4 +56,9 @@ string parameterAccess(Parameter p) {
     if p.getType() instanceof ContainerType
     then result = "Element of Argument[" + p.getPosition() + "]"
     else result = "Argument[" + p.getPosition() + "]"
+}
+
+predicate isInTestFile(Callable api) {
+  api.getCompilationUnit().getFile().getAbsolutePath().matches("%src/test/%") or
+  api.getCompilationUnit().getFile().getAbsolutePath().matches("%src/guava-tests/%")
 }

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -9,10 +9,11 @@ class TargetAPI extends Callable {
     this.getDeclaringType().isPublic() and
     isRelevantForModels(this)
   }
-  
 }
 
-private string isExtensible(RefType ref) { if ref.isFinal() then result = "false" else result = "true" }
+private string isExtensible(RefType ref) {
+  if ref.isFinal() then result = "false" else result = "true"
+}
 
 predicate isRelevantForModels(Callable api) {
   not isInTestFile(api.getCompilationUnit().getFile()) and
@@ -26,7 +27,9 @@ private predicate isInTestFile(File file) {
 }
 
 private predicate isJdkInternal(CompilationUnit cu) {
-  cu.getPackage().getName().matches("com.sun") or cu.getPackage().getName().matches("sun") or cu.getPackage().getName().matches("")
+  cu.getPackage().getName().matches("com.sun") or
+  cu.getPackage().getName().matches("sun") or
+  cu.getPackage().getName().matches("")
 }
 
 bindingset[input, output]

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -69,12 +69,25 @@ string asSourceModel(Callable api, string output, string kind) {
  */
 private string asPartialModel(Callable api) {
   result =
-    api.getCompilationUnit().getPackage().getName() + ";" //
-      + api.getDeclaringType().nestedName() + ";" //
+    asModelName(api) + ";" //
       + isExtensible(api.getDeclaringType()).toString() + ";" //
       + api.getName() + ";" //
       + paramsString(api) + ";" //
       + /* ext + */ ";" //
+}
+
+/**
+ * Returns the appropriate type name for the model. Either the type
+ * declaring the method or the supertype introducing the method.
+ */
+private string asModelName(Callable api) {
+  if api.(Method).getASourceOverriddenMethod().fromSource()
+  then result = typeAsModel(api.(Method).getASourceOverriddenMethod().getDeclaringType())
+  else result = typeAsModel(api.getDeclaringType())
+}
+
+private string typeAsModel(RefType type) {
+  result = type.getCompilationUnit().getPackage().getName() + ";" + type.nestedName()
 }
 
 string parameterAccess(Parameter p) {

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -69,7 +69,7 @@ string asSourceModel(Callable api, string output, string kind) {
  */
 private string asPartialModel(Callable api) {
   result =
-    asModelName(api) + ";" //
+    typeAsSummaryModel(api) + ";" //
       + isExtensible(api.getDeclaringType()).toString() + ";" //
       + api.getName() + ";" //
       + paramsString(api) + ";" //
@@ -80,10 +80,18 @@ private string asPartialModel(Callable api) {
  * Returns the appropriate type name for the model. Either the type
  * declaring the method or the supertype introducing the method.
  */
-private string asModelName(Callable api) {
-  if api.(Method).getASourceOverriddenMethod().fromSource()
-  then result = typeAsModel(api.(Method).getASourceOverriddenMethod().getDeclaringType())
+private string typeAsSummaryModel(Callable api) {
+  if exists(superImpl(api.(Method)))
+  then
+    superImpl(api.(Method)).fromSource() and
+    result = typeAsModel(superImpl(api.(Method)).getDeclaringType())
   else result = typeAsModel(api.getDeclaringType())
+}
+
+Method superImpl(Method m) {
+  result = m.getAnOverride() and
+  not exists(result.getAnOverride()) and
+  not m instanceof ToStringMethod
 }
 
 private string typeAsModel(RefType type) {

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -55,17 +55,17 @@ private predicate isJdkInternal(CompilationUnit cu) {
 }
 
 bindingset[input, output]
-string asTaintModel(Callable api, string input, string output) {
+string asTaintModel(TargetAPI api, string input, string output) {
   result = asSummaryModel(api, input, output, "taint")
 }
 
 bindingset[input, output]
-string asValueModel(Callable api, string input, string output) {
+string asValueModel(TargetAPI api, string input, string output) {
   result = asSummaryModel(api, input, output, "value")
 }
 
 bindingset[input, output, kind]
-string asSummaryModel(Callable api, string input, string output, string kind) {
+string asSummaryModel(TargetAPI api, string input, string output, string kind) {
   result =
     asPartialModel(api) + input + ";" //
       + output + ";" //
@@ -73,19 +73,19 @@ string asSummaryModel(Callable api, string input, string output, string kind) {
 }
 
 bindingset[input, kind]
-string asSinkModel(Callable api, string input, string kind) {
+string asSinkModel(TargetAPI api, string input, string kind) {
   result = asPartialModel(api) + input + ";" + kind
 }
 
 bindingset[output, kind]
-string asSourceModel(Callable api, string output, string kind) {
+string asSourceModel(TargetAPI api, string output, string kind) {
   result = asPartialModel(api) + output + ";" + kind
 }
 
 /**
  * Computes the first 6 columns for CSV rows.
  */
-private string asPartialModel(Callable api) {
+private string asPartialModel(TargetAPI api) {
   result =
     typeAsSummaryModel(api) + ";" //
       + isExtensible(bestTypeForModel(api)) + ";" //
@@ -98,9 +98,9 @@ private string asPartialModel(Callable api) {
  * Returns the appropriate type name for the model. Either the type
  * declaring the method or the supertype introducing the method.
  */
-private string typeAsSummaryModel(Callable api) { result = typeAsModel(bestTypeForModel(api)) }
+private string typeAsSummaryModel(TargetAPI api) { result = typeAsModel(bestTypeForModel(api)) }
 
-private RefType bestTypeForModel(Callable api) {
+private RefType bestTypeForModel(TargetAPI api) {
   if exists(superImpl(api))
   then superImpl(api).fromSource() and result = superImpl(api).getDeclaringType()
   else result = api.getDeclaringType()

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -1,5 +1,6 @@
 import java
 import semmle.code.java.dataflow.ExternalFlow
+import semmle.code.java.dataflow.internal.ContainerFlow
 
 string isExtensible(RefType ref) { if ref.isFinal() then result = "false" else result = "true" }
 
@@ -25,4 +26,13 @@ string asSummaryModel(Callable api, string input, string output, string kind) {
       + input + ";" //
       + output + ";" //
       + kind + ";" //
+}
+
+string parameterAccess(Parameter p) {
+  if p.getType() instanceof Array
+  then result = "ArrayElement of Argument[" + p.getPosition() + "]"
+  else
+    if p.getType() instanceof ContainerType
+    then result = "Element of Argument[" + p.getPosition() + "]"
+    else result = "Argument[" + p.getPosition() + "]"
 }

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -102,10 +102,16 @@ private string typeAsModel(RefType type) {
 }
 
 string parameterAccess(Parameter p) {
-  if p.getType() instanceof Array
+  if
+    p.getType() instanceof Array and
+    not isPrimitiveTypeUsedForBulkData(p.getType().(Array).getElementType())
   then result = "ArrayElement of Argument[" + p.getPosition() + "]"
   else
     if p.getType() instanceof ContainerType
     then result = "Element of Argument[" + p.getPosition() + "]"
     else result = "Argument[" + p.getPosition() + "]"
+}
+
+predicate isPrimitiveTypeUsedForBulkData(Type t) {
+  t.getName().regexpMatch("byte|char|Byte|Character")
 }

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -17,15 +17,29 @@ string asValueModel(Callable api, string input, string output) {
 bindingset[input, output, kind]
 string asSummaryModel(Callable api, string input, string output, string kind) {
   result =
+    asPartialModel(api) + input + ";" //
+      + output + ";" //
+      + kind + ";" //
+}
+
+bindingset[input, kind]
+string asSinkModel(Callable api, string input, string kind) {
+  result =
+    asPartialModel(api) + input + ";" //
+      + kind + ";" //
+}
+
+/**
+ * Computes the first 6 columns for CSV rows.
+ */
+private string asPartialModel(Callable api) {
+  result =
     api.getCompilationUnit().getPackage().getName() + ";" //
       + api.getDeclaringType().nestedName() + ";" //
       + isExtensible(api.getDeclaringType()).toString() + ";" //
       + api.getName() + ";" //
       + paramsString(api) + ";" //
       + /* ext + */ ";" //
-      + input + ";" //
-      + output + ";" //
-      + kind + ";" //
 }
 
 string parameterAccess(Parameter p) {

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -36,9 +36,22 @@ private predicate isInTestFile(File file) {
 }
 
 private predicate isJdkInternal(CompilationUnit cu) {
-  cu.getPackage().getName().matches("com.sun") or
-  cu.getPackage().getName().matches("sun") or
-  cu.getPackage().getName().matches("")
+  cu.getPackage().getName().matches("org.graalvm%") or
+  cu.getPackage().getName().matches("com.sun%") or
+  cu.getPackage().getName().matches("javax.swing%") or
+  cu.getPackage().getName().matches("java.awt%") or
+  cu.getPackage().getName().matches("sun%") or
+  cu.getPackage().getName().matches("jdk.%") or
+  cu.getPackage().getName().matches("java2d.%") or
+  cu.getPackage().getName().matches("build.tools.%") or
+  cu.getPackage().getName().matches("propertiesparser.%") or
+  cu.getPackage().getName().matches("org.jcp.%") or
+  cu.getPackage().getName().matches("org.w3c.%") or
+  cu.getPackage().getName().matches("org.ietf.jgss.%") or
+  cu.getPackage().getName().matches("org.xml.sax%") or
+  cu.getPackage().getName() = "compileproperties" or
+  cu.getPackage().getName() = "netscape.javascript" or
+  cu.getPackage().getName() = ""
 }
 
 bindingset[input, output]

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -60,5 +60,6 @@ string parameterAccess(Parameter p) {
 
 predicate isInTestFile(Callable api) {
   api.getCompilationUnit().getFile().getAbsolutePath().matches("%src/test/%") or
-  api.getCompilationUnit().getFile().getAbsolutePath().matches("%src/guava-tests/%")
+  api.getCompilationUnit().getFile().getAbsolutePath().matches("%/guava-tests/%") or
+  api.getCompilationUnit().getFile().getAbsolutePath().matches("%/guava-testlib/%")
 }

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -1,0 +1,28 @@
+import java
+import semmle.code.java.dataflow.ExternalFlow
+
+string isExtensible(RefType ref) { if ref.isFinal() then result = "false" else result = "true" }
+
+bindingset[input, output]
+string asTaintModel(Callable api, string input, string output) {
+  result = asSummaryModel(api, input, output, "taint")
+}
+
+bindingset[input, output]
+string asValueModel(Callable api, string input, string output) {
+  result = asSummaryModel(api, input, output, "value")
+}
+
+bindingset[input, output, kind]
+string asSummaryModel(Callable api, string input, string output, string kind) {
+  result =
+    api.getCompilationUnit().getPackage().getName() + ";" //
+      + api.getDeclaringType().nestedName() + ";" //
+      + isExtensible(api.getDeclaringType()).toString() + ";" //
+      + api.getName() + ";" //
+      + paramsString(api) + ";" //
+      + /* ext + */ ";" //
+      + input + ";" //
+      + output + ";" //
+      + kind + ";" //
+}

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -56,21 +56,17 @@ string asSummaryModel(Callable api, string input, string output, string kind) {
   result =
     asPartialModel(api) + input + ";" //
       + output + ";" //
-      + kind + ";" //
+      + kind
 }
 
 bindingset[input, kind]
 string asSinkModel(Callable api, string input, string kind) {
-  result =
-    asPartialModel(api) + input + ";" //
-      + kind + ";" //
+  result = asPartialModel(api) + input + ";" + kind
 }
 
 bindingset[output, kind]
 string asSourceModel(Callable api, string output, string kind) {
-  result =
-    asPartialModel(api) + output + ";" //
-      + kind + ";" //
+  result = asPartialModel(api) + output + ";" + kind
 }
 
 /**

--- a/java/ql/test/library-tests/dataflow/taint/CharSeq.java
+++ b/java/ql/test/library-tests/dataflow/taint/CharSeq.java
@@ -9,5 +9,8 @@ public class CharSeq {
   
       CharSequence seqFromSeq = seq.subSequence(0, 1);
       sink(seqFromSeq);
+
+      String stringFromSeq = seq.toString();
+      sink(stringFromSeq);
     }
   }

--- a/java/ql/test/library-tests/dataflow/taint/test.expected
+++ b/java/ql/test/library-tests/dataflow/taint/test.expected
@@ -43,6 +43,7 @@
 | B.java:15:21:15:27 | taint(...) | B.java:157:10:157:46 | toFile(...) |
 | CharSeq.java:7:26:7:32 | taint(...) | CharSeq.java:8:12:8:14 | seq |
 | CharSeq.java:7:26:7:32 | taint(...) | CharSeq.java:11:12:11:21 | seqFromSeq |
+| CharSeq.java:7:26:7:32 | taint(...) | CharSeq.java:14:12:14:24 | stringFromSeq |
 | MethodFlow.java:7:22:7:28 | taint(...) | MethodFlow.java:8:10:8:16 | tainted |
 | MethodFlow.java:9:31:9:37 | taint(...) | MethodFlow.java:10:10:10:17 | tainted2 |
 | MethodFlow.java:11:35:11:41 | taint(...) | MethodFlow.java:12:10:12:17 | tainted3 |

--- a/java/ql/test/utils/model-generator/CaptureSinkModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSinkModels.expected
@@ -1,0 +1,1 @@
+| p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];create-file; |

--- a/java/ql/test/utils/model-generator/CaptureSinkModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSinkModels.expected
@@ -1,3 +1,3 @@
 | p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];create-file; |
-| p;Sinks;true;readUrl;(URL,Charset);;url;open-url; |
-| p;Sources;true;readUrl;(URL);;url;open-url; |
+| p;Sinks;true;readUrl;(URL,Charset);;Argument[0];open-url; |
+| p;Sources;true;readUrl;(URL);;Argument[0];open-url; |

--- a/java/ql/test/utils/model-generator/CaptureSinkModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSinkModels.expected
@@ -1,1 +1,3 @@
 | p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];create-file; |
+| p;Sinks;true;readUrl;(URL,Charset);;url;open-url; |
+| p;Sources;true;readUrl;(URL);;url;open-url; |

--- a/java/ql/test/utils/model-generator/CaptureSinkModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSinkModels.expected
@@ -1,4 +1,4 @@
-| p;PrivateFlowViaPublicInterface$SPI;true;openStream;();;Argument[-1];create-file; |
-| p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];create-file; |
-| p;Sinks;true;readUrl;(URL,Charset);;Argument[0];open-url; |
-| p;Sources;true;readUrl;(URL);;Argument[0];open-url; |
+| p;PrivateFlowViaPublicInterface$SPI;true;openStream;();;Argument[-1];create-file |
+| p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];create-file |
+| p;Sinks;true;readUrl;(URL,Charset);;Argument[0];open-url |
+| p;Sources;true;readUrl;(URL);;Argument[0];open-url |

--- a/java/ql/test/utils/model-generator/CaptureSinkModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSinkModels.expected
@@ -1,3 +1,4 @@
+| p;PrivateFlowViaPublicInterface$SPI;true;openStream;();;Argument[-1];create-file; |
 | p;Sinks;true;copyFileToDirectory;(Path,Path,CopyOption[]);;Argument[1];create-file; |
 | p;Sinks;true;readUrl;(URL,Charset);;Argument[0];open-url; |
 | p;Sources;true;readUrl;(URL);;Argument[0];open-url; |

--- a/java/ql/test/utils/model-generator/CaptureSinkModels.qlref
+++ b/java/ql/test/utils/model-generator/CaptureSinkModels.qlref
@@ -1,0 +1,1 @@
+utils/model-generator/CaptureSinkModels.ql

--- a/java/ql/test/utils/model-generator/CaptureSourceModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSourceModels.expected
@@ -1,3 +1,2 @@
-| p;Sources;true;consumeSource;(int,Consumer);;Parameter[1];remote |
 | p;Sources;true;readUrl;(URL);;ReturnValue;remote |
 | p;Sources;true;socketStream;();;ReturnValue;remote |

--- a/java/ql/test/utils/model-generator/CaptureSourceModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSourceModels.expected
@@ -1,0 +1,1 @@
+| p;Sources;true;readUrl;(URL);;ReturnValue;remote; |

--- a/java/ql/test/utils/model-generator/CaptureSourceModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSourceModels.expected
@@ -1,1 +1,3 @@
+| p;Sources;true;consumeSource;(int,Consumer);;Parameter[1];remote; |
 | p;Sources;true;readUrl;(URL);;ReturnValue;remote; |
+| p;Sources;true;socketStream;();;ReturnValue;remote; |

--- a/java/ql/test/utils/model-generator/CaptureSourceModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSourceModels.expected
@@ -1,2 +1,4 @@
 | p;Sources;true;readUrl;(URL);;ReturnValue;remote |
 | p;Sources;true;socketStream;();;ReturnValue;remote |
+| p;Sources;true;sourceToParameter;(InputStream[],List);;ArrayElement of Argument[0];remote |
+| p;Sources;true;sourceToParameter;(InputStream[],List);;Element of Argument[1];remote |

--- a/java/ql/test/utils/model-generator/CaptureSourceModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSourceModels.expected
@@ -1,3 +1,3 @@
-| p;Sources;true;consumeSource;(int,Consumer);;Parameter[1];remote; |
-| p;Sources;true;readUrl;(URL);;ReturnValue;remote; |
-| p;Sources;true;socketStream;();;ReturnValue;remote; |
+| p;Sources;true;consumeSource;(int,Consumer);;Parameter[1];remote |
+| p;Sources;true;readUrl;(URL);;ReturnValue;remote |
+| p;Sources;true;socketStream;();;ReturnValue;remote |

--- a/java/ql/test/utils/model-generator/CaptureSourceModels.qlref
+++ b/java/ql/test/utils/model-generator/CaptureSourceModels.qlref
@@ -1,0 +1,1 @@
+utils/model-generator/CaptureSourceModels.ql

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,5 +1,5 @@
-| p;Factory;false;create;(String);;Argument[0];Argument[-1];taint; |
-| p;Factory;false;create;(String,int);;Argument[0];Argument[-1];taint; |
+| p;Factory;false;create;(String);;Argument[0];ReturnValue;taint; |
+| p;Factory;false;create;(String,int);;Argument[0];ReturnValue;taint; |
 | p;Factory;false;getValue;();;Argument[-1];ReturnValue;taint; |
 | p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |
@@ -38,3 +38,4 @@
 | p;Pojo;false;getCharArray;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint; |
+| p;PrivateFlowViaPublicInterface;true;createAnSPI;(File);;Argument[0];ReturnValue;taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,0 +1,1 @@
+| p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -9,6 +9,9 @@
 | p;ImmutablePojo;false;or;(String);;Argument[0];ReturnValue;taint |
 | p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint |
 | p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint |
+| p;InnerHolder;false;explicitSetContext;(String);;Argument[0];Argument[-1];taint |
+| p;InnerHolder;false;getValue;();;Argument[-1];ReturnValue;taint |
+| p;InnerHolder;false;setContext;(String);;Argument[0];Argument[-1];taint |
 | p;Joiner;false;Joiner;(CharSequence);;Argument[0];Argument[-1];taint |
 | p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[0];Argument[-1];taint |
 | p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[1];Argument[-1];taint |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,42 +1,42 @@
-| p;Factory;false;create;(String);;Argument[0];ReturnValue;taint; |
-| p;Factory;false;create;(String,int);;Argument[0];ReturnValue;taint; |
-| p;Factory;false;getValue;();;Argument[-1];ReturnValue;taint; |
-| p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint; |
-| p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |
-| p;ImmutablePojo;false;ImmutablePojo;(String,int);;Argument[0];Argument[-1];taint; |
-| p;ImmutablePojo;false;getValue;();;Argument[-1];ReturnValue;taint; |
-| p;ImmutablePojo;false;or;(String);;Argument[-1];ReturnValue;taint; |
-| p;ImmutablePojo;false;or;(String);;Argument[0];ReturnValue;taint; |
-| p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint; |
-| p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint; |
-| p;Joiner;false;Joiner;(CharSequence);;Argument[0];Argument[-1];taint; |
-| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[0];Argument[-1];taint; |
-| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[1];Argument[-1];taint; |
-| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[2];Argument[-1];taint; |
-| p;Joiner;false;add;(CharSequence);;Argument[-1];ReturnValue;value; |
-| p;Joiner;false;merge;(Joiner);;Argument[-1];ReturnValue;value; |
-| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[-1];ReturnValue;value; |
-| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[0];Argument[-1];taint; |
-| p;Joiner;false;toString;();;Argument[-1];ReturnValue;taint; |
-| p;MultipleImpls$Strat2;true;getValue;();;Argument[-1];ReturnValue;taint; |
-| p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];Argument[-1];taint; |
-| p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;addTo;(String,List);;Argument[0];Element of Argument[1];taint; |
-| p;ParamFlow;true;returnArrayElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;returnCollectionElement;(List);;Element of Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;returnIterableElement;(Iterable);;Element of Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;returnIteratorElement;(Iterator);;Element of Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[1];ReturnValue;taint; |
-| p;ParamFlow;true;returnVarArgElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;writeChunked;(byte[],OutputStream);;Argument[0];Argument[1];taint; |
-| p;ParamFlow;true;writeChunked;(char[],OutputStream);;Argument[0];Argument[1];taint; |
-| p;Pojo;false;fillIn;(List);;Argument[-1];Element of Argument[0];taint; |
-| p;Pojo;false;getBoxedBytes;();;Argument[-1];ReturnValue;taint; |
-| p;Pojo;false;getBoxedChars;();;Argument[-1];ReturnValue;taint; |
-| p;Pojo;false;getByteArray;();;Argument[-1];ReturnValue;taint; |
-| p;Pojo;false;getCharArray;();;Argument[-1];ReturnValue;taint; |
-| p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint; |
-| p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint; |
-| p;PrivateFlowViaPublicInterface;true;createAnSPI;(File);;Argument[0];ReturnValue;taint; |
+| p;Factory;false;create;(String);;Argument[0];ReturnValue;taint |
+| p;Factory;false;create;(String,int);;Argument[0];ReturnValue;taint |
+| p;Factory;false;getValue;();;Argument[-1];ReturnValue;taint |
+| p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint |
+| p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value |
+| p;ImmutablePojo;false;ImmutablePojo;(String,int);;Argument[0];Argument[-1];taint |
+| p;ImmutablePojo;false;getValue;();;Argument[-1];ReturnValue;taint |
+| p;ImmutablePojo;false;or;(String);;Argument[-1];ReturnValue;taint |
+| p;ImmutablePojo;false;or;(String);;Argument[0];ReturnValue;taint |
+| p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint |
+| p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint |
+| p;Joiner;false;Joiner;(CharSequence);;Argument[0];Argument[-1];taint |
+| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[0];Argument[-1];taint |
+| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[1];Argument[-1];taint |
+| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[2];Argument[-1];taint |
+| p;Joiner;false;add;(CharSequence);;Argument[-1];ReturnValue;value |
+| p;Joiner;false;merge;(Joiner);;Argument[-1];ReturnValue;value |
+| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[-1];ReturnValue;value |
+| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[0];Argument[-1];taint |
+| p;Joiner;false;toString;();;Argument[-1];ReturnValue;taint |
+| p;MultipleImpls$Strat2;true;getValue;();;Argument[-1];ReturnValue;taint |
+| p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];Argument[-1];taint |
+| p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;addTo;(String,List);;Argument[0];Element of Argument[1];taint |
+| p;ParamFlow;true;returnArrayElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;returnCollectionElement;(List);;Element of Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;returnIterableElement;(Iterable);;Element of Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;returnIteratorElement;(Iterator);;Element of Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[1];ReturnValue;taint |
+| p;ParamFlow;true;returnVarArgElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint |
+| p;ParamFlow;true;writeChunked;(byte[],OutputStream);;Argument[0];Argument[1];taint |
+| p;ParamFlow;true;writeChunked;(char[],OutputStream);;Argument[0];Argument[1];taint |
+| p;Pojo;false;fillIn;(List);;Argument[-1];Element of Argument[0];taint |
+| p;Pojo;false;getBoxedBytes;();;Argument[-1];ReturnValue;taint |
+| p;Pojo;false;getBoxedChars;();;Argument[-1];ReturnValue;taint |
+| p;Pojo;false;getByteArray;();;Argument[-1];ReturnValue;taint |
+| p;Pojo;false;getCharArray;();;Argument[-1];ReturnValue;taint |
+| p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint |
+| p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint |
+| p;PrivateFlowViaPublicInterface;true;createAnSPI;(File);;Argument[0];ReturnValue;taint |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -17,6 +17,9 @@
 | p;Joiner;false;setEmptyValue;(CharSequence);;Argument[-1];ReturnValue;value; |
 | p;Joiner;false;setEmptyValue;(CharSequence);;Argument[0];Argument[-1];taint; |
 | p;Joiner;false;toString;();;Argument[-1];ReturnValue;taint; |
+| p;MultipleImpls$Strat2;true;getValue;();;Argument[-1];ReturnValue;taint; |
+| p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];Argument[-1];taint; |
+| p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;addTo;(String,List);;Argument[0];Element of Argument[1];taint; |
 | p;ParamFlow;true;returnArrayElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;returnCollectionElement;(List);;Element of Argument[0];ReturnValue;taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,5 +1,6 @@
 | p;Factory;false;create;(String);;Argument[0];Argument[-1];taint; |
 | p;Factory;false;create;(String,int);;Argument[0];Argument[-1];taint; |
+| p;Factory;false;getValue;();;Argument[-1];ReturnValue;taint; |
 | p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |
 | p;ImmutablePojo;false;ImmutablePojo;(String,int);;Argument[0];Argument[-1];taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -9,6 +9,7 @@
 | p;ImmutablePojo;false;or;(String);;Argument[0];ReturnValue;taint |
 | p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint |
 | p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint |
+| p;InnerHolder;false;append;(String);;Argument[0];Argument[-1];taint |
 | p;InnerHolder;false;explicitSetContext;(String);;Argument[0];Argument[-1];taint |
 | p;InnerHolder;false;getValue;();;Argument[-1];ReturnValue;taint |
 | p;InnerHolder;false;setContext;(String);;Argument[0];Argument[-1];taint |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -2,3 +2,12 @@
 | p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |
 | p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint; |
 | p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;addTo;(String,List);;Argument[0];Element of Argument[1];taint; |
+| p;ParamFlow;true;returnArrayElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;returnCollectionElement;(List);;Element of Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;returnIterableElement;(Iterable);;Element of Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;returnIteratorElement;(Iterator);;Element of Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[1];ReturnValue;taint; |
+| p;ParamFlow;true;returnVarArgElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -32,6 +32,8 @@
 | p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;writeChunked;(byte[],OutputStream);;ArrayElement of Argument[0];Argument[1];taint; |
 | p;Pojo;false;fillIn;(List);;Argument[-1];Element of Argument[0];taint; |
+| p;Pojo;false;getBoxedBytes;();;Argument[-1];ReturnValue;taint; |
+| p;Pojo;false;getBoxedChars;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;getByteArray;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;getCharArray;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -21,6 +21,7 @@
 | p;Joiner;false;merge;(Joiner);;Argument[-1];ReturnValue;value |
 | p;Joiner;false;setEmptyValue;(CharSequence);;Argument[-1];ReturnValue;value |
 | p;Joiner;false;setEmptyValue;(CharSequence);;Argument[0];Argument[-1];taint |
+| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[0];ReturnValue;taint |
 | p;Joiner;false;toString;();;Argument[-1];ReturnValue;taint |
 | p;MultipleImpls$Strat2;true;getValue;();;Argument[-1];ReturnValue;taint |
 | p;MultipleImpls$Strategy;true;doSomething;(String);;Argument[0];Argument[-1];taint |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -32,5 +32,7 @@
 | p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;writeChunked;(byte[],OutputStream);;ArrayElement of Argument[0];Argument[1];taint; |
 | p;Pojo;false;fillIn;(List);;Argument[-1];Element of Argument[0];taint; |
+| p;Pojo;false;getByteArray;();;Argument[-1];ReturnValue;taint; |
+| p;Pojo;false;getCharArray;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -44,4 +44,3 @@
 | p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint |
 | p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint |
 | p;PrivateFlowViaPublicInterface;true;createAnSPI;(File);;Argument[0];ReturnValue;taint |
-| p;PrivateFlowViaPublicInterface;true;createAnSPIWithoutTrackingFile;(File);;Argument[0];ReturnValue;taint |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -30,7 +30,8 @@
 | p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[1];ReturnValue;taint; |
 | p;ParamFlow;true;returnVarArgElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint; |
-| p;ParamFlow;true;writeChunked;(byte[],OutputStream);;ArrayElement of Argument[0];Argument[1];taint; |
+| p;ParamFlow;true;writeChunked;(byte[],OutputStream);;Argument[0];Argument[1];taint; |
+| p;ParamFlow;true;writeChunked;(char[],OutputStream);;Argument[0];Argument[1];taint; |
 | p;Pojo;false;fillIn;(List);;Argument[-1];Element of Argument[0];taint; |
 | p;Pojo;false;getBoxedBytes;();;Argument[-1];ReturnValue;taint; |
 | p;Pojo;false;getBoxedChars;();;Argument[-1];ReturnValue;taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,7 +1,22 @@
+| p;Factory;false;create;(String);;Argument[0];Argument[-1];taint; |
+| p;Factory;false;create;(String,int);;Argument[0];Argument[-1];taint; |
 | p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |
+| p;ImmutablePojo;false;ImmutablePojo;(String,int);;Argument[0];Argument[-1];taint; |
+| p;ImmutablePojo;false;getValue;();;Argument[-1];ReturnValue;taint; |
+| p;ImmutablePojo;false;or;(String);;Argument[-1];ReturnValue;taint; |
+| p;ImmutablePojo;false;or;(String);;Argument[0];ReturnValue;taint; |
 | p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint; |
 | p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint; |
+| p;Joiner;false;Joiner;(CharSequence);;Argument[0];Argument[-1];taint; |
+| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[0];Argument[-1];taint; |
+| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[1];Argument[-1];taint; |
+| p;Joiner;false;Joiner;(CharSequence,CharSequence,CharSequence);;Argument[2];Argument[-1];taint; |
+| p;Joiner;false;add;(CharSequence);;Argument[-1];ReturnValue;value; |
+| p;Joiner;false;merge;(Joiner);;Argument[-1];ReturnValue;value; |
+| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[-1];ReturnValue;value; |
+| p;Joiner;false;setEmptyValue;(CharSequence);;Argument[0];Argument[-1];taint; |
+| p;Joiner;false;toString;();;Argument[-1];ReturnValue;taint; |
 | p;ParamFlow;true;addTo;(String,List);;Argument[0];Element of Argument[1];taint; |
 | p;ParamFlow;true;returnArrayElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;returnCollectionElement;(List);;Element of Argument[0];ReturnValue;taint; |
@@ -11,3 +26,7 @@
 | p;ParamFlow;true;returnMultipleParameters;(String,String);;Argument[1];ReturnValue;taint; |
 | p;ParamFlow;true;returnVarArgElement;(String[]);;ArrayElement of Argument[0];ReturnValue;taint; |
 | p;ParamFlow;true;returnsInput;(String);;Argument[0];ReturnValue;taint; |
+| p;ParamFlow;true;writeChunked;(byte[],OutputStream);;ArrayElement of Argument[0];Argument[1];taint; |
+| p;Pojo;false;fillIn;(List);;Argument[-1];Element of Argument[0];taint; |
+| p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint; |
+| p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,2 +1,4 @@
 | p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |
+| p;InnerClasses$CaptureMe;true;yesCm;(String);;Argument[0];ReturnValue;taint; |
+| p;InnerClasses;true;yes;(String);;Argument[0];ReturnValue;taint; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -1,1 +1,2 @@
+| p;FinalClass;false;returnsInput;(String);;Argument[0];ReturnValue;taint; |
 | p;FluentAPI;false;returnsThis;(String);;Argument[-1];ReturnValue;value; |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -44,3 +44,4 @@
 | p;Pojo;false;getValue;();;Argument[-1];ReturnValue;taint |
 | p;Pojo;false;setValue;(String);;Argument[0];Argument[-1];taint |
 | p;PrivateFlowViaPublicInterface;true;createAnSPI;(File);;Argument[0];ReturnValue;taint |
+| p;PrivateFlowViaPublicInterface;true;createAnSPIWithoutTrackingFile;(File);;Argument[0];ReturnValue;taint |

--- a/java/ql/test/utils/model-generator/CaptureSummaryModels.qlref
+++ b/java/ql/test/utils/model-generator/CaptureSummaryModels.qlref
@@ -1,0 +1,1 @@
+utils/model-generator/CaptureSummaryModels.ql

--- a/java/ql/test/utils/model-generator/p/AbstractImplOfExternalSPI.java
+++ b/java/ql/test/utils/model-generator/p/AbstractImplOfExternalSPI.java
@@ -1,0 +1,13 @@
+package p;
+
+import java.io.File;
+import java.io.FileFilter;
+
+public abstract class AbstractImplOfExternalSPI implements FileFilter {
+
+    @Override
+    public boolean accept(File pathname) {
+        return false;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Factory.java
+++ b/java/ql/test/utils/model-generator/p/Factory.java
@@ -19,4 +19,12 @@ public final class Factory {
         this.intValue = intValue;
     }
 
+    public String getValue() {
+        return value;
+    }
+
+    public int getIntValue() {
+        return intValue;
+    }
+
 }

--- a/java/ql/test/utils/model-generator/p/Factory.java
+++ b/java/ql/test/utils/model-generator/p/Factory.java
@@ -1,0 +1,22 @@
+package p;
+
+public final class Factory {
+
+    private String value;
+
+    private int intValue;
+
+    public static Factory create(String value, int foo) {
+        return new Factory(value, foo);
+    }
+
+    public static Factory create(String value) {
+        return new Factory(value, 0);
+    }
+
+    private Factory(String value, int intValue) {
+        this.value = value;
+        this.intValue = intValue;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/FinalClass.java
+++ b/java/ql/test/utils/model-generator/p/FinalClass.java
@@ -1,0 +1,15 @@
+package p;
+
+public final class FinalClass {
+
+    private static final String C = "constant";
+
+    public String returnsInput(String input) {
+        return input;
+    }
+
+    public String returnsConstant() {
+        return C;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/FluentAPI.java
+++ b/java/ql/test/utils/model-generator/p/FluentAPI.java
@@ -1,0 +1,9 @@
+package p;
+
+public final class FluentAPI {
+
+    public FluentAPI returnsThis(String input) {
+        return this;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/FluentAPI.java
+++ b/java/ql/test/utils/model-generator/p/FluentAPI.java
@@ -6,4 +6,10 @@ public final class FluentAPI {
         return this;
     }
 
+    public class Inner {
+        public FluentAPI notThis(String input) {
+            return FluentAPI.this;
+        }
+    }
+
 }

--- a/java/ql/test/utils/model-generator/p/ImmutablePojo.java
+++ b/java/ql/test/utils/model-generator/p/ImmutablePojo.java
@@ -1,0 +1,22 @@
+package p;
+
+public final class ImmutablePojo {
+
+    private final String value;
+
+    private final long x;
+
+    public ImmutablePojo(String value, int x) {
+        this.value = value;
+        this.x = x;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String or(String defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/ImmutablePojo.java
+++ b/java/ql/test/utils/model-generator/p/ImmutablePojo.java
@@ -15,6 +15,10 @@ public final class ImmutablePojo {
         return value;
     }
 
+    public long getX() {
+        return x;
+    }
+
     public String or(String defaultValue) {
         return value != null ? value : defaultValue;
     }

--- a/java/ql/test/utils/model-generator/p/ImplOfExternalSPI.java
+++ b/java/ql/test/utils/model-generator/p/ImplOfExternalSPI.java
@@ -1,0 +1,19 @@
+package p;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class ImplOfExternalSPI extends AbstractImplOfExternalSPI {
+
+    @Override
+    public boolean accept(File pathname) {
+        try {
+            Files.createFile(pathname.toPath());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/InnerClasses.java
+++ b/java/ql/test/utils/model-generator/p/InnerClasses.java
@@ -1,0 +1,21 @@
+package p;
+
+public class InnerClasses {
+    
+    class IgnoreMe {
+        public String no(String input) {
+            return input;
+        }
+    }
+    
+    public class CaptureMe {
+        public String yesCm(String input) {
+            return input;
+        }
+    }
+
+    public String yes(String input) {
+        return input;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/InnerHolder.java
+++ b/java/ql/test/utils/model-generator/p/InnerHolder.java
@@ -16,12 +16,18 @@ public final class InnerHolder {
 
     private Context context = null;
 
+    private StringBuilder sb = new StringBuilder();
+
     public void setContext(String value) {
         context = new Context(value);
     }
 
     public void explicitSetContext(String value) {
         this.context = new Context(value);
+    }
+
+    public void append(String value) {
+        sb.append(value);
     }
 
     public String getValue() {

--- a/java/ql/test/utils/model-generator/p/InnerHolder.java
+++ b/java/ql/test/utils/model-generator/p/InnerHolder.java
@@ -1,0 +1,31 @@
+package p;
+
+public final class InnerHolder {
+
+    private class Context {
+        private String value;
+
+        Context(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private Context context = null;
+
+    public void setContext(String value) {
+        context = new Context(value);
+    }
+
+    public void explicitSetContext(String value) {
+        this.context = new Context(value);
+    }
+
+    public String getValue() {
+        return context.getValue();
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Joiner.java
+++ b/java/ql/test/utils/model-generator/p/Joiner.java
@@ -1,0 +1,118 @@
+package p;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class Joiner {
+    private final String prefix;
+    private final String delimiter;
+    private final String suffix;
+    private String[] elts;
+    private int size;
+    private int len;
+    private String emptyValue;
+    public Joiner(CharSequence delimiter) {
+        this(delimiter, "", "");
+    }
+
+    public Joiner(CharSequence delimiter,
+                        CharSequence prefix,
+                        CharSequence suffix) {
+        Objects.requireNonNull(prefix, "The prefix must not be null");
+        Objects.requireNonNull(delimiter, "The delimiter must not be null");
+        Objects.requireNonNull(suffix, "The suffix must not be null");
+        this.prefix = prefix.toString();
+        this.delimiter = delimiter.toString();
+        this.suffix = suffix.toString();
+        checkAddLength(0, 0);
+    }
+
+    public Joiner setEmptyValue(CharSequence emptyValue) {
+        this.emptyValue = Objects.requireNonNull(emptyValue,
+            "The empty value must not be null").toString();
+        return this;
+    }
+
+    private static int getChars(String s, char[] chars, int start) {
+        int len = s.length();
+        s.getChars(0, len, chars, start);
+        return len;
+    }
+
+    @Override
+    public String toString() {
+        final String[] elts = this.elts;
+        if (elts == null && emptyValue != null) {
+            return emptyValue;
+        }
+        final int size = this.size;
+        final int addLen = prefix.length() + suffix.length();
+        if (addLen == 0) {
+            compactElts();
+            return size == 0 ? "" : elts[0];
+        }
+        final String delimiter = this.delimiter;
+        final char[] chars = new char[len + addLen];
+        int k = getChars(prefix, chars, 0);
+        if (size > 0) {
+            k += getChars(elts[0], chars, k);
+            for (int i = 1; i < size; i++) {
+                k += getChars(delimiter, chars, k);
+                k += getChars(elts[i], chars, k);
+            }
+        }
+        k += getChars(suffix, chars, k);
+        return new String(chars);
+    }
+
+    public Joiner add(CharSequence newElement) {
+        final String elt = String.valueOf(newElement);
+        if (elts == null) {
+            elts = new String[8];
+        } else {
+            if (size == elts.length)
+                elts = Arrays.copyOf(elts, 2 * size);
+            len = checkAddLength(len, delimiter.length());
+        }
+        len = checkAddLength(len, elt.length());
+        elts[size++] = elt;
+        return this;
+    }
+
+    private int checkAddLength(int oldLen, int inc) {
+        long newLen = (long)oldLen + (long)inc;
+        long tmpLen = newLen + (long)prefix.length() + (long)suffix.length();
+        if (tmpLen != (int)tmpLen) {
+            throw new OutOfMemoryError("Requested array size exceeds VM limit");
+        }
+        return (int)newLen;
+    }
+
+    public Joiner merge(Joiner other) {
+        Objects.requireNonNull(other);
+        if (other.elts == null) {
+            return this;
+        }
+        other.compactElts();
+        return add(other.elts[0]);
+    }
+
+    private void compactElts() {
+        if (size > 1) {
+            final char[] chars = new char[len];
+            int i = 1, k = getChars(elts[0], chars, 0);
+            do {
+                k += getChars(delimiter, chars, k);
+                k += getChars(elts[i], chars, k);
+                elts[i] = null;
+            } while (++i < size);
+            size = 1;
+            elts[0] = new String(chars);
+        }
+    }
+
+    public int length() {
+        return (size == 0 && emptyValue != null) ? emptyValue.length() :
+            len + prefix.length() + suffix.length();
+    }
+}

--- a/java/ql/test/utils/model-generator/p/MultipleImpls.java
+++ b/java/ql/test/utils/model-generator/p/MultipleImpls.java
@@ -1,9 +1,13 @@
 package p;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.Callable;
 
 public class MultipleImpls {
-    
+
     public static interface Strategy {
         String doSomething(String value);
     }
@@ -22,7 +26,7 @@ public class MultipleImpls {
             return null;
         }
 
-    }
+    }    
     public static class Strat2 implements Strategy {
         private String foo;
 

--- a/java/ql/test/utils/model-generator/p/MultipleImpls.java
+++ b/java/ql/test/utils/model-generator/p/MultipleImpls.java
@@ -1,9 +1,5 @@
 package p;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.concurrent.Callable;
 
 public class MultipleImpls {

--- a/java/ql/test/utils/model-generator/p/MultipleImpls.java
+++ b/java/ql/test/utils/model-generator/p/MultipleImpls.java
@@ -1,0 +1,38 @@
+package p;
+
+import java.util.concurrent.Callable;
+
+public class MultipleImpls {
+    
+    public static interface Strategy {
+        String doSomething(String value);
+    }
+
+    public static class Strat1 implements Strategy {
+        public String doSomething(String value) {
+            return value;
+        }
+    }
+
+    // implements in different library should not count as impl
+    public static class Strat3 implements Callable<String> {
+
+        @Override
+        public String call() throws Exception {
+            return null;
+        }
+
+    }
+    public static class Strat2 implements Strategy {
+        private String foo;
+
+        public String doSomething(String value) {
+            this.foo = value;
+            return "none";
+        }
+        
+        public String getValue() {
+            return this.foo;
+        }
+    }
+}

--- a/java/ql/test/utils/model-generator/p/ParamFlow.java
+++ b/java/ql/test/utils/model-generator/p/ParamFlow.java
@@ -1,0 +1,59 @@
+package p;
+
+import java.util.Iterator;
+import java.util.List;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+public class ParamFlow {
+
+    public String returnsInput(String input) {
+        return input;
+    }
+
+    public int ignorePrimitiveReturnValue(String input) {
+        return input.length();
+    }
+
+    public String returnMultipleParameters(String one, String two) {
+        if (System.currentTimeMillis() > 100) {
+            return two;
+        }
+        return one;
+    }
+
+    public String returnArrayElement(String[] input) {
+        return input[0];
+    }
+
+    public String returnVarArgElement(String... input) {
+        return input[0];
+    }
+
+    public String returnCollectionElement(List<String> input) {
+        return input.get(0);
+    }
+
+    public String returnIteratorElement(Iterator<String> input) {
+        return input.next();
+    }
+
+    public String returnIterableElement(Iterable<String> input) {
+        return input.iterator().next();
+    }
+
+    public Class<?> mapType(Class<?> input) {
+        return input;
+    }
+
+    public void writeChunked(byte[] data, OutputStream output)
+            throws IOException {
+        output.write(data, 0, data.length);
+    }
+
+    public void addTo(String data, List<String> target) {
+        target.add(data);
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/ParamFlow.java
+++ b/java/ql/test/utils/model-generator/p/ParamFlow.java
@@ -51,6 +51,11 @@ public class ParamFlow {
             throws IOException {
         output.write(data, 0, data.length);
     }
+    
+    public void writeChunked(char[] data, OutputStream output)
+            throws IOException {
+        output.write(String.valueOf(data).getBytes(), 0, data.length);
+    }
 
     public void addTo(String data, List<String> target) {
         target.add(data);

--- a/java/ql/test/utils/model-generator/p/Pojo.java
+++ b/java/ql/test/utils/model-generator/p/Pojo.java
@@ -1,5 +1,7 @@
 package p;
 
+import java.math.BigInteger;
+import java.util.Collection;
 import java.util.List;
 
 public final class Pojo {
@@ -35,6 +37,34 @@ public final class Pojo {
 
     public int getIntValue() {
         return intValue;
+    }
+
+    public Integer getBoxedValue() {
+        return Integer.valueOf(intValue);
+    }
+
+    public int[] getPrimitiveArray() {
+        return new int[] { intValue };
+    }
+
+    public char[] getCharArray() {
+        return Character.toChars(intValue);
+    }
+
+    public byte[] getByteArray() {
+        return new byte[] { (byte) intValue };
+    }
+    
+    public Integer[] getBoxedArray() {
+        return new Integer[] { Integer.valueOf(intValue) };
+    }
+    
+    public Collection<Integer> getBoxedCollection() {
+        return List.of(Integer.valueOf(intValue));
+    }
+
+    public BigInteger getBigInt() {
+        return BigInteger.valueOf(intValue);
     }
 
     public void fillIn(List<String> target) {

--- a/java/ql/test/utils/model-generator/p/Pojo.java
+++ b/java/ql/test/utils/model-generator/p/Pojo.java
@@ -67,6 +67,14 @@ public final class Pojo {
         return List.of(Integer.valueOf(intValue));
     }
 
+    public List<Character> getBoxedChars() {
+        return List.of((char)intValue);
+    }
+
+    public Byte[] getBoxedBytes() {
+        return new Byte[] { Byte.valueOf((byte) intValue) };
+    }
+    
     public BigInteger getBigInt() {
         return BigInteger.valueOf(intValue);
     }

--- a/java/ql/test/utils/model-generator/p/Pojo.java
+++ b/java/ql/test/utils/model-generator/p/Pojo.java
@@ -1,0 +1,44 @@
+package p;
+
+import java.util.List;
+
+public final class Pojo {
+
+    private class Holder {
+        private String value;
+
+        Holder(String value) {
+            this.value = value;
+        }
+
+        int length() {
+            return value.length();
+        }
+    }
+
+    private String value;
+
+    private int intValue = 2;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public int doNotSetValue(String value) {
+        Holder h = new Holder(value);
+        return h.length();
+    }
+
+    public int getIntValue() {
+        return intValue;
+    }
+
+    public void fillIn(List<String> target) {
+        target.add(value);
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Pojo.java
+++ b/java/ql/test/utils/model-generator/p/Pojo.java
@@ -1,5 +1,6 @@
 package p;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
@@ -84,6 +85,10 @@ public final class Pojo {
     
     public BigInteger getBigInt() {
         return BigInteger.valueOf(intValue);
+    }
+
+    public BigDecimal getBigDecimal() {
+        return new BigDecimal(value);
     }
 
     public void fillIn(List<String> target) {

--- a/java/ql/test/utils/model-generator/p/Pojo.java
+++ b/java/ql/test/utils/model-generator/p/Pojo.java
@@ -1,6 +1,7 @@
 package p;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -21,6 +22,12 @@ public final class Pojo {
     private String value;
 
     private int intValue = 2;
+
+    private byte[] byteArray = new byte[] {1, 2, 3} ;
+    private float[] floatArray = new float[] {1, 2, 3} ;
+    private char[] charArray = new char[] {'a', 'b', 'c'} ;
+    private List<Character> charList = Arrays.asList('a', 'b', 'c');
+    private Byte[] byteObjectArray = new Byte[] { 1, 2, 3 };
 
     public String getValue() {
         return value;
@@ -48,15 +55,15 @@ public final class Pojo {
     }
 
     public char[] getCharArray() {
-        return new char[] { (char) intValue };
+        return charArray;
     }
 
     public byte[] getByteArray() {
-        return new byte[] { (byte) intValue };
+        return byteArray;
     }
     
     public float[] getFloatArray() {
-        return new float[] { (float) intValue };
+        return floatArray;
     }
 
     public Integer[] getBoxedArray() {
@@ -68,11 +75,11 @@ public final class Pojo {
     }
 
     public List<Character> getBoxedChars() {
-        return List.of((char)intValue);
+        return charList;
     }
 
     public Byte[] getBoxedBytes() {
-        return new Byte[] { Byte.valueOf((byte) intValue) };
+        return byteObjectArray;
     }
     
     public BigInteger getBigInt() {

--- a/java/ql/test/utils/model-generator/p/Pojo.java
+++ b/java/ql/test/utils/model-generator/p/Pojo.java
@@ -48,13 +48,17 @@ public final class Pojo {
     }
 
     public char[] getCharArray() {
-        return Character.toChars(intValue);
+        return new char[] { (char) intValue };
     }
 
     public byte[] getByteArray() {
         return new byte[] { (byte) intValue };
     }
     
+    public float[] getFloatArray() {
+        return new float[] { (float) intValue };
+    }
+
     public Integer[] getBoxedArray() {
         return new Integer[] { Integer.valueOf(intValue) };
     }

--- a/java/ql/test/utils/model-generator/p/PrivateFlowViaPublicInterface.java
+++ b/java/ql/test/utils/model-generator/p/PrivateFlowViaPublicInterface.java
@@ -7,8 +7,15 @@ import java.io.OutputStream;
 
 public class PrivateFlowViaPublicInterface {
 
+    static class RandomPojo {
+        public File someFile = new File("someFile");
+    }
     public static interface SPI {
         OutputStream openStream() throws IOException;
+
+        default OutputStream openStreamNone() throws IOException {
+            return null;
+        };
     }
 
     private static final class PrivateImplWithSink implements SPI {
@@ -25,9 +32,30 @@ public class PrivateFlowViaPublicInterface {
         }
 
     }
+    
+    private static final class PrivateImplWithRandomField implements SPI {
+
+        public PrivateImplWithRandomField(File file) {
+        }
+
+        @Override
+        public OutputStream openStream() throws IOException {
+            return null;
+        }
+        
+        @Override
+        public OutputStream openStreamNone() throws IOException {
+            return new FileOutputStream(new RandomPojo().someFile);
+        }
+
+    }
 
     public static SPI createAnSPI(File file) {
         return new PrivateImplWithSink(file);
+    }
+    
+    public static SPI createAnSPIWithoutTrackingFile(File file) {
+        return new PrivateImplWithRandomField(file);
     }
 
 }

--- a/java/ql/test/utils/model-generator/p/PrivateFlowViaPublicInterface.java
+++ b/java/ql/test/utils/model-generator/p/PrivateFlowViaPublicInterface.java
@@ -1,0 +1,33 @@
+package p;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class PrivateFlowViaPublicInterface {
+
+    public static interface SPI {
+        OutputStream openStream() throws IOException;
+    }
+
+    private static final class PrivateImplWithSink implements SPI {
+
+        private File file;
+
+        public PrivateImplWithSink(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public OutputStream openStream() throws IOException {
+            return new FileOutputStream(file);
+        }
+
+    }
+
+    public static SPI createAnSPI(File file) {
+        return new PrivateImplWithSink(file);
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Sinks.java
+++ b/java/ql/test/utils/model-generator/p/Sinks.java
@@ -14,7 +14,6 @@ public class Sinks {
         return Files.copy(sourceFile, targetDirectory.resolve(sourceFile.getFileName()), copyOptions);
     }
 
-    // TODO: not detected
     public String readUrl(final URL url, Charset encoding) throws IOException {
         try (InputStream in = url.openStream()) {
             byte[] bytes = in.readAllBytes();

--- a/java/ql/test/utils/model-generator/p/Sinks.java
+++ b/java/ql/test/utils/model-generator/p/Sinks.java
@@ -1,0 +1,25 @@
+package p;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.CopyOption;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Sinks {
+    
+    public Path copyFileToDirectory(final Path sourceFile, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
+        return Files.copy(sourceFile, targetDirectory.resolve(sourceFile.getFileName()), copyOptions);
+    }
+
+    // TODO: not detected
+    public String readUrl(final URL url, Charset encoding) throws IOException {
+        try (InputStream in = url.openStream()) {
+            byte[] bytes = in.readAllBytes();
+            return new String(bytes, encoding);
+        }
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Sinks.java
+++ b/java/ql/test/utils/model-generator/p/Sinks.java
@@ -10,8 +10,8 @@ import java.nio.file.Path;
 
 public class Sinks {
     
-    public Path copyFileToDirectory(final Path sourceFile, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
-        return Files.copy(sourceFile, targetDirectory.resolve(sourceFile.getFileName()), copyOptions);
+    public Path copyFileToDirectory(final Path sourceFile, final Path targetFile, final CopyOption... copyOptions) throws IOException {
+        return Files.copy(sourceFile, targetFile, copyOptions);
     }
 
     public String readUrl(final URL url, Charset encoding) throws IOException {

--- a/java/ql/test/utils/model-generator/p/SomeEnum.java
+++ b/java/ql/test/utils/model-generator/p/SomeEnum.java
@@ -1,0 +1,17 @@
+package p;
+
+enum SomeEnum {
+
+    FOO("input");
+
+    private String input;
+
+    private SomeEnum(String input) {
+        this.input = input;
+    }
+
+    public String getValue() {
+        return input;
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Sources.java
+++ b/java/ql/test/utils/model-generator/p/Sources.java
@@ -2,7 +2,9 @@ package p;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ServerSocket;
 import java.net.URL;
+import java.util.function.Consumer;
 
 
 public class Sources {
@@ -11,4 +13,13 @@ public class Sources {
         return url.openConnection().getInputStream();
     }
 
+    public InputStream socketStream() throws IOException {
+        ServerSocket socket = new ServerSocket(123);
+        return socket.accept().getInputStream();
+    }
+
+    public void consumeSource(int port, Consumer<InputStream> consumer) throws IOException {
+        ServerSocket socket = new ServerSocket(port);
+        consumer.accept(socket.accept().getInputStream());
+    }
 }

--- a/java/ql/test/utils/model-generator/p/Sources.java
+++ b/java/ql/test/utils/model-generator/p/Sources.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.URL;
 import java.util.function.Consumer;
+import java.util.List;
 
 
 public class Sources {
@@ -16,6 +17,12 @@ public class Sources {
     public InputStream socketStream() throws IOException {
         ServerSocket socket = new ServerSocket(123);
         return socket.accept().getInputStream();
+    }
+
+    public void sourceToParameter(InputStream[] streams, List<InputStream> otherStreams) throws IOException {
+        ServerSocket socket = new ServerSocket(123);
+        streams[0] = socket.accept().getInputStream();
+        otherStreams.add(socket.accept().getInputStream());
     }
 
 }

--- a/java/ql/test/utils/model-generator/p/Sources.java
+++ b/java/ql/test/utils/model-generator/p/Sources.java
@@ -1,0 +1,14 @@
+package p;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+
+public class Sources {
+    
+    public InputStream readUrl(final URL url) throws IOException {
+        return url.openConnection().getInputStream();
+    }
+
+}

--- a/java/ql/test/utils/model-generator/p/Sources.java
+++ b/java/ql/test/utils/model-generator/p/Sources.java
@@ -18,8 +18,4 @@ public class Sources {
         return socket.accept().getInputStream();
     }
 
-    public void consumeSource(int port, Consumer<InputStream> consumer) throws IOException {
-        ServerSocket socket = new ServerSocket(port);
-        consumer.accept(socket.accept().getInputStream());
-    }
 }


### PR DESCRIPTION
Adds ability to generate flow summaries in CSV format given an existing library.
It supports detecting sinks/sources via propagation (so only existing sinks exposed through a new external API). 

Usage is either:
```
java/ql/src/utils/model-generator/GenerateFlowModel.py <path-some-db> <shortname>
```
The resulting `.qll` CSV model written to `codeql/java/ql/lib/semmle/code/java/frameworks/generated/<shortname>.qll`

[Examples (Guava, various Apache Commons projects)](https://gist.github.com/bmuskalla/fb2c91d1011ee399caf47b9582101d3d)

Alternatively, you can run any of the queries directly:
* `CaptureSummaryModels.ql`
* `CaptureSinkModels.ql`
* `CaptureSourceModels.ql`

Some initial stats (model as data rows)

| Framework  | Already supported rows | Newly generated rows | Runtime
| ------------- | :-------------: | :----: | :----: |
| Commons IO  | 22 | 637 | 105s
| Commons Codec  | 6  | [145](https://github.com/github/codeql/pull/6988) | 80s
| Commons Lang  | 423  | 1361 | 96s
| Commons Beanutils  | 0  | 517 | 106s
| Guava  | 734  | TBD | TBD
| JDK  | 557[^1]  | TBD[^1] | TBD

[^1]: Counting only `java.` APIs