### PR TITLE
Java: Extend functional interfaces test

### DIFF
--- a/java/ql/test/library-tests/functional-interfaces/Test.java
+++ b/java/ql/test/library-tests/functional-interfaces/Test.java
@@ -21,9 +21,19 @@ public class Test {
   interface FunctionalWithObjectMethods {
     int f();
 
-    String toString();
-
+    // Not actually abstract; implementation comes from Object
+    boolean equals(Object obj);
     int hashCode();
+    String toString();
+  }
+
+  interface NotFunctionalWithObjectMethods {
+    int f();
+
+    // Increases their visibility from `protected` to `public`; this requires subclasses to implement them
+    // See also JLS section "Functional Interfaces" which explicitly covers this
+    Object clone();
+    void finalize();
   }
 
 }


### PR DESCRIPTION
Follow-up for #6651

Covers `Object clone();` and `void finalize();` making sure that such an interface is not considered a functional interface, [as specified by the JLS](https://docs.oracle.com/javase/specs/jls/se16/html/jls-9.html#jls-9.8).