### PR TITLE
Update links in training notes to use CodeQL microsite

### DIFF
--- a/docs/codeql/codeql-language-guides/abstract-syntax-tree-classes-for-working-with-java-programs.rst
+++ b/docs/codeql/codeql-language-guides/abstract-syntax-tree-classes-for-working-with-java-programs.rst
@@ -252,8 +252,6 @@ Miscellaneous
 +=====================================+====================+============================================================================+
 | ``(int) f``                         | CastExpr_          |                                                                            |
 +-------------------------------------+--------------------+----------------------------------------------------------------------------+
-| ``(23 + 42)``                       | ParExpr_           |                                                                            |
-+-------------------------------------+--------------------+----------------------------------------------------------------------------+
 | ``o instanceof String``             | InstanceOfExpr_    |                                                                            |
 +-------------------------------------+--------------------+----------------------------------------------------------------------------+
 | `Expr`_ ``?`` `Expr`_ ``:`` `Expr`_ | ConditionalExpr_   |                                                                            |
@@ -378,7 +376,6 @@ Further reading
 .. _WildcardTypeAccess: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$WildcardTypeAccess.html
 .. _FieldAccess: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$FieldAccess.html
 .. _CastExpr: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$CastExpr.html
-.. _ParExpr: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$ParExpr.html
 .. _InstanceOfExpr: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$InstanceOfExpr.html
 .. _ConditionalExpr: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$ConditionalExpr.html
 .. _TypeLiteral: https://codeql.github.com/codeql-standard-libraries/java/semmle/code/java/Expr.qll/type.Expr$TypeLiteral.html

--- a/docs/codeql/ql-training/conf.py
+++ b/docs/codeql/ql-training/conf.py
@@ -47,7 +47,7 @@ import sys
 import os
 
 def setup(sphinx):
-    sys.path.insert(0, os.path.abspath('docs/codeql'))
+    sys.path.insert(0, os.path.join(os.path.dirname( __file__ ), '..'))
     from qllexer import QLLexer
     sphinx.add_lexer("ql", QLLexer())
 

--- a/docs/codeql/ql-training/cpp/bad-overflow-guard.rst
+++ b/docs/codeql/ql-training/cpp/bad-overflow-guard.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `ChakraCore database <https://downloads.lgtm.com/snapshots/cpp/microsoft/chakracore/ChakraCore-revision-2017-April-12--18-13-26.zip>`__
 
 .. note::
@@ -149,7 +149,7 @@ Let’s look for overflow guards of the form ``v + b < v``, using the classes
     - a ``RelationalOperation``: the overflow comparison check.
     - a ``Variable``: used as an argument to both the addition and comparison.
 
-  - The ``where`` part of the query ties these three variables together using `predicates <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ defined in the `standard CodeQL for C/C++ library <https://codeql.github.com/codeql-standard-libraries/cpp/>`__.
+  - The ``where`` part of the query ties these three variables together using `predicates <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ defined in the `standard CodeQL for C/C++ library <https://codeql.github.com/codeql-standard-libraries/cpp/>`__.
 
 CodeQL query: bad overflow guards
 =================================

--- a/docs/codeql/ql-training/cpp/bad-overflow-guard.rst
+++ b/docs/codeql/ql-training/cpp/bad-overflow-guard.rst
@@ -16,7 +16,7 @@ For this example you should download:
 
 .. note::
 
-   For the examples in this presentation, we will be analyzing `ChakraCore <https://github.com/microsoft/ChakraCore>`__.
+   For the examples in this presentation, we will be analyzing `ChakraCore <https://github.com/Chakra-Core/ChakraCore/>`__.
 
    You can query the project in `the query console <https://lgtm.com/query/project:2034240708/lang:cpp/>`__ on LGTM.com.
 
@@ -229,4 +229,4 @@ The final query
 .. literalinclude:: ../query-examples/cpp/bad-overflow-guard-3.ql
    :language: ql
 
