### PR TITLE
Java: Big Decimal DOS

### DIFF
--- a/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.java
+++ b/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.java
@@ -1,0 +1,28 @@
+	@GetMapping("/tonghuaroot-DOSDemo01")
+	@ResponseBody
+    // BAD:
+	public Long demo(@RequestParam(name = "num") BigDecimal num) {
+		Long startTime = System.currentTimeMillis();
+		BigDecimal num1 = new BigDecimal(0.005);
+		System.out.println(num1.add(num));
+		Long endTime = System.currentTimeMillis();
+		Long tempTime = (endTime - startTime);
+		System.out.println(tempTime);
+		return tempTime;
+	}
+
+    @GetMapping("/tonghuaroot-DOSDemo02")
+	@ResponseBody
+    // GOOD:
+	public Long demo02(@RequestParam(name = "num") String num) {
+        if (num.length() > 33 || num.matches("(?i)e")) { 
+            return "Input Parameter is too long."
+        }
+		Long startTime = System.currentTimeMillis();
+		BigDecimal num1 = new BigDecimal(0.005);
+		System.out.println(num1.add(num));
+		Long endTime = System.currentTimeMillis();
+		Long tempTime = (endTime - startTime);
+		System.out.println(tempTime);
+		return tempTime;
+	}

--- a/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.qhelp
+++ b/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.qhelp
@@ -1,0 +1,42 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+
+<overview>
+<p>Directly incorporating user input into an BigDecimal Operation Function without validating the input
+can facilitate DOS attacks. In these attacks, the server
+will consume a lot of computing resources, A typical scenario is that the CPU usage rises to close to 100%.
+This issue often occurs in scenarios that require scientific computing, such as e-commerce platforms and electronic payments.
+</p>
+
+</overview>
+<recommendation>
+
+<p>To guard against BigDecimal DOS attacks, you should avoid putting user-provided input
+directly into a BigDecimal Method(like: add(), subtract()). Instead, In some e-commerce payment scenarios, 
+we should verify the size of the incoming number. For example, under normal circumstances, 
+the number representing money will not contain "e".</p>
+
+</recommendation>
+<example>
+
+<p>The following example shows an BigDecimal parameter being used directly pass
+to BigDecimal Method(like: add(), subtract()) without validating the input, which facilitates DOS attacks.
+It also shows how to remedy the problem by validating the user input against a known fixed string.
+</p>
+
+<sample src="BigDecimalDOS.java" />
+
+</example>
+<references>
+  <li>
+    <a href="https://www.cuijianxiong.top/2021/03/30/%E6%9A%B4%E5%8A%9B%E7%9A%84%E6%94%BB%E5%87%BBDos/">暴力的攻击-Dos</a>
+  </li>
+  <li>
+    <a href="https://mp.weixin.qq.com/s/4YX7XA34fShdCpGawO-Q_Q">BigDecimal DOS</a>
+  </li>
+
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.ql
+++ b/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.ql
@@ -11,32 +11,28 @@ import semmle.code.java.dataflow.FlowSources
 import DataFlow::PathGraph
 
 class BigDecimalDOSConfig extends TaintTracking::Configuration {
-    BigDecimalDOSConfig() { this = "Java-BigDecimal-DOS-Vulnerability-Config" }
+  BigDecimalDOSConfig() { this = "Java-BigDecimal-DOS-Vulnerability-Config" }
 
   override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
   override predicate isSink(DataFlow::Node sink) {
     exists(Method method, MethodAccess call |
-      method.getDeclaringType().hasQualifiedName("java.math", "BigDecimal")
-      and
-      method.hasName("subtract")
-      and
+      method.getDeclaringType().hasQualifiedName("java.math", "BigDecimal") and
+      method.hasName("subtract") and
       call.getMethod() = method and
       sink.asExpr() = call.getArgument(0)
     )
     or
     exists(Method method, MethodAccess call |
-        method.getDeclaringType().hasQualifiedName("java.math", "BigDecimal")
-        and
-        method.hasName("add")
-        and
-        call.getMethod() = method and
-        sink.asExpr() = call.getArgument(0)
-      )
+      method.getDeclaringType().hasQualifiedName("java.math", "BigDecimal") and
+      method.hasName("add") and
+      call.getMethod() = method and
+      sink.asExpr() = call.getArgument(0)
+    )
   }
 }
 
 from BigDecimalDOSConfig config, DataFlow::PathNode source, DataFlow::PathNode sink
 where config.hasFlowPath(source, sink)
 select source.getNode(), source, sink, "Potential Java BigDecimal DOS Issue due to $@.",
-source.getNode(), "a user-provided value"
+  source.getNode(), "a user-provided value"

