### PR TITLE
JS: Restrict what PackageExports considers to be public

### DIFF
--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -52,7 +52,8 @@ private DataFlow::Node getAValueExportedByPackage() {
   result = getAValueExportedByPackage().getALocalSource()
   or
   // Nested property reads.
-  result = getAValueExportedByPackage().(DataFlow::SourceNode).getAPropertyReference(publicPropertyName())
+  result =
+    getAValueExportedByPackage().(DataFlow::SourceNode).getAPropertyReference(publicPropertyName())
   or
   // module.exports.foo = require("./other-module.js");
   exists(Module mod |
@@ -186,9 +187,7 @@ private DataFlow::Node getAnExportFromModule(Module mod) {
  * This only allows properties whose first character is a letter or number.
  */
 bindingset[result]
-private string publicPropertyName() {
-  result.regexpMatch("[a-zA-Z0-9].*")
-}
+private string publicPropertyName() { result.regexpMatch("[a-zA-Z0-9].*") }
 
 /**
  * Holds if the given function is part of a private (or protected) method declaration.

--- a/javascript/ql/test/library-tests/PackageExports/notPublic.ts
+++ b/javascript/ql/test/library-tests/PackageExports/notPublic.ts
@@ -1,0 +1,11 @@
+export class PublicClass {
+    protected constructor(p) {}
+    private privateMethod(p) {}
+    protected protectedMethod(p) {}
+    _kindaPrivateMethod(p) {}
+    $kindaPrivateMethod(p) {}
+    #esPrivateMethod(p) {}
+
+    _kindaPrivateFieldMethod = (p) => {};
+    private privateFieldMethod = (p) => {};
+}

--- a/javascript/ql/test/library-tests/PackageExports/tests.expected
+++ b/javascript/ql/test/library-tests/PackageExports/tests.expected
@@ -15,3 +15,4 @@ getAnExportedValue
 | lib1/reexport/a.js:1:1:3:1 | <toplevel> | reexported | lib1/reexport/a.js:2:17:2:40 | functio ... ed() {} |
 | lib1/reexport/b.js:1:1:6:1 | <toplevel> | base | lib1/reexport/b.js:4:11:4:28 | function base() {} |
 | lib1/reexport/b.js:1:1:6:1 | <toplevel> | reexported | lib1/reexport/a.js:2:17:2:40 | functio ... ed() {} |
+| notPublic.ts:1:1:12:0 | <toplevel> | PublicClass | notPublic.ts:1:8:11:1 | class P ... > {};\\n} |


### PR DESCRIPTION
Makes `PackageExports.qll` more conservative in what it considers to be public API:
- Require that the first name of a property is a letter or number (for array indices), excluding things like `_foo`, `$foo`, ES private names like `#foo`, symbol keys, and non-ascii names such as the [internal names used in Angular](https://github.com/angular/angular/blob/4ea3e7e0007b8bd8dbdd49b139a0b6f991f51247/packages/core/src/core_private_export.ts).
- Exclude methods/constructors declared as private or protected in a TypeScript file.