### PR TITLE
QlPacks: Add the defaultSuite to query packs that are missing it

### DIFF
--- a/csharp/ql/examples/qlpack.yml
+++ b/csharp/ql/examples/qlpack.yml
@@ -1,4 +1,4 @@
-name: codeql-csharp-examples
+name: codeql/csharp-examples
 version: 0.0.2
 dependencies:
   codeql/csharp-all: "*"

--- a/csharp/ql/src/qlpack.yml
+++ b/csharp/ql/src/qlpack.yml
@@ -2,6 +2,7 @@ name: codeql/csharp-queries
 version: 0.0.2
 suites: codeql-suites
 extractor: csharp
+defaultSuiteFile: codeql-suites/csharp-code-scanning.qls
 dependencies:
   codeql/csharp-all: "*"
   codeql/suite-helpers: "*"

--- a/java/ql/examples/qlpack.yml
+++ b/java/ql/examples/qlpack.yml
@@ -1,4 +1,4 @@
-name: codeql-java-examples
+name: codeql/java-examples
 version: 0.0.2
 dependencies:
     codeql/java-all: "*"

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -2,6 +2,7 @@ name: codeql/java-queries
 version: 0.0.2
 suites: codeql-suites
 extractor: java
+defaultSuiteFile: codeql-suites/java-code-scanning.qls
 dependencies:
     codeql/java-all: "*"
     codeql/suite-helpers: "*"

--- a/javascript/ql/examples/qlpack.yml
+++ b/javascript/ql/examples/qlpack.yml
@@ -1,4 +1,4 @@
-name: codeql-javascript-examples
+name: codeql/javascript-examples
 version: 0.0.3
 dependencies:
   codeql/javascript-all: "*"

--- a/javascript/ql/src/qlpack.yml
+++ b/javascript/ql/src/qlpack.yml
@@ -2,6 +2,7 @@ name: codeql/javascript-queries
 version: 0.0.3
 suites: codeql-suites
 extractor: javascript
+defaultSuiteFile: codeql-suites/javascript-code-scanning.qls
 dependencies:
     codeql/javascript-all: "*"
     codeql/suite-helpers: "*"


### PR DESCRIPTION
Also, change some examples pack names from `codeql-lang-examples` to `codeql/lang-examples`. These name changes don't affect behaviour since internally, the legacy name is converted to the modern name.