-This query finds a single result in our historic database, which was `a genuine bug in ChakraCore <https://github.com/Microsoft/ChakraCore/commit/2500e1cdc12cb35af73d5c8c9b85656aba6bab4d>`__.
+This query finds a single result in our historic database, which was `a genuine bug in ChakraCore <https://github.com/Chakra-Core/ChakraCore//commit/2500e1cdc12cb35af73d5c8c9b85656aba6bab4d>`__.

--- a/docs/codeql/ql-training/cpp/control-flow-cpp.rst
+++ b/docs/codeql/ql-training/cpp/control-flow-cpp.rst
@@ -13,7 +13,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `ChakraCore database <https://downloads.lgtm.com/snapshots/cpp/microsoft/chakracore/ChakraCore-revision-2017-April-12--18-13-26.zip>`__
 
 .. note::
@@ -222,7 +222,7 @@ A ``GuardCondition`` is a ``Boolean`` condition that controls one or more basic 
 Further materials
 =================
 
-- CodeQL for C/C++: https://help.semmle.com/QL/learn-ql/ql/cpp/ql-for-cpp.html 
+- CodeQL for C/C++: https://codeql.github.com/docs/codeql-language-guides/codeql-for-cpp/ 
 - API reference: https://codeql.github.com/codeql-standard-libraries/cpp 
 
 .. rst-class:: end-slide

--- a/docs/codeql/ql-training/cpp/control-flow-cpp.rst
+++ b/docs/codeql/ql-training/cpp/control-flow-cpp.rst
@@ -18,7 +18,7 @@ For this example you should download:
 
 .. note::
 
-   For the examples in this presentation, we will be analyzing `ChakraCore <https://github.com/microsoft/ChakraCore>`__.
+   For the examples in this presentation, we will be analyzing `ChakraCore <https://github.com/Chakra-Core/ChakraCore/>`__.
 
    You can query the project in `the query console <https://lgtm.com/query/project:2034240708/lang:cpp/>`__ on LGTM.com.
 

--- a/docs/codeql/ql-training/cpp/data-flow-cpp.rst
+++ b/docs/codeql/ql-training/cpp/data-flow-cpp.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `dotnet/coreclr database <http://downloads.lgtm.com/snapshots/cpp/dotnet/coreclr/dotnet_coreclr_fbe0c77.zip>`__
 
 .. note::
@@ -139,7 +139,7 @@ Define a subclass of ``DataFlow::Node`` representing “source” nodes, that is
 
 .. note::
 
-  Note the scoping of the `don’t-care variable <https://help.semmle.com/QL/ql-handbook/expressions.html#don-t-care-expressions>`__ “_” in this example: the body of the characteristic predicate is equivalent to:
+  Note the scoping of the `don’t-care variable <https://codeql.github.com/docs/ql-language-reference/expressions/#don-t-care-expressions>`__ “_” in this example: the body of the characteristic predicate is equivalent to:
   
   .. code-block:: ql
 

--- a/docs/codeql/ql-training/cpp/global-data-flow-cpp.rst
+++ b/docs/codeql/ql-training/cpp/global-data-flow-cpp.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `dotnet/coreclr database <http://downloads.lgtm.com/snapshots/cpp/dotnet/coreclr/dotnet_coreclr_fbe0c77.zip>`__
 
 .. note::

