### PR TITLE
C++: Exclude uninstantiated templates from AV Rule 114.

### DIFF
--- a/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
+++ b/cpp/ql/src/jsf/4.13 Functions/AV Rule 114.ql
@@ -63,6 +63,7 @@ where
   functionsMissingReturnStmt(f, blame) and
   reachable(blame) and
   not functionImperfectlyExtracted(f) and
+  not f.isFromUninstantiatedTemplate(_) and
   (blame = stmt or blame.(Expr).getEnclosingStmt() = stmt) and
   msg =
     "Function " + f.getName() + " should return a value of type " + f.getType().getName() +


### PR DESCRIPTION
Fixes #6669.
