### PR TITLE
Docs: Fix a few links in the training slides

### DIFF
--- a/docs/codeql/README.rst
+++ b/docs/codeql/README.rst
@@ -8,7 +8,7 @@ The CodeQL documentation in this repository is written in reStructuredText and c
 HTML using Sphinx. 
 
 For more information on writing in reStructuredText, 
-see http://docutils.sourceforge.net/rst.html.
+see https://docutils.sourceforge.io/rst.html.
 
 For more information on Sphinx, see https://www.sphinx-doc.org.
 
@@ -99,7 +99,7 @@ generates html slide shows in the ``<slides-output>`` directory when run from
 the ``ql-training`` source directory.
 
 For more information about creating slides for QL training and variant analysis 
-examples, see the `template slide deck <https://github.com/github/codeql/blob/main/docs/language/ql-training/template.rst>`__.
+examples, see the `template slide deck <https://github.com/github/codeql/blob/main/docs/codeql/ql-training/template.rst>`__.
 
 Viewing the current version of the CodeQL documentation
 *******************************************************

--- a/docs/codeql/ql-training/java/apache-struts-java.rst
+++ b/docs/codeql/ql-training/java/apache-struts-java.rst
@@ -134,4 +134,4 @@ Model answer, step 4
      and sink.getNode() instanceof UnsafeDeserializationSink
    select sink.getNode().(UnsafeDeserializationSink).getMethodAccess(), source, sink, "Unsafe    deserialization of $@.", source, "user input"
 
-More full-featured version: https://github.com/github/security-lab/tree/main/CodeQL_Queries/java/Apache_Struts_CVE-2017-9805
+More full-featured version: https://github.com/github/securitylab/tree/main/CodeQL_Queries/java/Apache_Struts_CVE-2017-9805

--- a/docs/codeql/ql-training/java/global-data-flow-java.rst
+++ b/docs/codeql/ql-training/java/global-data-flow-java.rst
@@ -54,7 +54,7 @@ Code injection in Apache struts
 .. note::
 
    More details on the CVE can be found here: https://securitylab.github.com/research/apache-struts-CVE-2018-11776 and 
-   https://github.com/github/security-lab/tree/main/CodeQL_Queries/java/Apache_Struts_CVE-2018-11776
+   https://github.com/github/securitylab/tree/main/CodeQL_Queries/java/Apache_Struts_CVE-2018-11776
 
    More details on OGNL can be found here: https://commons.apache.org/proper/commons-ognl/
 

--- a/docs/codeql/ql-training/slide-snippets/local-data-flow.rst
+++ b/docs/codeql/ql-training/slide-snippets/local-data-flow.rst
@@ -112,7 +112,7 @@ So all references will need to be qualified (that is, ``DataFlow::Node``)
   A **module** is a way of organizing QL code by grouping together related predicates, classes, and (sub-)modules. They can be either explicitly declared or implicit. A query library implicitly declares a module with the same name as the QLL file.
 
   For further information on libraries and modules in QL, see the chapter on `Modules <https://codeql.github.com/docs/ql-language-reference/modules/>`__ in the QL language reference.
-  For further information on importing QL libraries and modules, see the chapter on `Name resolution <>`__ in the QL language reference.
+  For further information on importing QL libraries and modules, see the chapter on `Name resolution <https://codeql.github.com/docs/ql-language-reference/name-resolution/>`__ in the QL language reference.
 
 Data flow graph
 ===============

--- a/docs/codeql/ql-training/template.rst
+++ b/docs/codeql/ql-training/template.rst
@@ -159,7 +159,7 @@ Specify the language to apply syntax highlighting and the lines of the fragment 
 Further details
 ===============
 
-- For more information on writing in reStructuredText, see http://docutils.sourceforge.net/rst.html.
+- For more information on writing in reStructuredText, see https://docutils.sourceforge.io/rst.html.
 
 - For more information on Sphinx, see https://www.sphinx-doc.org.
 


### PR DESCRIPTION
Spotted a few broken/redirected links, as well as an empty "Name resolution" link. That empty one was giving a warning:
```
data-flow-java.rst:: WARNING: Anonymous hyperlink mismatch: 1 references but 0 targets.
See "backrefs" attribute for IDs.
```

I think this should be fixed now 🙂

(Also fixed internally - see linked PR) 