### PR TITLE
Java: Use the standard URL format for Location.toString()

### DIFF
--- a/java/change-notes/2021-09-13-location-toString.md
+++ b/java/change-notes/2021-09-13-location-toString.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The format of the Location.toString() output has changed to
+  `file:///path/to/file:startLine:startColumn:endLine:endColumn`.

--- a/java/ql/lib/semmle/code/Location.qll
+++ b/java/ql/lib/semmle/code/Location.qll
@@ -168,18 +168,10 @@ class Location extends @location {
 
   /** Gets a string representation containing the file and range for this location. */
   string toString() {
-    exists(File f, int startLine, int startCol, int endLine, int endCol |
-      locations_default(this, f, startLine, startCol, endLine, endCol)
+    exists(string filepath, int startLine, int startCol, int endLine, int endCol |
+      this.hasLocationInfo(filepath, startLine, startCol, endLine, endCol)
     |
-      if endLine = startLine
-      then
-        result =
-          f.toString() + ":" + startLine.toString() + "[" + startCol.toString() + "-" +
-            endCol.toString() + "]"
-      else
-        result =
-          f.toString() + ":" + startLine.toString() + "[" + startCol.toString() + "]-" +
-            endLine.toString() + "[" + endCol.toString() + "]"
+      toUrl(filepath, startLine, startCol, endLine, endCol, result)
     )
   }
 


### PR DESCRIPTION
This also means that there is more information in the `toString()`, which is useful as Location.toString() uses are almost always for debugging.