### PR TITLE
Docs: Fix one-word typo

### DIFF
--- a/docs/codeql/reusables/license-note.rst
+++ b/docs/codeql/reusables/license-note.rst
@@ -4,7 +4,7 @@
    `GitHub CodeQL Terms and Conditions <https://securitylab.github.com/tools/codeql/license>`__.
    
    GitHub CodeQL is licensed on a per-user basis. Under the license restrictions,
-   you can CodeQL to perform the following tasks:
+   you can use CodeQL to perform the following tasks:
    
    - To perform academic research.
    - To demonstrate the software.


### PR DESCRIPTION
Fix the typo in: docs/codeql/reusables/license-note.rst: "you can CodeQL to perform". 

This is displayed on: 
* https://codeql.github.com/docs/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code/ 
* https://codeql.github.com/docs/codeql-cli/getting-started-with-the-codeql-cli/