### PR TITLE
C#: Filter discards in tuples in `ConstantCondition.ql`

### DIFF
--- a/csharp/change-notes/2021-10-04-constand-condition.md
+++ b/csharp/change-notes/2021-10-04-constand-condition.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Discards in tuple patterns, for example `(_, string s)`, are no longer flagged by the query "Constant condition".

--- a/csharp/ql/src/Bad Practices/Control-Flow/ConstantCondition.ql
+++ b/csharp/ql/src/Bad Practices/Control-Flow/ConstantCondition.ql
@@ -123,6 +123,8 @@ class ConstantMatchingCondition extends ConstantCondition {
       se.getCase(i).getPattern() = this.(DiscardExpr) and
       i > 0
     )
+    or
+    this = any(PositionalPatternExpr ppe).getPattern(_)
   }
 
   override string getMessage() {

--- a/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.cs
+++ b/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.cs
@@ -48,8 +48,8 @@ class ConstantNullness
         j = (int?)i ?? 1; // BAD
         s = ""?.CommaJoinWith(s); // BAD
         s = s ?? ""; // GOOD
-        s = (i==0 ? s : null) ?? s; // GOOD
-        var k = (i==0 ? s : null)?.Length; // GOOD
+        s = (i == 0 ? s : null) ?? s; // GOOD
+        var k = (i == 0 ? s : null)?.Length; // GOOD
     }
 }
 
@@ -59,12 +59,12 @@ class ConstantMatching
     {
         switch (1 + 2)
         {
-            case 2 : // BAD
-              break;
-            case 3 : // BAD
-              break;
-            case int _ : // GOOD
-              break;
+            case 2: // BAD
+                break;
+            case 3: // BAD
+                break;
+            case int _: // GOOD
+                break;
         }
     }
 
@@ -72,10 +72,10 @@ class ConstantMatching
     {
         switch ((object)s)
         {
-            case int _ : // BAD
-              break;
-            case "" : // GOOD
-              break;
+            case int _: // BAD
+                break;
+            case "": // GOOD
+                break;
         }
     }
 
@@ -83,8 +83,8 @@ class ConstantMatching
     {
         switch (o)
         {
-            case IList _ : // GOOD
-              break;
+            case IList _: // GOOD
+                break;
         }
     }
 
@@ -105,13 +105,24 @@ class ConstantMatching
         };
     }
 
-    void M6(bool b1, bool b2) {
+    void M6(bool b1, bool b2)
+    {
         if (!b1)
             return;
         if (!b2)
             return;
         if (b1 && b2) // BAD
             return;
+    }
+
+    string M7(object o)
+    {
+        return o switch
+        {
+            (string s, _) => s, // GOOD
+            (_, string s) => s, // GOOD
+            _ => "" // GOOD
+        };
     }
 }
 

--- a/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Control-Flow/ConstantCondition/ConstantCondition.expected
@@ -8,8 +8,8 @@
 | ConstantCondition.cs:64:18:64:18 | 3 | Pattern always matches. |
 | ConstantCondition.cs:75:18:75:20 | access to type Int32 | Pattern never matches. |
 | ConstantCondition.cs:95:13:95:13 | _ | Pattern always matches. |
-| ConstantCondition.cs:113:13:113:14 | access to parameter b1 | Condition always evaluates to 'true'. |
-| ConstantCondition.cs:113:19:113:20 | access to parameter b2 | Condition always evaluates to 'true'. |
+| ConstantCondition.cs:114:13:114:14 | access to parameter b1 | Condition always evaluates to 'true'. |
+| ConstantCondition.cs:114:19:114:20 | access to parameter b2 | Condition always evaluates to 'true'. |
 | ConstantConditionBad.cs:5:16:5:20 | ... > ... | Condition always evaluates to 'false'. |
 | ConstantConditionalExpressionCondition.cs:11:22:11:34 | ... == ... | Condition always evaluates to 'true'. |
 | ConstantConditionalExpressionCondition.cs:12:21:12:25 | false | Condition always evaluates to 'false'. |


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/6786.