--- a/docs/codeql/ql-training/cpp/intro-ql-cpp.rst
+++ b/docs/codeql/ql-training/cpp/intro-ql-cpp.rst
@@ -110,7 +110,7 @@ Each query library also implicitly defines a module.
 
   Parts of queries can be lifted into `library files <https://codeql.github.com/docs/ql-language-reference/modules/#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using ``import`` statements, and similarly QLL files can import each other’s definitions using “import” statements.
 
-  Logic can be encapsulated as user-defined `predicates <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ and `classes <hhttps://codeql.github.com/docs/ql-language-reference/types/#classes>`__, and organized into `modules <hhttps://codeql.github.com/docs/ql-language-reference/modules/>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.
+  Logic can be encapsulated as user-defined `predicates <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ and `classes <https://codeql.github.com/docs/ql-language-reference/types/#classes>`__, and organized into `modules <https://codeql.github.com/docs/ql-language-reference/modules/>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.
 
 Predicates
 ==========

--- a/docs/codeql/ql-training/cpp/intro-ql-cpp.rst
+++ b/docs/codeql/ql-training/cpp/intro-ql-cpp.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `exiv2 database <http://downloads.lgtm.com/snapshots/cpp/exiv2/Exiv2_exiv2_b090f4d.zip>`__
 
 .. note::
@@ -68,7 +68,7 @@ A simple CodeQL query
 
    We are going to write a simple query which finds “if statements” with empty “then” blocks, so we can highlight the results like those on the previous slide. The query can be run in the `query console on LGTM <https://lgtm.com/query>`__, or in your `IDE <https://lgtm.com/help/lgtm/running-queries-ide>`__.
 
-   A `query <https://help.semmle.com/QL/ql-handbook/queries.html>`__ consists of a “select” clause that indicates what results should be returned. Typically it will also provide a “from” clause to declare some variables, and a “where” clause to state conditions over those variables. For more information on the structure of query files (including links to useful topics in the `QL language reference <https://help.semmle.com/QL/ql-handbook/index.html>`__), see `About CodeQL queries <https://help.semmle.com/QL/learn-ql/ql/writing-queries/introduction-to-queries.html>`__.
+   A `query <https://codeql.github.com/docs/ql-language-reference/queries/>`__ consists of a “select” clause that indicates what results should be returned. Typically it will also provide a “from” clause to declare some variables, and a “where” clause to state conditions over those variables. For more information on the structure of query files (including links to useful topics in the `QL language reference <https://codeql.github.com/docs/ql-language-reference/>`__), see `About CodeQL queries <https://codeql.github.com/docs/writing-codeql-queries/about-codeql-queries/>`__.
 
    In our example here, the first line of the query imports the `CodeQL library for C/C++ <https://codeql.github.com/codeql-standard-libraries/cpp/>`__, which defines concepts like ``IfStmt`` and ``Block``.
    The query proper starts by declaring two variables–ifStmt and block. These variables represent sets of values in the database, according to the type of each of the variables. For example, ifStmt has the type IfStmt, which means it represents the set of all if statements in the program.
@@ -108,9 +108,9 @@ Each query library also implicitly defines a module.
 
   Queries are always contained in query files with the file extension ``.ql``.
 
-  Parts of queries can be lifted into `library files <https://help.semmle.com/QL/ql-handbook/modules.html#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using ``import`` statements, and similarly QLL files can import each other’s definitions using “import” statements.
+  Parts of queries can be lifted into `library files <https://codeql.github.com/docs/ql-language-reference/modules/#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using ``import`` statements, and similarly QLL files can import each other’s definitions using “import” statements.
 
-  Logic can be encapsulated as user-defined `predicates <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ and `classes <https://help.semmle.com/QL/ql-handbook/types.html#classes>`__, and organized into `modules <https://help.semmle.com/QL/ql-handbook/modules.html>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.
+  Logic can be encapsulated as user-defined `predicates <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ and `classes <hhttps://codeql.github.com/docs/ql-language-reference/types/#classes>`__, and organized into `modules <hhttps://codeql.github.com/docs/ql-language-reference/modules/>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.
 
 Predicates
 ==========
@@ -131,7 +131,7 @@ A predicate allows you to pull out and name parts of a query.
 
 .. note::
 
