### PR TITLE
JS: skip pipes and other special files when determining which files to extract

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -991,7 +991,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
           @Override
           public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
               throws IOException {
-            if (attrs.isSymbolicLink()) return FileVisitResult.SKIP_SUBTREE;
+            if (!attrs.isRegularFile() && !attrs.isDirectory()) return FileVisitResult.SKIP_SUBTREE;
 
             if (!file.equals(currentRoot[0]) && excludes.contains(file))
               return FileVisitResult.SKIP_SUBTREE;


### PR DESCRIPTION
I don't think we can add a test for this.