### PR TITLE
Data flow: Performance tweaks

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -3563,10 +3563,15 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, AccessPathApprox apa, Configuration config
+  AccessPath ap, Configuration config
 ) {
-  pathIntoArg(mid, i, outercc, call, ap, apa, config) and
-  callable = resolveCall(call, outercc)
+  exists(AccessPathApprox apa |
+    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+      pragma[only_bind_into](config)) and
+    callable = resolveCall(call, outercc) and
+    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+      pragma[only_bind_into](config))
+  )
 }
 
 /**
@@ -3579,9 +3584,8 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap, AccessPathApprox apa |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, apa, config) and
-    parameterCand(callable, i, apa, config) and
+  exists(int i, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
     p.isParameterOf(callable, i) and
     (
       sc = TSummaryCtxSome(p, ap)


### PR DESCRIPTION
The first commit prevents the following bad join-order:
```
[2021-10-13 15:40:13] (218s) Tuple counts for DataFlowImpl2::pathIntoCallable0#ffffff/6@i5#dc2236 after 32.5s:
                      26111     ~0%     {6} r1 = SCAN DataFlowImpl2::pathIntoArg#ffffff#reorder_0_5_1_2_3_4#prev_delta OUTPUT In.0 'mid', In.2 'i', In.3 'outercc', In.4 'call', In.5 'ap', In.1
                      26111     ~3%     {7} r2 = JOIN r1 WITH DataFlowImpl2::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev ON FIRST 1 OUTPUT Lhs.5, Rhs.1, Lhs.0 'mid', Lhs.1 'i', Lhs.2 'outercc', Lhs.3 'call', Lhs.4 'ap'
                      139380518 ~2%     {9} r3 = JOIN r2 WITH DataFlowImpl2::parameterCand#fffb_2301#join_rhs ON FIRST 2 OUTPUT Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.5 'call', Lhs.6 'ap', Lhs.0, Lhs.1, Rhs.2 'callable', Rhs.3
                      109467228 ~1%     {9} r4 = SELECT r3 ON In.8 <= In.1 'i'
                      104255056 ~1%     {9} r5 = SELECT r4 ON In.8 >= In.1 'i'
                      
                      104255056 ~2%     {6} r6 = SCAN r5 OUTPUT In.2 'outercc', In.0 'mid', In.1 'i', In.3 'call', In.4 'ap', In.7 'callable'
                      
                      104255056 ~6%     {6} r7 = JOIN r6 WITH DataFlowImplCommon::Cached::TAnyCallContext#f@staged_ext ON FIRST 1 OUTPUT Lhs.3 'call', Lhs.5 'callable', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap'
                      9078      ~0%     {6} r8 = JOIN r7 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 2 OUTPUT Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.0 'call', Lhs.5 'ap', Lhs.1 'callable'
                      
                      0         ~0%     {6} r9 = JOIN r6 WITH DataFlowImplCommon::Cached::TSomeCall#f@staged_ext ON FIRST 1 OUTPUT Lhs.3 'call', Lhs.5 'callable', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap'
                      0         ~0%     {6} r10 = JOIN r9 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 2 OUTPUT Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.0 'call', Lhs.5 'ap', Lhs.1 'callable'
                      
                      104255056 ~6%     {6} r11 = SCAN r5 OUTPUT In.3 'call', In.7 'callable', In.0 'mid', In.1 'i', In.2 'outercc', In.4 'ap'
                      9078      ~9%     {6} r12 = JOIN r11 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 2 OUTPUT Lhs.4 'outercc', Lhs.2 'mid', Lhs.3 'i', Lhs.0 'call', Lhs.5 'ap', Lhs.1 'callable'
                      0         ~0%     {6} r13 = JOIN r12 WITH DataFlowImplCommon::Cached::TReturn#fff_2#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.3 'call', Lhs.4 'ap', Lhs.5 'callable'
                      
                      0         ~0%     {6} r14 = r10 UNION r13
                      9078      ~0%     {6} r15 = r8 UNION r14
                      
                      0         ~0%     {7} r16 = JOIN r6 WITH DataFlowImplCommon::Cached::TSpecificCall#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.3 'call', Rhs.1, Lhs.5 'callable', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap'
                      0         ~0%     {7} r17 = JOIN r16 WITH DataFlowImplCommon::Cached::DispatchWithCallContext::prunedViableImplInCallContext#fff@staged_ext ON FIRST 3 OUTPUT Lhs.0 'call', Lhs.1, Lhs.3 'mid', Lhs.4 'i', Lhs.5 'outercc', Lhs.6 'ap', Lhs.2 'callable'
                      0         ~0%     {6} r18 = JOIN r17 WITH project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext ON FIRST 2 OUTPUT Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.0 'call', Lhs.5 'ap', Lhs.6 'callable'
                      
                      104255056 ~0%     {7} r19 = SCAN r5 OUTPUT In.2 'outercc', In.0 'mid', In.1 'i', In.3 'call', In.4 'ap', In.7 'callable', In.8
                      0         ~0%     {8} r20 = JOIN r19 WITH DataFlowImplCommon::Cached::TSpecificCall#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.3 'call', Lhs.5 'callable', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap', Lhs.6, Rhs.1
                      0         ~0%     {8} r21 = JOIN r20 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 2 OUTPUT Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.0 'call', Lhs.5 'ap', Lhs.1 'callable', Lhs.6, Lhs.7
                      0         ~0%     {8} r22 = r21 AND NOT project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext(Lhs.3 'call', Lhs.7)
                      0         ~0%     {6} r23 = SCAN r22 OUTPUT In.0 'mid', In.1 'i', In.2 'outercc', In.3 'call', In.4 'ap', In.5 'callable'
                      
                      26111     ~0%     {6} r24 = SCAN DataFlowImpl2::pathIntoArg#ffffff#reorder_0_5_1_2_3_4#prev OUTPUT In.0 'mid', In.2 'i', In.3 'outercc', In.4 'call', In.5 'ap', In.1
                      0         ~0%     {7} r25 = JOIN r24 WITH DataFlowImpl2::PathNodeMid#class#ffffff#reorder_0_5_1_2_3_4#prev_delta ON FIRST 1 OUTPUT Lhs.2 'outercc', Lhs.0 'mid', Lhs.1 'i', Lhs.3 'call', Lhs.4 'ap', Lhs.5, Rhs.1
                      
                      0         ~0%     {7} r26 = JOIN r25 WITH DataFlowImplCommon::Cached::TAnyCallContext#f@staged_ext ON FIRST 1 OUTPUT Lhs.3 'call', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap', Lhs.5, Lhs.6
                      0         ~0%     {8} r27 = JOIN r26 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 1 OUTPUT Rhs.1 'callable', Lhs.5, Lhs.6, Lhs.1 'mid', Lhs.2 'i', Lhs.3 'outercc', Lhs.0 'call', Lhs.4 'ap'
                      
                      0         ~0%     {7} r28 = JOIN r25 WITH DataFlowImplCommon::Cached::TSomeCall#f@staged_ext ON FIRST 1 OUTPUT Lhs.3 'call', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap', Lhs.5, Lhs.6
                      0         ~0%     {8} r29 = JOIN r28 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 1 OUTPUT Rhs.1 'callable', Lhs.5, Lhs.6, Lhs.1 'mid', Lhs.2 'i', Lhs.3 'outercc', Lhs.0 'call', Lhs.4 'ap'
                      
                      0         ~0%     {8} r30 = r27 UNION r29
                      
                      0         ~0%     {7} r31 = JOIN r25 WITH DataFlowImplCommon::Cached::TReturn#fff_2#join_rhs ON FIRST 1 OUTPUT Lhs.3 'call', Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap', Lhs.5, Lhs.6
                      0         ~0%     {8} r32 = JOIN r31 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 1 OUTPUT Rhs.1 'callable', Lhs.5, Lhs.6, Lhs.1 'mid', Lhs.2 'i', Lhs.3 'outercc', Lhs.0 'call', Lhs.4 'ap'
                      
                      0         ~0%     {8} r33 = JOIN r25 WITH DataFlowImplCommon::Cached::TSpecificCall#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.3 'call', Lhs.4 'ap', Lhs.5, Lhs.6, Rhs.1
                      0         ~0%     {8} r34 = r33 AND NOT project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext(Lhs.3 'call', Lhs.7)
                      0         ~0%     {7} r35 = SCAN r34 OUTPUT In.3 'call', In.0 'mid', In.1 'i', In.2 'outercc', In.4 'ap', In.5, In.6
                      0         ~0%     {8} r36 = JOIN r35 WITH DataFlowImplCommon::viableCallableExt#ff ON FIRST 1 OUTPUT Rhs.1 'callable', Lhs.5, Lhs.6, Lhs.1 'mid', Lhs.2 'i', Lhs.3 'outercc', Lhs.0 'call', Lhs.4 'ap'
                      
                      0         ~0%     {8} r37 = JOIN r25 WITH DataFlowImplCommon::Cached::TSpecificCall#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.3 'call', Rhs.1, Lhs.1 'mid', Lhs.2 'i', Lhs.0 'outercc', Lhs.4 'ap', Lhs.5, Lhs.6
                      0         ~0%     {8} r38 = JOIN r37 WITH project#DataFlowImplCommon::Cached::DispatchWithCallContext::reducedViableImplInCallContext ON FIRST 2 OUTPUT Lhs.0 'call', Lhs.1, Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.5 'ap', Lhs.6, Lhs.7
                      0         ~0%     {8} r39 = JOIN r38 WITH DataFlowImplCommon::Cached::DispatchWithCallContext::prunedViableImplInCallContext#fff@staged_ext ON FIRST 2 OUTPUT Rhs.2 'callable', Lhs.6, Lhs.7, Lhs.2 'mid', Lhs.3 'i', Lhs.4 'outercc', Lhs.0 'call', Lhs.5 'ap'
                      
                      0         ~0%     {8} r40 = r36 UNION r39
                      0         ~0%     {8} r41 = r32 UNION r40
                      0         ~0%     {8} r42 = r30 UNION r41
                      0         ~0%     {9} r43 = JOIN r42 WITH DataFlowImpl2::parameterCand#fffb_0231#join_rhs ON FIRST 3 OUTPUT Lhs.3 'mid', Lhs.4 'i', Lhs.5 'outercc', Lhs.6 'call', Lhs.7 'ap', Lhs.1, Lhs.2, Lhs.0 'callable', Rhs.3
                      0         ~0%     {9} r44 = SELECT r43 ON In.8 <= In.1 'i'
                      0         ~0%     {9} r45 = SELECT r44 ON In.8 >= In.1 'i'
                      0         ~0%     {6} r46 = SCAN r45 OUTPUT In.0 'mid', In.1 'i', In.2 'outercc', In.3 'call', In.4 'ap', In.7 'callable'
                      
                      0         ~0%     {6} r47 = r23 UNION r46
                      0         ~0%     {6} r48 = r18 UNION r47
                      9078      ~0%     {6} r49 = r15 UNION r48
                      9078      ~0%     {6} r50 = r49 AND NOT DataFlowImpl2::pathIntoCallable0#ffffff#prev(Lhs.0 'mid', Lhs.5 'callable', Lhs.1 'i', Lhs.2 'outercc', Lhs.3 'call', Lhs.4 'ap')
                      9078      ~2%     {6} r51 = SCAN r50 OUTPUT In.0 'mid', In.5 'callable', In.1 'i', In.2 'outercc', In.3 'call', In.4 'ap'
                                        return r51
```

The second commit avoids unnecessary non-linear recursion in `pathIntoCallable`, `pathThroughCallable0`, and `pathThroughCallable`, by avoiding calls to `mid.getConfiguration()`.