### PR TITLE
Java: Remove requirements for final and access mods from DateFormatThreadUnsafe

### DIFF
--- a/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.java
+++ b/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.java
@@ -1,5 +1,5 @@
 class DateFormattingThread implements Runnable {
-    private static DateFormat dateF = new SimpleDateFormat("yyyyMMdd");  // Static field declared
+    public static DateFormat dateF = new SimpleDateFormat("yyyyMMdd");  // Static field declared
 
     public void run() {
         for(int i=0; i < 10; i++){

--- a/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
@@ -16,8 +16,6 @@ import java
 from Field f, Class dateFormat
 where
   f.isStatic() and
-  f.isFinal() and
-  (f.isPublic() or f.isProtected()) and
   dateFormat.hasQualifiedName("java.text", "DateFormat") and
   f.getType().(RefType).hasSupertype*(dateFormat) and
   exists(MethodAccess m | m.getQualifier().(VarAccess).getVariable() = f)

--- a/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/DateFormatThreadUnsafe.ql
@@ -16,6 +16,7 @@ import java
 from Field f, Class dateFormat
 where
   f.isStatic() and
+  (f.isPublic() or f.isProtected()) and
   dateFormat.hasQualifiedName("java.text", "DateFormat") and
   f.getType().(RefType).hasSupertype*(dateFormat) and
   exists(MethodAccess m | m.getQualifier().(VarAccess).getVariable() = f)


### PR DESCRIPTION
The rule checking for unsafe use of the DateFormat class in Java is incorrectly requiring that the DateFormat variable be declared final and either public or protected.

This PR removes those two requirements