### PR TITLE
JS/Java: use the correct cwe tags

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-016/InsecureSpringActuatorConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-016/InsecureSpringActuatorConfig.ql
@@ -7,7 +7,7 @@
  * @precision high
  * @id java/insecure-spring-actuator-config
  * @tags security
- *       external/cwe-016
+ *       external/cwe/cwe-016
  */
 
 /*

--- a/java/ql/src/experimental/Security/CWE/CWE-094/JShellInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/JShellInjection.ql
@@ -7,7 +7,7 @@
  * @precision high
  * @id java/jshell-injection
  * @tags security
- *       external/cwe-094
+ *       external/cwe/cwe-094
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
@@ -8,7 +8,7 @@
  * @precision medium
  * @id java/unsafe-cert-trust
  * @tags security
- *       external/cwe-273
+ *       external/cwe/cwe-273
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureJavaMail.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureJavaMail.ql
@@ -8,7 +8,7 @@
  * @precision medium
  * @id java/insecure-smtp-ssl
  * @tags security
- *       external/cwe-297
+ *       external/cwe/cwe-297
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-297/InsecureLdapEndpoint.ql
@@ -8,7 +8,7 @@
  * @precision medium
  * @id java/insecure-ldaps-endpoint
  * @tags security
- *       external/cwe-297
+ *       external/cwe/cwe-297
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/EJBMain.ql
@@ -6,7 +6,7 @@
  * @precision medium
  * @id java/main-method-in-enterprise-bean
  * @tags security
- *       external/cwe-489
+ *       external/cwe/cwe-489
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-489/WebComponentMain.ql
@@ -6,7 +6,7 @@
  * @precision medium
  * @id java/main-method-in-web-components
  * @tags security
- *       external/cwe-489
+ *       external/cwe/cwe-489
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-522/InsecureBasicAuth.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-522/InsecureBasicAuth.ql
@@ -9,8 +9,8 @@
  * @precision medium
  * @id java/insecure-basic-auth
  * @tags security
- *       external/cwe-522
- *       external/cwe-319
+ *       external/cwe/cwe-522
+ *       external/cwe/cwe-319
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
@@ -6,8 +6,8 @@
  * @precision medium
  * @id java/insecure-ldap-auth
  * @tags security
- *       external/cwe-522
- *       external/cwe-319
+ *       external/cwe/cwe-522
+ *       external/cwe/cwe-319
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-532/SensitiveInfoLog.ql
@@ -7,7 +7,7 @@
  * @precision medium
  * @id java/sensitiveinfo-in-logfile
  * @tags security
- *       external/cwe-532
+ *       external/cwe/cwe-532
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -9,7 +9,7 @@
  * @precision medium
  * @id java/server-directory-listing
  * @tags security
- *       external/cwe-548
+ *       external/cwe/cwe-548
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
@@ -6,7 +6,7 @@
  * @precision medium
  * @id java/sensitive-query-with-get
  * @tags security
- *       external/cwe-598
+ *       external/cwe/cwe-598
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-600/UncaughtServletException.ql
@@ -9,7 +9,7 @@
  * @precision medium
  * @id java/uncaught-servlet-exception
  * @tags security
- *       external/cwe-600
+ *       external/cwe/cwe-600
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-601/SpringUrlRedirect.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-601/SpringUrlRedirect.ql
@@ -7,7 +7,7 @@
  * @precision high
  * @id java/spring-unvalidated-url-redirection
  * @tags security
- *       external/cwe-601
+ *       external/cwe/cwe-601
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-759/HashWithoutSalt.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-759/HashWithoutSalt.ql
@@ -6,7 +6,7 @@
  * @precision low
  * @id java/hash-without-salt
  * @tags security
- *       external/cwe-759
+ *       external/cwe/cwe-759
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-927/SensitiveBroadcast.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-927/SensitiveBroadcast.ql
@@ -8,7 +8,7 @@
  * @precision medium
  * @id java/sensitive-broadcast
  * @tags security
- *       external/cwe-927
+ *       external/cwe/cwe-927
  */
 
 import java

--- a/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
@@ -8,7 +8,7 @@
  * @precision medium
  * @id java/incorrect-url-verification
  * @tags security
- *       external/cwe-939
+ *       external/cwe/cwe-939
  */
 
 import java

--- a/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
+++ b/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
@@ -7,7 +7,7 @@
  * @precision very-high
  * @id js/disabling-certificate-validation
  * @tags security
- *       external/cwe-295
+ *       external/cwe/cwe-295
  */
 
 import javascript


### PR DESCRIPTION
The vast majority of queries use `external/cwe/cwe-XX` tags for documenting their CWE coverage.  
But a few used `external/cwe-XX`.   

For consistency I've changed all the `external/cwe-XX` tags to the `external/cwe/cwe-XX` form.  

This also fixes some scripting that detects CWE coverage. 