--- a/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.ql
+++ b/java/ql/src/experimental/Security/BigDecimalDOS/BigDecimalDOS.ql
@@ -1,0 +1,42 @@
+/**
+ * @id java/BigDecimalDOS
+ * @name Java-BigDecimal-DOS-Vulnerability
+ * @description When user-controllable data is pass to the relevant Methods in BigDecimal, it may cause DOS issues when computing resources are limited. This issue is common in business scenarios such as e-commerce platforms.
+ * @kind path-problem
+ * @problem.severity error
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+class BigDecimalDOSConfig extends TaintTracking::Configuration {
+    BigDecimalDOSConfig() { this = "Java-BigDecimal-DOS-Vulnerability-Config" }
+
+  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(Method method, MethodAccess call |
+      method.getDeclaringType().hasQualifiedName("java.math", "BigDecimal")
+      and
+      method.hasName("subtract")
+      and
+      call.getMethod() = method and
+      sink.asExpr() = call.getArgument(0)
+    )
+    or
+    exists(Method method, MethodAccess call |
+        method.getDeclaringType().hasQualifiedName("java.math", "BigDecimal")
+        and
+        method.hasName("add")
+        and
+        call.getMethod() = method and
+        sink.asExpr() = call.getArgument(0)
+      )
+  }
+}
+
+from BigDecimalDOSConfig config, DataFlow::PathNode source, DataFlow::PathNode sink
+where config.hasFlowPath(source, sink)
+select source.getNode(), source, sink, "Potential Java BigDecimal DOS Issue due to $@.",
+source.getNode(), "a user-provided value"

--- a/java/ql/test/experimental/query-tests/security/BigDecimalDOS/BigDecimalDOS.expected
+++ b/java/ql/test/experimental/query-tests/security/BigDecimalDOS/BigDecimalDOS.expected
@@ -1,0 +1,8 @@
+edges
+| BigDecimalDOS.java:12:28:12:69 | num : BigDecimal | BigDecimalDOS.java:14:30:14:32 | num |
+nodes
+| BigDecimalDOS.java:12:28:12:69 | num : BigDecimal | semmle.label | num : BigDecimal |
+| BigDecimalDOS.java:14:30:14:32 | num | semmle.label | num |
+subpaths
+#select
+| BigDecimalDOS.java:12:28:12:69 | num | BigDecimalDOS.java:12:28:12:69 | num : BigDecimal | BigDecimalDOS.java:14:30:14:32 | num | Potential Java BigDecimal DOS Issue due to $@. | BigDecimalDOS.java:12:28:12:69 | num | a user-provided value |

--- a/java/ql/test/experimental/query-tests/security/BigDecimalDOS/BigDecimalDOS.java
+++ b/java/ql/test/experimental/query-tests/security/BigDecimalDOS/BigDecimalDOS.java
@@ -1,0 +1,42 @@
+package com.example.servingwebcontent;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+@Controller
+public class GreetingController {
+	@GetMapping("/tonghuaroot-DOSDemo01")
+	@ResponseBody
+    // BAD:
+	public Long demo(@RequestParam(name = "num") BigDecimal num) {
+		Long startTime = System.currentTimeMillis();
+		BigDecimal num1 = new BigDecimal(0.005);
+		System.out.println(num1.add(num));
+		Long endTime = System.currentTimeMillis();
+		Long tempTime = (endTime - startTime);
+		System.out.println(tempTime);
+		return tempTime;
+	}
+
+    @GetMapping("/tonghuaroot-DOSDemo02")
+	@ResponseBody
+    // GOOD:
+	public Long demo02(@RequestParam(name = "num") String num) {
+        if (num.length() > 33 || num.matches("(?i)e")) { 
+            return "Input Parameter is too long."
+        }
+		Long startTime = System.currentTimeMillis();
+		BigDecimal num1 = new BigDecimal(0.005);
+		System.out.println(num1.add(num));
+		Long endTime = System.currentTimeMillis();
+		Long tempTime = (endTime - startTime);
+		System.out.println(tempTime);
+		return tempTime;
+	}
+}

--- a/java/ql/test/experimental/query-tests/security/BigDecimalDOS/BigDecimalDOS.qlref
+++ b/java/ql/test/experimental/query-tests/security/BigDecimalDOS/BigDecimalDOS.qlref
@@ -1,0 +1,1 @@
+experimental/Security/BigDecimalDOS/BigDecimalDOS.ql

--- a/java/ql/test/experimental/query-tests/security/BigDecimalDOS/options
+++ b/java/ql/test/experimental/query-tests/security/BigDecimalDOS/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/servlet-api-2.4:${testdir}/../../../../stubs/springframework-5.3.8/


### PR DESCRIPTION
Directly incorporating user input into an BigDecimal Operation Function without validating the input
can facilitate DOS attacks. In these attacks, the server
will consume a lot of computing resources, A typical scenario is that the CPU usage rises to close to 100%.
This issue often occurs in scenarios that require scientific computing, such as e-commerce platforms and electronic payments.