### PR TITLE
C#: Speedup GVN string `concat`s by pulling ranges into separate predicates

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Implements.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Implements.qll
@@ -398,6 +398,15 @@ private module Gvn {
       )
     }
 
+    pragma[noinline]
+    private predicate toStringPart(int i, int j) {
+      exists(Unification::GenericType t, int children |
+        t = this.getConstructedGenericDeclaringTypeAt(i) and
+        children = t.getNumberOfArgumentsSelf() and
+        if children = 0 then j = 0 else j in [0 .. 2 * children]
+      )
+    }
+
     language[monotonicAggregates]
     string toString() {
       this.isFullyConstructed() and
@@ -406,11 +415,7 @@ private module Gvn {
         or
         result =
           strictconcat(int i, int j |
-            exists(Unification::GenericType t, int children |
-              t = this.getConstructedGenericDeclaringTypeAt(i) and
-              children = t.getNumberOfArgumentsSelf() and
-              if children = 0 then j = 0 else j in [0 .. 2 * children]
-            )
+            this.toStringPart(i, j)
           |
             this.toStringConstructedPart(i, j) order by i desc, j
           )

--- a/csharp/ql/lib/semmle/code/csharp/Unification.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Unification.qll
@@ -277,6 +277,18 @@ module Gvn {
       )
     }
 
+    pragma[noinline]
+    private predicate toStringPart(int i, int j) {
+      exists(int offset |
+        exists(GenericType t, int children |
+          t = this.getConstructedGenericDeclaringTypeAt(i) and
+          children = t.getNumberOfArgumentsSelf() and
+          (if this.isDeclaringTypeAt(i) then offset = 1 else offset = 0) and
+          if children = 0 then j in [0 .. offset] else j in [0 .. 2 * children + offset]
+        )
+      )
+    }
+
     language[monotonicAggregates]
     string toString() {
       this.isFullyConstructed() and
@@ -284,13 +296,8 @@ module Gvn {
         result = k.toStringBuiltin(this.getArg(0).toString())
         or
         result =
-          strictconcat(int i, int j, int offset |
-            exists(GenericType t, int children |
-              t = this.getConstructedGenericDeclaringTypeAt(i) and
-              children = t.getNumberOfArgumentsSelf() and
-              (if this.isDeclaringTypeAt(i) then offset = 1 else offset = 0) and
-              if children = 0 then j in [0 .. offset] else j in [0 .. 2 * children + offset]
-            )
+          strictconcat(int i, int j |
+            toStringPart(i, j)
           |
             this.toStringConstructedPart(i, j) order by i desc, j
           )


### PR DESCRIPTION
Before:
```
[2021-10-07 11:31:13] (296s) Tuple counts for Unification::Gvn::ConstructedGvnTypeList::toString#ff/2@i3#ed625x after 12.7s:
                      0       ~0%       {3} r1 = JOIN Unification::Gvn::GvnType::toString_dispred#ff#prev_delta WITH Unification::Gvn::ConstructedGvnTypeList::toString#ff#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.2 'this', Lhs.1
                      
                      0       ~0%       {2} r2 = JOIN r1 WITH Unification::Gvn::Cached::TPointerTypeKind#f ON FIRST 1 OUTPUT Lhs.1 'this', (Lhs.2 ++ "*")
                      
                      0       ~0%       {2} r3 = JOIN r1 WITH Unification::Gvn::Cached::TNullableTypeKind#f ON FIRST 1 OUTPUT Lhs.1 'this', (Lhs.2 ++ "?")
                      
                      0       ~0%       {4} r4 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Lhs.2, Rhs.1
                      
                      0       ~0%       {6} r5 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Lhs.2, Rhs.1, (Rhs.1 - 2), 0
                      0       ~0%       {7} r6 = JOIN r5 WITH PRIMITIVE range#bbf ON Lhs.5,Lhs.4
                      0       ~0%       {4} r7 = SCAN r6 OUTPUT In.0, In.1 'this', In.2, In.3
                      0                 {4} r8 = MATERIALIZE r7 AS unknown
                      
                      0       ~0%       {4} r9 = r4 AND NOT r8(Lhs.0, Lhs.1 'this', Lhs.2, Lhs.3)
                      0       ~0%       {2} r10 = SCAN r9 OUTPUT In.1 'this', (In.2 ++ "[" ++ "" ++ "]")
                      
                      0       ~0%       {2} r11 = r3 UNION r10
                      0       ~0%       {2} r12 = r2 UNION r11
                      
                      0       ~0%       {3} r13 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'this', Lhs.2
                      
                      0       ~0%       {7} r14 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Lhs.2, Rhs.1, ",", (Rhs.1 - 2), 0
                      0       ~0%       {8} r15 = JOIN r14 WITH PRIMITIVE range#bbf ON Lhs.6,Lhs.5
                      
                      0       ~0%       {4} r16 = SCAN r15 OUTPUT In.3, In.7, ",", ""
                      0                 {4} r17 = MATERIALIZE r16 AS unknown
                      
                      0       ~0%       {6} r18 = SCAN r15 OUTPUT In.3, In.7, ",", "", ",", ""
                      0                 {6} r19 = MATERIALIZE r18 AS unknown
                      
                      0       ~0%       {2} r20 = AGGREGATE r17, r19 ON In.4, In.5 WITH CONCAT<0 ASC> OUTPUT In.0, Agg.0
                      0                 {2} r21 = MATERIALIZE r20 AS unknown
                      
                      0       ~0%       {2} r22 = JOIN r13 WITH r21 ON FIRST 1 OUTPUT Lhs.1 'this', (Lhs.2 ++ "[" ++ Rhs.1 ++ "]")
                      
                      2125206 ~815%     {4} r23 = JOIN Unification::Gvn::ConstructedGvnTypeList::toStringConstructedPart#ffff#prev_delta WITH Unification::Gvn::ConstructedGvnTypeList::toString#ff#join_rhs#1 ON FIRST 1 OUTPUT Rhs.0, Lhs.1, Rhs.1, Lhs.2
                      2125206 ~817%     {5} r24 = JOIN r23 WITH Unification::Gvn::ConstructedGvnTypeList::getConstructedGenericDeclaringTypeAt#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.0 'this', Lhs.1, Lhs.3
                      
                      236134  ~0%       {6} r25 = JOIN r24 WITH Unification::Gvn::GenericType::getNumberOfArgumentsSelf_dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.2 'this', Lhs.3, Lhs.4, Lhs.0, Rhs.1
                      
                      0       ~0%       {6} r26 = SELECT r25 ON In.5 = 0
                      0       ~0%       {5} r27 = SCAN r26 OUTPUT In.1 'this', In.0, In.2, In.3, 0
                      
                      1889072 ~709%     {5} r28 = JOIN r24 WITH Unification::Gvn::GenericType::getNumberOfArgumentsSelf_dispred#ff ON FIRST 1 OUTPUT Lhs.2 'this', Lhs.1, Lhs.3, Lhs.4, Rhs.1
                      1902176 ~697%     {7} r29 = JOIN r28 WITH Unification::Gvn::ConstructedGvnTypeList::getConstructedGenericDeclaringTypeAt#fff ON FIRST 1 OUTPUT Rhs.2, Lhs.1, Lhs.0, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                      1902176 ~671%     {8} r30 = JOIN r29 WITH Unification::Gvn::GenericType::getNumberOfArgumentsSelf_dispred#ff ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.0, Rhs.1
                      
                      7072    ~692%     {8} r31 = SELECT r30 ON In.7 = 0
                      
                      7072    ~705%     {7} r32 = SCAN r31 OUTPUT In.1, In.5, In.0, In.2, In.3, In.4, 0
                      240     ~716%     {9} r33 = JOIN r32 WITH Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.1, 0, 1, 0
                      
                      7072    ~720%     {7} r34 = SCAN r31 OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, 0
                      6832    ~725%     {7} r35 = r34 AND NOT Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff(Lhs.1, Lhs.5)
                      6832    ~707%     {9} r36 = SCAN r35 OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, 0, 0, 0
                      
                      7072    ~707%     {9} r37 = r33 UNION r36
                      7312    ~688%     {10} r38 = JOIN r37 WITH PRIMITIVE range#bbf ON Lhs.8,Lhs.7
                      
                      3656    ~461%     {4} r39 = SCAN r38 OUTPUT In.1, In.5, In.9, In.7
                      
                      1895104 ~674%     {8} r40 = SELECT r30 ON In.7 != 0
                      
                      1895104 ~712%     {7} r41 = SCAN r40 OUTPUT In.1, In.5, In.0, In.2, In.3, In.4, In.7
                      12864   ~655%     {10} r42 = JOIN r41 WITH Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3, Lhs.4, Lhs.5, Lhs.1, Lhs.6, 1, ((2 * Lhs.6) + 1), 0
                      
                      1895104 ~697%     {7} r43 = SCAN r40 OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, In.7
                      1882240 ~694%     {7} r44 = r43 AND NOT Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff(Lhs.1, Lhs.5)
                      1882240 ~671%     {10} r45 = SCAN r44 OUTPUT In.0, In.1, In.2, In.3, In.4, In.5, In.6, 0, ((2 * In.6) + 0), 0
                      
                      1895104 ~669%     {10} r46 = r42 UNION r45
                      6776560 ~659%     {11} r47 = JOIN r46 WITH PRIMITIVE range#bbf ON Lhs.9,Lhs.8
                      
                      3388280 ~423%     {4} r48 = SCAN r47 OUTPUT In.1, In.5, In.10, In.7
                      
                      3391936 ~423%     {4} r49 = r39 UNION r48
                      795329            {4} r50 = MATERIALIZE r49 AS unknown
                      
                      3656    ~444%     {7} r51 = SCAN r38 OUTPUT In.1, In.5, In.9, In.5, In.7, In.9, ""
                      
                      3388280 ~395%     {7} r52 = SCAN r47 OUTPUT In.1, In.5, In.10, In.5, In.7, In.10, ""
                      
                      3391936 ~396%     {7} r53 = r51 UNION r52
                      3387684 ~414%     {8} r54 = JOIN r53 WITH Unification::Gvn::ConstructedGvnTypeList::toStringConstructedPart#ffff#prev ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.5, Lhs.4, Rhs.3, "", Lhs.1, Lhs.2
                      794439            {8} r55 = MATERIALIZE r54 AS unknown
                      
                      826512  ~296%     {2} r56 = AGGREGATE r50, r55 ON In.4, In.5, In.6, In.7 WITH CONCAT<2 DESC3 ASC> OUTPUT In.0, Agg.0
                      206628            {2} r57 = MATERIALIZE r56 AS unknown
                      
                      0       ~0%       {6} r58 = JOIN r27 WITH r57 ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.2, Lhs.1, Lhs.3, 0, Rhs.1 'result'
                      0       ~0%       {7} r59 = JOIN r58 WITH Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.0 'this', Lhs.3, 0, Lhs.5 'result', 1, 0
                      
                      0       ~0%       {6} r60 = JOIN r27 WITH r57 ON FIRST 1 OUTPUT Lhs.1, Lhs.0 'this', Lhs.2, Lhs.3, 0, Rhs.1 'result'
                      0       ~0%       {6} r61 = r60 AND NOT Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff(Lhs.1 'this', Lhs.2)
                      0       ~0%       {7} r62 = SCAN r61 OUTPUT In.0, In.1 'this', In.3, 0, In.5 'result', 0, 0
                      
                      0       ~0%       {7} r63 = r59 UNION r62
                      0       ~0%       {7} r64 = JOIN r63 WITH PRIMITIVE range#bbb ON Lhs.6,Lhs.5,Lhs.2
                      0       ~0%       {2} r65 = SCAN r64 OUTPUT In.1 'this', In.4 'result'
                      
                      236134  ~0%       {6} r66 = SELECT r25 ON In.5 != 0
                      236134  ~1%       {5} r67 = SCAN r66 OUTPUT In.1 'this', In.0, In.2, In.3, In.5
                      
                      235074  ~0%       {6} r68 = JOIN r67 WITH r57 ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.2, Lhs.1, Lhs.3, Lhs.4, Rhs.1 'result'
                      1439    ~0%       {8} r69 = JOIN r68 WITH Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff ON FIRST 2 OUTPUT Lhs.2, Lhs.0 'this', Lhs.3, Lhs.4, Lhs.5 'result', 1, ((2 * Lhs.4) + 1), 0
                      
                      235074  ~5%       {6} r70 = JOIN r67 WITH r57 ON FIRST 1 OUTPUT Lhs.1, Lhs.0 'this', Lhs.2, Lhs.3, Lhs.4, Rhs.1 'result'
                      233635  ~5%       {6} r71 = r70 AND NOT Unification::Gvn::ConstructedGvnTypeList::isDeclaringTypeAt_dispred#ff(Lhs.1 'this', Lhs.2)
                      233635  ~0%       {8} r72 = SCAN r71 OUTPUT In.0, In.1 'this', In.3, In.4, In.5 'result', 0, ((2 * In.4) + 0), 0
                      
                      235074  ~0%       {8} r73 = r69 UNION r72
                      235074  ~0%       {8} r74 = JOIN r73 WITH PRIMITIVE range#bbb ON Lhs.7,Lhs.6,Lhs.2
                      235074  ~13%      {2} r75 = SCAN r74 OUTPUT In.1 'this', In.4 'result'
                      
                      235074  ~13%      {2} r76 = r65 UNION r75
                      235074  ~13%      {2} r77 = r22 UNION r76
                      235074  ~13%      {2} r78 = r12 UNION r77
                      235074  ~13%      {2} r79 = r78 AND NOT Unification::Gvn::ConstructedGvnTypeList::toString#ff#prev(Lhs.0 'this', Lhs.1 'result')
                                        return r79
[2021-10-07 11:31:13] (296s) 			 - Unification::Gvn::ConstructedGvnTypeList::toString#ff_delta has 206628 rows (order for disjuncts: delta=500000).
```

After:
```
[2021-10-07 13:42:27] (4s) Tuple counts for Unification::Gvn::ConstructedGvnTypeList::toString#ff/2@i3#655f8x after 1.3s:
                      0      ~0%       {3} r1 = JOIN Unification::Gvn::GvnType::toString_dispred#ff#prev_delta WITH Unification::Gvn::ConstructedGvnTypeList::toString#ff#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.2 'this', Lhs.1
                      
                      0      ~0%       {2} r2 = JOIN r1 WITH Unification::Gvn::Cached::TPointerTypeKind#f ON FIRST 1 OUTPUT Lhs.1 'this', (Lhs.2 ++ "*")
                      
                      0      ~0%       {2} r3 = JOIN r1 WITH Unification::Gvn::Cached::TNullableTypeKind#f ON FIRST 1 OUTPUT Lhs.1 'this', (Lhs.2 ++ "?")
                      
                      0      ~0%       {2} r4 = r2 UNION r3
                      
                      708402 ~188%     {3} r5 = JOIN Unification::Gvn::ConstructedGvnTypeList::toStringConstructedPart#ffff#prev_delta WITH Unification::Gvn::ConstructedGvnTypeList::toString#ff#join_rhs#1 ON FIRST 1 OUTPUT Rhs.0, Lhs.1, Lhs.2
                      708402 ~241%     {1} r6 = JOIN r5 WITH Unification::Gvn::ConstructedGvnTypeList::toStringPart#fff ON FIRST 3 OUTPUT Lhs.0 'this'
                      
                      847984 ~26%      {3} r7 = JOIN r6 WITH Unification::Gvn::ConstructedGvnTypeList::toStringPart#fff ON FIRST 1 OUTPUT Lhs.0 'this', Rhs.1, Rhs.2
                      795329           {3} r8 = MATERIALIZE r7 AS unknown
                      
                      847984 ~29%      {6} r9 = JOIN r6 WITH Unification::Gvn::ConstructedGvnTypeList::toStringPart#fff ON FIRST 1 OUTPUT Lhs.0 'this', Rhs.1, Rhs.2, Rhs.1, Rhs.2, ""
                      846921 ~23%      {7} r10 = JOIN r9 WITH Unification::Gvn::ConstructedGvnTypeList::toStringConstructedPart#ffff#prev ON FIRST 3 OUTPUT Lhs.0, Lhs.3, Lhs.4, Rhs.3, "", Lhs.1, Lhs.2
                      794439           {7} r11 = MATERIALIZE r10 AS unknown
                      
                      206628 ~0%       {2} r12 = AGGREGATE r8, r11 ON In.3, In.4, In.5, In.6 WITH CONCAT<2 DESC3 ASC> OUTPUT In.0, Agg.0
                      206628           {2} r13 = MATERIALIZE r12 AS unknown
                      
                      235074 ~13%      {2} r14 = JOIN r6 WITH r13 ON FIRST 1 OUTPUT Lhs.0 'this', Rhs.1 'result'
                      
                      0      ~0%       {4} r15 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Lhs.2, Rhs.1
                      
                      0      ~0%       {6} r16 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Lhs.2, Rhs.1, (Rhs.1 - 2), 0
                      0      ~0%       {7} r17 = JOIN r16 WITH PRIMITIVE range#bbf ON Lhs.5,Lhs.4
                      0      ~0%       {4} r18 = SCAN r17 OUTPUT In.0, In.1 'this', In.2, In.3
                      0                {4} r19 = MATERIALIZE r18 AS unknown
                      
                      0      ~0%       {4} r20 = r15 AND NOT r19(Lhs.0, Lhs.1 'this', Lhs.2, Lhs.3)
                      0      ~0%       {2} r21 = SCAN r20 OUTPUT In.1 'this', (In.2 ++ "[" ++ "" ++ "]")
                      
                      0      ~0%       {3} r22 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'this', Lhs.2
                      
                      0      ~0%       {7} r23 = JOIN r1 WITH Unification::Gvn::Cached::TArrayTypeKind#fff_21#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'this', Lhs.2, Rhs.1, ",", (Rhs.1 - 2), 0
                      0      ~0%       {8} r24 = JOIN r23 WITH PRIMITIVE range#bbf ON Lhs.6,Lhs.5
                      
                      0      ~0%       {4} r25 = SCAN r24 OUTPUT In.3, In.7, ",", ""
                      0                {4} r26 = MATERIALIZE r25 AS unknown
                      
                      0      ~0%       {6} r27 = SCAN r24 OUTPUT In.3, In.7, ",", "", ",", ""
                      0                {6} r28 = MATERIALIZE r27 AS unknown
                      
                      0      ~0%       {2} r29 = AGGREGATE r26, r28 ON In.4, In.5 WITH CONCAT<0 ASC> OUTPUT In.0, Agg.0
                      0                {2} r30 = MATERIALIZE r29 AS unknown
                      
                      0      ~0%       {2} r31 = JOIN r22 WITH r30 ON FIRST 1 OUTPUT Lhs.1 'this', (Lhs.2 ++ "[" ++ Rhs.1 ++ "]")
                      
                      0      ~0%       {2} r32 = r21 UNION r31
                      235074 ~13%      {2} r33 = r14 UNION r32
                      235074 ~13%      {2} r34 = r4 UNION r33
                      235074 ~13%      {2} r35 = r34 AND NOT Unification::Gvn::ConstructedGvnTypeList::toString#ff#prev(Lhs.0 'this', Lhs.1 'result')
                                       return r35
[2021-10-07 13:42:27] (4s) 			 - Unification::Gvn::ConstructedGvnTypeList::toString#ff_delta has 206628 rows (order for disjuncts: delta=500000).
```