### PR TITLE
Docs: Fix inconsistencies in sphinx config files

### DIFF
--- a/docs/codeql/ql-training/conf.py
+++ b/docs/codeql/ql-training/conf.py
@@ -47,7 +47,7 @@ import sys
 import os
 
 def setup(sphinx):
-    sys.path.insert(0, os.path.join(os.path.dirname( __file__ ), '..'))
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir))
     from qllexer import QLLexer
     sphinx.add_lexer("ql", QLLexer())
 

--- a/docs/codeql/support/conf.py
+++ b/docs/codeql/support/conf.py
@@ -69,9 +69,9 @@ html_theme_options = {'font_size': '16px',
                       'body_text': '#333', 
                       'link': '#2F1695',
                       'link_hover': '#2F1695',
-                      'font_family': 'Inter,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Segoe UI Symbol;',
                       'show_powered_by': False,
                       'nosidebar':True,
+                      'head_font_family': '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
                       }
 
 html_favicon = '../images/site/favicon.ico'


### PR DESCRIPTION
Two very small edits:
- Replaced `..` in the conf.py file with [`os.path.pardir`](https://docs.python.org/3.9/library/os.html#os.pardir) (which is a more platform-independent way of saying the same thing)
- Changed the `html_theme_options` in the "support" project to match the general config file, i.e. https://github.com/github/codeql/blob/bb6c079e5ac836ab50be939ed99f285af78cd8b1/docs/codeql/conf.py#L85-L92
This will make the font on help.semmle.com ([example](https://help.semmle.com/QL/ql-support/index.html)) match the font on codeql.github.com ([example](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/))

cc @jf205 or @felicitymay since you've probably interacted with these files the most 🙂 