### PR TITLE
Fix Android logging signature

### DIFF
--- a/java/ql/src/experimental/semmle/code/java/Logging.qll
+++ b/java/ql/src/experimental/semmle/code/java/Logging.qll
@@ -29,13 +29,8 @@ class LoggingCall extends MethodAccess {
     )
     or
     exists(RefType t, Method m | t.hasQualifiedName("android.util", "Log") |
-      (
-        m.hasName(["d", "e", "i", "v", "w", "wtf"])
-      ) and
-      (
-        m.getDeclaringType().getASourceSupertype*() = t or
-        m.getDeclaringType().extendsOrImplements*(t)
-      ) and
+      m.hasName(["d", "e", "i", "v", "w", "wtf"]) and
+      m.getDeclaringType() = t and
       m.getReturnType() instanceof IntegralType and
       this = m.getAReference()
     )

--- a/java/ql/src/experimental/semmle/code/java/Logging.qll
+++ b/java/ql/src/experimental/semmle/code/java/Logging.qll
@@ -30,12 +30,7 @@ class LoggingCall extends MethodAccess {
     or
     exists(RefType t, Method m | t.hasQualifiedName("android.util", "Log") |
       (
-        m.hasName("d") or
-        m.hasName("e") or
-        m.hasName("i") or
-        m.hasName("v") or
-        m.hasName("w") or
-        m.hasName("wtf")
+        m.hasName(["d", "e", "i", "v", "w", "wtf"])
       ) and
       (
         m.getDeclaringType().getASourceSupertype*() = t or

--- a/java/ql/src/experimental/semmle/code/java/Logging.qll
+++ b/java/ql/src/experimental/semmle/code/java/Logging.qll
@@ -18,14 +18,30 @@ class LoggingCall extends MethodAccess {
       t.hasQualifiedName("org.scijava.log", "Logger") or
       t.hasQualifiedName("com.google.common.flogger", "LoggingApi") or
       t.hasQualifiedName("java.lang", "System$Logger") or
-      t.hasQualifiedName("java.util.logging", "Logger") or
-      t.hasQualifiedName("android.util", "Log")
+      t.hasQualifiedName("java.util.logging", "Logger")
     |
       (
         m.getDeclaringType().getASourceSupertype*() = t or
         m.getDeclaringType().extendsOrImplements*(t)
       ) and
       m.getReturnType() instanceof VoidType and
+      this = m.getAReference()
+    )
+    or
+    exists(RefType t, Method m | t.hasQualifiedName("android.util", "Log") |
+      (
+        m.hasName("d") or
+        m.hasName("e") or
+        m.hasName("i") or
+        m.hasName("v") or
+        m.hasName("w") or
+        m.hasName("wtf")
+      ) and
+      (
+        m.getDeclaringType().getASourceSupertype*() = t or
+        m.getDeclaringType().extendsOrImplements*(t)
+      ) and
+      m.getReturnType() instanceof IntegralType and
       this = m.getAReference()
     )
   }

--- a/java/ql/src/experimental/semmle/code/java/Logging.qll
+++ b/java/ql/src/experimental/semmle/code/java/Logging.qll
@@ -31,7 +31,6 @@ class LoggingCall extends MethodAccess {
     exists(RefType t, Method m | t.hasQualifiedName("android.util", "Log") |
       m.hasName(["d", "e", "i", "v", "w", "wtf"]) and
       m.getDeclaringType() = t and
-      m.getReturnType() instanceof IntegralType and
       this = m.getAReference()
     )
   }


### PR DESCRIPTION
The method signature for the Android Logger methods in the **java/ql/src/experimental/semmle/code/java/Logging.qll** is wrong and prevents the proper identification of sensitive data logging in Android applications.