### PR TITLE
Docs: Update beta note for packaging

### DIFF
--- a/docs/codeql/reusables/beta-note-package-management.rst
+++ b/docs/codeql/reusables/beta-note-package-management.rst
@@ -2,4 +2,4 @@
 
     Note
 
-    The CodeQL package management functionality, including CodeQL packs, is currently available as a beta release and is subject to change. During the beta release, CodeQL packs are available only using GitHub Packages - the GitHub Container registry. To use this beta functionality, install the beta release of the CodeQL CLI bundle from: https://github.com/github/codeql-action/releases/tag/codeql-bundle-v2.6.0-beta.1.
+    The CodeQL package management functionality, including CodeQL packs, is currently available as a beta release and is subject to change. During the beta release, CodeQL packs are available only using GitHub Packages - the GitHub Container registry. To use this beta functionality, install version 2.6.0 or higher of the CodeQL CLI bundle from: https://github.com/github/codeql-action/releases.


### PR DESCRIPTION
The note at the top of https://codeql.github.com/docs/codeql-cli/about-codeql-packs/ is out-of-date. The packaging functionality is still in preview/beta, but any version of the CLI from 2.6.0 onwards contains the features (no need to download `2.6.0-beta` specifically!)