### PR TITLE
C++: Exclusion rules for system macros

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Exclusions.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Exclusions.qll
@@ -123,15 +123,13 @@ private predicate isFromMacroInvocation(Element e, MacroInvocation mi) {
  *   M(y + 1);
  * ```
  */
-predicate isFromMacroDefinition(Element e) {
-  isFromMacroInvocation(e, _)
-}
+predicate isFromMacroDefinition(Element e) { isFromMacroInvocation(e, _) }
 
 /**
  * Holds if `e` is completely or partially from a _system macro_ definition, as
  * opposed to being passed in as an argument. A system macro is a macro whose
  * definition is outside the source directory of the database.
- * 
+ *
  * If the system macro is invoked through a non-system macro, then this
  * predicate does not hold. That's a limitation of how macros are represented
  * in the database.

--- a/cpp/ql/lib/semmle/code/cpp/commons/Exclusions.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Exclusions.qll
@@ -131,8 +131,7 @@ predicate isFromMacroDefinition(Element e) { isFromMacroInvocation(e, _) }
  * definition is outside the source directory of the database.
  *
  * If the system macro is invoked through a non-system macro, then this
- * predicate does not hold. That's a limitation of how macros are represented
- * in the database.
+ * predicate does not hold.
  *
  * See also `isFromMacroDefinition`.
  */


### PR DESCRIPTION
Unwanted results were reported for our JPL Rule 24 queries. Inclusion of system headers with complex macros could lead to unpredictable alerts from these rules.

Fixes https://github.com/github/codeql/issues/6522.

It's hard to write unit tests for these changes, like it was in https://github.com/github/codeql/pull/5085, because there are no system headers in qltests. I tested manually on a vim/vim snapshot and found some examples:
- The `MultipleStmtsPerLine.ql` change removes [this alert for `FD_ISSET`](https://github.com/vim/vim/blob/770ddbe1595f6dab836304203d5ca2e0b069266f/src/channel.c#L4538).
- The `MultipleVarDeclsPerLine.ql` change removes [this alert for `FD_ZERO`](https://github.com/vim/vim/blob/770ddbe1595f6dab836304203d5ca2e0b069266f/src/channel.c#L3440).