-   A `predicate <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ takes zero or more parameters, and its body is a condition on those parameters. The predicate may (or may not) hold. Predicates may also be `recursive <https://help.semmle.com/QL/ql-handbook/predicates.html#recursive-predicates>`__, simply by referring to themselves (directly or indirectly).
+   A `predicate <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ takes zero or more parameters, and its body is a condition on those parameters. The predicate may (or may not) hold. Predicates may also be `recursive <https://codeql.github.com/docs/ql-language-reference/predicates/#recursive-predicates>`__, simply by referring to themselves (directly or indirectly).
 
    You can imagine a predicate to be a self-contained from-where-select statement, that produces an intermediate relation, or table. In this case, the ``isEmpty`` predicate will be the set of all blocks which are empty.
 
@@ -154,7 +154,7 @@ Member predicates are inherited and can be overridden.
 
 .. note::
 
-  `Classes <https://help.semmle.com/QL/ql-handbook/types.html#classes>`__ model sets of values from the database. A class has one or more supertypes, and inherits `member predicates <https://help.semmle.com/QL/ql-handbook/types.html#member-predicates>`__ (methods) from each of them. Each value in a class must be in every supertype, but additional conditions can be stated in a so-called **characteristic predicate**, which looks a bit like a zero-argument constructor.
+  `Classes <https://codeql.github.com/docs/ql-language-reference/types/#classes>`__ model sets of values from the database. A class has one or more supertypes, and inherits `member predicates <https://codeql.github.com/docs/ql-language-reference/types/#member-predicates>`__ (methods) from each of them. Each value in a class must be in every supertype, but additional conditions can be stated in a so-called **characteristic predicate**, which looks a bit like a zero-argument constructor.
 
   In the example, declaring a variable “EmptyBlock e” will allow it to range over only those blocks that have zero statements.
 

--- a/docs/codeql/ql-training/cpp/snprintf.rst
+++ b/docs/codeql/ql-training/cpp/snprintf.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `rsyslog database <https://downloads.lgtm.com/snapshots/cpp/rsyslog/rsyslog/rsyslog-all-revision-2018-April-27--14-12-31.zip>`__
 
 .. note::

--- a/docs/codeql/ql-training/java/apache-struts-java.rst
+++ b/docs/codeql/ql-training/java/apache-struts-java.rst
@@ -15,7 +15,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `Apache Struts database <https://downloads.lgtm.com/snapshots/java/apache/struts/apache-struts-7fd1622-CVE-2018-11776.zip>`__
 
 .. note::

--- a/docs/codeql/ql-training/java/data-flow-java.rst
+++ b/docs/codeql/ql-training/java/data-flow-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `VIVO Vitro database <http://downloads.lgtm.com/snapshots/java/vivo-project/Vitro/vivo-project_Vitro_java-srcVersion_47ae42c01954432c3c3b92d5d163551ce367f510-dist_odasa-lgtm-2019-04-23-7ceff95-linux64.zip>`__
 
 .. note::

--- a/docs/codeql/ql-training/java/global-data-flow-java.rst
+++ b/docs/codeql/ql-training/java/global-data-flow-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `Apache Struts database <https://downloads.lgtm.com/snapshots/java/apache/struts/apache-struts-7fd1622-CVE-2018-11776.zip>`__
 
 .. note::

--- a/docs/codeql/ql-training/java/intro-ql-java.rst
+++ b/docs/codeql/ql-training/java/intro-ql-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `Apache Struts database <https://downloads.lgtm.com/snapshots/java/apache/struts/apache-struts-7fd1622-CVE-2018-11776.zip>`__
 
 .. note::
@@ -68,7 +68,7 @@ A simple CodeQL query
 
    We are going to write a simple query which finds “if statements” with empty “then” blocks, so we can highlight the results like those on the previous slide. The query can be run in the `query console on LGTM <https://lgtm.com/query>`__, or in your `IDE <https://lgtm.com/help/lgtm/running-queries-ide>`__.
 
