### PR TITLE
Data flow: Add `compatibleContents/2`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -202,6 +202,13 @@ predicate compatibleTypes(Type t1, Type t2) {
   any() // stub implementation
 }
 
+/**
+ * Holds if `c1` and `c2` are compatible, that is, whether data stored into
+ * `c1` can be read out of `c2`.
+ */
+pragma[inline]
+predicate compatibleContents(Content c1, Content c2) { c1 = c2 }
+
 private predicate suppressUnusedNode(Node n) { any() }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -435,6 +435,13 @@ predicate compatibleTypes(IRType t1, IRType t2) {
   any() // stub implementation
 }
 
+/**
+ * Holds if `c1` and `c2` are compatible, that is, whether data stored into
+ * `c1` can be read out of `c2`.
+ */
+pragma[inline]
+predicate compatibleContents(Content c1, Content c2) { c1 = c2 }
+
 private predicate suppressUnusedNode(Node n) { any() }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1772,6 +1772,13 @@ predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
 }
 
 /**
+ * Holds if `c1` and `c2` are compatible, that is, whether data stored into
+ * `c1` can be read out of `c2`.
+ */
+pragma[inline]
+predicate compatibleContents(Content c1, Content c2) { c1 = c2 }
+
+/**
  * A node associated with an object after an operation that might have
  * changed its state.
  *

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -204,6 +204,13 @@ predicate compatibleTypes(Type t1, Type t2) {
   )
 }
 
+/**
+ * Holds if `c1` and `c2` are compatible, that is, whether data stored into
+ * `c1` can be read out of `c2`.
+ */
+pragma[inline]
+predicate compatibleContents(Content c1, Content c2) { c1 = c2 }
+
 /** A node that performs a type cast. */
 class CastNode extends ExprNode {
   CastNode() { this.getExpr() instanceof CastExpr }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -837,6 +837,13 @@ pragma[inline]
 predicate compatibleTypes(DataFlowType t1, DataFlowType t2) { any() }
 
 /**
+ * Holds if `c1` and `c2` are compatible, that is, whether data stored into
+ * `c1` can be read out of `c2`.
+ */
+pragma[inline]
+predicate compatibleContents(Content c1, Content c2) { c1 = c2 }
+
+/**
  * Gets the type of `node`.
  */
 DataFlowType getNodeType(Node node) {


### PR DESCRIPTION
Introduce a predicate
```ql
/**
 * Holds if `c1` and `c2` are compatible, that is, whether data stored into
 * `c1` can be read out of `c2`.
 */
predicate compatibleContents(Content c1, Content c2)
```

While the same effect could already be achieved today, by building content compatibility into the definition of `readStep`, this approach avoids replicating compatibility at all reads, and instead only does it at reads that can be reached in the first pruning stage.