### PR TITLE
C#: Filter using `var _ = ... results` from `DeadStoreOfLocal.ql`

### DIFF
--- a/csharp/change-notes/2021-10-04-dead-store-of-local.md
+++ b/csharp/change-notes/2021-10-04-dead-store-of-local.md
@@ -1,2 +1,2 @@
 lgtm,codescanning
-* Discarded `using` declarationg, `using var _ = ...`, are no longer flagged by the query "Useless assignment to local variable".
+* `using` declarations are no longer flagged by the query "Useless assignment to local variable".

--- a/csharp/change-notes/2021-10-04-dead-store-of-local.md
+++ b/csharp/change-notes/2021-10-04-dead-store-of-local.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Discarded `using` declarationg, `using var _ = ...`, are no longer flagged by the query "Useless assignment to local variable".

--- a/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
+++ b/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
@@ -72,7 +72,12 @@ predicate mayEscape(LocalVariable v) {
 
 class RelevantDefinition extends AssignableDefinition {
   RelevantDefinition() {
-    this instanceof AssignableDefinitions::AssignmentDefinition
+    this.(AssignableDefinitions::AssignmentDefinition).getAssignment() =
+      any(Assignment a |
+        if a = any(UsingStmt us).getAVariableDeclExpr()
+        then not a.getTargetVariable().hasName("_")
+        else any()
+      )
     or
     this instanceof AssignableDefinitions::MutationDefinition
     or

--- a/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
+++ b/csharp/ql/src/Dead Code/DeadStoreOfLocal.ql
@@ -73,11 +73,7 @@ predicate mayEscape(LocalVariable v) {
 class RelevantDefinition extends AssignableDefinition {
   RelevantDefinition() {
     this.(AssignableDefinitions::AssignmentDefinition).getAssignment() =
-      any(Assignment a |
-        if a = any(UsingStmt us).getAVariableDeclExpr()
-        then not a.getTargetVariable().hasName("_")
-        else any()
-      )
+      any(Assignment a | not a = any(UsingDeclStmt uds).getAVariableDeclExpr())
     or
     this instanceof AssignableDefinitions::MutationDefinition
     or

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
@@ -460,10 +460,17 @@ public static class AnonymousVariable
             count++;
         return count;
     }
+}
 
-    public static void Using()
+public static class Using
+{
+    public static void M()
     {
-        using var x = new System.IO.FileStream("", System.IO.FileMode.Open); // BAD
+        using var x = new System.IO.FileStream("", System.IO.FileMode.Open); // GOOD
         using var _ = new System.IO.FileStream("", System.IO.FileMode.Open); // GOOD
+
+        using (var y = new System.IO.FileStream("", System.IO.FileMode.Open)) // BAD
+        {
+        }
     }
 }

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.cs
@@ -460,4 +460,10 @@ public static class AnonymousVariable
             count++;
         return count;
     }
+
+    public static void Using()
+    {
+        using var x = new System.IO.FileStream("", System.IO.FileMode.Open); // BAD
+        using var _ = new System.IO.FileStream("", System.IO.FileMode.Open); // GOOD
+    }
 }

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -14,6 +14,7 @@
 | DeadStoreOfLocal.cs:331:9:331:32 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:327:23:327:23 | b | b |
 | DeadStoreOfLocal.cs:372:13:372:20 | String s = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:372:13:372:13 | s | s |
 | DeadStoreOfLocal.cs:398:13:398:21 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:396:13:396:13 | s | s |
+| DeadStoreOfLocal.cs:466:19:466:75 | FileStream x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:466:19:466:19 | x | x |
 | DeadStoreOfLocalBad.cs:7:13:7:48 | Boolean success = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:7:13:7:19 | success | success |
 | DeadStoreOfLocalBad.cs:23:32:23:32 | FormatException e | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:23:32:23:32 | e | e |
 | DeadStoreOfLocalBad.cs:32:22:32:22 | String s | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:32:22:32:22 | s | s |

--- a/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/csharp/ql/test/query-tests/Dead Code/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -14,7 +14,7 @@
 | DeadStoreOfLocal.cs:331:9:331:32 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:327:23:327:23 | b | b |
 | DeadStoreOfLocal.cs:372:13:372:20 | String s = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:372:13:372:13 | s | s |
 | DeadStoreOfLocal.cs:398:13:398:21 | ... = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:396:13:396:13 | s | s |
-| DeadStoreOfLocal.cs:466:19:466:75 | FileStream x = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:466:19:466:19 | x | x |
+| DeadStoreOfLocal.cs:472:20:472:76 | FileStream y = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.cs:472:20:472:20 | y | y |
 | DeadStoreOfLocalBad.cs:7:13:7:48 | Boolean success = ... | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:7:13:7:19 | success | success |
 | DeadStoreOfLocalBad.cs:23:32:23:32 | FormatException e | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:23:32:23:32 | e | e |
 | DeadStoreOfLocalBad.cs:32:22:32:22 | String s | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocalBad.cs:32:22:32:22 | s | s |


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/6788.