### PR TITLE
Ignore .codeql folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 /codeql/
 
 csharp/extractor/Semmle.Extraction.CSharp.Driver/Properties/launchSettings.json
+
+# Avoid committing cached package components
+.codeql


### PR DESCRIPTION
This folder contains the compiled components of a package. It should never be committed to git.