### PR TITLE
JS: Manually adjust some security-severity scores

### DIFF
--- a/javascript/ql/src/Security/CWE-078/IndirectCommandInjection.ql
+++ b/javascript/ql/src/Security/CWE-078/IndirectCommandInjection.ql
@@ -5,7 +5,7 @@
  *              command-line injection vulnerabilities.
  * @kind path-problem
  * @problem.severity warning
- * @security-severity 9.8
+ * @security-severity 6.3
  * @precision medium
  * @id js/indirect-command-line-injection
  * @tags correctness

--- a/javascript/ql/src/Security/CWE-078/ShellCommandInjectionFromEnvironment.ql
+++ b/javascript/ql/src/Security/CWE-078/ShellCommandInjectionFromEnvironment.ql
@@ -4,7 +4,7 @@
  *              environment may cause subtle bugs or vulnerabilities.
  * @kind path-problem
  * @problem.severity warning
- * @security-severity 9.8
+ * @security-severity 6.3
  * @precision high
  * @id js/shell-command-injection-from-environment
  * @tags correctness

--- a/javascript/ql/src/Security/CWE-078/UnsafeShellCommandConstruction.ql
+++ b/javascript/ql/src/Security/CWE-078/UnsafeShellCommandConstruction.ql
@@ -4,7 +4,7 @@
  *              user to change the meaning of the command.
  * @kind path-problem
  * @problem.severity error
- * @security-severity 9.8
+ * @security-severity 6.3
  * @precision high
  * @id js/shell-command-constructed-from-input
  * @tags correctness

--- a/javascript/ql/src/Security/CWE-078/UselessUseOfCat.ql
+++ b/javascript/ql/src/Security/CWE-078/UselessUseOfCat.ql
@@ -3,7 +3,7 @@
  * @description Using the  `cat` process to read a file is unnecessarily complex, inefficient, unportable, and can lead to subtle bugs, or even security vulnerabilities.
  * @kind problem
  * @problem.severity error
- * @security-severity 9.8
+ * @security-severity 6.3
  * @precision high
  * @id js/unnecessary-use-of-cat
  * @tags correctness

--- a/javascript/ql/src/Security/CWE-094/CodeInjection.ql
+++ b/javascript/ql/src/Security/CWE-094/CodeInjection.ql
@@ -4,11 +4,12 @@
  *              code execution.
  * @kind path-problem
  * @problem.severity error
- * @security-severity 6.1
+ * @security-severity 9.3
  * @precision high
  * @id js/code-injection
  * @tags security
  *       external/cwe/cwe-094
+ *       external/cwe/cwe-095
  *       external/cwe/cwe-079
  *       external/cwe/cwe-116
  */

--- a/javascript/ql/src/Security/CWE-134/TaintedFormatString.ql
+++ b/javascript/ql/src/Security/CWE-134/TaintedFormatString.ql
@@ -3,7 +3,7 @@
  * @description Using external input in format strings can lead to garbled output.
  * @kind path-problem
  * @problem.severity warning
- * @security-severity 9.3
+ * @security-severity 7.3
  * @precision high
  * @id js/tainted-format-string
  * @tags security

--- a/javascript/ql/src/Security/CWE-834/LoopBoundInjection.ql
+++ b/javascript/ql/src/Security/CWE-834/LoopBoundInjection.ql
@@ -4,10 +4,11 @@
  *              property can cause indefinite looping.
  * @kind path-problem
  * @problem.severity warning
- * @security-severity 6.5
+ * @security-severity 7.5
  * @id js/loop-bound-injection
  * @tags security
  *       external/cwe/cwe-834
+ *       external/cwe/cwe-730
  * @precision high
  */
 

--- a/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
+++ b/javascript/ql/src/Security/CWE-912/HttpToFileAccess.ql
@@ -3,7 +3,7 @@
  * @description Writing network data directly to the file system allows arbitrary file upload and might indicate a backdoor.
  * @kind path-problem
  * @problem.severity warning
- * @security-severity 9.8
+ * @security-severity 6.3
  * @precision medium
  * @id js/http-to-file-access
  * @tags security


### PR DESCRIPTION
This PR adjusts some of the security-severity scores to better reflect the quality of the queries producing the alerts.

-  **Queries with speculative threat model**
    Some queries use a speculative threat model, e.g. by using library inputs or environment variables as taint sources. This was generally reflected in the old precision/severity metadata, but not in the security-severity. For these queries, I've updated the scores using the CVSS calculator by setting 'Attack Complexity' to High and 'User Interaction' to Low (as opposed to None).

-  **Tainted format string**
    The CWE number for the `TaintedFormatString` query is associated with buffer overflows from printf/scanf-style functions in C++, which is probably why it had a high derived security-severity score (9.3). But in JavaScript, a tainted format string is unlikely to lead to anything worse than log injection so I've manually update its score to reflect this (7.3).

-  **Loop bound injection**
    The `LoopBoundInjection` query is a denial-of-service query, but was missing the CWE-730 tag
    ("denial of service") and had a lower score than the other DoS queries. I've added the CWE tag and
    updated its security-severity to match the other denial-of-service queries.

-  **Code injection query**
    The derived security-severity score of the JS `CodeInjection` query was much lower than for other languages (6.1 versus 9.3), possibly due some differences in CWE tags, such as the inclusion of CWE-079. I've also added the more specific CWE-095 ("eval injection") for consistency with other languages. It is a child of already-used CWE-094 ("code injection").
