### PR TITLE
Adjust locations of results in JSP files

### DIFF
--- a/java/ql/lib/semmle/code/SMAP.qll
+++ b/java/ql/lib/semmle/code/SMAP.qll
@@ -52,6 +52,6 @@ predicate hasSmapLocationInfo(
     smap(inputFile, isl, outputFile, osl) and
     smap(inputFile, iel - 1, outputFile, oel) and
     isc = 1 and
-    iec = 0
+    iec = 1
   )
 }


### PR DESCRIPTION
This is necessary due to [known limitations](https://github.com/github/vscode-codeql/issues/967) in VSCode which cause locations with zero character indices to be mapped to invalid ranges. It is, hopefully, a temporary workaround until this problem will have been properly addressed in VSCode.

@yo-h 