-   A `query <https://help.semmle.com/QL/ql-handbook/queries.html>`__ consists of a “select” clause that indicates what results should be returned. Typically it will also provide a “from” clause to declare some variables, and a “where” clause to state conditions over those variables. For more information on the structure of query files (including links to useful topics in the `QL language reference <https://help.semmle.com/QL/ql-handbook/index.html>`__), see `About CodeQL queries <https://help.semmle.com/QL/learn-ql/ql/writing-queries/introduction-to-queries.html>`__.
+   A `query <https://codeql.github.com/docs/ql-language-reference/queries/>`__ consists of a “select” clause that indicates what results should be returned. Typically it will also provide a “from” clause to declare some variables, and a “where” clause to state conditions over those variables. For more information on the structure of query files (including links to useful topics in the `QL language reference <https://codeql.github.com/docs/ql-language-reference/>`__), see `About CodeQL queries <https://codeql.github.com/docs/writing-codeql-queries/about-codeql-queries/>`__.
 
    In our example here, the first line of the query imports the `CodeQL library for Java <https://codeql.github.com/codeql-standard-libraries/java/>`__, which defines concepts like ``IfStmt`` and ``Block``.
    The query proper starts by declaring two variables–ifStmt and block. These variables represent sets of values in the database, according to the type of each of the variables. For example, ``ifStmt`` has the type ``IfStmt``, which means it represents the set of all if statements in the program.
@@ -107,9 +107,9 @@ Each query library also implicitly defines a module.
 
   Queries are always contained in query files with the file extension ``.ql``. 
   
-  Parts of queries can be lifted into `library files <https://help.semmle.com/QL/ql-handbook/modules.html#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using “import” statements, and similarly QLL files can import each other’s definitions using “import” statements.
+  Parts of queries can be lifted into `library files <https://codeql.github.com/docs/ql-language-reference/modules/#library-modules>`__ with the extension ``.qll``. Definitions within such libraries can be brought into scope using “import” statements, and similarly QLL files can import each other’s definitions using “import” statements.
 
-  Logic can be encapsulated as user-defined `predicates <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ and `classes <https://help.semmle.com/QL/ql-handbook/types.html#classes>`__, and organized into `modules <https://help.semmle.com/QL/ql-handbook/modules.html>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.
+  Logic can be encapsulated as user-defined `predicates <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ and `classes <https://codeql.github.com/docs/ql-language-reference/types/#classes>`__, and organized into `modules <https://codeql.github.com/docs/ql-language-reference/modules/>`__. Each QLL file implicitly defines a module, but QL and QLL files can also contain explicit module definitions, as we will see later.
 
 Predicates
 ==========
@@ -130,7 +130,7 @@ A predicate allows you to pull out and name parts of a query.
 
 .. note::
 
-   A `predicate <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ takes zero or more parameters, and its body is a condition on those parameters. The predicate may (or may not) hold. Predicates may also be `recursive <https://help.semmle.com/QL/ql-handbook/predicates.html#recursive-predicates>`__, simply by referring to themselves (directly or indirectly).
+   A `predicate <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ takes zero or more parameters, and its body is a condition on those parameters. The predicate may (or may not) hold. Predicates may also be `recursive <https://codeql.github.com/docs/ql-language-reference/predicates/#recursive-predicates>`__, simply by referring to themselves (directly or indirectly).
 
    You can imagine a predicate to be a self-contained from-where-select statement, that produces an intermediate relation, or table. In this case, the ``isEmpty`` predicate will be the set of all blocks which are empty.
 
@@ -154,7 +154,7 @@ Member predicates are inherited and can be overridden.
 
 .. note::
 
