### PR TITLE
Java: Add sources for content providers in Android

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -252,7 +252,10 @@ class ExportedAndroidIntentInput extends RemoteFlowSource, AndroidIntentInput {
 class AndroidContentProviderInput extends DataFlow::Node {
   AndroidContentProvider declaringType;
 
-  AndroidContentProviderInput() { sourceNode(this, "contentprovider") }
+  AndroidContentProviderInput() {
+    sourceNode(this, "contentprovider") and
+    this.asParameter().getCallable().getDeclaringType() = declaringType
+  }
 }
 
 /** A parameter of an entry-point method declared in an exported `ContentProvider` class. */

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -254,7 +254,7 @@ class AndroidContentProviderInput extends DataFlow::Node {
 
   AndroidContentProviderInput() {
     sourceNode(this, "contentprovider") and
-    this.asParameter().getCallable().getDeclaringType() = declaringType
+    this.getEnclosingCallable().getDeclaringType() = declaringType
   }
 }
 

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -247,3 +247,17 @@ class ExportedAndroidIntentInput extends RemoteFlowSource, AndroidIntentInput {
 
   override string getSourceType() { result = "Exported Android intent source" }
 }
+
+/** A parameter of an entry-point method declared in a `ContentProvider` class. */
+class AndroidContentProviderInput extends DataFlow::Node {
+  AndroidContentProvider declaringType;
+
+  AndroidContentProviderInput() { sourceNode(this, "contentprovider") }
+}
+
+/** A parameter of an entry-point method declared in an exported `ContentProvider` class. */
+class ExportedAndroidContentProviderInput extends RemoteFlowSource, AndroidContentProviderInput {
+  ExportedAndroidContentProviderInput() { declaringType.isExported() }
+
+  override string getSourceType() { result = "Exported Android content provider source" }
+}

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -72,6 +72,14 @@ class AndroidContentProvider extends ExportableAndroidComponent {
   AndroidContentProvider() {
     this.getASupertype*().hasQualifiedName("android.content", "ContentProvider")
   }
+
+  /**
+   * Holds if this content provider requires read and write permissions
+   * in an `AndroidManifest.xml` file.
+   */
+  predicate requiresPermissions() {
+    getAndroidComponentXmlElement().(AndroidProviderXmlElement).requiresPermissions()
+  }
 }
 
 /** An Android content resolver. */
@@ -145,6 +153,42 @@ private class UriModel extends SummaryModelCsv {
         "android.net;Uri$Builder;false;scheme;;;Argument[0];Argument[-1];taint",
         "android.net;Uri$Builder;false;scheme;;;Argument[-1];ReturnValue;value",
         "android.net;Uri$Builder;false;toString;;;Argument[-1];ReturnValue;taint"
+      ]
+  }
+}
+
+private class ContentProviderSourceModels extends SourceModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        // ContentInterface models are here for backwards compatibility (it was removed in API 28)
+        "android.content;ContentInterface;true;call;(String,String,String,Bundle);;Parameter[0..3];contentprovider",
+        "android.content;ContentProvider;true;call;(String,String,String,Bundle);;Parameter[0..3];contentprovider",
+        "android.content;ContentProvider;true;call;(String,String,Bundle);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;delete;(Uri,String,String[]);;Parameter[0..2];contentprovider",
+        "android.content;ContentInterface;true;delete;(Uri,Bundle);;Parameter[0..1];contentprovider",
+        "android.content;ContentProvider;true;delete;(Uri,Bundle);;Parameter[0..1];contentprovider",
+        "android.content;ContentInterface;true;getType;(Uri);;Parameter[0];contentprovider",
+        "android.content;ContentProvider;true;getType;(Uri);;Parameter[0];contentprovider",
+        "android.content;ContentInterface;true;insert;(Uri,ContentValues,Bundle);;Parameter[0];contentprovider",
+        "android.content;ContentProvider;true;insert;(Uri,ContentValues,Bundle);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;insert;(Uri,ContentValues);;Parameter[0..1];contentprovider",
+        "android.content;ContentInterface;true;openAssetFile;(Uri,String,CancellationSignal);;Parameter[0];contentprovider",
+        "android.content;ContentProvider;true;openAssetFile;(Uri,String,CancellationSignal);;Parameter[0];contentprovider",
+        "android.content;ContentProvider;true;openAssetFile;(Uri,String);;Parameter[0];contentprovider",
+        "android.content;ContentInterface;true;openTypedAssetFile;(Uri,String,Bundle,CancellationSignal);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;openTypedAssetFile;(Uri,String,Bundle,CancellationSignal);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;openTypedAssetFile;(Uri,String,Bundle);;Parameter[0..2];contentprovider",
+        "android.content;ContentInterface;true;openFile;(Uri,String,CancellationSignal);;Parameter[0];contentprovider",
+        "android.content;ContentProvider;true;openFile;(Uri,String,CancellationSignal);;Parameter[0];contentprovider",
+        "android.content;ContentProvider;true;openFile;(Uri,String);;Parameter[0];contentprovider",
+        "android.content;ContentInterface;true;query;(Uri,String[],Bundle,CancellationSignal);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;query;(Uri,String[],Bundle,CancellationSignal);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;query;(Uri,String[],String,String[],String);;Parameter[0..4];contentprovider",
+        "android.content;ContentProvider;true;query;(Uri,String[],String,String[],String,CancellationSignal);;Parameter[0..4];contentprovider",
+        "android.content;ContentInterface;true;update;(Uri,ContentValues,Bundle);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;update;(Uri,ContentValues,Bundle);;Parameter[0..2];contentprovider",
+        "android.content;ContentProvider;true;update;(Uri,ContentValues,String,String[]);;Parameter[0..3];contentprovider"
       ]
   }
 }

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -79,6 +79,47 @@ class AndroidReceiverXmlElement extends AndroidComponentXmlElement {
  */
 class AndroidProviderXmlElement extends AndroidComponentXmlElement {
   AndroidProviderXmlElement() { this.getName() = "provider" }
+
+  /**
+   * Holds if this provider element has explicitly set a value for either its
+   * `android:permission` attribute or its `android:readPermission` and `android:writePermission`
+   * attributes.
+   */
+  predicate requiresPermissions() {
+    this.getAnAttribute().(AndroidPermissionXmlAttribute).isFull()
+    or
+    this.getAnAttribute().(AndroidPermissionXmlAttribute).isWrite() and
+    this.getAnAttribute().(AndroidPermissionXmlAttribute).isRead()
+  }
+}
+
+/**
+ * The attribute `android:perrmission`, `android:readPermission`, or `android:writePermission`.
+ */
+class AndroidPermissionXmlAttribute extends XMLAttribute {
+  AndroidPermissionXmlAttribute() {
+    this.getNamespace().getPrefix() = "android" and
+    this.getName() = ["permission", "readPermission", "writePermission"]
+  }
+
+  /** Holds if this is an `android:permission` attribute. */
+  predicate isFull() { this.getName() = "permission" }
+
+  /** Holds if this is an `android:readPermission` attribute. */
+  predicate isRead() { this.getName() = "readPermission" }
+
+  /** Holds if this is an `android:writePermission` attribute. */
+  predicate isWrite() { this.getName() = "writePermission" }
+}
+
+/**
+ * The `<path-permission`> element of a `<provider>` in an Android manifest file.
+ */
+class AndroidPathPermissionXmlElement extends XMLElement {
+  AndroidPathPermissionXmlElement() {
+    this.getParent() instanceof AndroidProviderXmlElement and
+    this.hasName("path-permission")
+  }
 }
 
 /**

--- a/java/ql/test/library-tests/frameworks/android/content-provider/AndroidManifest.xml
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0"
+    package="com.example.app">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+
+        <activity
+            android:name=".MainActivity"
+            android:icon="@drawable/ic_launcher"
+			android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <provider
+            android:name=".Test"
+            android:authority="com.example.myapp.Test"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/java/ql/test/library-tests/frameworks/android/content-provider/AndroidManifest.xml
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/AndroidManifest.xml
@@ -27,5 +27,10 @@
             android:name=".Test"
             android:authority="com.example.myapp.Test"
             android:exported="true" />
+
+        <provider
+            android:name=".Safe"
+            android:authority="com.example.myapp.Safe"
+            android:exported="false" />
     </application>
 </manifest>

--- a/java/ql/test/library-tests/frameworks/android/content-provider/Safe.java
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/Safe.java
@@ -1,0 +1,174 @@
+package com.example.app;
+
+import java.io.FileNotFoundException;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.res.AssetFileDescriptor;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+
+// This Content Provider isn't exported, so there shouldn't be any flow
+public class Safe extends ContentProvider {
+
+	void sink(Object o) {}
+
+	@Override
+	public Bundle call(String authority, String method, String arg, Bundle extras) {
+		sink(authority);
+		sink(method);
+		sink(arg);
+		sink(extras.get("some_key"));
+		return null;
+	}
+
+	public Bundle call(String method, String arg, Bundle extras) {
+		sink(method);
+		sink(arg);
+		sink(extras.get("some_key"));
+		return null;
+	}
+
+	@Override
+	public int delete(Uri uri, String selection, String[] selectionArgs) {
+		sink(uri);
+		sink(selection);
+		sink(selectionArgs);
+		return 0;
+	}
+
+	@Override
+	public int delete(Uri uri, Bundle extras) {
+		sink(uri);
+		sink(extras.get("some_key"));
+		return 0;
+	}
+
+	@Override
+	public String getType(Uri uri) {
+		sink(uri);
+		return null;
+	}
+
+	@Override
+	public Uri insert(Uri uri, ContentValues values, Bundle extras) {
+		sink(uri);
+		sink(values);
+		sink(extras.get("some_key"));
+		return null;
+	}
+
+	@Override
+	public Uri insert(Uri uri, ContentValues values) {
+		sink(uri);
+		sink(values);
+		return null;
+	}
+
+	@Override
+	public AssetFileDescriptor openAssetFile(Uri uri, String mode, CancellationSignal signal) {
+		sink(uri);
+		sink(mode);
+		sink(signal);
+		return null;
+	}
+
+	@Override
+	public AssetFileDescriptor openAssetFile(Uri uri, String mode) {
+		sink(uri);
+		sink(mode);
+		return null;
+	}
+
+	@Override
+	public AssetFileDescriptor openTypedAssetFile(Uri uri, String mimeTypeFilter, Bundle opts,
+			CancellationSignal signal) throws RemoteException, FileNotFoundException {
+		sink(uri);
+		sink(mimeTypeFilter);
+		sink(opts.get("some_key"));
+		sink(signal);
+		return null;
+	}
+
+	@Override
+	public AssetFileDescriptor openTypedAssetFile(Uri uri, String mimeTypeFilter, Bundle opts)
+			throws FileNotFoundException {
+		sink(uri);
+		sink(mimeTypeFilter);
+		sink(opts.get("some_key"));
+		return null;
+	}
+
+	@Override
+	public ParcelFileDescriptor openFile(Uri uri, String mode, CancellationSignal signal) {
+		sink(uri);
+		sink(mode);
+		sink(signal);
+		return null;
+	}
+
+	@Override
+	public ParcelFileDescriptor openFile(Uri uri, String mode) {
+		sink(uri);
+		sink(mode);
+		return null;
+	}
+
+	@Override
+	public Cursor query(Uri uri, String[] projection, Bundle queryArgs,
+			CancellationSignal cancellationSignal) {
+		sink(uri);
+		sink(projection);
+		sink(queryArgs.get("some_key"));
+		sink(cancellationSignal);
+		return null;
+	}
+
+	@Override
+	public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+			String sortOrder) {
+		sink(uri);
+		sink(projection);
+		sink(selection);
+		sink(selectionArgs);
+		return null;
+	}
+
+	@Override
+	public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+			String sortOrder, CancellationSignal cancellationSignal) {
+		sink(uri);
+		sink(projection);
+		sink(selection);
+		sink(selectionArgs);
+		sink(sortOrder);
+		sink(cancellationSignal);
+		return null;
+	}
+
+	@Override
+	public int update(Uri uri, ContentValues values, Bundle extras) {
+		sink(uri);
+		sink(values);
+		sink(extras.get("some_key"));
+		return 0;
+	}
+
+	@Override
+	public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+		sink(uri);
+		sink(values);
+		sink(selection);
+		sink(selectionArgs);
+		return 0;
+	}
+
+
+	@Override
+	public boolean onCreate() {
+		return false;
+	}
+}

--- a/java/ql/test/library-tests/frameworks/android/content-provider/Test.java
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/Test.java
@@ -1,0 +1,190 @@
+package com.example.app;
+
+import java.io.FileNotFoundException;
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.res.AssetFileDescriptor;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+
+public class Test extends ContentProvider {
+
+	void sink(Object o) {}
+
+	// "android.content;ContentProvider;true;call;(String,String,String,Bundle);;Parameter[0..3];contentprovider",
+	@Override
+	public Bundle call(String authority, String method, String arg, Bundle extras) {
+		sink(authority); // $ hasTaintFlow
+		sink(method); // $ hasTaintFlow
+		sink(arg); // $ hasTaintFlow
+		sink(extras.get("some_key")); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;call;(String,String,Bundle);;Parameter[0..2];contentprovider",
+	public Bundle call(String method, String arg, Bundle extras) {
+		sink(method); // $ hasTaintFlow
+		sink(arg); // $ hasTaintFlow
+		sink(extras.get("some_key")); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;delete;(Uri,String,String[]);;Parameter[0..2];contentprovider",
+	@Override
+	public int delete(Uri uri, String selection, String[] selectionArgs) {
+		sink(uri); // $ hasTaintFlow
+		sink(selection); // $ hasTaintFlow
+		sink(selectionArgs); // $ hasTaintFlow
+		return 0;
+	}
+
+	// "android.content;ContentProvider;true;delete;(Uri,Bundle);;Parameter[0..1];contentprovider",
+	@Override
+	public int delete(Uri uri, Bundle extras) {
+		sink(uri); // $ hasTaintFlow
+		sink(extras.get("some_key")); // $ hasTaintFlow
+		return 0;
+	}
+
+	// "android.content;ContentProvider;true;getType;(Uri);;Parameter[0];contentprovider",
+	@Override
+	public String getType(Uri uri) {
+		sink(uri); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;insert;(Uri,ContentValues,Bundle);;Parameter[0..2];contentprovider",
+	@Override
+	public Uri insert(Uri uri, ContentValues values, Bundle extras) {
+		sink(uri); // $ hasTaintFlow
+		sink(values); // $ hasTaintFlow
+		sink(extras.get("some_key")); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;insert;(Uri,ContentValues);;Parameter[0..1];contentprovider",
+	@Override
+	public Uri insert(Uri uri, ContentValues values) {
+		sink(uri); // $ hasTaintFlow
+		sink(values); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;openAssetFile;(Uri,String,CancellationSignal);;Parameter[0];contentprovider",
+	@Override
+	public AssetFileDescriptor openAssetFile(Uri uri, String mode, CancellationSignal signal) {
+		sink(uri); // $ hasTaintFlow
+		sink(mode); // Safe
+		sink(signal); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;openAssetFile;(Uri,String);;Parameter[0];contentprovider",
+	@Override
+	public AssetFileDescriptor openAssetFile(Uri uri, String mode) {
+		sink(uri); // $ hasTaintFlow
+		sink(mode); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;openTypedAssetFile;(Uri,String,Bundle,CancellationSignal);;Parameter[0..2];contentprovider",
+	@Override
+	public AssetFileDescriptor openTypedAssetFile(Uri uri, String mimeTypeFilter, Bundle opts,
+			CancellationSignal signal) throws RemoteException, FileNotFoundException {
+		sink(uri); // $ hasTaintFlow
+		sink(mimeTypeFilter); // $ hasTaintFlow
+		sink(opts.get("some_key")); // $ hasTaintFlow
+		sink(signal); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;openTypedAssetFile;(Uri,String,Bundle);;Parameter[0..2];contentprovider",
+	@Override
+	public AssetFileDescriptor openTypedAssetFile(Uri uri, String mimeTypeFilter, Bundle opts)
+			throws FileNotFoundException {
+		sink(uri); // $ hasTaintFlow
+		sink(mimeTypeFilter); // $ hasTaintFlow
+		sink(opts.get("some_key")); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;openFile;(Uri,String,CancellationSignal);;Parameter[0];contentprovider",
+	@Override
+	public ParcelFileDescriptor openFile(Uri uri, String mode, CancellationSignal signal) {
+		sink(uri); // $ hasTaintFlow
+		sink(mode); // Safe
+		sink(signal); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;openFile;(Uri,String);;Parameter[0..1];contentprovider",
+	@Override
+	public ParcelFileDescriptor openFile(Uri uri, String mode) {
+		sink(uri); // $ hasTaintFlow
+		sink(mode); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;query;(Uri,String[],Bundle,CancellationSignal);;Parameter[0..2];contentprovider",
+	@Override
+	public Cursor query(Uri uri, String[] projection, Bundle queryArgs,
+			CancellationSignal cancellationSignal) {
+		sink(uri); // $ hasTaintFlow
+		sink(projection); // $ hasTaintFlow
+		sink(queryArgs.get("some_key")); // $ hasTaintFlow
+		sink(cancellationSignal); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;query;(Uri,String[],String,String[],String);;Parameter[0..4];contentprovider",
+	@Override
+	public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+			String sortOrder) {
+		sink(uri); // $ hasTaintFlow
+		sink(projection); // $ hasTaintFlow
+		sink(selection); // $ hasTaintFlow
+		sink(selectionArgs); // $ hasTaintFlow
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;query;(Uri,String[],String,String[],String,CancellationSignal);;Parameter[0..4];contentprovider",
+	@Override
+	public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+			String sortOrder, CancellationSignal cancellationSignal) {
+		sink(uri); // $ hasTaintFlow
+		sink(projection); // $ hasTaintFlow
+		sink(selection); // $ hasTaintFlow
+		sink(selectionArgs); // $ hasTaintFlow
+		sink(sortOrder); // $ hasTaintFlow
+		sink(cancellationSignal); // Safe
+		return null;
+	}
+
+	// "android.content;ContentProvider;true;update;(Uri,ContentValues,Bundle);;Parameter[0..2];contentprovider",
+	@Override
+	public int update(Uri uri, ContentValues values, Bundle extras) {
+		sink(uri); // $ hasTaintFlow
+		sink(values); // $ hasTaintFlow
+		sink(extras.get("some_key")); // $ hasTaintFlow
+		return 0;
+	}
+
+	// "android.content;ContentProvider;true;update;(Uri,ContentValues,String,String[]);;Parameter[0..3];contentprovider"
+	@Override
+	public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+		sink(uri); // $ hasTaintFlow
+		sink(values); // $ hasTaintFlow
+		sink(selection); // $ hasTaintFlow
+		sink(selectionArgs); // $ hasTaintFlow
+		return 0;
+	}
+
+	@Override
+	public boolean onCreate() {
+		return false;
+	}
+}

--- a/java/ql/test/library-tests/frameworks/android/content-provider/options
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0

--- a/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
@@ -8,6 +8,4 @@ class ProviderTaintFlowConf extends DefaultTaintFlowConf {
 
 class ProviderInlineFlowTest extends InlineFlowTest {
   override DataFlow::Configuration getValueFlowConfig() { none() }
-
-  override DataFlow::Configuration getTaintFlowConfig() { result instanceof ProviderTaintFlowConf }
 }

--- a/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/test.ql
@@ -1,0 +1,13 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import TestUtilities.InlineFlowTest
+
+class ProviderTaintFlowConf extends DefaultTaintFlowConf {
+  override predicate isSource(DataFlow::Node n) { n instanceof RemoteFlowSource }
+}
+
+class ProviderInlineFlowTest extends InlineFlowTest {
+  override DataFlow::Configuration getValueFlowConfig() { none() }
+
+  override DataFlow::Configuration getTaintFlowConfig() { result instanceof ProviderTaintFlowConf }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/annotation/Nullable.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/annotation/Nullable.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package android.annotation;
+
+public @interface Nullable {
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/ContentInterface.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/ContentInterface.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.content;
+
+import androidx.annotation.NonNull;
+import android.annotation.Nullable;
+import android.content.res.AssetFileDescriptor;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+import java.io.FileNotFoundException;
+
+public interface ContentInterface {
+        public @Nullable Cursor query(@NonNull Uri uri, @Nullable String[] projection,
+                        @Nullable Bundle queryArgs, @Nullable CancellationSignal cancellationSignal)
+                        throws RemoteException;
+
+        public @Nullable String getType(@NonNull Uri uri) throws RemoteException;
+
+        public @Nullable String[] getStreamTypes(@NonNull Uri uri, @NonNull String mimeTypeFilter)
+                        throws RemoteException;
+
+        public @Nullable Uri canonicalize(@NonNull Uri uri) throws RemoteException;
+
+        public @Nullable Uri uncanonicalize(@NonNull Uri uri) throws RemoteException;
+
+        public boolean refresh(@NonNull Uri uri, @Nullable Bundle extras,
+                        @Nullable CancellationSignal cancellationSignal) throws RemoteException;
+
+        public @Nullable Uri insert(@NonNull Uri uri, @Nullable ContentValues initialValues,
+                        @Nullable Bundle extras) throws RemoteException;
+
+        public int bulkInsert(@NonNull Uri uri, @NonNull ContentValues[] initialValues)
+                        throws RemoteException;
+
+        public int delete(@NonNull Uri uri, @Nullable Bundle extras) throws RemoteException;
+
+        public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable Bundle extras)
+                        throws RemoteException;
+
+        public @Nullable ParcelFileDescriptor openFile(@NonNull Uri uri, @NonNull String mode,
+                        @Nullable CancellationSignal signal)
+                        throws RemoteException, FileNotFoundException;
+
+        public @Nullable AssetFileDescriptor openAssetFile(@NonNull Uri uri, @NonNull String mode,
+                        @Nullable CancellationSignal signal)
+                        throws RemoteException, FileNotFoundException;
+
+        public @Nullable AssetFileDescriptor openTypedAssetFile(@NonNull Uri uri,
+                        @NonNull String mimeTypeFilter, @Nullable Bundle opts,
+                        @Nullable CancellationSignal signal)
+                        throws RemoteException, FileNotFoundException;
+
+        public @Nullable Bundle call(@NonNull String authority, @NonNull String method,
+                        @Nullable String arg, @Nullable Bundle extras) throws RemoteException;
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/ContentProvider.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/ContentProvider.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.content;
+
+import androidx.annotation.NonNull;
+import android.annotation.Nullable;
+import android.content.pm.PathPermission;
+import android.content.res.AssetFileDescriptor;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.CancellationSignal;
+import android.os.ParcelFileDescriptor;
+import android.util.Pair;
+import java.io.FileNotFoundException;
+
+public abstract class ContentProvider implements ContentInterface {
+  public ContentProvider() {}
+
+  public ContentProvider(Context context, String readPermission, String writePermission,
+      PathPermission[] pathPermissions) {}
+
+  public final @Nullable Context getContext() {
+    return null;
+  }
+
+  public final Context requireContext() {
+    return null;
+  }
+
+  public final @Nullable String getCallingPackage() {
+    return null;
+  }
+
+  public final @Nullable String getCallingAttributionTag() {
+    return null;
+  }
+
+  public final @Nullable String getCallingFeatureId() {
+    return null;
+  }
+
+  public final @Nullable String getCallingPackageUnchecked() {
+    return null;
+  }
+
+  public void onCallingPackageChanged() {}
+
+  public final class CallingIdentity {
+    public CallingIdentity(long binderToken, Pair<String, String> callingPackage) {}
+
+  }
+
+  public final @NonNull CallingIdentity clearCallingIdentity() {
+    return null;
+  }
+
+  public final void restoreCallingIdentity(@NonNull CallingIdentity identity) {}
+
+  public final @Nullable String getReadPermission() {
+    return null;
+  }
+
+  public final @Nullable String getWritePermission() {
+    return null;
+  }
+
+  public final @Nullable PathPermission[] getPathPermissions() {
+    return null;
+  }
+
+  public final void setAppOps(int readOp, int writeOp) {}
+
+  public final void setTransportLoggingEnabled(boolean enabled) {}
+
+  public abstract boolean onCreate();
+
+  public abstract @Nullable Cursor query(@NonNull Uri uri, @Nullable String[] projection,
+      @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder);
+
+  public @Nullable Cursor query(@NonNull Uri uri, @Nullable String[] projection,
+      @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder,
+      @Nullable CancellationSignal cancellationSignal) {
+    return null;
+  }
+
+  @Override
+  public @Nullable Cursor query(@NonNull Uri uri, @Nullable String[] projection,
+      @Nullable Bundle queryArgs, @Nullable CancellationSignal cancellationSignal) {
+    return null;
+  }
+
+  @Override
+  public abstract @Nullable String getType(@NonNull Uri uri);
+
+  @Override
+  public @Nullable Uri canonicalize(@NonNull Uri url) {
+    return null;
+  }
+
+  @Override
+  public @Nullable Uri uncanonicalize(@NonNull Uri url) {
+    return null;
+  }
+
+  @Override
+  public boolean refresh(Uri uri, @Nullable Bundle extras,
+      @Nullable CancellationSignal cancellationSignal) {
+    return false;
+  }
+
+  public Uri rejectInsert(Uri uri, ContentValues values) {
+    return null;
+  }
+
+  public abstract @Nullable Uri insert(@NonNull Uri uri, @Nullable ContentValues values);
+
+  @Override
+  public @Nullable Uri insert(@NonNull Uri uri, @Nullable ContentValues values,
+      @Nullable Bundle extras) {
+    return null;
+  }
+
+  @Override
+  public int bulkInsert(@NonNull Uri uri, @NonNull ContentValues[] values) {
+    return 0;
+  }
+
+  public abstract int delete(@NonNull Uri uri, @Nullable String selection,
+      @Nullable String[] selectionArgs);
+
+  @Override
+  public int delete(@NonNull Uri uri, @Nullable Bundle extras) {
+    return 0;
+  }
+
+  public abstract int update(@NonNull Uri uri, @Nullable ContentValues values,
+      @Nullable String selection, @Nullable String[] selectionArgs);
+
+  @Override
+  public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable Bundle extras) {
+    return 0;
+  }
+
+  public @Nullable ParcelFileDescriptor openFile(@NonNull Uri uri, @NonNull String mode)
+      throws FileNotFoundException {
+    return null;
+  }
+
+  @Override
+  public @Nullable ParcelFileDescriptor openFile(@NonNull Uri uri, @NonNull String mode,
+      @Nullable CancellationSignal signal) throws FileNotFoundException {
+    return null;
+  }
+
+  public @Nullable AssetFileDescriptor openAssetFile(@NonNull Uri uri, @NonNull String mode)
+      throws FileNotFoundException {
+    return null;
+  }
+
+  @Override
+  public @Nullable AssetFileDescriptor openAssetFile(@NonNull Uri uri, @NonNull String mode,
+      @Nullable CancellationSignal signal) throws FileNotFoundException {
+    return null;
+  }
+
+  @Override
+  public @Nullable String[] getStreamTypes(@NonNull Uri uri, @NonNull String mimeTypeFilter) {
+    return null;
+  }
+
+  public @Nullable AssetFileDescriptor openTypedAssetFile(@NonNull Uri uri,
+      @NonNull String mimeTypeFilter, @Nullable Bundle opts) throws FileNotFoundException {
+    return null;
+  }
+
+  public static int getUserIdFromAuthority(String auth, int defaultUserId) {
+    return 0;
+  }
+
+  public static int getUserIdFromAuthority(String auth) {
+    return 0;
+  }
+
+  public static int getUserIdFromUri(Uri uri, int defaultUserId) {
+    return 0;
+  }
+
+  public static int getUserIdFromUri(Uri uri) {
+    return 0;
+  }
+
+  public static String getAuthorityWithoutUserId(String auth) {
+    return null;
+  }
+
+  public static Uri getUriWithoutUserId(Uri uri) {
+    return null;
+  }
+
+  public static boolean uriHasUserId(Uri uri) {
+    return false;
+  }
+
+  public static Uri maybeAddUserId(Uri uri, int userId) {
+    return null;
+  }
+
+  public @Nullable Bundle call(@NonNull String method, @Nullable String arg,
+      @Nullable Bundle extras) {
+    return null;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/ContentValues.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/ContentValues.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.content;
+
+import android.annotation.Nullable;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.ArrayMap;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+
+public final class ContentValues implements Parcelable {
+    public ContentValues() {}
+
+    public ContentValues(int size) {}
+
+    public ContentValues(ContentValues from) {}
+
+    @Override
+    public boolean equals(Object object) {
+        return false;
+    }
+
+    public ArrayMap<String, Object> getValues() {
+        return null;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    public void put(String key, String value) {}
+
+    public void putAll(ContentValues other) {}
+
+    public void put(String key, Byte value) {}
+
+    public void put(String key, Short value) {}
+
+    public void put(String key, Integer value) {}
+
+    public void put(String key, Long value) {}
+
+    public void put(String key, Float value) {}
+
+    public void put(String key, Double value) {}
+
+    public void put(String key, Boolean value) {}
+
+    public void put(String key, byte[] value) {}
+
+    public void putNull(String key) {}
+
+    public void putObject(@Nullable String key, @Nullable Object value) {}
+
+    public int size() {
+        return 0;
+    }
+
+    public boolean isEmpty() {
+        return false;
+    }
+
+    public void remove(String key) {}
+
+    public void clear() {}
+
+    public boolean containsKey(String key) {
+        return false;
+    }
+
+    public Object get(String key) {
+        return null;
+    }
+
+    public String getAsString(String key) {
+        return null;
+    }
+
+    public Long getAsLong(String key) {
+        return null;
+    }
+
+    public Integer getAsInteger(String key) {
+        return null;
+    }
+
+    public Short getAsShort(String key) {
+        return null;
+    }
+
+    public Byte getAsByte(String key) {
+        return null;
+    }
+
+    public Double getAsDouble(String key) {
+        return null;
+    }
+
+    public Float getAsFloat(String key) {
+        return null;
+    }
+
+    public Boolean getAsBoolean(String key) {
+        return null;
+    }
+
+    public byte[] getAsByteArray(String key) {
+        return null;
+    }
+
+    public Set<Map.Entry<String, Object>> valueSet() {
+        return null;
+    }
+
+    public Set<String> keySet() {
+        return null;
+    }
+
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int flags) {}
+
+    public void putStringArrayList(String key, ArrayList<String> value) {}
+
+    public ArrayList<String> getStringArrayList(String key) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    public static boolean isSupportedValue(Object value) {
+        return false;
+    }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/pm/PathPermission.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/pm/PathPermission.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.content.pm;
+
+import android.os.Parcel;
+import android.os.PatternMatcher;
+
+public class PathPermission extends PatternMatcher {
+  public PathPermission(String pattern, int type, String readPermission, String writePermission) {
+    super(null);
+  }
+
+  public PathPermission(Parcel src) {
+    super(null);
+  }
+
+  public String getReadPermission() {
+    return null;
+  }
+
+  public String getWritePermission() {
+    return null;
+  }
+
+  public void writeToParcel(Parcel dest, int flags) {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/res/AssetFileDescriptor.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/res/AssetFileDescriptor.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.content.res;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.ParcelFileDescriptor;
+import android.os.Parcelable;
+import java.io.Closeable;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class AssetFileDescriptor implements Parcelable, Closeable {
+  public AssetFileDescriptor(ParcelFileDescriptor fd, long startOffset, long length) {}
+
+  public AssetFileDescriptor(ParcelFileDescriptor fd, long startOffset, long length,
+      Bundle extras) {}
+
+  public ParcelFileDescriptor getParcelFileDescriptor() {
+    return null;
+  }
+
+  public FileDescriptor getFileDescriptor() {
+    return null;
+  }
+
+  public long getStartOffset() {
+    return 0;
+  }
+
+  public Bundle getExtras() {
+    return null;
+  }
+
+  public long getLength() {
+    return 0;
+  }
+
+  public long getDeclaredLength() {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {}
+
+  public FileInputStream createInputStream() throws IOException {
+    return null;
+  }
+
+  public FileOutputStream createOutputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return null;
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel out, int flags) {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/database/Cursor.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/database/Cursor.java
@@ -1,0 +1,5 @@
+package android.database;
+
+public interface Cursor {
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/os/CancellationSignal.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/os/CancellationSignal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.os;
+
+public final class CancellationSignal {
+  public CancellationSignal() {}
+
+  public boolean isCanceled() {
+    return false;
+  }
+
+  public void throwIfCanceled() {}
+
+  public void cancel() {}
+
+  public void setOnCancelListener(OnCancelListener listener) {}
+
+  public interface OnCancelListener {
+    void onCancel();
+
+  }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/os/ParcelFileDescriptor.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/os/ParcelFileDescriptor.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.os;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.Socket;
+
+public class ParcelFileDescriptor implements Parcelable, Closeable {
+  public ParcelFileDescriptor(ParcelFileDescriptor wrapped) {}
+
+  public ParcelFileDescriptor(FileDescriptor fd) {}
+
+  public ParcelFileDescriptor(FileDescriptor fd, FileDescriptor commChannel) {}
+
+  public static ParcelFileDescriptor open(File file, int mode) throws FileNotFoundException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor dup(FileDescriptor orig) throws IOException {
+    return null;
+  }
+
+  public ParcelFileDescriptor dup() throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor fromFd(int fd) throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor adoptFd(int fd) {
+    return null;
+  }
+
+  public static ParcelFileDescriptor fromSocket(Socket socket) {
+    return null;
+  }
+
+  public static ParcelFileDescriptor fromDatagramSocket(DatagramSocket datagramSocket) {
+    return null;
+  }
+
+  public static ParcelFileDescriptor[] createPipe() throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor[] createReliablePipe() throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor[] createSocketPair() throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor[] createSocketPair(int type) throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor[] createReliableSocketPair() throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor[] createReliableSocketPair(int type) throws IOException {
+    return null;
+  }
+
+  public static ParcelFileDescriptor fromData(byte[] data, String name) throws IOException {
+    return null;
+  }
+
+  public static int parseMode(String mode) {
+    return 0;
+  }
+
+  public static File getFile(FileDescriptor fd) throws IOException {
+    return null;
+  }
+
+  public FileDescriptor getFileDescriptor() {
+    return null;
+  }
+
+  public long getStatSize() {
+    return 0;
+  }
+
+  public long seekTo(long pos) throws IOException {
+    return 0;
+  }
+
+  public int getFd() {
+    return 0;
+  }
+
+  public int detachFd() {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {}
+
+  public void closeWithError(String msg) throws IOException {}
+
+  public void releaseResources() {}
+
+  public boolean canDetectErrors() {
+    return false;
+  }
+
+  public void checkError() throws IOException {}
+
+  @Override
+  public String toString() {
+    return null;
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel out, int flags) {}
+
+  public interface OnCloseListener {
+    public void onClose(IOException e);
+
+  }
+  public static class FileDescriptorDetachedException extends IOException {
+    public FileDescriptorDetachedException() {}
+
+  }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/os/PatternMatcher.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/os/PatternMatcher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.os;
+
+public class PatternMatcher implements Parcelable {
+  public PatternMatcher(String pattern, int type) {}
+
+  public final String getPath() {
+    return null;
+  }
+
+  public final int getType() {
+    return 0;
+  }
+
+  public boolean match(String str) {
+    return false;
+  }
+
+  public String toString() {
+    return null;
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  public void writeToParcel(Parcel dest, int flags) {}
+
+  public PatternMatcher(Parcel src) {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/os/RemoteException.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/os/RemoteException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.os;
+
+import android.util.AndroidException;
+
+public class RemoteException extends AndroidException {
+  public RemoteException() {}
+
+  public RemoteException(String message) {}
+
+  public RemoteException(String message, Throwable cause, boolean enableSuppression,
+      boolean writableStackTrace) {}
+
+  public RuntimeException rethrowAsRuntimeException() {
+    return null;
+  }
+
+  public RuntimeException rethrowFromSystemServer() {
+    return null;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/util/AndroidException.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/util/AndroidException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.util;
+
+public class AndroidException extends Exception {
+    public AndroidException() {}
+
+    public AndroidException(String name) {}
+
+    public AndroidException(String name, Throwable cause) {}
+
+    public AndroidException(Exception cause) {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/util/ArrayMap.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/util/ArrayMap.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public final class ArrayMap<K, V> implements Map<K, V> {
+    public static final ArrayMap EMPTY = new ArrayMap<>(-1);
+
+    public ArrayMap() {}
+
+    public ArrayMap(int capacity) {}
+
+    public ArrayMap(int capacity, boolean identityHashCode) {}
+
+    public ArrayMap(ArrayMap<K, V> map) {}
+
+    @Override
+    public void clear() {}
+
+    public void erase() {}
+
+    public void ensureCapacity(int minimumCapacity) {}
+
+    @Override
+    public boolean containsKey(Object key) {
+        return false;
+    }
+
+    public int indexOfKey(Object key) {
+        return 0;
+    }
+
+    public int indexOfValue(Object value) {
+        return 0;
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return false;
+    }
+
+    @Override
+    public V get(Object key) {
+        return null;
+    }
+
+    public K keyAt(int index) {
+        return null;
+    }
+
+    public V valueAt(int index) {
+        return null;
+    }
+
+    public V setValueAt(int index, V value) {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return null;
+    }
+
+    public void append(K key, V value) {}
+
+    public void validate() {}
+
+    public void putAll(ArrayMap<? extends K, ? extends V> array) {}
+
+    @Override
+    public V remove(Object key) {
+        return null;
+    }
+
+    public V removeAt(int index) {
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    public boolean containsAll(Collection<?> collection) {
+        return false;
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {}
+
+    public boolean removeAll(Collection<?> collection) {
+        return false;
+    }
+
+    public boolean retainAll(Collection<?> collection) {
+        return false;
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        return null;
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return null;
+    }
+
+    @Override
+    public Collection<V> values() {
+        return null;
+    }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/util/Pair.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/util/Pair.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.util;
+
+public class Pair<F, S> {
+  public Pair(F first, S second) {}
+
+  @Override
+  public boolean equals(Object o) {
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+
+  @Override
+  public String toString() {
+    return null;
+  }
+
+  public static <A, B> Pair<A, B> create(A a, B b) {
+    return null;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/annotation/NonNull.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/annotation/NonNull.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.annotation;
+
+public @interface NonNull {
+}


### PR DESCRIPTION
[Content providers](https://developer.android.com/guide/topics/providers/content-provider-basics) manage access to a central repository of data. They can be accessed by Android applications through an interface that allows different actions (query, insert, update, delete, open a file...). If a content provider is `exported`, any application in the device can send arbitrary data to that interface, which opens a new attack surface against the application the provider is part of.

This PR adds source models for the entry-point methods of content providers that can be externally accessed when the content provider is `exported`. Note that some code was added for working with permissions in content providers, but it's ultimately not used to discard potential sources because a malicious application could request those permissions to exploit a vulnerability anyway.

This increases our CVE coverage by detecting [CVE-2019-5454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2019-5454).