### PR TITLE
Make VS Code autoformat QL files on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "omnisharp.autoStart": false
+    "omnisharp.autoStart": false,
+    "[ql]": {
+        "editor.formatOnSave": true,
+    },
 }


### PR DESCRIPTION
Specifies that VS Code autoformats QL files on save. This VS Code feature might not work correctly in some cases when used with auto-saving (see https://github.com/microsoft/vscode/issues/45997#issuecomment-669016666), but it hopefully works most of the time.

Autoformatting is quite useful because this repository enforces formatted QL files, and it is easy to forget manually formatting them.

⚠️ Autoformatting might be an intrusive change; additionally especially for larger files formatting might take some time.
Would it make sense to enable this for a 'trial' period and see what effects it has on regular development in this repository? E.g. whether it helps speeding up the work, or whether it hinder the work.