-  `Classes <https://help.semmle.com/QL/ql-handbook/types.html#classes>`__ model sets of values from the database. A class has one or more supertypes, and inherits `member predicates <https://help.semmle.com/QL/ql-handbook/types.html#member-predicates>`__ (methods) from each of them. Each value in a class must be in every supertype, but additional conditions can be stated in a so-called **characteristic predicate**, which looks a bit like a zero-argument constructor.
+  `Classes <https://codeql.github.com/docs/ql-language-reference/types/#classes>`__ model sets of values from the database. A class has one or more supertypes, and inherits `member predicates <https://codeql.github.com/docs/ql-language-reference/types/#member-predicates>`__ (methods) from each of them. Each value in a class must be in every supertype, but additional conditions can be stated in a so-called **characteristic predicate**, which looks a bit like a zero-argument constructor.
 
   In the example, declaring a variable “EmptyBlock e” will allow it to range over only those blocks that have zero statements.
 

--- a/docs/codeql/ql-training/java/query-injection-java.rst
+++ b/docs/codeql/ql-training/java/query-injection-java.rst
@@ -11,7 +11,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - `VIVO Vitro database <http://downloads.lgtm.com/snapshots/java/vivo-project/Vitro/vivo-project_Vitro_java-srcVersion_47ae42c01954432c3c3b92d5d163551ce367f510-dist_odasa-lgtm-2019-04-23-7ceff95-linux64.zip>`__
 
 .. note::
@@ -84,7 +84,7 @@ Let’s start by looking for calls to methods with names of the form ``sparql*Qu
     - a ``MethodAccess``: the call to a SPARQL query method
     - a ``Method``: the SPARQL query method.
   
-  - The ``where`` part of the query ties these variables together using `predicates <https://help.semmle.com/QL/ql-handbook/predicates.html>`__ defined in the `standard CodeQL library for Java <https://codeql.github.com/codeql-standard-libraries/java/>`__.
+  - The ``where`` part of the query ties these variables together using `predicates <https://codeql.github.com/docs/ql-language-reference/predicates/>`__ defined in the `standard CodeQL library for Java <https://codeql.github.com/codeql-standard-libraries/java/>`__.
 
 CodeQL query: find string concatenation
 =======================================

