### PR TITLE
Dataflow: Support side-effects for callbacks in summaries.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -186,7 +186,9 @@ module Private {
     TArgumentSummaryComponent(int i) { parameterPosition(i) } or
     TReturnSummaryComponent(ReturnKind rk)
 
-  private TSummaryComponent thisParam() { result = TParameterSummaryComponent(instanceParameterPosition()) }
+  private TSummaryComponent thisParam() {
+    result = TParameterSummaryComponent(instanceParameterPosition())
+  }
 
   newtype TSummaryComponentStack =
     TSingletonSummaryComponentStack(SummaryComponent c) or

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -16,6 +16,9 @@ private import semmle.code.csharp.dataflow.ExternalFlow
 /** Holds is `i` is a valid parameter position. */
 predicate parameterPosition(int i) { i in [-1 .. any(Parameter p).getPosition()] }
 
+/** Gets the parameter position of the instance parameter. */
+int instanceParameterPosition() { none() } // disables implicit summary flow to `this` for callbacks
+
 /** Gets the synthesized summary data-flow node for the given values. */
 Node summaryNode(SummarizedCallable c, SummaryNodeState state) { result = TSummaryNode(c, state) }
 

--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
@@ -45,6 +45,9 @@ edges
 | ExternalFlow.cs:91:30:91:30 | SSA def(i) : Int32 | ExternalFlow.cs:92:18:92:18 | (...) ... |
 | ExternalFlow.cs:121:46:121:46 | s : Object | ExternalFlow.cs:60:35:60:35 | o : Object |
 | ExternalFlow.cs:123:34:123:41 | elements [element] : Object | ExternalFlow.cs:72:23:72:23 | o : Object |
+| ExternalFlow.cs:123:34:123:41 | elements [element] : Object | ExternalFlow.cs:72:23:72:23 | o : Object |
+| ExternalFlow.cs:123:34:123:41 | elements [element] : Object | ExternalFlow.cs:123:34:123:41 | elements [element] : Object |
+| ExternalFlow.cs:123:34:123:41 | elements [element] : Object | ExternalFlow.cs:123:34:123:41 | elements [element] : Object |
 nodes
 | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes | semmle.label | call to method StepArgRes |
@@ -105,6 +108,7 @@ nodes
 | ExternalFlow.cs:91:30:91:30 | SSA def(i) : Int32 | semmle.label | SSA def(i) : Int32 |
 | ExternalFlow.cs:92:18:92:18 | (...) ... | semmle.label | (...) ... |
 | ExternalFlow.cs:121:46:121:46 | s : Object | semmle.label | s : Object |
+| ExternalFlow.cs:123:34:123:41 | elements [element] : Object | semmle.label | elements [element] : Object |
 | ExternalFlow.cs:123:34:123:41 | elements [element] : Object | semmle.label | elements [element] : Object |
 subpaths
 invalidModelRow

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -186,7 +186,9 @@ module Private {
     TArgumentSummaryComponent(int i) { parameterPosition(i) } or
     TReturnSummaryComponent(ReturnKind rk)
 
-  private TSummaryComponent thisParam() { result = TParameterSummaryComponent(instanceParameterPosition()) }
+  private TSummaryComponent thisParam() {
+    result = TParameterSummaryComponent(instanceParameterPosition())
+  }
 
   newtype TSummaryComponentStack =
     TSingletonSummaryComponentStack(SummaryComponent c) or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -16,6 +16,9 @@ private module FlowSummaries {
 /** Holds is `i` is a valid parameter position. */
 predicate parameterPosition(int i) { i in [-1 .. any(Parameter p).getPosition()] }
 
+/** Gets the parameter position of the instance parameter. */
+int instanceParameterPosition() { result = -1 }
+
 /** Gets the synthesized summary data-flow node for the given values. */
 Node summaryNode(SummarizedCallable c, SummaryNodeState state) { result = getSummaryNode(c, state) }
 
@@ -37,6 +40,8 @@ DataFlowType getReturnType(SummarizedCallable c, ReturnKind rk) {
  */
 DataFlowType getCallbackParameterType(DataFlowType t, int i) {
   result = getErasedRepr(t.(FunctionalInterface).getRunMethod().getParameterType(i))
+  or
+  result = getErasedRepr(t.(FunctionalInterface)) and i = -1
 }
 
 /**

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/A.java
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/A.java
@@ -1,5 +1,7 @@
 package my.callback.qltest;
 
+import java.util.*;
+
 public class A {
   public interface Consumer1 {
     void eat(Object o);
@@ -28,6 +30,20 @@ public class A {
     // con.eat(x);
   }
 
+  static <T> T applyConsumer3_ret_postup(Consumer3<T> con) {
+    // summary:
+    // x = new T();
+    // con.eat(x);
+    // return x;
+    return null;
+  }
+
+  static <T> void forEach(T[] xs, Consumer3<T> con) {
+    // summary:
+    // x = xs[..];
+    // con.eat(x);
+  }
+
   public interface Producer1<T> {
     T make();
   }
@@ -35,6 +51,14 @@ public class A {
   static <T> T applyProducer1(Producer1<T> prod) {
     // summary:
     // return prod.make();
+    return null;
+  }
+
+  static <T> T produceConsume(Producer1<T> prod, Consumer3<T> con) {
+    // summary:
+    // x = prod.make();
+    // con.eat(x);
+    // return x;
     return null;
   }
 
@@ -109,5 +133,40 @@ public class A {
     };
     applyConsumer3(new Integer[] { (Integer)source(12) }, pc);
     sink(applyProducer1(pc)[0]); // $ flow=11
+
+    Integer res = applyProducer1(new Producer1<Integer>() {
+      private Integer ii = (Integer)source(13);
+      @Override public Integer make() {
+        return this.ii;
+      }
+    });
+    sink(res); // $ flow=13
+
+    ArrayList<Object> list = new ArrayList<>();
+    applyConsumer3(list, l -> l.add(source(14)));
+    sink(list.get(0)); // $ flow=14
+
+    Consumer3<ArrayList<Object>> tainter = l -> l.add(source(15));
+    sink(applyConsumer3_ret_postup(tainter).get(0)); // $ flow=15
+
+    forEach(new Object[] {source(16)}, x -> sink(x)); // $ flow=16
+
+    // Spurious flow from 17 is reasonable as it would likely
+    // also occur if the lambda body was inlined in a for loop.
+    // It occurs from the combination of being able to observe
+    // the side-effect of the callback on the other argument and
+    // being able to chain summaries that update/read arguments,
+    // e.g. fluent apis.
+    // Spurious flow from 18 is due to not matching call targets
+    // in a return-from-call-to-enter-call flow sequence.
+    forEach(new Object[2][], xs -> { sink(xs[0]); xs[0] = source(17); }); // $ SPURIOUS: flow=17 flow=18
+
+    Object[][] xss = new Object[][] { { null } };
+    forEach(xss, x -> {x[0] = source(18);});
+    sink(xss[0][0]); // $ flow=18
+
+    Object res2 = produceConsume(() -> source(19), A::sink); // $ flow=19
+    sink(res2); // $ flow=19
   }
+
 }

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/test.ql
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/test.ql
@@ -10,7 +10,11 @@ class SummaryModelTest extends SummaryModelCsv {
         "my.callback.qltest;A;false;applyConsumer1;(Object,Consumer1);;Argument[0];Parameter[0] of Argument[1];value",
         "my.callback.qltest;A;false;applyConsumer2;(Object,Consumer2);;Argument[0];Parameter[0] of Argument[1];value",
         "my.callback.qltest;A;false;applyConsumer3;(Object,Consumer3);;Argument[0];Parameter[0] of Argument[1];value",
+        "my.callback.qltest;A;false;applyConsumer3_ret_postup;(Consumer3);;Parameter[0] of Argument[0];ReturnValue;value",
+        "my.callback.qltest;A;false;forEach;(Object[],Consumer3);;ArrayElement of Argument[0];Parameter[0] of Argument[1];value",
         "my.callback.qltest;A;false;applyProducer1;(Producer1);;ReturnValue of Argument[0];ReturnValue;value",
+        "my.callback.qltest;A;false;produceConsume;(Producer1,Consumer3);;ReturnValue of Argument[0];Parameter[0] of Argument[1];value",
+        "my.callback.qltest;A;false;produceConsume;(Producer1,Consumer3);;Parameter[0] of Argument[1];ReturnValue;value",
         "my.callback.qltest;A;false;applyConverter1;(Object,Converter1);;Argument[0];Parameter[0] of Argument[1];value",
         "my.callback.qltest;A;false;applyConverter1;(Object,Converter1);;ReturnValue of Argument[1];ReturnValue;value"
       ]


### PR DESCRIPTION
* Adds support for referring to the parameter of a callback as an input spec.
* Adds post-update nodes for callback arguments to support callback side-effects being reflected back as side-effects on the arguments to `SummarizedCallable`s (only when the input spec is `isContentOfArgument`).
* Adds support for chaining summaries on callback parameters. E.g. the two summaries `input -> Parameter[0] of Argument[0]` and `Parameter[0] of Argument[0] -> output` implies a third implicitly added summary `input -> output`.
* Adds implicit summaries for flow to the instance parameter of callbacks (optional feature).
* Minor refactor to make the reference to a callback into an input state rather than an output state.