### PR TITLE
C++: Add CWE-094 to `cpp/command-line-injection`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -11,6 +11,7 @@
  * @tags security
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
+ *       external/cwe/cwe-094
  */
 
 import cpp


### PR DESCRIPTION
The description of [CWE-094](https://cwe.mitre.org/data/definitions/94.html) is:

"The software constructs all or part of a code segment using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the syntax or behavior of the intended code segment."

I think this fits quite well with the spirit of `cpp/command-line-injection`. What do you think, @rdmarsh2?