--- a/docs/codeql/ql-training/slide-snippets/abstract-syntax-tree.rst
+++ b/docs/codeql/ql-training/slide-snippets/abstract-syntax-tree.rst
@@ -39,9 +39,9 @@ The basic representation of an analyzed program is an *abstract syntax tree (AST
 
   The following topics contain overviews of the important AST classes and CodeQL libraries for C/C++, C#, and Java: 
   
-  - `CodeQL library for C/C++ <https://help.semmle.com/QL/learn-ql/cpp/introduce-libraries-cpp.html>`__ 
-  - `CodeQL library for C# <https://help.semmle.com/QL/learn-ql/csharp/introduce-libraries-csharp.html>`__
-  - `CodeQL library for Java <https://help.semmle.com/QL/learn-ql/java/introduce-libraries-java.html>`__  
+  - `CodeQL library for C/C++ <https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-cpp/>`__ 
+  - `CodeQL library for C# <https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-csharp/>`__
+  - `CodeQL library for Java <https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-java/>`__  
 
 
 Database representations of ASTs

--- a/docs/codeql/ql-training/slide-snippets/abstract-syntax-tree.rst
+++ b/docs/codeql/ql-training/slide-snippets/abstract-syntax-tree.rst
@@ -65,6 +65,6 @@ Entity types are rarely used directly, the usual pattern is to define a class th
 
   For example, the database schemas for C/++, C#, and Java CodeQL databases are here: 
   
-  - https://github.com/github/codeql/blob/main/cpp/ql/src/semmlecode.cpp.dbscheme 
-  - https://github.com/github/codeql/blob/main/csharp/ql/src/semmlecode.csharp.dbscheme 
-  - https://github.com/github/codeql/blob/main/java/ql/src/config/semmlecode.dbscheme 
+  - https://github.com/github/codeql/blob/main/cpp/ql/lib/semmlecode.cpp.dbscheme 
+  - https://github.com/github/codeql/blob/main/csharp/ql/lib/semmlecode.csharp.dbscheme 
+  - https://github.com/github/codeql/blob/main/java/ql/lib/config/semmlecode.dbscheme 

--- a/docs/codeql/ql-training/slide-snippets/database-note.rst
+++ b/docs/codeql/ql-training/slide-snippets/database-note.rst
@@ -4,6 +4,6 @@ You can download the database as a zip file by clicking the link on the slide ab
 #. Add the unzipped database to Visual Studio Code
 #. Upgrade the database if necessary
 
-For further information, see `Analyzing your projects <https://help.semmle.com/codeql/codeql-for-vscode/procedures/using-extension.html>`__ in the CodeQL for Visual Studio Code help.
+For further information, see `Analyzing your projects <hhttps://codeql.github.com/docs/codeql-for-visual-studio-code/analyzing-your-projects/>`__ in the CodeQL for Visual Studio Code help.
 
 Note that results generated in the query console are likely to differ to those generated in CodeQL for Visual Studio Code as LGTM.com analyzes the most recent revisions of each project that has been added–the CodeQL database available to download above is based on an historical version of the codebase.

--- a/docs/codeql/ql-training/slide-snippets/database-note.rst
+++ b/docs/codeql/ql-training/slide-snippets/database-note.rst
@@ -4,6 +4,6 @@ You can download the database as a zip file by clicking the link on the slide ab
 #. Add the unzipped database to Visual Studio Code
 #. Upgrade the database if necessary
 
-For further information, see `Analyzing your projects <hhttps://codeql.github.com/docs/codeql-for-visual-studio-code/analyzing-your-projects/>`__ in the CodeQL for Visual Studio Code help.
+For further information, see `Analyzing your projects <https://codeql.github.com/docs/codeql-for-visual-studio-code/analyzing-your-projects/>`__ in the CodeQL for Visual Studio Code help.
 
 Note that results generated in the query console are likely to differ to those generated in CodeQL for Visual Studio Code as LGTM.com analyzes the most recent revisions of each project that has been added–the CodeQL database available to download above is based on an historical version of the codebase.

--- a/docs/codeql/ql-training/slide-snippets/intro-ql-general.rst
+++ b/docs/codeql/ql-training/slide-snippets/intro-ql-general.rst
@@ -103,7 +103,7 @@ Analysis overview
 
   CodeQL analysis works by extracting a queryable database from your project. For compiled languages, the tools observe an ordinary build of the source code. Each time a compiler is invoked to process a source file, a copy of that file is made, and all relevant information about the source code (syntactic data about the abstract syntax tree, semantic data like name binding and type information, data on the operation of the C preprocessor, etc.) is collected. For interpreted languages, the extractor gathers similar information by running directly on the source code. Multi-language code bases are analyzed one language at a time.
 
-  Once the extraction finishes, all this information is collected into a single `CodeQL database <https://help.semmle.com/codeql/about-codeql.html#about-codeql-databases>`__, which is then ready to query, possibly on a different machine. A copy of the source files, made at the time the database was created, is also included in the CodeQL database so analysis results can be displayed at the correct location in the code. The database schema is (source) language specific.
+  Once the extraction finishes, all this information is collected into a single `CodeQL database <https://codeql.github.com/docs/codeql-overview/about-codeql/#about-codeql-databases>`__, which is then ready to query, possibly on a different machine. A copy of the source files, made at the time the database was created, is also included in the CodeQL database so analysis results can be displayed at the correct location in the code. The database schema is (source) language specific.
 
   Queries are written in QL and usually depend on one or more of the `standard CodeQL libraries <https://github.com/github/codeql>`__ (and of course you can write your own custom libraries). They are compiled into an efficiently executable format by the QL compiler and then run on a CodeQL database by the QL evaluator, either on a remote worker machine or locally on a developer’s machine.
 
@@ -124,7 +124,7 @@ QL is:
 
 .. note::
 
-  QL is the high-level, object-oriented logic language that underpins all CodeQL libraries and analyses. You can learn lots more about QL by visiting the `QL language reference <https://help.semmle.com/QL/ql-handbook>`__.
+  QL is the high-level, object-oriented logic language that underpins all CodeQL libraries and analyses. You can learn lots more about QL by visiting the `QL language reference <https://codeql.github.com/docs/ql-language-reference/>`__.
   The key features of QL are:
   
   - All common logic connectives are available, including quantifiers like ``exist``, which can also introduce new variables. 

--- a/docs/codeql/ql-training/slide-snippets/local-data-flow.rst
+++ b/docs/codeql/ql-training/slide-snippets/local-data-flow.rst
@@ -70,7 +70,7 @@ Local vs global data flow
 
   For further information, see:
 
-  - `About data flow analysis <https://help.semmle.com/QL/learn-ql/ql/intro-to-data-flow.html>`__
+  - `About data flow analysis <https://codeql.github.com/docs/writing-codeql-queries/about-data-flow-analysis/>`__
 
 .. rst-class:: background2
 
@@ -111,8 +111,8 @@ So all references will need to be qualified (that is, ``DataFlow::Node``)
 
   A **module** is a way of organizing QL code by grouping together related predicates, classes, and (sub-)modules. They can be either explicitly declared or implicit. A query library implicitly declares a module with the same name as the QLL file.
 
-  For further information on libraries and modules in QL, see the chapter on `Modules <https://help.semmle.com/QL/ql-handbook/modules.html>`__ in the QL language reference.
-  For further information on importing QL libraries and modules, see the chapter on `Name resolution <https://help.semmle.com/QL/ql-handbook/name-resolution.html>`__ in the QL language reference.
+  For further information on libraries and modules in QL, see the chapter on `Modules <https://codeql.github.com/docs/ql-language-reference/modules/>`__ in the QL language reference.
+  For further information on importing QL libraries and modules, see the chapter on `Name resolution <>`__ in the QL language reference.
 
 Data flow graph
 ===============
@@ -131,7 +131,7 @@ Data flow graph
 
   The ``DataFlow::Node`` class is shared between both the local and global data flow graphs–the primary difference is the edges, which in the “global” case can link different functions.
 
-  ``localFlowStep`` is the “single step” flow relation–that is, it describes single edges in the local data flow graph. ``localFlow`` represents the `transitive <https://help.semmle.com/QL/ql-handbook/recursion.html#transitive-closures>`__ closure of this relation–in other words, it contains every pair of nodes where the second node is reachable from the first in the data flow graph.
+  ``localFlowStep`` is the “single step” flow relation–that is, it describes single edges in the local data flow graph. ``localFlow`` represents the `transitive <https://codeql.github.com/docs/ql-language-reference/recursion/#transitive-closures>`__ closure of this relation–in other words, it contains every pair of nodes where the second node is reachable from the first in the data flow graph.
 
   The data flow graph is separate from the `AST <https://en.wikipedia.org/wiki/Abstract_syntax_tree>`__, to allow for flexibility in how data flow is modeled. There are a small number of data flow node types–expression nodes, parameter nodes, uninitialized variable nodes, and definition by reference nodes. Each node provides mapping functions to and from the relevant AST (for example ``Expr``, ``Parameter`` etc.) or symbol table (for example ``Variable``) classes.
 

--- a/docs/codeql/ql-training/template.rst
+++ b/docs/codeql/ql-training/template.rst
@@ -36,7 +36,7 @@ Setup
 
 For this example you should download:
 
-- `CodeQL for Visual Studio Code <https://help.semmle.com/codeql/codeql-for-vscode/procedures/setting-up.html>`__
+- `CodeQL for Visual Studio Code <https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/>`__
 - A CodeQL database
 
 .. note::


### PR DESCRIPTION
This PR updates the training notes to use the current URLs for CodeQL docs, instead of relying on redirects. For more information, see the internal issue.