### PR TITLE
C#: Avoid bad magic in `interpretElement0`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -404,6 +404,7 @@ private string paramsString(InterpretedCallable c) {
     )
 }
 
+pragma[nomagic]
 private Element interpretElement0(
   string namespace, string type, boolean subtypes, string name, string signature
 ) {


### PR DESCRIPTION
This should hopefully fix the failing `UntrustedDataToExternalAPI.qlref` and `ExternalAPIsUsedWithUntrustedData.qlref` tests.