### PR TITLE
JS: add some CWEs to existing queries

### DIFF
--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
@@ -8,6 +8,7 @@
  * @id js/exposure-of-private-files
  * @tags security
  *       external/cwe/cwe-200
+ *       external/cwe/cwe-548
  * @precision high
  */
 

--- a/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
+++ b/javascript/ql/src/Security/CWE-313/PasswordInConfigurationFile.ql
@@ -10,6 +10,7 @@
  *       external/cwe/cwe-256
  *       external/cwe/cwe-260
  *       external/cwe/cwe-313
+ *       external/cwe/cwe-522
  */
 
 import javascript


### PR DESCRIPTION
Adds [CWE-548 (Exposure of Information Through Directory Listing)](https://cwe.mitre.org/data/definitions/548.html) to the `js/exposure-of-private-files` query.   
Some of the modeled packages (e.g. [`serve-handler`](https://www.npmjs.com/package/serve-handler)) will present a pretty directory listing when a directory is requested. 

Adds [CWE-522 (Insufficiently Protected Credentials)](https://cwe.mitre.org/data/definitions/522.html) to `js/password-in-configuration-file`. 