### PR TITLE
Java: Remove duplicate classes modeling Object.clone

### DIFF
--- a/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
+++ b/java/ql/src/Advisory/Java Objects/AvoidCloneMethodAccess.ql
@@ -11,14 +11,10 @@
 
 import java
 
-class ObjectCloneMethod extends Method {
-  ObjectCloneMethod() {
-    this.getDeclaringType() instanceof TypeObject and
-    this.getName() = "clone" and
-    this.hasNoParameters()
-  }
-}
-
-from MethodAccess ma, ObjectCloneMethod clone
-where ma.getMethod().overrides(clone)
+from MethodAccess ma, Method m
+where
+  m = ma.getMethod() and
+  m instanceof CloneMethod and
+  // But ignore direct calls to Object.clone
+  not m.getDeclaringType() instanceof TypeObject
 select ma, "Invoking a method that overrides clone() should be avoided."

--- a/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql
+++ b/java/ql/src/Advisory/Java Objects/AvoidCloneOverride.ql
@@ -11,16 +11,13 @@
 
 import java
 
-class ObjectCloneMethod extends Method {
-  ObjectCloneMethod() {
-    this.getDeclaringType() instanceof TypeObject and
-    this.getName() = "clone" and
-    this.hasNoParameters()
-  }
+class ObjectCloneMethod extends CloneMethod {
+  ObjectCloneMethod() { this.getDeclaringType() instanceof TypeObject }
 }
 
 from Method m, ObjectCloneMethod clone
 where
   m.fromSource() and
+  // Only consider direct overrides of Object.clone
   m.overrides(clone)
 select m, "Overriding the Object.clone() method should be avoided."


### PR DESCRIPTION
Reuses the existing `CloneMethod` class for two queries which had their own CodeQL class for this method.