### PR TITLE
Packaging: Add library flag to upgrades packs

### DIFF
--- a/cpp/upgrades/qlpack.yml
+++ b/cpp/upgrades/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/cpp-upgrades
 upgrades: .
 version: 0.0.2
+library: true

--- a/csharp/upgrades/qlpack.yml
+++ b/csharp/upgrades/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/csharp-upgrades
 upgrades: .
 version: 0.0.2
+library: true


### PR DESCRIPTION
This flag was missing. It should be there. Otherwise, this pack cannot be built.