### PR TITLE
Java: Add callback dispatch to more anonymous classes.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -326,18 +326,24 @@ class LambdaCallKind = Method; // the "apply" method in the functional interface
 
 /** Holds if `creation` is an expression that creates a lambda of kind `kind` for `c`. */
 predicate lambdaCreation(Node creation, LambdaCallKind kind, DataFlowCallable c) {
-  exists(FunctionalExpr func, FunctionalInterface interface |
+  exists(ClassInstanceExpr func, Interface t, FunctionalInterface interface |
     creation.asExpr() = func and
-    func.asMethod() = c and
-    func.getType().(RefType).getSourceDeclaration() = interface and
-    kind = interface.getRunMethod()
+    func.getAnonymousClass().getAMethod() = c and
+    func.getConstructedType().extendsOrImplements+(t) and
+    t.getSourceDeclaration() = interface and
+    c.(Method).overridesOrInstantiates+(pragma[only_bind_into](kind)) and
+    pragma[only_bind_into](kind) = interface.getRunMethod().getSourceDeclaration()
   )
 }
 
 /** Holds if `call` is a lambda call of kind `kind` where `receiver` is the lambda expression. */
 predicate lambdaCall(DataFlowCall call, LambdaCallKind kind, Node receiver) {
   receiver = call.(SummaryCall).getReceiver() and
-  getNodeDataFlowType(receiver).getSourceDeclaration().(FunctionalInterface).getRunMethod() = kind
+  getNodeDataFlowType(receiver)
+      .getSourceDeclaration()
+      .(FunctionalInterface)
+      .getRunMethod()
+      .getSourceDeclaration() = kind
 }
 
 /** Extra data-flow steps needed for lambda flow analysis. */

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/A.java
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/A.java
@@ -48,6 +48,8 @@ public class A {
     return null;
   }
 
+  public interface Producer1Consumer3<E> extends Producer1<E[]>, Consumer3<E[]> { }
+
   static Object source(int i) { return null; }
 
   static void sink(Object o) { }
@@ -71,7 +73,7 @@ public class A {
 
     applyConsumer1(source(4), new Consumer1() {
       @Override public void eat(Object o) {
-        sink(o); // $ MISSING: flow=4
+        sink(o); // $ flow=4
       }
     });
 
@@ -96,5 +98,16 @@ public class A {
     sink(applyConverter1((Integer)source(9), i -> i)); // $ flow=9
 
     sink(applyConverter1((Integer)source(10), i -> new int[]{i})[0]); // $ flow=10
+
+    Producer1Consumer3<Integer> pc = new Producer1Consumer3<Integer>() {
+      @Override public Integer[] make() {
+        return new Integer[] { (Integer)source(11) };
+      }
+      @Override public void eat(Integer[] xs) {
+        sink(xs[0]); // $ flow=12
+      }
+    };
+    applyConsumer3(new Integer[] { (Integer)source(12) }, pc);
+    sink(applyProducer1(pc)[0]); // $ flow=11
   }
 }


### PR DESCRIPTION
This adds support for callbacks dispatching to non-lambda, non-method-reference anonymous classes.
It also allows the functional interface to be higher in the type hierarchy than the immediately implemented interface.
Finally, a bug is fixed where we used to identify the called method with `FunctionalInterface.getRunMethod()`, but really it should be `FunctionalInterface.getRunMethod().getSourceDeclaration()` for the cases where a functional interface specialises another functional interface.