### PR TITLE
Java: Fix more performance issues with future versions of codeql.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -638,6 +638,7 @@ private string paramsStringPart(Callable c, int i) {
  * Returns the empty string if the callable has no parameters.
  * Parameter types are represented by their type erasure.
  */
+cached
 string paramsString(Callable c) { result = concat(int i | | paramsStringPart(c, i) order by i) }
 
 private Element interpretElement0(

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -7,18 +7,28 @@ import semmle.code.java.dataflow.ExternalFlow
 import semmle.code.xml.AndroidManifest
 
 /**
+ * Gets a transitive superType avoiding magic optimisation
+ */
+pragma[nomagic]
+private RefType getASuperTypePlus(RefType t) { result = t.getASupertype+() }
+
+/**
+ * Gets a reflexive/transitive superType avoiding magic optimisation
+ */
+pragma[inline]
+private RefType getASuperTypeStar(RefType t) { result = getASuperTypePlus(t) or result = t }
+
+/**
  * An Android component. That is, either an activity, a service,
  * a broadcast receiver, or a content provider.
  */
 class AndroidComponent extends Class {
   AndroidComponent() {
-    // The casts here are due to misoptimisation if they are missing
-    // but are not needed semantically.
-    this.(Class).getASupertype*().hasQualifiedName("android.app", "Activity") or
-    this.(Class).getASupertype*().hasQualifiedName("android.app", "Service") or
-    this.(Class).getASupertype*().hasQualifiedName("android.content", "BroadcastReceiver") or
-    this.(Class).getASupertype*().hasQualifiedName("android.content", "ContentProvider") or
-    this.(Class).getASupertype*().hasQualifiedName("android.content", "ContentResolver")
+    getASuperTypeStar(this).hasQualifiedName("android.app", "Activity") or
+    getASuperTypeStar(this).hasQualifiedName("android.app", "Service") or
+    getASuperTypeStar(this).hasQualifiedName("android.content", "BroadcastReceiver") or
+    getASuperTypeStar(this).hasQualifiedName("android.content", "ContentProvider") or
+    getASuperTypeStar(this).hasQualifiedName("android.content", "ContentResolver")
   }
 
   /** The XML element corresponding to this Android component. */
@@ -52,32 +62,32 @@ class ExportableAndroidComponent extends AndroidComponent {
 
 /** An Android activity. */
 class AndroidActivity extends ExportableAndroidComponent {
-  AndroidActivity() { this.getASupertype*().hasQualifiedName("android.app", "Activity") }
+  AndroidActivity() { getASuperTypeStar(this).hasQualifiedName("android.app", "Activity") }
 }
 
 /** An Android service. */
 class AndroidService extends ExportableAndroidComponent {
-  AndroidService() { this.getASupertype*().hasQualifiedName("android.app", "Service") }
+  AndroidService() { getASuperTypeStar(this).hasQualifiedName("android.app", "Service") }
 }
 
 /** An Android broadcast receiver. */
 class AndroidBroadcastReceiver extends ExportableAndroidComponent {
   AndroidBroadcastReceiver() {
-    this.getASupertype*().hasQualifiedName("android.content", "BroadcastReceiver")
+    getASuperTypeStar(this).hasQualifiedName("android.content", "BroadcastReceiver")
   }
 }
 
 /** An Android content provider. */
 class AndroidContentProvider extends ExportableAndroidComponent {
   AndroidContentProvider() {
-    this.getASupertype*().hasQualifiedName("android.content", "ContentProvider")
+    getASuperTypeStar(this).hasQualifiedName("android.content", "ContentProvider")
   }
 }
 
 /** An Android content resolver. */
 class AndroidContentResolver extends AndroidComponent {
   AndroidContentResolver() {
-    this.getASupertype*().hasQualifiedName("android.content", "ContentResolver")
+    getASuperTypeStar(this).hasQualifiedName("android.content", "ContentResolver")
   }
 }
 

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
@@ -50,6 +50,7 @@ private predicate whitelist(string name) { name = "visit" }
  * Method `m` has name `name`, number of parameters `numParams`
  * and is declared in `t` or inherited from a supertype of `t`.
  */
+pragma[nomagic]
 private predicate candidateMethod(RefType t, Method m, string name, int numParam) {
   exists(Method n | n.getSourceDeclaration() = m | t.inherits(n)) and
   m.getName() = name and


### PR DESCRIPTION
It turns out that between writing the previous fixes and retesting, even more problems arose for java. I think java is more affected because `Reftype` is bigger than `Class`, but most uses only need `Class` so trivial type tests affect java more than other langauges.

List of changes:
- The params string change was more important than I thought. Although the fix only removed 10s, that predicate was evaluated multiple times so the saving multiplied. This caches it instead so we only evalaute it in full once.
- The changes to `AndroidComponent` were no longer good enough. Instead this forces the TC to be materialised rather than use the bad magic version (which was done repeatedly). I decided to do this via `getAnAncestor` so I didn't have to define new predicates and as we evaluate the full TC we always want to use the non-magicked version after that. Note that only one use in each stage needs to be converted but as `AndroidComponent` was top in the magic as it has the first name alphabetically. I have opened an internal issue about making doing this change easier.
- There was fairly bad magic for `ConfusingOverloading.ql`, the existing magic didn't help much so removing it seems better. 