### PR TITLE
CLI docs: Add example for creating a database using a Bazel build command

### DIFF
--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -221,6 +221,23 @@ commands that you can specify for compiled languages.
 
      codeql database create java-database --language=java --command='ant -f build.xml'
 
+- Project built using Bazel::
+
+     # Navigate to the Bazel workspace.
+
+     # Stop all running Bazel server processes.
+     bazel shutdown
+
+     # Remove cached objects before building.
+     bazel clean --expunge
+
+     # Build using the following Bazel flags, to help CodeQL detect the build:
+     # `--spawn_strategy=local`: build locally, instead of using a distributed build
+     # `--nouse_action_cache`: turn off build caching, which might prevent recompilation of source code
+     # `--noremote_accept_cached`, `--noremote_upload_local_results`: avoid using a remote cache
+     codeql database create new-database --language=<language> \
+       --command='bazel build --spawn_strategy=local --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results //path/to/package:target'
+
 - Project built using a custom build script::
 
      codeql database create new-database --language=<language> --command='./scripts/build.sh'


### PR DESCRIPTION
We have internal material on this subject, so it makes sense to have a reference example.
Bazel builds could be in any compiled language, so follow the pattern of the generic build script example.
Include the build flags that we recommend to customers, which turn off Bazel's caching and distributed behaviour
so that CodeQL can observe the entire build.

See https://docs.bazel.build/versions/main/command-line-reference.html.