### PR TITLE
C++: Remove all uses of implicit `this`

### DIFF
--- a/cpp/ql/lib/external/ExternalArtifact.qll
+++ b/cpp/ql/lib/external/ExternalArtifact.qll
@@ -15,7 +15,7 @@ class ExternalData extends @externalDataElement {
    * Gets the path of the file this data was loaded from, with its
    * extension replaced by `.ql`.
    */
-  string getQueryPath() { result = getDataPath().regexpReplaceAll("\\.[^.]*$", ".ql") }
+  string getQueryPath() { result = this.getDataPath().regexpReplaceAll("\\.[^.]*$", ".ql") }
 
   /** Gets the number of fields in this data item. */
   int getNumFields() { result = 1 + max(int i | externalData(this, _, i, _) | i) }
@@ -24,22 +24,22 @@ class ExternalData extends @externalDataElement {
   string getField(int i) { externalData(this, _, i, result) }
 
   /** Gets the integer value of the `i`th field of this data item. */
-  int getFieldAsInt(int i) { result = getField(i).toInt() }
+  int getFieldAsInt(int i) { result = this.getField(i).toInt() }
 
   /** Gets the floating-point value of the `i`th field of this data item. */
-  float getFieldAsFloat(int i) { result = getField(i).toFloat() }
+  float getFieldAsFloat(int i) { result = this.getField(i).toFloat() }
 
   /** Gets the value of the `i`th field of this data item, interpreted as a date. */
-  date getFieldAsDate(int i) { result = getField(i).toDate() }
+  date getFieldAsDate(int i) { result = this.getField(i).toDate() }
 
   /** Gets a textual representation of this data item. */
-  string toString() { result = getQueryPath() + ": " + buildTupleString(0) }
+  string toString() { result = this.getQueryPath() + ": " + this.buildTupleString(0) }
 
   /** Gets a textual representation of this data item, starting with the `n`th field. */
   private string buildTupleString(int n) {
-    n = getNumFields() - 1 and result = getField(n)
+    n = this.getNumFields() - 1 and result = this.getField(n)
     or
-    n < getNumFields() - 1 and result = getField(n) + "," + buildTupleString(n + 1)
+    n < this.getNumFields() - 1 and result = this.getField(n) + "," + this.buildTupleString(n + 1)
   }
 }
 
@@ -53,8 +53,8 @@ class DefectExternalData extends ExternalData {
   }
 
   /** Gets the URL associated with this data item. */
-  string getURL() { result = getField(0) }
+  string getURL() { result = this.getField(0) }
 
   /** Gets the message associated with this data item. */
-  string getMessage() { result = getField(1) }
+  string getMessage() { result = this.getField(1) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/Class.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Class.qll
@@ -269,13 +269,13 @@ class Class extends UserType {
    * DEPRECATED: name changed to `hasImplicitCopyConstructor` to reflect that
    * `= default` members are no longer included.
    */
-  deprecated predicate hasGeneratedCopyConstructor() { hasImplicitCopyConstructor() }
+  deprecated predicate hasGeneratedCopyConstructor() { this.hasImplicitCopyConstructor() }
 
   /**
    * DEPRECATED: name changed to `hasImplicitCopyAssignmentOperator` to
    * reflect that `= default` members are no longer included.
    */
-  deprecated predicate hasGeneratedCopyAssignmentOperator() { hasImplicitCopyConstructor() }
+  deprecated predicate hasGeneratedCopyAssignmentOperator() { this.hasImplicitCopyConstructor() }
 
   /**
    * Holds if this class, struct or union has an implicitly-declared copy
@@ -487,7 +487,7 @@ class Class extends UserType {
     exists(ClassDerivation cd |
       // Add the offset of the direct base class and the offset of `baseClass`
       // within that direct base class.
-      cd = getADerivation() and
+      cd = this.getADerivation() and
       result = cd.getBaseClass().getANonVirtualBaseClassByteOffset(baseClass) + cd.getByteOffset()
     )
   }
@@ -502,12 +502,12 @@ class Class extends UserType {
    */
   int getABaseClassByteOffset(Class baseClass) {
     // Handle the non-virtual case.
-    result = getANonVirtualBaseClassByteOffset(baseClass)
+    result = this.getANonVirtualBaseClassByteOffset(baseClass)
     or
     exists(Class virtualBaseClass, int virtualBaseOffset, int offsetFromVirtualBase |
       // Look for the base class as a non-virtual base of a direct or indirect
       // virtual base, adding the two offsets.
-      getVirtualBaseClassByteOffset(virtualBaseClass) = virtualBaseOffset and
+      this.getVirtualBaseClassByteOffset(virtualBaseClass) = virtualBaseOffset and
       offsetFromVirtualBase = virtualBaseClass.getANonVirtualBaseClassByteOffset(baseClass) and
       result = virtualBaseOffset + offsetFromVirtualBase
     )
@@ -623,11 +623,11 @@ class Class extends UserType {
    * inherits one).
    */
   predicate isPolymorphic() {
-    exists(MemberFunction f | f.getDeclaringType() = getABaseClass*() and f.isVirtual())
+    exists(MemberFunction f | f.getDeclaringType() = this.getABaseClass*() and f.isVirtual())
   }
 
   override predicate involvesTemplateParameter() {
-    getATemplateArgument().(Type).involvesTemplateParameter()
+    this.getATemplateArgument().(Type).involvesTemplateParameter()
   }
 
   /** Holds if this class, struct or union was declared 'final'. */
@@ -765,7 +765,7 @@ class ClassDerivation extends Locatable, @derivation {
    * };
    * ```
    */
-  Class getBaseClass() { result = getBaseType().getUnderlyingType() }
+  Class getBaseClass() { result = this.getBaseType().getUnderlyingType() }
 
   override string getAPrimaryQlClass() { result = "ClassDerivation" }
 
@@ -818,7 +818,7 @@ class ClassDerivation extends Locatable, @derivation {
   predicate hasSpecifier(string s) { this.getASpecifier().hasName(s) }
 
   /** Holds if the derivation is for a virtual base class. */
-  predicate isVirtual() { hasSpecifier("virtual") }
+  predicate isVirtual() { this.hasSpecifier("virtual") }
 
   /** Gets the location of the derivation. */
   override Location getLocation() { derivations(underlyingElement(this), _, _, _, result) }
@@ -846,7 +846,7 @@ class ClassDerivation extends Locatable, @derivation {
  * ```
  */
 class LocalClass extends Class {
-  LocalClass() { isLocal() }
+  LocalClass() { this.isLocal() }
 
   override string getAPrimaryQlClass() { not this instanceof LocalStruct and result = "LocalClass" }
 
@@ -989,9 +989,9 @@ class ClassTemplateSpecialization extends Class {
   TemplateClass getPrimaryTemplate() {
     // Ignoring template arguments, the primary template has the same name
     // as each of its specializations.
-    result.getSimpleName() = getSimpleName() and
+    result.getSimpleName() = this.getSimpleName() and
     // It is in the same namespace as its specializations.
-    result.getNamespace() = getNamespace() and
+    result.getNamespace() = this.getNamespace() and
     // It is distinguished by the fact that each of its template arguments
     // is a distinct template parameter.
     count(TemplateParameter tp | tp = result.getATemplateArgument()) =
@@ -1108,7 +1108,7 @@ deprecated class Interface extends Class {
  * ```
  */
 class VirtualClassDerivation extends ClassDerivation {
-  VirtualClassDerivation() { hasSpecifier("virtual") }
+  VirtualClassDerivation() { this.hasSpecifier("virtual") }
 
   override string getAPrimaryQlClass() { result = "VirtualClassDerivation" }
 }
@@ -1136,7 +1136,7 @@ class VirtualBaseClass extends Class {
   VirtualClassDerivation getAVirtualDerivation() { result.getBaseClass() = this }
 
   /** A class/struct that is derived from this one using virtual inheritance. */
-  Class getAVirtuallyDerivedClass() { result = getAVirtualDerivation().getDerivedClass() }
+  Class getAVirtuallyDerivedClass() { result = this.getAVirtualDerivation().getDerivedClass() }
 }
 
 /**
@@ -1155,7 +1155,7 @@ class ProxyClass extends UserType {
   override string getAPrimaryQlClass() { result = "ProxyClass" }
 
   /** Gets the location of the proxy class. */
-  override Location getLocation() { result = getTemplateParameter().getDefinitionLocation() }
+  override Location getLocation() { result = this.getTemplateParameter().getDefinitionLocation() }
 
   /** Gets the template parameter for which this is the proxy class. */
   TemplateParameter getTemplateParameter() {

--- a/cpp/ql/lib/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Declaration.qll
@@ -184,7 +184,7 @@ class Declaration extends Locatable, @declaration {
   predicate hasDefinition() { exists(this.getDefinition()) }
 
   /** DEPRECATED: Use `hasDefinition` instead. */
-  predicate isDefined() { hasDefinition() }
+  predicate isDefined() { this.hasDefinition() }
 
   /** Gets the preferred location of this declaration, if any. */
   override Location getLocation() { none() }
@@ -209,7 +209,7 @@ class Declaration extends Locatable, @declaration {
   predicate isStatic() { this.hasSpecifier("static") }
 
   /** Holds if this declaration is a member of a class/struct/union. */
-  predicate isMember() { hasDeclaringType() }
+  predicate isMember() { this.hasDeclaringType() }
 
   /** Holds if this declaration is a member of a class/struct/union. */
   predicate hasDeclaringType() { exists(this.getDeclaringType()) }
@@ -226,14 +226,14 @@ class Declaration extends Locatable, @declaration {
    * When called on a template, this will return a template parameter type for
    * both typed and non-typed parameters.
    */
-  final Locatable getATemplateArgument() { result = getTemplateArgument(_) }
+  final Locatable getATemplateArgument() { result = this.getTemplateArgument(_) }
 
   /**
    * Gets a template argument used to instantiate this declaration from a template.
    * When called on a template, this will return a non-typed template
    * parameter value.
    */
-  final Locatable getATemplateArgumentKind() { result = getTemplateArgumentKind(_) }
+  final Locatable getATemplateArgumentKind() { result = this.getTemplateArgumentKind(_) }
 
   /**
    * Gets the `i`th template argument used to instantiate this declaration from a
@@ -252,9 +252,9 @@ class Declaration extends Locatable, @declaration {
    * `getTemplateArgument(1)` return `1`.
    */
   final Locatable getTemplateArgument(int index) {
-    if exists(getTemplateArgumentValue(index))
-    then result = getTemplateArgumentValue(index)
-    else result = getTemplateArgumentType(index)
+    if exists(this.getTemplateArgumentValue(index))
+    then result = this.getTemplateArgumentValue(index)
+    else result = this.getTemplateArgumentType(index)
   }
 
   /**
@@ -275,13 +275,13 @@ class Declaration extends Locatable, @declaration {
    * `getTemplateArgumentKind(0)`.
    */
   final Locatable getTemplateArgumentKind(int index) {
-    exists(getTemplateArgumentValue(index)) and
-    result = getTemplateArgumentType(index)
+    exists(this.getTemplateArgumentValue(index)) and
+    result = this.getTemplateArgumentType(index)
   }
 
   /** Gets the number of template arguments for this declaration. */
   final int getNumberOfTemplateArguments() {
-    result = count(int i | exists(getTemplateArgument(i)))
+    result = count(int i | exists(this.getTemplateArgument(i)))
   }
 
   private Type getTemplateArgumentType(int index) {
@@ -327,9 +327,9 @@ class DeclarationEntry extends Locatable, TDeclarationEntry {
    * available), or the name declared by this entry otherwise.
    */
   string getCanonicalName() {
-    if getDeclaration().hasDefinition()
-    then result = getDeclaration().getDefinition().getName()
-    else result = getName()
+    if this.getDeclaration().hasDefinition()
+    then result = this.getDeclaration().getDefinition().getName()
+    else result = this.getName()
   }
 
   /**
@@ -370,18 +370,18 @@ class DeclarationEntry extends Locatable, TDeclarationEntry {
   /**
    * Holds if this declaration entry has a specifier with the given name.
    */
-  predicate hasSpecifier(string specifier) { getASpecifier() = specifier }
+  predicate hasSpecifier(string specifier) { this.getASpecifier() = specifier }
 
   /** Holds if this declaration entry is a definition. */
   predicate isDefinition() { none() } // overridden in subclasses
 
   override string toString() {
-    if isDefinition()
-    then result = "definition of " + getName()
+    if this.isDefinition()
+    then result = "definition of " + this.getName()
     else
-      if getName() = getCanonicalName()
-      then result = "declaration of " + getName()
-      else result = "declaration of " + getCanonicalName() + " as " + getName()
+      if this.getName() = this.getCanonicalName()
+      then result = "declaration of " + this.getName()
+      else result = "declaration of " + this.getCanonicalName() + " as " + this.getName()
   }
 }
 
@@ -580,7 +580,7 @@ private class DirectAccessHolder extends Element {
     // transitive closure with a restricted base case.
     this.thisCanAccessClassStep(base, derived)
     or
-    exists(Class between | thisCanAccessClassTrans(base, between) |
+    exists(Class between | this.thisCanAccessClassTrans(base, between) |
       isDirectPublicBaseOf(between, derived) or
       this.thisCanAccessClassStep(between, derived)
     )

--- a/cpp/ql/lib/semmle/code/cpp/Element.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Element.qll
@@ -61,7 +61,7 @@ class ElementBase extends @element {
   /**
    * Gets a comma-separated list of the names of the primary CodeQL classes to which this element belongs.
    */
-  final string getPrimaryQlClasses() { result = concat(getAPrimaryQlClass(), ",") }
+  final string getPrimaryQlClasses() { result = concat(this.getAPrimaryQlClass(), ",") }
 
   /**
    * Gets the name of a primary CodeQL class to which this element belongs.
@@ -206,9 +206,9 @@ class Element extends ElementBase {
   /** Gets the closest `Element` enclosing this one. */
   cached
   Element getEnclosingElement() {
-    result = getEnclosingElementPref()
+    result = this.getEnclosingElementPref()
     or
-    not exists(getEnclosingElementPref()) and
+    not exists(this.getEnclosingElementPref()) and
     (
       this = result.(Class).getAMember()
       or
@@ -281,7 +281,7 @@ private predicate isFromUninstantiatedTemplateRec(Element e, Element template) {
  * ```
  */
 class StaticAssert extends Locatable, @static_assert {
-  override string toString() { result = "static_assert(..., \"" + getMessage() + "\")" }
+  override string toString() { result = "static_assert(..., \"" + this.getMessage() + "\")" }
 
   /**
    * Gets the expression which this static assertion ensures is true.

--- a/cpp/ql/lib/semmle/code/cpp/Enum.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Enum.qll
@@ -85,7 +85,7 @@ class Enum extends UserType, IntegralOrEnumType {
  * ```
  */
 class LocalEnum extends Enum {
-  LocalEnum() { isLocal() }
+  LocalEnum() { this.isLocal() }
 
   override string getAPrimaryQlClass() { result = "LocalEnum" }
 }

--- a/cpp/ql/lib/semmle/code/cpp/File.qll
+++ b/cpp/ql/lib/semmle/code/cpp/File.qll
@@ -52,7 +52,7 @@ class Container extends Locatable, @container {
    */
   string getRelativePath() {
     exists(string absPath, string pref |
-      absPath = getAbsolutePath() and sourceLocationPrefix(pref)
+      absPath = this.getAbsolutePath() and sourceLocationPrefix(pref)
     |
       absPath = pref and result = ""
       or
@@ -79,7 +79,7 @@ class Container extends Locatable, @container {
    * </table>
    */
   string getBaseName() {
-    result = getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
+    result = this.getAbsolutePath().regexpCapture(".*/(([^/]*?)(?:\\.([^.]*))?)", 1)
   }
 
   /**
@@ -105,7 +105,9 @@ class Container extends Locatable, @container {
    * <tr><td>"/tmp/x.tar.gz"</td><td>"gz"</td></tr>
    * </table>
    */
-  string getExtension() { result = getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3) }
+  string getExtension() {
+    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(\\.([^.]*))?", 3)
+  }
 
   /**
    * Gets the stem of this container, that is, the prefix of its base name up to
@@ -124,7 +126,9 @@ class Container extends Locatable, @container {
    * <tr><td>"/tmp/x.tar.gz"</td><td>"x.tar"</td></tr>
    * </table>
    */
-  string getStem() { result = getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1) }
+  string getStem() {
+    result = this.getAbsolutePath().regexpCapture(".*/([^/]*?)(?:\\.([^.]*))?", 1)
+  }
 
   /** Gets the parent container of this file or folder, if any. */
   Container getParentContainer() {
@@ -135,20 +139,20 @@ class Container extends Locatable, @container {
   Container getAChildContainer() { this = result.getParentContainer() }
 
   /** Gets a file in this container. */
-  File getAFile() { result = getAChildContainer() }
+  File getAFile() { result = this.getAChildContainer() }
 
   /** Gets the file in this container that has the given `baseName`, if any. */
   File getFile(string baseName) {
-    result = getAFile() and
+    result = this.getAFile() and
     result.getBaseName() = baseName
   }
 
   /** Gets a sub-folder in this container. */
-  Folder getAFolder() { result = getAChildContainer() }
+  Folder getAFolder() { result = this.getAChildContainer() }
 
   /** Gets the sub-folder in this container that has the given `baseName`, if any. */
   Folder getFolder(string baseName) {
-    result = getAFolder() and
+    result = this.getAFolder() and
     result.getBaseName() = baseName
   }
 
@@ -157,7 +161,7 @@ class Container extends Locatable, @container {
    *
    * This is the absolute path of the container.
    */
-  override string toString() { result = getAbsolutePath() }
+  override string toString() { result = this.getAbsolutePath() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/Function.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Function.qll
@@ -43,26 +43,26 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    */
   string getFullSignature() {
     exists(string name, string templateArgs, string args |
-      result = name + templateArgs + args + " -> " + getType().toString() and
-      name = getQualifiedName() and
+      result = name + templateArgs + args + " -> " + this.getType().toString() and
+      name = this.getQualifiedName() and
       (
-        if exists(getATemplateArgument())
+        if exists(this.getATemplateArgument())
         then
           templateArgs =
             "<" +
               concat(int i |
-                exists(getTemplateArgument(i))
+                exists(this.getTemplateArgument(i))
               |
-                getTemplateArgument(i).toString(), ", " order by i
+                this.getTemplateArgument(i).toString(), ", " order by i
               ) + ">"
         else templateArgs = ""
       ) and
       args =
         "(" +
           concat(int i |
-            exists(getParameter(i))
+            exists(this.getParameter(i))
           |
-            getParameter(i).getType().toString(), ", " order by i
+            this.getParameter(i).getType().toString(), ", " order by i
           ) + ")"
     )
   }
@@ -70,7 +70,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   /** Gets a specifier of this function. */
   override Specifier getASpecifier() {
     funspecifiers(underlyingElement(this), unresolveElement(result)) or
-    result.hasName(getADeclarationEntry().getASpecifier())
+    result.hasName(this.getADeclarationEntry().getASpecifier())
   }
 
   /** Gets an attribute of this function. */
@@ -149,7 +149,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * Holds if this function is declared with `__attribute__((naked))` or
    * `__declspec(naked)`.
    */
-  predicate isNaked() { getAnAttribute().hasName("naked") }
+  predicate isNaked() { this.getAnAttribute().hasName("naked") }
 
   /**
    * Holds if this function has a trailing return type.
@@ -172,7 +172,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * Gets the return type of this function after specifiers have been deeply
    * stripped and typedefs have been resolved.
    */
-  Type getUnspecifiedType() { result = getType().getUnspecifiedType() }
+  Type getUnspecifiedType() { result = this.getType().getUnspecifiedType() }
 
   /**
    * Gets the nth parameter of this function. There is no result for the
@@ -206,7 +206,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   int getEffectiveNumberOfParameters() {
     // This method is overridden in `MemberFunction`, where the result is
     // adjusted to account for the implicit `this` parameter.
-    result = getNumberOfParameters()
+    result = this.getNumberOfParameters()
   }
 
   /**
@@ -216,7 +216,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * return `int p1, int p2`.
    */
   string getParameterString() {
-    result = concat(int i | | min(getParameter(i).getTypedName()), ", " order by i)
+    result = concat(int i | | min(this.getParameter(i).getTypedName()), ", " order by i)
   }
 
   /** Gets a call to this function. */
@@ -229,7 +229,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    */
   override FunctionDeclarationEntry getADeclarationEntry() {
     if fun_decls(_, underlyingElement(this), _, _, _)
-    then declEntry(result)
+    then this.declEntry(result)
     else
       exists(Function f |
         this.isConstructedFrom(f) and
@@ -250,7 +250,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * Gets the location of a `FunctionDeclarationEntry` corresponding to this
    * declaration.
    */
-  override Location getADeclarationLocation() { result = getADeclarationEntry().getLocation() }
+  override Location getADeclarationLocation() { result = this.getADeclarationEntry().getLocation() }
 
   /** Holds if this Function is a Template specialization. */
   predicate isSpecialization() {
@@ -265,14 +265,14 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * definition, if any.
    */
   override FunctionDeclarationEntry getDefinition() {
-    result = getADeclarationEntry() and
+    result = this.getADeclarationEntry() and
     result.isDefinition()
   }
 
   /** Gets the location of the definition, if any. */
   override Location getDefinitionLocation() {
-    if exists(getDefinition())
-    then result = getDefinition().getLocation()
+    if exists(this.getDefinition())
+    then result = this.getDefinition().getLocation()
     else exists(Function f | this.isConstructedFrom(f) and result = f.getDefinition().getLocation())
   }
 
@@ -281,7 +281,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * definition, if possible.)
    */
   override Location getLocation() {
-    if exists(getDefinition())
+    if exists(this.getDefinition())
     then result = this.getDefinitionLocation()
     else result = this.getADeclarationLocation()
   }
@@ -299,7 +299,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
   BlockStmt getBlock() { result.getParentScope() = this }
 
   /** Holds if this function has an entry point. */
-  predicate hasEntryPoint() { exists(getEntryPoint()) }
+  predicate hasEntryPoint() { exists(this.getEntryPoint()) }
 
   /**
    * Gets the first node in this function's control flow graph.
@@ -392,7 +392,7 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * Holds if this function has C linkage, as specified by one of its
    * declaration entries. For example: `extern "C" void foo();`.
    */
-  predicate hasCLinkage() { getADeclarationEntry().hasCLinkage() }
+  predicate hasCLinkage() { this.getADeclarationEntry().hasCLinkage() }
 
   /**
    * Holds if this function is constructed from `f` as a result
@@ -409,27 +409,27 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * several functions that are not linked together have been compiled. An
    * example would be a project with many 'main' functions.
    */
-  predicate isMultiplyDefined() { strictcount(getFile()) > 1 }
+  predicate isMultiplyDefined() { strictcount(this.getFile()) > 1 }
 
   /** Holds if this function is a varargs function. */
-  predicate isVarargs() { hasSpecifier("varargs") }
+  predicate isVarargs() { this.hasSpecifier("varargs") }
 
   /** Gets a type that is specified to be thrown by the function. */
-  Type getAThrownType() { result = getADeclarationEntry().getAThrownType() }
+  Type getAThrownType() { result = this.getADeclarationEntry().getAThrownType() }
 
   /**
    * Gets the `i`th type specified to be thrown by the function.
    */
-  Type getThrownType(int i) { result = getADeclarationEntry().getThrownType(i) }
+  Type getThrownType(int i) { result = this.getADeclarationEntry().getThrownType(i) }
 
   /** Holds if the function has an exception specification. */
-  predicate hasExceptionSpecification() { getADeclarationEntry().hasExceptionSpecification() }
+  predicate hasExceptionSpecification() { this.getADeclarationEntry().hasExceptionSpecification() }
 
   /** Holds if this function has a `throw()` exception specification. */
-  predicate isNoThrow() { getADeclarationEntry().isNoThrow() }
+  predicate isNoThrow() { this.getADeclarationEntry().isNoThrow() }
 
   /** Holds if this function has a `noexcept` exception specification. */
-  predicate isNoExcept() { getADeclarationEntry().isNoExcept() }
+  predicate isNoExcept() { this.getADeclarationEntry().isNoExcept() }
 
   /**
    * Gets a function that overloads this one.
@@ -539,7 +539,7 @@ private predicate candGetAnOverloadNonMember(string name, Namespace namespace, F
  */
 class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
   /** Gets the function which is being declared or defined. */
-  override Function getDeclaration() { result = getFunction() }
+  override Function getDeclaration() { result = this.getFunction() }
 
   override string getAPrimaryQlClass() { result = "FunctionDeclarationEntry" }
 
@@ -586,7 +586,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    *   case, catch) plus the number of branching expressions (`?`, `&&`,
    *   `||`) plus one.
    */
-  int getCyclomaticComplexity() { result = 1 + cyclomaticComplexityBranches(getBlock()) }
+  int getCyclomaticComplexity() { result = 1 + cyclomaticComplexityBranches(this.getBlock()) }
 
   /**
    * If this is a function definition, get the block containing the
@@ -594,7 +594,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    */
   BlockStmt getBlock() {
     this.isDefinition() and
-    result = getFunction().getBlock() and
+    result = this.getFunction().getBlock() and
     result.getFile() = this.getFile()
   }
 
@@ -604,7 +604,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    */
   pragma[noopt]
   int getNumberOfLines() {
-    exists(BlockStmt b, Location l, int start, int end, int diff | b = getBlock() |
+    exists(BlockStmt b, Location l, int start, int end, int diff | b = this.getBlock() |
       l = b.getLocation() and
       start = l.getStartLine() and
       end = l.getEndLine() and
@@ -618,7 +618,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    * declaration.
    */
   ParameterDeclarationEntry getAParameterDeclarationEntry() {
-    result = getParameterDeclarationEntry(_)
+    result = this.getParameterDeclarationEntry(_)
   }
 
   /**
@@ -639,7 +639,8 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    * return 'int p1, int p2'.
    */
   string getParameterString() {
-    result = concat(int i | | min(getParameterDeclarationEntry(i).getTypedName()), ", " order by i)
+    result =
+      concat(int i | | min(this.getParameterDeclarationEntry(i).getTypedName()), ", " order by i)
   }
 
   /**
@@ -647,10 +648,10 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    *
    *    `extern "C" void foo();`
    */
-  predicate hasCLinkage() { getASpecifier() = "c_linkage" }
+  predicate hasCLinkage() { this.getASpecifier() = "c_linkage" }
 
   /** Holds if this declaration entry has a void parameter list. */
-  predicate hasVoidParamList() { getASpecifier() = "void_param_list" }
+  predicate hasVoidParamList() { this.getASpecifier() = "void_param_list" }
 
   /** Holds if this declaration is also a definition of its function. */
   override predicate isDefinition() { fun_def(underlyingElement(this)) }
@@ -665,7 +666,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
   predicate isImplicit() { fun_implicit(underlyingElement(this)) }
 
   /** Gets a type that is specified to be thrown by the declared function. */
-  Type getAThrownType() { result = getThrownType(_) }
+  Type getAThrownType() { result = this.getThrownType(_) }
 
   /**
    * Gets the `i`th type specified to be thrown by the declared function
@@ -690,8 +691,8 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
   predicate hasExceptionSpecification() {
     fun_decl_throws(underlyingElement(this), _, _) or
     fun_decl_noexcept(underlyingElement(this), _) or
-    isNoThrow() or
-    isNoExcept()
+    this.isNoThrow() or
+    this.isNoExcept()
   }
 
   /**
@@ -763,7 +764,7 @@ class Operator extends Function {
  */
 class TemplateFunction extends Function {
   TemplateFunction() {
-    is_function_template(underlyingElement(this)) and exists(getATemplateArgument())
+    is_function_template(underlyingElement(this)) and exists(this.getATemplateArgument())
   }
 
   override string getAPrimaryQlClass() { result = "TemplateFunction" }

--- a/cpp/ql/lib/semmle/code/cpp/Include.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Include.qll
@@ -23,7 +23,7 @@ class Include extends PreprocessorDirective, @ppd_include {
    * Gets the token which occurs after `#include`, for example `"filename"`
    * or `<filename>`.
    */
-  string getIncludeText() { result = getHead() }
+  string getIncludeText() { result = this.getHead() }
 
   /** Gets the file directly included by this `#include`. */
   File getIncludedFile() { includes(underlyingElement(this), unresolveElement(result)) }
@@ -53,7 +53,7 @@ class Include extends PreprocessorDirective, @ppd_include {
  * ```
  */
 class IncludeNext extends Include, @ppd_include_next {
-  override string toString() { result = "#include_next " + getIncludeText() }
+  override string toString() { result = "#include_next " + this.getIncludeText() }
 }
 
 /**
@@ -65,5 +65,5 @@ class IncludeNext extends Include, @ppd_include_next {
  * ```
  */
 class Import extends Include, @ppd_objc_import {
-  override string toString() { result = "#import " + getIncludeText() }
+  override string toString() { result = "#import " + this.getIncludeText() }
 }

--- a/cpp/ql/lib/semmle/code/cpp/Initializer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Initializer.qll
@@ -34,8 +34,8 @@ class Initializer extends ControlFlowNode, @initialiser {
   override predicate fromSource() { not this.getLocation() instanceof UnknownLocation }
 
   override string toString() {
-    if exists(getDeclaration())
-    then result = "initializer for " + max(getDeclaration().getName())
+    if exists(this.getDeclaration())
+    then result = "initializer for " + max(this.getDeclaration().getName())
     else result = "initializer"
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/Location.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Location.qll
@@ -79,8 +79,8 @@ class Location extends @location {
 
   /** Holds if location `l` is completely contained within this one. */
   predicate subsumes(Location l) {
-    exists(File f | f = getFile() |
-      exists(int thisStart, int thisEnd | charLoc(f, thisStart, thisEnd) |
+    exists(File f | f = this.getFile() |
+      exists(int thisStart, int thisEnd | this.charLoc(f, thisStart, thisEnd) |
         exists(int lStart, int lEnd | l.charLoc(f, lStart, lEnd) |
           thisStart <= lStart and lEnd <= thisEnd
         )
@@ -97,10 +97,10 @@ class Location extends @location {
    * see `subsumes`.
    */
   predicate charLoc(File f, int start, int end) {
-    f = getFile() and
+    f = this.getFile() and
     exists(int maxCols | maxCols = maxCols(f) |
-      start = getStartLine() * maxCols + getStartColumn() and
-      end = getEndLine() * maxCols + getEndColumn()
+      start = this.getStartLine() * maxCols + this.getStartColumn() and
+      end = this.getEndLine() * maxCols + this.getEndColumn()
     )
   }
 }
@@ -144,7 +144,7 @@ class Locatable extends Element { }
  * expressions, one for statements and one for other program elements.
  */
 class UnknownLocation extends Location {
-  UnknownLocation() { getFile().getAbsolutePath() = "" }
+  UnknownLocation() { this.getFile().getAbsolutePath() = "" }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/Macro.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Macro.qll
@@ -44,10 +44,10 @@ class Macro extends PreprocessorDirective, @ppd_define {
    * Gets the name of the macro.  For example, `MAX` in
    * `#define MAX(x,y) (((x)>(y))?(x):(y))`.
    */
-  string getName() { result = getHead().splitAt("(", 0) }
+  string getName() { result = this.getHead().splitAt("(", 0) }
 
   /** Holds if the macro has name `name`. */
-  predicate hasName(string name) { getName() = name }
+  predicate hasName(string name) { this.getName() = name }
 }
 
 /**
@@ -130,7 +130,7 @@ class MacroAccess extends Locatable, @macroinvocation {
   override string toString() { result = this.getMacro().getHead() }
 
   /** Gets the name of the accessed macro. */
-  string getMacroName() { result = getMacro().getName() }
+  string getMacroName() { result = this.getMacro().getName() }
 }
 
 /**
@@ -197,8 +197,8 @@ class MacroInvocation extends MacroAccess {
    * expression. In other cases, it may have multiple results or no results.
    */
   Expr getExpr() {
-    result = getAnExpandedElement() and
-    not result.getParent() = getAnExpandedElement() and
+    result = this.getAnExpandedElement() and
+    not result.getParent() = this.getAnExpandedElement() and
     not result instanceof Conversion
   }
 
@@ -208,8 +208,8 @@ class MacroInvocation extends MacroAccess {
    * element is not a statement (for example if it is an expression).
    */
   Stmt getStmt() {
-    result = getAnExpandedElement() and
-    not result.getParent() = getAnExpandedElement()
+    result = this.getAnExpandedElement() and
+    not result.getParent() = this.getAnExpandedElement()
   }
 
   /**
@@ -278,7 +278,7 @@ deprecated class MacroInvocationExpr extends Expr {
   MacroInvocation getInvocation() { result.getExpr() = this }
 
   /** Gets the name of the invoked macro. */
-  string getMacroName() { result = getInvocation().getMacroName() }
+  string getMacroName() { result = this.getInvocation().getMacroName() }
 }
 
 /**
@@ -298,7 +298,7 @@ deprecated class MacroInvocationStmt extends Stmt {
   MacroInvocation getInvocation() { result.getStmt() = this }
 
   /** Gets the name of the invoked macro. */
-  string getMacroName() { result = getInvocation().getMacroName() }
+  string getMacroName() { result = this.getInvocation().getMacroName() }
 }
 
 /** Holds if `l` is the location of a macro. */

--- a/cpp/ql/lib/semmle/code/cpp/MemberFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/MemberFunction.qll
@@ -36,7 +36,9 @@ class MemberFunction extends Function {
    * `this` parameter.
    */
   override int getEffectiveNumberOfParameters() {
-    if isStatic() then result = getNumberOfParameters() else result = getNumberOfParameters() + 1
+    if this.isStatic()
+    then result = this.getNumberOfParameters()
+    else result = this.getNumberOfParameters() + 1
   }
 
   /** Holds if this member is private. */
@@ -49,13 +51,13 @@ class MemberFunction extends Function {
   predicate isPublic() { this.hasSpecifier("public") }
 
   /** Holds if this declaration has the lvalue ref-qualifier */
-  predicate isLValueRefQualified() { hasSpecifier("&") }
+  predicate isLValueRefQualified() { this.hasSpecifier("&") }
 
   /** Holds if this declaration has the rvalue ref-qualifier */
-  predicate isRValueRefQualified() { hasSpecifier("&&") }
+  predicate isRValueRefQualified() { this.hasSpecifier("&&") }
 
   /** Holds if this declaration has a ref-qualifier */
-  predicate isRefQualified() { isLValueRefQualified() or isRValueRefQualified() }
+  predicate isRefQualified() { this.isLValueRefQualified() or this.isRValueRefQualified() }
 
   /** Holds if this function overrides that function. */
   predicate overrides(MemberFunction that) {
@@ -73,10 +75,10 @@ class MemberFunction extends Function {
    * class body.
    */
   FunctionDeclarationEntry getClassBodyDeclarationEntry() {
-    if strictcount(getADeclarationEntry()) = 1
-    then result = getDefinition()
+    if strictcount(this.getADeclarationEntry()) = 1
+    then result = this.getDefinition()
     else (
-      result = getADeclarationEntry() and result != getDefinition()
+      result = this.getADeclarationEntry() and result != this.getDefinition()
     )
   }
 
@@ -198,7 +200,7 @@ class Constructor extends MemberFunction {
    * compiler-generated action which initializes a base class or member
    * variable.
    */
-  ConstructorInit getAnInitializer() { result = getInitializer(_) }
+  ConstructorInit getAnInitializer() { result = this.getInitializer(_) }
 
   /**
    * Gets an entry in the constructor's initializer list, or a
@@ -220,8 +222,8 @@ class ImplicitConversionFunction extends MemberFunction {
     functions(underlyingElement(this), _, 4)
     or
     // ConversionConstructor (deprecated)
-    strictcount(Parameter p | p = getAParameter() and not p.hasInitializer()) = 1 and
-    not hasSpecifier("explicit")
+    strictcount(Parameter p | p = this.getAParameter() and not p.hasInitializer()) = 1 and
+    not this.hasSpecifier("explicit")
   }
 
   /** Gets the type this `ImplicitConversionFunction` takes as input. */
@@ -248,8 +250,8 @@ class ImplicitConversionFunction extends MemberFunction {
  */
 deprecated class ConversionConstructor extends Constructor, ImplicitConversionFunction {
   ConversionConstructor() {
-    strictcount(Parameter p | p = getAParameter() and not p.hasInitializer()) = 1 and
-    not hasSpecifier("explicit")
+    strictcount(Parameter p | p = this.getAParameter() and not p.hasInitializer()) = 1 and
+    not this.hasSpecifier("explicit")
   }
 
   override string getAPrimaryQlClass() {
@@ -301,15 +303,15 @@ class CopyConstructor extends Constructor {
     hasCopySignature(this) and
     (
       // The rest of the parameters all have default values
-      forall(int i | i > 0 and exists(getParameter(i)) | getParameter(i).hasInitializer())
+      forall(int i | i > 0 and exists(this.getParameter(i)) | this.getParameter(i).hasInitializer())
       or
       // or this is a template class, in which case the default values have
       // not been extracted even if they exist. In that case, we assume that
       // there are default values present since that is the most common case
       // in real-world code.
-      getDeclaringType() instanceof TemplateClass
+      this.getDeclaringType() instanceof TemplateClass
     ) and
-    not exists(getATemplateArgument())
+    not exists(this.getATemplateArgument())
   }
 
   override string getAPrimaryQlClass() { result = "CopyConstructor" }
@@ -325,8 +327,8 @@ class CopyConstructor extends Constructor {
     // type-checked for each template instantiation; if an argument in an
     // instantiation fails to type-check then the corresponding parameter has
     // no default argument in the instantiation.
-    getDeclaringType() instanceof TemplateClass and
-    getNumberOfParameters() > 1
+    this.getDeclaringType() instanceof TemplateClass and
+    this.getNumberOfParameters() > 1
   }
 }
 
@@ -358,15 +360,15 @@ class MoveConstructor extends Constructor {
     hasMoveSignature(this) and
     (
       // The rest of the parameters all have default values
-      forall(int i | i > 0 and exists(getParameter(i)) | getParameter(i).hasInitializer())
+      forall(int i | i > 0 and exists(this.getParameter(i)) | this.getParameter(i).hasInitializer())
       or
       // or this is a template class, in which case the default values have
       // not been extracted even if they exist. In that case, we assume that
       // there are default values present since that is the most common case
       // in real-world code.
-      getDeclaringType() instanceof TemplateClass
+      this.getDeclaringType() instanceof TemplateClass
     ) and
-    not exists(getATemplateArgument())
+    not exists(this.getATemplateArgument())
   }
 
   override string getAPrimaryQlClass() { result = "MoveConstructor" }
@@ -382,8 +384,8 @@ class MoveConstructor extends Constructor {
     // type-checked for each template instantiation; if an argument in an
     // instantiation fails to type-check then the corresponding parameter has
     // no default argument in the instantiation.
-    getDeclaringType() instanceof TemplateClass and
-    getNumberOfParameters() > 1
+    this.getDeclaringType() instanceof TemplateClass and
+    this.getNumberOfParameters() > 1
   }
 }
 
@@ -426,7 +428,7 @@ class Destructor extends MemberFunction {
    * Gets a compiler-generated action which destructs a base class or member
    * variable.
    */
-  DestructorDestruction getADestruction() { result = getDestruction(_) }
+  DestructorDestruction getADestruction() { result = this.getDestruction(_) }
 
   /**
    * Gets a compiler-generated action which destructs a base class or member
@@ -475,16 +477,16 @@ class ConversionOperator extends MemberFunction, ImplicitConversionFunction {
  */
 class CopyAssignmentOperator extends Operator {
   CopyAssignmentOperator() {
-    hasName("operator=") and
+    this.hasName("operator=") and
     (
       hasCopySignature(this)
       or
       // Unlike CopyConstructor, this member allows a non-reference
       // parameter.
-      getParameter(0).getUnspecifiedType() = getDeclaringType()
+      this.getParameter(0).getUnspecifiedType() = this.getDeclaringType()
     ) and
     not exists(this.getParameter(1)) and
-    not exists(getATemplateArgument())
+    not exists(this.getATemplateArgument())
   }
 
   override string getAPrimaryQlClass() { result = "CopyAssignmentOperator" }
@@ -507,10 +509,10 @@ class CopyAssignmentOperator extends Operator {
  */
 class MoveAssignmentOperator extends Operator {
   MoveAssignmentOperator() {
-    hasName("operator=") and
+    this.hasName("operator=") and
     hasMoveSignature(this) and
     not exists(this.getParameter(1)) and
-    not exists(getATemplateArgument())
+    not exists(this.getATemplateArgument())
   }
 
   override string getAPrimaryQlClass() { result = "MoveAssignmentOperator" }

--- a/cpp/ql/lib/semmle/code/cpp/Namespace.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Namespace.qll
@@ -38,8 +38,8 @@ class Namespace extends NameQualifyingElement, @namespace {
    * unless the namespace has exactly one declaration entry.
    */
   override Location getLocation() {
-    if strictcount(getADeclarationEntry()) = 1
-    then result = getADeclarationEntry().getLocation()
+    if strictcount(this.getADeclarationEntry()) = 1
+    then result = this.getADeclarationEntry().getLocation()
     else result instanceof UnknownDefaultLocation
   }
 
@@ -50,7 +50,7 @@ class Namespace extends NameQualifyingElement, @namespace {
   predicate hasName(string name) { name = this.getName() }
 
   /** Holds if this namespace is anonymous. */
-  predicate isAnonymous() { hasName("(unnamed namespace)") }
+  predicate isAnonymous() { this.hasName("(unnamed namespace)") }
 
   /** Gets the name of the parent namespace, if it exists. */
   private string getParentName() {
@@ -60,9 +60,9 @@ class Namespace extends NameQualifyingElement, @namespace {
 
   /** Gets the qualified name of this namespace. For example: `a::b`. */
   string getQualifiedName() {
-    if exists(getParentName())
-    then result = getParentNamespace().getQualifiedName() + "::" + getName()
-    else result = getName()
+    if exists(this.getParentName())
+    then result = this.getParentNamespace().getQualifiedName() + "::" + this.getName()
+    else result = this.getName()
   }
 
   /** Gets the parent namespace, if any. */
@@ -99,7 +99,7 @@ class Namespace extends NameQualifyingElement, @namespace {
   /** Gets a version of the `QualifiedName` that is more suitable for display purposes. */
   string getFriendlyName() { result = this.getQualifiedName() }
 
-  final override string toString() { result = getFriendlyName() }
+  final override string toString() { result = this.getFriendlyName() }
 
   /** Gets a declaration of (part of) this namespace. */
   NamespaceDeclarationEntry getADeclarationEntry() { result.getNamespace() = this }

--- a/cpp/ql/lib/semmle/code/cpp/Parameter.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Parameter.qll
@@ -40,12 +40,12 @@ class Parameter extends LocalScopeVariable, @parameter {
    */
   override string getName() {
     exists(VariableDeclarationEntry vde |
-      vde = getANamedDeclarationEntry() and result = vde.getName()
+      vde = this.getANamedDeclarationEntry() and result = vde.getName()
     |
-      vde.isDefinition() or not getANamedDeclarationEntry().isDefinition()
+      vde.isDefinition() or not this.getANamedDeclarationEntry().isDefinition()
     )
     or
-    not exists(getANamedDeclarationEntry()) and
+    not exists(this.getANamedDeclarationEntry()) and
     result = "(unnamed parameter " + this.getIndex().toString() + ")"
   }
 
@@ -58,8 +58,12 @@ class Parameter extends LocalScopeVariable, @parameter {
    */
   string getTypedName() {
     exists(string typeString, string nameString |
-      (if exists(getType().getName()) then typeString = getType().getName() else typeString = "") and
-      (if exists(getName()) then nameString = getName() else nameString = "") and
+      (
+        if exists(this.getType().getName())
+        then typeString = this.getType().getName()
+        else typeString = ""
+      ) and
+      (if exists(this.getName()) then nameString = this.getName() else nameString = "") and
       (
         if typeString != "" and nameString != ""
         then result = typeString + " " + nameString
@@ -69,7 +73,7 @@ class Parameter extends LocalScopeVariable, @parameter {
   }
 
   private VariableDeclarationEntry getANamedDeclarationEntry() {
-    result = getAnEffectiveDeclarationEntry() and result.getName() != ""
+    result = this.getAnEffectiveDeclarationEntry() and result.getName() != ""
   }
 
   /**
@@ -82,13 +86,13 @@ class Parameter extends LocalScopeVariable, @parameter {
    * own).
    */
   private VariableDeclarationEntry getAnEffectiveDeclarationEntry() {
-    if getFunction().isConstructedFrom(_)
+    if this.getFunction().isConstructedFrom(_)
     then
       exists(Function prototypeInstantiation |
-        prototypeInstantiation.getParameter(getIndex()) = result.getVariable() and
-        getFunction().isConstructedFrom(prototypeInstantiation)
+        prototypeInstantiation.getParameter(this.getIndex()) = result.getVariable() and
+        this.getFunction().isConstructedFrom(prototypeInstantiation)
       )
-    else result = getADeclarationEntry()
+    else result = this.getADeclarationEntry()
   }
 
   /**
@@ -114,7 +118,7 @@ class Parameter extends LocalScopeVariable, @parameter {
    * `getName()` is not "(unnamed parameter i)" (where `i` is the index
    * of the parameter).
    */
-  predicate isNamed() { exists(getANamedDeclarationEntry()) }
+  predicate isNamed() { exists(this.getANamedDeclarationEntry()) }
 
   /**
    * Gets the function to which this parameter belongs, if it is a function
@@ -157,9 +161,9 @@ class Parameter extends LocalScopeVariable, @parameter {
    */
   override Location getLocation() {
     exists(VariableDeclarationEntry vde |
-      vde = getAnEffectiveDeclarationEntry() and result = vde.getLocation()
+      vde = this.getAnEffectiveDeclarationEntry() and result = vde.getLocation()
     |
-      vde.isDefinition() or not getAnEffectiveDeclarationEntry().isDefinition()
+      vde.isDefinition() or not this.getAnEffectiveDeclarationEntry().isDefinition()
     )
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/Preprocessor.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Preprocessor.qll
@@ -29,8 +29,8 @@ class PreprocessorDirective extends Locatable, @preprocdirect {
   PreprocessorBranch getAGuard() {
     exists(PreprocessorEndif e, int line |
       result.getEndIf() = e and
-      e.getFile() = getFile() and
-      result.getFile() = getFile() and
+      e.getFile() = this.getFile() and
+      result.getFile() = this.getFile() and
       line = this.getLocation().getStartLine() and
       result.getLocation().getStartLine() < line and
       line < e.getLocation().getEndLine()
@@ -69,7 +69,9 @@ class PreprocessorBranchDirective extends PreprocessorDirective, TPreprocessorBr
    * directives in different translation units, then there can be more than
    * one result.
    */
-  PreprocessorEndif getEndIf() { preprocpair(unresolveElement(getIf()), unresolveElement(result)) }
+  PreprocessorEndif getEndIf() {
+    preprocpair(unresolveElement(this.getIf()), unresolveElement(result))
+  }
 
   /**
    * Gets the next `#elif`, `#else` or `#endif` matching this branching
@@ -137,7 +139,7 @@ class PreprocessorBranch extends PreprocessorBranchDirective, @ppd_branch {
    * which evaluated it, or was not taken by any translation unit which
    * evaluated it.
    */
-  predicate wasPredictable() { not (wasTaken() and wasNotTaken()) }
+  predicate wasPredictable() { not (this.wasTaken() and this.wasNotTaken()) }
 }
 
 /**
@@ -268,7 +270,7 @@ class PreprocessorUndef extends PreprocessorDirective, @ppd_undef {
   /**
    * Gets the name of the macro that is undefined.
    */
-  string getName() { result = getHead() }
+  string getName() { result = this.getHead() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/Print.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Print.qll
@@ -105,8 +105,8 @@ private class DumpType extends Type {
     // for a `SpecifiedType`, insert the qualifiers after
     // `getDeclaratorSuffixBeforeQualifiers()`.
     result =
-      getTypeSpecifier() + getDeclaratorPrefix() + getDeclaratorSuffixBeforeQualifiers() +
-        getDeclaratorSuffix()
+      this.getTypeSpecifier() + this.getDeclaratorPrefix() +
+        this.getDeclaratorSuffixBeforeQualifiers() + this.getDeclaratorSuffix()
   }
 
   /**
@@ -147,29 +147,35 @@ private class DumpType extends Type {
 }
 
 private class BuiltInDumpType extends DumpType, BuiltInType {
-  override string getTypeSpecifier() { result = toString() }
+  override string getTypeSpecifier() { result = this.toString() }
 }
 
 private class IntegralDumpType extends BuiltInDumpType, IntegralType {
-  override string getTypeSpecifier() { result = getCanonicalArithmeticType().toString() }
+  override string getTypeSpecifier() { result = this.getCanonicalArithmeticType().toString() }
 }
 
 private class DerivedDumpType extends DumpType, DerivedType {
-  override string getTypeSpecifier() { result = getBaseType().(DumpType).getTypeSpecifier() }
+  override string getTypeSpecifier() { result = this.getBaseType().(DumpType).getTypeSpecifier() }
 
   override string getDeclaratorSuffixBeforeQualifiers() {
-    result = getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
+    result = this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
   }
 
-  override string getDeclaratorSuffix() { result = getBaseType().(DumpType).getDeclaratorSuffix() }
+  override string getDeclaratorSuffix() {
+    result = this.getBaseType().(DumpType).getDeclaratorSuffix()
+  }
 }
 
 private class DecltypeDumpType extends DumpType, Decltype {
-  override string getTypeSpecifier() { result = getBaseType().(DumpType).getTypeSpecifier() }
+  override string getTypeSpecifier() { result = this.getBaseType().(DumpType).getTypeSpecifier() }
 
-  override string getDeclaratorPrefix() { result = getBaseType().(DumpType).getDeclaratorPrefix() }
+  override string getDeclaratorPrefix() {
+    result = this.getBaseType().(DumpType).getDeclaratorPrefix()
+  }
 
-  override string getDeclaratorSuffix() { result = getBaseType().(DumpType).getDeclaratorSuffix() }
+  override string getDeclaratorSuffix() {
+    result = this.getBaseType().(DumpType).getDeclaratorSuffix()
+  }
 }
 
 private class PointerIshDumpType extends DerivedDumpType {
@@ -180,10 +186,10 @@ private class PointerIshDumpType extends DerivedDumpType {
 
   override string getDeclaratorPrefix() {
     exists(string declarator |
-      result = getBaseType().(DumpType).getDeclaratorPrefix() + declarator and
-      if getBaseType().getUnspecifiedType() instanceof ArrayType
-      then declarator = "(" + getDeclaratorToken() + ")"
-      else declarator = getDeclaratorToken()
+      result = this.getBaseType().(DumpType).getDeclaratorPrefix() + declarator and
+      if this.getBaseType().getUnspecifiedType() instanceof ArrayType
+      then declarator = "(" + this.getDeclaratorToken() + ")"
+      else declarator = this.getDeclaratorToken()
     )
   }
 
@@ -206,13 +212,13 @@ private class RValueReferenceDumpType extends PointerIshDumpType, RValueReferenc
 }
 
 private class PointerToMemberDumpType extends DumpType, PointerToMemberType {
-  override string getTypeSpecifier() { result = getBaseType().(DumpType).getTypeSpecifier() }
+  override string getTypeSpecifier() { result = this.getBaseType().(DumpType).getTypeSpecifier() }
 
   override string getDeclaratorPrefix() {
     exists(string declarator, string parenDeclarator, Type baseType |
-      declarator = getClass().(DumpType).getTypeIdentityString() + "::*" and
-      result = getBaseType().(DumpType).getDeclaratorPrefix() + " " + parenDeclarator and
-      baseType = getBaseType().getUnspecifiedType() and
+      declarator = this.getClass().(DumpType).getTypeIdentityString() + "::*" and
+      result = this.getBaseType().(DumpType).getDeclaratorPrefix() + " " + parenDeclarator and
+      baseType = this.getBaseType().getUnspecifiedType() and
       if baseType instanceof ArrayType or baseType instanceof RoutineType
       then parenDeclarator = "(" + declarator
       else parenDeclarator = declarator
@@ -221,38 +227,44 @@ private class PointerToMemberDumpType extends DumpType, PointerToMemberType {
 
   override string getDeclaratorSuffixBeforeQualifiers() {
     exists(Type baseType |
-      baseType = getBaseType().getUnspecifiedType() and
+      baseType = this.getBaseType().getUnspecifiedType() and
       if baseType instanceof ArrayType or baseType instanceof RoutineType
-      then result = ")" + getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
-      else result = getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
+      then result = ")" + this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
+      else result = this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
     )
   }
 
-  override string getDeclaratorSuffix() { result = getBaseType().(DumpType).getDeclaratorSuffix() }
+  override string getDeclaratorSuffix() {
+    result = this.getBaseType().(DumpType).getDeclaratorSuffix()
+  }
 }
 
 private class ArrayDumpType extends DerivedDumpType, ArrayType {
-  override string getDeclaratorPrefix() { result = getBaseType().(DumpType).getDeclaratorPrefix() }
+  override string getDeclaratorPrefix() {
+    result = this.getBaseType().(DumpType).getDeclaratorPrefix()
+  }
 
   override string getDeclaratorSuffixBeforeQualifiers() {
-    if exists(getArraySize())
+    if exists(this.getArraySize())
     then
       result =
-        "[" + getArraySize().toString() + "]" +
-          getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
-    else result = "[]" + getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
+        "[" + this.getArraySize().toString() + "]" +
+          this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
+    else result = "[]" + this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
   }
 }
 
 private class FunctionPointerIshDumpType extends DerivedDumpType, FunctionPointerIshType {
   override string getDeclaratorSuffixBeforeQualifiers() {
-    result = ")" + getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
+    result = ")" + this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers()
   }
 
-  override string getDeclaratorSuffix() { result = getBaseType().(DumpType).getDeclaratorSuffix() }
+  override string getDeclaratorSuffix() {
+    result = this.getBaseType().(DumpType).getDeclaratorSuffix()
+  }
 
   override string getDeclaratorPrefix() {
-    result = getBaseType().(DumpType).getDeclaratorPrefix() + "(" + getDeclaratorToken()
+    result = this.getBaseType().(DumpType).getDeclaratorPrefix() + "(" + this.getDeclaratorToken()
   }
 
   /**
@@ -274,10 +286,10 @@ private class BlockDumpType extends FunctionPointerIshDumpType, BlockType {
 }
 
 private class RoutineDumpType extends DumpType, RoutineType {
-  override string getTypeSpecifier() { result = getReturnType().(DumpType).getTypeSpecifier() }
+  override string getTypeSpecifier() { result = this.getReturnType().(DumpType).getTypeSpecifier() }
 
   override string getDeclaratorPrefix() {
-    result = getReturnType().(DumpType).getDeclaratorPrefix()
+    result = this.getReturnType().(DumpType).getDeclaratorPrefix()
   }
 
   language[monotonicAggregates]
@@ -285,39 +297,41 @@ private class RoutineDumpType extends DumpType, RoutineType {
     result =
       "(" +
         concat(int i |
-          exists(getParameterType(i))
+          exists(this.getParameterType(i))
         |
-          getParameterTypeString(getParameterType(i)), ", " order by i
+          getParameterTypeString(this.getParameterType(i)), ", " order by i
         ) + ")"
   }
 
   override string getDeclaratorSuffix() {
     result =
-      getReturnType().(DumpType).getDeclaratorSuffixBeforeQualifiers() +
-        getReturnType().(DumpType).getDeclaratorSuffix()
+      this.getReturnType().(DumpType).getDeclaratorSuffixBeforeQualifiers() +
+        this.getReturnType().(DumpType).getDeclaratorSuffix()
   }
 }
 
 private class SpecifiedDumpType extends DerivedDumpType, SpecifiedType {
   override string getDeclaratorPrefix() {
     exists(string basePrefix |
-      basePrefix = getBaseType().(DumpType).getDeclaratorPrefix() and
-      if getBaseType().getUnspecifiedType() instanceof RoutineType
+      basePrefix = this.getBaseType().(DumpType).getDeclaratorPrefix() and
+      if this.getBaseType().getUnspecifiedType() instanceof RoutineType
       then result = basePrefix
-      else result = basePrefix + " " + getSpecifierString()
+      else result = basePrefix + " " + this.getSpecifierString()
     )
   }
 
   override string getDeclaratorSuffixBeforeQualifiers() {
     exists(string baseSuffix |
-      baseSuffix = getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers() and
-      if getBaseType().getUnspecifiedType() instanceof RoutineType
-      then result = baseSuffix + " " + getSpecifierString()
+      baseSuffix = this.getBaseType().(DumpType).getDeclaratorSuffixBeforeQualifiers() and
+      if this.getBaseType().getUnspecifiedType() instanceof RoutineType
+      then result = baseSuffix + " " + this.getSpecifierString()
       else result = baseSuffix
     )
   }
 
-  override string getDeclaratorSuffix() { result = getBaseType().(DumpType).getDeclaratorSuffix() }
+  override string getDeclaratorSuffix() {
+    result = this.getBaseType().(DumpType).getDeclaratorSuffix()
+  }
 }
 
 private class UserDumpType extends DumpType, DumpDeclaration, UserType {
@@ -330,18 +344,18 @@ private class UserDumpType extends DumpType, DumpDeclaration, UserType {
           // "lambda [] type at line 12, col. 40"
           // Use `min(getSimpleName())` to work around an extractor bug where a lambda can have different names
           // from different compilation units.
-          simpleName = "(" + min(getSimpleName()) + ")"
-        else simpleName = getSimpleName()
+          simpleName = "(" + min(this.getSimpleName()) + ")"
+        else simpleName = this.getSimpleName()
       ) and
-      result = getScopePrefix(this) + simpleName + getTemplateArgumentsString()
+      result = getScopePrefix(this) + simpleName + this.getTemplateArgumentsString()
     )
   }
 
-  override string getTypeSpecifier() { result = getIdentityString() }
+  override string getTypeSpecifier() { result = this.getIdentityString() }
 }
 
 private class DumpProxyClass extends UserDumpType, ProxyClass {
-  override string getIdentityString() { result = getName() }
+  override string getIdentityString() { result = this.getName() }
 }
 
 private class DumpVariable extends DumpDeclaration, Variable {
@@ -360,9 +374,9 @@ private class DumpVariable extends DumpDeclaration, Variable {
 private class DumpFunction extends DumpDeclaration, Function {
   override string getIdentityString() {
     result =
-      getType().(DumpType).getTypeSpecifier() + getType().(DumpType).getDeclaratorPrefix() + " " +
-        getScopePrefix(this) + getName() + getTemplateArgumentsString() +
-        getDeclaratorSuffixBeforeQualifiers() + getDeclaratorSuffix()
+      this.getType().(DumpType).getTypeSpecifier() + this.getType().(DumpType).getDeclaratorPrefix()
+        + " " + getScopePrefix(this) + this.getName() + this.getTemplateArgumentsString() +
+        this.getDeclaratorSuffixBeforeQualifiers() + this.getDeclaratorSuffix()
   }
 
   language[monotonicAggregates]
@@ -370,28 +384,29 @@ private class DumpFunction extends DumpDeclaration, Function {
     result =
       "(" +
         concat(int i |
-          exists(getParameter(i).getType())
+          exists(this.getParameter(i).getType())
         |
-          getParameterTypeString(getParameter(i).getType()), ", " order by i
-        ) + ")" + getQualifierString()
+          getParameterTypeString(this.getParameter(i).getType()), ", " order by i
+        ) + ")" + this.getQualifierString()
   }
 
   private string getQualifierString() {
-    if exists(getACVQualifier())
+    if exists(this.getACVQualifier())
     then
-      result = " " + strictconcat(string qualifier | qualifier = getACVQualifier() | qualifier, " ")
+      result =
+        " " + strictconcat(string qualifier | qualifier = this.getACVQualifier() | qualifier, " ")
     else result = ""
   }
 
   private string getACVQualifier() {
-    result = getASpecifier().getName() and
+    result = this.getASpecifier().getName() and
     result = ["const", "volatile"]
   }
 
   private string getDeclaratorSuffix() {
     result =
-      getType().(DumpType).getDeclaratorSuffixBeforeQualifiers() +
-        getType().(DumpType).getDeclaratorSuffix()
+      this.getType().(DumpType).getDeclaratorSuffixBeforeQualifiers() +
+        this.getType().(DumpType).getDeclaratorSuffix()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/Specifier.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Specifier.qll
@@ -140,7 +140,7 @@ class Attribute extends Element, @attribute {
   AttributeArgument getArgument(int i) { result.getAttribute() = this and result.getIndex() = i }
 
   /** Gets an argument of the attribute. */
-  AttributeArgument getAnArgument() { result = getArgument(_) }
+  AttributeArgument getAnArgument() { result = this.getArgument(_) }
 }
 
 /**
@@ -166,7 +166,7 @@ class StdAttribute extends Attribute, @stdattribute {
    * Holds if this attribute has the given namespace and name.
    */
   predicate hasQualifiedName(string namespace, string name) {
-    namespace = getNamespace() and hasName(name)
+    namespace = this.getNamespace() and this.hasName(name)
   }
 }
 
@@ -184,7 +184,7 @@ class Declspec extends Attribute, @declspec { }
  */
 class MicrosoftAttribute extends Attribute, @msattribute {
   AttributeArgument getNamedArgument(string name) {
-    result = getAnArgument() and result.getName() = name
+    result = this.getAnArgument() and result.getName() = name
   }
 }
 
@@ -212,13 +212,13 @@ class AlignAs extends Attribute, @alignas {
  * ```
  */
 class FormatAttribute extends GnuAttribute {
-  FormatAttribute() { getName() = "format" }
+  FormatAttribute() { this.getName() = "format" }
 
   /**
    * Gets the archetype of this format attribute, for example
    * `"printf"`.
    */
-  string getArchetype() { result = getArgument(0).getValueText() }
+  string getArchetype() { result = this.getArgument(0).getValueText() }
 
   /**
    * Gets the index in (1-based) format attribute notation associated
@@ -236,7 +236,7 @@ class FormatAttribute extends GnuAttribute {
    * Gets the (0-based) index of the format string,
    * according to this attribute.
    */
-  int getFormatIndex() { result = getArgument(1).getValueInt() - firstArgumentNumber() }
+  int getFormatIndex() { result = this.getArgument(1).getValueInt() - this.firstArgumentNumber() }
 
   /**
    * Gets the (0-based) index of the first format argument (if any),
@@ -244,8 +244,8 @@ class FormatAttribute extends GnuAttribute {
    */
   int getFirstFormatArgIndex() {
     exists(int val |
-      val = getArgument(2).getValueInt() and
-      result = val - firstArgumentNumber() and
+      val = this.getArgument(2).getValueInt() and
+      result = val - this.firstArgumentNumber() and
       not val = 0 // indicates a `vprintf` style format function with arguments not directly available.
     )
   }
@@ -277,7 +277,7 @@ class AttributeArgument extends Element, @attribute_arg {
   /**
    * Gets the value of this argument, if its value is integral.
    */
-  int getValueInt() { result = getValueText().toInt() }
+  int getValueInt() { result = this.getValueText().toInt() }
 
   /**
    * Gets the value of this argument, if its value is a type.
@@ -304,11 +304,11 @@ class AttributeArgument extends Element, @attribute_arg {
     then result = "empty argument"
     else
       exists(string prefix, string tail |
-        (if exists(getName()) then prefix = getName() + "=" else prefix = "") and
+        (if exists(this.getName()) then prefix = this.getName() + "=" else prefix = "") and
         (
           if exists(@attribute_arg_type self | self = underlyingElement(this))
-          then tail = getValueType().getName()
-          else tail = getValueText()
+          then tail = this.getValueType().getName()
+          else tail = this.getValueText()
         ) and
         result = prefix + tail
       )

--- a/cpp/ql/lib/semmle/code/cpp/Struct.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Struct.qll
@@ -41,7 +41,7 @@ class Struct extends Class {
  * ```
  */
 class LocalStruct extends Struct {
-  LocalStruct() { isLocal() }
+  LocalStruct() { this.isLocal() }
 
   override string getAPrimaryQlClass() { not this instanceof LocalUnion and result = "LocalStruct" }
 }

--- a/cpp/ql/lib/semmle/code/cpp/TestFile.qll
+++ b/cpp/ql/lib/semmle/code/cpp/TestFile.qll
@@ -10,8 +10,8 @@ import semmle.code.cpp.File
  */
 private class GoogleTestHeader extends File {
   GoogleTestHeader() {
-    getBaseName() = "gtest.h" and
-    getParentContainer().getBaseName() = "gtest"
+    this.getBaseName() = "gtest.h" and
+    this.getParentContainer().getBaseName() = "gtest"
   }
 }
 
@@ -30,8 +30,8 @@ private class GoogleTest extends MacroInvocation {
  */
 private class BoostTestFolder extends Folder {
   BoostTestFolder() {
-    getBaseName() = "test" and
-    getParentContainer().getBaseName() = "boost"
+    this.getBaseName() = "test" and
+    this.getParentContainer().getBaseName() = "boost"
   }
 }
 
@@ -49,7 +49,7 @@ private class BoostTest extends MacroInvocation {
  * The `cppunit` directory.
  */
 private class CppUnitFolder extends Folder {
-  CppUnitFolder() { getBaseName() = "cppunit" }
+  CppUnitFolder() { this.getBaseName() = "cppunit" }
 }
 
 /**
@@ -57,8 +57,8 @@ private class CppUnitFolder extends Folder {
  */
 private class CppUnitClass extends Class {
   CppUnitClass() {
-    getFile().getParentContainer+() instanceof CppUnitFolder and
-    getNamespace().getParentNamespace*().getName() = "CppUnit"
+    this.getFile().getParentContainer+() instanceof CppUnitFolder and
+    this.getNamespace().getParentNamespace*().getName() = "CppUnit"
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/Type.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Type.qll
@@ -81,7 +81,7 @@ class Type extends Locatable, @type {
    * Holds if this type refers to type `t` (by default,
    * a type always refers to itself).
    */
-  predicate refersTo(Type t) { refersToDirectly*(t) }
+  predicate refersTo(Type t) { this.refersToDirectly*(t) }
 
   /**
    * Holds if this type refers to type `t` directly.
@@ -1080,11 +1080,11 @@ class DerivedType extends Type, @derivedtype {
 
   override predicate refersToDirectly(Type t) { t = this.getBaseType() }
 
-  override predicate involvesReference() { getBaseType().involvesReference() }
+  override predicate involvesReference() { this.getBaseType().involvesReference() }
 
-  override predicate involvesTemplateParameter() { getBaseType().involvesTemplateParameter() }
+  override predicate involvesTemplateParameter() { this.getBaseType().involvesTemplateParameter() }
 
-  override Type stripType() { result = getBaseType().stripType() }
+  override Type stripType() { result = this.getBaseType().stripType() }
 
   /**
    * Holds if this type has the `__autoreleasing` specifier or if it points to
@@ -1165,33 +1165,35 @@ class Decltype extends Type, @decltype {
    */
   predicate parenthesesWouldChangeMeaning() { decltypes(underlyingElement(this), _, _, true) }
 
-  override Type getUnderlyingType() { result = getBaseType().getUnderlyingType() }
+  override Type getUnderlyingType() { result = this.getBaseType().getUnderlyingType() }
 
-  override Type stripTopLevelSpecifiers() { result = getBaseType().stripTopLevelSpecifiers() }
+  override Type stripTopLevelSpecifiers() { result = this.getBaseType().stripTopLevelSpecifiers() }
 
-  override Type stripType() { result = getBaseType().stripType() }
+  override Type stripType() { result = this.getBaseType().stripType() }
 
-  override Type resolveTypedefs() { result = getBaseType().resolveTypedefs() }
+  override Type resolveTypedefs() { result = this.getBaseType().resolveTypedefs() }
 
-  override Location getLocation() { result = getExpr().getLocation() }
+  override Location getLocation() { result = this.getExpr().getLocation() }
 
   override string toString() { result = "decltype(...)" }
 
   override string getName() { none() }
 
-  override int getSize() { result = getBaseType().getSize() }
+  override int getSize() { result = this.getBaseType().getSize() }
 
-  override int getAlignment() { result = getBaseType().getAlignment() }
+  override int getAlignment() { result = this.getBaseType().getAlignment() }
 
-  override int getPointerIndirectionLevel() { result = getBaseType().getPointerIndirectionLevel() }
+  override int getPointerIndirectionLevel() {
+    result = this.getBaseType().getPointerIndirectionLevel()
+  }
 
   override string explain() {
     result = "decltype resulting in {" + this.getBaseType().explain() + "}"
   }
 
-  override predicate involvesReference() { getBaseType().involvesReference() }
+  override predicate involvesReference() { this.getBaseType().involvesReference() }
 
-  override predicate involvesTemplateParameter() { getBaseType().involvesTemplateParameter() }
+  override predicate involvesTemplateParameter() { this.getBaseType().involvesTemplateParameter() }
 
   override predicate isDeeplyConst() { this.getBaseType().isDeeplyConst() }
 
@@ -1223,7 +1225,7 @@ class PointerType extends DerivedType {
   override predicate isDeeplyConstBelow() { this.getBaseType().isDeeplyConst() }
 
   override Type resolveTypedefs() {
-    result.(PointerType).getBaseType() = getBaseType().resolveTypedefs()
+    result.(PointerType).getBaseType() = this.getBaseType().resolveTypedefs()
   }
 }
 
@@ -1240,7 +1242,9 @@ class ReferenceType extends DerivedType {
 
   override string getAPrimaryQlClass() { result = "ReferenceType" }
 
-  override int getPointerIndirectionLevel() { result = getBaseType().getPointerIndirectionLevel() }
+  override int getPointerIndirectionLevel() {
+    result = this.getBaseType().getPointerIndirectionLevel()
+  }
 
   override string explain() { result = "reference to {" + this.getBaseType().explain() + "}" }
 
@@ -1251,7 +1255,7 @@ class ReferenceType extends DerivedType {
   override predicate involvesReference() { any() }
 
   override Type resolveTypedefs() {
-    result.(ReferenceType).getBaseType() = getBaseType().resolveTypedefs()
+    result.(ReferenceType).getBaseType() = this.getBaseType().resolveTypedefs()
   }
 }
 
@@ -1330,11 +1334,11 @@ class SpecifiedType extends DerivedType {
   }
 
   override Type resolveTypedefs() {
-    result.(SpecifiedType).getBaseType() = getBaseType().resolveTypedefs() and
-    result.getASpecifier() = getASpecifier()
+    result.(SpecifiedType).getBaseType() = this.getBaseType().resolveTypedefs() and
+    result.getASpecifier() = this.getASpecifier()
   }
 
-  override Type stripTopLevelSpecifiers() { result = getBaseType().stripTopLevelSpecifiers() }
+  override Type stripTopLevelSpecifiers() { result = this.getBaseType().stripTopLevelSpecifiers() }
 }
 
 /**
@@ -1433,7 +1437,8 @@ class GNUVectorType extends DerivedType {
   override int getAlignment() { arraysizes(underlyingElement(this), _, _, result) }
 
   override string explain() {
-    result = "GNU " + getNumElements() + " element vector of {" + this.getBaseType().explain() + "}"
+    result =
+      "GNU " + this.getNumElements() + " element vector of {" + this.getBaseType().explain() + "}"
   }
 
   override predicate isDeeplyConstBelow() { this.getBaseType().isDeeplyConst() }
@@ -1468,7 +1473,9 @@ class FunctionReferenceType extends FunctionPointerIshType {
 
   override string getAPrimaryQlClass() { result = "FunctionReferenceType" }
 
-  override int getPointerIndirectionLevel() { result = getBaseType().getPointerIndirectionLevel() }
+  override int getPointerIndirectionLevel() {
+    result = this.getBaseType().getPointerIndirectionLevel()
+  }
 
   override string explain() {
     result = "reference to {" + this.getBaseType().(RoutineType).explain() + "}"
@@ -1535,8 +1542,8 @@ class FunctionPointerIshType extends DerivedType {
   int getNumberOfParameters() { result = count(int i | exists(this.getParameterType(i))) }
 
   override predicate involvesTemplateParameter() {
-    getReturnType().involvesTemplateParameter() or
-    getAParameterType().involvesTemplateParameter()
+    this.getReturnType().involvesTemplateParameter() or
+    this.getAParameterType().involvesTemplateParameter()
   }
 
   override predicate isDeeplyConstBelow() { this.getBaseType().isDeeplyConst() }
@@ -1581,7 +1588,7 @@ class PointerToMemberType extends Type, @ptrtomember {
         this.getBaseType().explain() + "}"
   }
 
-  override predicate involvesTemplateParameter() { getBaseType().involvesTemplateParameter() }
+  override predicate involvesTemplateParameter() { this.getBaseType().involvesTemplateParameter() }
 
   override predicate isDeeplyConstBelow() { this.getBaseType().isDeeplyConst() }
 }
@@ -1671,8 +1678,8 @@ class RoutineType extends Type, @routinetype {
   override predicate isDeeplyConstBelow() { none() } // Current limitation: no such thing as a const routine type
 
   override predicate involvesTemplateParameter() {
-    getReturnType().involvesTemplateParameter() or
-    getAParameterType().involvesTemplateParameter()
+    this.getReturnType().involvesTemplateParameter() or
+    this.getAParameterType().involvesTemplateParameter()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/TypedefType.qll
+++ b/cpp/ql/lib/semmle/code/cpp/TypedefType.qll
@@ -25,7 +25,7 @@ class TypedefType extends UserType {
 
   override Type getUnderlyingType() { result = this.getBaseType().getUnderlyingType() }
 
-  override Type stripTopLevelSpecifiers() { result = getBaseType().stripTopLevelSpecifiers() }
+  override Type stripTopLevelSpecifiers() { result = this.getBaseType().stripTopLevelSpecifiers() }
 
   override int getSize() { result = this.getBaseType().getSize() }
 
@@ -43,11 +43,11 @@ class TypedefType extends UserType {
     result = this.getBaseType().getASpecifier()
   }
 
-  override predicate involvesReference() { getBaseType().involvesReference() }
+  override predicate involvesReference() { this.getBaseType().involvesReference() }
 
-  override Type resolveTypedefs() { result = getBaseType().resolveTypedefs() }
+  override Type resolveTypedefs() { result = this.getBaseType().resolveTypedefs() }
 
-  override Type stripType() { result = getBaseType().stripType() }
+  override Type stripType() { result = this.getBaseType().stripType() }
 }
 
 /**
@@ -90,7 +90,7 @@ class UsingAliasTypedefType extends TypedefType {
  * ```
  */
 class LocalTypedefType extends TypedefType {
-  LocalTypedefType() { isLocal() }
+  LocalTypedefType() { this.isLocal() }
 
   override string getAPrimaryQlClass() { result = "LocalTypedefType" }
 }

--- a/cpp/ql/lib/semmle/code/cpp/Union.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Union.qll
@@ -37,7 +37,7 @@ class Union extends Struct {
  * ```
  */
 class LocalUnion extends Union {
-  LocalUnion() { isLocal() }
+  LocalUnion() { this.isLocal() }
 
   override string getAPrimaryQlClass() { result = "LocalUnion" }
 }

--- a/cpp/ql/lib/semmle/code/cpp/UserType.qll
+++ b/cpp/ql/lib/semmle/code/cpp/UserType.qll
@@ -30,19 +30,19 @@ class UserType extends Type, Declaration, NameQualifyingElement, AccessHolder, @
    * Gets the simple name of this type, without any template parameters.  For example
    * if the name of the type is `"myType<int>"`, the simple name is just `"myType"`.
    */
-  string getSimpleName() { result = getName().regexpReplaceAll("<.*", "") }
+  string getSimpleName() { result = this.getName().regexpReplaceAll("<.*", "") }
 
   override predicate hasName(string name) { usertypes(underlyingElement(this), name, _) }
 
   /** Holds if this type is anonymous. */
-  predicate isAnonymous() { getName().matches("(unnamed%") }
+  predicate isAnonymous() { this.getName().matches("(unnamed%") }
 
   override predicate hasSpecifier(string s) { Type.super.hasSpecifier(s) }
 
   override Specifier getASpecifier() { result = Type.super.getASpecifier() }
 
   override Location getLocation() {
-    if hasDefinition()
+    if this.hasDefinition()
     then result = this.getDefinitionLocation()
     else result = this.getADeclarationLocation()
   }
@@ -53,16 +53,16 @@ class UserType extends Type, Declaration, NameQualifyingElement, AccessHolder, @
     else exists(Class t | this.(Class).isConstructedFrom(t) and result = t.getADeclarationEntry())
   }
 
-  override Location getADeclarationLocation() { result = getADeclarationEntry().getLocation() }
+  override Location getADeclarationLocation() { result = this.getADeclarationEntry().getLocation() }
 
   override TypeDeclarationEntry getDefinition() {
-    result = getADeclarationEntry() and
+    result = this.getADeclarationEntry() and
     result.isDefinition()
   }
 
   override Location getDefinitionLocation() {
-    if exists(getDefinition())
-    then result = getDefinition().getLocation()
+    if exists(this.getDefinition())
+    then result = this.getDefinition().getLocation()
     else
       exists(Class t |
         this.(Class).isConstructedFrom(t) and result = t.getDefinition().getLocation()
@@ -80,7 +80,7 @@ class UserType extends Type, Declaration, NameQualifyingElement, AccessHolder, @
    * Holds if this is a local type (that is, a type that has a directly-enclosing
    * function).
    */
-  predicate isLocal() { exists(getEnclosingFunction()) }
+  predicate isLocal() { exists(this.getEnclosingFunction()) }
 
   /*
    * Dummy implementations of inherited methods. This class must not be
@@ -107,9 +107,9 @@ class UserType extends Type, Declaration, NameQualifyingElement, AccessHolder, @
  * ```
  */
 class TypeDeclarationEntry extends DeclarationEntry, @type_decl {
-  override UserType getDeclaration() { result = getType() }
+  override UserType getDeclaration() { result = this.getType() }
 
-  override string getName() { result = getType().getName() }
+  override string getName() { result = this.getType().getName() }
 
   override string getAPrimaryQlClass() { result = "TypeDeclarationEntry" }
 

--- a/cpp/ql/lib/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Variable.qll
@@ -104,17 +104,17 @@ class Variable extends Declaration, @variable {
 
   override VariableDeclarationEntry getADeclarationEntry() { result.getDeclaration() = this }
 
-  override Location getADeclarationLocation() { result = getADeclarationEntry().getLocation() }
+  override Location getADeclarationLocation() { result = this.getADeclarationEntry().getLocation() }
 
   override VariableDeclarationEntry getDefinition() {
-    result = getADeclarationEntry() and
+    result = this.getADeclarationEntry() and
     result.isDefinition()
   }
 
-  override Location getDefinitionLocation() { result = getDefinition().getLocation() }
+  override Location getDefinitionLocation() { result = this.getDefinition().getLocation() }
 
   override Location getLocation() {
-    if exists(getDefinition())
+    if exists(this.getDefinition())
     then result = this.getDefinitionLocation()
     else result = this.getADeclarationLocation()
   }
@@ -199,7 +199,7 @@ class Variable extends Declaration, @variable {
  * ```
  */
 class VariableDeclarationEntry extends DeclarationEntry, @var_decl {
-  override Variable getDeclaration() { result = getVariable() }
+  override Variable getDeclaration() { result = this.getVariable() }
 
   override string getAPrimaryQlClass() { result = "VariableDeclarationEntry" }
 
@@ -276,32 +276,33 @@ class ParameterDeclarationEntry extends VariableDeclarationEntry {
   int getIndex() { param_decl_bind(underlyingElement(this), result, _) }
 
   private string getAnonymousParameterDescription() {
-    not exists(getName()) and
+    not exists(this.getName()) and
     exists(string idx |
       idx =
-        ((getIndex() + 1).toString() + "th")
+        ((this.getIndex() + 1).toString() + "th")
             .replaceAll("1th", "1st")
             .replaceAll("2th", "2nd")
             .replaceAll("3th", "3rd")
             .replaceAll("11st", "11th")
             .replaceAll("12nd", "12th")
             .replaceAll("13rd", "13th") and
-      if exists(getCanonicalName())
-      then result = "declaration of " + getCanonicalName() + " as anonymous " + idx + " parameter"
+      if exists(this.getCanonicalName())
+      then
+        result = "declaration of " + this.getCanonicalName() + " as anonymous " + idx + " parameter"
       else result = "declaration of " + idx + " parameter"
     )
   }
 
   override string toString() {
-    isDefinition() and
-    result = "definition of " + getName()
+    this.isDefinition() and
+    result = "definition of " + this.getName()
     or
-    not isDefinition() and
-    if getName() = getCanonicalName()
-    then result = "declaration of " + getName()
-    else result = "declaration of " + getCanonicalName() + " as " + getName()
+    not this.isDefinition() and
+    if this.getName() = this.getCanonicalName()
+    then result = "declaration of " + this.getName()
+    else result = "declaration of " + this.getCanonicalName() + " as " + this.getName()
     or
-    result = getAnonymousParameterDescription()
+    result = this.getAnonymousParameterDescription()
   }
 
   /**
@@ -311,8 +312,12 @@ class ParameterDeclarationEntry extends VariableDeclarationEntry {
    */
   string getTypedName() {
     exists(string typeString, string nameString |
-      (if exists(getType().getName()) then typeString = getType().getName() else typeString = "") and
-      (if exists(getName()) then nameString = getName() else nameString = "") and
+      (
+        if exists(this.getType().getName())
+        then typeString = this.getType().getName()
+        else typeString = ""
+      ) and
+      (if exists(this.getName()) then nameString = this.getName() else nameString = "") and
       if typeString != "" and nameString != ""
       then result = typeString + " " + nameString
       else result = typeString + nameString
@@ -540,7 +545,7 @@ class MemberVariable extends Variable, @membervariable {
   }
 
   /** Holds if this member is mutable. */
-  predicate isMutable() { getADeclarationEntry().hasSpecifier("mutable") }
+  predicate isMutable() { this.getADeclarationEntry().hasSpecifier("mutable") }
 
   private Type getAType() { membervariables(underlyingElement(this), unresolveElement(result), _) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/XML.qll
+++ b/cpp/ql/lib/semmle/code/cpp/XML.qll
@@ -108,7 +108,7 @@ class XMLParent extends @xmlparent {
   }
 
   /** Gets the text value contained in this XML parent. */
-  string getTextValue() { result = allCharactersString() }
+  string getTextValue() { result = this.allCharactersString() }
 
   /** Gets a printable representation of this XML parent. */
   string toString() { result = this.getName() }
@@ -119,7 +119,7 @@ class XMLFile extends XMLParent, File {
   XMLFile() { xmlEncoding(this, _) }
 
   /** Gets a printable representation of this XML file. */
-  override string toString() { result = getName() }
+  override string toString() { result = this.getName() }
 
   /** Gets the name of this XML file. */
   override string getName() { result = File.super.getAbsolutePath() }
@@ -129,14 +129,14 @@ class XMLFile extends XMLParent, File {
    *
    * Gets the path of this XML file.
    */
-  deprecated string getPath() { result = getAbsolutePath() }
+  deprecated string getPath() { result = this.getAbsolutePath() }
 
   /**
    * DEPRECATED: Use `getParentContainer().getAbsolutePath()` instead.
    *
    * Gets the path of the folder that contains this XML file.
    */
-  deprecated string getFolder() { result = getParentContainer().getAbsolutePath() }
+  deprecated string getFolder() { result = this.getParentContainer().getAbsolutePath() }
 
   /** Gets the encoding of this XML file. */
   string getEncoding() { xmlEncoding(this, result) }
@@ -200,7 +200,7 @@ class XMLDTD extends XMLLocatable, @xmldtd {
  */
 class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   /** Holds if this XML element has the given `name`. */
-  predicate hasName(string name) { name = getName() }
+  predicate hasName(string name) { name = this.getName() }
 
   /** Gets the name of this XML element. */
   override string getName() { xmlElements(this, result, _, _, _) }
@@ -239,7 +239,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }
 
   /** Gets a printable representation of this XML element. */
-  override string toString() { result = getName() }
+  override string toString() { result = this.getName() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/commons/CommonType.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/CommonType.qll
@@ -375,8 +375,8 @@ class Wchar_t extends Type {
 class MicrosoftInt8Type extends IntegralType {
   MicrosoftInt8Type() {
     this instanceof CharType and
-    not isExplicitlyUnsigned() and
-    not isExplicitlySigned()
+    not this.isExplicitlyUnsigned() and
+    not this.isExplicitlySigned()
   }
 }
 
@@ -391,8 +391,8 @@ class MicrosoftInt8Type extends IntegralType {
 class MicrosoftInt16Type extends IntegralType {
   MicrosoftInt16Type() {
     this instanceof ShortType and
-    not isExplicitlyUnsigned() and
-    not isExplicitlySigned()
+    not this.isExplicitlyUnsigned() and
+    not this.isExplicitlySigned()
   }
 }
 
@@ -407,8 +407,8 @@ class MicrosoftInt16Type extends IntegralType {
 class MicrosoftInt32Type extends IntegralType {
   MicrosoftInt32Type() {
     this instanceof IntType and
-    not isExplicitlyUnsigned() and
-    not isExplicitlySigned()
+    not this.isExplicitlyUnsigned() and
+    not this.isExplicitlySigned()
   }
 }
 
@@ -423,8 +423,8 @@ class MicrosoftInt32Type extends IntegralType {
 class MicrosoftInt64Type extends IntegralType {
   MicrosoftInt64Type() {
     this instanceof LongLongType and
-    not isExplicitlyUnsigned() and
-    not isExplicitlySigned()
+    not this.isExplicitlyUnsigned() and
+    not this.isExplicitlySigned()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
@@ -33,7 +33,7 @@ DependencyOptions getDependencyOptions() { any() }
 class DependsSource extends Element {
   DependsSource() {
     // not inside a template instantiation
-    not exists(Element other | isFromTemplateInstantiation(other)) or
+    not exists(Element other | this.isFromTemplateInstantiation(other)) or
     // allow DeclarationEntrys of template specializations
     this.(DeclarationEntry).getDeclaration().(Function).isConstructedFrom(_) or
     this.(DeclarationEntry).getDeclaration().(Class).isConstructedFrom(_)

--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -8,7 +8,7 @@ import semmle.code.cpp.commons.StringAnalysis
 import semmle.code.cpp.models.interfaces.FormattingFunction
 
 class PrintfFormatAttribute extends FormatAttribute {
-  PrintfFormatAttribute() { getArchetype() = ["printf", "__printf__"] }
+  PrintfFormatAttribute() { this.getArchetype() = ["printf", "__printf__"] }
 }
 
 /**
@@ -20,13 +20,13 @@ class AttributeFormattingFunction extends FormattingFunction {
 
   AttributeFormattingFunction() {
     exists(PrintfFormatAttribute printf_attrib |
-      printf_attrib = getAnAttribute() and
+      printf_attrib = this.getAnAttribute() and
       exists(printf_attrib.getFirstFormatArgIndex()) // exclude `vprintf` style format functions
     )
   }
 
   override int getFormatParameterIndex() {
-    forex(PrintfFormatAttribute printf_attrib | printf_attrib = getAnAttribute() |
+    forex(PrintfFormatAttribute printf_attrib | printf_attrib = this.getAnAttribute() |
       result = printf_attrib.getFormatIndex()
     )
   }
@@ -132,7 +132,7 @@ deprecated predicate variadicFormatter(Function f, int formatParamIndex) {
 class UserDefinedFormattingFunction extends FormattingFunction {
   override string getAPrimaryQlClass() { result = "UserDefinedFormattingFunction" }
 
-  UserDefinedFormattingFunction() { isVarargs() and callsVariadicFormatter(this, _, _, _) }
+  UserDefinedFormattingFunction() { this.isVarargs() and callsVariadicFormatter(this, _, _, _) }
 
   override int getFormatParameterIndex() { callsVariadicFormatter(this, _, result, _) }
 
@@ -191,7 +191,7 @@ class FormattingFunctionCall extends Expr {
     exists(int i |
       result = this.getArgument(i) and
       n >= 0 and
-      n = i - getTarget().(FormattingFunction).getFirstFormatArgumentIndex()
+      n = i - this.getTarget().(FormattingFunction).getFirstFormatArgumentIndex()
     )
   }
 
@@ -251,7 +251,7 @@ class FormattingFunctionCall extends Expr {
   int getNumFormatArgument() {
     result = count(this.getFormatArgument(_)) and
     // format arguments must be known
-    exists(getTarget().(FormattingFunction).getFirstFormatArgumentIndex())
+    exists(this.getTarget().(FormattingFunction).getFirstFormatArgumentIndex())
   }
 
   /**
@@ -290,7 +290,7 @@ class FormatLiteral extends Literal {
    * DEPRECATED: Use getDefaultCharType() instead.
    */
   deprecated predicate isWideCharDefault() {
-    getUse().getTarget().(FormattingFunction).isWideCharDefault()
+    this.getUse().getTarget().(FormattingFunction).isWideCharDefault()
   }
 
   /**
@@ -298,7 +298,7 @@ class FormatLiteral extends Literal {
    * `char` or `wchar_t`.
    */
   Type getDefaultCharType() {
-    result = getUse().getTarget().(FormattingFunction).getDefaultCharType()
+    result = this.getUse().getTarget().(FormattingFunction).getDefaultCharType()
   }
 
   /**
@@ -307,7 +307,7 @@ class FormatLiteral extends Literal {
    * which is correct for a particular function.
    */
   Type getNonDefaultCharType() {
-    result = getUse().getTarget().(FormattingFunction).getNonDefaultCharType()
+    result = this.getUse().getTarget().(FormattingFunction).getNonDefaultCharType()
   }
 
   /**
@@ -315,7 +315,9 @@ class FormatLiteral extends Literal {
    * snapshots there may be multiple results where we can't tell which is correct for a
    * particular function.
    */
-  Type getWideCharType() { result = getUse().getTarget().(FormattingFunction).getWideCharType() }
+  Type getWideCharType() {
+    result = this.getUse().getTarget().(FormattingFunction).getWideCharType()
+  }
 
   /**
    * Holds if this `FormatLiteral` is in a context that supports
@@ -353,7 +355,7 @@ class FormatLiteral extends Literal {
   }
 
   private string getFlagRegexp() {
-    if isMicrosoft() then result = "[-+ #0']*" else result = "[-+ #0'I]*"
+    if this.isMicrosoft() then result = "[-+ #0']*" else result = "[-+ #0'I]*"
   }
 
   private string getFieldWidthRegexp() { result = "(?:[1-9][0-9]*|\\*|\\*[0-9]+\\$)?" }
@@ -361,13 +363,13 @@ class FormatLiteral extends Literal {
   private string getPrecRegexp() { result = "(?:\\.(?:[0-9]*|\\*|\\*[0-9]+\\$))?" }
 
   private string getLengthRegexp() {
-    if isMicrosoft()
+    if this.isMicrosoft()
     then result = "(?:hh?|ll?|L|q|j|z|t|w|I32|I64|I)?"
     else result = "(?:hh?|ll?|L|q|j|z|Z|t)?"
   }
 
   private string getConvCharRegexp() {
-    if isMicrosoft()
+    if this.isMicrosoft()
     then result = "[aAcCdeEfFgGimnopsSuxXZ@]"
     else result = "[aAcCdeEfFgGimnopsSuxX@]"
   }
@@ -747,16 +749,16 @@ class FormatLiteral extends Literal {
    * Gets the argument type required by the nth conversion specifier.
    */
   Type getConversionType(int n) {
-    result = getConversionType1(n) or
-    result = getConversionType1b(n) or
-    result = getConversionType2(n) or
-    result = getConversionType3(n) or
-    result = getConversionType4(n) or
-    result = getConversionType6(n) or
-    result = getConversionType7(n) or
-    result = getConversionType8(n) or
-    result = getConversionType9(n) or
-    result = getConversionType10(n)
+    result = this.getConversionType1(n) or
+    result = this.getConversionType1b(n) or
+    result = this.getConversionType2(n) or
+    result = this.getConversionType3(n) or
+    result = this.getConversionType4(n) or
+    result = this.getConversionType6(n) or
+    result = this.getConversionType7(n) or
+    result = this.getConversionType8(n) or
+    result = this.getConversionType9(n) or
+    result = this.getConversionType10(n)
   }
 
   private Type getConversionType1(int n) {
@@ -786,15 +788,15 @@ class FormatLiteral extends Literal {
         or
         conv = ["c", "C"] and
         len = ["l", "w"] and
-        result = getWideCharType()
+        result = this.getWideCharType()
         or
         conv = "c" and
         (len != "l" and len != "w" and len != "h") and
-        result = getDefaultCharType()
+        result = this.getDefaultCharType()
         or
         conv = "C" and
         (len != "l" and len != "w" and len != "h") and
-        result = getNonDefaultCharType()
+        result = this.getNonDefaultCharType()
       )
     )
   }
@@ -831,15 +833,15 @@ class FormatLiteral extends Literal {
         or
         conv = ["s", "S"] and
         len = ["l", "w"] and
-        result.(PointerType).getBaseType() = getWideCharType()
+        result.(PointerType).getBaseType() = this.getWideCharType()
         or
         conv = "s" and
         (len != "l" and len != "w" and len != "h") and
-        result.(PointerType).getBaseType() = getDefaultCharType()
+        result.(PointerType).getBaseType() = this.getDefaultCharType()
         or
         conv = "S" and
         (len != "l" and len != "w" and len != "h") and
-        result.(PointerType).getBaseType() = getNonDefaultCharType()
+        result.(PointerType).getBaseType() = this.getNonDefaultCharType()
       )
     )
   }
@@ -894,19 +896,19 @@ class FormatLiteral extends Literal {
     exists(string len, string conv |
       this.parseConvSpec(n, _, _, _, _, _, len, conv) and
       (len != "l" and len != "w" and len != "h") and
-      getUse().getTarget().(FormattingFunction).getFormatCharType().getSize() > 1 and // wide function
+      this.getUse().getTarget().(FormattingFunction).getFormatCharType().getSize() > 1 and // wide function
       (
         conv = "c" and
-        result = getNonDefaultCharType()
+        result = this.getNonDefaultCharType()
         or
         conv = "C" and
-        result = getDefaultCharType()
+        result = this.getDefaultCharType()
         or
         conv = "s" and
-        result.(PointerType).getBaseType() = getNonDefaultCharType()
+        result.(PointerType).getBaseType() = this.getNonDefaultCharType()
         or
         conv = "S" and
-        result.(PointerType).getBaseType() = getDefaultCharType()
+        result.(PointerType).getBaseType() = this.getDefaultCharType()
       )
     )
   }
@@ -939,9 +941,13 @@ class FormatLiteral extends Literal {
    * not account for positional arguments (`$`).
    */
   int getFormatArgumentIndexFor(int n, int mode) {
-    hasFormatArgumentIndexFor(n, mode) and
+    this.hasFormatArgumentIndexFor(n, mode) and
     (3 * n) + mode =
-      rank[result + 1](int n2, int mode2 | hasFormatArgumentIndexFor(n2, mode2) | (3 * n2) + mode2)
+      rank[result + 1](int n2, int mode2 |
+        this.hasFormatArgumentIndexFor(n2, mode2)
+      |
+        (3 * n2) + mode2
+      )
   }
 
   /**
@@ -951,7 +957,7 @@ class FormatLiteral extends Literal {
   int getNumArgNeeded(int n) {
     exists(this.getConvSpecOffset(n)) and
     exists(this.getConversionChar(n)) and
-    result = count(int mode | hasFormatArgumentIndexFor(n, mode))
+    result = count(int mode | this.hasFormatArgumentIndexFor(n, mode))
   }
 
   /**
@@ -963,7 +969,7 @@ class FormatLiteral extends Literal {
       // At least one conversion specifier has a parameter field, in which case,
       // they all should have.
       result = max(string s | this.getParameterField(_) = s + "$" | s.toInt())
-    else result = count(int n, int mode | hasFormatArgumentIndexFor(n, mode))
+    else result = count(int n, int mode | this.hasFormatArgumentIndexFor(n, mode))
   }
 
   /**
@@ -1053,10 +1059,10 @@ class FormatLiteral extends Literal {
         exists(int sizeBits |
           sizeBits =
             min(int bits |
-              bits = getIntegralDisplayType(n).getSize() * 8
+              bits = this.getIntegralDisplayType(n).getSize() * 8
               or
               exists(IntegralType t |
-                t = getUse().getConversionArgument(n).getType().getUnderlyingType()
+                t = this.getUse().getConversionArgument(n).getType().getUnderlyingType()
               |
                 t.isSigned() and bits = t.getSize() * 8
               )
@@ -1071,10 +1077,10 @@ class FormatLiteral extends Literal {
         exists(int sizeBits |
           sizeBits =
             min(int bits |
-              bits = getIntegralDisplayType(n).getSize() * 8
+              bits = this.getIntegralDisplayType(n).getSize() * 8
               or
               exists(IntegralType t |
-                t = getUse().getConversionArgument(n).getType().getUnderlyingType()
+                t = this.getUse().getConversionArgument(n).getType().getUnderlyingType()
               |
                 t.isUnsigned() and bits = t.getSize() * 8
               )
@@ -1089,26 +1095,26 @@ class FormatLiteral extends Literal {
         exists(int sizeBytes, int baseLen |
           sizeBytes =
             min(int bytes |
-              bytes = getIntegralDisplayType(n).getSize()
+              bytes = this.getIntegralDisplayType(n).getSize()
               or
               exists(IntegralType t |
-                t = getUse().getConversionArgument(n).getType().getUnderlyingType()
+                t = this.getUse().getConversionArgument(n).getType().getUnderlyingType()
               |
                 t.isUnsigned() and bytes = t.getSize()
               )
             ) and
           baseLen = sizeBytes * 2 and
           (
-            if hasAlternateFlag(n) then len = 2 + baseLen else len = baseLen // "0x"
+            if this.hasAlternateFlag(n) then len = 2 + baseLen else len = baseLen // "0x"
           )
         )
         or
         this.getConversionChar(n).toLowerCase() = "p" and
         exists(PointerType ptrType, int baseLen |
-          ptrType = getFullyConverted().getType() and
+          ptrType = this.getFullyConverted().getType() and
           baseLen = max(ptrType.getSize() * 2) and // e.g. "0x1234567812345678"; exact format is platform dependent
           (
-            if hasAlternateFlag(n) then len = 2 + baseLen else len = baseLen // "0x"
+            if this.hasAlternateFlag(n) then len = 2 + baseLen else len = baseLen // "0x"
           )
         )
         or
@@ -1117,17 +1123,17 @@ class FormatLiteral extends Literal {
         exists(int sizeBits, int baseLen |
           sizeBits =
             min(int bits |
-              bits = getIntegralDisplayType(n).getSize() * 8
+              bits = this.getIntegralDisplayType(n).getSize() * 8
               or
               exists(IntegralType t |
-                t = getUse().getConversionArgument(n).getType().getUnderlyingType()
+                t = this.getUse().getConversionArgument(n).getType().getUnderlyingType()
               |
                 t.isUnsigned() and bits = t.getSize() * 8
               )
             ) and
           baseLen = (sizeBits / 3.0).ceil() and
           (
-            if hasAlternateFlag(n) then len = 1 + baseLen else len = baseLen // "0"
+            if this.hasAlternateFlag(n) then len = 1 + baseLen else len = baseLen // "0"
           )
         )
         or
@@ -1150,8 +1156,8 @@ class FormatLiteral extends Literal {
    */
   int getMaxConvertedLengthLimited(int n) {
     if this.getConversionChar(n).toLowerCase() = "f"
-    then result = getMaxConvertedLength(n).minimum(8)
-    else result = getMaxConvertedLength(n)
+    then result = this.getMaxConvertedLength(n).minimum(8)
+    else result = this.getMaxConvertedLength(n)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Scanf.qll
@@ -24,7 +24,7 @@ abstract class ScanfFunction extends Function {
    * Holds if the default meaning of `%s` is a `wchar_t*` string
    * (rather than a `char*`).
    */
-  predicate isWideCharDefault() { exists(getName().indexOf("wscanf")) }
+  predicate isWideCharDefault() { exists(this.getName().indexOf("wscanf")) }
 }
 
 /**
@@ -34,10 +34,10 @@ class Scanf extends ScanfFunction {
   Scanf() {
     this instanceof TopLevelFunction and
     (
-      hasGlobalOrStdOrBslName("scanf") or // scanf(format, args...)
-      hasGlobalOrStdOrBslName("wscanf") or // wscanf(format, args...)
-      hasGlobalName("_scanf_l") or // _scanf_l(format, locale, args...)
-      hasGlobalName("_wscanf_l") // _wscanf_l(format, locale, args...)
+      this.hasGlobalOrStdOrBslName("scanf") or // scanf(format, args...)
+      this.hasGlobalOrStdOrBslName("wscanf") or // wscanf(format, args...)
+      this.hasGlobalName("_scanf_l") or // _scanf_l(format, locale, args...)
+      this.hasGlobalName("_wscanf_l") // _wscanf_l(format, locale, args...)
     )
   }
 
@@ -53,10 +53,10 @@ class Fscanf extends ScanfFunction {
   Fscanf() {
     this instanceof TopLevelFunction and
     (
-      hasGlobalOrStdOrBslName("fscanf") or // fscanf(src_stream, format, args...)
-      hasGlobalOrStdOrBslName("fwscanf") or // fwscanf(src_stream, format, args...)
-      hasGlobalName("_fscanf_l") or // _fscanf_l(src_stream, format, locale, args...)
-      hasGlobalName("_fwscanf_l") // _fwscanf_l(src_stream, format, locale, args...)
+      this.hasGlobalOrStdOrBslName("fscanf") or // fscanf(src_stream, format, args...)
+      this.hasGlobalOrStdOrBslName("fwscanf") or // fwscanf(src_stream, format, args...)
+      this.hasGlobalName("_fscanf_l") or // _fscanf_l(src_stream, format, locale, args...)
+      this.hasGlobalName("_fwscanf_l") // _fwscanf_l(src_stream, format, locale, args...)
     )
   }
 
@@ -72,10 +72,10 @@ class Sscanf extends ScanfFunction {
   Sscanf() {
     this instanceof TopLevelFunction and
     (
-      hasGlobalOrStdOrBslName("sscanf") or // sscanf(src_stream, format, args...)
-      hasGlobalOrStdOrBslName("swscanf") or // swscanf(src, format, args...)
-      hasGlobalName("_sscanf_l") or // _sscanf_l(src, format, locale, args...)
-      hasGlobalName("_swscanf_l") // _swscanf_l(src, format, locale, args...)
+      this.hasGlobalOrStdOrBslName("sscanf") or // sscanf(src_stream, format, args...)
+      this.hasGlobalOrStdOrBslName("swscanf") or // swscanf(src, format, args...)
+      this.hasGlobalName("_sscanf_l") or // _sscanf_l(src, format, locale, args...)
+      this.hasGlobalName("_swscanf_l") // _swscanf_l(src, format, locale, args...)
     )
   }
 
@@ -91,10 +91,10 @@ class Snscanf extends ScanfFunction {
   Snscanf() {
     this instanceof TopLevelFunction and
     (
-      hasGlobalName("_snscanf") or // _snscanf(src, max_amount, format, args...)
-      hasGlobalName("_snwscanf") or // _snwscanf(src, max_amount, format, args...)
-      hasGlobalName("_snscanf_l") or // _snscanf_l(src, max_amount, format, locale, args...)
-      hasGlobalName("_snwscanf_l") // _snwscanf_l(src, max_amount, format, locale, args...)
+      this.hasGlobalName("_snscanf") or // _snscanf(src, max_amount, format, args...)
+      this.hasGlobalName("_snwscanf") or // _snwscanf(src, max_amount, format, args...)
+      this.hasGlobalName("_snscanf_l") or // _snscanf_l(src, max_amount, format, locale, args...)
+      this.hasGlobalName("_snwscanf_l") // _snwscanf_l(src, max_amount, format, locale, args...)
       // note that the max_amount is not a limit on the output length, it's an input length
       // limit used with non null-terminated strings.
     )
@@ -120,18 +120,18 @@ class ScanfFunctionCall extends FunctionCall {
   /**
    * Gets the `scanf`-like function that is called.
    */
-  ScanfFunction getScanfFunction() { result = getTarget() }
+  ScanfFunction getScanfFunction() { result = this.getTarget() }
 
   /**
    * Gets the position at which the input string or stream parameter occurs,
    * if this function call does not read from standard input.
    */
-  int getInputParameterIndex() { result = getScanfFunction().getInputParameterIndex() }
+  int getInputParameterIndex() { result = this.getScanfFunction().getInputParameterIndex() }
 
   /**
    * Gets the position at which the format parameter occurs.
    */
-  int getFormatParameterIndex() { result = getScanfFunction().getFormatParameterIndex() }
+  int getFormatParameterIndex() { result = this.getScanfFunction().getFormatParameterIndex() }
 
   /**
    * Gets the format expression used in this call.
@@ -142,7 +142,7 @@ class ScanfFunctionCall extends FunctionCall {
    * Holds if the default meaning of `%s` is a `wchar_t*` string
    * (rather than a `char*`).
    */
-  predicate isWideCharDefault() { getScanfFunction().isWideCharDefault() }
+  predicate isWideCharDefault() { this.getScanfFunction().isWideCharDefault() }
 }
 
 /**
@@ -158,7 +158,7 @@ class ScanfFormatLiteral extends Expr {
   ScanfFunctionCall getUse() { result.getFormat() = this }
 
   /** Holds if the default meaning of `%s` is a `wchar_t*` (rather than a `char*`). */
-  predicate isWideCharDefault() { getUse().getTarget().(ScanfFunction).isWideCharDefault() }
+  predicate isWideCharDefault() { this.getUse().getTarget().(ScanfFunction).isWideCharDefault() }
 
   /**
    * Gets the format string itself, transformed as follows:

--- a/cpp/ql/lib/semmle/code/cpp/commons/Synchronization.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Synchronization.qll
@@ -40,8 +40,8 @@ abstract class MutexType extends Type {
    * Gets a call that locks or tries to lock any mutex of this type.
    */
   FunctionCall getLockAccess() {
-    result = getMustlockAccess() or
-    result = getTrylockAccess()
+    result = this.getMustlockAccess() or
+    result = this.getTrylockAccess()
   }
 
   /**
@@ -63,22 +63,22 @@ abstract class MutexType extends Type {
   /**
    * DEPRECATED: use mustlockAccess(fc, arg) instead.
    */
-  deprecated Function getMustlockFunction() { result = getMustlockAccess().getTarget() }
+  deprecated Function getMustlockFunction() { result = this.getMustlockAccess().getTarget() }
 
   /**
    * DEPRECATED: use trylockAccess(fc, arg) instead.
    */
-  deprecated Function getTrylockFunction() { result = getTrylockAccess().getTarget() }
+  deprecated Function getTrylockFunction() { result = this.getTrylockAccess().getTarget() }
 
   /**
    * DEPRECATED: use lockAccess(fc, arg) instead.
    */
-  deprecated Function getLockFunction() { result = getLockAccess().getTarget() }
+  deprecated Function getLockFunction() { result = this.getLockAccess().getTarget() }
 
   /**
    * DEPRECATED: use unlockAccess(fc, arg) instead.
    */
-  deprecated Function getUnlockFunction() { result = getUnlockAccess().getTarget() }
+  deprecated Function getUnlockFunction() { result = this.getUnlockAccess().getTarget() }
 }
 
 /**
@@ -155,17 +155,17 @@ class DefaultMutexType extends MutexType {
 
   override predicate mustlockAccess(FunctionCall fc, Expr arg) {
     fc.getTarget() = mustlockCandidate() and
-    lockArgType(fc, arg)
+    this.lockArgType(fc, arg)
   }
 
   override predicate trylockAccess(FunctionCall fc, Expr arg) {
     fc.getTarget() = trylockCandidate() and
-    lockArgType(fc, arg)
+    this.lockArgType(fc, arg)
   }
 
   override predicate unlockAccess(FunctionCall fc, Expr arg) {
     fc.getTarget() = unlockCandidate() and
-    lockArgType(fc, arg)
+    this.lockArgType(fc, arg)
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/BasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/BasicBlocks.qll
@@ -201,7 +201,7 @@ class BasicBlock extends ControlFlowNodeBase {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    hasLocationInfoInternal(filepath, startline, startcolumn, filepath, endline, endcolumn)
+    this.hasLocationInfoInternal(filepath, startline, startcolumn, filepath, endline, endcolumn)
   }
 
   pragma[noinline]
@@ -276,7 +276,7 @@ class EntryBasicBlock extends BasicBlock {
  */
 class ExitBasicBlock extends BasicBlock {
   ExitBasicBlock() {
-    getEnd() instanceof Function or
-    aborting(getEnd())
+    this.getEnd() instanceof Function or
+    aborting(this.getEnd())
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/ControlFlowGraph.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/ControlFlowGraph.qll
@@ -66,7 +66,7 @@ class ControlFlowNode extends Locatable, ControlFlowNodeBase {
    */
   ControlFlowNode getATrueSuccessor() {
     qlCFGTrueSuccessor(this, result) and
-    result = getASuccessor()
+    result = this.getASuccessor()
   }
 
   /**
@@ -75,7 +75,7 @@ class ControlFlowNode extends Locatable, ControlFlowNodeBase {
    */
   ControlFlowNode getAFalseSuccessor() {
     qlCFGFalseSuccessor(this, result) and
-    result = getASuccessor()
+    result = this.getASuccessor()
   }
 
   /** Gets the `BasicBlock` containing this control-flow node. */

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -121,7 +121,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
 
   override predicate ensuresLt(Expr left, Expr right, int k, BasicBlock block, boolean isLessThan) {
     exists(boolean testIsTrue |
-      comparesLt(left, right, k, isLessThan, testIsTrue) and this.controls(block, testIsTrue)
+      this.comparesLt(left, right, k, isLessThan, testIsTrue) and this.controls(block, testIsTrue)
     )
   }
 
@@ -135,7 +135,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
 
   override predicate ensuresEq(Expr left, Expr right, int k, BasicBlock block, boolean areEqual) {
     exists(boolean testIsTrue |
-      comparesEq(left, right, k, areEqual, testIsTrue) and this.controls(block, testIsTrue)
+      this.comparesEq(left, right, k, areEqual, testIsTrue) and this.controls(block, testIsTrue)
     )
   }
 }
@@ -147,27 +147,29 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
 private class GuardConditionFromShortCircuitNot extends GuardCondition, NotExpr {
   GuardConditionFromShortCircuitNot() {
     not exists(Instruction inst | this.getFullyConverted() = inst.getAST()) and
-    exists(IRGuardCondition ir | getOperand() = ir.getAST())
+    exists(IRGuardCondition ir | this.getOperand() = ir.getAST())
   }
 
   override predicate controls(BasicBlock controlled, boolean testIsTrue) {
-    getOperand().(GuardCondition).controls(controlled, testIsTrue.booleanNot())
+    this.getOperand().(GuardCondition).controls(controlled, testIsTrue.booleanNot())
   }
 
   override predicate comparesLt(Expr left, Expr right, int k, boolean isLessThan, boolean testIsTrue) {
-    getOperand().(GuardCondition).comparesLt(left, right, k, isLessThan, testIsTrue.booleanNot())
+    this.getOperand()
+        .(GuardCondition)
+        .comparesLt(left, right, k, isLessThan, testIsTrue.booleanNot())
   }
 
   override predicate ensuresLt(Expr left, Expr right, int k, BasicBlock block, boolean isLessThan) {
-    getOperand().(GuardCondition).ensuresLt(left, right, k, block, isLessThan.booleanNot())
+    this.getOperand().(GuardCondition).ensuresLt(left, right, k, block, isLessThan.booleanNot())
   }
 
   override predicate comparesEq(Expr left, Expr right, int k, boolean areEqual, boolean testIsTrue) {
-    getOperand().(GuardCondition).comparesEq(left, right, k, areEqual, testIsTrue.booleanNot())
+    this.getOperand().(GuardCondition).comparesEq(left, right, k, areEqual, testIsTrue.booleanNot())
   }
 
   override predicate ensuresEq(Expr left, Expr right, int k, BasicBlock block, boolean areEqual) {
-    getOperand().(GuardCondition).ensuresEq(left, right, k, block, areEqual.booleanNot())
+    this.getOperand().(GuardCondition).ensuresEq(left, right, k, block, areEqual.booleanNot())
   }
 }
 
@@ -303,9 +305,9 @@ class IRGuardCondition extends Instruction {
   cached
   predicate controlsEdge(IRBlock pred, IRBlock succ, boolean testIsTrue) {
     pred.getASuccessor() = succ and
-    controls(pred, testIsTrue)
+    this.controls(pred, testIsTrue)
     or
-    succ = getBranchSuccessor(testIsTrue) and
+    succ = this.getBranchSuccessor(testIsTrue) and
     branch.getCondition() = this and
     branch.getBlock() = pred
   }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/LocalScopeVariableReachability.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/LocalScopeVariableReachability.qll
@@ -73,19 +73,19 @@ abstract deprecated class LocalScopeVariableReachability extends string {
      */
 
     exists(BasicBlock bb, int i |
-      isSource(source, v) and
+      this.isSource(source, v) and
       bb.getNode(i) = source and
       not bb.isUnreachable()
     |
       exists(int j |
         j > i and
         sink = bb.getNode(j) and
-        isSink(sink, v) and
-        not exists(int k | isBarrier(bb.getNode(k), v) | k in [i + 1 .. j - 1])
+        this.isSink(sink, v) and
+        not exists(int k | this.isBarrier(bb.getNode(k), v) | k in [i + 1 .. j - 1])
       )
       or
-      not exists(int k | isBarrier(bb.getNode(k), v) | k > i) and
-      bbSuccessorEntryReaches(bb, v, sink, _)
+      not exists(int k | this.isBarrier(bb.getNode(k), v) | k > i) and
+      this.bbSuccessorEntryReaches(bb, v, sink, _)
     )
   }
 
@@ -97,11 +97,11 @@ abstract deprecated class LocalScopeVariableReachability extends string {
       bbSuccessorEntryReachesLoopInvariant(bb, succ, skipsFirstLoopAlwaysTrueUponEntry,
         succSkipsFirstLoopAlwaysTrueUponEntry)
     |
-      bbEntryReachesLocally(succ, v, node) and
+      this.bbEntryReachesLocally(succ, v, node) and
       succSkipsFirstLoopAlwaysTrueUponEntry = false
       or
-      not isBarrier(succ.getNode(_), v) and
-      bbSuccessorEntryReaches(succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
+      not this.isBarrier(succ.getNode(_), v) and
+      this.bbSuccessorEntryReaches(succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
     )
   }
 
@@ -110,7 +110,7 @@ abstract deprecated class LocalScopeVariableReachability extends string {
   ) {
     exists(int n |
       node = bb.getNode(n) and
-      isSink(node, v)
+      this.isSink(node, v)
     |
       not exists(this.firstBarrierIndexIn(bb, v))
       or
@@ -119,7 +119,7 @@ abstract deprecated class LocalScopeVariableReachability extends string {
   }
 
   private int firstBarrierIndexIn(BasicBlock bb, SemanticStackVariable v) {
-    result = min(int m | isBarrier(bb.getNode(m), v))
+    result = min(int m | this.isBarrier(bb.getNode(m), v))
   }
 }
 
@@ -271,7 +271,7 @@ abstract deprecated class LocalScopeVariableReachabilityWithReassignment extends
    * accounts for loops where the condition is provably true upon entry.
    */
   override predicate reaches(ControlFlowNode source, SemanticStackVariable v, ControlFlowNode sink) {
-    reachesTo(source, v, sink, _)
+    this.reachesTo(source, v, sink, _)
   }
 
   /**
@@ -281,21 +281,21 @@ abstract deprecated class LocalScopeVariableReachabilityWithReassignment extends
     ControlFlowNode source, SemanticStackVariable v, ControlFlowNode sink, SemanticStackVariable v0
   ) {
     exists(ControlFlowNode def |
-      actualSourceReaches(source, v, def, v0) and
+      this.actualSourceReaches(source, v, def, v0) and
       LocalScopeVariableReachability.super.reaches(def, v0, sink) and
-      isSinkActual(sink, v0)
+      this.isSinkActual(sink, v0)
     )
   }
 
   private predicate actualSourceReaches(
     ControlFlowNode source, SemanticStackVariable v, ControlFlowNode def, SemanticStackVariable v0
   ) {
-    isSourceActual(source, v) and def = source and v0 = v
+    this.isSourceActual(source, v) and def = source and v0 = v
     or
     exists(ControlFlowNode source1, SemanticStackVariable v1 |
-      actualSourceReaches(source, v, source1, v1)
+      this.actualSourceReaches(source, v, source1, v1)
     |
-      reassignment(source1, v1, def, v0)
+      this.reassignment(source1, v1, def, v0)
     )
   }
 
@@ -307,14 +307,14 @@ abstract deprecated class LocalScopeVariableReachabilityWithReassignment extends
   }
 
   final override predicate isSource(ControlFlowNode node, LocalScopeVariable v) {
-    isSourceActual(node, v)
+    this.isSourceActual(node, v)
     or
     // Reassignment generates a new (non-actual) source
-    reassignment(_, _, node, v)
+    this.reassignment(_, _, node, v)
   }
 
   final override predicate isSink(ControlFlowNode node, LocalScopeVariable v) {
-    isSinkActual(node, v)
+    this.isSinkActual(node, v)
     or
     // Reassignment generates a new (non-actual) sink
     exprDefinition(_, node, v.getAnAccess())
@@ -347,21 +347,21 @@ abstract deprecated class LocalScopeVariableReachabilityExt extends string {
   /** See `LocalScopeVariableReachability.reaches`. */
   predicate reaches(ControlFlowNode source, SemanticStackVariable v, ControlFlowNode sink) {
     exists(BasicBlock bb, int i |
-      isSource(source, v) and
+      this.isSource(source, v) and
       bb.getNode(i) = source and
       not bb.isUnreachable()
     |
       exists(int j |
         j > i and
         sink = bb.getNode(j) and
-        isSink(sink, v) and
-        not exists(int k | isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) |
+        this.isSink(sink, v) and
+        not exists(int k | this.isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) |
           k in [i .. j - 1]
         )
       )
       or
-      not exists(int k | isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) | k >= i) and
-      bbSuccessorEntryReaches(source, bb, v, sink, _)
+      not exists(int k | this.isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) | k >= i) and
+      this.bbSuccessorEntryReaches(source, bb, v, sink, _)
     )
   }
 
@@ -372,22 +372,22 @@ abstract deprecated class LocalScopeVariableReachabilityExt extends string {
     exists(BasicBlock succ, boolean succSkipsFirstLoopAlwaysTrueUponEntry |
       bbSuccessorEntryReachesLoopInvariant(bb, succ, skipsFirstLoopAlwaysTrueUponEntry,
         succSkipsFirstLoopAlwaysTrueUponEntry) and
-      not isBarrier(source, bb.getEnd(), succ.getStart(), v)
+      not this.isBarrier(source, bb.getEnd(), succ.getStart(), v)
     |
-      bbEntryReachesLocally(source, succ, v, node) and
+      this.bbEntryReachesLocally(source, succ, v, node) and
       succSkipsFirstLoopAlwaysTrueUponEntry = false
       or
-      not exists(int k | isBarrier(source, succ.getNode(k), succ.getNode(k + 1), v)) and
-      bbSuccessorEntryReaches(source, succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
+      not exists(int k | this.isBarrier(source, succ.getNode(k), succ.getNode(k + 1), v)) and
+      this.bbSuccessorEntryReaches(source, succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
     )
   }
 
   private predicate bbEntryReachesLocally(
     ControlFlowNode source, BasicBlock bb, SemanticStackVariable v, ControlFlowNode node
   ) {
-    isSource(source, v) and
-    exists(int n | node = bb.getNode(n) and isSink(node, v) |
-      not exists(int m | m < n | isBarrier(source, bb.getNode(m), bb.getNode(m + 1), v))
+    this.isSource(source, v) and
+    exists(int n | node = bb.getNode(n) and this.isSink(node, v) |
+      not exists(int m | m < n | this.isBarrier(source, bb.getNode(m), bb.getNode(m + 1), v))
     )
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSA.qll
@@ -59,7 +59,7 @@ class SsaDefinition extends ControlFlowNodeBase {
   ControlFlowNode getDefinition() { result = this }
 
   /** Gets the `BasicBlock` containing this definition. */
-  BasicBlock getBasicBlock() { result.contains(getDefinition()) }
+  BasicBlock getBasicBlock() { result.contains(this.getDefinition()) }
 
   /** Holds if this definition is a phi node for variable `v`. */
   predicate isPhiNode(StackVariable v) { exists(StandardSSA x | x.phi_node(v, this.(BasicBlock))) }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/StackVariableReachability.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/StackVariableReachability.qll
@@ -72,19 +72,19 @@ abstract class StackVariableReachability extends string {
      */
 
     exists(BasicBlock bb, int i |
-      isSource(source, v) and
+      this.isSource(source, v) and
       bb.getNode(i) = source and
       not bb.isUnreachable()
     |
       exists(int j |
         j > i and
         sink = bb.getNode(j) and
-        isSink(sink, v) and
-        not exists(int k | isBarrier(bb.getNode(k), v) | k in [i + 1 .. j - 1])
+        this.isSink(sink, v) and
+        not exists(int k | this.isBarrier(bb.getNode(k), v) | k in [i + 1 .. j - 1])
       )
       or
-      not exists(int k | isBarrier(bb.getNode(k), v) | k > i) and
-      bbSuccessorEntryReaches(bb, v, sink, _)
+      not exists(int k | this.isBarrier(bb.getNode(k), v) | k > i) and
+      this.bbSuccessorEntryReaches(bb, v, sink, _)
     )
   }
 
@@ -96,11 +96,11 @@ abstract class StackVariableReachability extends string {
       bbSuccessorEntryReachesLoopInvariant(bb, succ, skipsFirstLoopAlwaysTrueUponEntry,
         succSkipsFirstLoopAlwaysTrueUponEntry)
     |
-      bbEntryReachesLocally(succ, v, node) and
+      this.bbEntryReachesLocally(succ, v, node) and
       succSkipsFirstLoopAlwaysTrueUponEntry = false
       or
-      not isBarrier(succ.getNode(_), v) and
-      bbSuccessorEntryReaches(succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
+      not this.isBarrier(succ.getNode(_), v) and
+      this.bbSuccessorEntryReaches(succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
     )
   }
 
@@ -109,7 +109,7 @@ abstract class StackVariableReachability extends string {
   ) {
     exists(int n |
       node = bb.getNode(n) and
-      isSink(node, v)
+      this.isSink(node, v)
     |
       not exists(this.firstBarrierIndexIn(bb, v))
       or
@@ -118,7 +118,7 @@ abstract class StackVariableReachability extends string {
   }
 
   private int firstBarrierIndexIn(BasicBlock bb, SemanticStackVariable v) {
-    result = min(int m | isBarrier(bb.getNode(m), v))
+    result = min(int m | this.isBarrier(bb.getNode(m), v))
   }
 }
 
@@ -268,7 +268,7 @@ abstract class StackVariableReachabilityWithReassignment extends StackVariableRe
    * accounts for loops where the condition is provably true upon entry.
    */
   override predicate reaches(ControlFlowNode source, SemanticStackVariable v, ControlFlowNode sink) {
-    reachesTo(source, v, sink, _)
+    this.reachesTo(source, v, sink, _)
   }
 
   /**
@@ -278,21 +278,21 @@ abstract class StackVariableReachabilityWithReassignment extends StackVariableRe
     ControlFlowNode source, SemanticStackVariable v, ControlFlowNode sink, SemanticStackVariable v0
   ) {
     exists(ControlFlowNode def |
-      actualSourceReaches(source, v, def, v0) and
+      this.actualSourceReaches(source, v, def, v0) and
       StackVariableReachability.super.reaches(def, v0, sink) and
-      isSinkActual(sink, v0)
+      this.isSinkActual(sink, v0)
     )
   }
 
   private predicate actualSourceReaches(
     ControlFlowNode source, SemanticStackVariable v, ControlFlowNode def, SemanticStackVariable v0
   ) {
-    isSourceActual(source, v) and def = source and v0 = v
+    this.isSourceActual(source, v) and def = source and v0 = v
     or
     exists(ControlFlowNode source1, SemanticStackVariable v1 |
-      actualSourceReaches(source, v, source1, v1)
+      this.actualSourceReaches(source, v, source1, v1)
     |
-      reassignment(source1, v1, def, v0)
+      this.reassignment(source1, v1, def, v0)
     )
   }
 
@@ -304,14 +304,14 @@ abstract class StackVariableReachabilityWithReassignment extends StackVariableRe
   }
 
   final override predicate isSource(ControlFlowNode node, StackVariable v) {
-    isSourceActual(node, v)
+    this.isSourceActual(node, v)
     or
     // Reassignment generates a new (non-actual) source
-    reassignment(_, _, node, v)
+    this.reassignment(_, _, node, v)
   }
 
   final override predicate isSink(ControlFlowNode node, StackVariable v) {
-    isSinkActual(node, v)
+    this.isSinkActual(node, v)
     or
     // Reassignment generates a new (non-actual) sink
     exprDefinition(_, node, v.getAnAccess())
@@ -342,21 +342,21 @@ abstract class StackVariableReachabilityExt extends string {
   /** See `StackVariableReachability.reaches`. */
   predicate reaches(ControlFlowNode source, SemanticStackVariable v, ControlFlowNode sink) {
     exists(BasicBlock bb, int i |
-      isSource(source, v) and
+      this.isSource(source, v) and
       bb.getNode(i) = source and
       not bb.isUnreachable()
     |
       exists(int j |
         j > i and
         sink = bb.getNode(j) and
-        isSink(sink, v) and
-        not exists(int k | isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) |
+        this.isSink(sink, v) and
+        not exists(int k | this.isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) |
           k in [i .. j - 1]
         )
       )
       or
-      not exists(int k | isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) | k >= i) and
-      bbSuccessorEntryReaches(source, bb, v, sink, _)
+      not exists(int k | this.isBarrier(source, bb.getNode(k), bb.getNode(k + 1), v) | k >= i) and
+      this.bbSuccessorEntryReaches(source, bb, v, sink, _)
     )
   }
 
@@ -367,22 +367,22 @@ abstract class StackVariableReachabilityExt extends string {
     exists(BasicBlock succ, boolean succSkipsFirstLoopAlwaysTrueUponEntry |
       bbSuccessorEntryReachesLoopInvariant(bb, succ, skipsFirstLoopAlwaysTrueUponEntry,
         succSkipsFirstLoopAlwaysTrueUponEntry) and
-      not isBarrier(source, bb.getEnd(), succ.getStart(), v)
+      not this.isBarrier(source, bb.getEnd(), succ.getStart(), v)
     |
-      bbEntryReachesLocally(source, succ, v, node) and
+      this.bbEntryReachesLocally(source, succ, v, node) and
       succSkipsFirstLoopAlwaysTrueUponEntry = false
       or
-      not exists(int k | isBarrier(source, succ.getNode(k), succ.getNode(k + 1), v)) and
-      bbSuccessorEntryReaches(source, succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
+      not exists(int k | this.isBarrier(source, succ.getNode(k), succ.getNode(k + 1), v)) and
+      this.bbSuccessorEntryReaches(source, succ, v, node, succSkipsFirstLoopAlwaysTrueUponEntry)
     )
   }
 
   private predicate bbEntryReachesLocally(
     ControlFlowNode source, BasicBlock bb, SemanticStackVariable v, ControlFlowNode node
   ) {
-    isSource(source, v) and
-    exists(int n | node = bb.getNode(n) and isSink(node, v) |
-      not exists(int m | m < n | isBarrier(source, bb.getNode(m), bb.getNode(m + 1), v))
+    this.isSource(source, v) and
+    exists(int n | node = bb.getNode(n) and this.isSink(node, v) |
+      not exists(int m | m < n | this.isBarrier(source, bb.getNode(m), bb.getNode(m + 1), v))
     )
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SubBasicBlocks.qll
@@ -80,7 +80,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
    * returns a 0-based position, while `getRankInBasicBlock` returns a 1-based
    * position.
    */
-  deprecated int getPosInBasicBlock(BasicBlock bb) { result = getRankInBasicBlock(bb) - 1 }
+  deprecated int getPosInBasicBlock(BasicBlock bb) { result = this.getRankInBasicBlock(bb) - 1 }
 
   pragma[noinline]
   private int getIndexInBasicBlock(BasicBlock bb) { this = bb.getNode(result) }
@@ -102,7 +102,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
     exists(BasicBlock bb |
       exists(int outerIndex |
         result = bb.getNode(outerIndex) and
-        index = outerToInnerIndex(bb, outerIndex)
+        index = this.outerToInnerIndex(bb, outerIndex)
       )
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -937,7 +937,7 @@ class CallContextSpecificCall extends CallContextCall, TSpecificCall {
   }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    recordDataFlowCallSite(getCall(), callable)
+    recordDataFlowCallSite(this.getCall(), callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { call = this.getCall() }
@@ -1257,7 +1257,7 @@ abstract class AccessPathFront extends TAccessPathFront {
 
   TypedContent getHead() { this = TFrontHead(result) }
 
-  predicate isClearedAt(Node n) { clearsContentCached(n, getHead().getContent()) }
+  predicate isClearedAt(Node n) { clearsContentCached(n, this.getHead().getContent()) }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -106,13 +106,13 @@ class Node extends TNode {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 
   /**
    * Gets an upper bound on the type of this node.
    */
-  Type getTypeBound() { result = getType() }
+  Type getTypeBound() { result = this.getType() }
 }
 
 /**
@@ -293,11 +293,11 @@ abstract class PostUpdateNode extends Node {
    */
   abstract Node getPreUpdateNode();
 
-  override Function getFunction() { result = getPreUpdateNode().getFunction() }
+  override Function getFunction() { result = this.getPreUpdateNode().getFunction() }
 
-  override Type getType() { result = getPreUpdateNode().getType() }
+  override Type getType() { result = this.getPreUpdateNode().getType() }
 
-  override Location getLocation() { result = getPreUpdateNode().getLocation() }
+  override Location getLocation() { result = this.getPreUpdateNode().getLocation() }
 }
 
 abstract private class PartialDefinitionNode extends PostUpdateNode, TPartialDefinitionNode {
@@ -309,7 +309,7 @@ abstract private class PartialDefinitionNode extends PostUpdateNode, TPartialDef
 
   PartialDefinition getPartialDefinition() { result = pd }
 
-  override string toString() { result = getPreUpdateNode().toString() + " [post update]" }
+  override string toString() { result = this.getPreUpdateNode().toString() + " [post update]" }
 }
 
 private class VariablePartialDefinitionNode extends PartialDefinitionNode {
@@ -380,13 +380,13 @@ private class ObjectInitializerNode extends PostUpdateNode, TExprNode {
 class PreObjectInitializerNode extends Node, TPreObjectInitializerNode {
   Expr getExpr() { this = TPreObjectInitializerNode(result) }
 
-  override Function getFunction() { result = getExpr().getEnclosingFunction() }
+  override Function getFunction() { result = this.getExpr().getEnclosingFunction() }
 
-  override Type getType() { result = getExpr().getType() }
+  override Type getType() { result = this.getExpr().getType() }
 
-  override Location getLocation() { result = getExpr().getLocation() }
+  override Location getLocation() { result = this.getExpr().getLocation() }
 
-  override string toString() { result = getExpr().toString() + " [pre init]" }
+  override string toString() { result = this.getExpr().toString() + " [pre init]" }
 }
 
 /**
@@ -401,7 +401,7 @@ private class PostConstructorInitThis extends PostUpdateNode, TPostConstructorIn
   }
 
   override string toString() {
-    result = getPreUpdateNode().getConstructorFieldInit().toString() + " [post-this]"
+    result = this.getPreUpdateNode().getConstructorFieldInit().toString() + " [post-this]"
   }
 }
 
@@ -416,15 +416,17 @@ private class PostConstructorInitThis extends PostUpdateNode, TPostConstructorIn
 class PreConstructorInitThis extends Node, TPreConstructorInitThis {
   ConstructorFieldInit getConstructorFieldInit() { this = TPreConstructorInitThis(result) }
 
-  override Constructor getFunction() { result = getConstructorFieldInit().getEnclosingFunction() }
-
-  override PointerType getType() {
-    result.getBaseType() = getConstructorFieldInit().getEnclosingFunction().getDeclaringType()
+  override Constructor getFunction() {
+    result = this.getConstructorFieldInit().getEnclosingFunction()
   }
 
-  override Location getLocation() { result = getConstructorFieldInit().getLocation() }
+  override PointerType getType() {
+    result.getBaseType() = this.getConstructorFieldInit().getEnclosingFunction().getDeclaringType()
+  }
 
-  override string toString() { result = getConstructorFieldInit().toString() + " [pre-this]" }
+  override Location getLocation() { result = this.getConstructorFieldInit().getLocation() }
+
+  override string toString() { result = this.getConstructorFieldInit().toString() + " [pre-this]" }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -354,7 +354,7 @@ module FlowVar_internal {
         result = def.getAUse(v)
         or
         exists(SsaDefinition descendentDef |
-          getASuccessorSsaVar+() = TSsaVar(descendentDef, _) and
+          this.getASuccessorSsaVar+() = TSsaVar(descendentDef, _) and
           result = descendentDef.getAUse(v)
         )
       )
@@ -515,7 +515,7 @@ module FlowVar_internal {
       this.bbInLoopCondition(bbInside) and
       not this.bbInLoop(bbOutside) and
       bbOutside = bbInside.getASuccessor() and
-      not reachesWithoutAssignment(bbInside, v)
+      not this.reachesWithoutAssignment(bbInside, v)
     }
 
     /**
@@ -546,7 +546,7 @@ module FlowVar_internal {
     private predicate bbInLoop(BasicBlock bb) {
       bbDominates(this.(Loop).getStmt(), bb)
       or
-      bbInLoopCondition(bb)
+      this.bbInLoopCondition(bb)
     }
 
     /** Holds if `sbb` is inside this loop. */
@@ -563,7 +563,7 @@ module FlowVar_internal {
         bb = this.(Loop).getStmt() and
         v = this.getARelevantVariable()
         or
-        reachesWithoutAssignment(bb.getAPredecessor(), v) and
+        this.reachesWithoutAssignment(bb.getAPredecessor(), v) and
         this.bbInLoop(bb)
       ) and
       not assignsToVar(bb, v)

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
@@ -80,7 +80,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
    * returns a 0-based position, while `getRankInBasicBlock` returns a 1-based
    * position.
    */
-  deprecated int getPosInBasicBlock(BasicBlock bb) { result = getRankInBasicBlock(bb) - 1 }
+  deprecated int getPosInBasicBlock(BasicBlock bb) { result = this.getRankInBasicBlock(bb) - 1 }
 
   pragma[noinline]
   private int getIndexInBasicBlock(BasicBlock bb) { this = bb.getNode(result) }
@@ -102,7 +102,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
     exists(BasicBlock bb |
       exists(int outerIndex |
         result = bb.getNode(outerIndex) and
-        index = outerToInnerIndex(bb, outerIndex)
+        index = this.outerToInnerIndex(bb, outerIndex)
       )
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -75,24 +75,26 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isSanitizer(DataFlow::Node node) { none() }
 
   final override predicate isBarrier(DataFlow::Node node) {
-    isSanitizer(node) or
+    this.isSanitizer(node) or
     defaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */
   predicate isSanitizerIn(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierIn(DataFlow::Node node) { isSanitizerIn(node) }
+  final override predicate isBarrierIn(DataFlow::Node node) { this.isSanitizerIn(node) }
 
   /** Holds if taint propagation out of `node` is prohibited. */
   predicate isSanitizerOut(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierOut(DataFlow::Node node) { isSanitizerOut(node) }
+  final override predicate isBarrierOut(DataFlow::Node node) { this.isSanitizerOut(node) }
 
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    this.isSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`
@@ -101,7 +103,7 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2) or
     defaultAdditionalTaintStep(node1, node2)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -75,24 +75,26 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isSanitizer(DataFlow::Node node) { none() }
 
   final override predicate isBarrier(DataFlow::Node node) {
-    isSanitizer(node) or
+    this.isSanitizer(node) or
     defaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */
   predicate isSanitizerIn(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierIn(DataFlow::Node node) { isSanitizerIn(node) }
+  final override predicate isBarrierIn(DataFlow::Node node) { this.isSanitizerIn(node) }
 
   /** Holds if taint propagation out of `node` is prohibited. */
   predicate isSanitizerOut(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierOut(DataFlow::Node node) { isSanitizerOut(node) }
+  final override predicate isBarrierOut(DataFlow::Node node) { this.isSanitizerOut(node) }
 
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    this.isSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`
@@ -101,7 +103,7 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2) or
     defaultAdditionalTaintStep(node1, node2)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -203,7 +203,7 @@ class PointerFieldAccess extends FieldAccess {
 
   PointerFieldAccess() {
     exists(PointerType t |
-      t = getQualifier().getFullyConverted().getUnspecifiedType() and
+      t = this.getQualifier().getFullyConverted().getUnspecifiedType() and
       t.getBaseType() instanceof Class
     )
   }
@@ -218,7 +218,9 @@ class PointerFieldAccess extends FieldAccess {
 class DotFieldAccess extends FieldAccess {
   override string getAPrimaryQlClass() { result = "DotFieldAccess" }
 
-  DotFieldAccess() { exists(Class c | c = getQualifier().getFullyConverted().getUnspecifiedType()) }
+  DotFieldAccess() {
+    exists(Class c | c = this.getQualifier().getFullyConverted().getUnspecifiedType())
+  }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/exprs/ArithmeticOperation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/ArithmeticOperation.qll
@@ -148,7 +148,7 @@ class PostfixIncrExpr extends IncrementOperation, PostfixCrementOperation, @post
 
   override int getPrecedence() { result = 17 }
 
-  override string toString() { result = "... " + getOperator() }
+  override string toString() { result = "... " + this.getOperator() }
 }
 
 /**
@@ -166,7 +166,7 @@ class PostfixDecrExpr extends DecrementOperation, PostfixCrementOperation, @post
 
   override int getPrecedence() { result = 17 }
 
-  override string toString() { result = "... " + getOperator() }
+  override string toString() { result = "... " + this.getOperator() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/exprs/BuiltInOperations.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/BuiltInOperations.qll
@@ -35,12 +35,12 @@ class BuiltInVarArgsStart extends VarArgsExpr, @vastartexpr {
   /**
    * Gets the `va_list` argument.
    */
-  final Expr getVAList() { result = getChild(0) }
+  final Expr getVAList() { result = this.getChild(0) }
 
   /**
    * Gets the argument that specifies the last named parameter before the ellipsis.
    */
-  final VariableAccess getLastNamedParameter() { result = getChild(1) }
+  final VariableAccess getLastNamedParameter() { result = this.getChild(1) }
 }
 
 /**
@@ -60,7 +60,7 @@ class BuiltInVarArgsEnd extends VarArgsExpr, @vaendexpr {
   /**
    * Gets the `va_list` argument.
    */
-  final Expr getVAList() { result = getChild(0) }
+  final Expr getVAList() { result = this.getChild(0) }
 }
 
 /**
@@ -78,7 +78,7 @@ class BuiltInVarArg extends VarArgsExpr, @vaargexpr {
   /**
    * Gets the `va_list` argument.
    */
-  final Expr getVAList() { result = getChild(0) }
+  final Expr getVAList() { result = this.getChild(0) }
 }
 
 /**
@@ -98,12 +98,12 @@ class BuiltInVarArgCopy extends VarArgsExpr, @vacopyexpr {
   /**
    * Gets the destination `va_list` argument.
    */
-  final Expr getDestinationVAList() { result = getChild(0) }
+  final Expr getDestinationVAList() { result = this.getChild(0) }
 
   /**
    * Gets the the source `va_list` argument.
    */
-  final Expr getSourceVAList() { result = getChild(1) }
+  final Expr getSourceVAList() { result = this.getChild(1) }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Call.qll
@@ -71,10 +71,10 @@ class Call extends Expr, NameQualifiableElement, TCall {
    * at index 2, respectively.
    */
   Expr getAnArgumentSubExpr(int index) {
-    result = getArgument(index)
+    result = this.getArgument(index)
     or
     exists(Expr mid |
-      mid = getAnArgumentSubExpr(index) and
+      mid = this.getAnArgumentSubExpr(index) and
       not mid instanceof Call and
       not mid instanceof SizeofOperator and
       result = mid.getAChild()
@@ -167,27 +167,27 @@ class FunctionCall extends Call, @funbindexpr {
   override string getAPrimaryQlClass() { result = "FunctionCall" }
 
   /** Gets an explicit template argument for this call. */
-  Locatable getAnExplicitTemplateArgument() { result = getExplicitTemplateArgument(_) }
+  Locatable getAnExplicitTemplateArgument() { result = this.getExplicitTemplateArgument(_) }
 
   /** Gets an explicit template argument value for this call. */
-  Locatable getAnExplicitTemplateArgumentKind() { result = getExplicitTemplateArgumentKind(_) }
+  Locatable getAnExplicitTemplateArgumentKind() { result = this.getExplicitTemplateArgumentKind(_) }
 
   /** Gets a template argument for this call. */
-  Locatable getATemplateArgument() { result = getTarget().getATemplateArgument() }
+  Locatable getATemplateArgument() { result = this.getTarget().getATemplateArgument() }
 
   /** Gets a template argument value for this call. */
-  Locatable getATemplateArgumentKind() { result = getTarget().getATemplateArgumentKind() }
+  Locatable getATemplateArgumentKind() { result = this.getTarget().getATemplateArgumentKind() }
 
   /** Gets the nth explicit template argument for this call. */
   Locatable getExplicitTemplateArgument(int n) {
-    n < getNumberOfExplicitTemplateArguments() and
-    result = getTemplateArgument(n)
+    n < this.getNumberOfExplicitTemplateArguments() and
+    result = this.getTemplateArgument(n)
   }
 
   /** Gets the nth explicit template argument value for this call. */
   Locatable getExplicitTemplateArgumentKind(int n) {
-    n < getNumberOfExplicitTemplateArguments() and
-    result = getTemplateArgumentKind(n)
+    n < this.getNumberOfExplicitTemplateArguments() and
+    result = this.getTemplateArgumentKind(n)
   }
 
   /** Gets the number of explicit template arguments for this call. */
@@ -198,19 +198,19 @@ class FunctionCall extends Call, @funbindexpr {
   }
 
   /** Gets the number of template arguments for this call. */
-  int getNumberOfTemplateArguments() { result = count(int i | exists(getTemplateArgument(i))) }
+  int getNumberOfTemplateArguments() { result = count(int i | exists(this.getTemplateArgument(i))) }
 
   /** Gets the nth template argument for this call (indexed from 0). */
-  Locatable getTemplateArgument(int n) { result = getTarget().getTemplateArgument(n) }
+  Locatable getTemplateArgument(int n) { result = this.getTarget().getTemplateArgument(n) }
 
   /** Gets the nth template argument value for this call (indexed from 0). */
-  Locatable getTemplateArgumentKind(int n) { result = getTarget().getTemplateArgumentKind(n) }
+  Locatable getTemplateArgumentKind(int n) { result = this.getTarget().getTemplateArgumentKind(n) }
 
   /** Holds if any template arguments for this call are implicit / deduced. */
   predicate hasImplicitTemplateArguments() {
     exists(int i |
-      exists(getTemplateArgument(i)) and
-      not exists(getExplicitTemplateArgument(i))
+      exists(this.getTemplateArgument(i)) and
+      not exists(this.getExplicitTemplateArgument(i))
     )
   }
 
@@ -233,9 +233,9 @@ class FunctionCall extends Call, @funbindexpr {
    * visible at the call site.
    */
   Type getExpectedReturnType() {
-    if getTargetType() instanceof RoutineType
-    then result = getTargetType().(RoutineType).getReturnType()
-    else result = getTarget().getType()
+    if this.getTargetType() instanceof RoutineType
+    then result = this.getTargetType().(RoutineType).getReturnType()
+    else result = this.getTarget().getType()
   }
 
   /**
@@ -247,9 +247,9 @@ class FunctionCall extends Call, @funbindexpr {
    * was visible at the call site.
    */
   Type getExpectedParameterType(int n) {
-    if getTargetType() instanceof RoutineType
-    then result = getTargetType().(RoutineType).getParameterType(n)
-    else result = getTarget().getParameter(n).getType()
+    if this.getTargetType() instanceof RoutineType
+    then result = this.getTargetType().(RoutineType).getParameterType(n)
+    else result = this.getTarget().getParameter(n).getType()
   }
 
   /**
@@ -263,7 +263,7 @@ class FunctionCall extends Call, @funbindexpr {
   /**
    * Gets the type of this expression, that is, the return type of the function being called.
    */
-  override Type getType() { result = getExpectedReturnType() }
+  override Type getType() { result = this.getExpectedReturnType() }
 
   /**
    * Holds if this is a call to a virtual function.
@@ -280,7 +280,7 @@ class FunctionCall extends Call, @funbindexpr {
 
   /** Gets a textual representation of this function call. */
   override string toString() {
-    if exists(getTarget())
+    if exists(this.getTarget())
     then result = "call to " + this.getTarget().getName()
     else result = "call to unknown function"
   }
@@ -288,15 +288,15 @@ class FunctionCall extends Call, @funbindexpr {
   override predicate mayBeImpure() {
     this.getChild(_).mayBeImpure() or
     this.getTarget().mayHaveSideEffects() or
-    isVirtual() or
-    getTarget().getAnAttribute().getName() = "weak"
+    this.isVirtual() or
+    this.getTarget().getAnAttribute().getName() = "weak"
   }
 
   override predicate mayBeGloballyImpure() {
     this.getChild(_).mayBeGloballyImpure() or
     this.getTarget().mayHaveSideEffects() or
-    isVirtual() or
-    getTarget().getAnAttribute().getName() = "weak"
+    this.isVirtual() or
+    this.getTarget().getAnAttribute().getName() = "weak"
   }
 }
 
@@ -367,7 +367,7 @@ class OverloadedPointerDereferenceExpr extends FunctionCall {
  * ```
  */
 class OverloadedArrayExpr extends FunctionCall {
-  OverloadedArrayExpr() { getTarget().hasName("operator[]") }
+  OverloadedArrayExpr() { this.getTarget().hasName("operator[]") }
 
   override string getAPrimaryQlClass() { result = "OverloadedArrayExpr" }
 
@@ -585,7 +585,7 @@ class ConstructorFieldInit extends ConstructorInit, @ctorfieldinit {
    */
   Expr getExpr() { result = this.getChild(0) }
 
-  override string toString() { result = "constructor init of field " + getTarget().getName() }
+  override string toString() { result = "constructor init of field " + this.getTarget().getName() }
 
   override predicate mayBeImpure() { this.getExpr().mayBeImpure() }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Cast.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Cast.qll
@@ -188,8 +188,8 @@ private predicate isPointerToMemberOrNullPointer(Type type) {
 class ArithmeticConversion extends Cast {
   ArithmeticConversion() {
     conversionkinds(underlyingElement(this), 0) and
-    isArithmeticOrEnum(getUnspecifiedType()) and
-    isArithmeticOrEnum(getExpr().getUnspecifiedType())
+    isArithmeticOrEnum(this.getUnspecifiedType()) and
+    isArithmeticOrEnum(this.getExpr().getUnspecifiedType())
   }
 
   override string getSemanticConversionString() { result = "arithmetic conversion" }
@@ -204,8 +204,8 @@ class ArithmeticConversion extends Cast {
  */
 class IntegralConversion extends ArithmeticConversion {
   IntegralConversion() {
-    isIntegralOrEnum(getUnspecifiedType()) and
-    isIntegralOrEnum(getExpr().getUnspecifiedType())
+    isIntegralOrEnum(this.getUnspecifiedType()) and
+    isIntegralOrEnum(this.getExpr().getUnspecifiedType())
   }
 
   override string getAPrimaryQlClass() {
@@ -224,8 +224,8 @@ class IntegralConversion extends ArithmeticConversion {
  */
 class FloatingPointConversion extends ArithmeticConversion {
   FloatingPointConversion() {
-    getUnspecifiedType() instanceof FloatingPointType and
-    getExpr().getUnspecifiedType() instanceof FloatingPointType
+    this.getUnspecifiedType() instanceof FloatingPointType and
+    this.getExpr().getUnspecifiedType() instanceof FloatingPointType
   }
 
   override string getAPrimaryQlClass() {
@@ -244,8 +244,8 @@ class FloatingPointConversion extends ArithmeticConversion {
  */
 class FloatingPointToIntegralConversion extends ArithmeticConversion {
   FloatingPointToIntegralConversion() {
-    isIntegralOrEnum(getUnspecifiedType()) and
-    getExpr().getUnspecifiedType() instanceof FloatingPointType
+    isIntegralOrEnum(this.getUnspecifiedType()) and
+    this.getExpr().getUnspecifiedType() instanceof FloatingPointType
   }
 
   override string getAPrimaryQlClass() {
@@ -264,8 +264,8 @@ class FloatingPointToIntegralConversion extends ArithmeticConversion {
  */
 class IntegralToFloatingPointConversion extends ArithmeticConversion {
   IntegralToFloatingPointConversion() {
-    getUnspecifiedType() instanceof FloatingPointType and
-    isIntegralOrEnum(getExpr().getUnspecifiedType())
+    this.getUnspecifiedType() instanceof FloatingPointType and
+    isIntegralOrEnum(this.getExpr().getUnspecifiedType())
   }
 
   override string getAPrimaryQlClass() {
@@ -290,8 +290,8 @@ class IntegralToFloatingPointConversion extends ArithmeticConversion {
 class PointerConversion extends Cast {
   PointerConversion() {
     conversionkinds(underlyingElement(this), 0) and
-    isPointerOrNullPointer(getUnspecifiedType()) and
-    isPointerOrNullPointer(getExpr().getUnspecifiedType())
+    isPointerOrNullPointer(this.getUnspecifiedType()) and
+    isPointerOrNullPointer(this.getExpr().getUnspecifiedType())
   }
 
   override string getAPrimaryQlClass() { not exists(qlCast(this)) and result = "PointerConversion" }
@@ -315,8 +315,8 @@ class PointerToMemberConversion extends Cast {
   PointerToMemberConversion() {
     conversionkinds(underlyingElement(this), 0) and
     exists(Type fromType, Type toType |
-      fromType = getExpr().getUnspecifiedType() and
-      toType = getUnspecifiedType() and
+      fromType = this.getExpr().getUnspecifiedType() and
+      toType = this.getUnspecifiedType() and
       isPointerToMemberOrNullPointer(fromType) and
       isPointerToMemberOrNullPointer(toType) and
       // A conversion from nullptr to nullptr is a `PointerConversion`, not a
@@ -345,8 +345,8 @@ class PointerToMemberConversion extends Cast {
 class PointerToIntegralConversion extends Cast {
   PointerToIntegralConversion() {
     conversionkinds(underlyingElement(this), 0) and
-    isIntegralOrEnum(getUnspecifiedType()) and
-    isPointerOrNullPointer(getExpr().getUnspecifiedType())
+    isIntegralOrEnum(this.getUnspecifiedType()) and
+    isPointerOrNullPointer(this.getExpr().getUnspecifiedType())
   }
 
   override string getAPrimaryQlClass() {
@@ -366,8 +366,8 @@ class PointerToIntegralConversion extends Cast {
 class IntegralToPointerConversion extends Cast {
   IntegralToPointerConversion() {
     conversionkinds(underlyingElement(this), 0) and
-    isPointerOrNullPointer(getUnspecifiedType()) and
-    isIntegralOrEnum(getExpr().getUnspecifiedType())
+    isPointerOrNullPointer(this.getUnspecifiedType()) and
+    isIntegralOrEnum(this.getExpr().getUnspecifiedType())
   }
 
   override string getAPrimaryQlClass() {
@@ -403,7 +403,7 @@ class BoolConversion extends Cast {
 class VoidConversion extends Cast {
   VoidConversion() {
     conversionkinds(underlyingElement(this), 0) and
-    getUnspecifiedType() instanceof VoidType
+    this.getUnspecifiedType() instanceof VoidType
   }
 
   override string getAPrimaryQlClass() { not exists(qlCast(this)) and result = "VoidConversion" }
@@ -434,8 +434,8 @@ class InheritanceConversion extends Cast {
    * conversion is to an indirect virtual base class.
    */
   final ClassDerivation getDerivation() {
-    result.getBaseClass() = getBaseClass() and
-    result.getDerivedClass() = getDerivedClass()
+    result.getBaseClass() = this.getBaseClass() and
+    result.getDerivedClass() = this.getDerivedClass()
   }
 
   /**
@@ -490,12 +490,12 @@ class BaseClassConversion extends InheritanceConversion {
 
   override Class getBaseClass() { result = getConversionClass(this) }
 
-  override Class getDerivedClass() { result = getConversionClass(getExpr()) }
+  override Class getDerivedClass() { result = getConversionClass(this.getExpr()) }
 
   /**
    * Holds if this conversion is to a virtual base class.
    */
-  predicate isVirtual() { getDerivation().isVirtual() or not exists(getDerivation()) }
+  predicate isVirtual() { this.getDerivation().isVirtual() or not exists(this.getDerivation()) }
 }
 
 /**
@@ -515,7 +515,7 @@ class DerivedClassConversion extends InheritanceConversion {
 
   override string getSemanticConversionString() { result = "derived class conversion" }
 
-  override Class getBaseClass() { result = getConversionClass(getExpr()) }
+  override Class getBaseClass() { result = getConversionClass(this.getExpr()) }
 
   override Class getDerivedClass() { result = getConversionClass(this) }
 }
@@ -637,8 +637,8 @@ class DynamicCast extends Cast, @dynamic_cast {
  */
 class UuidofOperator extends Expr, @uuidof {
   override string toString() {
-    if exists(getTypeOperand())
-    then result = "__uuidof(" + getTypeOperand().getName() + ")"
+    if exists(this.getTypeOperand())
+    then result = "__uuidof(" + this.getTypeOperand().getName() + ")"
     else result = "__uuidof(0)"
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Lambda.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Lambda.qll
@@ -24,7 +24,7 @@ class LambdaExpression extends Expr, @lambdaexpr {
   /**
    * Gets an implicitly or explicitly captured value of this lambda expression.
    */
-  LambdaCapture getACapture() { result = getCapture(_) }
+  LambdaCapture getACapture() { result = this.getCapture(_) }
 
   /**
    * Gets the nth implicitly or explicitly captured value of this lambda expression.
@@ -58,13 +58,13 @@ class LambdaExpression extends Expr, @lambdaexpr {
    *   - The return type.
    *   - The statements comprising the lambda body.
    */
-  Operator getLambdaFunction() { result = getType().(Closure).getLambdaFunction() }
+  Operator getLambdaFunction() { result = this.getType().(Closure).getLambdaFunction() }
 
   /**
    * Gets the initializer that initializes the captured variables in the closure, if any.
    * A lambda that does not capture any variables will not have an initializer.
    */
-  ClassAggregateLiteral getInitializer() { result = getChild(0) }
+  ClassAggregateLiteral getInitializer() { result = this.getChild(0) }
 }
 
 /**
@@ -103,7 +103,7 @@ class Closure extends Class {
  * ```
  */
 class LambdaCapture extends Locatable, @lambdacapture {
-  override string toString() { result = getField().getName() }
+  override string toString() { result = this.getField().getName() }
 
   override string getAPrimaryQlClass() { result = "LambdaCapture" }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Literal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Literal.qll
@@ -60,12 +60,12 @@ class TextLiteral extends Literal {
 
   /** Gets a hex escape sequence that appears in the character or string literal (see [lex.ccon] in the C++ Standard). */
   string getAHexEscapeSequence(int occurrence, int offset) {
-    result = getValueText().regexpFind("(?<!\\\\)\\\\x[0-9a-fA-F]+", occurrence, offset)
+    result = this.getValueText().regexpFind("(?<!\\\\)\\\\x[0-9a-fA-F]+", occurrence, offset)
   }
 
   /** Gets an octal escape sequence that appears in the character or string literal (see [lex.ccon] in the C++ Standard). */
   string getAnOctalEscapeSequence(int occurrence, int offset) {
-    result = getValueText().regexpFind("(?<!\\\\)\\\\[0-7]{1,3}", occurrence, offset)
+    result = this.getValueText().regexpFind("(?<!\\\\)\\\\[0-7]{1,3}", occurrence, offset)
   }
 
   /**
@@ -75,27 +75,27 @@ class TextLiteral extends Literal {
   string getANonStandardEscapeSequence(int occurrence, int offset) {
     // Find all single character escape sequences (ignoring the start of octal escape sequences),
     // together with anything starting like a hex escape sequence but not followed by a hex digit.
-    result = getValueText().regexpFind("\\\\[^x0-7\\s]|\\\\x[^0-9a-fA-F]", occurrence, offset) and
+    result = this.getValueText().regexpFind("\\\\[^x0-7\\s]|\\\\x[^0-9a-fA-F]", occurrence, offset) and
     // From these, exclude all standard escape sequences.
-    not result = getAStandardEscapeSequence(_, _)
+    not result = this.getAStandardEscapeSequence(_, _)
   }
 
   /** Gets a simple escape sequence that appears in the char or string literal (see [lex.ccon] in the C++ Standard). */
   string getASimpleEscapeSequence(int occurrence, int offset) {
-    result = getValueText().regexpFind("\\\\['\"?\\\\abfnrtv]", occurrence, offset)
+    result = this.getValueText().regexpFind("\\\\['\"?\\\\abfnrtv]", occurrence, offset)
   }
 
   /** Gets a standard escape sequence that appears in the char or string literal (see [lex.ccon] in the C++ Standard). */
   string getAStandardEscapeSequence(int occurrence, int offset) {
-    result = getASimpleEscapeSequence(occurrence, offset) or
-    result = getAnOctalEscapeSequence(occurrence, offset) or
-    result = getAHexEscapeSequence(occurrence, offset)
+    result = this.getASimpleEscapeSequence(occurrence, offset) or
+    result = this.getAnOctalEscapeSequence(occurrence, offset) or
+    result = this.getAHexEscapeSequence(occurrence, offset)
   }
 
   /**
    * Gets the length of the string literal (including null) before escape sequences added by the extractor.
    */
-  int getOriginalLength() { result = getValue().length() + 1 }
+  int getOriginalLength() { result = this.getValue().length() + 1 }
 }
 
 /**
@@ -216,7 +216,7 @@ class ClassAggregateLiteral extends AggregateLiteral {
     (
       // If the field has an explicit initializer expression, then the field is
       // initialized.
-      exists(getFieldExpr(field))
+      exists(this.getFieldExpr(field))
       or
       // If the type is not a union, all fields without initializers are value
       // initialized.
@@ -224,7 +224,7 @@ class ClassAggregateLiteral extends AggregateLiteral {
       or
       // If the type is a union, and there are no explicit initializers, then
       // the first declared field is value initialized.
-      not exists(getAChild()) and
+      not exists(this.getAChild()) and
       field.getInitializationOrder() = 0
     )
   }
@@ -239,8 +239,8 @@ class ClassAggregateLiteral extends AggregateLiteral {
    */
   pragma[inline]
   predicate isValueInitialized(Field field) {
-    isInitialized(field) and
-    not exists(getFieldExpr(field))
+    this.isInitialized(field) and
+    not exists(this.getFieldExpr(field))
   }
 }
 
@@ -285,7 +285,7 @@ class ArrayOrVectorAggregateLiteral extends AggregateLiteral {
   bindingset[elementIndex]
   predicate isInitialized(int elementIndex) {
     elementIndex >= 0 and
-    elementIndex < getArraySize()
+    elementIndex < this.getArraySize()
   }
 
   /**
@@ -298,8 +298,8 @@ class ArrayOrVectorAggregateLiteral extends AggregateLiteral {
    */
   bindingset[elementIndex]
   predicate isValueInitialized(int elementIndex) {
-    isInitialized(elementIndex) and
-    not exists(getElementExpr(elementIndex))
+    this.isInitialized(elementIndex) and
+    not exists(this.getElementExpr(elementIndex))
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/internal/QualifiedName.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/QualifiedName.qll
@@ -173,7 +173,7 @@ class LocalVariable extends LocalScopeVariable, @localvariable { }
 class VariableDeclarationEntry extends @var_decl {
   string toString() { result = "QualifiedName DeclarationEntry" }
 
-  Variable getDeclaration() { result = getVariable() }
+  Variable getDeclaration() { result = this.getVariable() }
 
   /**
    * Gets the variable which is being declared or defined.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -110,12 +110,12 @@ abstract class Configuration extends string {
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowTo(Node sink) { hasFlow(_, sink) }
+  predicate hasFlowTo(Node sink) { this.hasFlow(_, sink) }
 
   /**
    * Holds if data may flow from some source to `sink` for this configuration.
    */
-  predicate hasFlowToExpr(DataFlowExpr sink) { hasFlowTo(exprNode(sink)) }
+  predicate hasFlowToExpr(DataFlowExpr sink) { this.hasFlowTo(exprNode(sink)) }
 
   /**
    * Gets the exploration limit for `hasPartialFlow` and `hasPartialFlowRev`
@@ -3170,7 +3170,7 @@ private class AccessPathCons extends AccessPath, TAccessPathCons {
   }
 
   override string toString() {
-    result = "[" + this.toStringImpl(true) + length().toString() + ")]"
+    result = "[" + this.toStringImpl(true) + this.length().toString() + ")]"
     or
     result = "[" + this.toStringImpl(false)
   }
@@ -3309,9 +3309,11 @@ abstract private class PathNodeImpl extends PathNode {
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
   }
 
-  override string toString() { result = this.getNodeEx().toString() + ppAp() }
+  override string toString() { result = this.getNodeEx().toString() + this.ppAp() }
 
-  override string toStringWithContext() { result = this.getNodeEx().toString() + ppAp() + ppCtx() }
+  override string toStringWithContext() {
+    result = this.getNodeEx().toString() + this.ppAp() + this.ppCtx()
+  }
 
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
@@ -3379,11 +3381,11 @@ private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
 
   override PathNodeImpl getASuccessorImpl() {
     // an intermediate step to another intermediate node
-    result = getSuccMid()
+    result = this.getSuccMid()
     or
     // a final step to a sink via zero steps means we merge the last two steps to prevent trivial-looking edges
     exists(PathNodeMid mid, PathNodeSink sink |
-      mid = getSuccMid() and
+      mid = this.getSuccMid() and
       mid.getNodeEx() = sink.getNodeEx() and
       mid.getAp() instanceof AccessPathNil and
       sink.getConfiguration() = unbindConf(mid.getConfiguration()) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -937,7 +937,7 @@ class CallContextSpecificCall extends CallContextCall, TSpecificCall {
   }
 
   override predicate relevantFor(DataFlowCallable callable) {
-    recordDataFlowCallSite(getCall(), callable)
+    recordDataFlowCallSite(this.getCall(), callable)
   }
 
   override predicate matchesCall(DataFlowCall call) { call = this.getCall() }
@@ -1257,7 +1257,7 @@ abstract class AccessPathFront extends TAccessPathFront {
 
   TypedContent getHead() { this = TFrontHead(result) }
 
-  predicate isClearedAt(Node n) { clearsContentCached(n, getHead().getContent()) }
+  predicate isClearedAt(Node n) { clearsContentCached(n, this.getHead().getContent()) }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -110,7 +110,7 @@ class Node extends TIRDataFlowNode {
   /**
    * Gets an upper bound on the type of this node.
    */
-  IRType getTypeBound() { result = getType() }
+  IRType getTypeBound() { result = this.getType() }
 
   /** Gets the location of this element. */
   Location getLocation() { none() } // overridden by subclasses
@@ -831,7 +831,7 @@ class FieldContent extends Content, TFieldContent {
   FieldContent() { this = TFieldContent(c, startBit, endBit) }
 
   // Ensure that there's just 1 result for `toString`.
-  override string toString() { result = min(Field f | f = getAField() | f.toString()) }
+  override string toString() { result = min(Field f | f = this.getAField() | f.toString()) }
 
   predicate hasOffset(Class cl, int start, int end) { cl = c and start = startBit and end = endBit }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -75,24 +75,26 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isSanitizer(DataFlow::Node node) { none() }
 
   final override predicate isBarrier(DataFlow::Node node) {
-    isSanitizer(node) or
+    this.isSanitizer(node) or
     defaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */
   predicate isSanitizerIn(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierIn(DataFlow::Node node) { isSanitizerIn(node) }
+  final override predicate isBarrierIn(DataFlow::Node node) { this.isSanitizerIn(node) }
 
   /** Holds if taint propagation out of `node` is prohibited. */
   predicate isSanitizerOut(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierOut(DataFlow::Node node) { isSanitizerOut(node) }
+  final override predicate isBarrierOut(DataFlow::Node node) { this.isSanitizerOut(node) }
 
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    this.isSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`
@@ -101,7 +103,7 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2) or
     defaultAdditionalTaintStep(node1, node2)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -75,24 +75,26 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isSanitizer(DataFlow::Node node) { none() }
 
   final override predicate isBarrier(DataFlow::Node node) {
-    isSanitizer(node) or
+    this.isSanitizer(node) or
     defaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */
   predicate isSanitizerIn(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierIn(DataFlow::Node node) { isSanitizerIn(node) }
+  final override predicate isBarrierIn(DataFlow::Node node) { this.isSanitizerIn(node) }
 
   /** Holds if taint propagation out of `node` is prohibited. */
   predicate isSanitizerOut(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierOut(DataFlow::Node node) { isSanitizerOut(node) }
+  final override predicate isBarrierOut(DataFlow::Node node) { this.isSanitizerOut(node) }
 
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    this.isSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`
@@ -101,7 +103,7 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2) or
     defaultAdditionalTaintStep(node1, node2)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -75,24 +75,26 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isSanitizer(DataFlow::Node node) { none() }
 
   final override predicate isBarrier(DataFlow::Node node) {
-    isSanitizer(node) or
+    this.isSanitizer(node) or
     defaultTaintSanitizer(node)
   }
 
   /** Holds if taint propagation into `node` is prohibited. */
   predicate isSanitizerIn(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierIn(DataFlow::Node node) { isSanitizerIn(node) }
+  final override predicate isBarrierIn(DataFlow::Node node) { this.isSanitizerIn(node) }
 
   /** Holds if taint propagation out of `node` is prohibited. */
   predicate isSanitizerOut(DataFlow::Node node) { none() }
 
-  final override predicate isBarrierOut(DataFlow::Node node) { isSanitizerOut(node) }
+  final override predicate isBarrierOut(DataFlow::Node node) { this.isSanitizerOut(node) }
 
   /** Holds if taint propagation through nodes guarded by `guard` is prohibited. */
   predicate isSanitizerGuard(DataFlow::BarrierGuard guard) { none() }
 
-  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) { isSanitizerGuard(guard) }
+  final override predicate isBarrierGuard(DataFlow::BarrierGuard guard) {
+    this.isSanitizerGuard(guard)
+  }
 
   /**
    * Holds if the additional taint propagation step from `node1` to `node2`
@@ -101,7 +103,7 @@ abstract class Configuration extends DataFlow::Configuration {
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
   final override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
-    isAdditionalTaintStep(node1, node2) or
+    this.isAdditionalTaintStep(node1, node2) or
     defaultAdditionalTaintStep(node1, node2)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -24,7 +24,7 @@ class IRBlockBase extends TIRBlock {
   final string toString() { result = getFirstInstruction(this).toString() }
 
   /** Gets the source location of the first non-`Phi` instruction in this block. */
-  final Language::Location getLocation() { result = getFirstInstruction().getLocation() }
+  final Language::Location getLocation() { result = this.getFirstInstruction().getLocation() }
 
   /**
    * INTERNAL: Do not use.
@@ -39,7 +39,7 @@ class IRBlockBase extends TIRBlock {
     ) and
     this =
       rank[result + 1](IRBlock funcBlock, int sortOverride, int sortKey1, int sortKey2 |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        funcBlock.getEnclosingFunction() = this.getEnclosingFunction() and
         funcBlock.getFirstInstruction().hasSortKeys(sortKey1, sortKey2) and
         // Ensure that the block containing `EnterFunction` always comes first.
         if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
@@ -59,15 +59,15 @@ class IRBlockBase extends TIRBlock {
    * Get the `Phi` instructions that appear at the start of this block.
    */
   final PhiInstruction getAPhiInstruction() {
-    Construction::getPhiInstructionBlockStart(result) = getFirstInstruction()
+    Construction::getPhiInstructionBlockStart(result) = this.getFirstInstruction()
   }
 
   /**
    * Gets an instruction in this block. This includes `Phi` instructions.
    */
   final Instruction getAnInstruction() {
-    result = getInstruction(_) or
-    result = getAPhiInstruction()
+    result = this.getInstruction(_) or
+    result = this.getAPhiInstruction()
   }
 
   /**
@@ -78,7 +78,9 @@ class IRBlockBase extends TIRBlock {
   /**
    * Gets the last instruction in this block.
    */
-  final Instruction getLastInstruction() { result = getInstruction(getInstructionCount() - 1) }
+  final Instruction getLastInstruction() {
+    result = this.getInstruction(this.getInstructionCount() - 1)
+  }
 
   /**
    * Gets the number of non-`Phi` instructions in this block.
@@ -149,7 +151,7 @@ class IRBlock extends IRBlockBase {
    * Block `A` dominates block `B` if any control flow path from the entry block of the function to
    * block `B` must pass through block `A`. A block always dominates itself.
    */
-  final predicate dominates(IRBlock block) { strictlyDominates(block) or this = block }
+  final predicate dominates(IRBlock block) { this.strictlyDominates(block) or this = block }
 
   /**
    * Gets a block on the dominance frontier of this block.
@@ -159,8 +161,8 @@ class IRBlock extends IRBlockBase {
    */
   pragma[noinline]
   final IRBlock dominanceFrontier() {
-    dominates(result.getAPredecessor()) and
-    not strictlyDominates(result)
+    this.dominates(result.getAPredecessor()) and
+    not this.strictlyDominates(result)
   }
 
   /**
@@ -189,7 +191,7 @@ class IRBlock extends IRBlockBase {
    * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
    * function must pass through block `A`. A block always post-dominates itself.
    */
-  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+  final predicate postDominates(IRBlock block) { this.strictlyPostDominates(block) or this = block }
 
   /**
    * Gets a block on the post-dominance frontier of this block.
@@ -199,16 +201,16 @@ class IRBlock extends IRBlockBase {
    */
   pragma[noinline]
   final IRBlock postPominanceFrontier() {
-    postDominates(result.getASuccessor()) and
-    not strictlyPostDominates(result)
+    this.postDominates(result.getASuccessor()) and
+    not this.strictlyPostDominates(result)
   }
 
   /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
-    this = getEnclosingIRFunction().getEntryBlock() or
-    getAPredecessor().isReachableFromFunctionEntry()
+    this = this.getEnclosingIRFunction().getEntryBlock() or
+    this.getAPredecessor().isReachableFromFunctionEntry()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -41,7 +41,7 @@ class Instruction extends Construction::TStageInstruction {
   }
 
   /** Gets a textual representation of this element. */
-  final string toString() { result = getOpcode().toString() + ": " + getAST().toString() }
+  final string toString() { result = this.getOpcode().toString() + ": " + this.getAST().toString() }
 
   /**
    * Gets a string showing the result, opcode, and operands of the instruction, equivalent to what
@@ -50,7 +50,8 @@ class Instruction extends Construction::TStageInstruction {
    * `mu0_28(int) = Store r0_26, r0_27`
    */
   final string getDumpString() {
-    result = getResultString() + " = " + getOperationString() + " " + getOperandsString()
+    result =
+      this.getResultString() + " = " + this.getOperationString() + " " + this.getOperandsString()
   }
 
   private predicate shouldGenerateDumpStrings() {
@@ -66,10 +67,13 @@ class Instruction extends Construction::TStageInstruction {
    * VariableAddress[x]
    */
   final string getOperationString() {
-    shouldGenerateDumpStrings() and
-    if exists(getImmediateString())
-    then result = getOperationPrefix() + getOpcode().toString() + "[" + getImmediateString() + "]"
-    else result = getOperationPrefix() + getOpcode().toString()
+    this.shouldGenerateDumpStrings() and
+    if exists(this.getImmediateString())
+    then
+      result =
+        this.getOperationPrefix() + this.getOpcode().toString() + "[" + this.getImmediateString() +
+          "]"
+    else result = this.getOperationPrefix() + this.getOpcode().toString()
   }
 
   /**
@@ -78,17 +82,17 @@ class Instruction extends Construction::TStageInstruction {
   string getImmediateString() { none() }
 
   private string getOperationPrefix() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     if this instanceof SideEffectInstruction then result = "^" else result = ""
   }
 
   private string getResultPrefix() {
-    shouldGenerateDumpStrings() and
-    if getResultIRType() instanceof IRVoidType
+    this.shouldGenerateDumpStrings() and
+    if this.getResultIRType() instanceof IRVoidType
     then result = "v"
     else
-      if hasMemoryResult()
-      then if isResultModeled() then result = "m" else result = "mu"
+      if this.hasMemoryResult()
+      then if this.isResultModeled() then result = "m" else result = "mu"
       else result = "r"
   }
 
@@ -97,7 +101,7 @@ class Instruction extends Construction::TStageInstruction {
    * used by debugging and printing code only.
    */
   int getDisplayIndexInBlock() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     exists(IRBlock block |
       this = block.getInstruction(result)
       or
@@ -111,12 +115,12 @@ class Instruction extends Construction::TStageInstruction {
   }
 
   private int getLineRank() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     this =
       rank[result](Instruction instr |
         instr =
-          getAnInstructionAtLine(getEnclosingIRFunction(), getLocation().getFile(),
-            getLocation().getStartLine())
+          getAnInstructionAtLine(this.getEnclosingIRFunction(), this.getLocation().getFile(),
+            this.getLocation().getStartLine())
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )
@@ -130,8 +134,9 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `r1_1`
    */
   string getResultId() {
-    shouldGenerateDumpStrings() and
-    result = getResultPrefix() + getAST().getLocation().getStartLine() + "_" + getLineRank()
+    this.shouldGenerateDumpStrings() and
+    result =
+      this.getResultPrefix() + this.getAST().getLocation().getStartLine() + "_" + this.getLineRank()
   }
 
   /**
@@ -142,8 +147,8 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `r1_1(int*)`
    */
   final string getResultString() {
-    shouldGenerateDumpStrings() and
-    result = getResultId() + "(" + getResultLanguageType().getDumpString() + ")"
+    this.shouldGenerateDumpStrings() and
+    result = this.getResultId() + "(" + this.getResultLanguageType().getDumpString() + ")"
   }
 
   /**
@@ -153,10 +158,10 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `func:r3_4, this:r3_5`
    */
   string getOperandsString() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     result =
       concat(Operand operand |
-        operand = getAnOperand()
+        operand = this.getAnOperand()
       |
         operand.getDumpString(), ", " order by operand.getDumpSortOrder()
       )
@@ -190,7 +195,7 @@ class Instruction extends Construction::TStageInstruction {
    * Gets the function that contains this instruction.
    */
   final Language::Function getEnclosingFunction() {
-    result = getEnclosingIRFunction().getFunction()
+    result = this.getEnclosingIRFunction().getFunction()
   }
 
   /**
@@ -208,7 +213,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the location of the source code for this instruction.
    */
-  final Language::Location getLocation() { result = getAST().getLocation() }
+  final Language::Location getLocation() { result = this.getAST().getLocation() }
 
   /**
    * Gets the  `Expr` whose result is computed by this instruction, if any. The `Expr` may be a
@@ -243,7 +248,7 @@ class Instruction extends Construction::TStageInstruction {
    * a result, its result type will be `IRVoidType`.
    */
   cached
-  final IRType getResultIRType() { result = getResultLanguageType().getIRType() }
+  final IRType getResultIRType() { result = this.getResultLanguageType().getIRType() }
 
   /**
    * Gets the type of the result produced by this instruction. If the
@@ -254,7 +259,7 @@ class Instruction extends Construction::TStageInstruction {
    */
   final Language::Type getResultType() {
     exists(Language::LanguageType resultType |
-      resultType = getResultLanguageType() and
+      resultType = this.getResultLanguageType() and
       (
         resultType.hasUnspecifiedType(result, _)
         or
@@ -283,7 +288,7 @@ class Instruction extends Construction::TStageInstruction {
    * result of the `Load` instruction is a prvalue of type `int`, representing
    * the integer value loaded from variable `x`.
    */
-  final predicate isGLValue() { getResultLanguageType().hasType(_, true) }
+  final predicate isGLValue() { this.getResultLanguageType().hasType(_, true) }
 
   /**
    * Gets the size of the result produced by this instruction, in bytes. If the
@@ -292,7 +297,7 @@ class Instruction extends Construction::TStageInstruction {
    * If `this.isGLValue()` holds for this instruction, the value of
    * `getResultSize()` will always be the size of a pointer.
    */
-  final int getResultSize() { result = getResultLanguageType().getByteSize() }
+  final int getResultSize() { result = this.getResultLanguageType().getByteSize() }
 
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
@@ -314,14 +319,16 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Holds if this instruction produces a memory result.
    */
-  final predicate hasMemoryResult() { exists(getResultMemoryAccess()) }
+  final predicate hasMemoryResult() { exists(this.getResultMemoryAccess()) }
 
   /**
    * Gets the kind of memory access performed by this instruction's result.
    * Holds only for instructions with a memory result.
    */
   pragma[inline]
-  final MemoryAccessKind getResultMemoryAccess() { result = getOpcode().getWriteMemoryAccess() }
+  final MemoryAccessKind getResultMemoryAccess() {
+    result = this.getOpcode().getWriteMemoryAccess()
+  }
 
   /**
    * Holds if the memory access performed by this instruction's result will not always write to
@@ -332,7 +339,7 @@ class Instruction extends Construction::TStageInstruction {
    * (for example, the global side effects of a function call).
    */
   pragma[inline]
-  final predicate hasResultMayMemoryAccess() { getOpcode().hasMayWriteMemoryAccess() }
+  final predicate hasResultMayMemoryAccess() { this.getOpcode().hasMayWriteMemoryAccess() }
 
   /**
    * Gets the operand that holds the memory address to which this instruction stores its
@@ -340,7 +347,7 @@ class Instruction extends Construction::TStageInstruction {
    * is `r1`.
    */
   final AddressOperand getResultAddressOperand() {
-    getResultMemoryAccess().usesAddressOperand() and
+    this.getResultMemoryAccess().usesAddressOperand() and
     result.getUse() = this
   }
 
@@ -349,7 +356,7 @@ class Instruction extends Construction::TStageInstruction {
    * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
    * is the instruction that defines `r1`.
    */
-  final Instruction getResultAddress() { result = getResultAddressOperand().getDef() }
+  final Instruction getResultAddress() { result = this.getResultAddressOperand().getDef() }
 
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
@@ -368,7 +375,7 @@ class Instruction extends Construction::TStageInstruction {
    */
   final predicate isResultModeled() {
     // Register results are always in SSA form.
-    not hasMemoryResult() or
+    not this.hasMemoryResult() or
     Construction::hasModeledMemoryResult(this)
   }
 
@@ -412,7 +419,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets all direct successors of this instruction.
    */
-  final Instruction getASuccessor() { result = getSuccessor(_) }
+  final Instruction getASuccessor() { result = this.getSuccessor(_) }
 
   /**
    * Gets a predecessor of this instruction such that the predecessor reaches
@@ -423,7 +430,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets all direct predecessors of this instruction.
    */
-  final Instruction getAPredecessor() { result = getPredecessor(_) }
+  final Instruction getAPredecessor() { result = this.getPredecessor(_) }
 }
 
 /**
@@ -543,7 +550,7 @@ class IndexedInstruction extends Instruction {
  * at this instruction. This instruction has no predecessors.
  */
 class EnterFunctionInstruction extends Instruction {
-  EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
+  EnterFunctionInstruction() { this.getOpcode() instanceof Opcode::EnterFunction }
 }
 
 /**
@@ -554,7 +561,7 @@ class EnterFunctionInstruction extends Instruction {
  * struct, or union, see `FieldAddressInstruction`.
  */
 class VariableAddressInstruction extends VariableInstruction {
-  VariableAddressInstruction() { getOpcode() instanceof Opcode::VariableAddress }
+  VariableAddressInstruction() { this.getOpcode() instanceof Opcode::VariableAddress }
 }
 
 /**
@@ -566,7 +573,7 @@ class VariableAddressInstruction extends VariableInstruction {
  * The result has an `IRFunctionAddress` type.
  */
 class FunctionAddressInstruction extends FunctionInstruction {
-  FunctionAddressInstruction() { getOpcode() instanceof Opcode::FunctionAddress }
+  FunctionAddressInstruction() { this.getOpcode() instanceof Opcode::FunctionAddress }
 }
 
 /**
@@ -577,7 +584,7 @@ class FunctionAddressInstruction extends FunctionInstruction {
  * initializes that parameter.
  */
 class InitializeParameterInstruction extends VariableInstruction {
-  InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
+  InitializeParameterInstruction() { this.getOpcode() instanceof Opcode::InitializeParameter }
 
   /**
    * Gets the parameter initialized by this instruction.
@@ -603,7 +610,7 @@ class InitializeParameterInstruction extends VariableInstruction {
  * initialized elsewhere, would not otherwise have a definition in this function.
  */
 class InitializeNonLocalInstruction extends Instruction {
-  InitializeNonLocalInstruction() { getOpcode() instanceof Opcode::InitializeNonLocal }
+  InitializeNonLocalInstruction() { this.getOpcode() instanceof Opcode::InitializeNonLocal }
 }
 
 /**
@@ -611,7 +618,7 @@ class InitializeNonLocalInstruction extends Instruction {
  * with the value of that memory on entry to the function.
  */
 class InitializeIndirectionInstruction extends VariableInstruction {
-  InitializeIndirectionInstruction() { getOpcode() instanceof Opcode::InitializeIndirection }
+  InitializeIndirectionInstruction() { this.getOpcode() instanceof Opcode::InitializeIndirection }
 
   /**
    * Gets the parameter initialized by this instruction.
@@ -635,24 +642,24 @@ class InitializeIndirectionInstruction extends VariableInstruction {
  * An instruction that initializes the `this` pointer parameter of the enclosing function.
  */
 class InitializeThisInstruction extends Instruction {
-  InitializeThisInstruction() { getOpcode() instanceof Opcode::InitializeThis }
+  InitializeThisInstruction() { this.getOpcode() instanceof Opcode::InitializeThis }
 }
 
 /**
  * An instruction that computes the address of a non-static field of an object.
  */
 class FieldAddressInstruction extends FieldInstruction {
-  FieldAddressInstruction() { getOpcode() instanceof Opcode::FieldAddress }
+  FieldAddressInstruction() { this.getOpcode() instanceof Opcode::FieldAddress }
 
   /**
    * Gets the operand that provides the address of the object containing the field.
    */
-  final UnaryOperand getObjectAddressOperand() { result = getAnOperand() }
+  final UnaryOperand getObjectAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the object containing the field.
    */
-  final Instruction getObjectAddress() { result = getObjectAddressOperand().getDef() }
+  final Instruction getObjectAddress() { result = this.getObjectAddressOperand().getDef() }
 }
 
 /**
@@ -661,17 +668,19 @@ class FieldAddressInstruction extends FieldInstruction {
  * This instruction is used for element access to C# arrays.
  */
 class ElementsAddressInstruction extends UnaryInstruction {
-  ElementsAddressInstruction() { getOpcode() instanceof Opcode::ElementsAddress }
+  ElementsAddressInstruction() { this.getOpcode() instanceof Opcode::ElementsAddress }
 
   /**
    * Gets the operand that provides the address of the array object.
    */
-  final UnaryOperand getArrayObjectAddressOperand() { result = getAnOperand() }
+  final UnaryOperand getArrayObjectAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the array object.
    */
-  final Instruction getArrayObjectAddress() { result = getArrayObjectAddressOperand().getDef() }
+  final Instruction getArrayObjectAddress() {
+    result = this.getArrayObjectAddressOperand().getDef()
+  }
 }
 
 /**
@@ -685,7 +694,7 @@ class ElementsAddressInstruction extends UnaryInstruction {
  * taken may want to ignore any function that contains an `ErrorInstruction`.
  */
 class ErrorInstruction extends Instruction {
-  ErrorInstruction() { getOpcode() instanceof Opcode::Error }
+  ErrorInstruction() { this.getOpcode() instanceof Opcode::Error }
 }
 
 /**
@@ -695,7 +704,7 @@ class ErrorInstruction extends Instruction {
  * an initializer, or whose initializer only partially initializes the variable.
  */
 class UninitializedInstruction extends VariableInstruction {
-  UninitializedInstruction() { getOpcode() instanceof Opcode::Uninitialized }
+  UninitializedInstruction() { this.getOpcode() instanceof Opcode::Uninitialized }
 
   /**
    * Gets the variable that is uninitialized.
@@ -710,7 +719,7 @@ class UninitializedInstruction extends VariableInstruction {
  * least one instruction, even when the AST has no semantic effect.
  */
 class NoOpInstruction extends Instruction {
-  NoOpInstruction() { getOpcode() instanceof Opcode::NoOp }
+  NoOpInstruction() { this.getOpcode() instanceof Opcode::NoOp }
 }
 
 /**
@@ -732,32 +741,32 @@ class NoOpInstruction extends Instruction {
  * `void`-returning function.
  */
 class ReturnInstruction extends Instruction {
-  ReturnInstruction() { getOpcode() instanceof ReturnOpcode }
+  ReturnInstruction() { this.getOpcode() instanceof ReturnOpcode }
 }
 
 /**
  * An instruction that returns control to the caller of the function, without returning a value.
  */
 class ReturnVoidInstruction extends ReturnInstruction {
-  ReturnVoidInstruction() { getOpcode() instanceof Opcode::ReturnVoid }
+  ReturnVoidInstruction() { this.getOpcode() instanceof Opcode::ReturnVoid }
 }
 
 /**
  * An instruction that returns control to the caller of the function, including a return value.
  */
 class ReturnValueInstruction extends ReturnInstruction {
-  ReturnValueInstruction() { getOpcode() instanceof Opcode::ReturnValue }
+  ReturnValueInstruction() { this.getOpcode() instanceof Opcode::ReturnValue }
 
   /**
    * Gets the operand that provides the value being returned by the function.
    */
-  final LoadOperand getReturnValueOperand() { result = getAnOperand() }
+  final LoadOperand getReturnValueOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value being returned by the function, if an
    * exact definition is available.
    */
-  final Instruction getReturnValue() { result = getReturnValueOperand().getDef() }
+  final Instruction getReturnValue() { result = this.getReturnValueOperand().getDef() }
 }
 
 /**
@@ -770,28 +779,28 @@ class ReturnValueInstruction extends ReturnInstruction {
  * that the caller initialized the memory pointed to by the parameter before the call.
  */
 class ReturnIndirectionInstruction extends VariableInstruction {
-  ReturnIndirectionInstruction() { getOpcode() instanceof Opcode::ReturnIndirection }
+  ReturnIndirectionInstruction() { this.getOpcode() instanceof Opcode::ReturnIndirection }
 
   /**
    * Gets the operand that provides the value of the pointed-to memory.
    */
-  final SideEffectOperand getSideEffectOperand() { result = getAnOperand() }
+  final SideEffectOperand getSideEffectOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value of the pointed-to memory, if an exact
    * definition is available.
    */
-  final Instruction getSideEffect() { result = getSideEffectOperand().getDef() }
+  final Instruction getSideEffect() { result = this.getSideEffectOperand().getDef() }
 
   /**
    * Gets the operand that provides the address of the pointed-to memory.
    */
-  final AddressOperand getSourceAddressOperand() { result = getAnOperand() }
+  final AddressOperand getSourceAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the pointed-to memory.
    */
-  final Instruction getSourceAddress() { result = getSourceAddressOperand().getDef() }
+  final Instruction getSourceAddress() { result = this.getSourceAddressOperand().getDef() }
 
   /**
    * Gets the parameter for which this instruction reads the final pointed-to value within the
@@ -826,7 +835,7 @@ class ReturnIndirectionInstruction extends VariableInstruction {
  * - `StoreInstruction` - Copies a register operand to a memory result.
  */
 class CopyInstruction extends Instruction {
-  CopyInstruction() { getOpcode() instanceof CopyOpcode }
+  CopyInstruction() { this.getOpcode() instanceof CopyOpcode }
 
   /**
    * Gets the operand that provides the input value of the copy.
@@ -837,16 +846,16 @@ class CopyInstruction extends Instruction {
    * Gets the instruction whose result provides the input value of the copy, if an exact definition
    * is available.
    */
-  final Instruction getSourceValue() { result = getSourceValueOperand().getDef() }
+  final Instruction getSourceValue() { result = this.getSourceValueOperand().getDef() }
 }
 
 /**
  * An instruction that returns a register result containing a copy of its register operand.
  */
 class CopyValueInstruction extends CopyInstruction, UnaryInstruction {
-  CopyValueInstruction() { getOpcode() instanceof Opcode::CopyValue }
+  CopyValueInstruction() { this.getOpcode() instanceof Opcode::CopyValue }
 
-  final override UnaryOperand getSourceValueOperand() { result = getAnOperand() }
+  final override UnaryOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
@@ -863,47 +872,49 @@ private string getAddressOperandDescription(AddressOperand operand) {
  * An instruction that returns a register result containing a copy of its memory operand.
  */
 class LoadInstruction extends CopyInstruction {
-  LoadInstruction() { getOpcode() instanceof Opcode::Load }
+  LoadInstruction() { this.getOpcode() instanceof Opcode::Load }
 
   final override string getImmediateString() {
-    result = getAddressOperandDescription(getSourceAddressOperand())
+    result = getAddressOperandDescription(this.getSourceAddressOperand())
   }
 
   /**
    * Gets the operand that provides the address of the value being loaded.
    */
-  final AddressOperand getSourceAddressOperand() { result = getAnOperand() }
+  final AddressOperand getSourceAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the value being loaded.
    */
-  final Instruction getSourceAddress() { result = getSourceAddressOperand().getDef() }
+  final Instruction getSourceAddress() { result = this.getSourceAddressOperand().getDef() }
 
-  final override LoadOperand getSourceValueOperand() { result = getAnOperand() }
+  final override LoadOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
  * An instruction that returns a memory result containing a copy of its register operand.
  */
 class StoreInstruction extends CopyInstruction {
-  StoreInstruction() { getOpcode() instanceof Opcode::Store }
+  StoreInstruction() { this.getOpcode() instanceof Opcode::Store }
 
   final override string getImmediateString() {
-    result = getAddressOperandDescription(getDestinationAddressOperand())
+    result = getAddressOperandDescription(this.getDestinationAddressOperand())
   }
 
   /**
    * Gets the operand that provides the address of the location to which the value will be stored.
    */
-  final AddressOperand getDestinationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getDestinationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the location to which the value will
    * be stored, if an exact definition is available.
    */
-  final Instruction getDestinationAddress() { result = getDestinationAddressOperand().getDef() }
+  final Instruction getDestinationAddress() {
+    result = this.getDestinationAddressOperand().getDef()
+  }
 
-  final override StoreValueOperand getSourceValueOperand() { result = getAnOperand() }
+  final override StoreValueOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
@@ -911,27 +922,27 @@ class StoreInstruction extends CopyInstruction {
  * operand.
  */
 class ConditionalBranchInstruction extends Instruction {
-  ConditionalBranchInstruction() { getOpcode() instanceof Opcode::ConditionalBranch }
+  ConditionalBranchInstruction() { this.getOpcode() instanceof Opcode::ConditionalBranch }
 
   /**
    * Gets the operand that provides the Boolean condition controlling the branch.
    */
-  final ConditionOperand getConditionOperand() { result = getAnOperand() }
+  final ConditionOperand getConditionOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the Boolean condition controlling the branch.
    */
-  final Instruction getCondition() { result = getConditionOperand().getDef() }
+  final Instruction getCondition() { result = this.getConditionOperand().getDef() }
 
   /**
    * Gets the instruction to which control will flow if the condition is true.
    */
-  final Instruction getTrueSuccessor() { result = getSuccessor(EdgeKind::trueEdge()) }
+  final Instruction getTrueSuccessor() { result = this.getSuccessor(EdgeKind::trueEdge()) }
 
   /**
    * Gets the instruction to which control will flow if the condition is false.
    */
-  final Instruction getFalseSuccessor() { result = getSuccessor(EdgeKind::falseEdge()) }
+  final Instruction getFalseSuccessor() { result = this.getSuccessor(EdgeKind::falseEdge()) }
 }
 
 /**
@@ -943,14 +954,14 @@ class ConditionalBranchInstruction extends Instruction {
  * successors.
  */
 class ExitFunctionInstruction extends Instruction {
-  ExitFunctionInstruction() { getOpcode() instanceof Opcode::ExitFunction }
+  ExitFunctionInstruction() { this.getOpcode() instanceof Opcode::ExitFunction }
 }
 
 /**
  * An instruction whose result is a constant value.
  */
 class ConstantInstruction extends ConstantValueInstruction {
-  ConstantInstruction() { getOpcode() instanceof Opcode::Constant }
+  ConstantInstruction() { this.getOpcode() instanceof Opcode::Constant }
 }
 
 /**
@@ -959,7 +970,7 @@ class ConstantInstruction extends ConstantValueInstruction {
 class IntegerConstantInstruction extends ConstantInstruction {
   IntegerConstantInstruction() {
     exists(IRType resultType |
-      resultType = getResultIRType() and
+      resultType = this.getResultIRType() and
       (resultType instanceof IRIntegerType or resultType instanceof IRBooleanType)
     )
   }
@@ -969,7 +980,7 @@ class IntegerConstantInstruction extends ConstantInstruction {
  * An instruction whose result is a constant value of floating-point type.
  */
 class FloatConstantInstruction extends ConstantInstruction {
-  FloatConstantInstruction() { getResultIRType() instanceof IRFloatingPointType }
+  FloatConstantInstruction() { this.getResultIRType() instanceof IRFloatingPointType }
 }
 
 /**
@@ -978,7 +989,9 @@ class FloatConstantInstruction extends ConstantInstruction {
 class StringConstantInstruction extends VariableInstruction {
   override IRStringLiteral var;
 
-  final override string getImmediateString() { result = Language::getStringLiteralText(getValue()) }
+  final override string getImmediateString() {
+    result = Language::getStringLiteralText(this.getValue())
+  }
 
   /**
    * Gets the string literal whose address is returned by this instruction.
@@ -990,37 +1003,37 @@ class StringConstantInstruction extends VariableInstruction {
  * An instruction whose result is computed from two operands.
  */
 class BinaryInstruction extends Instruction {
-  BinaryInstruction() { getOpcode() instanceof BinaryOpcode }
+  BinaryInstruction() { this.getOpcode() instanceof BinaryOpcode }
 
   /**
    * Gets the left operand of this binary instruction.
    */
-  final LeftOperand getLeftOperand() { result = getAnOperand() }
+  final LeftOperand getLeftOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the right operand of this binary instruction.
    */
-  final RightOperand getRightOperand() { result = getAnOperand() }
+  final RightOperand getRightOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value of the left operand of this binary
    * instruction.
    */
-  final Instruction getLeft() { result = getLeftOperand().getDef() }
+  final Instruction getLeft() { result = this.getLeftOperand().getDef() }
 
   /**
    * Gets the instruction whose result provides the value of the right operand of this binary
    * instruction.
    */
-  final Instruction getRight() { result = getRightOperand().getDef() }
+  final Instruction getRight() { result = this.getRightOperand().getDef() }
 
   /**
    * Holds if this instruction's operands are `op1` and `op2`, in either order.
    */
   final predicate hasOperands(Operand op1, Operand op2) {
-    op1 = getLeftOperand() and op2 = getRightOperand()
+    op1 = this.getLeftOperand() and op2 = this.getRightOperand()
     or
-    op1 = getRightOperand() and op2 = getLeftOperand()
+    op1 = this.getRightOperand() and op2 = this.getLeftOperand()
   }
 }
 
@@ -1028,7 +1041,7 @@ class BinaryInstruction extends Instruction {
  * An instruction that computes the result of an arithmetic operation.
  */
 class ArithmeticInstruction extends Instruction {
-  ArithmeticInstruction() { getOpcode() instanceof ArithmeticOpcode }
+  ArithmeticInstruction() { this.getOpcode() instanceof ArithmeticOpcode }
 }
 
 /**
@@ -1050,7 +1063,7 @@ class UnaryArithmeticInstruction extends ArithmeticInstruction, UnaryInstruction
  * performed according to IEEE-754.
  */
 class AddInstruction extends BinaryArithmeticInstruction {
-  AddInstruction() { getOpcode() instanceof Opcode::Add }
+  AddInstruction() { this.getOpcode() instanceof Opcode::Add }
 }
 
 /**
@@ -1061,7 +1074,7 @@ class AddInstruction extends BinaryArithmeticInstruction {
  * according to IEEE-754.
  */
 class SubInstruction extends BinaryArithmeticInstruction {
-  SubInstruction() { getOpcode() instanceof Opcode::Sub }
+  SubInstruction() { this.getOpcode() instanceof Opcode::Sub }
 }
 
 /**
@@ -1072,7 +1085,7 @@ class SubInstruction extends BinaryArithmeticInstruction {
  * performed according to IEEE-754.
  */
 class MulInstruction extends BinaryArithmeticInstruction {
-  MulInstruction() { getOpcode() instanceof Opcode::Mul }
+  MulInstruction() { this.getOpcode() instanceof Opcode::Mul }
 }
 
 /**
@@ -1083,7 +1096,7 @@ class MulInstruction extends BinaryArithmeticInstruction {
  * to IEEE-754.
  */
 class DivInstruction extends BinaryArithmeticInstruction {
-  DivInstruction() { getOpcode() instanceof Opcode::Div }
+  DivInstruction() { this.getOpcode() instanceof Opcode::Div }
 }
 
 /**
@@ -1093,7 +1106,7 @@ class DivInstruction extends BinaryArithmeticInstruction {
  * division by zero or integer overflow is undefined.
  */
 class RemInstruction extends BinaryArithmeticInstruction {
-  RemInstruction() { getOpcode() instanceof Opcode::Rem }
+  RemInstruction() { this.getOpcode() instanceof Opcode::Rem }
 }
 
 /**
@@ -1104,14 +1117,14 @@ class RemInstruction extends BinaryArithmeticInstruction {
  * is performed according to IEEE-754.
  */
 class NegateInstruction extends UnaryArithmeticInstruction {
-  NegateInstruction() { getOpcode() instanceof Opcode::Negate }
+  NegateInstruction() { this.getOpcode() instanceof Opcode::Negate }
 }
 
 /**
  * An instruction that computes the result of a bitwise operation.
  */
 class BitwiseInstruction extends Instruction {
-  BitwiseInstruction() { getOpcode() instanceof BitwiseOpcode }
+  BitwiseInstruction() { this.getOpcode() instanceof BitwiseOpcode }
 }
 
 /**
@@ -1130,7 +1143,7 @@ class UnaryBitwiseInstruction extends BitwiseInstruction, UnaryInstruction { }
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitAndInstruction extends BinaryBitwiseInstruction {
-  BitAndInstruction() { getOpcode() instanceof Opcode::BitAnd }
+  BitAndInstruction() { this.getOpcode() instanceof Opcode::BitAnd }
 }
 
 /**
@@ -1139,7 +1152,7 @@ class BitAndInstruction extends BinaryBitwiseInstruction {
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitOrInstruction extends BinaryBitwiseInstruction {
-  BitOrInstruction() { getOpcode() instanceof Opcode::BitOr }
+  BitOrInstruction() { this.getOpcode() instanceof Opcode::BitOr }
 }
 
 /**
@@ -1148,7 +1161,7 @@ class BitOrInstruction extends BinaryBitwiseInstruction {
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitXorInstruction extends BinaryBitwiseInstruction {
-  BitXorInstruction() { getOpcode() instanceof Opcode::BitXor }
+  BitXorInstruction() { this.getOpcode() instanceof Opcode::BitXor }
 }
 
 /**
@@ -1159,7 +1172,7 @@ class BitXorInstruction extends BinaryBitwiseInstruction {
  * rightmost bits are zero-filled.
  */
 class ShiftLeftInstruction extends BinaryBitwiseInstruction {
-  ShiftLeftInstruction() { getOpcode() instanceof Opcode::ShiftLeft }
+  ShiftLeftInstruction() { this.getOpcode() instanceof Opcode::ShiftLeft }
 }
 
 /**
@@ -1172,7 +1185,7 @@ class ShiftLeftInstruction extends BinaryBitwiseInstruction {
  * of the left operand.
  */
 class ShiftRightInstruction extends BinaryBitwiseInstruction {
-  ShiftRightInstruction() { getOpcode() instanceof Opcode::ShiftRight }
+  ShiftRightInstruction() { this.getOpcode() instanceof Opcode::ShiftRight }
 }
 
 /**
@@ -1183,7 +1196,7 @@ class PointerArithmeticInstruction extends BinaryInstruction {
   int elementSize;
 
   PointerArithmeticInstruction() {
-    getOpcode() instanceof PointerArithmeticOpcode and
+    this.getOpcode() instanceof PointerArithmeticOpcode and
     elementSize = Raw::getInstructionElementSize(this)
   }
 
@@ -1206,7 +1219,7 @@ class PointerArithmeticInstruction extends BinaryInstruction {
  * An instruction that adds or subtracts an integer offset from a pointer.
  */
 class PointerOffsetInstruction extends PointerArithmeticInstruction {
-  PointerOffsetInstruction() { getOpcode() instanceof PointerOffsetOpcode }
+  PointerOffsetInstruction() { this.getOpcode() instanceof PointerOffsetOpcode }
 }
 
 /**
@@ -1217,7 +1230,7 @@ class PointerOffsetInstruction extends PointerArithmeticInstruction {
  * overflow is undefined.
  */
 class PointerAddInstruction extends PointerOffsetInstruction {
-  PointerAddInstruction() { getOpcode() instanceof Opcode::PointerAdd }
+  PointerAddInstruction() { this.getOpcode() instanceof Opcode::PointerAdd }
 }
 
 /**
@@ -1228,7 +1241,7 @@ class PointerAddInstruction extends PointerOffsetInstruction {
  * pointer underflow is undefined.
  */
 class PointerSubInstruction extends PointerOffsetInstruction {
-  PointerSubInstruction() { getOpcode() instanceof Opcode::PointerSub }
+  PointerSubInstruction() { this.getOpcode() instanceof Opcode::PointerSub }
 }
 
 /**
@@ -1241,31 +1254,31 @@ class PointerSubInstruction extends PointerOffsetInstruction {
  * undefined.
  */
 class PointerDiffInstruction extends PointerArithmeticInstruction {
-  PointerDiffInstruction() { getOpcode() instanceof Opcode::PointerDiff }
+  PointerDiffInstruction() { this.getOpcode() instanceof Opcode::PointerDiff }
 }
 
 /**
  * An instruction whose result is computed from a single operand.
  */
 class UnaryInstruction extends Instruction {
-  UnaryInstruction() { getOpcode() instanceof UnaryOpcode }
+  UnaryInstruction() { this.getOpcode() instanceof UnaryOpcode }
 
   /**
    * Gets the sole operand of this instruction.
    */
-  final UnaryOperand getUnaryOperand() { result = getAnOperand() }
+  final UnaryOperand getUnaryOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the sole operand of this instruction.
    */
-  final Instruction getUnary() { result = getUnaryOperand().getDef() }
+  final Instruction getUnary() { result = this.getUnaryOperand().getDef() }
 }
 
 /**
  * An instruction that converts the value of its operand to a value of a different type.
  */
 class ConvertInstruction extends UnaryInstruction {
-  ConvertInstruction() { getOpcode() instanceof Opcode::Convert }
+  ConvertInstruction() { this.getOpcode() instanceof Opcode::Convert }
 }
 
 /**
@@ -1279,7 +1292,7 @@ class ConvertInstruction extends UnaryInstruction {
  * `as` expression.
  */
 class CheckedConvertOrNullInstruction extends UnaryInstruction {
-  CheckedConvertOrNullInstruction() { getOpcode() instanceof Opcode::CheckedConvertOrNull }
+  CheckedConvertOrNullInstruction() { this.getOpcode() instanceof Opcode::CheckedConvertOrNull }
 }
 
 /**
@@ -1293,7 +1306,7 @@ class CheckedConvertOrNullInstruction extends UnaryInstruction {
  * expression.
  */
 class CheckedConvertOrThrowInstruction extends UnaryInstruction {
-  CheckedConvertOrThrowInstruction() { getOpcode() instanceof Opcode::CheckedConvertOrThrow }
+  CheckedConvertOrThrowInstruction() { this.getOpcode() instanceof Opcode::CheckedConvertOrThrow }
 }
 
 /**
@@ -1306,7 +1319,7 @@ class CheckedConvertOrThrowInstruction extends UnaryInstruction {
  * the most-derived object.
  */
 class CompleteObjectAddressInstruction extends UnaryInstruction {
-  CompleteObjectAddressInstruction() { getOpcode() instanceof Opcode::CompleteObjectAddress }
+  CompleteObjectAddressInstruction() { this.getOpcode() instanceof Opcode::CompleteObjectAddress }
 }
 
 /**
@@ -1351,7 +1364,7 @@ class InheritanceConversionInstruction extends UnaryInstruction {
  * An instruction that converts from the address of a derived class to the address of a base class.
  */
 class ConvertToBaseInstruction extends InheritanceConversionInstruction {
-  ConvertToBaseInstruction() { getOpcode() instanceof ConvertToBaseOpcode }
+  ConvertToBaseInstruction() { this.getOpcode() instanceof ConvertToBaseOpcode }
 }
 
 /**
@@ -1361,7 +1374,9 @@ class ConvertToBaseInstruction extends InheritanceConversionInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToNonVirtualBaseInstruction extends ConvertToBaseInstruction {
-  ConvertToNonVirtualBaseInstruction() { getOpcode() instanceof Opcode::ConvertToNonVirtualBase }
+  ConvertToNonVirtualBaseInstruction() {
+    this.getOpcode() instanceof Opcode::ConvertToNonVirtualBase
+  }
 }
 
 /**
@@ -1371,7 +1386,7 @@ class ConvertToNonVirtualBaseInstruction extends ConvertToBaseInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToVirtualBaseInstruction extends ConvertToBaseInstruction {
-  ConvertToVirtualBaseInstruction() { getOpcode() instanceof Opcode::ConvertToVirtualBase }
+  ConvertToVirtualBaseInstruction() { this.getOpcode() instanceof Opcode::ConvertToVirtualBase }
 }
 
 /**
@@ -1381,7 +1396,7 @@ class ConvertToVirtualBaseInstruction extends ConvertToBaseInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToDerivedInstruction extends InheritanceConversionInstruction {
-  ConvertToDerivedInstruction() { getOpcode() instanceof Opcode::ConvertToDerived }
+  ConvertToDerivedInstruction() { this.getOpcode() instanceof Opcode::ConvertToDerived }
 }
 
 /**
@@ -1390,7 +1405,7 @@ class ConvertToDerivedInstruction extends InheritanceConversionInstruction {
  * The operand must have an integer type, which will also be the result type.
  */
 class BitComplementInstruction extends UnaryBitwiseInstruction {
-  BitComplementInstruction() { getOpcode() instanceof Opcode::BitComplement }
+  BitComplementInstruction() { this.getOpcode() instanceof Opcode::BitComplement }
 }
 
 /**
@@ -1399,14 +1414,14 @@ class BitComplementInstruction extends UnaryBitwiseInstruction {
  * The operand must have a Boolean type, which will also be the result type.
  */
 class LogicalNotInstruction extends UnaryInstruction {
-  LogicalNotInstruction() { getOpcode() instanceof Opcode::LogicalNot }
+  LogicalNotInstruction() { this.getOpcode() instanceof Opcode::LogicalNot }
 }
 
 /**
  * An instruction that compares two numeric operands.
  */
 class CompareInstruction extends BinaryInstruction {
-  CompareInstruction() { getOpcode() instanceof CompareOpcode }
+  CompareInstruction() { this.getOpcode() instanceof CompareOpcode }
 }
 
 /**
@@ -1417,7 +1432,7 @@ class CompareInstruction extends BinaryInstruction {
  * unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareEQInstruction extends CompareInstruction {
-  CompareEQInstruction() { getOpcode() instanceof Opcode::CompareEQ }
+  CompareEQInstruction() { this.getOpcode() instanceof Opcode::CompareEQ }
 }
 
 /**
@@ -1428,14 +1443,14 @@ class CompareEQInstruction extends CompareInstruction {
  * `left == right`. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareNEInstruction extends CompareInstruction {
-  CompareNEInstruction() { getOpcode() instanceof Opcode::CompareNE }
+  CompareNEInstruction() { this.getOpcode() instanceof Opcode::CompareNE }
 }
 
 /**
  * An instruction that does a relative comparison of two values, such as `<` or `>=`.
  */
 class RelationalInstruction extends CompareInstruction {
-  RelationalInstruction() { getOpcode() instanceof RelationalOpcode }
+  RelationalInstruction() { this.getOpcode() instanceof RelationalOpcode }
 
   /**
    * Gets the operand on the "greater" (or "greater-or-equal") side
@@ -1467,11 +1482,11 @@ class RelationalInstruction extends CompareInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareLTInstruction extends RelationalInstruction {
-  CompareLTInstruction() { getOpcode() instanceof Opcode::CompareLT }
+  CompareLTInstruction() { this.getOpcode() instanceof Opcode::CompareLT }
 
-  override Instruction getLesser() { result = getLeft() }
+  override Instruction getLesser() { result = this.getLeft() }
 
-  override Instruction getGreater() { result = getRight() }
+  override Instruction getGreater() { result = this.getRight() }
 
   override predicate isStrict() { any() }
 }
@@ -1484,11 +1499,11 @@ class CompareLTInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareGTInstruction extends RelationalInstruction {
-  CompareGTInstruction() { getOpcode() instanceof Opcode::CompareGT }
+  CompareGTInstruction() { this.getOpcode() instanceof Opcode::CompareGT }
 
-  override Instruction getLesser() { result = getRight() }
+  override Instruction getLesser() { result = this.getRight() }
 
-  override Instruction getGreater() { result = getLeft() }
+  override Instruction getGreater() { result = this.getLeft() }
 
   override predicate isStrict() { any() }
 }
@@ -1502,11 +1517,11 @@ class CompareGTInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareLEInstruction extends RelationalInstruction {
-  CompareLEInstruction() { getOpcode() instanceof Opcode::CompareLE }
+  CompareLEInstruction() { this.getOpcode() instanceof Opcode::CompareLE }
 
-  override Instruction getLesser() { result = getLeft() }
+  override Instruction getLesser() { result = this.getLeft() }
 
-  override Instruction getGreater() { result = getRight() }
+  override Instruction getGreater() { result = this.getRight() }
 
   override predicate isStrict() { none() }
 }
@@ -1520,11 +1535,11 @@ class CompareLEInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareGEInstruction extends RelationalInstruction {
-  CompareGEInstruction() { getOpcode() instanceof Opcode::CompareGE }
+  CompareGEInstruction() { this.getOpcode() instanceof Opcode::CompareGE }
 
-  override Instruction getLesser() { result = getRight() }
+  override Instruction getLesser() { result = this.getRight() }
 
-  override Instruction getGreater() { result = getLeft() }
+  override Instruction getGreater() { result = this.getLeft() }
 
   override predicate isStrict() { none() }
 }
@@ -1543,78 +1558,78 @@ class CompareGEInstruction extends RelationalInstruction {
  * of any case edge.
  */
 class SwitchInstruction extends Instruction {
-  SwitchInstruction() { getOpcode() instanceof Opcode::Switch }
+  SwitchInstruction() { this.getOpcode() instanceof Opcode::Switch }
 
   /** Gets the operand that provides the integer value controlling the switch. */
-  final ConditionOperand getExpressionOperand() { result = getAnOperand() }
+  final ConditionOperand getExpressionOperand() { result = this.getAnOperand() }
 
   /** Gets the instruction whose result provides the integer value controlling the switch. */
-  final Instruction getExpression() { result = getExpressionOperand().getDef() }
+  final Instruction getExpression() { result = this.getExpressionOperand().getDef() }
 
   /** Gets the successor instructions along the case edges of the switch. */
-  final Instruction getACaseSuccessor() { exists(CaseEdge edge | result = getSuccessor(edge)) }
+  final Instruction getACaseSuccessor() { exists(CaseEdge edge | result = this.getSuccessor(edge)) }
 
   /** Gets the successor instruction along the default edge of the switch, if any. */
-  final Instruction getDefaultSuccessor() { result = getSuccessor(EdgeKind::defaultEdge()) }
+  final Instruction getDefaultSuccessor() { result = this.getSuccessor(EdgeKind::defaultEdge()) }
 }
 
 /**
  * An instruction that calls a function.
  */
 class CallInstruction extends Instruction {
-  CallInstruction() { getOpcode() instanceof Opcode::Call }
+  CallInstruction() { this.getOpcode() instanceof Opcode::Call }
 
   final override string getImmediateString() {
-    result = getStaticCallTarget().toString()
+    result = this.getStaticCallTarget().toString()
     or
-    not exists(getStaticCallTarget()) and result = "?"
+    not exists(this.getStaticCallTarget()) and result = "?"
   }
 
   /**
    * Gets the operand the specifies the target function of the call.
    */
-  final CallTargetOperand getCallTargetOperand() { result = getAnOperand() }
+  final CallTargetOperand getCallTargetOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `Instruction` that computes the target function of the call. This is usually a
    * `FunctionAddress` instruction, but can also be an arbitrary instruction that produces a
    * function pointer.
    */
-  final Instruction getCallTarget() { result = getCallTargetOperand().getDef() }
+  final Instruction getCallTarget() { result = this.getCallTargetOperand().getDef() }
 
   /**
    * Gets all of the argument operands of the call, including the `this` pointer, if any.
    */
-  final ArgumentOperand getAnArgumentOperand() { result = getAnOperand() }
+  final ArgumentOperand getAnArgumentOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `Function` that the call targets, if this is statically known.
    */
   final Language::Function getStaticCallTarget() {
-    result = getCallTarget().(FunctionAddressInstruction).getFunctionSymbol()
+    result = this.getCallTarget().(FunctionAddressInstruction).getFunctionSymbol()
   }
 
   /**
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
-  final Instruction getAnArgument() { result = getAnArgumentOperand().getDef() }
+  final Instruction getAnArgument() { result = this.getAnArgumentOperand().getDef() }
 
   /**
    * Gets the `this` pointer argument operand of the call, if any.
    */
-  final ThisArgumentOperand getThisArgumentOperand() { result = getAnOperand() }
+  final ThisArgumentOperand getThisArgumentOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `this` pointer argument of the call, if any.
    */
-  final Instruction getThisArgument() { result = getThisArgumentOperand().getDef() }
+  final Instruction getThisArgument() { result = this.getThisArgumentOperand().getDef() }
 
   /**
    * Gets the argument operand at the specified index.
    */
   pragma[noinline]
   final PositionalArgumentOperand getPositionalArgumentOperand(int index) {
-    result = getAnOperand() and
+    result = this.getAnOperand() and
     result.getIndex() = index
   }
 
@@ -1623,7 +1638,7 @@ class CallInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getDef()
+    result = this.getPositionalArgumentOperand(index).getDef()
   }
 
   /**
@@ -1631,16 +1646,16 @@ class CallInstruction extends Instruction {
    */
   pragma[noinline]
   final ArgumentOperand getArgumentOperand(int index) {
-    index >= 0 and result = getPositionalArgumentOperand(index)
+    index >= 0 and result = this.getPositionalArgumentOperand(index)
     or
-    index = -1 and result = getThisArgumentOperand()
+    index = -1 and result = this.getThisArgumentOperand()
   }
 
   /**
    * Gets the argument at the specified index, or `this` if `index` is `-1`.
    */
   pragma[noinline]
-  final Instruction getArgument(int index) { result = getArgumentOperand(index).getDef() }
+  final Instruction getArgument(int index) { result = this.getArgumentOperand(index).getDef() }
 
   /**
    * Gets the number of arguments of the call, including the `this` pointer, if any.
@@ -1665,7 +1680,7 @@ class CallInstruction extends Instruction {
  * An instruction representing a side effect of a function call.
  */
 class SideEffectInstruction extends Instruction {
-  SideEffectInstruction() { getOpcode() instanceof SideEffectOpcode }
+  SideEffectInstruction() { this.getOpcode() instanceof SideEffectOpcode }
 
   /**
    * Gets the instruction whose execution causes this side effect.
@@ -1680,7 +1695,7 @@ class SideEffectInstruction extends Instruction {
  * accessed by that call.
  */
 class CallSideEffectInstruction extends SideEffectInstruction {
-  CallSideEffectInstruction() { getOpcode() instanceof Opcode::CallSideEffect }
+  CallSideEffectInstruction() { this.getOpcode() instanceof Opcode::CallSideEffect }
 }
 
 /**
@@ -1691,7 +1706,7 @@ class CallSideEffectInstruction extends SideEffectInstruction {
  * call target cannot write to escaped memory.
  */
 class CallReadSideEffectInstruction extends SideEffectInstruction {
-  CallReadSideEffectInstruction() { getOpcode() instanceof Opcode::CallReadSideEffect }
+  CallReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::CallReadSideEffect }
 }
 
 /**
@@ -1699,33 +1714,33 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * specific parameter.
  */
 class ReadSideEffectInstruction extends SideEffectInstruction, IndexedInstruction {
-  ReadSideEffectInstruction() { getOpcode() instanceof ReadSideEffectOpcode }
+  ReadSideEffectInstruction() { this.getOpcode() instanceof ReadSideEffectOpcode }
 
   /** Gets the operand for the value that will be read from this instruction, if known. */
-  final SideEffectOperand getSideEffectOperand() { result = getAnOperand() }
+  final SideEffectOperand getSideEffectOperand() { result = this.getAnOperand() }
 
   /** Gets the value that will be read from this instruction, if known. */
-  final Instruction getSideEffect() { result = getSideEffectOperand().getDef() }
+  final Instruction getSideEffect() { result = this.getSideEffectOperand().getDef() }
 
   /** Gets the operand for the address from which this instruction may read. */
-  final AddressOperand getArgumentOperand() { result = getAnOperand() }
+  final AddressOperand getArgumentOperand() { result = this.getAnOperand() }
 
   /** Gets the address from which this instruction may read. */
-  final Instruction getArgumentDef() { result = getArgumentOperand().getDef() }
+  final Instruction getArgumentDef() { result = this.getArgumentOperand().getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends ReadSideEffectInstruction {
-  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
+  IndirectReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::IndirectReadSideEffect }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends ReadSideEffectInstruction {
-  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
+  BufferReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::BufferReadSideEffect }
 }
 
 /**
@@ -1733,18 +1748,18 @@ class BufferReadSideEffectInstruction extends ReadSideEffectInstruction {
  */
 class SizedBufferReadSideEffectInstruction extends ReadSideEffectInstruction {
   SizedBufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferReadSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes read from the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes read from the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1752,17 +1767,17 @@ class SizedBufferReadSideEffectInstruction extends ReadSideEffectInstruction {
  * specific parameter.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction, IndexedInstruction {
-  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
+  WriteSideEffectInstruction() { this.getOpcode() instanceof WriteSideEffectOpcode }
 
   /**
    * Get the operand that holds the address of the memory to be written.
    */
-  final AddressOperand getDestinationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getDestinationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the memory to be written.
    */
-  Instruction getDestinationAddress() { result = getDestinationAddressOperand().getDef() }
+  Instruction getDestinationAddress() { result = this.getDestinationAddressOperand().getDef() }
 }
 
 /**
@@ -1770,7 +1785,7 @@ class WriteSideEffectInstruction extends SideEffectInstruction, IndexedInstructi
  */
 class IndirectMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   IndirectMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::IndirectMustWriteSideEffect
   }
 }
 
@@ -1780,7 +1795,7 @@ class IndirectMustWriteSideEffectInstruction extends WriteSideEffectInstruction 
  */
 class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   BufferMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::BufferMustWriteSideEffect
   }
 }
 
@@ -1790,18 +1805,18 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
  */
 class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   SizedBufferMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes written to the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes written to the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1812,7 +1827,7 @@ class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstructi
  */
 class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   IndirectMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectMayWriteSideEffect
+    this.getOpcode() instanceof Opcode::IndirectMayWriteSideEffect
   }
 }
 
@@ -1822,7 +1837,9 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
+  BufferMayWriteSideEffectInstruction() {
+    this.getOpcode() instanceof Opcode::BufferMayWriteSideEffect
+  }
 }
 
 /**
@@ -1832,18 +1849,18 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  */
 class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   SizedBufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes written to the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes written to the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1852,80 +1869,80 @@ class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstructio
  */
 class InitializeDynamicAllocationInstruction extends SideEffectInstruction {
   InitializeDynamicAllocationInstruction() {
-    getOpcode() instanceof Opcode::InitializeDynamicAllocation
+    this.getOpcode() instanceof Opcode::InitializeDynamicAllocation
   }
 
   /**
    * Gets the operand that represents the address of the allocation this instruction is initializing.
    */
-  final AddressOperand getAllocationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getAllocationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the address for the allocation this instruction is initializing.
    */
-  final Instruction getAllocationAddress() { result = getAllocationAddressOperand().getDef() }
+  final Instruction getAllocationAddress() { result = this.getAllocationAddressOperand().getDef() }
 }
 
 /**
  * An instruction representing a GNU or MSVC inline assembly statement.
  */
 class InlineAsmInstruction extends Instruction {
-  InlineAsmInstruction() { getOpcode() instanceof Opcode::InlineAsm }
+  InlineAsmInstruction() { this.getOpcode() instanceof Opcode::InlineAsm }
 }
 
 /**
  * An instruction that throws an exception.
  */
 class ThrowInstruction extends Instruction {
-  ThrowInstruction() { getOpcode() instanceof ThrowOpcode }
+  ThrowInstruction() { this.getOpcode() instanceof ThrowOpcode }
 }
 
 /**
  * An instruction that throws a new exception.
  */
 class ThrowValueInstruction extends ThrowInstruction {
-  ThrowValueInstruction() { getOpcode() instanceof Opcode::ThrowValue }
+  ThrowValueInstruction() { this.getOpcode() instanceof Opcode::ThrowValue }
 
   /**
    * Gets the address operand of the exception thrown by this instruction.
    */
-  final AddressOperand getExceptionAddressOperand() { result = getAnOperand() }
+  final AddressOperand getExceptionAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the address of the exception thrown by this instruction.
    */
-  final Instruction getExceptionAddress() { result = getExceptionAddressOperand().getDef() }
+  final Instruction getExceptionAddress() { result = this.getExceptionAddressOperand().getDef() }
 
   /**
    * Gets the operand for the exception thrown by this instruction.
    */
-  final LoadOperand getExceptionOperand() { result = getAnOperand() }
+  final LoadOperand getExceptionOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the exception thrown by this instruction.
    */
-  final Instruction getException() { result = getExceptionOperand().getDef() }
+  final Instruction getException() { result = this.getExceptionOperand().getDef() }
 }
 
 /**
  * An instruction that re-throws the current exception.
  */
 class ReThrowInstruction extends ThrowInstruction {
-  ReThrowInstruction() { getOpcode() instanceof Opcode::ReThrow }
+  ReThrowInstruction() { this.getOpcode() instanceof Opcode::ReThrow }
 }
 
 /**
  * An instruction that exits the current function by propagating an exception.
  */
 class UnwindInstruction extends Instruction {
-  UnwindInstruction() { getOpcode() instanceof Opcode::Unwind }
+  UnwindInstruction() { this.getOpcode() instanceof Opcode::Unwind }
 }
 
 /**
  * An instruction that starts a `catch` handler.
  */
 class CatchInstruction extends Instruction {
-  CatchInstruction() { getOpcode() instanceof CatchOpcode }
+  CatchInstruction() { this.getOpcode() instanceof CatchOpcode }
 }
 
 /**
@@ -1935,7 +1952,7 @@ class CatchByTypeInstruction extends CatchInstruction {
   Language::LanguageType exceptionType;
 
   CatchByTypeInstruction() {
-    getOpcode() instanceof Opcode::CatchByType and
+    this.getOpcode() instanceof Opcode::CatchByType and
     exceptionType = Raw::getInstructionExceptionType(this)
   }
 
@@ -1951,21 +1968,21 @@ class CatchByTypeInstruction extends CatchInstruction {
  * An instruction that catches any exception.
  */
 class CatchAnyInstruction extends CatchInstruction {
-  CatchAnyInstruction() { getOpcode() instanceof Opcode::CatchAny }
+  CatchAnyInstruction() { this.getOpcode() instanceof Opcode::CatchAny }
 }
 
 /**
  * An instruction that initializes all escaped memory.
  */
 class AliasedDefinitionInstruction extends Instruction {
-  AliasedDefinitionInstruction() { getOpcode() instanceof Opcode::AliasedDefinition }
+  AliasedDefinitionInstruction() { this.getOpcode() instanceof Opcode::AliasedDefinition }
 }
 
 /**
  * An instruction that consumes all escaped memory on exit from the function.
  */
 class AliasedUseInstruction extends Instruction {
-  AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
+  AliasedUseInstruction() { this.getOpcode() instanceof Opcode::AliasedUse }
 }
 
 /**
@@ -1979,7 +1996,7 @@ class AliasedUseInstruction extends Instruction {
  * runtime.
  */
 class PhiInstruction extends Instruction {
-  PhiInstruction() { getOpcode() instanceof Opcode::Phi }
+  PhiInstruction() { this.getOpcode() instanceof Opcode::Phi }
 
   /**
    * Gets all of the instruction's `PhiInputOperand`s, representing the values that flow from each predecessor block.
@@ -2047,29 +2064,29 @@ class PhiInstruction extends Instruction {
  * https://link.springer.com/content/pdf/10.1007%2F3-540-61053-7_66.pdf.
  */
 class ChiInstruction extends Instruction {
-  ChiInstruction() { getOpcode() instanceof Opcode::Chi }
+  ChiInstruction() { this.getOpcode() instanceof Opcode::Chi }
 
   /**
    * Gets the operand that represents the previous state of all memory that might be aliased by the
    * memory write.
    */
-  final ChiTotalOperand getTotalOperand() { result = getAnOperand() }
+  final ChiTotalOperand getTotalOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the operand that represents the previous state of all memory that might be aliased by the
    * memory write.
    */
-  final Instruction getTotal() { result = getTotalOperand().getDef() }
+  final Instruction getTotal() { result = this.getTotalOperand().getDef() }
 
   /**
    * Gets the operand that represents the new value written by the memory write.
    */
-  final ChiPartialOperand getPartialOperand() { result = getAnOperand() }
+  final ChiPartialOperand getPartialOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the operand that represents the new value written by the memory write.
    */
-  final Instruction getPartial() { result = getPartialOperand().getDef() }
+  final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
    * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
@@ -2093,7 +2110,7 @@ class ChiInstruction extends Instruction {
  * or `Switch` instruction where that particular edge is infeasible.
  */
 class UnreachedInstruction extends Instruction {
-  UnreachedInstruction() { getOpcode() instanceof Opcode::Unreached }
+  UnreachedInstruction() { this.getOpcode() instanceof Opcode::Unreached }
 }
 
 /**
@@ -2106,7 +2123,7 @@ class BuiltInOperationInstruction extends Instruction {
   Language::BuiltInOperation operation;
 
   BuiltInOperationInstruction() {
-    getOpcode() instanceof BuiltInOperationOpcode and
+    this.getOpcode() instanceof BuiltInOperationOpcode and
     operation = Raw::getInstructionBuiltInOperation(this)
   }
 
@@ -2122,9 +2139,9 @@ class BuiltInOperationInstruction extends Instruction {
  * actual operation is specified by the `getBuiltInOperation()` predicate.
  */
 class BuiltInInstruction extends BuiltInOperationInstruction {
-  BuiltInInstruction() { getOpcode() instanceof Opcode::BuiltIn }
+  BuiltInInstruction() { this.getOpcode() instanceof Opcode::BuiltIn }
 
-  final override string getImmediateString() { result = getBuiltInOperation().toString() }
+  final override string getImmediateString() { result = this.getBuiltInOperation().toString() }
 }
 
 /**
@@ -2135,7 +2152,7 @@ class BuiltInInstruction extends BuiltInOperationInstruction {
  * to the `...` parameter.
  */
 class VarArgsStartInstruction extends UnaryInstruction {
-  VarArgsStartInstruction() { getOpcode() instanceof Opcode::VarArgsStart }
+  VarArgsStartInstruction() { this.getOpcode() instanceof Opcode::VarArgsStart }
 }
 
 /**
@@ -2145,7 +2162,7 @@ class VarArgsStartInstruction extends UnaryInstruction {
  * a result.
  */
 class VarArgsEndInstruction extends UnaryInstruction {
-  VarArgsEndInstruction() { getOpcode() instanceof Opcode::VarArgsEnd }
+  VarArgsEndInstruction() { this.getOpcode() instanceof Opcode::VarArgsEnd }
 }
 
 /**
@@ -2155,7 +2172,7 @@ class VarArgsEndInstruction extends UnaryInstruction {
  * argument.
  */
 class VarArgInstruction extends UnaryInstruction {
-  VarArgInstruction() { getOpcode() instanceof Opcode::VarArg }
+  VarArgInstruction() { this.getOpcode() instanceof Opcode::VarArg }
 }
 
 /**
@@ -2166,7 +2183,7 @@ class VarArgInstruction extends UnaryInstruction {
  * argument of the `...` parameter.
  */
 class NextVarArgInstruction extends UnaryInstruction {
-  NextVarArgInstruction() { getOpcode() instanceof Opcode::NextVarArg }
+  NextVarArgInstruction() { this.getOpcode() instanceof Opcode::NextVarArg }
 }
 
 /**
@@ -2180,5 +2197,5 @@ class NextVarArgInstruction extends UnaryInstruction {
  * The result is the address of the newly allocated object.
  */
 class NewObjInstruction extends Instruction {
-  NewObjInstruction() { getOpcode() instanceof Opcode::NewObj }
+  NewObjInstruction() { this.getOpcode() instanceof Opcode::NewObj }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -46,12 +46,12 @@ class Operand extends TStageOperand {
   /**
    * Gets the location of the source code for this operand.
    */
-  final Language::Location getLocation() { result = getUse().getLocation() }
+  final Language::Location getLocation() { result = this.getUse().getLocation() }
 
   /**
    * Gets the function that contains this operand.
    */
-  final IRFunction getEnclosingIRFunction() { result = getUse().getEnclosingIRFunction() }
+  final IRFunction getEnclosingIRFunction() { result = this.getUse().getEnclosingIRFunction() }
 
   /**
    * Gets the `Instruction` that consumes this operand.
@@ -74,7 +74,7 @@ class Operand extends TStageOperand {
    */
   final Instruction getDef() {
     result = this.getAnyDef() and
-    getDefinitionOverlap() instanceof MustExactlyOverlap
+    this.getDefinitionOverlap() instanceof MustExactlyOverlap
   }
 
   /**
@@ -82,7 +82,7 @@ class Operand extends TStageOperand {
    *
    * Gets the `Instruction` that consumes this operand.
    */
-  deprecated final Instruction getUseInstruction() { result = getUse() }
+  deprecated final Instruction getUseInstruction() { result = this.getUse() }
 
   /**
    * DEPRECATED: use `getAnyDef` or `getDef`. The exact replacement for this
@@ -91,7 +91,7 @@ class Operand extends TStageOperand {
    *
    * Gets the `Instruction` whose result is the value of the operand.
    */
-  deprecated final Instruction getDefinitionInstruction() { result = getAnyDef() }
+  deprecated final Instruction getDefinitionInstruction() { result = this.getAnyDef() }
 
   /**
    * Gets the overlap relationship between the operand's definition and its use.
@@ -101,7 +101,9 @@ class Operand extends TStageOperand {
   /**
    * Holds if the result of the definition instruction does not exactly overlap this use.
    */
-  final predicate isDefinitionInexact() { not getDefinitionOverlap() instanceof MustExactlyOverlap }
+  final predicate isDefinitionInexact() {
+    not this.getDefinitionOverlap() instanceof MustExactlyOverlap
+  }
 
   /**
    * Gets a prefix to use when dumping the operand in an operand list.
@@ -121,7 +123,7 @@ class Operand extends TStageOperand {
    * For example: `this:r3_5`
    */
   final string getDumpString() {
-    result = getDumpLabel() + getInexactSpecifier() + getDefinitionId()
+    result = this.getDumpLabel() + this.getInexactSpecifier() + this.getDefinitionId()
   }
 
   /**
@@ -129,9 +131,9 @@ class Operand extends TStageOperand {
    * definition is not modeled in SSA.
    */
   private string getDefinitionId() {
-    result = getAnyDef().getResultId()
+    result = this.getAnyDef().getResultId()
     or
-    not exists(getAnyDef()) and result = "m?"
+    not exists(this.getAnyDef()) and result = "m?"
   }
 
   /**
@@ -140,7 +142,7 @@ class Operand extends TStageOperand {
    * the empty string.
    */
   private string getInexactSpecifier() {
-    if isDefinitionInexact() then result = "~" else result = ""
+    if this.isDefinitionInexact() then result = "~" else result = ""
   }
 
   /**
@@ -155,7 +157,7 @@ class Operand extends TStageOperand {
    * the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  Language::LanguageType getLanguageType() { result = getAnyDef().getResultLanguageType() }
+  Language::LanguageType getLanguageType() { result = this.getAnyDef().getResultLanguageType() }
 
   /**
    * Gets the language-neutral type of the value consumed by this operand. This is usually the same
@@ -164,7 +166,7 @@ class Operand extends TStageOperand {
    * from the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the value consumed by this operand. This is usually the same as the
@@ -173,7 +175,7 @@ class Operand extends TStageOperand {
    * the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, _) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, _) }
 
   /**
    * Holds if the value consumed by this operand is a glvalue. If this
@@ -182,13 +184,13 @@ class Operand extends TStageOperand {
    * not hold, the value of the operand represents a value whose type is
    * given by `getType()`.
    */
-  final predicate isGLValue() { getLanguageType().hasType(_, true) }
+  final predicate isGLValue() { this.getLanguageType().hasType(_, true) }
 
   /**
    * Gets the size of the value consumed by this operand, in bytes. If the operand does not have
    * a known constant size, this predicate does not hold.
    */
-  final int getSize() { result = getLanguageType().getByteSize() }
+  final int getSize() { result = this.getLanguageType().getByteSize() }
 }
 
 /**
@@ -205,7 +207,7 @@ class MemoryOperand extends Operand {
   /**
    * Gets the kind of memory access performed by the operand.
    */
-  MemoryAccessKind getMemoryAccess() { result = getUse().getOpcode().getReadMemoryAccess() }
+  MemoryAccessKind getMemoryAccess() { result = this.getUse().getOpcode().getReadMemoryAccess() }
 
   /**
    * Holds if the memory access performed by this operand will not always read from every bit in the
@@ -215,7 +217,7 @@ class MemoryOperand extends Operand {
    * conservative estimate of the memory that might actually be accessed at runtime (for example,
    * the global side effects of a function call).
    */
-  predicate hasMayReadMemoryAccess() { getUse().getOpcode().hasMayReadMemoryAccess() }
+  predicate hasMayReadMemoryAccess() { this.getUse().getOpcode().hasMayReadMemoryAccess() }
 
   /**
    * Returns the operand that holds the memory address from which the current operand loads its
@@ -223,8 +225,8 @@ class MemoryOperand extends Operand {
    * is `r1`.
    */
   final AddressOperand getAddressOperand() {
-    getMemoryAccess().usesAddressOperand() and
-    result.getUse() = getUse()
+    this.getMemoryAccess().usesAddressOperand() and
+    result.getUse() = this.getUse()
   }
 }
 
@@ -294,7 +296,7 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, TNonPhiMemoryOpe
     result = unique(Instruction defInstr | hasDefinition(defInstr, _))
   }
 
-  final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
+  final override Overlap getDefinitionOverlap() { this.hasDefinition(_, result) }
 
   pragma[noinline]
   private predicate hasDefinition(Instruction defInstr, Overlap overlap) {
@@ -449,13 +451,17 @@ class PhiInputOperand extends MemoryOperand, TPhiOperand {
 
   final override Overlap getDefinitionOverlap() { result = overlap }
 
-  final override int getDumpSortOrder() { result = 11 + getPredecessorBlock().getDisplayIndex() }
-
-  final override string getDumpLabel() {
-    result = "from " + getPredecessorBlock().getDisplayIndex().toString() + ":"
+  final override int getDumpSortOrder() {
+    result = 11 + this.getPredecessorBlock().getDisplayIndex()
   }
 
-  final override string getDumpId() { result = getPredecessorBlock().getDisplayIndex().toString() }
+  final override string getDumpLabel() {
+    result = "from " + this.getPredecessorBlock().getDisplayIndex().toString() + ":"
+  }
+
+  final override string getDumpId() {
+    result = this.getPredecessorBlock().getDisplayIndex().toString()
+  }
 
   /**
    * Gets the predecessor block from which this value comes.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -24,7 +24,7 @@ class IRBlockBase extends TIRBlock {
   final string toString() { result = getFirstInstruction(this).toString() }
 
   /** Gets the source location of the first non-`Phi` instruction in this block. */
-  final Language::Location getLocation() { result = getFirstInstruction().getLocation() }
+  final Language::Location getLocation() { result = this.getFirstInstruction().getLocation() }
 
   /**
    * INTERNAL: Do not use.
@@ -39,7 +39,7 @@ class IRBlockBase extends TIRBlock {
     ) and
     this =
       rank[result + 1](IRBlock funcBlock, int sortOverride, int sortKey1, int sortKey2 |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        funcBlock.getEnclosingFunction() = this.getEnclosingFunction() and
         funcBlock.getFirstInstruction().hasSortKeys(sortKey1, sortKey2) and
         // Ensure that the block containing `EnterFunction` always comes first.
         if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
@@ -59,15 +59,15 @@ class IRBlockBase extends TIRBlock {
    * Get the `Phi` instructions that appear at the start of this block.
    */
   final PhiInstruction getAPhiInstruction() {
-    Construction::getPhiInstructionBlockStart(result) = getFirstInstruction()
+    Construction::getPhiInstructionBlockStart(result) = this.getFirstInstruction()
   }
 
   /**
    * Gets an instruction in this block. This includes `Phi` instructions.
    */
   final Instruction getAnInstruction() {
-    result = getInstruction(_) or
-    result = getAPhiInstruction()
+    result = this.getInstruction(_) or
+    result = this.getAPhiInstruction()
   }
 
   /**
@@ -78,7 +78,9 @@ class IRBlockBase extends TIRBlock {
   /**
    * Gets the last instruction in this block.
    */
-  final Instruction getLastInstruction() { result = getInstruction(getInstructionCount() - 1) }
+  final Instruction getLastInstruction() {
+    result = this.getInstruction(this.getInstructionCount() - 1)
+  }
 
   /**
    * Gets the number of non-`Phi` instructions in this block.
@@ -149,7 +151,7 @@ class IRBlock extends IRBlockBase {
    * Block `A` dominates block `B` if any control flow path from the entry block of the function to
    * block `B` must pass through block `A`. A block always dominates itself.
    */
-  final predicate dominates(IRBlock block) { strictlyDominates(block) or this = block }
+  final predicate dominates(IRBlock block) { this.strictlyDominates(block) or this = block }
 
   /**
    * Gets a block on the dominance frontier of this block.
@@ -159,8 +161,8 @@ class IRBlock extends IRBlockBase {
    */
   pragma[noinline]
   final IRBlock dominanceFrontier() {
-    dominates(result.getAPredecessor()) and
-    not strictlyDominates(result)
+    this.dominates(result.getAPredecessor()) and
+    not this.strictlyDominates(result)
   }
 
   /**
@@ -189,7 +191,7 @@ class IRBlock extends IRBlockBase {
    * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
    * function must pass through block `A`. A block always post-dominates itself.
    */
-  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+  final predicate postDominates(IRBlock block) { this.strictlyPostDominates(block) or this = block }
 
   /**
    * Gets a block on the post-dominance frontier of this block.
@@ -199,16 +201,16 @@ class IRBlock extends IRBlockBase {
    */
   pragma[noinline]
   final IRBlock postPominanceFrontier() {
-    postDominates(result.getASuccessor()) and
-    not strictlyPostDominates(result)
+    this.postDominates(result.getASuccessor()) and
+    not this.strictlyPostDominates(result)
   }
 
   /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
-    this = getEnclosingIRFunction().getEntryBlock() or
-    getAPredecessor().isReachableFromFunctionEntry()
+    this = this.getEnclosingIRFunction().getEntryBlock() or
+    this.getAPredecessor().isReachableFromFunctionEntry()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -41,7 +41,7 @@ class Instruction extends Construction::TStageInstruction {
   }
 
   /** Gets a textual representation of this element. */
-  final string toString() { result = getOpcode().toString() + ": " + getAST().toString() }
+  final string toString() { result = this.getOpcode().toString() + ": " + this.getAST().toString() }
 
   /**
    * Gets a string showing the result, opcode, and operands of the instruction, equivalent to what
@@ -50,7 +50,8 @@ class Instruction extends Construction::TStageInstruction {
    * `mu0_28(int) = Store r0_26, r0_27`
    */
   final string getDumpString() {
-    result = getResultString() + " = " + getOperationString() + " " + getOperandsString()
+    result =
+      this.getResultString() + " = " + this.getOperationString() + " " + this.getOperandsString()
   }
 
   private predicate shouldGenerateDumpStrings() {
@@ -66,10 +67,13 @@ class Instruction extends Construction::TStageInstruction {
    * VariableAddress[x]
    */
   final string getOperationString() {
-    shouldGenerateDumpStrings() and
-    if exists(getImmediateString())
-    then result = getOperationPrefix() + getOpcode().toString() + "[" + getImmediateString() + "]"
-    else result = getOperationPrefix() + getOpcode().toString()
+    this.shouldGenerateDumpStrings() and
+    if exists(this.getImmediateString())
+    then
+      result =
+        this.getOperationPrefix() + this.getOpcode().toString() + "[" + this.getImmediateString() +
+          "]"
+    else result = this.getOperationPrefix() + this.getOpcode().toString()
   }
 
   /**
@@ -78,17 +82,17 @@ class Instruction extends Construction::TStageInstruction {
   string getImmediateString() { none() }
 
   private string getOperationPrefix() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     if this instanceof SideEffectInstruction then result = "^" else result = ""
   }
 
   private string getResultPrefix() {
-    shouldGenerateDumpStrings() and
-    if getResultIRType() instanceof IRVoidType
+    this.shouldGenerateDumpStrings() and
+    if this.getResultIRType() instanceof IRVoidType
     then result = "v"
     else
-      if hasMemoryResult()
-      then if isResultModeled() then result = "m" else result = "mu"
+      if this.hasMemoryResult()
+      then if this.isResultModeled() then result = "m" else result = "mu"
       else result = "r"
   }
 
@@ -97,7 +101,7 @@ class Instruction extends Construction::TStageInstruction {
    * used by debugging and printing code only.
    */
   int getDisplayIndexInBlock() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     exists(IRBlock block |
       this = block.getInstruction(result)
       or
@@ -111,12 +115,12 @@ class Instruction extends Construction::TStageInstruction {
   }
 
   private int getLineRank() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     this =
       rank[result](Instruction instr |
         instr =
-          getAnInstructionAtLine(getEnclosingIRFunction(), getLocation().getFile(),
-            getLocation().getStartLine())
+          getAnInstructionAtLine(this.getEnclosingIRFunction(), this.getLocation().getFile(),
+            this.getLocation().getStartLine())
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )
@@ -130,8 +134,9 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `r1_1`
    */
   string getResultId() {
-    shouldGenerateDumpStrings() and
-    result = getResultPrefix() + getAST().getLocation().getStartLine() + "_" + getLineRank()
+    this.shouldGenerateDumpStrings() and
+    result =
+      this.getResultPrefix() + this.getAST().getLocation().getStartLine() + "_" + this.getLineRank()
   }
 
   /**
@@ -142,8 +147,8 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `r1_1(int*)`
    */
   final string getResultString() {
-    shouldGenerateDumpStrings() and
-    result = getResultId() + "(" + getResultLanguageType().getDumpString() + ")"
+    this.shouldGenerateDumpStrings() and
+    result = this.getResultId() + "(" + this.getResultLanguageType().getDumpString() + ")"
   }
 
   /**
@@ -153,10 +158,10 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `func:r3_4, this:r3_5`
    */
   string getOperandsString() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     result =
       concat(Operand operand |
-        operand = getAnOperand()
+        operand = this.getAnOperand()
       |
         operand.getDumpString(), ", " order by operand.getDumpSortOrder()
       )
@@ -190,7 +195,7 @@ class Instruction extends Construction::TStageInstruction {
    * Gets the function that contains this instruction.
    */
   final Language::Function getEnclosingFunction() {
-    result = getEnclosingIRFunction().getFunction()
+    result = this.getEnclosingIRFunction().getFunction()
   }
 
   /**
@@ -208,7 +213,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the location of the source code for this instruction.
    */
-  final Language::Location getLocation() { result = getAST().getLocation() }
+  final Language::Location getLocation() { result = this.getAST().getLocation() }
 
   /**
    * Gets the  `Expr` whose result is computed by this instruction, if any. The `Expr` may be a
@@ -243,7 +248,7 @@ class Instruction extends Construction::TStageInstruction {
    * a result, its result type will be `IRVoidType`.
    */
   cached
-  final IRType getResultIRType() { result = getResultLanguageType().getIRType() }
+  final IRType getResultIRType() { result = this.getResultLanguageType().getIRType() }
 
   /**
    * Gets the type of the result produced by this instruction. If the
@@ -254,7 +259,7 @@ class Instruction extends Construction::TStageInstruction {
    */
   final Language::Type getResultType() {
     exists(Language::LanguageType resultType |
-      resultType = getResultLanguageType() and
+      resultType = this.getResultLanguageType() and
       (
         resultType.hasUnspecifiedType(result, _)
         or
@@ -283,7 +288,7 @@ class Instruction extends Construction::TStageInstruction {
    * result of the `Load` instruction is a prvalue of type `int`, representing
    * the integer value loaded from variable `x`.
    */
-  final predicate isGLValue() { getResultLanguageType().hasType(_, true) }
+  final predicate isGLValue() { this.getResultLanguageType().hasType(_, true) }
 
   /**
    * Gets the size of the result produced by this instruction, in bytes. If the
@@ -292,7 +297,7 @@ class Instruction extends Construction::TStageInstruction {
    * If `this.isGLValue()` holds for this instruction, the value of
    * `getResultSize()` will always be the size of a pointer.
    */
-  final int getResultSize() { result = getResultLanguageType().getByteSize() }
+  final int getResultSize() { result = this.getResultLanguageType().getByteSize() }
 
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
@@ -314,14 +319,16 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Holds if this instruction produces a memory result.
    */
-  final predicate hasMemoryResult() { exists(getResultMemoryAccess()) }
+  final predicate hasMemoryResult() { exists(this.getResultMemoryAccess()) }
 
   /**
    * Gets the kind of memory access performed by this instruction's result.
    * Holds only for instructions with a memory result.
    */
   pragma[inline]
-  final MemoryAccessKind getResultMemoryAccess() { result = getOpcode().getWriteMemoryAccess() }
+  final MemoryAccessKind getResultMemoryAccess() {
+    result = this.getOpcode().getWriteMemoryAccess()
+  }
 
   /**
    * Holds if the memory access performed by this instruction's result will not always write to
@@ -332,7 +339,7 @@ class Instruction extends Construction::TStageInstruction {
    * (for example, the global side effects of a function call).
    */
   pragma[inline]
-  final predicate hasResultMayMemoryAccess() { getOpcode().hasMayWriteMemoryAccess() }
+  final predicate hasResultMayMemoryAccess() { this.getOpcode().hasMayWriteMemoryAccess() }
 
   /**
    * Gets the operand that holds the memory address to which this instruction stores its
@@ -340,7 +347,7 @@ class Instruction extends Construction::TStageInstruction {
    * is `r1`.
    */
   final AddressOperand getResultAddressOperand() {
-    getResultMemoryAccess().usesAddressOperand() and
+    this.getResultMemoryAccess().usesAddressOperand() and
     result.getUse() = this
   }
 
@@ -349,7 +356,7 @@ class Instruction extends Construction::TStageInstruction {
    * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
    * is the instruction that defines `r1`.
    */
-  final Instruction getResultAddress() { result = getResultAddressOperand().getDef() }
+  final Instruction getResultAddress() { result = this.getResultAddressOperand().getDef() }
 
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
@@ -368,7 +375,7 @@ class Instruction extends Construction::TStageInstruction {
    */
   final predicate isResultModeled() {
     // Register results are always in SSA form.
-    not hasMemoryResult() or
+    not this.hasMemoryResult() or
     Construction::hasModeledMemoryResult(this)
   }
 
@@ -412,7 +419,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets all direct successors of this instruction.
    */
-  final Instruction getASuccessor() { result = getSuccessor(_) }
+  final Instruction getASuccessor() { result = this.getSuccessor(_) }
 
   /**
    * Gets a predecessor of this instruction such that the predecessor reaches
@@ -423,7 +430,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets all direct predecessors of this instruction.
    */
-  final Instruction getAPredecessor() { result = getPredecessor(_) }
+  final Instruction getAPredecessor() { result = this.getPredecessor(_) }
 }
 
 /**
@@ -543,7 +550,7 @@ class IndexedInstruction extends Instruction {
  * at this instruction. This instruction has no predecessors.
  */
 class EnterFunctionInstruction extends Instruction {
-  EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
+  EnterFunctionInstruction() { this.getOpcode() instanceof Opcode::EnterFunction }
 }
 
 /**
@@ -554,7 +561,7 @@ class EnterFunctionInstruction extends Instruction {
  * struct, or union, see `FieldAddressInstruction`.
  */
 class VariableAddressInstruction extends VariableInstruction {
-  VariableAddressInstruction() { getOpcode() instanceof Opcode::VariableAddress }
+  VariableAddressInstruction() { this.getOpcode() instanceof Opcode::VariableAddress }
 }
 
 /**
@@ -566,7 +573,7 @@ class VariableAddressInstruction extends VariableInstruction {
  * The result has an `IRFunctionAddress` type.
  */
 class FunctionAddressInstruction extends FunctionInstruction {
-  FunctionAddressInstruction() { getOpcode() instanceof Opcode::FunctionAddress }
+  FunctionAddressInstruction() { this.getOpcode() instanceof Opcode::FunctionAddress }
 }
 
 /**
@@ -577,7 +584,7 @@ class FunctionAddressInstruction extends FunctionInstruction {
  * initializes that parameter.
  */
 class InitializeParameterInstruction extends VariableInstruction {
-  InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
+  InitializeParameterInstruction() { this.getOpcode() instanceof Opcode::InitializeParameter }
 
   /**
    * Gets the parameter initialized by this instruction.
@@ -603,7 +610,7 @@ class InitializeParameterInstruction extends VariableInstruction {
  * initialized elsewhere, would not otherwise have a definition in this function.
  */
 class InitializeNonLocalInstruction extends Instruction {
-  InitializeNonLocalInstruction() { getOpcode() instanceof Opcode::InitializeNonLocal }
+  InitializeNonLocalInstruction() { this.getOpcode() instanceof Opcode::InitializeNonLocal }
 }
 
 /**
@@ -611,7 +618,7 @@ class InitializeNonLocalInstruction extends Instruction {
  * with the value of that memory on entry to the function.
  */
 class InitializeIndirectionInstruction extends VariableInstruction {
-  InitializeIndirectionInstruction() { getOpcode() instanceof Opcode::InitializeIndirection }
+  InitializeIndirectionInstruction() { this.getOpcode() instanceof Opcode::InitializeIndirection }
 
   /**
    * Gets the parameter initialized by this instruction.
@@ -635,24 +642,24 @@ class InitializeIndirectionInstruction extends VariableInstruction {
  * An instruction that initializes the `this` pointer parameter of the enclosing function.
  */
 class InitializeThisInstruction extends Instruction {
-  InitializeThisInstruction() { getOpcode() instanceof Opcode::InitializeThis }
+  InitializeThisInstruction() { this.getOpcode() instanceof Opcode::InitializeThis }
 }
 
 /**
  * An instruction that computes the address of a non-static field of an object.
  */
 class FieldAddressInstruction extends FieldInstruction {
-  FieldAddressInstruction() { getOpcode() instanceof Opcode::FieldAddress }
+  FieldAddressInstruction() { this.getOpcode() instanceof Opcode::FieldAddress }
 
   /**
    * Gets the operand that provides the address of the object containing the field.
    */
-  final UnaryOperand getObjectAddressOperand() { result = getAnOperand() }
+  final UnaryOperand getObjectAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the object containing the field.
    */
-  final Instruction getObjectAddress() { result = getObjectAddressOperand().getDef() }
+  final Instruction getObjectAddress() { result = this.getObjectAddressOperand().getDef() }
 }
 
 /**
@@ -661,17 +668,19 @@ class FieldAddressInstruction extends FieldInstruction {
  * This instruction is used for element access to C# arrays.
  */
 class ElementsAddressInstruction extends UnaryInstruction {
-  ElementsAddressInstruction() { getOpcode() instanceof Opcode::ElementsAddress }
+  ElementsAddressInstruction() { this.getOpcode() instanceof Opcode::ElementsAddress }
 
   /**
    * Gets the operand that provides the address of the array object.
    */
-  final UnaryOperand getArrayObjectAddressOperand() { result = getAnOperand() }
+  final UnaryOperand getArrayObjectAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the array object.
    */
-  final Instruction getArrayObjectAddress() { result = getArrayObjectAddressOperand().getDef() }
+  final Instruction getArrayObjectAddress() {
+    result = this.getArrayObjectAddressOperand().getDef()
+  }
 }
 
 /**
@@ -685,7 +694,7 @@ class ElementsAddressInstruction extends UnaryInstruction {
  * taken may want to ignore any function that contains an `ErrorInstruction`.
  */
 class ErrorInstruction extends Instruction {
-  ErrorInstruction() { getOpcode() instanceof Opcode::Error }
+  ErrorInstruction() { this.getOpcode() instanceof Opcode::Error }
 }
 
 /**
@@ -695,7 +704,7 @@ class ErrorInstruction extends Instruction {
  * an initializer, or whose initializer only partially initializes the variable.
  */
 class UninitializedInstruction extends VariableInstruction {
-  UninitializedInstruction() { getOpcode() instanceof Opcode::Uninitialized }
+  UninitializedInstruction() { this.getOpcode() instanceof Opcode::Uninitialized }
 
   /**
    * Gets the variable that is uninitialized.
@@ -710,7 +719,7 @@ class UninitializedInstruction extends VariableInstruction {
  * least one instruction, even when the AST has no semantic effect.
  */
 class NoOpInstruction extends Instruction {
-  NoOpInstruction() { getOpcode() instanceof Opcode::NoOp }
+  NoOpInstruction() { this.getOpcode() instanceof Opcode::NoOp }
 }
 
 /**
@@ -732,32 +741,32 @@ class NoOpInstruction extends Instruction {
  * `void`-returning function.
  */
 class ReturnInstruction extends Instruction {
-  ReturnInstruction() { getOpcode() instanceof ReturnOpcode }
+  ReturnInstruction() { this.getOpcode() instanceof ReturnOpcode }
 }
 
 /**
  * An instruction that returns control to the caller of the function, without returning a value.
  */
 class ReturnVoidInstruction extends ReturnInstruction {
-  ReturnVoidInstruction() { getOpcode() instanceof Opcode::ReturnVoid }
+  ReturnVoidInstruction() { this.getOpcode() instanceof Opcode::ReturnVoid }
 }
 
 /**
  * An instruction that returns control to the caller of the function, including a return value.
  */
 class ReturnValueInstruction extends ReturnInstruction {
-  ReturnValueInstruction() { getOpcode() instanceof Opcode::ReturnValue }
+  ReturnValueInstruction() { this.getOpcode() instanceof Opcode::ReturnValue }
 
   /**
    * Gets the operand that provides the value being returned by the function.
    */
-  final LoadOperand getReturnValueOperand() { result = getAnOperand() }
+  final LoadOperand getReturnValueOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value being returned by the function, if an
    * exact definition is available.
    */
-  final Instruction getReturnValue() { result = getReturnValueOperand().getDef() }
+  final Instruction getReturnValue() { result = this.getReturnValueOperand().getDef() }
 }
 
 /**
@@ -770,28 +779,28 @@ class ReturnValueInstruction extends ReturnInstruction {
  * that the caller initialized the memory pointed to by the parameter before the call.
  */
 class ReturnIndirectionInstruction extends VariableInstruction {
-  ReturnIndirectionInstruction() { getOpcode() instanceof Opcode::ReturnIndirection }
+  ReturnIndirectionInstruction() { this.getOpcode() instanceof Opcode::ReturnIndirection }
 
   /**
    * Gets the operand that provides the value of the pointed-to memory.
    */
-  final SideEffectOperand getSideEffectOperand() { result = getAnOperand() }
+  final SideEffectOperand getSideEffectOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value of the pointed-to memory, if an exact
    * definition is available.
    */
-  final Instruction getSideEffect() { result = getSideEffectOperand().getDef() }
+  final Instruction getSideEffect() { result = this.getSideEffectOperand().getDef() }
 
   /**
    * Gets the operand that provides the address of the pointed-to memory.
    */
-  final AddressOperand getSourceAddressOperand() { result = getAnOperand() }
+  final AddressOperand getSourceAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the pointed-to memory.
    */
-  final Instruction getSourceAddress() { result = getSourceAddressOperand().getDef() }
+  final Instruction getSourceAddress() { result = this.getSourceAddressOperand().getDef() }
 
   /**
    * Gets the parameter for which this instruction reads the final pointed-to value within the
@@ -826,7 +835,7 @@ class ReturnIndirectionInstruction extends VariableInstruction {
  * - `StoreInstruction` - Copies a register operand to a memory result.
  */
 class CopyInstruction extends Instruction {
-  CopyInstruction() { getOpcode() instanceof CopyOpcode }
+  CopyInstruction() { this.getOpcode() instanceof CopyOpcode }
 
   /**
    * Gets the operand that provides the input value of the copy.
@@ -837,16 +846,16 @@ class CopyInstruction extends Instruction {
    * Gets the instruction whose result provides the input value of the copy, if an exact definition
    * is available.
    */
-  final Instruction getSourceValue() { result = getSourceValueOperand().getDef() }
+  final Instruction getSourceValue() { result = this.getSourceValueOperand().getDef() }
 }
 
 /**
  * An instruction that returns a register result containing a copy of its register operand.
  */
 class CopyValueInstruction extends CopyInstruction, UnaryInstruction {
-  CopyValueInstruction() { getOpcode() instanceof Opcode::CopyValue }
+  CopyValueInstruction() { this.getOpcode() instanceof Opcode::CopyValue }
 
-  final override UnaryOperand getSourceValueOperand() { result = getAnOperand() }
+  final override UnaryOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
@@ -863,47 +872,49 @@ private string getAddressOperandDescription(AddressOperand operand) {
  * An instruction that returns a register result containing a copy of its memory operand.
  */
 class LoadInstruction extends CopyInstruction {
-  LoadInstruction() { getOpcode() instanceof Opcode::Load }
+  LoadInstruction() { this.getOpcode() instanceof Opcode::Load }
 
   final override string getImmediateString() {
-    result = getAddressOperandDescription(getSourceAddressOperand())
+    result = getAddressOperandDescription(this.getSourceAddressOperand())
   }
 
   /**
    * Gets the operand that provides the address of the value being loaded.
    */
-  final AddressOperand getSourceAddressOperand() { result = getAnOperand() }
+  final AddressOperand getSourceAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the value being loaded.
    */
-  final Instruction getSourceAddress() { result = getSourceAddressOperand().getDef() }
+  final Instruction getSourceAddress() { result = this.getSourceAddressOperand().getDef() }
 
-  final override LoadOperand getSourceValueOperand() { result = getAnOperand() }
+  final override LoadOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
  * An instruction that returns a memory result containing a copy of its register operand.
  */
 class StoreInstruction extends CopyInstruction {
-  StoreInstruction() { getOpcode() instanceof Opcode::Store }
+  StoreInstruction() { this.getOpcode() instanceof Opcode::Store }
 
   final override string getImmediateString() {
-    result = getAddressOperandDescription(getDestinationAddressOperand())
+    result = getAddressOperandDescription(this.getDestinationAddressOperand())
   }
 
   /**
    * Gets the operand that provides the address of the location to which the value will be stored.
    */
-  final AddressOperand getDestinationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getDestinationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the location to which the value will
    * be stored, if an exact definition is available.
    */
-  final Instruction getDestinationAddress() { result = getDestinationAddressOperand().getDef() }
+  final Instruction getDestinationAddress() {
+    result = this.getDestinationAddressOperand().getDef()
+  }
 
-  final override StoreValueOperand getSourceValueOperand() { result = getAnOperand() }
+  final override StoreValueOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
@@ -911,27 +922,27 @@ class StoreInstruction extends CopyInstruction {
  * operand.
  */
 class ConditionalBranchInstruction extends Instruction {
-  ConditionalBranchInstruction() { getOpcode() instanceof Opcode::ConditionalBranch }
+  ConditionalBranchInstruction() { this.getOpcode() instanceof Opcode::ConditionalBranch }
 
   /**
    * Gets the operand that provides the Boolean condition controlling the branch.
    */
-  final ConditionOperand getConditionOperand() { result = getAnOperand() }
+  final ConditionOperand getConditionOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the Boolean condition controlling the branch.
    */
-  final Instruction getCondition() { result = getConditionOperand().getDef() }
+  final Instruction getCondition() { result = this.getConditionOperand().getDef() }
 
   /**
    * Gets the instruction to which control will flow if the condition is true.
    */
-  final Instruction getTrueSuccessor() { result = getSuccessor(EdgeKind::trueEdge()) }
+  final Instruction getTrueSuccessor() { result = this.getSuccessor(EdgeKind::trueEdge()) }
 
   /**
    * Gets the instruction to which control will flow if the condition is false.
    */
-  final Instruction getFalseSuccessor() { result = getSuccessor(EdgeKind::falseEdge()) }
+  final Instruction getFalseSuccessor() { result = this.getSuccessor(EdgeKind::falseEdge()) }
 }
 
 /**
@@ -943,14 +954,14 @@ class ConditionalBranchInstruction extends Instruction {
  * successors.
  */
 class ExitFunctionInstruction extends Instruction {
-  ExitFunctionInstruction() { getOpcode() instanceof Opcode::ExitFunction }
+  ExitFunctionInstruction() { this.getOpcode() instanceof Opcode::ExitFunction }
 }
 
 /**
  * An instruction whose result is a constant value.
  */
 class ConstantInstruction extends ConstantValueInstruction {
-  ConstantInstruction() { getOpcode() instanceof Opcode::Constant }
+  ConstantInstruction() { this.getOpcode() instanceof Opcode::Constant }
 }
 
 /**
@@ -959,7 +970,7 @@ class ConstantInstruction extends ConstantValueInstruction {
 class IntegerConstantInstruction extends ConstantInstruction {
   IntegerConstantInstruction() {
     exists(IRType resultType |
-      resultType = getResultIRType() and
+      resultType = this.getResultIRType() and
       (resultType instanceof IRIntegerType or resultType instanceof IRBooleanType)
     )
   }
@@ -969,7 +980,7 @@ class IntegerConstantInstruction extends ConstantInstruction {
  * An instruction whose result is a constant value of floating-point type.
  */
 class FloatConstantInstruction extends ConstantInstruction {
-  FloatConstantInstruction() { getResultIRType() instanceof IRFloatingPointType }
+  FloatConstantInstruction() { this.getResultIRType() instanceof IRFloatingPointType }
 }
 
 /**
@@ -978,7 +989,9 @@ class FloatConstantInstruction extends ConstantInstruction {
 class StringConstantInstruction extends VariableInstruction {
   override IRStringLiteral var;
 
-  final override string getImmediateString() { result = Language::getStringLiteralText(getValue()) }
+  final override string getImmediateString() {
+    result = Language::getStringLiteralText(this.getValue())
+  }
 
   /**
    * Gets the string literal whose address is returned by this instruction.
@@ -990,37 +1003,37 @@ class StringConstantInstruction extends VariableInstruction {
  * An instruction whose result is computed from two operands.
  */
 class BinaryInstruction extends Instruction {
-  BinaryInstruction() { getOpcode() instanceof BinaryOpcode }
+  BinaryInstruction() { this.getOpcode() instanceof BinaryOpcode }
 
   /**
    * Gets the left operand of this binary instruction.
    */
-  final LeftOperand getLeftOperand() { result = getAnOperand() }
+  final LeftOperand getLeftOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the right operand of this binary instruction.
    */
-  final RightOperand getRightOperand() { result = getAnOperand() }
+  final RightOperand getRightOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value of the left operand of this binary
    * instruction.
    */
-  final Instruction getLeft() { result = getLeftOperand().getDef() }
+  final Instruction getLeft() { result = this.getLeftOperand().getDef() }
 
   /**
    * Gets the instruction whose result provides the value of the right operand of this binary
    * instruction.
    */
-  final Instruction getRight() { result = getRightOperand().getDef() }
+  final Instruction getRight() { result = this.getRightOperand().getDef() }
 
   /**
    * Holds if this instruction's operands are `op1` and `op2`, in either order.
    */
   final predicate hasOperands(Operand op1, Operand op2) {
-    op1 = getLeftOperand() and op2 = getRightOperand()
+    op1 = this.getLeftOperand() and op2 = this.getRightOperand()
     or
-    op1 = getRightOperand() and op2 = getLeftOperand()
+    op1 = this.getRightOperand() and op2 = this.getLeftOperand()
   }
 }
 
@@ -1028,7 +1041,7 @@ class BinaryInstruction extends Instruction {
  * An instruction that computes the result of an arithmetic operation.
  */
 class ArithmeticInstruction extends Instruction {
-  ArithmeticInstruction() { getOpcode() instanceof ArithmeticOpcode }
+  ArithmeticInstruction() { this.getOpcode() instanceof ArithmeticOpcode }
 }
 
 /**
@@ -1050,7 +1063,7 @@ class UnaryArithmeticInstruction extends ArithmeticInstruction, UnaryInstruction
  * performed according to IEEE-754.
  */
 class AddInstruction extends BinaryArithmeticInstruction {
-  AddInstruction() { getOpcode() instanceof Opcode::Add }
+  AddInstruction() { this.getOpcode() instanceof Opcode::Add }
 }
 
 /**
@@ -1061,7 +1074,7 @@ class AddInstruction extends BinaryArithmeticInstruction {
  * according to IEEE-754.
  */
 class SubInstruction extends BinaryArithmeticInstruction {
-  SubInstruction() { getOpcode() instanceof Opcode::Sub }
+  SubInstruction() { this.getOpcode() instanceof Opcode::Sub }
 }
 
 /**
@@ -1072,7 +1085,7 @@ class SubInstruction extends BinaryArithmeticInstruction {
  * performed according to IEEE-754.
  */
 class MulInstruction extends BinaryArithmeticInstruction {
-  MulInstruction() { getOpcode() instanceof Opcode::Mul }
+  MulInstruction() { this.getOpcode() instanceof Opcode::Mul }
 }
 
 /**
@@ -1083,7 +1096,7 @@ class MulInstruction extends BinaryArithmeticInstruction {
  * to IEEE-754.
  */
 class DivInstruction extends BinaryArithmeticInstruction {
-  DivInstruction() { getOpcode() instanceof Opcode::Div }
+  DivInstruction() { this.getOpcode() instanceof Opcode::Div }
 }
 
 /**
@@ -1093,7 +1106,7 @@ class DivInstruction extends BinaryArithmeticInstruction {
  * division by zero or integer overflow is undefined.
  */
 class RemInstruction extends BinaryArithmeticInstruction {
-  RemInstruction() { getOpcode() instanceof Opcode::Rem }
+  RemInstruction() { this.getOpcode() instanceof Opcode::Rem }
 }
 
 /**
@@ -1104,14 +1117,14 @@ class RemInstruction extends BinaryArithmeticInstruction {
  * is performed according to IEEE-754.
  */
 class NegateInstruction extends UnaryArithmeticInstruction {
-  NegateInstruction() { getOpcode() instanceof Opcode::Negate }
+  NegateInstruction() { this.getOpcode() instanceof Opcode::Negate }
 }
 
 /**
  * An instruction that computes the result of a bitwise operation.
  */
 class BitwiseInstruction extends Instruction {
-  BitwiseInstruction() { getOpcode() instanceof BitwiseOpcode }
+  BitwiseInstruction() { this.getOpcode() instanceof BitwiseOpcode }
 }
 
 /**
@@ -1130,7 +1143,7 @@ class UnaryBitwiseInstruction extends BitwiseInstruction, UnaryInstruction { }
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitAndInstruction extends BinaryBitwiseInstruction {
-  BitAndInstruction() { getOpcode() instanceof Opcode::BitAnd }
+  BitAndInstruction() { this.getOpcode() instanceof Opcode::BitAnd }
 }
 
 /**
@@ -1139,7 +1152,7 @@ class BitAndInstruction extends BinaryBitwiseInstruction {
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitOrInstruction extends BinaryBitwiseInstruction {
-  BitOrInstruction() { getOpcode() instanceof Opcode::BitOr }
+  BitOrInstruction() { this.getOpcode() instanceof Opcode::BitOr }
 }
 
 /**
@@ -1148,7 +1161,7 @@ class BitOrInstruction extends BinaryBitwiseInstruction {
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitXorInstruction extends BinaryBitwiseInstruction {
-  BitXorInstruction() { getOpcode() instanceof Opcode::BitXor }
+  BitXorInstruction() { this.getOpcode() instanceof Opcode::BitXor }
 }
 
 /**
@@ -1159,7 +1172,7 @@ class BitXorInstruction extends BinaryBitwiseInstruction {
  * rightmost bits are zero-filled.
  */
 class ShiftLeftInstruction extends BinaryBitwiseInstruction {
-  ShiftLeftInstruction() { getOpcode() instanceof Opcode::ShiftLeft }
+  ShiftLeftInstruction() { this.getOpcode() instanceof Opcode::ShiftLeft }
 }
 
 /**
@@ -1172,7 +1185,7 @@ class ShiftLeftInstruction extends BinaryBitwiseInstruction {
  * of the left operand.
  */
 class ShiftRightInstruction extends BinaryBitwiseInstruction {
-  ShiftRightInstruction() { getOpcode() instanceof Opcode::ShiftRight }
+  ShiftRightInstruction() { this.getOpcode() instanceof Opcode::ShiftRight }
 }
 
 /**
@@ -1183,7 +1196,7 @@ class PointerArithmeticInstruction extends BinaryInstruction {
   int elementSize;
 
   PointerArithmeticInstruction() {
-    getOpcode() instanceof PointerArithmeticOpcode and
+    this.getOpcode() instanceof PointerArithmeticOpcode and
     elementSize = Raw::getInstructionElementSize(this)
   }
 
@@ -1206,7 +1219,7 @@ class PointerArithmeticInstruction extends BinaryInstruction {
  * An instruction that adds or subtracts an integer offset from a pointer.
  */
 class PointerOffsetInstruction extends PointerArithmeticInstruction {
-  PointerOffsetInstruction() { getOpcode() instanceof PointerOffsetOpcode }
+  PointerOffsetInstruction() { this.getOpcode() instanceof PointerOffsetOpcode }
 }
 
 /**
@@ -1217,7 +1230,7 @@ class PointerOffsetInstruction extends PointerArithmeticInstruction {
  * overflow is undefined.
  */
 class PointerAddInstruction extends PointerOffsetInstruction {
-  PointerAddInstruction() { getOpcode() instanceof Opcode::PointerAdd }
+  PointerAddInstruction() { this.getOpcode() instanceof Opcode::PointerAdd }
 }
 
 /**
@@ -1228,7 +1241,7 @@ class PointerAddInstruction extends PointerOffsetInstruction {
  * pointer underflow is undefined.
  */
 class PointerSubInstruction extends PointerOffsetInstruction {
-  PointerSubInstruction() { getOpcode() instanceof Opcode::PointerSub }
+  PointerSubInstruction() { this.getOpcode() instanceof Opcode::PointerSub }
 }
 
 /**
@@ -1241,31 +1254,31 @@ class PointerSubInstruction extends PointerOffsetInstruction {
  * undefined.
  */
 class PointerDiffInstruction extends PointerArithmeticInstruction {
-  PointerDiffInstruction() { getOpcode() instanceof Opcode::PointerDiff }
+  PointerDiffInstruction() { this.getOpcode() instanceof Opcode::PointerDiff }
 }
 
 /**
  * An instruction whose result is computed from a single operand.
  */
 class UnaryInstruction extends Instruction {
-  UnaryInstruction() { getOpcode() instanceof UnaryOpcode }
+  UnaryInstruction() { this.getOpcode() instanceof UnaryOpcode }
 
   /**
    * Gets the sole operand of this instruction.
    */
-  final UnaryOperand getUnaryOperand() { result = getAnOperand() }
+  final UnaryOperand getUnaryOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the sole operand of this instruction.
    */
-  final Instruction getUnary() { result = getUnaryOperand().getDef() }
+  final Instruction getUnary() { result = this.getUnaryOperand().getDef() }
 }
 
 /**
  * An instruction that converts the value of its operand to a value of a different type.
  */
 class ConvertInstruction extends UnaryInstruction {
-  ConvertInstruction() { getOpcode() instanceof Opcode::Convert }
+  ConvertInstruction() { this.getOpcode() instanceof Opcode::Convert }
 }
 
 /**
@@ -1279,7 +1292,7 @@ class ConvertInstruction extends UnaryInstruction {
  * `as` expression.
  */
 class CheckedConvertOrNullInstruction extends UnaryInstruction {
-  CheckedConvertOrNullInstruction() { getOpcode() instanceof Opcode::CheckedConvertOrNull }
+  CheckedConvertOrNullInstruction() { this.getOpcode() instanceof Opcode::CheckedConvertOrNull }
 }
 
 /**
@@ -1293,7 +1306,7 @@ class CheckedConvertOrNullInstruction extends UnaryInstruction {
  * expression.
  */
 class CheckedConvertOrThrowInstruction extends UnaryInstruction {
-  CheckedConvertOrThrowInstruction() { getOpcode() instanceof Opcode::CheckedConvertOrThrow }
+  CheckedConvertOrThrowInstruction() { this.getOpcode() instanceof Opcode::CheckedConvertOrThrow }
 }
 
 /**
@@ -1306,7 +1319,7 @@ class CheckedConvertOrThrowInstruction extends UnaryInstruction {
  * the most-derived object.
  */
 class CompleteObjectAddressInstruction extends UnaryInstruction {
-  CompleteObjectAddressInstruction() { getOpcode() instanceof Opcode::CompleteObjectAddress }
+  CompleteObjectAddressInstruction() { this.getOpcode() instanceof Opcode::CompleteObjectAddress }
 }
 
 /**
@@ -1351,7 +1364,7 @@ class InheritanceConversionInstruction extends UnaryInstruction {
  * An instruction that converts from the address of a derived class to the address of a base class.
  */
 class ConvertToBaseInstruction extends InheritanceConversionInstruction {
-  ConvertToBaseInstruction() { getOpcode() instanceof ConvertToBaseOpcode }
+  ConvertToBaseInstruction() { this.getOpcode() instanceof ConvertToBaseOpcode }
 }
 
 /**
@@ -1361,7 +1374,9 @@ class ConvertToBaseInstruction extends InheritanceConversionInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToNonVirtualBaseInstruction extends ConvertToBaseInstruction {
-  ConvertToNonVirtualBaseInstruction() { getOpcode() instanceof Opcode::ConvertToNonVirtualBase }
+  ConvertToNonVirtualBaseInstruction() {
+    this.getOpcode() instanceof Opcode::ConvertToNonVirtualBase
+  }
 }
 
 /**
@@ -1371,7 +1386,7 @@ class ConvertToNonVirtualBaseInstruction extends ConvertToBaseInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToVirtualBaseInstruction extends ConvertToBaseInstruction {
-  ConvertToVirtualBaseInstruction() { getOpcode() instanceof Opcode::ConvertToVirtualBase }
+  ConvertToVirtualBaseInstruction() { this.getOpcode() instanceof Opcode::ConvertToVirtualBase }
 }
 
 /**
@@ -1381,7 +1396,7 @@ class ConvertToVirtualBaseInstruction extends ConvertToBaseInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToDerivedInstruction extends InheritanceConversionInstruction {
-  ConvertToDerivedInstruction() { getOpcode() instanceof Opcode::ConvertToDerived }
+  ConvertToDerivedInstruction() { this.getOpcode() instanceof Opcode::ConvertToDerived }
 }
 
 /**
@@ -1390,7 +1405,7 @@ class ConvertToDerivedInstruction extends InheritanceConversionInstruction {
  * The operand must have an integer type, which will also be the result type.
  */
 class BitComplementInstruction extends UnaryBitwiseInstruction {
-  BitComplementInstruction() { getOpcode() instanceof Opcode::BitComplement }
+  BitComplementInstruction() { this.getOpcode() instanceof Opcode::BitComplement }
 }
 
 /**
@@ -1399,14 +1414,14 @@ class BitComplementInstruction extends UnaryBitwiseInstruction {
  * The operand must have a Boolean type, which will also be the result type.
  */
 class LogicalNotInstruction extends UnaryInstruction {
-  LogicalNotInstruction() { getOpcode() instanceof Opcode::LogicalNot }
+  LogicalNotInstruction() { this.getOpcode() instanceof Opcode::LogicalNot }
 }
 
 /**
  * An instruction that compares two numeric operands.
  */
 class CompareInstruction extends BinaryInstruction {
-  CompareInstruction() { getOpcode() instanceof CompareOpcode }
+  CompareInstruction() { this.getOpcode() instanceof CompareOpcode }
 }
 
 /**
@@ -1417,7 +1432,7 @@ class CompareInstruction extends BinaryInstruction {
  * unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareEQInstruction extends CompareInstruction {
-  CompareEQInstruction() { getOpcode() instanceof Opcode::CompareEQ }
+  CompareEQInstruction() { this.getOpcode() instanceof Opcode::CompareEQ }
 }
 
 /**
@@ -1428,14 +1443,14 @@ class CompareEQInstruction extends CompareInstruction {
  * `left == right`. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareNEInstruction extends CompareInstruction {
-  CompareNEInstruction() { getOpcode() instanceof Opcode::CompareNE }
+  CompareNEInstruction() { this.getOpcode() instanceof Opcode::CompareNE }
 }
 
 /**
  * An instruction that does a relative comparison of two values, such as `<` or `>=`.
  */
 class RelationalInstruction extends CompareInstruction {
-  RelationalInstruction() { getOpcode() instanceof RelationalOpcode }
+  RelationalInstruction() { this.getOpcode() instanceof RelationalOpcode }
 
   /**
    * Gets the operand on the "greater" (or "greater-or-equal") side
@@ -1467,11 +1482,11 @@ class RelationalInstruction extends CompareInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareLTInstruction extends RelationalInstruction {
-  CompareLTInstruction() { getOpcode() instanceof Opcode::CompareLT }
+  CompareLTInstruction() { this.getOpcode() instanceof Opcode::CompareLT }
 
-  override Instruction getLesser() { result = getLeft() }
+  override Instruction getLesser() { result = this.getLeft() }
 
-  override Instruction getGreater() { result = getRight() }
+  override Instruction getGreater() { result = this.getRight() }
 
   override predicate isStrict() { any() }
 }
@@ -1484,11 +1499,11 @@ class CompareLTInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareGTInstruction extends RelationalInstruction {
-  CompareGTInstruction() { getOpcode() instanceof Opcode::CompareGT }
+  CompareGTInstruction() { this.getOpcode() instanceof Opcode::CompareGT }
 
-  override Instruction getLesser() { result = getRight() }
+  override Instruction getLesser() { result = this.getRight() }
 
-  override Instruction getGreater() { result = getLeft() }
+  override Instruction getGreater() { result = this.getLeft() }
 
   override predicate isStrict() { any() }
 }
@@ -1502,11 +1517,11 @@ class CompareGTInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareLEInstruction extends RelationalInstruction {
-  CompareLEInstruction() { getOpcode() instanceof Opcode::CompareLE }
+  CompareLEInstruction() { this.getOpcode() instanceof Opcode::CompareLE }
 
-  override Instruction getLesser() { result = getLeft() }
+  override Instruction getLesser() { result = this.getLeft() }
 
-  override Instruction getGreater() { result = getRight() }
+  override Instruction getGreater() { result = this.getRight() }
 
   override predicate isStrict() { none() }
 }
@@ -1520,11 +1535,11 @@ class CompareLEInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareGEInstruction extends RelationalInstruction {
-  CompareGEInstruction() { getOpcode() instanceof Opcode::CompareGE }
+  CompareGEInstruction() { this.getOpcode() instanceof Opcode::CompareGE }
 
-  override Instruction getLesser() { result = getRight() }
+  override Instruction getLesser() { result = this.getRight() }
 
-  override Instruction getGreater() { result = getLeft() }
+  override Instruction getGreater() { result = this.getLeft() }
 
   override predicate isStrict() { none() }
 }
@@ -1543,78 +1558,78 @@ class CompareGEInstruction extends RelationalInstruction {
  * of any case edge.
  */
 class SwitchInstruction extends Instruction {
-  SwitchInstruction() { getOpcode() instanceof Opcode::Switch }
+  SwitchInstruction() { this.getOpcode() instanceof Opcode::Switch }
 
   /** Gets the operand that provides the integer value controlling the switch. */
-  final ConditionOperand getExpressionOperand() { result = getAnOperand() }
+  final ConditionOperand getExpressionOperand() { result = this.getAnOperand() }
 
   /** Gets the instruction whose result provides the integer value controlling the switch. */
-  final Instruction getExpression() { result = getExpressionOperand().getDef() }
+  final Instruction getExpression() { result = this.getExpressionOperand().getDef() }
 
   /** Gets the successor instructions along the case edges of the switch. */
-  final Instruction getACaseSuccessor() { exists(CaseEdge edge | result = getSuccessor(edge)) }
+  final Instruction getACaseSuccessor() { exists(CaseEdge edge | result = this.getSuccessor(edge)) }
 
   /** Gets the successor instruction along the default edge of the switch, if any. */
-  final Instruction getDefaultSuccessor() { result = getSuccessor(EdgeKind::defaultEdge()) }
+  final Instruction getDefaultSuccessor() { result = this.getSuccessor(EdgeKind::defaultEdge()) }
 }
 
 /**
  * An instruction that calls a function.
  */
 class CallInstruction extends Instruction {
-  CallInstruction() { getOpcode() instanceof Opcode::Call }
+  CallInstruction() { this.getOpcode() instanceof Opcode::Call }
 
   final override string getImmediateString() {
-    result = getStaticCallTarget().toString()
+    result = this.getStaticCallTarget().toString()
     or
-    not exists(getStaticCallTarget()) and result = "?"
+    not exists(this.getStaticCallTarget()) and result = "?"
   }
 
   /**
    * Gets the operand the specifies the target function of the call.
    */
-  final CallTargetOperand getCallTargetOperand() { result = getAnOperand() }
+  final CallTargetOperand getCallTargetOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `Instruction` that computes the target function of the call. This is usually a
    * `FunctionAddress` instruction, but can also be an arbitrary instruction that produces a
    * function pointer.
    */
-  final Instruction getCallTarget() { result = getCallTargetOperand().getDef() }
+  final Instruction getCallTarget() { result = this.getCallTargetOperand().getDef() }
 
   /**
    * Gets all of the argument operands of the call, including the `this` pointer, if any.
    */
-  final ArgumentOperand getAnArgumentOperand() { result = getAnOperand() }
+  final ArgumentOperand getAnArgumentOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `Function` that the call targets, if this is statically known.
    */
   final Language::Function getStaticCallTarget() {
-    result = getCallTarget().(FunctionAddressInstruction).getFunctionSymbol()
+    result = this.getCallTarget().(FunctionAddressInstruction).getFunctionSymbol()
   }
 
   /**
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
-  final Instruction getAnArgument() { result = getAnArgumentOperand().getDef() }
+  final Instruction getAnArgument() { result = this.getAnArgumentOperand().getDef() }
 
   /**
    * Gets the `this` pointer argument operand of the call, if any.
    */
-  final ThisArgumentOperand getThisArgumentOperand() { result = getAnOperand() }
+  final ThisArgumentOperand getThisArgumentOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `this` pointer argument of the call, if any.
    */
-  final Instruction getThisArgument() { result = getThisArgumentOperand().getDef() }
+  final Instruction getThisArgument() { result = this.getThisArgumentOperand().getDef() }
 
   /**
    * Gets the argument operand at the specified index.
    */
   pragma[noinline]
   final PositionalArgumentOperand getPositionalArgumentOperand(int index) {
-    result = getAnOperand() and
+    result = this.getAnOperand() and
     result.getIndex() = index
   }
 
@@ -1623,7 +1638,7 @@ class CallInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getDef()
+    result = this.getPositionalArgumentOperand(index).getDef()
   }
 
   /**
@@ -1631,16 +1646,16 @@ class CallInstruction extends Instruction {
    */
   pragma[noinline]
   final ArgumentOperand getArgumentOperand(int index) {
-    index >= 0 and result = getPositionalArgumentOperand(index)
+    index >= 0 and result = this.getPositionalArgumentOperand(index)
     or
-    index = -1 and result = getThisArgumentOperand()
+    index = -1 and result = this.getThisArgumentOperand()
   }
 
   /**
    * Gets the argument at the specified index, or `this` if `index` is `-1`.
    */
   pragma[noinline]
-  final Instruction getArgument(int index) { result = getArgumentOperand(index).getDef() }
+  final Instruction getArgument(int index) { result = this.getArgumentOperand(index).getDef() }
 
   /**
    * Gets the number of arguments of the call, including the `this` pointer, if any.
@@ -1665,7 +1680,7 @@ class CallInstruction extends Instruction {
  * An instruction representing a side effect of a function call.
  */
 class SideEffectInstruction extends Instruction {
-  SideEffectInstruction() { getOpcode() instanceof SideEffectOpcode }
+  SideEffectInstruction() { this.getOpcode() instanceof SideEffectOpcode }
 
   /**
    * Gets the instruction whose execution causes this side effect.
@@ -1680,7 +1695,7 @@ class SideEffectInstruction extends Instruction {
  * accessed by that call.
  */
 class CallSideEffectInstruction extends SideEffectInstruction {
-  CallSideEffectInstruction() { getOpcode() instanceof Opcode::CallSideEffect }
+  CallSideEffectInstruction() { this.getOpcode() instanceof Opcode::CallSideEffect }
 }
 
 /**
@@ -1691,7 +1706,7 @@ class CallSideEffectInstruction extends SideEffectInstruction {
  * call target cannot write to escaped memory.
  */
 class CallReadSideEffectInstruction extends SideEffectInstruction {
-  CallReadSideEffectInstruction() { getOpcode() instanceof Opcode::CallReadSideEffect }
+  CallReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::CallReadSideEffect }
 }
 
 /**
@@ -1699,33 +1714,33 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * specific parameter.
  */
 class ReadSideEffectInstruction extends SideEffectInstruction, IndexedInstruction {
-  ReadSideEffectInstruction() { getOpcode() instanceof ReadSideEffectOpcode }
+  ReadSideEffectInstruction() { this.getOpcode() instanceof ReadSideEffectOpcode }
 
   /** Gets the operand for the value that will be read from this instruction, if known. */
-  final SideEffectOperand getSideEffectOperand() { result = getAnOperand() }
+  final SideEffectOperand getSideEffectOperand() { result = this.getAnOperand() }
 
   /** Gets the value that will be read from this instruction, if known. */
-  final Instruction getSideEffect() { result = getSideEffectOperand().getDef() }
+  final Instruction getSideEffect() { result = this.getSideEffectOperand().getDef() }
 
   /** Gets the operand for the address from which this instruction may read. */
-  final AddressOperand getArgumentOperand() { result = getAnOperand() }
+  final AddressOperand getArgumentOperand() { result = this.getAnOperand() }
 
   /** Gets the address from which this instruction may read. */
-  final Instruction getArgumentDef() { result = getArgumentOperand().getDef() }
+  final Instruction getArgumentDef() { result = this.getArgumentOperand().getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends ReadSideEffectInstruction {
-  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
+  IndirectReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::IndirectReadSideEffect }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends ReadSideEffectInstruction {
-  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
+  BufferReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::BufferReadSideEffect }
 }
 
 /**
@@ -1733,18 +1748,18 @@ class BufferReadSideEffectInstruction extends ReadSideEffectInstruction {
  */
 class SizedBufferReadSideEffectInstruction extends ReadSideEffectInstruction {
   SizedBufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferReadSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes read from the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes read from the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1752,17 +1767,17 @@ class SizedBufferReadSideEffectInstruction extends ReadSideEffectInstruction {
  * specific parameter.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction, IndexedInstruction {
-  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
+  WriteSideEffectInstruction() { this.getOpcode() instanceof WriteSideEffectOpcode }
 
   /**
    * Get the operand that holds the address of the memory to be written.
    */
-  final AddressOperand getDestinationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getDestinationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the memory to be written.
    */
-  Instruction getDestinationAddress() { result = getDestinationAddressOperand().getDef() }
+  Instruction getDestinationAddress() { result = this.getDestinationAddressOperand().getDef() }
 }
 
 /**
@@ -1770,7 +1785,7 @@ class WriteSideEffectInstruction extends SideEffectInstruction, IndexedInstructi
  */
 class IndirectMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   IndirectMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::IndirectMustWriteSideEffect
   }
 }
 
@@ -1780,7 +1795,7 @@ class IndirectMustWriteSideEffectInstruction extends WriteSideEffectInstruction 
  */
 class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   BufferMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::BufferMustWriteSideEffect
   }
 }
 
@@ -1790,18 +1805,18 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
  */
 class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   SizedBufferMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes written to the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes written to the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1812,7 +1827,7 @@ class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstructi
  */
 class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   IndirectMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectMayWriteSideEffect
+    this.getOpcode() instanceof Opcode::IndirectMayWriteSideEffect
   }
 }
 
@@ -1822,7 +1837,9 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
+  BufferMayWriteSideEffectInstruction() {
+    this.getOpcode() instanceof Opcode::BufferMayWriteSideEffect
+  }
 }
 
 /**
@@ -1832,18 +1849,18 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  */
 class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   SizedBufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes written to the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes written to the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1852,80 +1869,80 @@ class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstructio
  */
 class InitializeDynamicAllocationInstruction extends SideEffectInstruction {
   InitializeDynamicAllocationInstruction() {
-    getOpcode() instanceof Opcode::InitializeDynamicAllocation
+    this.getOpcode() instanceof Opcode::InitializeDynamicAllocation
   }
 
   /**
    * Gets the operand that represents the address of the allocation this instruction is initializing.
    */
-  final AddressOperand getAllocationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getAllocationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the address for the allocation this instruction is initializing.
    */
-  final Instruction getAllocationAddress() { result = getAllocationAddressOperand().getDef() }
+  final Instruction getAllocationAddress() { result = this.getAllocationAddressOperand().getDef() }
 }
 
 /**
  * An instruction representing a GNU or MSVC inline assembly statement.
  */
 class InlineAsmInstruction extends Instruction {
-  InlineAsmInstruction() { getOpcode() instanceof Opcode::InlineAsm }
+  InlineAsmInstruction() { this.getOpcode() instanceof Opcode::InlineAsm }
 }
 
 /**
  * An instruction that throws an exception.
  */
 class ThrowInstruction extends Instruction {
-  ThrowInstruction() { getOpcode() instanceof ThrowOpcode }
+  ThrowInstruction() { this.getOpcode() instanceof ThrowOpcode }
 }
 
 /**
  * An instruction that throws a new exception.
  */
 class ThrowValueInstruction extends ThrowInstruction {
-  ThrowValueInstruction() { getOpcode() instanceof Opcode::ThrowValue }
+  ThrowValueInstruction() { this.getOpcode() instanceof Opcode::ThrowValue }
 
   /**
    * Gets the address operand of the exception thrown by this instruction.
    */
-  final AddressOperand getExceptionAddressOperand() { result = getAnOperand() }
+  final AddressOperand getExceptionAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the address of the exception thrown by this instruction.
    */
-  final Instruction getExceptionAddress() { result = getExceptionAddressOperand().getDef() }
+  final Instruction getExceptionAddress() { result = this.getExceptionAddressOperand().getDef() }
 
   /**
    * Gets the operand for the exception thrown by this instruction.
    */
-  final LoadOperand getExceptionOperand() { result = getAnOperand() }
+  final LoadOperand getExceptionOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the exception thrown by this instruction.
    */
-  final Instruction getException() { result = getExceptionOperand().getDef() }
+  final Instruction getException() { result = this.getExceptionOperand().getDef() }
 }
 
 /**
  * An instruction that re-throws the current exception.
  */
 class ReThrowInstruction extends ThrowInstruction {
-  ReThrowInstruction() { getOpcode() instanceof Opcode::ReThrow }
+  ReThrowInstruction() { this.getOpcode() instanceof Opcode::ReThrow }
 }
 
 /**
  * An instruction that exits the current function by propagating an exception.
  */
 class UnwindInstruction extends Instruction {
-  UnwindInstruction() { getOpcode() instanceof Opcode::Unwind }
+  UnwindInstruction() { this.getOpcode() instanceof Opcode::Unwind }
 }
 
 /**
  * An instruction that starts a `catch` handler.
  */
 class CatchInstruction extends Instruction {
-  CatchInstruction() { getOpcode() instanceof CatchOpcode }
+  CatchInstruction() { this.getOpcode() instanceof CatchOpcode }
 }
 
 /**
@@ -1935,7 +1952,7 @@ class CatchByTypeInstruction extends CatchInstruction {
   Language::LanguageType exceptionType;
 
   CatchByTypeInstruction() {
-    getOpcode() instanceof Opcode::CatchByType and
+    this.getOpcode() instanceof Opcode::CatchByType and
     exceptionType = Raw::getInstructionExceptionType(this)
   }
 
@@ -1951,21 +1968,21 @@ class CatchByTypeInstruction extends CatchInstruction {
  * An instruction that catches any exception.
  */
 class CatchAnyInstruction extends CatchInstruction {
-  CatchAnyInstruction() { getOpcode() instanceof Opcode::CatchAny }
+  CatchAnyInstruction() { this.getOpcode() instanceof Opcode::CatchAny }
 }
 
 /**
  * An instruction that initializes all escaped memory.
  */
 class AliasedDefinitionInstruction extends Instruction {
-  AliasedDefinitionInstruction() { getOpcode() instanceof Opcode::AliasedDefinition }
+  AliasedDefinitionInstruction() { this.getOpcode() instanceof Opcode::AliasedDefinition }
 }
 
 /**
  * An instruction that consumes all escaped memory on exit from the function.
  */
 class AliasedUseInstruction extends Instruction {
-  AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
+  AliasedUseInstruction() { this.getOpcode() instanceof Opcode::AliasedUse }
 }
 
 /**
@@ -1979,7 +1996,7 @@ class AliasedUseInstruction extends Instruction {
  * runtime.
  */
 class PhiInstruction extends Instruction {
-  PhiInstruction() { getOpcode() instanceof Opcode::Phi }
+  PhiInstruction() { this.getOpcode() instanceof Opcode::Phi }
 
   /**
    * Gets all of the instruction's `PhiInputOperand`s, representing the values that flow from each predecessor block.
@@ -2047,29 +2064,29 @@ class PhiInstruction extends Instruction {
  * https://link.springer.com/content/pdf/10.1007%2F3-540-61053-7_66.pdf.
  */
 class ChiInstruction extends Instruction {
-  ChiInstruction() { getOpcode() instanceof Opcode::Chi }
+  ChiInstruction() { this.getOpcode() instanceof Opcode::Chi }
 
   /**
    * Gets the operand that represents the previous state of all memory that might be aliased by the
    * memory write.
    */
-  final ChiTotalOperand getTotalOperand() { result = getAnOperand() }
+  final ChiTotalOperand getTotalOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the operand that represents the previous state of all memory that might be aliased by the
    * memory write.
    */
-  final Instruction getTotal() { result = getTotalOperand().getDef() }
+  final Instruction getTotal() { result = this.getTotalOperand().getDef() }
 
   /**
    * Gets the operand that represents the new value written by the memory write.
    */
-  final ChiPartialOperand getPartialOperand() { result = getAnOperand() }
+  final ChiPartialOperand getPartialOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the operand that represents the new value written by the memory write.
    */
-  final Instruction getPartial() { result = getPartialOperand().getDef() }
+  final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
    * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
@@ -2093,7 +2110,7 @@ class ChiInstruction extends Instruction {
  * or `Switch` instruction where that particular edge is infeasible.
  */
 class UnreachedInstruction extends Instruction {
-  UnreachedInstruction() { getOpcode() instanceof Opcode::Unreached }
+  UnreachedInstruction() { this.getOpcode() instanceof Opcode::Unreached }
 }
 
 /**
@@ -2106,7 +2123,7 @@ class BuiltInOperationInstruction extends Instruction {
   Language::BuiltInOperation operation;
 
   BuiltInOperationInstruction() {
-    getOpcode() instanceof BuiltInOperationOpcode and
+    this.getOpcode() instanceof BuiltInOperationOpcode and
     operation = Raw::getInstructionBuiltInOperation(this)
   }
 
@@ -2122,9 +2139,9 @@ class BuiltInOperationInstruction extends Instruction {
  * actual operation is specified by the `getBuiltInOperation()` predicate.
  */
 class BuiltInInstruction extends BuiltInOperationInstruction {
-  BuiltInInstruction() { getOpcode() instanceof Opcode::BuiltIn }
+  BuiltInInstruction() { this.getOpcode() instanceof Opcode::BuiltIn }
 
-  final override string getImmediateString() { result = getBuiltInOperation().toString() }
+  final override string getImmediateString() { result = this.getBuiltInOperation().toString() }
 }
 
 /**
@@ -2135,7 +2152,7 @@ class BuiltInInstruction extends BuiltInOperationInstruction {
  * to the `...` parameter.
  */
 class VarArgsStartInstruction extends UnaryInstruction {
-  VarArgsStartInstruction() { getOpcode() instanceof Opcode::VarArgsStart }
+  VarArgsStartInstruction() { this.getOpcode() instanceof Opcode::VarArgsStart }
 }
 
 /**
@@ -2145,7 +2162,7 @@ class VarArgsStartInstruction extends UnaryInstruction {
  * a result.
  */
 class VarArgsEndInstruction extends UnaryInstruction {
-  VarArgsEndInstruction() { getOpcode() instanceof Opcode::VarArgsEnd }
+  VarArgsEndInstruction() { this.getOpcode() instanceof Opcode::VarArgsEnd }
 }
 
 /**
@@ -2155,7 +2172,7 @@ class VarArgsEndInstruction extends UnaryInstruction {
  * argument.
  */
 class VarArgInstruction extends UnaryInstruction {
-  VarArgInstruction() { getOpcode() instanceof Opcode::VarArg }
+  VarArgInstruction() { this.getOpcode() instanceof Opcode::VarArg }
 }
 
 /**
@@ -2166,7 +2183,7 @@ class VarArgInstruction extends UnaryInstruction {
  * argument of the `...` parameter.
  */
 class NextVarArgInstruction extends UnaryInstruction {
-  NextVarArgInstruction() { getOpcode() instanceof Opcode::NextVarArg }
+  NextVarArgInstruction() { this.getOpcode() instanceof Opcode::NextVarArg }
 }
 
 /**
@@ -2180,5 +2197,5 @@ class NextVarArgInstruction extends UnaryInstruction {
  * The result is the address of the newly allocated object.
  */
 class NewObjInstruction extends Instruction {
-  NewObjInstruction() { getOpcode() instanceof Opcode::NewObj }
+  NewObjInstruction() { this.getOpcode() instanceof Opcode::NewObj }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -46,12 +46,12 @@ class Operand extends TStageOperand {
   /**
    * Gets the location of the source code for this operand.
    */
-  final Language::Location getLocation() { result = getUse().getLocation() }
+  final Language::Location getLocation() { result = this.getUse().getLocation() }
 
   /**
    * Gets the function that contains this operand.
    */
-  final IRFunction getEnclosingIRFunction() { result = getUse().getEnclosingIRFunction() }
+  final IRFunction getEnclosingIRFunction() { result = this.getUse().getEnclosingIRFunction() }
 
   /**
    * Gets the `Instruction` that consumes this operand.
@@ -74,7 +74,7 @@ class Operand extends TStageOperand {
    */
   final Instruction getDef() {
     result = this.getAnyDef() and
-    getDefinitionOverlap() instanceof MustExactlyOverlap
+    this.getDefinitionOverlap() instanceof MustExactlyOverlap
   }
 
   /**
@@ -82,7 +82,7 @@ class Operand extends TStageOperand {
    *
    * Gets the `Instruction` that consumes this operand.
    */
-  deprecated final Instruction getUseInstruction() { result = getUse() }
+  deprecated final Instruction getUseInstruction() { result = this.getUse() }
 
   /**
    * DEPRECATED: use `getAnyDef` or `getDef`. The exact replacement for this
@@ -91,7 +91,7 @@ class Operand extends TStageOperand {
    *
    * Gets the `Instruction` whose result is the value of the operand.
    */
-  deprecated final Instruction getDefinitionInstruction() { result = getAnyDef() }
+  deprecated final Instruction getDefinitionInstruction() { result = this.getAnyDef() }
 
   /**
    * Gets the overlap relationship between the operand's definition and its use.
@@ -101,7 +101,9 @@ class Operand extends TStageOperand {
   /**
    * Holds if the result of the definition instruction does not exactly overlap this use.
    */
-  final predicate isDefinitionInexact() { not getDefinitionOverlap() instanceof MustExactlyOverlap }
+  final predicate isDefinitionInexact() {
+    not this.getDefinitionOverlap() instanceof MustExactlyOverlap
+  }
 
   /**
    * Gets a prefix to use when dumping the operand in an operand list.
@@ -121,7 +123,7 @@ class Operand extends TStageOperand {
    * For example: `this:r3_5`
    */
   final string getDumpString() {
-    result = getDumpLabel() + getInexactSpecifier() + getDefinitionId()
+    result = this.getDumpLabel() + this.getInexactSpecifier() + this.getDefinitionId()
   }
 
   /**
@@ -129,9 +131,9 @@ class Operand extends TStageOperand {
    * definition is not modeled in SSA.
    */
   private string getDefinitionId() {
-    result = getAnyDef().getResultId()
+    result = this.getAnyDef().getResultId()
     or
-    not exists(getAnyDef()) and result = "m?"
+    not exists(this.getAnyDef()) and result = "m?"
   }
 
   /**
@@ -140,7 +142,7 @@ class Operand extends TStageOperand {
    * the empty string.
    */
   private string getInexactSpecifier() {
-    if isDefinitionInexact() then result = "~" else result = ""
+    if this.isDefinitionInexact() then result = "~" else result = ""
   }
 
   /**
@@ -155,7 +157,7 @@ class Operand extends TStageOperand {
    * the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  Language::LanguageType getLanguageType() { result = getAnyDef().getResultLanguageType() }
+  Language::LanguageType getLanguageType() { result = this.getAnyDef().getResultLanguageType() }
 
   /**
    * Gets the language-neutral type of the value consumed by this operand. This is usually the same
@@ -164,7 +166,7 @@ class Operand extends TStageOperand {
    * from the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the value consumed by this operand. This is usually the same as the
@@ -173,7 +175,7 @@ class Operand extends TStageOperand {
    * the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, _) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, _) }
 
   /**
    * Holds if the value consumed by this operand is a glvalue. If this
@@ -182,13 +184,13 @@ class Operand extends TStageOperand {
    * not hold, the value of the operand represents a value whose type is
    * given by `getType()`.
    */
-  final predicate isGLValue() { getLanguageType().hasType(_, true) }
+  final predicate isGLValue() { this.getLanguageType().hasType(_, true) }
 
   /**
    * Gets the size of the value consumed by this operand, in bytes. If the operand does not have
    * a known constant size, this predicate does not hold.
    */
-  final int getSize() { result = getLanguageType().getByteSize() }
+  final int getSize() { result = this.getLanguageType().getByteSize() }
 }
 
 /**
@@ -205,7 +207,7 @@ class MemoryOperand extends Operand {
   /**
    * Gets the kind of memory access performed by the operand.
    */
-  MemoryAccessKind getMemoryAccess() { result = getUse().getOpcode().getReadMemoryAccess() }
+  MemoryAccessKind getMemoryAccess() { result = this.getUse().getOpcode().getReadMemoryAccess() }
 
   /**
    * Holds if the memory access performed by this operand will not always read from every bit in the
@@ -215,7 +217,7 @@ class MemoryOperand extends Operand {
    * conservative estimate of the memory that might actually be accessed at runtime (for example,
    * the global side effects of a function call).
    */
-  predicate hasMayReadMemoryAccess() { getUse().getOpcode().hasMayReadMemoryAccess() }
+  predicate hasMayReadMemoryAccess() { this.getUse().getOpcode().hasMayReadMemoryAccess() }
 
   /**
    * Returns the operand that holds the memory address from which the current operand loads its
@@ -223,8 +225,8 @@ class MemoryOperand extends Operand {
    * is `r1`.
    */
   final AddressOperand getAddressOperand() {
-    getMemoryAccess().usesAddressOperand() and
-    result.getUse() = getUse()
+    this.getMemoryAccess().usesAddressOperand() and
+    result.getUse() = this.getUse()
   }
 }
 
@@ -294,7 +296,7 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, TNonPhiMemoryOpe
     result = unique(Instruction defInstr | hasDefinition(defInstr, _))
   }
 
-  final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
+  final override Overlap getDefinitionOverlap() { this.hasDefinition(_, result) }
 
   pragma[noinline]
   private predicate hasDefinition(Instruction defInstr, Overlap overlap) {
@@ -449,13 +451,17 @@ class PhiInputOperand extends MemoryOperand, TPhiOperand {
 
   final override Overlap getDefinitionOverlap() { result = overlap }
 
-  final override int getDumpSortOrder() { result = 11 + getPredecessorBlock().getDisplayIndex() }
-
-  final override string getDumpLabel() {
-    result = "from " + getPredecessorBlock().getDisplayIndex().toString() + ":"
+  final override int getDumpSortOrder() {
+    result = 11 + this.getPredecessorBlock().getDisplayIndex()
   }
 
-  final override string getDumpId() { result = getPredecessorBlock().getDisplayIndex().toString() }
+  final override string getDumpLabel() {
+    result = "from " + this.getPredecessorBlock().getDisplayIndex().toString() + ":"
+  }
+
+  final override string getDumpId() {
+    result = this.getPredecessorBlock().getDisplayIndex().toString()
+  }
 
   /**
    * Gets the predecessor block from which this value comes.

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -55,7 +55,7 @@ abstract class TranslatedExpr extends TranslatedElement {
   abstract predicate producesExprResult();
 
   final CppType getResultType() {
-    if isResultGLValue()
+    if this.isResultGLValue()
     then result = getTypeForGLValue(expr.getType())
     else result = getTypeForPRValue(expr.getType())
   }
@@ -128,9 +128,9 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
   TTranslatedConditionValue {
   TranslatedConditionValue() { this = TTranslatedConditionValue(expr) }
 
-  override TranslatedElement getChild(int id) { id = 0 and result = getCondition() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getCondition() }
 
-  override Instruction getFirstInstruction() { result = getCondition().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getCondition().getFirstInstruction() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     (
@@ -146,46 +146,46 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
       tag = ConditionValueFalseConstantTag()
     ) and
     opcode instanceof Opcode::Constant and
-    resultType = getResultType()
+    resultType = this.getResultType()
     or
     (
       tag = ConditionValueTrueStoreTag() or
       tag = ConditionValueFalseStoreTag()
     ) and
     opcode instanceof Opcode::Store and
-    resultType = getResultType()
+    resultType = this.getResultType()
     or
     tag = ConditionValueResultLoadTag() and
     opcode instanceof Opcode::Load and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     kind instanceof GotoEdge and
     (
       tag = ConditionValueTrueTempAddressTag() and
-      result = getInstruction(ConditionValueTrueConstantTag())
+      result = this.getInstruction(ConditionValueTrueConstantTag())
       or
       tag = ConditionValueTrueConstantTag() and
-      result = getInstruction(ConditionValueTrueStoreTag())
+      result = this.getInstruction(ConditionValueTrueStoreTag())
       or
       tag = ConditionValueTrueStoreTag() and
-      result = getInstruction(ConditionValueResultTempAddressTag())
+      result = this.getInstruction(ConditionValueResultTempAddressTag())
       or
       tag = ConditionValueFalseTempAddressTag() and
-      result = getInstruction(ConditionValueFalseConstantTag())
+      result = this.getInstruction(ConditionValueFalseConstantTag())
       or
       tag = ConditionValueFalseConstantTag() and
-      result = getInstruction(ConditionValueFalseStoreTag())
+      result = this.getInstruction(ConditionValueFalseStoreTag())
       or
       tag = ConditionValueFalseStoreTag() and
-      result = getInstruction(ConditionValueResultTempAddressTag())
+      result = this.getInstruction(ConditionValueResultTempAddressTag())
       or
       tag = ConditionValueResultTempAddressTag() and
-      result = getInstruction(ConditionValueResultLoadTag())
+      result = this.getInstruction(ConditionValueResultLoadTag())
       or
       tag = ConditionValueResultLoadTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
@@ -193,25 +193,25 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
     tag = ConditionValueTrueStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(ConditionValueTrueTempAddressTag())
+      result = this.getInstruction(ConditionValueTrueTempAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(ConditionValueTrueConstantTag())
+      result = this.getInstruction(ConditionValueTrueConstantTag())
     )
     or
     tag = ConditionValueFalseStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(ConditionValueFalseTempAddressTag())
+      result = this.getInstruction(ConditionValueFalseTempAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(ConditionValueFalseConstantTag())
+      result = this.getInstruction(ConditionValueFalseConstantTag())
     )
     or
     tag = ConditionValueResultLoadTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(ConditionValueResultTempAddressTag())
+      result = this.getInstruction(ConditionValueResultTempAddressTag())
     )
   }
 
@@ -226,7 +226,7 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
       tag = ConditionValueFalseTempAddressTag() or
       tag = ConditionValueResultTempAddressTag()
     ) and
-    result = getTempVariable(ConditionValueTempVar())
+    result = this.getTempVariable(ConditionValueTempVar())
   }
 
   override string getInstructionConstantValue(InstructionTag tag) {
@@ -235,18 +235,18 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
     tag = ConditionValueFalseConstantTag() and result = "0"
   }
 
-  override Instruction getResult() { result = getInstruction(ConditionValueResultLoadTag()) }
+  override Instruction getResult() { result = this.getInstruction(ConditionValueResultLoadTag()) }
 
   override Instruction getChildSuccessor(TranslatedElement child) { none() }
 
   override Instruction getChildTrueSuccessor(TranslatedCondition child) {
-    child = getCondition() and
-    result = getInstruction(ConditionValueTrueTempAddressTag())
+    child = this.getCondition() and
+    result = this.getInstruction(ConditionValueTrueTempAddressTag())
   }
 
   override Instruction getChildFalseSuccessor(TranslatedCondition child) {
-    child = getCondition() and
-    result = getInstruction(ConditionValueFalseTempAddressTag())
+    child = this.getCondition() and
+    result = this.getInstruction(ConditionValueFalseTempAddressTag())
   }
 
   private TranslatedCondition getCondition() { result = getTranslatedCondition(expr) }
@@ -260,9 +260,11 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
  *   temporary variable.
  */
 abstract class TranslatedValueCategoryAdjustment extends TranslatedExpr {
-  final override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getOperand().getFirstInstruction()
+  }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   final override predicate producesExprResult() {
     // A temp object always produces the result of the expression.
@@ -284,28 +286,28 @@ class TranslatedLoad extends TranslatedValueCategoryAdjustment, TTranslatedLoad 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = LoadTag() and
     opcode instanceof Opcode::Load and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
   override predicate isResultGLValue() { none() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = LoadTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(LoadTag())
+    child = this.getOperand() and result = this.getInstruction(LoadTag())
   }
 
-  override Instruction getResult() { result = getInstruction(LoadTag()) }
+  override Instruction getResult() { result = this.getInstruction(LoadTag()) }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = LoadTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getOperand().getResult()
+      result = this.getOperand().getResult()
     )
   }
 }
@@ -337,28 +339,28 @@ class TranslatedSyntheticTemporaryObject extends TranslatedValueCategoryAdjustme
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = InitializerVariableAddressTag() and
-    result = getInstruction(InitializerStoreTag()) and
+    result = this.getInstruction(InitializerStoreTag()) and
     kind instanceof GotoEdge
     or
     tag = InitializerStoreTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(InitializerVariableAddressTag())
+    child = this.getOperand() and result = this.getInstruction(InitializerVariableAddressTag())
   }
 
-  override Instruction getResult() { result = getInstruction(InitializerVariableAddressTag()) }
+  override Instruction getResult() { result = this.getInstruction(InitializerVariableAddressTag()) }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(InitializerVariableAddressTag())
+      result = this.getInstruction(InitializerVariableAddressTag())
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getOperand().getResult()
+      result = this.getOperand().getResult()
     )
   }
 
@@ -383,32 +385,32 @@ class TranslatedResultCopy extends TranslatedExpr, TTranslatedResultCopy {
 
   override string toString() { result = "Result of " + expr.toString() }
 
-  override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getOperand().getFirstInstruction() }
 
-  override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = ResultCopyTag() and
     opcode instanceof Opcode::CopyValue and
-    resultType = getOperand().getResultType()
+    resultType = this.getOperand().getResultType()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = ResultCopyTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(ResultCopyTag())
+    child = this.getOperand() and result = this.getInstruction(ResultCopyTag())
   }
 
-  override Instruction getResult() { result = getInstruction(ResultCopyTag()) }
+  override Instruction getResult() { result = this.getInstruction(ResultCopyTag()) }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ResultCopyTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getOperand().getResult()
+    result = this.getOperand().getResult()
   }
 
   final override predicate producesExprResult() { any() }
@@ -419,23 +421,25 @@ class TranslatedResultCopy extends TranslatedExpr, TTranslatedResultCopy {
 class TranslatedCommaExpr extends TranslatedNonConstantExpr {
   override CommaExpr expr;
 
-  override Instruction getFirstInstruction() { result = getLeftOperand().getFirstInstruction() }
-
-  override TranslatedElement getChild(int id) {
-    id = 0 and result = getLeftOperand()
-    or
-    id = 1 and result = getRightOperand()
+  override Instruction getFirstInstruction() {
+    result = this.getLeftOperand().getFirstInstruction()
   }
 
-  override Instruction getResult() { result = getRightOperand().getResult() }
+  override TranslatedElement getChild(int id) {
+    id = 0 and result = this.getLeftOperand()
+    or
+    id = 1 and result = this.getRightOperand()
+  }
+
+  override Instruction getResult() { result = this.getRightOperand().getResult() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getLeftOperand() and
-    result = getRightOperand().getFirstInstruction()
+    child = this.getLeftOperand() and
+    result = this.getRightOperand().getFirstInstruction()
     or
-    child = getRightOperand() and result = getParent().getChildSuccessor(this)
+    child = this.getRightOperand() and result = this.getParent().getChildSuccessor(this)
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -462,7 +466,7 @@ private int getElementSize(Type type) {
 abstract class TranslatedCrementOperation extends TranslatedNonConstantExpr {
   override CrementOperation expr;
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getLoadedOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getLoadedOperand() }
 
   final override string getInstructionConstantValue(InstructionTag tag) {
     tag = CrementConstantTag() and
@@ -493,10 +497,10 @@ abstract class TranslatedCrementOperation extends TranslatedNonConstantExpr {
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = CrementConstantTag() and
     opcode instanceof Opcode::Constant and
-    resultType = getConstantType()
+    resultType = this.getConstantType()
     or
     tag = CrementOpTag() and
-    opcode = getOpcode() and
+    opcode = this.getOpcode() and
     resultType = getTypeForPRValue(expr.getType())
     or
     tag = CrementStoreTag() and
@@ -508,49 +512,49 @@ abstract class TranslatedCrementOperation extends TranslatedNonConstantExpr {
     tag = CrementOpTag() and
     (
       operandTag instanceof LeftOperandTag and
-      result = getLoadedOperand().getResult()
+      result = this.getLoadedOperand().getResult()
       or
       operandTag instanceof RightOperandTag and
-      result = getInstruction(CrementConstantTag())
+      result = this.getInstruction(CrementConstantTag())
     )
     or
     tag = CrementStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getUnloadedOperand().getResult()
+      result = this.getUnloadedOperand().getResult()
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getInstruction(CrementOpTag())
+      result = this.getInstruction(CrementOpTag())
     )
   }
 
   final override Instruction getFirstInstruction() {
-    result = getLoadedOperand().getFirstInstruction()
+    result = this.getLoadedOperand().getFirstInstruction()
   }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     kind instanceof GotoEdge and
     (
       tag = CrementConstantTag() and
-      result = getInstruction(CrementOpTag())
+      result = this.getInstruction(CrementOpTag())
       or
       tag = CrementOpTag() and
-      result = getInstruction(CrementStoreTag())
+      result = this.getInstruction(CrementStoreTag())
       or
       tag = CrementStoreTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getLoadedOperand() and result = getInstruction(CrementConstantTag())
+    child = this.getLoadedOperand() and result = this.getInstruction(CrementConstantTag())
   }
 
   final override int getInstructionElementSize(InstructionTag tag) {
     tag = CrementOpTag() and
     (
-      getOpcode() instanceof Opcode::PointerAdd or
-      getOpcode() instanceof Opcode::PointerSub
+      this.getOpcode() instanceof Opcode::PointerAdd or
+      this.getOpcode() instanceof Opcode::PointerSub
     ) and
     result = getElementSize(expr.getType())
   }
@@ -567,7 +571,7 @@ abstract class TranslatedCrementOperation extends TranslatedNonConstantExpr {
   /**
    * Gets the address to which the result of this crement will be stored.
    */
-  final TranslatedExpr getUnloadedOperand() { result = getLoadedOperand().getOperand() }
+  final TranslatedExpr getUnloadedOperand() { result = this.getLoadedOperand().getOperand() }
 
   final Opcode getOpcode() {
     exists(Type resultType |
@@ -601,18 +605,18 @@ class TranslatedPrefixCrementOperation extends TranslatedCrementOperation {
       // new value assigned to the operand. If this is C++, then the result is
       // an lvalue, but that lvalue is being loaded as part of this expression.
       // EDG doesn't mark this as a load.
-      result = getInstruction(CrementOpTag())
+      result = this.getInstruction(CrementOpTag())
     else
       // This is C++, where the result is an lvalue for the operand, and that
       // lvalue is not being loaded as part of this expression.
-      result = getUnloadedOperand().getResult()
+      result = this.getUnloadedOperand().getResult()
   }
 }
 
 class TranslatedPostfixCrementOperation extends TranslatedCrementOperation {
   override PostfixCrementOperation expr;
 
-  override Instruction getResult() { result = getLoadedOperand().getResult() }
+  override Instruction getResult() { result = this.getLoadedOperand().getResult() }
 }
 
 /**
@@ -624,30 +628,30 @@ class TranslatedArrayExpr extends TranslatedNonConstantExpr {
   override ArrayExpr expr;
 
   final override Instruction getFirstInstruction() {
-    result = getBaseOperand().getFirstInstruction()
+    result = this.getBaseOperand().getFirstInstruction()
   }
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getBaseOperand()
+    id = 0 and result = this.getBaseOperand()
     or
-    id = 1 and result = getOffsetOperand()
+    id = 1 and result = this.getOffsetOperand()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getBaseOperand() and
-    result = getOffsetOperand().getFirstInstruction()
+    child = this.getBaseOperand() and
+    result = this.getOffsetOperand().getFirstInstruction()
     or
-    child = getOffsetOperand() and
-    result = getInstruction(OnlyInstructionTag())
+    child = this.getOffsetOperand() and
+    result = this.getInstruction(OnlyInstructionTag())
   }
 
-  override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -659,10 +663,10 @@ class TranslatedArrayExpr extends TranslatedNonConstantExpr {
     tag = OnlyInstructionTag() and
     (
       operandTag instanceof LeftOperandTag and
-      result = getBaseOperand().getResult()
+      result = this.getBaseOperand().getResult()
       or
       operandTag instanceof RightOperandTag and
-      result = getOffsetOperand().getResult()
+      result = this.getOffsetOperand().getResult()
     )
   }
 
@@ -681,21 +685,23 @@ class TranslatedArrayExpr extends TranslatedNonConstantExpr {
 }
 
 abstract class TranslatedTransparentExpr extends TranslatedNonConstantExpr {
-  final override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getOperand().getFirstInstruction()
+  }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getParent().getChildSuccessor(this)
+    child = this.getOperand() and result = this.getParent().getChildSuccessor(this)
   }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     none()
   }
 
-  final override Instruction getResult() { result = getOperand().getResult() }
+  final override Instruction getResult() { result = this.getOperand().getResult() }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
@@ -749,21 +755,23 @@ class TranslatedThisExpr extends TranslatedNonConstantExpr {
     or
     tag = ThisLoadTag() and
     opcode instanceof Opcode::Load and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
-  final override Instruction getResult() { result = getInstruction(ThisLoadTag()) }
+  final override Instruction getResult() { result = this.getInstruction(ThisLoadTag()) }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(ThisAddressTag()) }
+  final override Instruction getFirstInstruction() {
+    result = this.getInstruction(ThisAddressTag())
+  }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     kind instanceof GotoEdge and
     tag = ThisAddressTag() and
-    result = getInstruction(ThisLoadTag())
+    result = this.getInstruction(ThisLoadTag())
     or
     kind instanceof GotoEdge and
     tag = ThisLoadTag() and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) { none() }
@@ -771,7 +779,7 @@ class TranslatedThisExpr extends TranslatedNonConstantExpr {
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ThisLoadTag() and
     operandTag instanceof AddressOperandTag and
-    result = getInstruction(ThisAddressTag())
+    result = this.getInstruction(ThisAddressTag())
   }
 
   override IRVariable getInstructionVariable(InstructionTag tag) {
@@ -784,23 +792,23 @@ abstract class TranslatedVariableAccess extends TranslatedNonConstantExpr {
   override VariableAccess expr;
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getQualifier() // Might not exist
+    id = 0 and result = this.getQualifier() // Might not exist
   }
 
   final TranslatedExpr getQualifier() {
     result = getTranslatedExpr(expr.getQualifier().getFullyConverted())
   }
 
-  override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getQualifier() and result = getInstruction(OnlyInstructionTag())
+    child = this.getQualifier() and result = this.getInstruction(OnlyInstructionTag())
   }
 }
 
@@ -808,9 +816,9 @@ class TranslatedNonFieldVariableAccess extends TranslatedVariableAccess {
   TranslatedNonFieldVariableAccess() { not expr instanceof FieldAccess }
 
   override Instruction getFirstInstruction() {
-    if exists(getQualifier())
-    then result = getQualifier().getFirstInstruction()
-    else result = getInstruction(OnlyInstructionTag())
+    if exists(this.getQualifier())
+    then result = this.getQualifier().getFirstInstruction()
+    else result = this.getInstruction(OnlyInstructionTag())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
@@ -832,12 +840,12 @@ class TranslatedNonFieldVariableAccess extends TranslatedVariableAccess {
 class TranslatedFieldAccess extends TranslatedVariableAccess {
   override FieldAccess expr;
 
-  override Instruction getFirstInstruction() { result = getQualifier().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getQualifier().getFirstInstruction() }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getQualifier().getResult()
+    result = this.getQualifier().getResult()
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -857,20 +865,20 @@ class TranslatedFunctionAccess extends TranslatedNonConstantExpr {
 
   override TranslatedElement getChild(int id) { none() }
 
-  override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(OnlyInstructionTag()) }
 
-  override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
     opcode instanceof Opcode::FunctionAddress and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
   override Function getInstructionFunction(InstructionTag tag) {
@@ -902,11 +910,13 @@ abstract class TranslatedConstantExpr extends TranslatedCoreExpr, TTranslatedVal
     isIRConstant(expr)
   }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getFirstInstruction() {
+    result = this.getInstruction(OnlyInstructionTag())
+  }
 
   final override TranslatedElement getChild(int id) { none() }
 
-  final override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
@@ -914,13 +924,13 @@ abstract class TranslatedConstantExpr extends TranslatedCoreExpr, TTranslatedVal
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
-    opcode = getOpcode() and
-    resultType = getResultType()
+    opcode = this.getOpcode() and
+    resultType = this.getResultType()
   }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
@@ -962,12 +972,12 @@ abstract class TranslatedSingleInstructionExpr extends TranslatedNonConstantExpr
   abstract Opcode getOpcode();
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
-    opcode = getOpcode() and
+    opcode = this.getOpcode() and
     tag = OnlyInstructionTag() and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
-  final override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 }
 
 class TranslatedUnaryExpr extends TranslatedSingleInstructionExpr {
@@ -978,23 +988,25 @@ class TranslatedUnaryExpr extends TranslatedSingleInstructionExpr {
     expr instanceof UnaryMinusExpr
   }
 
-  final override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getOperand().getFirstInstruction()
+  }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(OnlyInstructionTag())
+    child = this.getOperand() and result = this.getInstruction(OnlyInstructionTag())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
-    result = getOperand().getResult() and
+    result = this.getOperand().getResult() and
     operandTag instanceof UnaryOperandTag
   }
 
@@ -1016,9 +1028,9 @@ class TranslatedUnaryExpr extends TranslatedSingleInstructionExpr {
 abstract class TranslatedConversion extends TranslatedNonConstantExpr {
   override Conversion expr;
 
-  override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getOperand().getFirstInstruction() }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   final TranslatedExpr getOperand() { result = getTranslatedExpr(expr.(Conversion).getExpr()) }
 }
@@ -1030,26 +1042,26 @@ abstract class TranslatedConversion extends TranslatedNonConstantExpr {
 abstract class TranslatedSingleInstructionConversion extends TranslatedConversion {
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(OnlyInstructionTag())
+    child = this.getOperand() and result = this.getInstruction(OnlyInstructionTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
-    opcode = getOpcode() and
-    resultType = getResultType()
+    opcode = this.getOpcode() and
+    resultType = this.getResultType()
   }
 
-  override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getOperand().getResult()
+    result = this.getOperand().getResult()
   }
 
   /**
@@ -1133,37 +1145,37 @@ class TranslatedBoolConversion extends TranslatedConversion {
     kind instanceof GotoEdge and
     (
       tag = BoolConversionConstantTag() and
-      result = getInstruction(BoolConversionCompareTag())
+      result = this.getInstruction(BoolConversionCompareTag())
       or
       tag = BoolConversionCompareTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(BoolConversionConstantTag())
+    child = this.getOperand() and result = this.getInstruction(BoolConversionConstantTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = BoolConversionConstantTag() and
     opcode instanceof Opcode::Constant and
-    resultType = getOperand().getResultType()
+    resultType = this.getOperand().getResultType()
     or
     tag = BoolConversionCompareTag() and
     opcode instanceof Opcode::CompareNE and
     resultType = getBoolType()
   }
 
-  override Instruction getResult() { result = getInstruction(BoolConversionCompareTag()) }
+  override Instruction getResult() { result = this.getInstruction(BoolConversionCompareTag()) }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = BoolConversionCompareTag() and
     (
       operandTag instanceof LeftOperandTag and
-      result = getOperand().getResult()
+      result = this.getOperand().getResult()
       or
       operandTag instanceof RightOperandTag and
-      result = getInstruction(BoolConversionConstantTag())
+      result = this.getInstruction(BoolConversionConstantTag())
     )
   }
 
@@ -1250,44 +1262,46 @@ class TranslatedBinaryOperation extends TranslatedSingleInstructionExpr {
     expr instanceof ComparisonOperation
   }
 
-  override Instruction getFirstInstruction() { result = getLeftOperand().getFirstInstruction() }
+  override Instruction getFirstInstruction() {
+    result = this.getLeftOperand().getFirstInstruction()
+  }
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getLeftOperand()
+    id = 0 and result = this.getLeftOperand()
     or
-    id = 1 and result = getRightOperand()
+    id = 1 and result = this.getRightOperand()
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
-    if swapOperandsOnOp()
+    if this.swapOperandsOnOp()
     then (
       operandTag instanceof RightOperandTag and
-      result = getLeftOperand().getResult()
+      result = this.getLeftOperand().getResult()
       or
       operandTag instanceof LeftOperandTag and
-      result = getRightOperand().getResult()
+      result = this.getRightOperand().getResult()
     ) else (
       operandTag instanceof LeftOperandTag and
-      result = getLeftOperand().getResult()
+      result = this.getLeftOperand().getResult()
       or
       operandTag instanceof RightOperandTag and
-      result = getRightOperand().getResult()
+      result = this.getRightOperand().getResult()
     )
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getLeftOperand() and
-    result = getRightOperand().getFirstInstruction()
+    child = this.getLeftOperand() and
+    result = this.getRightOperand().getFirstInstruction()
     or
-    child = getRightOperand() and
-    result = getInstruction(OnlyInstructionTag())
+    child = this.getRightOperand() and
+    result = this.getInstruction(OnlyInstructionTag())
   }
 
   override Opcode getOpcode() {
@@ -1299,18 +1313,20 @@ class TranslatedBinaryOperation extends TranslatedSingleInstructionExpr {
   override int getInstructionElementSize(InstructionTag tag) {
     tag = OnlyInstructionTag() and
     exists(Opcode opcode |
-      opcode = getOpcode() and
+      opcode = this.getOpcode() and
       (
         opcode instanceof Opcode::PointerAdd or
         opcode instanceof Opcode::PointerSub or
         opcode instanceof Opcode::PointerDiff
       ) and
-      result = getElementSize(getPointerOperand().getExpr().getType())
+      result = getElementSize(this.getPointerOperand().getExpr().getType())
     )
   }
 
   private TranslatedExpr getPointerOperand() {
-    if swapOperandsOnOp() then result = getRightOperand() else result = getLeftOperand()
+    if this.swapOperandsOnOp()
+    then result = this.getRightOperand()
+    else result = this.getLeftOperand()
   }
 
   private predicate swapOperandsOnOp() {
@@ -1337,14 +1353,14 @@ class TranslatedAssignExpr extends TranslatedNonConstantExpr {
   override AssignExpr expr;
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getLeftOperand()
+    id = 0 and result = this.getLeftOperand()
     or
-    id = 1 and result = getRightOperand()
+    id = 1 and result = this.getRightOperand()
   }
 
   final override Instruction getFirstInstruction() {
     // Evaluation is right-to-left
-    result = getRightOperand().getFirstInstruction()
+    result = this.getRightOperand().getFirstInstruction()
   }
 
   final override Instruction getResult() {
@@ -1354,11 +1370,11 @@ class TranslatedAssignExpr extends TranslatedNonConstantExpr {
       // value assigned to the left operand. If this is C++, then the result is
       // an lvalue, but that lvalue is being loaded as part of this expression.
       // EDG doesn't mark this as a load.
-      result = getRightOperand().getResult()
+      result = this.getRightOperand().getResult()
     else
       // This is C++, where the result is an lvalue for the left operand,
       // and that lvalue is not being loaded as part of this expression.
-      result = getLeftOperand().getResult()
+      result = this.getLeftOperand().getResult()
   }
 
   abstract Instruction getStoredValue();
@@ -1373,17 +1389,17 @@ class TranslatedAssignExpr extends TranslatedNonConstantExpr {
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = AssignmentStoreTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     // Operands are evaluated right-to-left.
-    child = getRightOperand() and
-    result = getLeftOperand().getFirstInstruction()
+    child = this.getRightOperand() and
+    result = this.getLeftOperand().getFirstInstruction()
     or
-    child = getLeftOperand() and
-    result = getInstruction(AssignmentStoreTag())
+    child = this.getLeftOperand() and
+    result = this.getInstruction(AssignmentStoreTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -1396,10 +1412,10 @@ class TranslatedAssignExpr extends TranslatedNonConstantExpr {
     tag = AssignmentStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getLeftOperand().getResult()
+      result = this.getLeftOperand().getResult()
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getRightOperand().getResult()
+      result = this.getRightOperand().getResult()
     )
   }
 }
@@ -1408,14 +1424,14 @@ class TranslatedAssignOperation extends TranslatedNonConstantExpr {
   override AssignOperation expr;
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getLoadedLeftOperand()
+    id = 0 and result = this.getLoadedLeftOperand()
     or
-    id = 1 and result = getRightOperand()
+    id = 1 and result = this.getRightOperand()
   }
 
   final override Instruction getFirstInstruction() {
     // Evaluation is right-to-left
-    result = getRightOperand().getFirstInstruction()
+    result = this.getRightOperand().getFirstInstruction()
   }
 
   final override Instruction getResult() {
@@ -1425,14 +1441,16 @@ class TranslatedAssignOperation extends TranslatedNonConstantExpr {
       // value assigned to the left operand. If this is C++, then the result is
       // an lvalue, but that lvalue is being loaded as part of this expression.
       // EDG doesn't mark this as a load.
-      result = getStoredValue()
+      result = this.getStoredValue()
     else
       // This is C++, where the result is an lvalue for the left operand,
       // and that lvalue is not being loaded as part of this expression.
-      result = getUnloadedLeftOperand().getResult()
+      result = this.getUnloadedLeftOperand().getResult()
   }
 
-  final TranslatedExpr getUnloadedLeftOperand() { result = getLoadedLeftOperand().getOperand() }
+  final TranslatedExpr getUnloadedLeftOperand() {
+    result = this.getLoadedLeftOperand().getOperand()
+  }
 
   /**
    * Gets the `TranslatedLoad` on the `e` in this `e += ...` which is the
@@ -1454,38 +1472,38 @@ class TranslatedAssignOperation extends TranslatedNonConstantExpr {
     kind instanceof GotoEdge and
     (
       tag = AssignOperationConvertLeftTag() and
-      result = getInstruction(AssignOperationOpTag())
+      result = this.getInstruction(AssignOperationOpTag())
       or
       (
         tag = AssignOperationOpTag() and
-        if leftOperandNeedsConversion()
-        then result = getInstruction(AssignOperationConvertResultTag())
-        else result = getInstruction(AssignmentStoreTag())
+        if this.leftOperandNeedsConversion()
+        then result = this.getInstruction(AssignOperationConvertResultTag())
+        else result = this.getInstruction(AssignmentStoreTag())
       )
       or
       tag = AssignOperationConvertResultTag() and
-      result = getInstruction(AssignmentStoreTag())
+      result = this.getInstruction(AssignmentStoreTag())
       or
       tag = AssignmentStoreTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     // Operands are evaluated right-to-left.
-    child = getRightOperand() and
-    result = getLoadedLeftOperand().getFirstInstruction()
+    child = this.getRightOperand() and
+    result = this.getLoadedLeftOperand().getFirstInstruction()
     or
-    child = getLoadedLeftOperand() and
-    if leftOperandNeedsConversion()
-    then result = getInstruction(AssignOperationConvertLeftTag())
-    else result = getInstruction(AssignOperationOpTag())
+    child = this.getLoadedLeftOperand() and
+    if this.leftOperandNeedsConversion()
+    then result = this.getInstruction(AssignOperationConvertLeftTag())
+    else result = this.getInstruction(AssignOperationOpTag())
   }
 
   private Instruction getStoredValue() {
-    if leftOperandNeedsConversion()
-    then result = getInstruction(AssignOperationConvertResultTag())
-    else result = getInstruction(AssignOperationOpTag())
+    if this.leftOperandNeedsConversion()
+    then result = this.getInstruction(AssignOperationConvertResultTag())
+    else result = this.getInstruction(AssignOperationOpTag())
   }
 
   private Type getConvertedLeftOperandType() {
@@ -1502,15 +1520,15 @@ class TranslatedAssignOperation extends TranslatedNonConstantExpr {
       // anyway. If we really want to model this case perfectly, we'll need the
       // extractor to tell us what the promoted type of the left operand would
       // be.
-      result = getLoadedLeftOperand().getExpr().getType()
+      result = this.getLoadedLeftOperand().getExpr().getType()
     else
       // The right operand has already been converted to the type of the op.
-      result = getRightOperand().getExpr().getType()
+      result = this.getRightOperand().getExpr().getType()
   }
 
   private predicate leftOperandNeedsConversion() {
-    getConvertedLeftOperandType().getUnspecifiedType() !=
-      getLoadedLeftOperand().getExpr().getUnspecifiedType()
+    this.getConvertedLeftOperandType().getUnspecifiedType() !=
+      this.getLoadedLeftOperand().getExpr().getUnspecifiedType()
   }
 
   private Opcode getOpcode() {
@@ -1541,64 +1559,64 @@ class TranslatedAssignOperation extends TranslatedNonConstantExpr {
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = AssignOperationOpTag() and
-    opcode = getOpcode() and
-    resultType = getTypeForPRValue(getConvertedLeftOperandType())
+    opcode = this.getOpcode() and
+    resultType = getTypeForPRValue(this.getConvertedLeftOperandType())
     or
     tag = AssignmentStoreTag() and
     opcode instanceof Opcode::Store and
     resultType = getTypeForPRValue(expr.getType()) // Always a prvalue
     or
-    leftOperandNeedsConversion() and
+    this.leftOperandNeedsConversion() and
     opcode instanceof Opcode::Convert and
     (
       tag = AssignOperationConvertLeftTag() and
-      resultType = getTypeForPRValue(getConvertedLeftOperandType())
+      resultType = getTypeForPRValue(this.getConvertedLeftOperandType())
       or
       tag = AssignOperationConvertResultTag() and
-      resultType = getTypeForPRValue(getLoadedLeftOperand().getExpr().getType())
+      resultType = getTypeForPRValue(this.getLoadedLeftOperand().getExpr().getType())
     )
   }
 
   override int getInstructionElementSize(InstructionTag tag) {
     tag = AssignOperationOpTag() and
     exists(Opcode opcode |
-      opcode = getOpcode() and
+      opcode = this.getOpcode() and
       (opcode instanceof Opcode::PointerAdd or opcode instanceof Opcode::PointerSub)
     ) and
     result = getElementSize(expr.getType())
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
-    leftOperandNeedsConversion() and
+    this.leftOperandNeedsConversion() and
     tag = AssignOperationConvertLeftTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getLoadedLeftOperand().getResult()
+    result = this.getLoadedLeftOperand().getResult()
     or
     tag = AssignOperationOpTag() and
     (
       (
         operandTag instanceof LeftOperandTag and
-        if leftOperandNeedsConversion()
-        then result = getInstruction(AssignOperationConvertLeftTag())
-        else result = getLoadedLeftOperand().getResult()
+        if this.leftOperandNeedsConversion()
+        then result = this.getInstruction(AssignOperationConvertLeftTag())
+        else result = this.getLoadedLeftOperand().getResult()
       )
       or
       operandTag instanceof RightOperandTag and
-      result = getRightOperand().getResult()
+      result = this.getRightOperand().getResult()
     )
     or
-    leftOperandNeedsConversion() and
+    this.leftOperandNeedsConversion() and
     tag = AssignOperationConvertResultTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getInstruction(AssignOperationOpTag())
+    result = this.getInstruction(AssignOperationOpTag())
     or
     tag = AssignmentStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getUnloadedLeftOperand().getResult()
+      result = this.getUnloadedLeftOperand().getResult()
       or
       operandTag instanceof StoreValueOperandTag and
-      result = getStoredValue()
+      result = this.getStoredValue()
     )
   }
 }
@@ -1619,7 +1637,7 @@ abstract class TranslatedAllocationSize extends TranslatedExpr, TTranslatedAlloc
 
   final override predicate producesExprResult() { none() }
 
-  final override Instruction getResult() { result = getInstruction(AllocationSizeTag()) }
+  final override Instruction getResult() { result = this.getInstruction(AllocationSizeTag()) }
 }
 
 TranslatedAllocationSize getTranslatedAllocationSize(NewOrNewArrayExpr newExpr) {
@@ -1636,7 +1654,9 @@ TranslatedAllocationSize getTranslatedAllocationSize(NewOrNewArrayExpr newExpr) 
 class TranslatedConstantAllocationSize extends TranslatedAllocationSize {
   TranslatedConstantAllocationSize() { not exists(expr.(NewArrayExpr).getExtent()) }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(AllocationSizeTag()) }
+  final override Instruction getFirstInstruction() {
+    result = this.getInstruction(AllocationSizeTag())
+  }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = AllocationSizeTag() and
@@ -1647,7 +1667,7 @@ class TranslatedConstantAllocationSize extends TranslatedAllocationSize {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = AllocationSizeTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override TranslatedElement getChild(int id) { none() }
@@ -1672,7 +1692,9 @@ class TranslatedNonConstantAllocationSize extends TranslatedAllocationSize {
 
   TranslatedNonConstantAllocationSize() { exists(expr.getExtent()) }
 
-  final override Instruction getFirstInstruction() { result = getExtent().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getExtent().getFirstInstruction()
+  }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     resultType = getTypeForPRValue(expr.getAllocator().getParameter(0).getType()) and
@@ -1690,21 +1712,21 @@ class TranslatedNonConstantAllocationSize extends TranslatedAllocationSize {
     kind instanceof GotoEdge and
     (
       tag = AllocationExtentConvertTag() and
-      result = getInstruction(AllocationElementSizeTag())
+      result = this.getInstruction(AllocationElementSizeTag())
       or
       tag = AllocationElementSizeTag() and
-      result = getInstruction(AllocationSizeTag())
+      result = this.getInstruction(AllocationSizeTag())
       or
       tag = AllocationSizeTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getExtent() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getExtent() }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getExtent() and
-    result = getInstruction(AllocationExtentConvertTag())
+    child = this.getExtent() and
+    result = this.getInstruction(AllocationExtentConvertTag())
   }
 
   final override string getInstructionConstantValue(InstructionTag tag) {
@@ -1715,14 +1737,16 @@ class TranslatedNonConstantAllocationSize extends TranslatedAllocationSize {
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = AllocationSizeTag() and
     (
-      operandTag instanceof LeftOperandTag and result = getInstruction(AllocationExtentConvertTag())
+      operandTag instanceof LeftOperandTag and
+      result = this.getInstruction(AllocationExtentConvertTag())
       or
-      operandTag instanceof RightOperandTag and result = getInstruction(AllocationElementSizeTag())
+      operandTag instanceof RightOperandTag and
+      result = this.getInstruction(AllocationElementSizeTag())
     )
     or
     tag = AllocationExtentConvertTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getExtent().getResult()
+    result = this.getExtent().getResult()
   }
 
   private TranslatedExpr getExtent() {
@@ -1806,7 +1830,7 @@ abstract class StructorCallContext extends TranslatedElement {
 class TranslatedDestructorFieldDestruction extends TranslatedNonConstantExpr, StructorCallContext {
   override DestructorFieldDestruction expr;
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getDestructorCall() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getDestructorCall() }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -1817,17 +1841,19 @@ class TranslatedDestructorFieldDestruction extends TranslatedNonConstantExpr, St
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
     kind instanceof GotoEdge and
-    result = getDestructorCall().getFirstInstruction()
+    result = this.getDestructorCall().getFirstInstruction()
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getDestructorCall() and
-    result = getParent().getChildSuccessor(this)
+    child = this.getDestructorCall() and
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getResult() { none() }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getFirstInstruction() {
+    result = this.getInstruction(OnlyInstructionTag())
+  }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
@@ -1840,7 +1866,7 @@ class TranslatedDestructorFieldDestruction extends TranslatedNonConstantExpr, St
     result = expr.getTarget()
   }
 
-  final override Instruction getReceiver() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getReceiver() { result = this.getInstruction(OnlyInstructionTag()) }
 
   private TranslatedExpr getDestructorCall() { result = getTranslatedExpr(expr.getExpr()) }
 }
@@ -1859,12 +1885,12 @@ abstract class TranslatedConditionalExpr extends TranslatedNonConstantExpr {
     // the condition directly to the appropriate then/else block via
     // `getChild[True|False]Successor()`.
     // The binary flavor will override this predicate to add the `ConditionalBranch`.
-    not resultIsVoid() and
+    not this.resultIsVoid() and
     (
       (
-        not thenIsVoid() and tag = ConditionValueTrueTempAddressTag()
+        not this.thenIsVoid() and tag = ConditionValueTrueTempAddressTag()
         or
-        not elseIsVoid() and tag = ConditionValueFalseTempAddressTag()
+        not this.elseIsVoid() and tag = ConditionValueFalseTempAddressTag()
         or
         tag = ConditionValueResultTempAddressTag()
       ) and
@@ -1876,106 +1902,106 @@ abstract class TranslatedConditionalExpr extends TranslatedNonConstantExpr {
       )
       or
       (
-        not thenIsVoid() and tag = ConditionValueTrueStoreTag()
+        not this.thenIsVoid() and tag = ConditionValueTrueStoreTag()
         or
-        not elseIsVoid() and tag = ConditionValueFalseStoreTag()
+        not this.elseIsVoid() and tag = ConditionValueFalseStoreTag()
       ) and
       opcode instanceof Opcode::Store and
-      resultType = getResultType()
+      resultType = this.getResultType()
       or
       tag = ConditionValueResultLoadTag() and
       opcode instanceof Opcode::Load and
-      resultType = getResultType()
+      resultType = this.getResultType()
     )
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
-    not resultIsVoid() and
+    not this.resultIsVoid() and
     kind instanceof GotoEdge and
     (
-      not thenIsVoid() and
+      not this.thenIsVoid() and
       (
         tag = ConditionValueTrueTempAddressTag() and
-        result = getInstruction(ConditionValueTrueStoreTag())
+        result = this.getInstruction(ConditionValueTrueStoreTag())
         or
         tag = ConditionValueTrueStoreTag() and
-        result = getInstruction(ConditionValueResultTempAddressTag())
+        result = this.getInstruction(ConditionValueResultTempAddressTag())
       )
       or
-      not elseIsVoid() and
+      not this.elseIsVoid() and
       (
         tag = ConditionValueFalseTempAddressTag() and
-        result = getInstruction(ConditionValueFalseStoreTag())
+        result = this.getInstruction(ConditionValueFalseStoreTag())
         or
         tag = ConditionValueFalseStoreTag() and
-        result = getInstruction(ConditionValueResultTempAddressTag())
+        result = this.getInstruction(ConditionValueResultTempAddressTag())
       )
       or
       tag = ConditionValueResultTempAddressTag() and
-      result = getInstruction(ConditionValueResultLoadTag())
+      result = this.getInstruction(ConditionValueResultLoadTag())
       or
       tag = ConditionValueResultLoadTag() and
-      result = getParent().getChildSuccessor(this)
+      result = this.getParent().getChildSuccessor(this)
     )
   }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
-    not resultIsVoid() and
+    not this.resultIsVoid() and
     (
-      not thenIsVoid() and
+      not this.thenIsVoid() and
       tag = ConditionValueTrueStoreTag() and
       (
         operandTag instanceof AddressOperandTag and
-        result = getInstruction(ConditionValueTrueTempAddressTag())
+        result = this.getInstruction(ConditionValueTrueTempAddressTag())
         or
         operandTag instanceof StoreValueOperandTag and
-        result = getThen().getResult()
+        result = this.getThen().getResult()
       )
       or
-      not elseIsVoid() and
+      not this.elseIsVoid() and
       tag = ConditionValueFalseStoreTag() and
       (
         operandTag instanceof AddressOperandTag and
-        result = getInstruction(ConditionValueFalseTempAddressTag())
+        result = this.getInstruction(ConditionValueFalseTempAddressTag())
         or
         operandTag instanceof StoreValueOperandTag and
-        result = getElse().getResult()
+        result = this.getElse().getResult()
       )
       or
       tag = ConditionValueResultLoadTag() and
       (
         operandTag instanceof AddressOperandTag and
-        result = getInstruction(ConditionValueResultTempAddressTag())
+        result = this.getInstruction(ConditionValueResultTempAddressTag())
       )
     )
   }
 
   final override predicate hasTempVariable(TempVariableTag tag, CppType type) {
-    not resultIsVoid() and
+    not this.resultIsVoid() and
     tag = ConditionValueTempVar() and
-    type = getResultType()
+    type = this.getResultType()
   }
 
   final override IRVariable getInstructionVariable(InstructionTag tag) {
-    not resultIsVoid() and
+    not this.resultIsVoid() and
     (
       tag = ConditionValueTrueTempAddressTag() or
       tag = ConditionValueFalseTempAddressTag() or
       tag = ConditionValueResultTempAddressTag()
     ) and
-    result = getTempVariable(ConditionValueTempVar())
+    result = this.getTempVariable(ConditionValueTempVar())
   }
 
   final override Instruction getResult() {
-    not resultIsVoid() and
-    result = getInstruction(ConditionValueResultLoadTag())
+    not this.resultIsVoid() and
+    result = this.getInstruction(ConditionValueResultLoadTag())
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getElse() and
-    if elseIsVoid()
-    then result = getParent().getChildSuccessor(this)
-    else result = getInstruction(ConditionValueFalseTempAddressTag())
+    child = this.getElse() and
+    if this.elseIsVoid()
+    then result = this.getParent().getChildSuccessor(this)
+    else result = this.getInstruction(ConditionValueFalseTempAddressTag())
   }
 
   /**
@@ -1990,7 +2016,7 @@ abstract class TranslatedConditionalExpr extends TranslatedNonConstantExpr {
   final TranslatedExpr getElse() { result = getTranslatedExpr(expr.getElse().getFullyConverted()) }
 
   final predicate thenIsVoid() {
-    getThen().getResultType().getIRType() instanceof IRVoidType
+    this.getThen().getResultType().getIRType() instanceof IRVoidType
     or
     // A `ThrowExpr.getType()` incorrectly returns the type of exception being
     // thrown, rather than `void`. Handle that case here.
@@ -1998,14 +2024,14 @@ abstract class TranslatedConditionalExpr extends TranslatedNonConstantExpr {
   }
 
   private predicate elseIsVoid() {
-    getElse().getResultType().getIRType() instanceof IRVoidType
+    this.getElse().getResultType().getIRType() instanceof IRVoidType
     or
     // A `ThrowExpr.getType()` incorrectly returns the type of exception being
     // thrown, rather than `void`. Handle that case here.
     expr.getElse() instanceof ThrowExpr
   }
 
-  private predicate resultIsVoid() { getResultType().getIRType() instanceof IRVoidType }
+  private predicate resultIsVoid() { this.getResultType().getIRType() instanceof IRVoidType }
 }
 
 /**
@@ -2017,34 +2043,34 @@ class TranslatedTernaryConditionalExpr extends TranslatedConditionalExpr, Condit
   TranslatedTernaryConditionalExpr() { not expr.isTwoOperand() }
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getCondition()
+    id = 0 and result = this.getCondition()
     or
-    id = 1 and result = getThen()
+    id = 1 and result = this.getThen()
     or
-    id = 2 and result = getElse()
+    id = 2 and result = this.getElse()
   }
 
-  override Instruction getFirstInstruction() { result = getCondition().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getCondition().getFirstInstruction() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     result = TranslatedConditionalExpr.super.getChildSuccessor(child)
     or
     (
-      child = getThen() and
-      if thenIsVoid()
-      then result = getParent().getChildSuccessor(this)
-      else result = getInstruction(ConditionValueTrueTempAddressTag())
+      child = this.getThen() and
+      if this.thenIsVoid()
+      then result = this.getParent().getChildSuccessor(this)
+      else result = this.getInstruction(ConditionValueTrueTempAddressTag())
     )
   }
 
   override Instruction getChildTrueSuccessor(TranslatedCondition child) {
-    child = getCondition() and
-    result = getThen().getFirstInstruction()
+    child = this.getCondition() and
+    result = this.getThen().getFirstInstruction()
   }
 
   override Instruction getChildFalseSuccessor(TranslatedCondition child) {
-    child = getCondition() and
-    result = getElse().getFirstInstruction()
+    child = this.getCondition() and
+    result = this.getElse().getFirstInstruction()
   }
 
   private TranslatedCondition getCondition() {
@@ -2069,12 +2095,12 @@ class TranslatedBinaryConditionalExpr extends TranslatedConditionalExpr {
   final override TranslatedElement getChild(int id) {
     // We only truly have two children, because our "condition" and "then" are the same as far as
     // the extractor is concerned.
-    id = 0 and result = getCondition()
+    id = 0 and result = this.getCondition()
     or
-    id = 1 and result = getElse()
+    id = 1 and result = this.getElse()
   }
 
-  override Instruction getFirstInstruction() { result = getCondition().getFirstInstruction() }
+  override Instruction getFirstInstruction() { result = this.getCondition().getFirstInstruction() }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     super.hasInstruction(opcode, tag, resultType)
@@ -2091,10 +2117,10 @@ class TranslatedBinaryConditionalExpr extends TranslatedConditionalExpr {
     tag = ValueConditionConditionalBranchTag() and
     (
       kind instanceof TrueEdge and
-      result = getInstruction(ConditionValueTrueTempAddressTag())
+      result = this.getInstruction(ConditionValueTrueTempAddressTag())
       or
       kind instanceof FalseEdge and
-      result = getElse().getFirstInstruction()
+      result = this.getElse().getFirstInstruction()
     )
   }
 
@@ -2103,13 +2129,14 @@ class TranslatedBinaryConditionalExpr extends TranslatedConditionalExpr {
     or
     tag = ValueConditionConditionalBranchTag() and
     operandTag instanceof ConditionOperandTag and
-    result = getCondition().getResult()
+    result = this.getCondition().getResult()
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
     result = super.getChildSuccessor(child)
     or
-    child = getCondition() and result = getInstruction(ValueConditionConditionalBranchTag())
+    child = this.getCondition() and
+    result = this.getInstruction(ValueConditionConditionalBranchTag())
   }
 
   private TranslatedExpr getCondition() {
@@ -2154,10 +2181,10 @@ class TranslatedTemporaryObjectExpr extends TranslatedNonConstantExpr,
   }
 
   final override Instruction getInitializationSuccessor() {
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
-  final override Instruction getResult() { result = getTargetAddress() }
+  final override Instruction getResult() { result = this.getTargetAddress() }
 }
 
 /**
@@ -2168,14 +2195,14 @@ abstract class TranslatedThrowExpr extends TranslatedNonConstantExpr {
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = ThrowTag() and
-    opcode = getThrowOpcode() and
+    opcode = this.getThrowOpcode() and
     resultType = getVoidType()
   }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = ThrowTag() and
     kind instanceof ExceptionEdge and
-    result = getParent().getExceptionSuccessorInstruction()
+    result = this.getParent().getExceptionSuccessorInstruction()
   }
 
   override Instruction getResult() { none() }
@@ -2202,11 +2229,13 @@ class TranslatedThrowValueExpr extends TranslatedThrowExpr, TranslatedVariableIn
     result = TranslatedVariableInitialization.super.getInstructionSuccessor(tag, kind)
   }
 
-  final override Instruction getInitializationSuccessor() { result = getInstruction(ThrowTag()) }
+  final override Instruction getInitializationSuccessor() {
+    result = this.getInstruction(ThrowTag())
+  }
 
   final override predicate hasTempVariable(TempVariableTag tag, CppType type) {
     tag = ThrowTempVar() and
-    type = getTypeForPRValue(getExceptionType())
+    type = getTypeForPRValue(this.getExceptionType())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
@@ -2215,7 +2244,7 @@ class TranslatedThrowValueExpr extends TranslatedThrowExpr, TranslatedVariableIn
     tag = ThrowTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(InitializerVariableAddressTag())
+      result = this.getInstruction(InitializerVariableAddressTag())
     )
   }
 
@@ -2224,10 +2253,10 @@ class TranslatedThrowValueExpr extends TranslatedThrowExpr, TranslatedVariableIn
   ) {
     tag = ThrowTag() and
     operandTag instanceof LoadOperandTag and
-    result = getTypeForPRValue(getExceptionType())
+    result = getTypeForPRValue(this.getExceptionType())
   }
 
-  override Type getTargetType() { result = getExceptionType() }
+  override Type getTargetType() { result = this.getExceptionType() }
 
   final override TranslatedInitialization getInitialization() {
     result = getTranslatedInitialization(expr.getExpr().getFullyConverted())
@@ -2248,7 +2277,7 @@ class TranslatedReThrowExpr extends TranslatedThrowExpr {
 
   override TranslatedElement getChild(int id) { none() }
 
-  override Instruction getFirstInstruction() { result = getInstruction(ThrowTag()) }
+  override Instruction getFirstInstruction() { result = this.getInstruction(ThrowTag()) }
 
   override Instruction getChildSuccessor(TranslatedElement child) { none() }
 
@@ -2271,12 +2300,12 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
     not expr instanceof BuiltInVarArgCopy
   }
 
-  final override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override Instruction getFirstInstruction() {
-    if exists(getChild(0))
-    then result = getChild(0).getFirstInstruction()
-    else result = getInstruction(OnlyInstructionTag())
+    if exists(this.getChild(0))
+    then result = this.getChild(0).getFirstInstruction()
+    else result = this.getInstruction(OnlyInstructionTag())
   }
 
   final override TranslatedElement getChild(int id) {
@@ -2286,31 +2315,31 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
     exists(int id |
-      child = getChild(id) and
+      child = this.getChild(id) and
       (
-        result = getChild(id + 1).getFirstInstruction()
+        result = this.getChild(id + 1).getFirstInstruction()
         or
-        not exists(getChild(id + 1)) and result = getInstruction(OnlyInstructionTag())
+        not exists(this.getChild(id + 1)) and result = this.getInstruction(OnlyInstructionTag())
       )
     )
   }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
-    opcode = getOpcode() and
-    resultType = getResultType()
+    opcode = this.getOpcode() and
+    resultType = this.getResultType()
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     exists(int index |
       operandTag = positionalArgumentOperand(index) and
-      result = getChild(index).(TranslatedExpr).getResult()
+      result = this.getChild(index).(TranslatedExpr).getResult()
     )
   }
 
@@ -2391,12 +2420,12 @@ class TranslatedVarArgsStart extends TranslatedNonConstantExpr {
   }
 
   final override Instruction getFirstInstruction() {
-    result = getInstruction(VarArgsStartEllipsisAddressTag())
+    result = this.getInstruction(VarArgsStartEllipsisAddressTag())
   }
 
   final override Instruction getResult() { none() }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getVAList() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getVAList() }
 
   private TranslatedExpr getVAList() {
     result = getTranslatedExpr(expr.getVAList().getFullyConverted())
@@ -2405,37 +2434,37 @@ class TranslatedVarArgsStart extends TranslatedNonConstantExpr {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = VarArgsStartEllipsisAddressTag() and
     kind instanceof GotoEdge and
-    result = getInstruction(VarArgsStartTag())
+    result = this.getInstruction(VarArgsStartTag())
     or
     tag = VarArgsStartTag() and
     kind instanceof GotoEdge and
-    result = getVAList().getFirstInstruction()
+    result = this.getVAList().getFirstInstruction()
     or
     tag = VarArgsVAListStoreTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getVAList() and
-    result = getInstruction(VarArgsVAListStoreTag())
+    child = this.getVAList() and
+    result = this.getInstruction(VarArgsVAListStoreTag())
   }
 
   final override IRVariable getInstructionVariable(InstructionTag tag) {
     tag = VarArgsStartEllipsisAddressTag() and
-    result = getEnclosingFunction().getEllipsisVariable()
+    result = this.getEnclosingFunction().getEllipsisVariable()
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = VarArgsStartTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getInstruction(VarArgsStartEllipsisAddressTag())
+    result = this.getInstruction(VarArgsStartEllipsisAddressTag())
     or
     tag = VarArgsVAListStoreTag() and
     (
-      operandTag instanceof AddressOperandTag and result = getVAList().getResult()
+      operandTag instanceof AddressOperandTag and result = this.getVAList().getResult()
       or
-      operandTag instanceof StoreValueOperandTag and result = getInstruction(VarArgsStartTag())
+      operandTag instanceof StoreValueOperandTag and result = this.getInstruction(VarArgsStartTag())
     )
   }
 }
@@ -2453,7 +2482,7 @@ class TranslatedVarArg extends TranslatedNonConstantExpr {
     or
     tag = VarArgsArgAddressTag() and
     opcode instanceof Opcode::VarArg and
-    resultType = getResultType()
+    resultType = this.getResultType()
     or
     tag = VarArgsMoveNextTag() and
     opcode instanceof Opcode::NextVarArg and
@@ -2464,11 +2493,13 @@ class TranslatedVarArg extends TranslatedNonConstantExpr {
     resultType = getTypeForPRValue(getVAListType(expr.getVAList().getFullyConverted()))
   }
 
-  final override Instruction getFirstInstruction() { result = getVAList().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getVAList().getFirstInstruction()
+  }
 
-  final override Instruction getResult() { result = getInstruction(VarArgsArgAddressTag()) }
+  final override Instruction getResult() { result = this.getInstruction(VarArgsArgAddressTag()) }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getVAList() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getVAList() }
 
   private TranslatedExpr getVAList() {
     result = getTranslatedExpr(expr.getVAList().getFullyConverted())
@@ -2477,46 +2508,47 @@ class TranslatedVarArg extends TranslatedNonConstantExpr {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = VarArgsVAListLoadTag() and
     kind instanceof GotoEdge and
-    result = getInstruction(VarArgsArgAddressTag())
+    result = this.getInstruction(VarArgsArgAddressTag())
     or
     tag = VarArgsArgAddressTag() and
     kind instanceof GotoEdge and
-    result = getInstruction(VarArgsMoveNextTag())
+    result = this.getInstruction(VarArgsMoveNextTag())
     or
     tag = VarArgsMoveNextTag() and
     kind instanceof GotoEdge and
-    result = getInstruction(VarArgsVAListStoreTag())
+    result = this.getInstruction(VarArgsVAListStoreTag())
     or
     tag = VarArgsVAListStoreTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getVAList() and
-    result = getInstruction(VarArgsVAListLoadTag())
+    child = this.getVAList() and
+    result = this.getInstruction(VarArgsVAListLoadTag())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = VarArgsVAListLoadTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getVAList().getResult()
+      result = this.getVAList().getResult()
     )
     or
     tag = VarArgsArgAddressTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getInstruction(VarArgsVAListLoadTag())
+    result = this.getInstruction(VarArgsVAListLoadTag())
     or
     tag = VarArgsMoveNextTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getInstruction(VarArgsVAListLoadTag())
+    result = this.getInstruction(VarArgsVAListLoadTag())
     or
     tag = VarArgsVAListStoreTag() and
     (
-      operandTag instanceof AddressOperandTag and result = getVAList().getResult()
+      operandTag instanceof AddressOperandTag and result = this.getVAList().getResult()
       or
-      operandTag instanceof StoreValueOperandTag and result = getInstruction(VarArgsMoveNextTag())
+      operandTag instanceof StoreValueOperandTag and
+      result = this.getInstruction(VarArgsMoveNextTag())
     )
   }
 }
@@ -2533,11 +2565,13 @@ class TranslatedVarArgsEnd extends TranslatedNonConstantExpr {
     resultType = getVoidType()
   }
 
-  final override Instruction getFirstInstruction() { result = getVAList().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getVAList().getFirstInstruction()
+  }
 
   final override Instruction getResult() { none() }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getVAList() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getVAList() }
 
   private TranslatedExpr getVAList() {
     result = getTranslatedExpr(expr.getVAList().getFullyConverted())
@@ -2546,18 +2580,18 @@ class TranslatedVarArgsEnd extends TranslatedNonConstantExpr {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getVAList() and
-    result = getInstruction(OnlyInstructionTag())
+    child = this.getVAList() and
+    result = this.getInstruction(OnlyInstructionTag())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getVAList().getResult()
+    result = this.getVAList().getResult()
   }
 }
 
@@ -2578,15 +2612,15 @@ class TranslatedVarArgCopy extends TranslatedNonConstantExpr {
   }
 
   final override Instruction getFirstInstruction() {
-    result = getSourceVAList().getFirstInstruction()
+    result = this.getSourceVAList().getFirstInstruction()
   }
 
-  final override Instruction getResult() { result = getInstruction(VarArgsVAListStoreTag()) }
+  final override Instruction getResult() { result = this.getInstruction(VarArgsVAListStoreTag()) }
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getDestinationVAList()
+    id = 0 and result = this.getDestinationVAList()
     or
-    id = 1 and result = getSourceVAList()
+    id = 1 and result = this.getSourceVAList()
   }
 
   private TranslatedExpr getDestinationVAList() {
@@ -2600,33 +2634,34 @@ class TranslatedVarArgCopy extends TranslatedNonConstantExpr {
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = VarArgsVAListLoadTag() and
     kind instanceof GotoEdge and
-    result = getDestinationVAList().getFirstInstruction()
+    result = this.getDestinationVAList().getFirstInstruction()
     or
     tag = VarArgsVAListStoreTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getSourceVAList() and
-    result = getInstruction(VarArgsVAListLoadTag())
+    child = this.getSourceVAList() and
+    result = this.getInstruction(VarArgsVAListLoadTag())
     or
-    child = getDestinationVAList() and
-    result = getInstruction(VarArgsVAListStoreTag())
+    child = this.getDestinationVAList() and
+    result = this.getInstruction(VarArgsVAListStoreTag())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = VarArgsVAListLoadTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getSourceVAList().getResult()
+      result = this.getSourceVAList().getResult()
     )
     or
     tag = VarArgsVAListStoreTag() and
     (
-      operandTag instanceof AddressOperandTag and result = getDestinationVAList().getResult()
+      operandTag instanceof AddressOperandTag and result = this.getDestinationVAList().getResult()
       or
-      operandTag instanceof StoreValueOperandTag and result = getInstruction(VarArgsVAListLoadTag())
+      operandTag instanceof StoreValueOperandTag and
+      result = this.getInstruction(VarArgsVAListLoadTag())
     )
   }
 }
@@ -2638,44 +2673,46 @@ abstract class TranslatedNewOrNewArrayExpr extends TranslatedNonConstantExpr, In
   override NewOrNewArrayExpr expr;
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getAllocatorCall()
+    id = 0 and result = this.getAllocatorCall()
     or
-    id = 1 and result = getInitialization()
+    id = 1 and result = this.getInitialization()
   }
 
   final override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
     opcode instanceof Opcode::Convert and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
   final override Instruction getFirstInstruction() {
-    result = getAllocatorCall().getFirstInstruction()
+    result = this.getAllocatorCall().getFirstInstruction()
   }
 
-  final override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     kind instanceof GotoEdge and
     tag = OnlyInstructionTag() and
-    if exists(getInitialization())
-    then result = getInitialization().getFirstInstruction()
-    else result = getParent().getChildSuccessor(this)
+    if exists(this.getInitialization())
+    then result = this.getInitialization().getFirstInstruction()
+    else result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getAllocatorCall() and result = getInstruction(OnlyInstructionTag())
+    child = this.getAllocatorCall() and result = this.getInstruction(OnlyInstructionTag())
     or
-    child = getInitialization() and result = getParent().getChildSuccessor(this)
+    child = this.getInitialization() and result = this.getParent().getChildSuccessor(this)
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
-    result = getAllocatorCall().getResult()
+    result = this.getAllocatorCall().getResult()
   }
 
-  final override Instruction getTargetAddress() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getTargetAddress() {
+    result = this.getInstruction(OnlyInstructionTag())
+  }
 
   private TranslatedAllocatorCall getAllocatorCall() { result = getTranslatedAllocatorCall(expr) }
 
@@ -2718,18 +2755,20 @@ class TranslatedNewArrayExpr extends TranslatedNewOrNewArrayExpr {
 class TranslatedDeleteArrayExprPlaceHolder extends TranslatedSingleInstructionExpr {
   override DeleteArrayExpr expr;
 
-  final override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getOperand().getFirstInstruction()
+  }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(OnlyInstructionTag())
+    child = this.getOperand() and result = this.getInstruction(OnlyInstructionTag())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
@@ -2752,18 +2791,20 @@ class TranslatedDeleteArrayExprPlaceHolder extends TranslatedSingleInstructionEx
 class TranslatedDeleteExprPlaceHolder extends TranslatedSingleInstructionExpr {
   override DeleteExpr expr;
 
-  final override Instruction getFirstInstruction() { result = getOperand().getFirstInstruction() }
+  final override Instruction getFirstInstruction() {
+    result = this.getOperand().getFirstInstruction()
+  }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getOperand() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
   final override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getOperand() and result = getInstruction(OnlyInstructionTag())
+    child = this.getOperand() and result = this.getInstruction(OnlyInstructionTag())
   }
 
   final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
@@ -2788,23 +2829,23 @@ class TranslatedDeleteExprPlaceHolder extends TranslatedSingleInstructionExpr {
 class TranslatedConditionDeclExpr extends TranslatedNonConstantExpr {
   override ConditionDeclExpr expr;
 
-  final override Instruction getFirstInstruction() { result = getDecl().getFirstInstruction() }
+  final override Instruction getFirstInstruction() { result = this.getDecl().getFirstInstruction() }
 
   final override TranslatedElement getChild(int id) {
-    id = 0 and result = getDecl()
+    id = 0 and result = this.getDecl()
     or
-    id = 1 and result = getConditionExpr()
+    id = 1 and result = this.getConditionExpr()
   }
 
-  override Instruction getResult() { result = getConditionExpr().getResult() }
+  override Instruction getResult() { result = this.getConditionExpr().getResult() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) { none() }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getDecl() and
-    result = getConditionExpr().getFirstInstruction()
+    child = this.getDecl() and
+    result = this.getConditionExpr().getFirstInstruction()
     or
-    child = getConditionExpr() and result = getParent().getChildSuccessor(this)
+    child = this.getConditionExpr() and result = this.getParent().getChildSuccessor(this)
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -2826,34 +2867,34 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
   override LambdaExpression expr;
 
   final override Instruction getFirstInstruction() {
-    result = getInstruction(InitializerVariableAddressTag())
+    result = this.getInstruction(InitializerVariableAddressTag())
   }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getInitialization() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getInitialization() }
 
-  override Instruction getResult() { result = getInstruction(LoadTag()) }
+  override Instruction getResult() { result = this.getInstruction(LoadTag()) }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = InitializerVariableAddressTag() and
     kind instanceof GotoEdge and
-    result = getInstruction(InitializerStoreTag())
+    result = this.getInstruction(InitializerStoreTag())
     or
     tag = InitializerStoreTag() and
     kind instanceof GotoEdge and
     (
-      result = getInitialization().getFirstInstruction()
+      result = this.getInitialization().getFirstInstruction()
       or
-      not hasInitializer() and result = getInstruction(LoadTag())
+      not this.hasInitializer() and result = this.getInstruction(LoadTag())
     )
     or
     tag = LoadTag() and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getInitialization() and
-    result = getInstruction(LoadTag())
+    child = this.getInitialization() and
+    result = this.getInstruction(LoadTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
@@ -2873,12 +2914,12 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerStoreTag() and
     operandTag instanceof AddressOperandTag and
-    result = getInstruction(InitializerVariableAddressTag())
+    result = this.getInstruction(InitializerVariableAddressTag())
     or
     tag = LoadTag() and
     (
       operandTag instanceof AddressOperandTag and
-      result = getInstruction(InitializerVariableAddressTag())
+      result = this.getInstruction(InitializerVariableAddressTag())
     )
   }
 
@@ -2887,7 +2928,7 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
       tag = InitializerVariableAddressTag() or
       tag = InitializerStoreTag()
     ) and
-    result = getTempVariable(LambdaTempVar())
+    result = this.getTempVariable(LambdaTempVar())
   }
 
   override predicate hasTempVariable(TempVariableTag tag, CppType type) {
@@ -2896,12 +2937,12 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
   }
 
   final override Instruction getTargetAddress() {
-    result = getInstruction(InitializerVariableAddressTag())
+    result = this.getInstruction(InitializerVariableAddressTag())
   }
 
   final override Type getTargetType() { result = expr.getType() }
 
-  private predicate hasInitializer() { exists(getInitialization()) }
+  private predicate hasInitializer() { exists(this.getInitialization()) }
 
   private TranslatedInitialization getInitialization() {
     result = getTranslatedInitialization(expr.getChild(0).getFullyConverted())
@@ -2915,28 +2956,28 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
 class TranslatedStmtExpr extends TranslatedNonConstantExpr {
   override StmtExpr expr;
 
-  final override Instruction getFirstInstruction() { result = getStmt().getFirstInstruction() }
+  final override Instruction getFirstInstruction() { result = this.getStmt().getFirstInstruction() }
 
-  final override TranslatedElement getChild(int id) { id = 0 and result = getStmt() }
+  final override TranslatedElement getChild(int id) { id = 0 and result = this.getStmt() }
 
   override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag instanceof OnlyInstructionTag and
     kind instanceof GotoEdge and
-    result = getParent().getChildSuccessor(this)
+    result = this.getParent().getChildSuccessor(this)
   }
 
   override Instruction getChildSuccessor(TranslatedElement child) {
-    child = getStmt() and
-    result = getInstruction(OnlyInstructionTag())
+    child = this.getStmt() and
+    result = this.getInstruction(OnlyInstructionTag())
   }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     opcode instanceof Opcode::CopyValue and
     tag instanceof OnlyInstructionTag and
-    resultType = getResultType()
+    resultType = this.getResultType()
   }
 
-  override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
+  override Instruction getResult() { result = this.getInstruction(OnlyInstructionTag()) }
 
   override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag instanceof OnlyInstructionTag and
@@ -2950,13 +2991,15 @@ class TranslatedStmtExpr extends TranslatedNonConstantExpr {
 class TranslatedErrorExpr extends TranslatedSingleInstructionExpr {
   override ErrorExpr expr;
 
-  final override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getFirstInstruction() {
+    result = this.getInstruction(OnlyInstructionTag())
+  }
 
   final override TranslatedElement getChild(int id) { none() }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 
@@ -3034,13 +3077,15 @@ class TranslatedAssumeExpr extends TranslatedSingleInstructionExpr {
 
   final override Opcode getOpcode() { result instanceof Opcode::NoOp }
 
-  final override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
+  final override Instruction getFirstInstruction() {
+    result = this.getInstruction(OnlyInstructionTag())
+  }
 
   final override TranslatedElement getChild(int id) { none() }
 
   final override Instruction getInstructionSuccessor(InstructionTag tag, EdgeKind kind) {
     tag = OnlyInstructionTag() and
-    result = getParent().getChildSuccessor(this) and
+    result = this.getParent().getChildSuccessor(this) and
     kind instanceof GotoEdge
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -24,7 +24,7 @@ class IRBlockBase extends TIRBlock {
   final string toString() { result = getFirstInstruction(this).toString() }
 
   /** Gets the source location of the first non-`Phi` instruction in this block. */
-  final Language::Location getLocation() { result = getFirstInstruction().getLocation() }
+  final Language::Location getLocation() { result = this.getFirstInstruction().getLocation() }
 
   /**
    * INTERNAL: Do not use.
@@ -39,7 +39,7 @@ class IRBlockBase extends TIRBlock {
     ) and
     this =
       rank[result + 1](IRBlock funcBlock, int sortOverride, int sortKey1, int sortKey2 |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        funcBlock.getEnclosingFunction() = this.getEnclosingFunction() and
         funcBlock.getFirstInstruction().hasSortKeys(sortKey1, sortKey2) and
         // Ensure that the block containing `EnterFunction` always comes first.
         if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
@@ -59,15 +59,15 @@ class IRBlockBase extends TIRBlock {
    * Get the `Phi` instructions that appear at the start of this block.
    */
   final PhiInstruction getAPhiInstruction() {
-    Construction::getPhiInstructionBlockStart(result) = getFirstInstruction()
+    Construction::getPhiInstructionBlockStart(result) = this.getFirstInstruction()
   }
 
   /**
    * Gets an instruction in this block. This includes `Phi` instructions.
    */
   final Instruction getAnInstruction() {
-    result = getInstruction(_) or
-    result = getAPhiInstruction()
+    result = this.getInstruction(_) or
+    result = this.getAPhiInstruction()
   }
 
   /**
@@ -78,7 +78,9 @@ class IRBlockBase extends TIRBlock {
   /**
    * Gets the last instruction in this block.
    */
-  final Instruction getLastInstruction() { result = getInstruction(getInstructionCount() - 1) }
+  final Instruction getLastInstruction() {
+    result = this.getInstruction(this.getInstructionCount() - 1)
+  }
 
   /**
    * Gets the number of non-`Phi` instructions in this block.
@@ -149,7 +151,7 @@ class IRBlock extends IRBlockBase {
    * Block `A` dominates block `B` if any control flow path from the entry block of the function to
    * block `B` must pass through block `A`. A block always dominates itself.
    */
-  final predicate dominates(IRBlock block) { strictlyDominates(block) or this = block }
+  final predicate dominates(IRBlock block) { this.strictlyDominates(block) or this = block }
 
   /**
    * Gets a block on the dominance frontier of this block.
@@ -159,8 +161,8 @@ class IRBlock extends IRBlockBase {
    */
   pragma[noinline]
   final IRBlock dominanceFrontier() {
-    dominates(result.getAPredecessor()) and
-    not strictlyDominates(result)
+    this.dominates(result.getAPredecessor()) and
+    not this.strictlyDominates(result)
   }
 
   /**
@@ -189,7 +191,7 @@ class IRBlock extends IRBlockBase {
    * Block `A` post-dominates block `B` if any control flow path from `B` to the exit block of the
    * function must pass through block `A`. A block always post-dominates itself.
    */
-  final predicate postDominates(IRBlock block) { strictlyPostDominates(block) or this = block }
+  final predicate postDominates(IRBlock block) { this.strictlyPostDominates(block) or this = block }
 
   /**
    * Gets a block on the post-dominance frontier of this block.
@@ -199,16 +201,16 @@ class IRBlock extends IRBlockBase {
    */
   pragma[noinline]
   final IRBlock postPominanceFrontier() {
-    postDominates(result.getASuccessor()) and
-    not strictlyPostDominates(result)
+    this.postDominates(result.getASuccessor()) and
+    not this.strictlyPostDominates(result)
   }
 
   /**
    * Holds if this block is reachable from the entry block of its function.
    */
   final predicate isReachableFromFunctionEntry() {
-    this = getEnclosingIRFunction().getEntryBlock() or
-    getAPredecessor().isReachableFromFunctionEntry()
+    this = this.getEnclosingIRFunction().getEntryBlock() or
+    this.getAPredecessor().isReachableFromFunctionEntry()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -41,7 +41,7 @@ class Instruction extends Construction::TStageInstruction {
   }
 
   /** Gets a textual representation of this element. */
-  final string toString() { result = getOpcode().toString() + ": " + getAST().toString() }
+  final string toString() { result = this.getOpcode().toString() + ": " + this.getAST().toString() }
 
   /**
    * Gets a string showing the result, opcode, and operands of the instruction, equivalent to what
@@ -50,7 +50,8 @@ class Instruction extends Construction::TStageInstruction {
    * `mu0_28(int) = Store r0_26, r0_27`
    */
   final string getDumpString() {
-    result = getResultString() + " = " + getOperationString() + " " + getOperandsString()
+    result =
+      this.getResultString() + " = " + this.getOperationString() + " " + this.getOperandsString()
   }
 
   private predicate shouldGenerateDumpStrings() {
@@ -66,10 +67,13 @@ class Instruction extends Construction::TStageInstruction {
    * VariableAddress[x]
    */
   final string getOperationString() {
-    shouldGenerateDumpStrings() and
-    if exists(getImmediateString())
-    then result = getOperationPrefix() + getOpcode().toString() + "[" + getImmediateString() + "]"
-    else result = getOperationPrefix() + getOpcode().toString()
+    this.shouldGenerateDumpStrings() and
+    if exists(this.getImmediateString())
+    then
+      result =
+        this.getOperationPrefix() + this.getOpcode().toString() + "[" + this.getImmediateString() +
+          "]"
+    else result = this.getOperationPrefix() + this.getOpcode().toString()
   }
 
   /**
@@ -78,17 +82,17 @@ class Instruction extends Construction::TStageInstruction {
   string getImmediateString() { none() }
 
   private string getOperationPrefix() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     if this instanceof SideEffectInstruction then result = "^" else result = ""
   }
 
   private string getResultPrefix() {
-    shouldGenerateDumpStrings() and
-    if getResultIRType() instanceof IRVoidType
+    this.shouldGenerateDumpStrings() and
+    if this.getResultIRType() instanceof IRVoidType
     then result = "v"
     else
-      if hasMemoryResult()
-      then if isResultModeled() then result = "m" else result = "mu"
+      if this.hasMemoryResult()
+      then if this.isResultModeled() then result = "m" else result = "mu"
       else result = "r"
   }
 
@@ -97,7 +101,7 @@ class Instruction extends Construction::TStageInstruction {
    * used by debugging and printing code only.
    */
   int getDisplayIndexInBlock() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     exists(IRBlock block |
       this = block.getInstruction(result)
       or
@@ -111,12 +115,12 @@ class Instruction extends Construction::TStageInstruction {
   }
 
   private int getLineRank() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     this =
       rank[result](Instruction instr |
         instr =
-          getAnInstructionAtLine(getEnclosingIRFunction(), getLocation().getFile(),
-            getLocation().getStartLine())
+          getAnInstructionAtLine(this.getEnclosingIRFunction(), this.getLocation().getFile(),
+            this.getLocation().getStartLine())
       |
         instr order by instr.getBlock().getDisplayIndex(), instr.getDisplayIndexInBlock()
       )
@@ -130,8 +134,9 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `r1_1`
    */
   string getResultId() {
-    shouldGenerateDumpStrings() and
-    result = getResultPrefix() + getAST().getLocation().getStartLine() + "_" + getLineRank()
+    this.shouldGenerateDumpStrings() and
+    result =
+      this.getResultPrefix() + this.getAST().getLocation().getStartLine() + "_" + this.getLineRank()
   }
 
   /**
@@ -142,8 +147,8 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `r1_1(int*)`
    */
   final string getResultString() {
-    shouldGenerateDumpStrings() and
-    result = getResultId() + "(" + getResultLanguageType().getDumpString() + ")"
+    this.shouldGenerateDumpStrings() and
+    result = this.getResultId() + "(" + this.getResultLanguageType().getDumpString() + ")"
   }
 
   /**
@@ -153,10 +158,10 @@ class Instruction extends Construction::TStageInstruction {
    * Example: `func:r3_4, this:r3_5`
    */
   string getOperandsString() {
-    shouldGenerateDumpStrings() and
+    this.shouldGenerateDumpStrings() and
     result =
       concat(Operand operand |
-        operand = getAnOperand()
+        operand = this.getAnOperand()
       |
         operand.getDumpString(), ", " order by operand.getDumpSortOrder()
       )
@@ -190,7 +195,7 @@ class Instruction extends Construction::TStageInstruction {
    * Gets the function that contains this instruction.
    */
   final Language::Function getEnclosingFunction() {
-    result = getEnclosingIRFunction().getFunction()
+    result = this.getEnclosingIRFunction().getFunction()
   }
 
   /**
@@ -208,7 +213,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets the location of the source code for this instruction.
    */
-  final Language::Location getLocation() { result = getAST().getLocation() }
+  final Language::Location getLocation() { result = this.getAST().getLocation() }
 
   /**
    * Gets the  `Expr` whose result is computed by this instruction, if any. The `Expr` may be a
@@ -243,7 +248,7 @@ class Instruction extends Construction::TStageInstruction {
    * a result, its result type will be `IRVoidType`.
    */
   cached
-  final IRType getResultIRType() { result = getResultLanguageType().getIRType() }
+  final IRType getResultIRType() { result = this.getResultLanguageType().getIRType() }
 
   /**
    * Gets the type of the result produced by this instruction. If the
@@ -254,7 +259,7 @@ class Instruction extends Construction::TStageInstruction {
    */
   final Language::Type getResultType() {
     exists(Language::LanguageType resultType |
-      resultType = getResultLanguageType() and
+      resultType = this.getResultLanguageType() and
       (
         resultType.hasUnspecifiedType(result, _)
         or
@@ -283,7 +288,7 @@ class Instruction extends Construction::TStageInstruction {
    * result of the `Load` instruction is a prvalue of type `int`, representing
    * the integer value loaded from variable `x`.
    */
-  final predicate isGLValue() { getResultLanguageType().hasType(_, true) }
+  final predicate isGLValue() { this.getResultLanguageType().hasType(_, true) }
 
   /**
    * Gets the size of the result produced by this instruction, in bytes. If the
@@ -292,7 +297,7 @@ class Instruction extends Construction::TStageInstruction {
    * If `this.isGLValue()` holds for this instruction, the value of
    * `getResultSize()` will always be the size of a pointer.
    */
-  final int getResultSize() { result = getResultLanguageType().getByteSize() }
+  final int getResultSize() { result = this.getResultLanguageType().getByteSize() }
 
   /**
    * Gets the opcode that specifies the operation performed by this instruction.
@@ -314,14 +319,16 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Holds if this instruction produces a memory result.
    */
-  final predicate hasMemoryResult() { exists(getResultMemoryAccess()) }
+  final predicate hasMemoryResult() { exists(this.getResultMemoryAccess()) }
 
   /**
    * Gets the kind of memory access performed by this instruction's result.
    * Holds only for instructions with a memory result.
    */
   pragma[inline]
-  final MemoryAccessKind getResultMemoryAccess() { result = getOpcode().getWriteMemoryAccess() }
+  final MemoryAccessKind getResultMemoryAccess() {
+    result = this.getOpcode().getWriteMemoryAccess()
+  }
 
   /**
    * Holds if the memory access performed by this instruction's result will not always write to
@@ -332,7 +339,7 @@ class Instruction extends Construction::TStageInstruction {
    * (for example, the global side effects of a function call).
    */
   pragma[inline]
-  final predicate hasResultMayMemoryAccess() { getOpcode().hasMayWriteMemoryAccess() }
+  final predicate hasResultMayMemoryAccess() { this.getOpcode().hasMayWriteMemoryAccess() }
 
   /**
    * Gets the operand that holds the memory address to which this instruction stores its
@@ -340,7 +347,7 @@ class Instruction extends Construction::TStageInstruction {
    * is `r1`.
    */
   final AddressOperand getResultAddressOperand() {
-    getResultMemoryAccess().usesAddressOperand() and
+    this.getResultMemoryAccess().usesAddressOperand() and
     result.getUse() = this
   }
 
@@ -349,7 +356,7 @@ class Instruction extends Construction::TStageInstruction {
    * result, if any. For example, in `m3 = Store r1, r2`, the result of `getResultAddressOperand()`
    * is the instruction that defines `r1`.
    */
-  final Instruction getResultAddress() { result = getResultAddressOperand().getDef() }
+  final Instruction getResultAddress() { result = this.getResultAddressOperand().getDef() }
 
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
@@ -368,7 +375,7 @@ class Instruction extends Construction::TStageInstruction {
    */
   final predicate isResultModeled() {
     // Register results are always in SSA form.
-    not hasMemoryResult() or
+    not this.hasMemoryResult() or
     Construction::hasModeledMemoryResult(this)
   }
 
@@ -412,7 +419,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets all direct successors of this instruction.
    */
-  final Instruction getASuccessor() { result = getSuccessor(_) }
+  final Instruction getASuccessor() { result = this.getSuccessor(_) }
 
   /**
    * Gets a predecessor of this instruction such that the predecessor reaches
@@ -423,7 +430,7 @@ class Instruction extends Construction::TStageInstruction {
   /**
    * Gets all direct predecessors of this instruction.
    */
-  final Instruction getAPredecessor() { result = getPredecessor(_) }
+  final Instruction getAPredecessor() { result = this.getPredecessor(_) }
 }
 
 /**
@@ -543,7 +550,7 @@ class IndexedInstruction extends Instruction {
  * at this instruction. This instruction has no predecessors.
  */
 class EnterFunctionInstruction extends Instruction {
-  EnterFunctionInstruction() { getOpcode() instanceof Opcode::EnterFunction }
+  EnterFunctionInstruction() { this.getOpcode() instanceof Opcode::EnterFunction }
 }
 
 /**
@@ -554,7 +561,7 @@ class EnterFunctionInstruction extends Instruction {
  * struct, or union, see `FieldAddressInstruction`.
  */
 class VariableAddressInstruction extends VariableInstruction {
-  VariableAddressInstruction() { getOpcode() instanceof Opcode::VariableAddress }
+  VariableAddressInstruction() { this.getOpcode() instanceof Opcode::VariableAddress }
 }
 
 /**
@@ -566,7 +573,7 @@ class VariableAddressInstruction extends VariableInstruction {
  * The result has an `IRFunctionAddress` type.
  */
 class FunctionAddressInstruction extends FunctionInstruction {
-  FunctionAddressInstruction() { getOpcode() instanceof Opcode::FunctionAddress }
+  FunctionAddressInstruction() { this.getOpcode() instanceof Opcode::FunctionAddress }
 }
 
 /**
@@ -577,7 +584,7 @@ class FunctionAddressInstruction extends FunctionInstruction {
  * initializes that parameter.
  */
 class InitializeParameterInstruction extends VariableInstruction {
-  InitializeParameterInstruction() { getOpcode() instanceof Opcode::InitializeParameter }
+  InitializeParameterInstruction() { this.getOpcode() instanceof Opcode::InitializeParameter }
 
   /**
    * Gets the parameter initialized by this instruction.
@@ -603,7 +610,7 @@ class InitializeParameterInstruction extends VariableInstruction {
  * initialized elsewhere, would not otherwise have a definition in this function.
  */
 class InitializeNonLocalInstruction extends Instruction {
-  InitializeNonLocalInstruction() { getOpcode() instanceof Opcode::InitializeNonLocal }
+  InitializeNonLocalInstruction() { this.getOpcode() instanceof Opcode::InitializeNonLocal }
 }
 
 /**
@@ -611,7 +618,7 @@ class InitializeNonLocalInstruction extends Instruction {
  * with the value of that memory on entry to the function.
  */
 class InitializeIndirectionInstruction extends VariableInstruction {
-  InitializeIndirectionInstruction() { getOpcode() instanceof Opcode::InitializeIndirection }
+  InitializeIndirectionInstruction() { this.getOpcode() instanceof Opcode::InitializeIndirection }
 
   /**
    * Gets the parameter initialized by this instruction.
@@ -635,24 +642,24 @@ class InitializeIndirectionInstruction extends VariableInstruction {
  * An instruction that initializes the `this` pointer parameter of the enclosing function.
  */
 class InitializeThisInstruction extends Instruction {
-  InitializeThisInstruction() { getOpcode() instanceof Opcode::InitializeThis }
+  InitializeThisInstruction() { this.getOpcode() instanceof Opcode::InitializeThis }
 }
 
 /**
  * An instruction that computes the address of a non-static field of an object.
  */
 class FieldAddressInstruction extends FieldInstruction {
-  FieldAddressInstruction() { getOpcode() instanceof Opcode::FieldAddress }
+  FieldAddressInstruction() { this.getOpcode() instanceof Opcode::FieldAddress }
 
   /**
    * Gets the operand that provides the address of the object containing the field.
    */
-  final UnaryOperand getObjectAddressOperand() { result = getAnOperand() }
+  final UnaryOperand getObjectAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the object containing the field.
    */
-  final Instruction getObjectAddress() { result = getObjectAddressOperand().getDef() }
+  final Instruction getObjectAddress() { result = this.getObjectAddressOperand().getDef() }
 }
 
 /**
@@ -661,17 +668,19 @@ class FieldAddressInstruction extends FieldInstruction {
  * This instruction is used for element access to C# arrays.
  */
 class ElementsAddressInstruction extends UnaryInstruction {
-  ElementsAddressInstruction() { getOpcode() instanceof Opcode::ElementsAddress }
+  ElementsAddressInstruction() { this.getOpcode() instanceof Opcode::ElementsAddress }
 
   /**
    * Gets the operand that provides the address of the array object.
    */
-  final UnaryOperand getArrayObjectAddressOperand() { result = getAnOperand() }
+  final UnaryOperand getArrayObjectAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the array object.
    */
-  final Instruction getArrayObjectAddress() { result = getArrayObjectAddressOperand().getDef() }
+  final Instruction getArrayObjectAddress() {
+    result = this.getArrayObjectAddressOperand().getDef()
+  }
 }
 
 /**
@@ -685,7 +694,7 @@ class ElementsAddressInstruction extends UnaryInstruction {
  * taken may want to ignore any function that contains an `ErrorInstruction`.
  */
 class ErrorInstruction extends Instruction {
-  ErrorInstruction() { getOpcode() instanceof Opcode::Error }
+  ErrorInstruction() { this.getOpcode() instanceof Opcode::Error }
 }
 
 /**
@@ -695,7 +704,7 @@ class ErrorInstruction extends Instruction {
  * an initializer, or whose initializer only partially initializes the variable.
  */
 class UninitializedInstruction extends VariableInstruction {
-  UninitializedInstruction() { getOpcode() instanceof Opcode::Uninitialized }
+  UninitializedInstruction() { this.getOpcode() instanceof Opcode::Uninitialized }
 
   /**
    * Gets the variable that is uninitialized.
@@ -710,7 +719,7 @@ class UninitializedInstruction extends VariableInstruction {
  * least one instruction, even when the AST has no semantic effect.
  */
 class NoOpInstruction extends Instruction {
-  NoOpInstruction() { getOpcode() instanceof Opcode::NoOp }
+  NoOpInstruction() { this.getOpcode() instanceof Opcode::NoOp }
 }
 
 /**
@@ -732,32 +741,32 @@ class NoOpInstruction extends Instruction {
  * `void`-returning function.
  */
 class ReturnInstruction extends Instruction {
-  ReturnInstruction() { getOpcode() instanceof ReturnOpcode }
+  ReturnInstruction() { this.getOpcode() instanceof ReturnOpcode }
 }
 
 /**
  * An instruction that returns control to the caller of the function, without returning a value.
  */
 class ReturnVoidInstruction extends ReturnInstruction {
-  ReturnVoidInstruction() { getOpcode() instanceof Opcode::ReturnVoid }
+  ReturnVoidInstruction() { this.getOpcode() instanceof Opcode::ReturnVoid }
 }
 
 /**
  * An instruction that returns control to the caller of the function, including a return value.
  */
 class ReturnValueInstruction extends ReturnInstruction {
-  ReturnValueInstruction() { getOpcode() instanceof Opcode::ReturnValue }
+  ReturnValueInstruction() { this.getOpcode() instanceof Opcode::ReturnValue }
 
   /**
    * Gets the operand that provides the value being returned by the function.
    */
-  final LoadOperand getReturnValueOperand() { result = getAnOperand() }
+  final LoadOperand getReturnValueOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value being returned by the function, if an
    * exact definition is available.
    */
-  final Instruction getReturnValue() { result = getReturnValueOperand().getDef() }
+  final Instruction getReturnValue() { result = this.getReturnValueOperand().getDef() }
 }
 
 /**
@@ -770,28 +779,28 @@ class ReturnValueInstruction extends ReturnInstruction {
  * that the caller initialized the memory pointed to by the parameter before the call.
  */
 class ReturnIndirectionInstruction extends VariableInstruction {
-  ReturnIndirectionInstruction() { getOpcode() instanceof Opcode::ReturnIndirection }
+  ReturnIndirectionInstruction() { this.getOpcode() instanceof Opcode::ReturnIndirection }
 
   /**
    * Gets the operand that provides the value of the pointed-to memory.
    */
-  final SideEffectOperand getSideEffectOperand() { result = getAnOperand() }
+  final SideEffectOperand getSideEffectOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value of the pointed-to memory, if an exact
    * definition is available.
    */
-  final Instruction getSideEffect() { result = getSideEffectOperand().getDef() }
+  final Instruction getSideEffect() { result = this.getSideEffectOperand().getDef() }
 
   /**
    * Gets the operand that provides the address of the pointed-to memory.
    */
-  final AddressOperand getSourceAddressOperand() { result = getAnOperand() }
+  final AddressOperand getSourceAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the pointed-to memory.
    */
-  final Instruction getSourceAddress() { result = getSourceAddressOperand().getDef() }
+  final Instruction getSourceAddress() { result = this.getSourceAddressOperand().getDef() }
 
   /**
    * Gets the parameter for which this instruction reads the final pointed-to value within the
@@ -826,7 +835,7 @@ class ReturnIndirectionInstruction extends VariableInstruction {
  * - `StoreInstruction` - Copies a register operand to a memory result.
  */
 class CopyInstruction extends Instruction {
-  CopyInstruction() { getOpcode() instanceof CopyOpcode }
+  CopyInstruction() { this.getOpcode() instanceof CopyOpcode }
 
   /**
    * Gets the operand that provides the input value of the copy.
@@ -837,16 +846,16 @@ class CopyInstruction extends Instruction {
    * Gets the instruction whose result provides the input value of the copy, if an exact definition
    * is available.
    */
-  final Instruction getSourceValue() { result = getSourceValueOperand().getDef() }
+  final Instruction getSourceValue() { result = this.getSourceValueOperand().getDef() }
 }
 
 /**
  * An instruction that returns a register result containing a copy of its register operand.
  */
 class CopyValueInstruction extends CopyInstruction, UnaryInstruction {
-  CopyValueInstruction() { getOpcode() instanceof Opcode::CopyValue }
+  CopyValueInstruction() { this.getOpcode() instanceof Opcode::CopyValue }
 
-  final override UnaryOperand getSourceValueOperand() { result = getAnOperand() }
+  final override UnaryOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
@@ -863,47 +872,49 @@ private string getAddressOperandDescription(AddressOperand operand) {
  * An instruction that returns a register result containing a copy of its memory operand.
  */
 class LoadInstruction extends CopyInstruction {
-  LoadInstruction() { getOpcode() instanceof Opcode::Load }
+  LoadInstruction() { this.getOpcode() instanceof Opcode::Load }
 
   final override string getImmediateString() {
-    result = getAddressOperandDescription(getSourceAddressOperand())
+    result = getAddressOperandDescription(this.getSourceAddressOperand())
   }
 
   /**
    * Gets the operand that provides the address of the value being loaded.
    */
-  final AddressOperand getSourceAddressOperand() { result = getAnOperand() }
+  final AddressOperand getSourceAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the value being loaded.
    */
-  final Instruction getSourceAddress() { result = getSourceAddressOperand().getDef() }
+  final Instruction getSourceAddress() { result = this.getSourceAddressOperand().getDef() }
 
-  final override LoadOperand getSourceValueOperand() { result = getAnOperand() }
+  final override LoadOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
  * An instruction that returns a memory result containing a copy of its register operand.
  */
 class StoreInstruction extends CopyInstruction {
-  StoreInstruction() { getOpcode() instanceof Opcode::Store }
+  StoreInstruction() { this.getOpcode() instanceof Opcode::Store }
 
   final override string getImmediateString() {
-    result = getAddressOperandDescription(getDestinationAddressOperand())
+    result = getAddressOperandDescription(this.getDestinationAddressOperand())
   }
 
   /**
    * Gets the operand that provides the address of the location to which the value will be stored.
    */
-  final AddressOperand getDestinationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getDestinationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the location to which the value will
    * be stored, if an exact definition is available.
    */
-  final Instruction getDestinationAddress() { result = getDestinationAddressOperand().getDef() }
+  final Instruction getDestinationAddress() {
+    result = this.getDestinationAddressOperand().getDef()
+  }
 
-  final override StoreValueOperand getSourceValueOperand() { result = getAnOperand() }
+  final override StoreValueOperand getSourceValueOperand() { result = this.getAnOperand() }
 }
 
 /**
@@ -911,27 +922,27 @@ class StoreInstruction extends CopyInstruction {
  * operand.
  */
 class ConditionalBranchInstruction extends Instruction {
-  ConditionalBranchInstruction() { getOpcode() instanceof Opcode::ConditionalBranch }
+  ConditionalBranchInstruction() { this.getOpcode() instanceof Opcode::ConditionalBranch }
 
   /**
    * Gets the operand that provides the Boolean condition controlling the branch.
    */
-  final ConditionOperand getConditionOperand() { result = getAnOperand() }
+  final ConditionOperand getConditionOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the Boolean condition controlling the branch.
    */
-  final Instruction getCondition() { result = getConditionOperand().getDef() }
+  final Instruction getCondition() { result = this.getConditionOperand().getDef() }
 
   /**
    * Gets the instruction to which control will flow if the condition is true.
    */
-  final Instruction getTrueSuccessor() { result = getSuccessor(EdgeKind::trueEdge()) }
+  final Instruction getTrueSuccessor() { result = this.getSuccessor(EdgeKind::trueEdge()) }
 
   /**
    * Gets the instruction to which control will flow if the condition is false.
    */
-  final Instruction getFalseSuccessor() { result = getSuccessor(EdgeKind::falseEdge()) }
+  final Instruction getFalseSuccessor() { result = this.getSuccessor(EdgeKind::falseEdge()) }
 }
 
 /**
@@ -943,14 +954,14 @@ class ConditionalBranchInstruction extends Instruction {
  * successors.
  */
 class ExitFunctionInstruction extends Instruction {
-  ExitFunctionInstruction() { getOpcode() instanceof Opcode::ExitFunction }
+  ExitFunctionInstruction() { this.getOpcode() instanceof Opcode::ExitFunction }
 }
 
 /**
  * An instruction whose result is a constant value.
  */
 class ConstantInstruction extends ConstantValueInstruction {
-  ConstantInstruction() { getOpcode() instanceof Opcode::Constant }
+  ConstantInstruction() { this.getOpcode() instanceof Opcode::Constant }
 }
 
 /**
@@ -959,7 +970,7 @@ class ConstantInstruction extends ConstantValueInstruction {
 class IntegerConstantInstruction extends ConstantInstruction {
   IntegerConstantInstruction() {
     exists(IRType resultType |
-      resultType = getResultIRType() and
+      resultType = this.getResultIRType() and
       (resultType instanceof IRIntegerType or resultType instanceof IRBooleanType)
     )
   }
@@ -969,7 +980,7 @@ class IntegerConstantInstruction extends ConstantInstruction {
  * An instruction whose result is a constant value of floating-point type.
  */
 class FloatConstantInstruction extends ConstantInstruction {
-  FloatConstantInstruction() { getResultIRType() instanceof IRFloatingPointType }
+  FloatConstantInstruction() { this.getResultIRType() instanceof IRFloatingPointType }
 }
 
 /**
@@ -978,7 +989,9 @@ class FloatConstantInstruction extends ConstantInstruction {
 class StringConstantInstruction extends VariableInstruction {
   override IRStringLiteral var;
 
-  final override string getImmediateString() { result = Language::getStringLiteralText(getValue()) }
+  final override string getImmediateString() {
+    result = Language::getStringLiteralText(this.getValue())
+  }
 
   /**
    * Gets the string literal whose address is returned by this instruction.
@@ -990,37 +1003,37 @@ class StringConstantInstruction extends VariableInstruction {
  * An instruction whose result is computed from two operands.
  */
 class BinaryInstruction extends Instruction {
-  BinaryInstruction() { getOpcode() instanceof BinaryOpcode }
+  BinaryInstruction() { this.getOpcode() instanceof BinaryOpcode }
 
   /**
    * Gets the left operand of this binary instruction.
    */
-  final LeftOperand getLeftOperand() { result = getAnOperand() }
+  final LeftOperand getLeftOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the right operand of this binary instruction.
    */
-  final RightOperand getRightOperand() { result = getAnOperand() }
+  final RightOperand getRightOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the value of the left operand of this binary
    * instruction.
    */
-  final Instruction getLeft() { result = getLeftOperand().getDef() }
+  final Instruction getLeft() { result = this.getLeftOperand().getDef() }
 
   /**
    * Gets the instruction whose result provides the value of the right operand of this binary
    * instruction.
    */
-  final Instruction getRight() { result = getRightOperand().getDef() }
+  final Instruction getRight() { result = this.getRightOperand().getDef() }
 
   /**
    * Holds if this instruction's operands are `op1` and `op2`, in either order.
    */
   final predicate hasOperands(Operand op1, Operand op2) {
-    op1 = getLeftOperand() and op2 = getRightOperand()
+    op1 = this.getLeftOperand() and op2 = this.getRightOperand()
     or
-    op1 = getRightOperand() and op2 = getLeftOperand()
+    op1 = this.getRightOperand() and op2 = this.getLeftOperand()
   }
 }
 
@@ -1028,7 +1041,7 @@ class BinaryInstruction extends Instruction {
  * An instruction that computes the result of an arithmetic operation.
  */
 class ArithmeticInstruction extends Instruction {
-  ArithmeticInstruction() { getOpcode() instanceof ArithmeticOpcode }
+  ArithmeticInstruction() { this.getOpcode() instanceof ArithmeticOpcode }
 }
 
 /**
@@ -1050,7 +1063,7 @@ class UnaryArithmeticInstruction extends ArithmeticInstruction, UnaryInstruction
  * performed according to IEEE-754.
  */
 class AddInstruction extends BinaryArithmeticInstruction {
-  AddInstruction() { getOpcode() instanceof Opcode::Add }
+  AddInstruction() { this.getOpcode() instanceof Opcode::Add }
 }
 
 /**
@@ -1061,7 +1074,7 @@ class AddInstruction extends BinaryArithmeticInstruction {
  * according to IEEE-754.
  */
 class SubInstruction extends BinaryArithmeticInstruction {
-  SubInstruction() { getOpcode() instanceof Opcode::Sub }
+  SubInstruction() { this.getOpcode() instanceof Opcode::Sub }
 }
 
 /**
@@ -1072,7 +1085,7 @@ class SubInstruction extends BinaryArithmeticInstruction {
  * performed according to IEEE-754.
  */
 class MulInstruction extends BinaryArithmeticInstruction {
-  MulInstruction() { getOpcode() instanceof Opcode::Mul }
+  MulInstruction() { this.getOpcode() instanceof Opcode::Mul }
 }
 
 /**
@@ -1083,7 +1096,7 @@ class MulInstruction extends BinaryArithmeticInstruction {
  * to IEEE-754.
  */
 class DivInstruction extends BinaryArithmeticInstruction {
-  DivInstruction() { getOpcode() instanceof Opcode::Div }
+  DivInstruction() { this.getOpcode() instanceof Opcode::Div }
 }
 
 /**
@@ -1093,7 +1106,7 @@ class DivInstruction extends BinaryArithmeticInstruction {
  * division by zero or integer overflow is undefined.
  */
 class RemInstruction extends BinaryArithmeticInstruction {
-  RemInstruction() { getOpcode() instanceof Opcode::Rem }
+  RemInstruction() { this.getOpcode() instanceof Opcode::Rem }
 }
 
 /**
@@ -1104,14 +1117,14 @@ class RemInstruction extends BinaryArithmeticInstruction {
  * is performed according to IEEE-754.
  */
 class NegateInstruction extends UnaryArithmeticInstruction {
-  NegateInstruction() { getOpcode() instanceof Opcode::Negate }
+  NegateInstruction() { this.getOpcode() instanceof Opcode::Negate }
 }
 
 /**
  * An instruction that computes the result of a bitwise operation.
  */
 class BitwiseInstruction extends Instruction {
-  BitwiseInstruction() { getOpcode() instanceof BitwiseOpcode }
+  BitwiseInstruction() { this.getOpcode() instanceof BitwiseOpcode }
 }
 
 /**
@@ -1130,7 +1143,7 @@ class UnaryBitwiseInstruction extends BitwiseInstruction, UnaryInstruction { }
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitAndInstruction extends BinaryBitwiseInstruction {
-  BitAndInstruction() { getOpcode() instanceof Opcode::BitAnd }
+  BitAndInstruction() { this.getOpcode() instanceof Opcode::BitAnd }
 }
 
 /**
@@ -1139,7 +1152,7 @@ class BitAndInstruction extends BinaryBitwiseInstruction {
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitOrInstruction extends BinaryBitwiseInstruction {
-  BitOrInstruction() { getOpcode() instanceof Opcode::BitOr }
+  BitOrInstruction() { this.getOpcode() instanceof Opcode::BitOr }
 }
 
 /**
@@ -1148,7 +1161,7 @@ class BitOrInstruction extends BinaryBitwiseInstruction {
  * Both operands must have the same integer type, which will also be the result type.
  */
 class BitXorInstruction extends BinaryBitwiseInstruction {
-  BitXorInstruction() { getOpcode() instanceof Opcode::BitXor }
+  BitXorInstruction() { this.getOpcode() instanceof Opcode::BitXor }
 }
 
 /**
@@ -1159,7 +1172,7 @@ class BitXorInstruction extends BinaryBitwiseInstruction {
  * rightmost bits are zero-filled.
  */
 class ShiftLeftInstruction extends BinaryBitwiseInstruction {
-  ShiftLeftInstruction() { getOpcode() instanceof Opcode::ShiftLeft }
+  ShiftLeftInstruction() { this.getOpcode() instanceof Opcode::ShiftLeft }
 }
 
 /**
@@ -1172,7 +1185,7 @@ class ShiftLeftInstruction extends BinaryBitwiseInstruction {
  * of the left operand.
  */
 class ShiftRightInstruction extends BinaryBitwiseInstruction {
-  ShiftRightInstruction() { getOpcode() instanceof Opcode::ShiftRight }
+  ShiftRightInstruction() { this.getOpcode() instanceof Opcode::ShiftRight }
 }
 
 /**
@@ -1183,7 +1196,7 @@ class PointerArithmeticInstruction extends BinaryInstruction {
   int elementSize;
 
   PointerArithmeticInstruction() {
-    getOpcode() instanceof PointerArithmeticOpcode and
+    this.getOpcode() instanceof PointerArithmeticOpcode and
     elementSize = Raw::getInstructionElementSize(this)
   }
 
@@ -1206,7 +1219,7 @@ class PointerArithmeticInstruction extends BinaryInstruction {
  * An instruction that adds or subtracts an integer offset from a pointer.
  */
 class PointerOffsetInstruction extends PointerArithmeticInstruction {
-  PointerOffsetInstruction() { getOpcode() instanceof PointerOffsetOpcode }
+  PointerOffsetInstruction() { this.getOpcode() instanceof PointerOffsetOpcode }
 }
 
 /**
@@ -1217,7 +1230,7 @@ class PointerOffsetInstruction extends PointerArithmeticInstruction {
  * overflow is undefined.
  */
 class PointerAddInstruction extends PointerOffsetInstruction {
-  PointerAddInstruction() { getOpcode() instanceof Opcode::PointerAdd }
+  PointerAddInstruction() { this.getOpcode() instanceof Opcode::PointerAdd }
 }
 
 /**
@@ -1228,7 +1241,7 @@ class PointerAddInstruction extends PointerOffsetInstruction {
  * pointer underflow is undefined.
  */
 class PointerSubInstruction extends PointerOffsetInstruction {
-  PointerSubInstruction() { getOpcode() instanceof Opcode::PointerSub }
+  PointerSubInstruction() { this.getOpcode() instanceof Opcode::PointerSub }
 }
 
 /**
@@ -1241,31 +1254,31 @@ class PointerSubInstruction extends PointerOffsetInstruction {
  * undefined.
  */
 class PointerDiffInstruction extends PointerArithmeticInstruction {
-  PointerDiffInstruction() { getOpcode() instanceof Opcode::PointerDiff }
+  PointerDiffInstruction() { this.getOpcode() instanceof Opcode::PointerDiff }
 }
 
 /**
  * An instruction whose result is computed from a single operand.
  */
 class UnaryInstruction extends Instruction {
-  UnaryInstruction() { getOpcode() instanceof UnaryOpcode }
+  UnaryInstruction() { this.getOpcode() instanceof UnaryOpcode }
 
   /**
    * Gets the sole operand of this instruction.
    */
-  final UnaryOperand getUnaryOperand() { result = getAnOperand() }
+  final UnaryOperand getUnaryOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the sole operand of this instruction.
    */
-  final Instruction getUnary() { result = getUnaryOperand().getDef() }
+  final Instruction getUnary() { result = this.getUnaryOperand().getDef() }
 }
 
 /**
  * An instruction that converts the value of its operand to a value of a different type.
  */
 class ConvertInstruction extends UnaryInstruction {
-  ConvertInstruction() { getOpcode() instanceof Opcode::Convert }
+  ConvertInstruction() { this.getOpcode() instanceof Opcode::Convert }
 }
 
 /**
@@ -1279,7 +1292,7 @@ class ConvertInstruction extends UnaryInstruction {
  * `as` expression.
  */
 class CheckedConvertOrNullInstruction extends UnaryInstruction {
-  CheckedConvertOrNullInstruction() { getOpcode() instanceof Opcode::CheckedConvertOrNull }
+  CheckedConvertOrNullInstruction() { this.getOpcode() instanceof Opcode::CheckedConvertOrNull }
 }
 
 /**
@@ -1293,7 +1306,7 @@ class CheckedConvertOrNullInstruction extends UnaryInstruction {
  * expression.
  */
 class CheckedConvertOrThrowInstruction extends UnaryInstruction {
-  CheckedConvertOrThrowInstruction() { getOpcode() instanceof Opcode::CheckedConvertOrThrow }
+  CheckedConvertOrThrowInstruction() { this.getOpcode() instanceof Opcode::CheckedConvertOrThrow }
 }
 
 /**
@@ -1306,7 +1319,7 @@ class CheckedConvertOrThrowInstruction extends UnaryInstruction {
  * the most-derived object.
  */
 class CompleteObjectAddressInstruction extends UnaryInstruction {
-  CompleteObjectAddressInstruction() { getOpcode() instanceof Opcode::CompleteObjectAddress }
+  CompleteObjectAddressInstruction() { this.getOpcode() instanceof Opcode::CompleteObjectAddress }
 }
 
 /**
@@ -1351,7 +1364,7 @@ class InheritanceConversionInstruction extends UnaryInstruction {
  * An instruction that converts from the address of a derived class to the address of a base class.
  */
 class ConvertToBaseInstruction extends InheritanceConversionInstruction {
-  ConvertToBaseInstruction() { getOpcode() instanceof ConvertToBaseOpcode }
+  ConvertToBaseInstruction() { this.getOpcode() instanceof ConvertToBaseOpcode }
 }
 
 /**
@@ -1361,7 +1374,9 @@ class ConvertToBaseInstruction extends InheritanceConversionInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToNonVirtualBaseInstruction extends ConvertToBaseInstruction {
-  ConvertToNonVirtualBaseInstruction() { getOpcode() instanceof Opcode::ConvertToNonVirtualBase }
+  ConvertToNonVirtualBaseInstruction() {
+    this.getOpcode() instanceof Opcode::ConvertToNonVirtualBase
+  }
 }
 
 /**
@@ -1371,7 +1386,7 @@ class ConvertToNonVirtualBaseInstruction extends ConvertToBaseInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToVirtualBaseInstruction extends ConvertToBaseInstruction {
-  ConvertToVirtualBaseInstruction() { getOpcode() instanceof Opcode::ConvertToVirtualBase }
+  ConvertToVirtualBaseInstruction() { this.getOpcode() instanceof Opcode::ConvertToVirtualBase }
 }
 
 /**
@@ -1381,7 +1396,7 @@ class ConvertToVirtualBaseInstruction extends ConvertToBaseInstruction {
  * If the operand holds a null address, the result is a null address.
  */
 class ConvertToDerivedInstruction extends InheritanceConversionInstruction {
-  ConvertToDerivedInstruction() { getOpcode() instanceof Opcode::ConvertToDerived }
+  ConvertToDerivedInstruction() { this.getOpcode() instanceof Opcode::ConvertToDerived }
 }
 
 /**
@@ -1390,7 +1405,7 @@ class ConvertToDerivedInstruction extends InheritanceConversionInstruction {
  * The operand must have an integer type, which will also be the result type.
  */
 class BitComplementInstruction extends UnaryBitwiseInstruction {
-  BitComplementInstruction() { getOpcode() instanceof Opcode::BitComplement }
+  BitComplementInstruction() { this.getOpcode() instanceof Opcode::BitComplement }
 }
 
 /**
@@ -1399,14 +1414,14 @@ class BitComplementInstruction extends UnaryBitwiseInstruction {
  * The operand must have a Boolean type, which will also be the result type.
  */
 class LogicalNotInstruction extends UnaryInstruction {
-  LogicalNotInstruction() { getOpcode() instanceof Opcode::LogicalNot }
+  LogicalNotInstruction() { this.getOpcode() instanceof Opcode::LogicalNot }
 }
 
 /**
  * An instruction that compares two numeric operands.
  */
 class CompareInstruction extends BinaryInstruction {
-  CompareInstruction() { getOpcode() instanceof CompareOpcode }
+  CompareInstruction() { this.getOpcode() instanceof CompareOpcode }
 }
 
 /**
@@ -1417,7 +1432,7 @@ class CompareInstruction extends BinaryInstruction {
  * unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareEQInstruction extends CompareInstruction {
-  CompareEQInstruction() { getOpcode() instanceof Opcode::CompareEQ }
+  CompareEQInstruction() { this.getOpcode() instanceof Opcode::CompareEQ }
 }
 
 /**
@@ -1428,14 +1443,14 @@ class CompareEQInstruction extends CompareInstruction {
  * `left == right`. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareNEInstruction extends CompareInstruction {
-  CompareNEInstruction() { getOpcode() instanceof Opcode::CompareNE }
+  CompareNEInstruction() { this.getOpcode() instanceof Opcode::CompareNE }
 }
 
 /**
  * An instruction that does a relative comparison of two values, such as `<` or `>=`.
  */
 class RelationalInstruction extends CompareInstruction {
-  RelationalInstruction() { getOpcode() instanceof RelationalOpcode }
+  RelationalInstruction() { this.getOpcode() instanceof RelationalOpcode }
 
   /**
    * Gets the operand on the "greater" (or "greater-or-equal") side
@@ -1467,11 +1482,11 @@ class RelationalInstruction extends CompareInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareLTInstruction extends RelationalInstruction {
-  CompareLTInstruction() { getOpcode() instanceof Opcode::CompareLT }
+  CompareLTInstruction() { this.getOpcode() instanceof Opcode::CompareLT }
 
-  override Instruction getLesser() { result = getLeft() }
+  override Instruction getLesser() { result = this.getLeft() }
 
-  override Instruction getGreater() { result = getRight() }
+  override Instruction getGreater() { result = this.getRight() }
 
   override predicate isStrict() { any() }
 }
@@ -1484,11 +1499,11 @@ class CompareLTInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareGTInstruction extends RelationalInstruction {
-  CompareGTInstruction() { getOpcode() instanceof Opcode::CompareGT }
+  CompareGTInstruction() { this.getOpcode() instanceof Opcode::CompareGT }
 
-  override Instruction getLesser() { result = getRight() }
+  override Instruction getLesser() { result = this.getRight() }
 
-  override Instruction getGreater() { result = getLeft() }
+  override Instruction getGreater() { result = this.getLeft() }
 
   override predicate isStrict() { any() }
 }
@@ -1502,11 +1517,11 @@ class CompareGTInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareLEInstruction extends RelationalInstruction {
-  CompareLEInstruction() { getOpcode() instanceof Opcode::CompareLE }
+  CompareLEInstruction() { this.getOpcode() instanceof Opcode::CompareLE }
 
-  override Instruction getLesser() { result = getLeft() }
+  override Instruction getLesser() { result = this.getLeft() }
 
-  override Instruction getGreater() { result = getRight() }
+  override Instruction getGreater() { result = this.getRight() }
 
   override predicate isStrict() { none() }
 }
@@ -1520,11 +1535,11 @@ class CompareLEInstruction extends RelationalInstruction {
  * are unordered. Floating-point comparison is performed according to IEEE-754.
  */
 class CompareGEInstruction extends RelationalInstruction {
-  CompareGEInstruction() { getOpcode() instanceof Opcode::CompareGE }
+  CompareGEInstruction() { this.getOpcode() instanceof Opcode::CompareGE }
 
-  override Instruction getLesser() { result = getRight() }
+  override Instruction getLesser() { result = this.getRight() }
 
-  override Instruction getGreater() { result = getLeft() }
+  override Instruction getGreater() { result = this.getLeft() }
 
   override predicate isStrict() { none() }
 }
@@ -1543,78 +1558,78 @@ class CompareGEInstruction extends RelationalInstruction {
  * of any case edge.
  */
 class SwitchInstruction extends Instruction {
-  SwitchInstruction() { getOpcode() instanceof Opcode::Switch }
+  SwitchInstruction() { this.getOpcode() instanceof Opcode::Switch }
 
   /** Gets the operand that provides the integer value controlling the switch. */
-  final ConditionOperand getExpressionOperand() { result = getAnOperand() }
+  final ConditionOperand getExpressionOperand() { result = this.getAnOperand() }
 
   /** Gets the instruction whose result provides the integer value controlling the switch. */
-  final Instruction getExpression() { result = getExpressionOperand().getDef() }
+  final Instruction getExpression() { result = this.getExpressionOperand().getDef() }
 
   /** Gets the successor instructions along the case edges of the switch. */
-  final Instruction getACaseSuccessor() { exists(CaseEdge edge | result = getSuccessor(edge)) }
+  final Instruction getACaseSuccessor() { exists(CaseEdge edge | result = this.getSuccessor(edge)) }
 
   /** Gets the successor instruction along the default edge of the switch, if any. */
-  final Instruction getDefaultSuccessor() { result = getSuccessor(EdgeKind::defaultEdge()) }
+  final Instruction getDefaultSuccessor() { result = this.getSuccessor(EdgeKind::defaultEdge()) }
 }
 
 /**
  * An instruction that calls a function.
  */
 class CallInstruction extends Instruction {
-  CallInstruction() { getOpcode() instanceof Opcode::Call }
+  CallInstruction() { this.getOpcode() instanceof Opcode::Call }
 
   final override string getImmediateString() {
-    result = getStaticCallTarget().toString()
+    result = this.getStaticCallTarget().toString()
     or
-    not exists(getStaticCallTarget()) and result = "?"
+    not exists(this.getStaticCallTarget()) and result = "?"
   }
 
   /**
    * Gets the operand the specifies the target function of the call.
    */
-  final CallTargetOperand getCallTargetOperand() { result = getAnOperand() }
+  final CallTargetOperand getCallTargetOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `Instruction` that computes the target function of the call. This is usually a
    * `FunctionAddress` instruction, but can also be an arbitrary instruction that produces a
    * function pointer.
    */
-  final Instruction getCallTarget() { result = getCallTargetOperand().getDef() }
+  final Instruction getCallTarget() { result = this.getCallTargetOperand().getDef() }
 
   /**
    * Gets all of the argument operands of the call, including the `this` pointer, if any.
    */
-  final ArgumentOperand getAnArgumentOperand() { result = getAnOperand() }
+  final ArgumentOperand getAnArgumentOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `Function` that the call targets, if this is statically known.
    */
   final Language::Function getStaticCallTarget() {
-    result = getCallTarget().(FunctionAddressInstruction).getFunctionSymbol()
+    result = this.getCallTarget().(FunctionAddressInstruction).getFunctionSymbol()
   }
 
   /**
    * Gets all of the arguments of the call, including the `this` pointer, if any.
    */
-  final Instruction getAnArgument() { result = getAnArgumentOperand().getDef() }
+  final Instruction getAnArgument() { result = this.getAnArgumentOperand().getDef() }
 
   /**
    * Gets the `this` pointer argument operand of the call, if any.
    */
-  final ThisArgumentOperand getThisArgumentOperand() { result = getAnOperand() }
+  final ThisArgumentOperand getThisArgumentOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the `this` pointer argument of the call, if any.
    */
-  final Instruction getThisArgument() { result = getThisArgumentOperand().getDef() }
+  final Instruction getThisArgument() { result = this.getThisArgumentOperand().getDef() }
 
   /**
    * Gets the argument operand at the specified index.
    */
   pragma[noinline]
   final PositionalArgumentOperand getPositionalArgumentOperand(int index) {
-    result = getAnOperand() and
+    result = this.getAnOperand() and
     result.getIndex() = index
   }
 
@@ -1623,7 +1638,7 @@ class CallInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getPositionalArgument(int index) {
-    result = getPositionalArgumentOperand(index).getDef()
+    result = this.getPositionalArgumentOperand(index).getDef()
   }
 
   /**
@@ -1631,16 +1646,16 @@ class CallInstruction extends Instruction {
    */
   pragma[noinline]
   final ArgumentOperand getArgumentOperand(int index) {
-    index >= 0 and result = getPositionalArgumentOperand(index)
+    index >= 0 and result = this.getPositionalArgumentOperand(index)
     or
-    index = -1 and result = getThisArgumentOperand()
+    index = -1 and result = this.getThisArgumentOperand()
   }
 
   /**
    * Gets the argument at the specified index, or `this` if `index` is `-1`.
    */
   pragma[noinline]
-  final Instruction getArgument(int index) { result = getArgumentOperand(index).getDef() }
+  final Instruction getArgument(int index) { result = this.getArgumentOperand(index).getDef() }
 
   /**
    * Gets the number of arguments of the call, including the `this` pointer, if any.
@@ -1665,7 +1680,7 @@ class CallInstruction extends Instruction {
  * An instruction representing a side effect of a function call.
  */
 class SideEffectInstruction extends Instruction {
-  SideEffectInstruction() { getOpcode() instanceof SideEffectOpcode }
+  SideEffectInstruction() { this.getOpcode() instanceof SideEffectOpcode }
 
   /**
    * Gets the instruction whose execution causes this side effect.
@@ -1680,7 +1695,7 @@ class SideEffectInstruction extends Instruction {
  * accessed by that call.
  */
 class CallSideEffectInstruction extends SideEffectInstruction {
-  CallSideEffectInstruction() { getOpcode() instanceof Opcode::CallSideEffect }
+  CallSideEffectInstruction() { this.getOpcode() instanceof Opcode::CallSideEffect }
 }
 
 /**
@@ -1691,7 +1706,7 @@ class CallSideEffectInstruction extends SideEffectInstruction {
  * call target cannot write to escaped memory.
  */
 class CallReadSideEffectInstruction extends SideEffectInstruction {
-  CallReadSideEffectInstruction() { getOpcode() instanceof Opcode::CallReadSideEffect }
+  CallReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::CallReadSideEffect }
 }
 
 /**
@@ -1699,33 +1714,33 @@ class CallReadSideEffectInstruction extends SideEffectInstruction {
  * specific parameter.
  */
 class ReadSideEffectInstruction extends SideEffectInstruction, IndexedInstruction {
-  ReadSideEffectInstruction() { getOpcode() instanceof ReadSideEffectOpcode }
+  ReadSideEffectInstruction() { this.getOpcode() instanceof ReadSideEffectOpcode }
 
   /** Gets the operand for the value that will be read from this instruction, if known. */
-  final SideEffectOperand getSideEffectOperand() { result = getAnOperand() }
+  final SideEffectOperand getSideEffectOperand() { result = this.getAnOperand() }
 
   /** Gets the value that will be read from this instruction, if known. */
-  final Instruction getSideEffect() { result = getSideEffectOperand().getDef() }
+  final Instruction getSideEffect() { result = this.getSideEffectOperand().getDef() }
 
   /** Gets the operand for the address from which this instruction may read. */
-  final AddressOperand getArgumentOperand() { result = getAnOperand() }
+  final AddressOperand getArgumentOperand() { result = this.getAnOperand() }
 
   /** Gets the address from which this instruction may read. */
-  final Instruction getArgumentDef() { result = getArgumentOperand().getDef() }
+  final Instruction getArgumentDef() { result = this.getArgumentOperand().getDef() }
 }
 
 /**
  * An instruction representing the read of an indirect parameter within a function call.
  */
 class IndirectReadSideEffectInstruction extends ReadSideEffectInstruction {
-  IndirectReadSideEffectInstruction() { getOpcode() instanceof Opcode::IndirectReadSideEffect }
+  IndirectReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::IndirectReadSideEffect }
 }
 
 /**
  * An instruction representing the read of an indirect buffer parameter within a function call.
  */
 class BufferReadSideEffectInstruction extends ReadSideEffectInstruction {
-  BufferReadSideEffectInstruction() { getOpcode() instanceof Opcode::BufferReadSideEffect }
+  BufferReadSideEffectInstruction() { this.getOpcode() instanceof Opcode::BufferReadSideEffect }
 }
 
 /**
@@ -1733,18 +1748,18 @@ class BufferReadSideEffectInstruction extends ReadSideEffectInstruction {
  */
 class SizedBufferReadSideEffectInstruction extends ReadSideEffectInstruction {
   SizedBufferReadSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferReadSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferReadSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes read from the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes read from the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1752,17 +1767,17 @@ class SizedBufferReadSideEffectInstruction extends ReadSideEffectInstruction {
  * specific parameter.
  */
 class WriteSideEffectInstruction extends SideEffectInstruction, IndexedInstruction {
-  WriteSideEffectInstruction() { getOpcode() instanceof WriteSideEffectOpcode }
+  WriteSideEffectInstruction() { this.getOpcode() instanceof WriteSideEffectOpcode }
 
   /**
    * Get the operand that holds the address of the memory to be written.
    */
-  final AddressOperand getDestinationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getDestinationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the address of the memory to be written.
    */
-  Instruction getDestinationAddress() { result = getDestinationAddressOperand().getDef() }
+  Instruction getDestinationAddress() { result = this.getDestinationAddressOperand().getDef() }
 }
 
 /**
@@ -1770,7 +1785,7 @@ class WriteSideEffectInstruction extends SideEffectInstruction, IndexedInstructi
  */
 class IndirectMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   IndirectMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::IndirectMustWriteSideEffect
   }
 }
 
@@ -1780,7 +1795,7 @@ class IndirectMustWriteSideEffectInstruction extends WriteSideEffectInstruction 
  */
 class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   BufferMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::BufferMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::BufferMustWriteSideEffect
   }
 }
 
@@ -1790,18 +1805,18 @@ class BufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
  */
 class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstruction {
   SizedBufferMustWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferMustWriteSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes written to the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes written to the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1812,7 +1827,7 @@ class SizedBufferMustWriteSideEffectInstruction extends WriteSideEffectInstructi
  */
 class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   IndirectMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::IndirectMayWriteSideEffect
+    this.getOpcode() instanceof Opcode::IndirectMayWriteSideEffect
   }
 }
 
@@ -1822,7 +1837,9 @@ class IndirectMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  * Unlike `BufferWriteSideEffectInstruction`, the buffer might not be completely overwritten.
  */
 class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
-  BufferMayWriteSideEffectInstruction() { getOpcode() instanceof Opcode::BufferMayWriteSideEffect }
+  BufferMayWriteSideEffectInstruction() {
+    this.getOpcode() instanceof Opcode::BufferMayWriteSideEffect
+  }
 }
 
 /**
@@ -1832,18 +1849,18 @@ class BufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
  */
 class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstruction {
   SizedBufferMayWriteSideEffectInstruction() {
-    getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
+    this.getOpcode() instanceof Opcode::SizedBufferMayWriteSideEffect
   }
 
   /**
    * Gets the operand that holds the number of bytes written to the buffer.
    */
-  final BufferSizeOperand getBufferSizeOperand() { result = getAnOperand() }
+  final BufferSizeOperand getBufferSizeOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the instruction whose result provides the number of bytes written to the buffer.
    */
-  final Instruction getBufferSize() { result = getBufferSizeOperand().getDef() }
+  final Instruction getBufferSize() { result = this.getBufferSizeOperand().getDef() }
 }
 
 /**
@@ -1852,80 +1869,80 @@ class SizedBufferMayWriteSideEffectInstruction extends WriteSideEffectInstructio
  */
 class InitializeDynamicAllocationInstruction extends SideEffectInstruction {
   InitializeDynamicAllocationInstruction() {
-    getOpcode() instanceof Opcode::InitializeDynamicAllocation
+    this.getOpcode() instanceof Opcode::InitializeDynamicAllocation
   }
 
   /**
    * Gets the operand that represents the address of the allocation this instruction is initializing.
    */
-  final AddressOperand getAllocationAddressOperand() { result = getAnOperand() }
+  final AddressOperand getAllocationAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the address for the allocation this instruction is initializing.
    */
-  final Instruction getAllocationAddress() { result = getAllocationAddressOperand().getDef() }
+  final Instruction getAllocationAddress() { result = this.getAllocationAddressOperand().getDef() }
 }
 
 /**
  * An instruction representing a GNU or MSVC inline assembly statement.
  */
 class InlineAsmInstruction extends Instruction {
-  InlineAsmInstruction() { getOpcode() instanceof Opcode::InlineAsm }
+  InlineAsmInstruction() { this.getOpcode() instanceof Opcode::InlineAsm }
 }
 
 /**
  * An instruction that throws an exception.
  */
 class ThrowInstruction extends Instruction {
-  ThrowInstruction() { getOpcode() instanceof ThrowOpcode }
+  ThrowInstruction() { this.getOpcode() instanceof ThrowOpcode }
 }
 
 /**
  * An instruction that throws a new exception.
  */
 class ThrowValueInstruction extends ThrowInstruction {
-  ThrowValueInstruction() { getOpcode() instanceof Opcode::ThrowValue }
+  ThrowValueInstruction() { this.getOpcode() instanceof Opcode::ThrowValue }
 
   /**
    * Gets the address operand of the exception thrown by this instruction.
    */
-  final AddressOperand getExceptionAddressOperand() { result = getAnOperand() }
+  final AddressOperand getExceptionAddressOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the address of the exception thrown by this instruction.
    */
-  final Instruction getExceptionAddress() { result = getExceptionAddressOperand().getDef() }
+  final Instruction getExceptionAddress() { result = this.getExceptionAddressOperand().getDef() }
 
   /**
    * Gets the operand for the exception thrown by this instruction.
    */
-  final LoadOperand getExceptionOperand() { result = getAnOperand() }
+  final LoadOperand getExceptionOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the exception thrown by this instruction.
    */
-  final Instruction getException() { result = getExceptionOperand().getDef() }
+  final Instruction getException() { result = this.getExceptionOperand().getDef() }
 }
 
 /**
  * An instruction that re-throws the current exception.
  */
 class ReThrowInstruction extends ThrowInstruction {
-  ReThrowInstruction() { getOpcode() instanceof Opcode::ReThrow }
+  ReThrowInstruction() { this.getOpcode() instanceof Opcode::ReThrow }
 }
 
 /**
  * An instruction that exits the current function by propagating an exception.
  */
 class UnwindInstruction extends Instruction {
-  UnwindInstruction() { getOpcode() instanceof Opcode::Unwind }
+  UnwindInstruction() { this.getOpcode() instanceof Opcode::Unwind }
 }
 
 /**
  * An instruction that starts a `catch` handler.
  */
 class CatchInstruction extends Instruction {
-  CatchInstruction() { getOpcode() instanceof CatchOpcode }
+  CatchInstruction() { this.getOpcode() instanceof CatchOpcode }
 }
 
 /**
@@ -1935,7 +1952,7 @@ class CatchByTypeInstruction extends CatchInstruction {
   Language::LanguageType exceptionType;
 
   CatchByTypeInstruction() {
-    getOpcode() instanceof Opcode::CatchByType and
+    this.getOpcode() instanceof Opcode::CatchByType and
     exceptionType = Raw::getInstructionExceptionType(this)
   }
 
@@ -1951,21 +1968,21 @@ class CatchByTypeInstruction extends CatchInstruction {
  * An instruction that catches any exception.
  */
 class CatchAnyInstruction extends CatchInstruction {
-  CatchAnyInstruction() { getOpcode() instanceof Opcode::CatchAny }
+  CatchAnyInstruction() { this.getOpcode() instanceof Opcode::CatchAny }
 }
 
 /**
  * An instruction that initializes all escaped memory.
  */
 class AliasedDefinitionInstruction extends Instruction {
-  AliasedDefinitionInstruction() { getOpcode() instanceof Opcode::AliasedDefinition }
+  AliasedDefinitionInstruction() { this.getOpcode() instanceof Opcode::AliasedDefinition }
 }
 
 /**
  * An instruction that consumes all escaped memory on exit from the function.
  */
 class AliasedUseInstruction extends Instruction {
-  AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
+  AliasedUseInstruction() { this.getOpcode() instanceof Opcode::AliasedUse }
 }
 
 /**
@@ -1979,7 +1996,7 @@ class AliasedUseInstruction extends Instruction {
  * runtime.
  */
 class PhiInstruction extends Instruction {
-  PhiInstruction() { getOpcode() instanceof Opcode::Phi }
+  PhiInstruction() { this.getOpcode() instanceof Opcode::Phi }
 
   /**
    * Gets all of the instruction's `PhiInputOperand`s, representing the values that flow from each predecessor block.
@@ -2047,29 +2064,29 @@ class PhiInstruction extends Instruction {
  * https://link.springer.com/content/pdf/10.1007%2F3-540-61053-7_66.pdf.
  */
 class ChiInstruction extends Instruction {
-  ChiInstruction() { getOpcode() instanceof Opcode::Chi }
+  ChiInstruction() { this.getOpcode() instanceof Opcode::Chi }
 
   /**
    * Gets the operand that represents the previous state of all memory that might be aliased by the
    * memory write.
    */
-  final ChiTotalOperand getTotalOperand() { result = getAnOperand() }
+  final ChiTotalOperand getTotalOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the operand that represents the previous state of all memory that might be aliased by the
    * memory write.
    */
-  final Instruction getTotal() { result = getTotalOperand().getDef() }
+  final Instruction getTotal() { result = this.getTotalOperand().getDef() }
 
   /**
    * Gets the operand that represents the new value written by the memory write.
    */
-  final ChiPartialOperand getPartialOperand() { result = getAnOperand() }
+  final ChiPartialOperand getPartialOperand() { result = this.getAnOperand() }
 
   /**
    * Gets the operand that represents the new value written by the memory write.
    */
-  final Instruction getPartial() { result = getPartialOperand().getDef() }
+  final Instruction getPartial() { result = this.getPartialOperand().getDef() }
 
   /**
    * Gets the bit range `[startBit, endBit)` updated by the partial operand of this `ChiInstruction`, relative to the start address of the total operand.
@@ -2093,7 +2110,7 @@ class ChiInstruction extends Instruction {
  * or `Switch` instruction where that particular edge is infeasible.
  */
 class UnreachedInstruction extends Instruction {
-  UnreachedInstruction() { getOpcode() instanceof Opcode::Unreached }
+  UnreachedInstruction() { this.getOpcode() instanceof Opcode::Unreached }
 }
 
 /**
@@ -2106,7 +2123,7 @@ class BuiltInOperationInstruction extends Instruction {
   Language::BuiltInOperation operation;
 
   BuiltInOperationInstruction() {
-    getOpcode() instanceof BuiltInOperationOpcode and
+    this.getOpcode() instanceof BuiltInOperationOpcode and
     operation = Raw::getInstructionBuiltInOperation(this)
   }
 
@@ -2122,9 +2139,9 @@ class BuiltInOperationInstruction extends Instruction {
  * actual operation is specified by the `getBuiltInOperation()` predicate.
  */
 class BuiltInInstruction extends BuiltInOperationInstruction {
-  BuiltInInstruction() { getOpcode() instanceof Opcode::BuiltIn }
+  BuiltInInstruction() { this.getOpcode() instanceof Opcode::BuiltIn }
 
-  final override string getImmediateString() { result = getBuiltInOperation().toString() }
+  final override string getImmediateString() { result = this.getBuiltInOperation().toString() }
 }
 
 /**
@@ -2135,7 +2152,7 @@ class BuiltInInstruction extends BuiltInOperationInstruction {
  * to the `...` parameter.
  */
 class VarArgsStartInstruction extends UnaryInstruction {
-  VarArgsStartInstruction() { getOpcode() instanceof Opcode::VarArgsStart }
+  VarArgsStartInstruction() { this.getOpcode() instanceof Opcode::VarArgsStart }
 }
 
 /**
@@ -2145,7 +2162,7 @@ class VarArgsStartInstruction extends UnaryInstruction {
  * a result.
  */
 class VarArgsEndInstruction extends UnaryInstruction {
-  VarArgsEndInstruction() { getOpcode() instanceof Opcode::VarArgsEnd }
+  VarArgsEndInstruction() { this.getOpcode() instanceof Opcode::VarArgsEnd }
 }
 
 /**
@@ -2155,7 +2172,7 @@ class VarArgsEndInstruction extends UnaryInstruction {
  * argument.
  */
 class VarArgInstruction extends UnaryInstruction {
-  VarArgInstruction() { getOpcode() instanceof Opcode::VarArg }
+  VarArgInstruction() { this.getOpcode() instanceof Opcode::VarArg }
 }
 
 /**
@@ -2166,7 +2183,7 @@ class VarArgInstruction extends UnaryInstruction {
  * argument of the `...` parameter.
  */
 class NextVarArgInstruction extends UnaryInstruction {
-  NextVarArgInstruction() { getOpcode() instanceof Opcode::NextVarArg }
+  NextVarArgInstruction() { this.getOpcode() instanceof Opcode::NextVarArg }
 }
 
 /**
@@ -2180,5 +2197,5 @@ class NextVarArgInstruction extends UnaryInstruction {
  * The result is the address of the newly allocated object.
  */
 class NewObjInstruction extends Instruction {
-  NewObjInstruction() { getOpcode() instanceof Opcode::NewObj }
+  NewObjInstruction() { this.getOpcode() instanceof Opcode::NewObj }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -46,12 +46,12 @@ class Operand extends TStageOperand {
   /**
    * Gets the location of the source code for this operand.
    */
-  final Language::Location getLocation() { result = getUse().getLocation() }
+  final Language::Location getLocation() { result = this.getUse().getLocation() }
 
   /**
    * Gets the function that contains this operand.
    */
-  final IRFunction getEnclosingIRFunction() { result = getUse().getEnclosingIRFunction() }
+  final IRFunction getEnclosingIRFunction() { result = this.getUse().getEnclosingIRFunction() }
 
   /**
    * Gets the `Instruction` that consumes this operand.
@@ -74,7 +74,7 @@ class Operand extends TStageOperand {
    */
   final Instruction getDef() {
     result = this.getAnyDef() and
-    getDefinitionOverlap() instanceof MustExactlyOverlap
+    this.getDefinitionOverlap() instanceof MustExactlyOverlap
   }
 
   /**
@@ -82,7 +82,7 @@ class Operand extends TStageOperand {
    *
    * Gets the `Instruction` that consumes this operand.
    */
-  deprecated final Instruction getUseInstruction() { result = getUse() }
+  deprecated final Instruction getUseInstruction() { result = this.getUse() }
 
   /**
    * DEPRECATED: use `getAnyDef` or `getDef`. The exact replacement for this
@@ -91,7 +91,7 @@ class Operand extends TStageOperand {
    *
    * Gets the `Instruction` whose result is the value of the operand.
    */
-  deprecated final Instruction getDefinitionInstruction() { result = getAnyDef() }
+  deprecated final Instruction getDefinitionInstruction() { result = this.getAnyDef() }
 
   /**
    * Gets the overlap relationship between the operand's definition and its use.
@@ -101,7 +101,9 @@ class Operand extends TStageOperand {
   /**
    * Holds if the result of the definition instruction does not exactly overlap this use.
    */
-  final predicate isDefinitionInexact() { not getDefinitionOverlap() instanceof MustExactlyOverlap }
+  final predicate isDefinitionInexact() {
+    not this.getDefinitionOverlap() instanceof MustExactlyOverlap
+  }
 
   /**
    * Gets a prefix to use when dumping the operand in an operand list.
@@ -121,7 +123,7 @@ class Operand extends TStageOperand {
    * For example: `this:r3_5`
    */
   final string getDumpString() {
-    result = getDumpLabel() + getInexactSpecifier() + getDefinitionId()
+    result = this.getDumpLabel() + this.getInexactSpecifier() + this.getDefinitionId()
   }
 
   /**
@@ -129,9 +131,9 @@ class Operand extends TStageOperand {
    * definition is not modeled in SSA.
    */
   private string getDefinitionId() {
-    result = getAnyDef().getResultId()
+    result = this.getAnyDef().getResultId()
     or
-    not exists(getAnyDef()) and result = "m?"
+    not exists(this.getAnyDef()) and result = "m?"
   }
 
   /**
@@ -140,7 +142,7 @@ class Operand extends TStageOperand {
    * the empty string.
    */
   private string getInexactSpecifier() {
-    if isDefinitionInexact() then result = "~" else result = ""
+    if this.isDefinitionInexact() then result = "~" else result = ""
   }
 
   /**
@@ -155,7 +157,7 @@ class Operand extends TStageOperand {
    * the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  Language::LanguageType getLanguageType() { result = getAnyDef().getResultLanguageType() }
+  Language::LanguageType getLanguageType() { result = this.getAnyDef().getResultLanguageType() }
 
   /**
    * Gets the language-neutral type of the value consumed by this operand. This is usually the same
@@ -164,7 +166,7 @@ class Operand extends TStageOperand {
    * from the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  final IRType getIRType() { result = getLanguageType().getIRType() }
+  final IRType getIRType() { result = this.getLanguageType().getIRType() }
 
   /**
    * Gets the type of the value consumed by this operand. This is usually the same as the
@@ -173,7 +175,7 @@ class Operand extends TStageOperand {
    * the definition type, such as in the case of a partial read or a read from a pointer that
    * has been cast to a different type.
    */
-  final Language::Type getType() { getLanguageType().hasType(result, _) }
+  final Language::Type getType() { this.getLanguageType().hasType(result, _) }
 
   /**
    * Holds if the value consumed by this operand is a glvalue. If this
@@ -182,13 +184,13 @@ class Operand extends TStageOperand {
    * not hold, the value of the operand represents a value whose type is
    * given by `getType()`.
    */
-  final predicate isGLValue() { getLanguageType().hasType(_, true) }
+  final predicate isGLValue() { this.getLanguageType().hasType(_, true) }
 
   /**
    * Gets the size of the value consumed by this operand, in bytes. If the operand does not have
    * a known constant size, this predicate does not hold.
    */
-  final int getSize() { result = getLanguageType().getByteSize() }
+  final int getSize() { result = this.getLanguageType().getByteSize() }
 }
 
 /**
@@ -205,7 +207,7 @@ class MemoryOperand extends Operand {
   /**
    * Gets the kind of memory access performed by the operand.
    */
-  MemoryAccessKind getMemoryAccess() { result = getUse().getOpcode().getReadMemoryAccess() }
+  MemoryAccessKind getMemoryAccess() { result = this.getUse().getOpcode().getReadMemoryAccess() }
 
   /**
    * Holds if the memory access performed by this operand will not always read from every bit in the
@@ -215,7 +217,7 @@ class MemoryOperand extends Operand {
    * conservative estimate of the memory that might actually be accessed at runtime (for example,
    * the global side effects of a function call).
    */
-  predicate hasMayReadMemoryAccess() { getUse().getOpcode().hasMayReadMemoryAccess() }
+  predicate hasMayReadMemoryAccess() { this.getUse().getOpcode().hasMayReadMemoryAccess() }
 
   /**
    * Returns the operand that holds the memory address from which the current operand loads its
@@ -223,8 +225,8 @@ class MemoryOperand extends Operand {
    * is `r1`.
    */
   final AddressOperand getAddressOperand() {
-    getMemoryAccess().usesAddressOperand() and
-    result.getUse() = getUse()
+    this.getMemoryAccess().usesAddressOperand() and
+    result.getUse() = this.getUse()
   }
 }
 
@@ -294,7 +296,7 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, TNonPhiMemoryOpe
     result = unique(Instruction defInstr | hasDefinition(defInstr, _))
   }
 
-  final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
+  final override Overlap getDefinitionOverlap() { this.hasDefinition(_, result) }
 
   pragma[noinline]
   private predicate hasDefinition(Instruction defInstr, Overlap overlap) {
@@ -449,13 +451,17 @@ class PhiInputOperand extends MemoryOperand, TPhiOperand {
 
   final override Overlap getDefinitionOverlap() { result = overlap }
 
-  final override int getDumpSortOrder() { result = 11 + getPredecessorBlock().getDisplayIndex() }
-
-  final override string getDumpLabel() {
-    result = "from " + getPredecessorBlock().getDisplayIndex().toString() + ":"
+  final override int getDumpSortOrder() {
+    result = 11 + this.getPredecessorBlock().getDisplayIndex()
   }
 
-  final override string getDumpId() { result = getPredecessorBlock().getDisplayIndex().toString() }
+  final override string getDumpLabel() {
+    result = "from " + this.getPredecessorBlock().getDisplayIndex().toString() + ":"
+  }
+
+  final override string getDumpId() {
+    result = this.getPredecessorBlock().getDisplayIndex().toString()
+  }
 
   /**
    * Gets the predecessor block from which this value comes.

--- a/cpp/ql/lib/semmle/code/cpp/metrics/MetricClass.qll
+++ b/cpp/ql/lib/semmle/code/cpp/metrics/MetricClass.qll
@@ -366,7 +366,7 @@ class MetricClass extends Class {
       1 +
         count(string s |
           exists(Operation op | op = this.getAnEnclosedExpression() and s = op.getOperator())
-        ) + count(string s | s = getAUsedHalsteadN1Operator())
+        ) + count(string s | s = this.getAUsedHalsteadN1Operator())
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/metrics/MetricFile.qll
+++ b/cpp/ql/lib/semmle/code/cpp/metrics/MetricFile.qll
@@ -134,7 +134,7 @@ class MetricFile extends File {
     result =
       // avoid 0 values
       1 + count(string s | exists(Operation op | op.getFile() = this and s = op.getOperator())) +
-        count(string s | s = getAUsedHalsteadN1Operator())
+        count(string s | s = this.getAUsedHalsteadN1Operator())
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/metrics/MetricFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/metrics/MetricFunction.qll
@@ -41,7 +41,7 @@ class MetricFunction extends Function {
    * `&&`, and `||`) plus one.
    */
   int getCyclomaticComplexity() {
-    result = 1 + cyclomaticComplexityBranches(getBlock()) and
+    result = 1 + cyclomaticComplexityBranches(this.getBlock()) and
     not this.isMultiplyDefined()
   }
 
@@ -295,7 +295,7 @@ class MetricFunction extends Function {
   int getNestingDepth() {
     result =
       max(Stmt s, int aDepth | s.getEnclosingFunction() = this and nestingDepth(s, aDepth) | aDepth) and
-    not isMultiplyDefined()
+    not this.isMultiplyDefined()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
@@ -15,10 +15,10 @@ private class MallocAllocationFunction extends AllocationFunction {
 
   MallocAllocationFunction() {
     // --- C library allocation
-    hasGlobalOrStdOrBslName("malloc") and // malloc(size)
+    this.hasGlobalOrStdOrBslName("malloc") and // malloc(size)
     sizeArg = 0
     or
-    hasGlobalName([
+    this.hasGlobalName([
         // --- Windows Memory Management for Windows Drivers
         "MmAllocateContiguousMemory", // MmAllocateContiguousMemory(size, maxaddress)
         "MmAllocateContiguousNodeMemory", // MmAllocateContiguousNodeMemory(size, minaddress, maxaddress, bound, flag, prefer)
@@ -39,7 +39,7 @@ private class MallocAllocationFunction extends AllocationFunction {
       ]) and
     sizeArg = 0
     or
-    hasGlobalName([
+    this.hasGlobalName([
         // --- Windows Memory Management for Windows Drivers
         "ExAllocatePool", // ExAllocatePool(type, size)
         "ExAllocatePoolWithTag", // ExAllocatePool(type, size, tag)
@@ -56,10 +56,10 @@ private class MallocAllocationFunction extends AllocationFunction {
       ]) and
     sizeArg = 1
     or
-    hasGlobalName(["HeapAlloc"]) and // HeapAlloc(heap, flags, size)
+    this.hasGlobalName(["HeapAlloc"]) and // HeapAlloc(heap, flags, size)
     sizeArg = 2
     or
-    hasGlobalName([
+    this.hasGlobalName([
         // --- Windows Memory Management for Windows Drivers
         "MmAllocatePagesForMdl", // MmAllocatePagesForMdl(minaddress, maxaddress, skip, size)
         "MmAllocatePagesForMdlEx", // MmAllocatePagesForMdlEx(minaddress, maxaddress, skip, size, type, flags)
@@ -79,7 +79,7 @@ private class AllocaAllocationFunction extends AllocationFunction {
   int sizeArg;
 
   AllocaAllocationFunction() {
-    hasGlobalName([
+    this.hasGlobalName([
         // --- stack allocation
         "alloca", // // alloca(size)
         "__builtin_alloca", // __builtin_alloca(size)
@@ -104,7 +104,7 @@ private class CallocAllocationFunction extends AllocationFunction {
 
   CallocAllocationFunction() {
     // --- C library allocation
-    hasGlobalOrStdOrBslName("calloc") and // calloc(num, size)
+    this.hasGlobalOrStdOrBslName("calloc") and // calloc(num, size)
     sizeArg = 1 and
     multArg = 0
   }
@@ -124,11 +124,11 @@ private class ReallocAllocationFunction extends AllocationFunction {
 
   ReallocAllocationFunction() {
     // --- C library allocation
-    hasGlobalOrStdOrBslName("realloc") and // realloc(ptr, size)
+    this.hasGlobalOrStdOrBslName("realloc") and // realloc(ptr, size)
     sizeArg = 1 and
     reallocArg = 0
     or
-    hasGlobalName([
+    this.hasGlobalName([
         // --- Windows Global / Local legacy allocation
         "LocalReAlloc", // LocalReAlloc(ptr, size, flags)
         "GlobalReAlloc", // GlobalReAlloc(ptr, size, flags)
@@ -140,7 +140,7 @@ private class ReallocAllocationFunction extends AllocationFunction {
     sizeArg = 1 and
     reallocArg = 0
     or
-    hasGlobalName("HeapReAlloc") and // HeapReAlloc(heap, flags, ptr, size)
+    this.hasGlobalName("HeapReAlloc") and // HeapReAlloc(heap, flags, ptr, size)
     sizeArg = 3 and
     reallocArg = 2
   }
@@ -156,7 +156,7 @@ private class ReallocAllocationFunction extends AllocationFunction {
  */
 private class SizelessAllocationFunction extends AllocationFunction {
   SizelessAllocationFunction() {
-    hasGlobalName([
+    this.hasGlobalName([
         // --- Windows Memory Management for Windows Drivers
         "ExAllocateFromLookasideListEx", // ExAllocateFromLookasideListEx(list)
         "ExAllocateFromPagedLookasideList", // ExAllocateFromPagedLookasideList(list)
@@ -209,18 +209,18 @@ private class CallAllocationExpr extends AllocationExpr, FunctionCall {
   AllocationFunction target;
 
   CallAllocationExpr() {
-    target = getTarget() and
+    target = this.getTarget() and
     // realloc(ptr, 0) only frees the pointer
     not (
       exists(target.getReallocPtrArg()) and
-      getArgument(target.getSizeArg()).getValue().toInt() = 0
+      this.getArgument(target.getSizeArg()).getValue().toInt() = 0
     ) and
     // these are modelled directly (and more accurately), avoid duplication
     not exists(NewOrNewArrayExpr new | new.getAllocatorCall() = this)
   }
 
   override Expr getSizeExpr() {
-    exists(Expr sizeExpr | sizeExpr = getArgument(target.getSizeArg()) |
+    exists(Expr sizeExpr | sizeExpr = this.getArgument(target.getSizeArg()) |
       if exists(target.getSizeMult())
       then result = sizeExpr
       else
@@ -233,16 +233,18 @@ private class CallAllocationExpr extends AllocationExpr, FunctionCall {
 
   override int getSizeMult() {
     // malloc with multiplier argument that is a constant
-    result = getArgument(target.getSizeMult()).getValue().toInt()
+    result = this.getArgument(target.getSizeMult()).getValue().toInt()
     or
     // malloc with no multiplier argument
     not exists(target.getSizeMult()) and
-    deconstructSizeExpr(getArgument(target.getSizeArg()), _, result)
+    deconstructSizeExpr(this.getArgument(target.getSizeArg()), _, result)
   }
 
-  override int getSizeBytes() { result = getSizeExpr().getValue().toInt() * getSizeMult() }
+  override int getSizeBytes() {
+    result = this.getSizeExpr().getValue().toInt() * this.getSizeMult()
+  }
 
-  override Expr getReallocPtr() { result = getArgument(target.getReallocPtrArg()) }
+  override Expr getReallocPtr() { result = this.getArgument(target.getReallocPtrArg()) }
 
   override Type getAllocatedElementType() {
     result =
@@ -259,11 +261,11 @@ private class CallAllocationExpr extends AllocationExpr, FunctionCall {
 private class NewAllocationExpr extends AllocationExpr, NewExpr {
   NewAllocationExpr() { this instanceof NewExpr }
 
-  override int getSizeBytes() { result = getAllocatedType().getSize() }
+  override int getSizeBytes() { result = this.getAllocatedType().getSize() }
 
-  override Type getAllocatedElementType() { result = getAllocatedType() }
+  override Type getAllocatedElementType() { result = this.getAllocatedType() }
 
-  override predicate requiresDealloc() { not exists(getPlacementPointer()) }
+  override predicate requiresDealloc() { not exists(this.getPlacementPointer()) }
 }
 
 /**
@@ -274,18 +276,18 @@ private class NewArrayAllocationExpr extends AllocationExpr, NewArrayExpr {
 
   override Expr getSizeExpr() {
     // new array expr with variable size
-    result = getExtent()
+    result = this.getExtent()
   }
 
   override int getSizeMult() {
     // new array expr with variable size
-    exists(getExtent()) and
-    result = getAllocatedElementType().getSize()
+    exists(this.getExtent()) and
+    result = this.getAllocatedElementType().getSize()
   }
 
   override Type getAllocatedElementType() { result = NewArrayExpr.super.getAllocatedElementType() }
 
-  override int getSizeBytes() { result = getAllocatedType().getSize() }
+  override int getSizeBytes() { result = this.getAllocatedType().getSize() }
 
-  override predicate requiresDealloc() { not exists(getPlacementPointer()) }
+  override predicate requiresDealloc() { not exists(this.getPlacementPointer()) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/GetDelim.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/GetDelim.qll
@@ -8,7 +8,7 @@ import semmle.code.cpp.models.interfaces.FlowSource
  */
 private class GetDelimFunction extends TaintFunction, AliasFunction, SideEffectFunction,
   RemoteFlowSourceFunction {
-  GetDelimFunction() { hasGlobalName(["getdelim", "getwdelim", "__getdelim"]) }
+  GetDelimFunction() { this.hasGlobalName(["getdelim", "getwdelim", "__getdelim"]) }
 
   override predicate hasTaintFlow(FunctionInput i, FunctionOutput o) {
     i.isParameter(3) and o.isParameterDeref(0)

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
@@ -19,7 +19,7 @@ private class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunctio
     // gets(str)
     // fgets(str, num, stream)
     // fgetws(wstr, num, stream)
-    hasGlobalOrStdOrBslName(["gets", "fgets", "fgetws"])
+    this.hasGlobalOrStdOrBslName(["gets", "fgets", "fgetws"])
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
@@ -54,13 +54,13 @@ private class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunctio
   }
 
   override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
-    not hasName("gets") and
+    not this.hasName("gets") and
     bufParam = 0 and
     countParam = 1
   }
 
   override predicate hasArrayWithUnknownSize(int bufParam) {
-    hasName("gets") and
+    this.hasName("gets") and
     bufParam = 0
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Memcpy.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Memcpy.qll
@@ -44,27 +44,27 @@ private class MemcpyFunction extends ArrayFunction, DataFlowFunction, SideEffect
    */
   int getParamSize() { if this.hasGlobalName("memccpy") then result = 3 else result = 2 }
 
-  override predicate hasArrayInput(int bufParam) { bufParam = getParamSrc() }
+  override predicate hasArrayInput(int bufParam) { bufParam = this.getParamSrc() }
 
-  override predicate hasArrayOutput(int bufParam) { bufParam = getParamDest() }
+  override predicate hasArrayOutput(int bufParam) { bufParam = this.getParamDest() }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
-    input.isParameterDeref(getParamSrc()) and
-    output.isParameterDeref(getParamDest())
+    input.isParameterDeref(this.getParamSrc()) and
+    output.isParameterDeref(this.getParamDest())
     or
-    input.isParameterDeref(getParamSrc()) and
+    input.isParameterDeref(this.getParamSrc()) and
     output.isReturnValueDeref()
     or
-    input.isParameter(getParamDest()) and
+    input.isParameter(this.getParamDest()) and
     output.isReturnValue()
   }
 
   override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
     (
-      bufParam = getParamDest() or
-      bufParam = getParamSrc()
+      bufParam = this.getParamDest() or
+      bufParam = this.getParamSrc()
     ) and
-    countParam = getParamSize()
+    countParam = this.getParamSize()
   }
 
   override predicate hasOnlySpecificReadSideEffects() { any() }
@@ -72,37 +72,37 @@ private class MemcpyFunction extends ArrayFunction, DataFlowFunction, SideEffect
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
-    i = getParamDest() and
+    i = this.getParamDest() and
     buffer = true and
     // memccpy only writes until a given character `c` is found
     (if this.hasGlobalName("memccpy") then mustWrite = false else mustWrite = true)
   }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    i = getParamSrc() and buffer = true
+    i = this.getParamSrc() and buffer = true
   }
 
   override ParameterIndex getParameterSizeIndex(ParameterIndex i) {
-    result = getParamSize() and
+    result = this.getParamSize() and
     (
-      i = getParamDest() or
-      i = getParamSrc()
+      i = this.getParamDest() or
+      i = this.getParamSrc()
     )
   }
 
   override predicate parameterNeverEscapes(int index) {
-    index = getParamSrc()
+    index = this.getParamSrc()
     or
-    this.hasGlobalName("bcopy") and index = getParamDest()
+    this.hasGlobalName("bcopy") and index = this.getParamDest()
   }
 
   override predicate parameterEscapesOnlyViaReturn(int index) {
-    not this.hasGlobalName("bcopy") and index = getParamDest()
+    not this.hasGlobalName("bcopy") and index = this.getParamDest()
   }
 
   override predicate parameterIsAlwaysReturned(int index) {
     not this.hasGlobalName(["bcopy", mempcpy(), "memccpy"]) and
-    index = getParamDest()
+    index = this.getParamDest()
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Memset.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Memset.qll
@@ -31,17 +31,17 @@ private class MemsetFunction extends ArrayFunction, DataFlowFunction, AliasFunct
 
   override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
     bufParam = 0 and
-    (if hasGlobalName(bzero()) then countParam = 1 else countParam = 2)
+    (if this.hasGlobalName(bzero()) then countParam = 1 else countParam = 2)
   }
 
-  override predicate parameterNeverEscapes(int index) { hasGlobalName(bzero()) and index = 0 }
+  override predicate parameterNeverEscapes(int index) { this.hasGlobalName(bzero()) and index = 0 }
 
   override predicate parameterEscapesOnlyViaReturn(int index) {
-    not hasGlobalName(bzero()) and index = 0
+    not this.hasGlobalName(bzero()) and index = 0
   }
 
   override predicate parameterIsAlwaysReturned(int index) {
-    not hasGlobalName(bzero()) and index = 0
+    not this.hasGlobalName(bzero()) and index = 0
   }
 
   override predicate hasOnlySpecificReadSideEffects() { any() }
@@ -54,7 +54,7 @@ private class MemsetFunction extends ArrayFunction, DataFlowFunction, AliasFunct
 
   override ParameterIndex getParameterSizeIndex(ParameterIndex i) {
     i = 0 and
-    if hasGlobalName(bzero()) then result = 1 else result = 2
+    if this.hasGlobalName(bzero()) then result = 1 else result = 2
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Pure.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Pure.qll
@@ -10,49 +10,49 @@ import semmle.code.cpp.models.interfaces.SideEffect
 private class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction,
   SideEffectFunction {
   PureStrFunction() {
-    hasGlobalOrStdOrBslName([
+    this.hasGlobalOrStdOrBslName([
         atoi(), "strcasestr", "strchnul", "strchr", "strchrnul", "strstr", "strpbrk", "strrchr",
         "strspn", strtol(), strrev(), strcmp(), strlwr(), strupr()
       ])
   }
 
   override predicate hasArrayInput(int bufParam) {
-    getParameter(bufParam).getUnspecifiedType() instanceof PointerType
+    this.getParameter(bufParam).getUnspecifiedType() instanceof PointerType
   }
 
   override predicate hasArrayWithNullTerminator(int bufParam) {
-    getParameter(bufParam).getUnspecifiedType() instanceof PointerType
+    this.getParameter(bufParam).getUnspecifiedType() instanceof PointerType
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     exists(ParameterIndex i |
       (
         input.isParameter(i) and
-        exists(getParameter(i))
+        exists(this.getParameter(i))
         or
         input.isParameterDeref(i) and
-        getParameter(i).getUnspecifiedType() instanceof PointerType
+        this.getParameter(i).getUnspecifiedType() instanceof PointerType
       ) and
       // Functions that end with _l also take a locale argument (always as the last argument),
       // and we don't want taint from those arguments.
-      (not this.getName().matches("%\\_l") or exists(getParameter(i + 1)))
+      (not this.getName().matches("%\\_l") or exists(this.getParameter(i + 1)))
     ) and
     (
       output.isReturnValueDeref() and
-      getUnspecifiedType() instanceof PointerType
+      this.getUnspecifiedType() instanceof PointerType
       or
       output.isReturnValue()
     )
   }
 
   override predicate parameterNeverEscapes(int i) {
-    getParameter(i).getUnspecifiedType() instanceof PointerType and
-    not parameterEscapesOnlyViaReturn(i)
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType and
+    not this.parameterEscapesOnlyViaReturn(i)
   }
 
   override predicate parameterEscapesOnlyViaReturn(int i) {
     i = 0 and
-    getUnspecifiedType() instanceof PointerType
+    this.getUnspecifiedType() instanceof PointerType
   }
 
   override predicate parameterIsAlwaysReturned(int i) { none() }
@@ -62,7 +62,7 @@ private class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunctio
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    getParameter(i).getUnspecifiedType() instanceof PointerType and
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType and
     buffer = true
   }
 }
@@ -97,21 +97,21 @@ private string strcmp() {
  */
 private class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFunction {
   StrLenFunction() {
-    hasGlobalOrStdOrBslName(["strlen", "strnlen", "wcslen"])
+    this.hasGlobalOrStdOrBslName(["strlen", "strnlen", "wcslen"])
     or
-    hasGlobalName(["_mbslen", "_mbslen_l", "_mbstrlen", "_mbstrlen_l"])
+    this.hasGlobalName(["_mbslen", "_mbslen_l", "_mbstrlen", "_mbstrlen_l"])
   }
 
   override predicate hasArrayInput(int bufParam) {
-    getParameter(bufParam).getUnspecifiedType() instanceof PointerType
+    this.getParameter(bufParam).getUnspecifiedType() instanceof PointerType
   }
 
   override predicate hasArrayWithNullTerminator(int bufParam) {
-    getParameter(bufParam).getUnspecifiedType() instanceof PointerType
+    this.getParameter(bufParam).getUnspecifiedType() instanceof PointerType
   }
 
   override predicate parameterNeverEscapes(int i) {
-    getParameter(i).getUnspecifiedType() instanceof PointerType
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType
   }
 
   override predicate parameterEscapesOnlyViaReturn(int i) { none() }
@@ -123,7 +123,7 @@ private class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFun
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    getParameter(i).getUnspecifiedType() instanceof PointerType and
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType and
     buffer = true
   }
 }
@@ -133,12 +133,12 @@ private class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFun
  * side-effect free. Excludes functions modeled by `PureStrFunction` and `PureMemFunction`.
  */
 private class PureFunction extends TaintFunction, SideEffectFunction {
-  PureFunction() { hasGlobalOrStdOrBslName(["abs", "labs"]) }
+  PureFunction() { this.hasGlobalOrStdOrBslName(["abs", "labs"]) }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     exists(ParameterIndex i |
       input.isParameter(i) and
-      exists(getParameter(i))
+      exists(this.getParameter(i))
     ) and
     output.isReturnValue()
   }
@@ -155,44 +155,44 @@ private class PureFunction extends TaintFunction, SideEffectFunction {
 private class PureMemFunction extends AliasFunction, ArrayFunction, TaintFunction,
   SideEffectFunction {
   PureMemFunction() {
-    hasGlobalOrStdOrBslName([
+    this.hasGlobalOrStdOrBslName([
         "memchr", "__builtin_memchr", "memrchr", "rawmemchr", "memcmp", "__builtin_memcmp", "memmem"
       ]) or
     this.hasGlobalName("memfrob")
   }
 
   override predicate hasArrayInput(int bufParam) {
-    getParameter(bufParam).getUnspecifiedType() instanceof PointerType
+    this.getParameter(bufParam).getUnspecifiedType() instanceof PointerType
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     exists(ParameterIndex i |
       (
         input.isParameter(i) and
-        exists(getParameter(i))
+        exists(this.getParameter(i))
         or
         input.isParameterDeref(i) and
-        getParameter(i).getUnspecifiedType() instanceof PointerType
+        this.getParameter(i).getUnspecifiedType() instanceof PointerType
       ) and
       // `memfrob` should not have taint from the size argument.
       (not this.hasGlobalName("memfrob") or i = 0)
     ) and
     (
       output.isReturnValueDeref() and
-      getUnspecifiedType() instanceof PointerType
+      this.getUnspecifiedType() instanceof PointerType
       or
       output.isReturnValue()
     )
   }
 
   override predicate parameterNeverEscapes(int i) {
-    getParameter(i).getUnspecifiedType() instanceof PointerType and
-    not parameterEscapesOnlyViaReturn(i)
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType and
+    not this.parameterEscapesOnlyViaReturn(i)
   }
 
   override predicate parameterEscapesOnlyViaReturn(int i) {
     i = 0 and
-    getUnspecifiedType() instanceof PointerType
+    this.getUnspecifiedType() instanceof PointerType
   }
 
   override predicate parameterIsAlwaysReturned(int i) { none() }
@@ -202,7 +202,7 @@ private class PureMemFunction extends AliasFunction, ArrayFunction, TaintFunctio
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    getParameter(i).getUnspecifiedType() instanceof PointerType and
+    this.getParameter(i).getUnspecifiedType() instanceof PointerType and
     buffer = true
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/SmartPointer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/SmartPointer.qll
@@ -72,9 +72,9 @@ private class MakeUniqueOrShared extends TaintFunction {
     // since these just take a size argument, which we don't want to propagate taint through.
     not this.isArray() and
     (
-      input.isParameter([0 .. getNumberOfParameters() - 1])
+      input.isParameter([0 .. this.getNumberOfParameters() - 1])
       or
-      input.isParameterDeref([0 .. getNumberOfParameters() - 1])
+      input.isParameterDeref([0 .. this.getNumberOfParameters() - 1])
     ) and
     output.isReturnValue()
   }
@@ -116,14 +116,14 @@ private class SmartPtrSetterFunction extends MemberFunction, AliasFunction, Side
     or
     // When taking ownership of a smart pointer via an rvalue reference, always overwrite the input
     // smart pointer.
-    getPointerInput().isParameterDeref(i) and
+    this.getPointerInput().isParameterDeref(i) and
     this.getParameter(i).getUnspecifiedType() instanceof RValueReferenceType and
     buffer = false and
     mustWrite = true
   }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    getPointerInput().isParameterDeref(i) and
+    this.getPointerInput().isParameterDeref(i) and
     buffer = false
     or
     not this instanceof Constructor and
@@ -136,7 +136,7 @@ private class SmartPtrSetterFunction extends MemberFunction, AliasFunction, Side
   override predicate parameterEscapesOnlyViaReturn(int index) { none() }
 
   override predicate hasAddressFlow(FunctionInput input, FunctionOutput output) {
-    input = getPointerInput() and
+    input = this.getPointerInput() and
     output.isQualifierObject()
     or
     // Assignment operator always returns a reference to `*this`.

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Sscanf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Sscanf.qll
@@ -23,15 +23,15 @@ private class SscanfModel extends ArrayFunction, TaintFunction, AliasFunction, S
     bufParam = this.(ScanfFunction).getInputParameterIndex()
   }
 
-  override predicate hasArrayInput(int bufParam) { hasArrayWithNullTerminator(bufParam) }
+  override predicate hasArrayInput(int bufParam) { this.hasArrayWithNullTerminator(bufParam) }
 
   private int getLengthParameterIndex() { result = this.(Snscanf).getInputLengthParameterIndex() }
 
   private int getLocaleParameterIndex() {
     this.getName().matches("%\\_l") and
     (
-      if exists(getLengthParameterIndex())
-      then result = getLengthParameterIndex() + 2
+      if exists(this.getLengthParameterIndex())
+      then result = this.getLengthParameterIndex() + 2
       else result = 2
     )
   }
@@ -40,11 +40,11 @@ private class SscanfModel extends ArrayFunction, TaintFunction, AliasFunction, S
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     input.isParameterDeref(this.(ScanfFunction).getInputParameterIndex()) and
-    output.isParameterDeref(any(int i | i >= getArgsStartPosition()))
+    output.isParameterDeref(any(int i | i >= this.getArgsStartPosition()))
   }
 
   override predicate parameterNeverEscapes(int index) {
-    index = [0 .. max(getACallToThisFunction().getNumberOfArguments())]
+    index = [0 .. max(this.getACallToThisFunction().getNumberOfArguments())]
   }
 
   override predicate parameterEscapesOnlyViaReturn(int index) { none() }
@@ -56,7 +56,7 @@ private class SscanfModel extends ArrayFunction, TaintFunction, AliasFunction, S
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
-    i >= getArgsStartPosition() and
+    i >= this.getArgsStartPosition() and
     buffer = true and
     mustWrite = true
   }
@@ -66,7 +66,7 @@ private class SscanfModel extends ArrayFunction, TaintFunction, AliasFunction, S
     i =
       [
         this.(ScanfFunction).getInputParameterIndex(),
-        this.(ScanfFunction).getFormatParameterIndex(), getLocaleParameterIndex()
+        this.(ScanfFunction).getFormatParameterIndex(), this.getLocaleParameterIndex()
       ]
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -61,20 +61,20 @@ private class StdSequenceContainerConstructor extends Constructor, TaintFunction
    * value type of the container.
    */
   int getAValueTypeParameterIndex() {
-    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
-      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
+    this.getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+      this.getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
   }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
    */
-  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+  int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of the value type to the returned object
     (
-      input.isParameterDeref(getAValueTypeParameterIndex()) or
-      input.isParameter(getAnIteratorParameterIndex())
+      input.isParameterDeref(this.getAValueTypeParameterIndex()) or
+      input.isParameter(this.getAnIteratorParameterIndex())
     ) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
@@ -158,21 +158,21 @@ private class StdSequenceContainerInsert extends TaintFunction {
    * value type of the container.
    */
   int getAValueTypeParameterIndex() {
-    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
-      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
+    this.getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+      this.getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
   }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
    */
-  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+  int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from parameter to container itself (qualifier) and return value
     (
       input.isQualifierObject() or
-      input.isParameterDeref(getAValueTypeParameterIndex()) or
-      input.isParameter(getAnIteratorParameterIndex())
+      input.isParameterDeref(this.getAValueTypeParameterIndex()) or
+      input.isParameter(this.getAnIteratorParameterIndex())
     ) and
     (
       output.isQualifierObject() or
@@ -197,20 +197,20 @@ private class StdSequenceContainerAssign extends TaintFunction {
    * value type of the container.
    */
   int getAValueTypeParameterIndex() {
-    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
-      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
+    this.getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+      this.getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
   }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
    */
-  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+  int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from parameter to container itself (qualifier)
     (
-      input.isParameterDeref(getAValueTypeParameterIndex()) or
-      input.isParameter(getAnIteratorParameterIndex())
+      input.isParameterDeref(this.getAValueTypeParameterIndex()) or
+      input.isParameter(this.getAnIteratorParameterIndex())
     ) and
     output.isQualifierObject()
   }
@@ -246,7 +246,7 @@ class StdVectorEmplace extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from any parameter except the position iterator to qualifier and return value
     // (here we assume taint flow from any constructor parameter to the constructed object)
-    input.isParameterDeref([1 .. getNumberOfParameters() - 1]) and
+    input.isParameterDeref([1 .. this.getNumberOfParameters() - 1]) and
     (
       output.isQualifierObject() or
       output.isReturnValue()
@@ -263,7 +263,7 @@ class StdVectorEmplaceBack extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from any parameter to qualifier
     // (here we assume taint flow from any constructor parameter to the constructed object)
-    input.isParameterDeref([0 .. getNumberOfParameters() - 1]) and
+    input.isParameterDeref([0 .. this.getNumberOfParameters() - 1]) and
     output.isQualifierObject()
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdMap.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdMap.qll
@@ -22,12 +22,12 @@ private class StdMapConstructor extends Constructor, TaintFunction {
    * Gets the index of a parameter to this function that is an iterator.
    */
   int getAnIteratorParameterIndex() {
-    getParameter(result).getUnspecifiedType() instanceof Iterator
+    this.getParameter(result).getUnspecifiedType() instanceof Iterator
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of an iterator type to the qualifier
-    input.isParameterDeref(getAnIteratorParameterIndex()) and
+    input.isParameterDeref(this.getAnIteratorParameterIndex()) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
       or
@@ -47,7 +47,7 @@ private class StdMapInsert extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from last parameter to qualifier and return value
     // (where the return value is a pair, this should really flow just to the first part of it)
-    input.isParameterDeref(getNumberOfParameters() - 1) and
+    input.isParameterDeref(this.getNumberOfParameters() - 1) and
     (
       output.isQualifierObject() or
       output.isReturnValue()
@@ -66,7 +66,7 @@ private class StdMapEmplace extends TaintFunction {
     // construct a pair, or a pair to be copied / moved) to the qualifier and
     // return value.
     // (where the return value is a pair, this should really flow just to the first part of it)
-    input.isParameterDeref(getNumberOfParameters() - 1) and
+    input.isParameterDeref(this.getNumberOfParameters() - 1) and
     (
       output.isQualifierObject() or
       output.isReturnValue()
@@ -87,9 +87,9 @@ private class StdMapTryEmplace extends TaintFunction {
     // flow from any parameter apart from the key to qualifier and return value
     // (here we assume taint flow from any constructor parameter to the constructed object)
     // (where the return value is a pair, this should really flow just to the first part of it)
-    exists(int arg | arg = [1 .. getNumberOfParameters() - 1] |
+    exists(int arg | arg = [1 .. this.getNumberOfParameters() - 1] |
       (
-        not getUnspecifiedType() instanceof Iterator or
+        not this.getUnspecifiedType() instanceof Iterator or
         arg != 1
       ) and
       input.isParameterDeref(arg)
@@ -154,7 +154,7 @@ private class StdMapErase extends TaintFunction {
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from qualifier to iterator return value
-    getType().getUnderlyingType() instanceof Iterator and
+    this.getType().getUnderlyingType() instanceof Iterator and
     input.isQualifierObject() and
     output.isReturnValue()
   }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdPair.qll
@@ -51,13 +51,13 @@ private class StdPairConstructor extends Constructor, TaintFunction {
    * either value type of the pair.
    */
   int getAValueTypeParameterIndex() {
-    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
-      getDeclaringType().getTemplateArgument(_).(Type).getUnspecifiedType() // i.e. the `T1` or `T2` of this `std::pair<T1, T2>`
+    this.getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+      this.getDeclaringType().getTemplateArgument(_).(Type).getUnspecifiedType() // i.e. the `T1` or `T2` of this `std::pair<T1, T2>`
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from second parameter of a value type to the qualifier
-    getAValueTypeParameterIndex() = 1 and
+    this.getAValueTypeParameterIndex() = 1 and
     input.isParameterDeref(1) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdSet.qll
@@ -22,12 +22,12 @@ private class StdSetConstructor extends Constructor, TaintFunction {
    * Gets the index of a parameter to this function that is an iterator.
    */
   int getAnIteratorParameterIndex() {
-    getParameter(result).getUnspecifiedType() instanceof Iterator
+    this.getParameter(result).getUnspecifiedType() instanceof Iterator
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of an iterator type to the qualifier
-    input.isParameterDeref(getAnIteratorParameterIndex()) and
+    input.isParameterDeref(this.getAnIteratorParameterIndex()) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
       or
@@ -45,7 +45,7 @@ private class StdSetInsert extends TaintFunction {
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from last parameter to qualifier and return value
     // (where the return value is a pair, this should really flow just to the first part of it)
-    input.isParameterDeref(getNumberOfParameters() - 1) and
+    input.isParameterDeref(this.getNumberOfParameters() - 1) and
     (
       output.isQualifierObject() or
       output.isReturnValue()
@@ -63,7 +63,7 @@ private class StdSetEmplace extends TaintFunction {
     // flow from any parameter to qualifier and return value
     // (here we assume taint flow from any constructor parameter to the constructed object)
     // (where the return value is a pair, this should really flow just to the first part of it)
-    input.isParameterDeref([0 .. getNumberOfParameters() - 1]) and
+    input.isParameterDeref([0 .. this.getNumberOfParameters() - 1]) and
     (
       output.isQualifierObject() or
       output.isReturnValue()
@@ -107,7 +107,7 @@ private class StdSetErase extends TaintFunction {
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from qualifier to iterator return value
-    getType().getUnderlyingType() instanceof Iterator and
+    this.getType().getUnderlyingType() instanceof Iterator and
     input.isQualifierObject() and
     output.isReturnValue()
   }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/StdString.qll
@@ -31,31 +31,31 @@ private class StdStringConstructor extends Constructor, TaintFunction {
    * character).
    */
   int getAStringParameterIndex() {
-    exists(Type paramType | paramType = getParameter(result).getUnspecifiedType() |
+    exists(Type paramType | paramType = this.getParameter(result).getUnspecifiedType() |
       // e.g. `std::basic_string::CharT *`
       paramType instanceof PointerType
       or
       // e.g. `std::basic_string &`, avoiding `const Allocator&`
       paramType instanceof ReferenceType and
       not paramType.(ReferenceType).getBaseType() =
-        getDeclaringType().getTemplateArgument(2).(Type).getUnspecifiedType()
+        this.getDeclaringType().getTemplateArgument(2).(Type).getUnspecifiedType()
       or
       // i.e. `std::basic_string::CharT`
-      getParameter(result).getUnspecifiedType() =
-        getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType()
+      this.getParameter(result).getUnspecifiedType() =
+        this.getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType()
     )
   }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
    */
-  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+  int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of the value type to the returned object
     (
-      input.isParameterDeref(getAStringParameterIndex()) or
-      input.isParameter(getAnIteratorParameterIndex())
+      input.isParameterDeref(this.getAStringParameterIndex()) or
+      input.isParameter(this.getAnIteratorParameterIndex())
     ) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
@@ -156,23 +156,23 @@ private class StdStringAppend extends TaintFunction {
    * character).
    */
   int getAStringParameterIndex() {
-    getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
-    getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
-    getParameter(result).getUnspecifiedType() =
-      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
+    this.getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
+    this.getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
+    this.getParameter(result).getUnspecifiedType() =
+      this.getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
   }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
    */
-  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+  int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from string and parameter to string (qualifier) and return value
     (
       input.isQualifierObject() or
-      input.isParameterDeref(getAStringParameterIndex()) or
-      input.isParameter(getAnIteratorParameterIndex())
+      input.isParameterDeref(this.getAStringParameterIndex()) or
+      input.isParameter(this.getAnIteratorParameterIndex())
     ) and
     (
       output.isQualifierObject() or
@@ -197,22 +197,22 @@ private class StdStringAssign extends TaintFunction {
    * character).
    */
   int getAStringParameterIndex() {
-    getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
-    getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
-    getParameter(result).getUnspecifiedType() =
-      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
+    this.getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
+    this.getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
+    this.getParameter(result).getUnspecifiedType() =
+      this.getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
   }
 
   /**
    * Gets the index of a parameter to this function that is an iterator.
    */
-  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+  int getAnIteratorParameterIndex() { this.getParameter(result).getType() instanceof Iterator }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from parameter to string itself (qualifier) and return value
     (
-      input.isParameterDeref(getAStringParameterIndex()) or
-      input.isParameter(getAnIteratorParameterIndex())
+      input.isParameterDeref(this.getAStringParameterIndex()) or
+      input.isParameter(this.getAnIteratorParameterIndex())
     ) and
     (
       output.isQualifierObject() or
@@ -574,12 +574,12 @@ private class StdStringStreamConstructor extends Constructor, TaintFunction {
    * Gets the index of a parameter to this function that is a string.
    */
   int getAStringParameterIndex() {
-    getParameter(result).getType() instanceof ReferenceType // `const std::basic_string &`
+    this.getParameter(result).getType() instanceof ReferenceType // `const std::basic_string &`
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of string type to the returned object
-    input.isParameterDeref(getAStringParameterIndex()) and
+    input.isParameterDeref(this.getAStringParameterIndex()) and
     (
       output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
       or

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcat.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcat.qll
@@ -32,7 +32,7 @@ class StrcatFunction extends TaintFunction, DataFlowFunction, ArrayFunction, Sid
   /**
    * Gets the index of the parameter that is the size of the copy (in characters).
    */
-  int getParamSize() { exists(getParameter(2)) and result = 2 }
+  int getParamSize() { exists(this.getParameter(2)) and result = 2 }
 
   /**
    * Gets the index of the parameter that is the source of the copy.
@@ -50,11 +50,11 @@ class StrcatFunction extends TaintFunction, DataFlowFunction, ArrayFunction, Sid
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    getName() = ["strncat", "wcsncat", "_mbsncat", "_mbsncat_l"] and
+    this.getName() = ["strncat", "wcsncat", "_mbsncat", "_mbsncat_l"] and
     input.isParameter(2) and
     output.isParameterDeref(0)
     or
-    getName() = ["_mbsncat_l", "_mbsnbcat_l"] and
+    this.getName() = ["_mbsncat_l", "_mbsnbcat_l"] and
     input.isParameter(3) and
     output.isParameterDeref(0)
     or

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -45,22 +45,22 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, Sid
     ) and
     // exclude the 2-parameter template versions
     // that find the size of a fixed size destination buffer.
-    getNumberOfParameters() = 3
+    this.getNumberOfParameters() = 3
   }
 
   /**
    * Holds if this is one of the `strcpy_s` variants.
    */
-  private predicate isSVariant() { getName().matches("%\\_s") }
+  private predicate isSVariant() { this.getName().matches("%\\_s") }
 
   /**
    * Gets the index of the parameter that is the maximum size of the copy (in characters).
    */
   int getParamSize() {
-    if isSVariant()
+    if this.isSVariant()
     then result = 1
     else (
-      getName().matches(["%ncpy%", "%nbcpy%", "%xfrm%"]) and
+      this.getName().matches(["%ncpy%", "%nbcpy%", "%xfrm%"]) and
       result = 2
     )
   }
@@ -68,49 +68,49 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, Sid
   /**
    * Gets the index of the parameter that is the source of the copy.
    */
-  int getParamSrc() { if isSVariant() then result = 2 else result = 1 }
+  int getParamSrc() { if this.isSVariant() then result = 2 else result = 1 }
 
   /**
    * Gets the index of the parameter that is the destination of the copy.
    */
   int getParamDest() { result = 0 }
 
-  override predicate hasArrayInput(int bufParam) { bufParam = getParamSrc() }
+  override predicate hasArrayInput(int bufParam) { bufParam = this.getParamSrc() }
 
-  override predicate hasArrayOutput(int bufParam) { bufParam = getParamDest() }
+  override predicate hasArrayOutput(int bufParam) { bufParam = this.getParamDest() }
 
-  override predicate hasArrayWithNullTerminator(int bufParam) { bufParam = getParamSrc() }
+  override predicate hasArrayWithNullTerminator(int bufParam) { bufParam = this.getParamSrc() }
 
   override predicate hasArrayWithVariableSize(int bufParam, int countParam) {
-    bufParam = getParamDest() and
-    countParam = getParamSize()
+    bufParam = this.getParamDest() and
+    countParam = this.getParamSize()
   }
 
   override predicate hasArrayWithUnknownSize(int bufParam) {
-    not exists(getParamSize()) and
-    bufParam = getParamDest()
+    not exists(this.getParamSize()) and
+    bufParam = this.getParamDest()
   }
 
   override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
-    not exists(getParamSize()) and
-    input.isParameterDeref(getParamSrc()) and
-    output.isParameterDeref(getParamDest())
+    not exists(this.getParamSize()) and
+    input.isParameterDeref(this.getParamSrc()) and
+    output.isParameterDeref(this.getParamDest())
     or
-    not exists(getParamSize()) and
-    input.isParameterDeref(getParamSrc()) and
+    not exists(this.getParamSize()) and
+    input.isParameterDeref(this.getParamSrc()) and
     output.isReturnValueDeref()
     or
-    input.isParameter(getParamDest()) and
+    input.isParameter(this.getParamDest()) and
     output.isReturnValue()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // these may do only a partial copy of the input buffer to the output
     // buffer
-    exists(getParamSize()) and
-    input.isParameter(getParamSrc()) and
+    exists(this.getParamSize()) and
+    input.isParameter(this.getParamSrc()) and
     (
-      output.isParameterDeref(getParamDest()) or
+      output.isParameterDeref(this.getParamDest()) or
       output.isReturnValueDeref()
     )
   }
@@ -120,18 +120,18 @@ class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, Sid
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificWriteSideEffect(ParameterIndex i, boolean buffer, boolean mustWrite) {
-    i = getParamDest() and
+    i = this.getParamDest() and
     buffer = true and
     mustWrite = false
   }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    i = getParamSrc() and
+    i = this.getParamSrc() and
     buffer = true
   }
 
   override ParameterIndex getParameterSizeIndex(ParameterIndex i) {
-    i = getParamDest() and
-    result = getParamSize()
+    i = this.getParamDest() and
+    result = this.getParamSize()
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcrement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcrement.qll
@@ -29,10 +29,10 @@ private class Strcrement extends ArrayFunction, TaintFunction, SideEffectFunctio
     this.getParameter(bufParam).getUnspecifiedType() instanceof PointerType
   }
 
-  override predicate hasArrayInput(int bufParam) { hasArrayWithNullTerminator(bufParam) }
+  override predicate hasArrayInput(int bufParam) { this.hasArrayWithNullTerminator(bufParam) }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    exists(int index | hasArrayInput(index) |
+    exists(int index | this.hasArrayInput(index) |
       input.isParameter(index) and output.isReturnValue()
       or
       input.isParameterDeref(index) and output.isReturnValueDeref()
@@ -44,6 +44,6 @@ private class Strcrement extends ArrayFunction, TaintFunction, SideEffectFunctio
   override predicate hasOnlySpecificWriteSideEffects() { any() }
 
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
-    hasArrayInput(i) and buffer = true
+    this.hasArrayInput(i) and buffer = true
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Swap.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Swap.qll
@@ -31,7 +31,7 @@ private class MemberSwap extends TaintFunction, MemberFunction, AliasFunction {
     this.hasName("swap") and
     this.getNumberOfParameters() = 1 and
     this.getParameter(0).getType().(ReferenceType).getBaseType().getUnspecifiedType() =
-      getDeclaringType()
+      this.getDeclaringType()
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FunctionInputsAndOutputs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FunctionInputsAndOutputs.qll
@@ -44,7 +44,7 @@ class FunctionInput extends TFunctionInput {
    * Holds if this is the input value of the parameter with index `index`.
    * DEPRECATED: Use `isParameter(index)` instead.
    */
-  deprecated final predicate isInParameter(ParameterIndex index) { isParameter(index) }
+  deprecated final predicate isInParameter(ParameterIndex index) { this.isParameter(index) }
 
   /**
    * Holds if this is the input value pointed to by a pointer parameter to a function, or the input
@@ -70,7 +70,9 @@ class FunctionInput extends TFunctionInput {
    * `index`.
    * DEPRECATED: Use `isParameterDeref(index)` instead.
    */
-  deprecated final predicate isInParameterPointer(ParameterIndex index) { isParameterDeref(index) }
+  deprecated final predicate isInParameterPointer(ParameterIndex index) {
+    this.isParameterDeref(index)
+  }
 
   /**
    * Holds if this is the input value pointed to by the `this` pointer of an instance member
@@ -92,7 +94,7 @@ class FunctionInput extends TFunctionInput {
    * function.
    * DEPRECATED: Use `isQualifierObject()` instead.
    */
-  deprecated final predicate isInQualifier() { isQualifierObject() }
+  deprecated final predicate isInQualifier() { this.isQualifierObject() }
 
   /**
    * Holds if this is the input value of the `this` pointer of an instance member function.
@@ -314,7 +316,9 @@ class FunctionOutput extends TFunctionOutput {
    * index `index`.
    * DEPRECATED: Use `isParameterDeref(index)` instead.
    */
-  deprecated final predicate isOutParameterPointer(ParameterIndex index) { isParameterDeref(index) }
+  deprecated final predicate isOutParameterPointer(ParameterIndex index) {
+    this.isParameterDeref(index)
+  }
 
   /**
    * Holds if this is the output value pointed to by the `this` pointer of an instance member
@@ -336,7 +340,7 @@ class FunctionOutput extends TFunctionOutput {
    * function.
    * DEPRECATED: Use `isQualifierObject()` instead.
    */
-  deprecated final predicate isOutQualifier() { isQualifierObject() }
+  deprecated final predicate isOutQualifier() { this.isQualifierObject() }
 
   /**
    * Holds if this is the value returned by a function.
@@ -361,7 +365,7 @@ class FunctionOutput extends TFunctionOutput {
    * Holds if this is the value returned by a function.
    * DEPRECATED: Use `isReturnValue()` instead.
    */
-  deprecated final predicate isOutReturnValue() { isReturnValue() }
+  deprecated final predicate isOutReturnValue() { this.isReturnValue() }
 
   /**
    * Holds if this is the output value pointed to by the return value of a function, if the function
@@ -389,7 +393,7 @@ class FunctionOutput extends TFunctionOutput {
    * function returns a reference.
    * DEPRECATED: Use `isReturnValueDeref()` instead.
    */
-  deprecated final predicate isOutReturnPointer() { isReturnValueDeref() }
+  deprecated final predicate isOutReturnPointer() { this.isReturnValueDeref() }
 
   /**
    * Holds if `i >= 0` and `isParameterDeref(i)` holds for this is the value, or

--- a/cpp/ql/lib/semmle/code/cpp/padding/Padding.qll
+++ b/cpp/ql/lib/semmle/code/cpp/padding/Padding.qll
@@ -72,7 +72,7 @@ abstract class Architecture extends string {
     or
     t instanceof CharType and result = 8
     or
-    t instanceof WideCharType and result = wideCharSize()
+    t instanceof WideCharType and result = this.wideCharSize()
     or
     t instanceof Char8Type and result = 8
     or
@@ -84,22 +84,22 @@ abstract class Architecture extends string {
     or
     t instanceof IntType and result = 32
     or
-    t instanceof LongType and result = longSize()
+    t instanceof LongType and result = this.longSize()
     or
-    t instanceof LongLongType and result = longLongSize()
+    t instanceof LongLongType and result = this.longLongSize()
     or
-    result = enumBitSize(t.(Enum))
+    result = this.enumBitSize(t.(Enum))
     or
-    result = integralBitSize(t.(SpecifiedType).getBaseType())
+    result = this.integralBitSize(t.(SpecifiedType).getBaseType())
     or
-    result = integralBitSize(t.(TypedefType).getBaseType())
+    result = this.integralBitSize(t.(TypedefType).getBaseType())
   }
 
   /**
    * Gets the bit size of enum type `e`.
    */
   int enumBitSize(Enum e) {
-    result = integralBitSize(e.getExplicitUnderlyingType())
+    result = this.integralBitSize(e.getExplicitUnderlyingType())
     or
     not exists(e.getExplicitUnderlyingType()) and result = 32
   }
@@ -108,7 +108,7 @@ abstract class Architecture extends string {
    * Gets the alignment of enum type `e`.
    */
   int enumAlignment(Enum e) {
-    result = alignment(e.getExplicitUnderlyingType())
+    result = this.alignment(e.getExplicitUnderlyingType())
     or
     not exists(e.getExplicitUnderlyingType()) and result = 32
   }
@@ -120,26 +120,26 @@ abstract class Architecture extends string {
    */
   cached
   int bitSize(Type t) {
-    result = integralBitSize(t)
+    result = this.integralBitSize(t)
     or
     t instanceof FloatType and result = 32
     or
     t instanceof DoubleType and result = 64
     or
-    t instanceof LongDoubleType and result = longDoubleSize()
+    t instanceof LongDoubleType and result = this.longDoubleSize()
     or
-    t instanceof PointerType and result = pointerSize()
+    t instanceof PointerType and result = this.pointerSize()
     or
-    t instanceof ReferenceType and result = pointerSize()
+    t instanceof ReferenceType and result = this.pointerSize()
     or
-    t instanceof FunctionPointerType and result = pointerSize()
+    t instanceof FunctionPointerType and result = this.pointerSize()
     or
-    result = bitSize(t.(SpecifiedType).getBaseType())
+    result = this.bitSize(t.(SpecifiedType).getBaseType())
     or
-    result = bitSize(t.(TypedefType).getBaseType())
+    result = this.bitSize(t.(TypedefType).getBaseType())
     or
     exists(ArrayType array | array = t |
-      result = array.getArraySize() * paddedSize(array.getBaseType())
+      result = array.getArraySize() * this.paddedSize(array.getBaseType())
     )
     or
     result = t.(PaddedType).typeBitSize(this)
@@ -155,7 +155,7 @@ abstract class Architecture extends string {
     or
     t instanceof CharType and result = 8
     or
-    t instanceof WideCharType and result = wideCharSize()
+    t instanceof WideCharType and result = this.wideCharSize()
     or
     t instanceof Char8Type and result = 8
     or
@@ -169,27 +169,27 @@ abstract class Architecture extends string {
     or
     t instanceof FloatType and result = 32
     or
-    t instanceof DoubleType and result = doubleAlign()
+    t instanceof DoubleType and result = this.doubleAlign()
     or
-    t instanceof LongType and result = longSize()
+    t instanceof LongType and result = this.longSize()
     or
-    t instanceof LongDoubleType and result = longDoubleAlign()
+    t instanceof LongDoubleType and result = this.longDoubleAlign()
     or
-    t instanceof LongLongType and result = longLongAlign()
+    t instanceof LongLongType and result = this.longLongAlign()
     or
-    t instanceof PointerType and result = pointerSize()
+    t instanceof PointerType and result = this.pointerSize()
     or
-    t instanceof FunctionPointerType and result = pointerSize()
+    t instanceof FunctionPointerType and result = this.pointerSize()
     or
-    t instanceof ReferenceType and result = pointerSize()
+    t instanceof ReferenceType and result = this.pointerSize()
     or
-    result = enumAlignment(t.(Enum))
+    result = this.enumAlignment(t.(Enum))
     or
-    result = alignment(t.(SpecifiedType).getBaseType())
+    result = this.alignment(t.(SpecifiedType).getBaseType())
     or
-    result = alignment(t.(TypedefType).getBaseType())
+    result = this.alignment(t.(TypedefType).getBaseType())
     or
-    result = alignment(t.(ArrayType).getBaseType())
+    result = this.alignment(t.(ArrayType).getBaseType())
     or
     result = t.(PaddedType).typeAlignment(this)
   }
@@ -203,7 +203,7 @@ abstract class Architecture extends string {
     exists(Type realType | realType = stripSpecifiers(t) |
       if realType instanceof PaddedType
       then result = realType.(PaddedType).paddedSize(this)
-      else result = bitSize(realType)
+      else result = this.bitSize(realType)
     )
   }
 
@@ -429,7 +429,7 @@ class PaddedType extends Class {
    * Gets the number of bits wasted by padding at the end of this
    * struct.
    */
-  int trailingPadding(Architecture arch) { result = paddedSize(arch) - arch.bitSize(this) }
+  int trailingPadding(Architecture arch) { result = this.paddedSize(arch) - arch.bitSize(this) }
 
   /**
    * Gets the number of bits wasted in this struct definition; that is.
@@ -440,7 +440,7 @@ class PaddedType extends Class {
    * laid out one after another, and hence there is no padding between
    * them.
    */
-  int wastedSpace(Architecture arch) { result = arch.paddedSize(this) - dataSize(arch) }
+  int wastedSpace(Architecture arch) { result = arch.paddedSize(this) - this.dataSize(arch) }
 
   /**
    * Gets the total size of all fields declared in this class, not including any
@@ -448,8 +448,8 @@ class PaddedType extends Class {
    */
   private int fieldDataSize(Architecture arch) {
     if this instanceof Union
-    then result = max(Field f | f = this.getAMember() | fieldSize(f, arch))
-    else result = sum(Field f | f = this.getAMember() | fieldSize(f, arch))
+    then result = max(Field f | f = this.getAMember() | this.fieldSize(f, arch))
+    else result = sum(Field f | f = this.getAMember() | this.fieldSize(f, arch))
   }
 
   /**
@@ -472,7 +472,7 @@ class PaddedType extends Class {
    * reorganizing member structs' field layouts.
    */
   int optimalSize(Architecture arch) {
-    result = alignUp(dataSize(arch), arch.alignment(this)).maximum(8)
+    result = alignUp(this.dataSize(arch), arch.alignment(this)).maximum(8)
   }
 
   /**
@@ -490,11 +490,11 @@ class PaddedType extends Class {
       // but that uses a recursive aggregate, which isn't supported in
       // QL. We therefore use this slightly more complex implementation
       // instead.
-      result = biggestFieldSizeUpTo(lastFieldIndex(), arch)
+      result = this.biggestFieldSizeUpTo(this.lastFieldIndex(), arch)
     else
       // If we're not a union type, the size is the padded
       // sum of field sizes, padded.
-      result = fieldEnd(lastFieldIndex(), arch)
+      result = this.fieldEnd(this.lastFieldIndex(), arch)
   }
 
   /**
@@ -522,8 +522,8 @@ class PaddedType extends Class {
     if index = 0
     then result = 0
     else
-      exists(Field f, int fSize | index = fieldIndex(f) and fSize = fieldSize(f, arch) |
-        result = fSize.maximum(biggestFieldSizeUpTo(index - 1, arch))
+      exists(Field f, int fSize | index = this.fieldIndex(f) and fSize = this.fieldSize(f, arch) |
+        result = fSize.maximum(this.biggestFieldSizeUpTo(index - 1, arch))
       )
   }
 
@@ -536,8 +536,10 @@ class PaddedType extends Class {
     if index = 0
     then result = 1 // Minimum possible alignment
     else
-      exists(Field f, int fAlign | index = fieldIndex(f) and fAlign = arch.alignment(f.getType()) |
-        result = fAlign.maximum(biggestAlignmentUpTo(index - 1, arch))
+      exists(Field f, int fAlign |
+        index = this.fieldIndex(f) and fAlign = arch.alignment(f.getType())
+      |
+        result = fAlign.maximum(this.biggestAlignmentUpTo(index - 1, arch))
       )
   }
 
@@ -545,17 +547,18 @@ class PaddedType extends Class {
    * Gets the 1-based index for each field.
    */
   int fieldIndex(Field f) {
-    memberIndex(f) = rank[result](Field field, int index | memberIndex(field) = index | index)
+    this.memberIndex(f) =
+      rank[result](Field field, int index | this.memberIndex(field) = index | index)
   }
 
-  private int memberIndex(Field f) { result = min(int i | getCanonicalMember(i) = f) }
+  private int memberIndex(Field f) { result = min(int i | this.getCanonicalMember(i) = f) }
 
   /**
    * Gets the 1-based index for the last field.
    */
   int lastFieldIndex() {
-    if exists(lastField())
-    then result = fieldIndex(lastField())
+    if exists(this.lastField())
+    then result = this.fieldIndex(this.lastField())
     else
       // Field indices are 1-based, so return 0 to represent the lack of fields.
       result = 0
@@ -566,25 +569,27 @@ class PaddedType extends Class {
    * `arch`.
    */
   int fieldSize(Field f, Architecture arch) {
-    exists(fieldIndex(f)) and
+    exists(this.fieldIndex(f)) and
     if f instanceof BitField
     then result = f.(BitField).getNumBits()
     else result = arch.paddedSize(f.getType())
   }
 
   /** Gets the last field of this type. */
-  Field lastField() { fieldIndex(result) = max(Field other | | fieldIndex(other)) }
+  Field lastField() { this.fieldIndex(result) = max(Field other | | this.fieldIndex(other)) }
 
   /**
    * Gets the offset, in bits, of the end of the class' last base class
    * subobject, or zero if the class has no base classes.
    */
   int baseClassEnd(Architecture arch) {
-    if exists(getABaseClass()) then result = arch.baseClassSize(getADerivation()) else result = 0
+    if exists(this.getABaseClass())
+    then result = arch.baseClassSize(this.getADerivation())
+    else result = 0
   }
 
   /** Gets the bitfield at field index `index`, if that field is a bitfield. */
-  private BitField bitFieldAt(int index) { fieldIndex(result) = index }
+  private BitField bitFieldAt(int index) { this.fieldIndex(result) = index }
 
   /**
    * Gets the 0-based offset, in bits, of the first free bit after
@@ -596,13 +601,13 @@ class PaddedType extends Class {
     then
       // Base case: No fields seen yet, so return the offset of the end of the
       // base class subojects.
-      result = baseClassEnd(arch)
+      result = this.baseClassEnd(arch)
     else
-      exists(Field f | index = fieldIndex(f) |
-        exists(int fSize | fSize = fieldSize(f, arch) |
+      exists(Field f | index = this.fieldIndex(f) |
+        exists(int fSize | fSize = this.fieldSize(f, arch) |
           // Recursive case: Take previous field's end point, pad and add
           // this field's size
-          exists(int firstFree | firstFree = fieldEnd(index - 1, arch) |
+          exists(int firstFree | firstFree = this.fieldEnd(index - 1, arch) |
             if f instanceof BitField
             then
               // Bitfield packing:
@@ -629,9 +634,11 @@ class PaddedType extends Class {
                     // No additional restrictions, so just pack it in with no padding.
                     result = firstFree + fSize
                 ) else (
-                  if exists(bitFieldAt(index - 1))
+                  if exists(this.bitFieldAt(index - 1))
                   then
-                    exists(BitField previousBitField | previousBitField = bitFieldAt(index - 1) |
+                    exists(BitField previousBitField |
+                      previousBitField = this.bitFieldAt(index - 1)
+                    |
                       // Previous field was a bitfield.
                       if
                         nextSizeofBoundary >= (firstFree + fSize) and

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeSSA.qll
@@ -88,7 +88,7 @@ class RangeSsaDefinition extends ControlFlowNodeBase {
   ControlFlowNode getDefinition() { result = this }
 
   /** Gets the basic block containing this definition. */
-  BasicBlock getBasicBlock() { result.contains(getDefinition()) }
+  BasicBlock getBasicBlock() { result.contains(this.getDefinition()) }
 
   /** Whether this definition is a phi node for variable `v`. */
   predicate isPhiNode(StackVariable v) { exists(RangeSSA x | x.phi_node(v, this.(BasicBlock))) }

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -127,17 +127,22 @@ private string getValue(Expr e) {
 private class UnsignedBitwiseAndExpr extends BitwiseAndExpr {
   UnsignedBitwiseAndExpr() {
     (
-      getLeftOperand().getFullyConverted().getType().getUnderlyingType().(IntegralType).isUnsigned() or
-      getValue(getLeftOperand().getFullyConverted()).toInt() >= 0
-    ) and
-    (
-      getRightOperand()
+      this.getLeftOperand()
           .getFullyConverted()
           .getType()
           .getUnderlyingType()
           .(IntegralType)
           .isUnsigned() or
-      getValue(getRightOperand().getFullyConverted()).toInt() >= 0
+      getValue(this.getLeftOperand().getFullyConverted()).toInt() >= 0
+    ) and
+    (
+      this.getRightOperand()
+          .getFullyConverted()
+          .getType()
+          .getUnderlyingType()
+          .(IntegralType)
+          .isUnsigned() or
+      getValue(this.getRightOperand().getFullyConverted()).toInt() >= 0
     )
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/security/BufferWrite.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/BufferWrite.qll
@@ -77,21 +77,21 @@ abstract class BufferWrite extends Expr {
    * much smaller (8 bytes) than their true maximum length.  This can be
    * helpful in determining the cause of a buffer overflow issue.
    */
-  int getMaxDataLimited() { result = getMaxData() }
+  int getMaxDataLimited() { result = this.getMaxData() }
 
   /**
    * Gets the size of a single character of the type this
    * operation works with, in bytes.
    */
   int getCharSize() {
-    result = getBufferType().(PointerType).getBaseType().getSize() or
-    result = getBufferType().(ArrayType).getBaseType().getSize()
+    result = this.getBufferType().(PointerType).getBaseType().getSize() or
+    result = this.getBufferType().(ArrayType).getBaseType().getSize()
   }
 
   /**
    * Gets a description of this buffer write.
    */
-  string getBWDesc() { result = toString() }
+  string getBWDesc() { result = this.toString() }
 }
 
 /**
@@ -109,7 +109,7 @@ abstract class BufferWriteCall extends BufferWrite, FunctionCall { }
 class StrCopyBW extends BufferWriteCall {
   StrcpyFunction f;
 
-  StrCopyBW() { getTarget() = f.(TopLevelFunction) }
+  StrCopyBW() { this.getTarget() = f.(TopLevelFunction) }
 
   /**
    * Gets the index of the parameter that is the maximum size of the copy (in characters).
@@ -122,21 +122,22 @@ class StrCopyBW extends BufferWriteCall {
   int getParamSrc() { result = f.getParamSrc() }
 
   override Type getBufferType() {
-    result = this.getTarget().getParameter(getParamSrc()).getUnspecifiedType()
+    result = this.getTarget().getParameter(this.getParamSrc()).getUnspecifiedType()
   }
 
-  override Expr getASource() { result = getArgument(getParamSrc()) }
+  override Expr getASource() { result = this.getArgument(this.getParamSrc()) }
 
-  override Expr getDest() { result = getArgument(f.getParamDest()) }
+  override Expr getDest() { result = this.getArgument(f.getParamDest()) }
 
-  override predicate hasExplicitLimit() { exists(getParamSize()) }
+  override predicate hasExplicitLimit() { exists(this.getParamSize()) }
 
   override int getExplicitLimit() {
-    result = getArgument(getParamSize()).getValue().toInt() * getCharSize()
+    result = this.getArgument(this.getParamSize()).getValue().toInt() * this.getCharSize()
   }
 
   override int getMaxData() {
-    result = getArgument(getParamSrc()).(AnalysedString).getMaxLength() * getCharSize()
+    result =
+      this.getArgument(this.getParamSrc()).(AnalysedString).getMaxLength() * this.getCharSize()
   }
 }
 
@@ -146,7 +147,7 @@ class StrCopyBW extends BufferWriteCall {
 class StrCatBW extends BufferWriteCall {
   StrcatFunction f;
 
-  StrCatBW() { getTarget() = f.(TopLevelFunction) }
+  StrCatBW() { this.getTarget() = f.(TopLevelFunction) }
 
   /**
    * Gets the index of the parameter that is the maximum size of the copy (in characters).
@@ -159,21 +160,22 @@ class StrCatBW extends BufferWriteCall {
   int getParamSrc() { result = f.getParamSrc() }
 
   override Type getBufferType() {
-    result = this.getTarget().getParameter(getParamSrc()).getUnspecifiedType()
+    result = this.getTarget().getParameter(this.getParamSrc()).getUnspecifiedType()
   }
 
-  override Expr getASource() { result = getArgument(getParamSrc()) }
+  override Expr getASource() { result = this.getArgument(this.getParamSrc()) }
 
-  override Expr getDest() { result = getArgument(f.getParamDest()) }
+  override Expr getDest() { result = this.getArgument(f.getParamDest()) }
 
-  override predicate hasExplicitLimit() { exists(getParamSize()) }
+  override predicate hasExplicitLimit() { exists(this.getParamSize()) }
 
   override int getExplicitLimit() {
-    result = getArgument(getParamSize()).getValue().toInt() * getCharSize()
+    result = this.getArgument(this.getParamSize()).getValue().toInt() * this.getCharSize()
   }
 
   override int getMaxData() {
-    result = getArgument(getParamSrc()).(AnalysedString).getMaxLength() * getCharSize()
+    result =
+      this.getArgument(this.getParamSrc()).(AnalysedString).getMaxLength() * this.getCharSize()
   }
 }
 
@@ -184,7 +186,7 @@ class SprintfBW extends BufferWriteCall {
   FormattingFunction f;
 
   SprintfBW() {
-    exists(string name | f = getTarget().(TopLevelFunction) and name = f.getName() |
+    exists(string name | f = this.getTarget().(TopLevelFunction) and name = f.getName() |
       /*
        * C sprintf variants:
        */
@@ -229,19 +231,19 @@ class SprintfBW extends BufferWriteCall {
     result = this.(FormattingFunctionCall).getFormatArgument(_)
   }
 
-  override Expr getDest() { result = getArgument(f.getOutputParameterIndex(false)) }
+  override Expr getDest() { result = this.getArgument(f.getOutputParameterIndex(false)) }
 
   override int getMaxData() {
     exists(FormatLiteral fl |
       fl = this.(FormattingFunctionCall).getFormat() and
-      result = fl.getMaxConvertedLength() * getCharSize()
+      result = fl.getMaxConvertedLength() * this.getCharSize()
     )
   }
 
   override int getMaxDataLimited() {
     exists(FormatLiteral fl |
       fl = this.(FormattingFunctionCall).getFormat() and
-      result = fl.getMaxConvertedLengthLimited() * getCharSize()
+      result = fl.getMaxConvertedLengthLimited() * this.getCharSize()
     )
   }
 }
@@ -251,7 +253,7 @@ class SprintfBW extends BufferWriteCall {
  */
 class SnprintfBW extends BufferWriteCall {
   SnprintfBW() {
-    exists(TopLevelFunction fn, string name | fn = getTarget() and name = fn.getName() |
+    exists(TopLevelFunction fn, string name | fn = this.getTarget() and name = fn.getName() |
       /*
        * C snprintf variants:
        */
@@ -326,25 +328,25 @@ class SnprintfBW extends BufferWriteCall {
     result = this.(FormattingFunctionCall).getFormatArgument(_)
   }
 
-  override Expr getDest() { result = getArgument(0) }
+  override Expr getDest() { result = this.getArgument(0) }
 
-  override predicate hasExplicitLimit() { exists(getParamSize()) }
+  override predicate hasExplicitLimit() { exists(this.getParamSize()) }
 
   override int getExplicitLimit() {
-    result = getArgument(getParamSize()).getValue().toInt() * getCharSize()
+    result = this.getArgument(this.getParamSize()).getValue().toInt() * this.getCharSize()
   }
 
   override int getMaxData() {
     exists(FormatLiteral fl |
       fl = this.(FormattingFunctionCall).getFormat() and
-      result = fl.getMaxConvertedLength() * getCharSize()
+      result = fl.getMaxConvertedLength() * this.getCharSize()
     )
   }
 
   override int getMaxDataLimited() {
     exists(FormatLiteral fl |
       fl = this.(FormattingFunctionCall).getFormat() and
-      result = fl.getMaxConvertedLengthLimited() * getCharSize()
+      result = fl.getMaxConvertedLengthLimited() * this.getCharSize()
     )
   }
 }
@@ -354,7 +356,7 @@ class SnprintfBW extends BufferWriteCall {
  */
 class GetsBW extends BufferWriteCall {
   GetsBW() {
-    getTarget().(TopLevelFunction).getName() =
+    this.getTarget().(TopLevelFunction).getName() =
       [
         "gets", // gets(dst)
         "fgets", // fgets(dst, max_amount, src_stream)
@@ -365,24 +367,24 @@ class GetsBW extends BufferWriteCall {
   /**
    * Gets the index of the parameter that is the maximum number of characters to be read.
    */
-  int getParamSize() { exists(getArgument(1)) and result = 1 }
+  int getParamSize() { exists(this.getArgument(1)) and result = 1 }
 
   override Type getBufferType() { result = this.getTarget().getParameter(0).getUnspecifiedType() }
 
   override Expr getASource() {
-    if exists(getArgument(2))
-    then result = getArgument(2)
+    if exists(this.getArgument(2))
+    then result = this.getArgument(2)
     else
       // the source is input inside the 'gets' call itself
       result = this
   }
 
-  override Expr getDest() { result = getArgument(0) }
+  override Expr getDest() { result = this.getArgument(0) }
 
-  override predicate hasExplicitLimit() { exists(getParamSize()) }
+  override predicate hasExplicitLimit() { exists(this.getParamSize()) }
 
   override int getExplicitLimit() {
-    result = getArgument(getParamSize()).getValue().toInt() * getCharSize()
+    result = this.getArgument(this.getParamSize()).getValue().toInt() * this.getCharSize()
   }
 }
 
@@ -438,7 +440,7 @@ class ScanfBW extends BufferWrite {
     exists(ScanfFunctionCall fc, ScanfFormatLiteral fl, int arg |
       this = fc.getArgument(arg) and
       fl = fc.getFormat() and
-      result = (fl.getMaxConvertedLength(arg - getParamArgs()) + 1) * getCharSize() // +1 is for the terminating null
+      result = (fl.getMaxConvertedLength(arg - this.getParamArgs()) + 1) * this.getCharSize() // +1 is for the terminating null
     )
   }
 
@@ -463,14 +465,14 @@ private int path_max() {
 class RealpathBW extends BufferWriteCall {
   RealpathBW() {
     exists(path_max()) and // Ignore realpath() calls if PATH_MAX cannot be determined
-    getTarget().hasGlobalName("realpath") // realpath(path, resolved_path);
+    this.getTarget().hasGlobalName("realpath") // realpath(path, resolved_path);
   }
 
   override Type getBufferType() { result = this.getTarget().getParameter(0).getUnspecifiedType() }
 
-  override Expr getDest() { result = getArgument(1) }
+  override Expr getDest() { result = this.getArgument(1) }
 
-  override Expr getASource() { result = getArgument(0) }
+  override Expr getASource() { result = this.getArgument(0) }
 
   override int getMaxData() {
     result = path_max() and

--- a/cpp/ql/lib/semmle/code/cpp/security/FileWrite.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FileWrite.qll
@@ -52,9 +52,9 @@ class BasicOStreamClass extends Type {
  */
 class BasicOStreamCall extends FunctionCall {
   BasicOStreamCall() {
-    if getTarget() instanceof MemberFunction
-    then getQualifier().getType() instanceof BasicOStreamClass
-    else getArgument(0).getType() instanceof BasicOStreamClass
+    if this.getTarget() instanceof MemberFunction
+    then this.getQualifier().getType() instanceof BasicOStreamClass
+    else this.getArgument(0).getType() instanceof BasicOStreamClass
   }
 }
 
@@ -77,10 +77,10 @@ abstract class ChainedOutputCall extends BasicOStreamCall {
    */
   Expr getEndDest() {
     // recurse into the destination
-    result = getDest().(ChainedOutputCall).getEndDest()
+    result = this.getDest().(ChainedOutputCall).getEndDest()
     or
     // or return something other than a ChainedOutputCall
-    result = getDest() and
+    result = this.getDest() and
     not result instanceof ChainedOutputCall
   }
 }
@@ -89,18 +89,18 @@ abstract class ChainedOutputCall extends BasicOStreamCall {
  * A call to `operator<<` on an output stream.
  */
 class OperatorLShiftCall extends ChainedOutputCall {
-  OperatorLShiftCall() { getTarget().(Operator).hasName("operator<<") }
+  OperatorLShiftCall() { this.getTarget().(Operator).hasName("operator<<") }
 
   override Expr getSource() {
-    if getTarget() instanceof MemberFunction
-    then result = getArgument(0)
-    else result = getArgument(1)
+    if this.getTarget() instanceof MemberFunction
+    then result = this.getArgument(0)
+    else result = this.getArgument(1)
   }
 
   override Expr getDest() {
-    if getTarget() instanceof MemberFunction
-    then result = getQualifier()
-    else result = getArgument(0)
+    if this.getTarget() instanceof MemberFunction
+    then result = this.getQualifier()
+    else result = this.getArgument(0)
   }
 }
 
@@ -108,22 +108,22 @@ class OperatorLShiftCall extends ChainedOutputCall {
  * A call to 'put'.
  */
 class PutFunctionCall extends ChainedOutputCall {
-  PutFunctionCall() { getTarget().(MemberFunction).hasName("put") }
+  PutFunctionCall() { this.getTarget().(MemberFunction).hasName("put") }
 
-  override Expr getSource() { result = getArgument(0) }
+  override Expr getSource() { result = this.getArgument(0) }
 
-  override Expr getDest() { result = getQualifier() }
+  override Expr getDest() { result = this.getQualifier() }
 }
 
 /**
  * A call to 'write'.
  */
 class WriteFunctionCall extends ChainedOutputCall {
-  WriteFunctionCall() { getTarget().(MemberFunction).hasName("write") }
+  WriteFunctionCall() { this.getTarget().(MemberFunction).hasName("write") }
 
-  override Expr getSource() { result = getArgument(0) }
+  override Expr getSource() { result = this.getArgument(0) }
 
-  override Expr getDest() { result = getQualifier() }
+  override Expr getDest() { result = this.getQualifier() }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FlowSources.qll
@@ -24,7 +24,7 @@ private class RemoteReturnSource extends RemoteFlowSource {
 
   RemoteReturnSource() {
     exists(RemoteFlowSourceFunction func, CallInstruction instr, FunctionOutput output |
-      asInstruction() = instr and
+      this.asInstruction() = instr and
       instr.getStaticCallTarget() = func and
       func.hasRemoteFlowSource(output, sourceType) and
       (
@@ -43,7 +43,7 @@ private class RemoteParameterSource extends RemoteFlowSource {
 
   RemoteParameterSource() {
     exists(RemoteFlowSourceFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
-      asInstruction() = instr and
+      this.asInstruction() = instr and
       instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
       func.hasRemoteFlowSource(output, sourceType) and
       output.isParameterDerefOrQualifierObject(instr.getIndex())
@@ -58,7 +58,7 @@ private class LocalReturnSource extends LocalFlowSource {
 
   LocalReturnSource() {
     exists(LocalFlowSourceFunction func, CallInstruction instr, FunctionOutput output |
-      asInstruction() = instr and
+      this.asInstruction() = instr and
       instr.getStaticCallTarget() = func and
       func.hasLocalFlowSource(output, sourceType) and
       (
@@ -77,7 +77,7 @@ private class LocalParameterSource extends LocalFlowSource {
 
   LocalParameterSource() {
     exists(LocalFlowSourceFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
-      asInstruction() = instr and
+      this.asInstruction() = instr and
       instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
       func.hasLocalFlowSource(output, sourceType) and
       output.isParameterDerefOrQualifierObject(instr.getIndex())

--- a/cpp/ql/lib/semmle/code/cpp/security/FunctionWithWrappers.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FunctionWithWrappers.qll
@@ -77,7 +77,7 @@ abstract class FunctionWithWrappers extends Function {
   ) {
     // base case
     func = this and
-    interestingArg(paramIndex) and
+    this.interestingArg(paramIndex) and
     callChain = toCause(func, paramIndex) and
     depth = 0
     or
@@ -101,7 +101,7 @@ abstract class FunctionWithWrappers extends Function {
   private predicate wrapperFunctionAnyDepth(Function func, int paramIndex, string cause) {
     // base case
     func = this and
-    interestingArg(paramIndex) and
+    this.interestingArg(paramIndex) and
     cause = toCause(func, paramIndex)
     or
     // recursive step
@@ -147,7 +147,7 @@ abstract class FunctionWithWrappers extends Function {
       )
     or
     not this.wrapperFunctionLimitedDepth(func, paramIndex, _, _) and
-    cause = wrapperFunctionAnyDepthUnique(func, paramIndex)
+    cause = this.wrapperFunctionAnyDepthUnique(func, paramIndex)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/security/Security.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/Security.qll
@@ -78,7 +78,7 @@ class SecurityOptions extends string {
       functionCall.getTarget().getName() = fname and
       (
         fname = ["fgets", "gets"] or
-        userInputReturn(fname)
+        this.userInputReturn(fname)
       )
     )
     or

--- a/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
@@ -29,7 +29,7 @@ private predicate suspicious(string s) {
  */
 class SensitiveVariable extends Variable {
   SensitiveVariable() {
-    suspicious(getName().toLowerCase()) and
+    suspicious(this.getName().toLowerCase()) and
     not this.getUnspecifiedType() instanceof IntegralType
   }
 }
@@ -39,7 +39,7 @@ class SensitiveVariable extends Variable {
  */
 class SensitiveFunction extends Function {
   SensitiveFunction() {
-    suspicious(getName().toLowerCase()) and
+    suspicious(this.getName().toLowerCase()) and
     not this.getUnspecifiedType() instanceof IntegralType
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/security/boostorg/asio/protocols.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/boostorg/asio/protocols.qll
@@ -113,7 +113,7 @@ module BoostorgAsio {
         result.getName() = "tls_server"
       )
       or
-      result = getASslv23ProtocolConstant()
+      result = this.getASslv23ProtocolConstant()
     }
 
     /**

--- a/cpp/ql/lib/semmle/code/cpp/stmts/Block.qll
+++ b/cpp/ql/lib/semmle/code/cpp/stmts/Block.qll
@@ -76,9 +76,9 @@ class BlockStmt extends Stmt, @stmt_block {
    * the result is the expression statement `a = b`.
    */
   Stmt getLastStmtIn() {
-    if getLastStmt() instanceof BlockStmt
-    then result = getLastStmt().(BlockStmt).getLastStmtIn()
-    else result = getLastStmt()
+    if this.getLastStmt() instanceof BlockStmt
+    then result = this.getLastStmt().(BlockStmt).getLastStmtIn()
+    else result = this.getLastStmt()
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/stmts/Stmt.qll
+++ b/cpp/ql/lib/semmle/code/cpp/stmts/Stmt.qll
@@ -27,10 +27,10 @@ class Stmt extends StmtParent, @stmt {
    */
   BlockStmt getEnclosingBlock() {
     if
-      getParentStmt() instanceof BlockStmt and
-      not getParentStmt().(BlockStmt).getLocation() instanceof UnknownLocation
-    then result = getParentStmt()
-    else result = getParentStmt().getEnclosingBlock()
+      this.getParentStmt() instanceof BlockStmt and
+      not this.getParentStmt().(BlockStmt).getLocation() instanceof UnknownLocation
+    then result = this.getParentStmt()
+    else result = this.getParentStmt().getEnclosingBlock()
   }
 
   /** Gets a child of this statement. */
@@ -438,7 +438,7 @@ class WhileStmt extends Loop, @stmt_while {
    * while(1) { ...; if(b) break; ...; }
    * ```
    */
-  predicate conditionAlwaysTrue() { conditionAlwaysTrue(getCondition()) }
+  predicate conditionAlwaysTrue() { conditionAlwaysTrue(this.getCondition()) }
 
   /**
    * Holds if the loop condition is provably `false`.
@@ -448,7 +448,7 @@ class WhileStmt extends Loop, @stmt_while {
    * while(0) { ...; }
    * ```
    */
-  predicate conditionAlwaysFalse() { conditionAlwaysFalse(getCondition()) }
+  predicate conditionAlwaysFalse() { conditionAlwaysFalse(this.getCondition()) }
 
   /**
    * Holds if the loop condition is provably `true` upon entry,
@@ -857,7 +857,7 @@ class RangeBasedForStmt extends Loop, @stmt_range_based_for {
    * ```
    * the result is `int x`.
    */
-  LocalVariable getVariable() { result = getChild(4).(DeclStmt).getADeclaration() }
+  LocalVariable getVariable() { result = this.getChild(4).(DeclStmt).getADeclaration() }
 
   /**
    * Gets the expression giving the range to iterate over.
@@ -868,10 +868,10 @@ class RangeBasedForStmt extends Loop, @stmt_range_based_for {
    * ```
    * the result is `xs`.
    */
-  Expr getRange() { result = getRangeVariable().getInitializer().getExpr() }
+  Expr getRange() { result = this.getRangeVariable().getInitializer().getExpr() }
 
   /** Gets the compiler-generated `__range` variable after desugaring. */
-  LocalVariable getRangeVariable() { result = getChild(0).(DeclStmt).getADeclaration() }
+  LocalVariable getRangeVariable() { result = this.getChild(0).(DeclStmt).getADeclaration() }
 
   /**
    * Gets the compiler-generated `__begin != __end` which is the
@@ -891,10 +891,10 @@ class RangeBasedForStmt extends Loop, @stmt_range_based_for {
   DeclStmt getBeginEndDeclaration() { result = this.getChild(1) }
 
   /** Gets the compiler-generated `__begin` variable after desugaring. */
-  LocalVariable getBeginVariable() { result = getBeginEndDeclaration().getDeclaration(0) }
+  LocalVariable getBeginVariable() { result = this.getBeginEndDeclaration().getDeclaration(0) }
 
   /** Gets the compiler-generated `__end` variable after desugaring. */
-  LocalVariable getEndVariable() { result = getBeginEndDeclaration().getDeclaration(1) }
+  LocalVariable getEndVariable() { result = this.getBeginEndDeclaration().getDeclaration(1) }
 
   /**
    * Gets the compiler-generated `++__begin` which is the update
@@ -905,7 +905,7 @@ class RangeBasedForStmt extends Loop, @stmt_range_based_for {
   Expr getUpdate() { result = this.getChild(3) }
 
   /** Gets the compiler-generated `__begin` variable after desugaring. */
-  LocalVariable getAnIterationVariable() { result = getBeginVariable() }
+  LocalVariable getAnIterationVariable() { result = this.getBeginVariable() }
 }
 
 /**
@@ -1067,7 +1067,7 @@ class ForStmt extends Loop, @stmt_for {
    * for(x = 0; 1; ++x) { sum += x; }
    * ```
    */
-  predicate conditionAlwaysTrue() { conditionAlwaysTrue(getCondition()) }
+  predicate conditionAlwaysTrue() { conditionAlwaysTrue(this.getCondition()) }
 
   /**
    * Holds if the loop condition is provably `false`.
@@ -1077,7 +1077,7 @@ class ForStmt extends Loop, @stmt_for {
    * for(x = 0; 0; ++x) { sum += x; }
    * ```
    */
-  predicate conditionAlwaysFalse() { conditionAlwaysFalse(getCondition()) }
+  predicate conditionAlwaysFalse() { conditionAlwaysFalse(this.getCondition()) }
 
   /**
    * Holds if the loop condition is provably `true` upon entry,
@@ -1723,10 +1723,10 @@ class Handler extends Stmt, @stmt_handler {
   /**
    * Gets the block containing the implementation of this handler.
    */
-  CatchBlock getBlock() { result = getChild(0) }
+  CatchBlock getBlock() { result = this.getChild(0) }
 
   /** Gets the 'try' statement corresponding to this 'catch block'. */
-  TryStmt getTryStmt() { result = getParent() }
+  TryStmt getTryStmt() { result = this.getParent() }
 
   /**
    * Gets the parameter introduced by this 'catch block', if any.
@@ -1734,7 +1734,7 @@ class Handler extends Stmt, @stmt_handler {
    * For example, `catch(std::exception&amp; e)` introduces a
    * parameter `e`, whereas `catch(...)` does not introduce a parameter.
    */
-  Parameter getParameter() { result = getBlock().getParameter() }
+  Parameter getParameter() { result = this.getBlock().getParameter() }
 
   override predicate mayBeImpure() { none() }
 
@@ -1921,15 +1921,15 @@ class MicrosoftTryStmt extends Stmt, @stmt_microsoft_try {
  * This is a Microsoft C/C++ extension.
  */
 class MicrosoftTryExceptStmt extends MicrosoftTryStmt {
-  MicrosoftTryExceptStmt() { getChild(1) instanceof Expr }
+  MicrosoftTryExceptStmt() { this.getChild(1) instanceof Expr }
 
   override string toString() { result = "__try { ... } __except( ... ) { ... }" }
 
   /** Gets the expression guarding the `__except` statement. */
-  Expr getCondition() { result = getChild(1) }
+  Expr getCondition() { result = this.getChild(1) }
 
   /** Gets the `__except` statement (usually a `BlockStmt`). */
-  Stmt getExcept() { result = getChild(2) }
+  Stmt getExcept() { result = this.getChild(2) }
 
   override string getAPrimaryQlClass() { result = "MicrosoftTryExceptStmt" }
 }
@@ -1948,12 +1948,12 @@ class MicrosoftTryExceptStmt extends MicrosoftTryStmt {
  * This is a Microsoft C/C++ extension.
  */
 class MicrosoftTryFinallyStmt extends MicrosoftTryStmt {
-  MicrosoftTryFinallyStmt() { not getChild(1) instanceof Expr }
+  MicrosoftTryFinallyStmt() { not this.getChild(1) instanceof Expr }
 
   override string toString() { result = "__try { ... } __finally { ... }" }
 
   /** Gets the `__finally` statement (usually a `BlockStmt`). */
-  Stmt getFinally() { result = getChild(1) }
+  Stmt getFinally() { result = this.getChild(1) }
 
   override string getAPrimaryQlClass() { result = "MicrosoftTryFinallyStmt" }
 }

--- a/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
+++ b/cpp/ql/src/Architecture/Refactoring Opportunities/ClassesWithManyFields.ql
@@ -68,12 +68,12 @@ class VariableDeclarationLine extends TVariableDeclarationInfo {
   /**
    * Gets the start column of the first `VariableDeclarationEntry` on this line.
    */
-  int getStartColumn() { result = min(getAVDE().getLocation().getStartColumn()) }
+  int getStartColumn() { result = min(this.getAVDE().getLocation().getStartColumn()) }
 
   /**
    * Gets the end column of the last `VariableDeclarationEntry` on this line.
    */
-  int getEndColumn() { result = max(getAVDE().getLocation().getEndColumn()) }
+  int getEndColumn() { result = max(this.getAVDE().getLocation().getEndColumn()) }
 
   /**
    * Gets the rank of this `VariableDeclarationLine` in its file and class
@@ -89,14 +89,14 @@ class VariableDeclarationLine extends TVariableDeclarationInfo {
    */
   VariableDeclarationLine getNext() {
     result = TVariableDeclarationLine(c, f, _) and
-    result.getRank() = getRank() + 1
+    result.getRank() = this.getRank() + 1
   }
 
   /**
    * Gets the `VariableDeclarationLine` following this one, if it is nearby.
    */
   VariableDeclarationLine getProximateNext() {
-    result = getNext() and
+    result = this.getNext() and
     result.getLine() <= this.getLine() + 3
   }
 
@@ -114,14 +114,14 @@ class VariableDeclarationGroup extends VariableDeclarationLine {
     // there is no `VariableDeclarationLine` within three lines previously
     not any(VariableDeclarationLine prev).getProximateNext() = this and
     // `end` is the last transitively proximate line
-    end = getProximateNext*() and
+    end = this.getProximateNext*() and
     not exists(end.getProximateNext())
   }
 
   predicate hasLocationInfo(string path, int startline, int startcol, int endline, int endcol) {
     path = f.getAbsolutePath() and
-    startline = getLine() and
-    startcol = getStartColumn() and
+    startline = this.getLine() and
+    startcol = this.getStartColumn() and
     endline = end.getLine() and
     endcol = end.getEndColumn()
   }
@@ -132,18 +132,18 @@ class VariableDeclarationGroup extends VariableDeclarationLine {
   int getCount() {
     result =
       count(VariableDeclarationLine l |
-        l = getProximateNext*()
+        l = this.getProximateNext*()
       |
         l.getAVDE().getVariable().getName()
       )
   }
 
   override string toString() {
-    getCount() = 1 and
-    result = "declaration of " + getAVDE().getVariable().getName()
+    this.getCount() = 1 and
+    result = "declaration of " + this.getAVDE().getVariable().getName()
     or
-    getCount() > 1 and
-    result = "group of " + getCount() + " fields here"
+    this.getCount() > 1 and
+    result = "group of " + this.getCount() + " fields here"
   }
 }
 

--- a/cpp/ql/src/JPL_C/LOC-2/Rule 09/Semaphores.qll
+++ b/cpp/ql/src/JPL_C/LOC-2/Rule 09/Semaphores.qll
@@ -50,7 +50,7 @@ class SemaphoreTake extends LockOperation {
     result.(SemaphoreGive).getLocked() = this.getLocked()
   }
 
-  override string say() { result = "semaphore take of " + getLocked().getName() }
+  override string say() { result = "semaphore take of " + this.getLocked().getName() }
 }
 
 class SemaphoreGive extends UnlockOperation {
@@ -76,13 +76,13 @@ class LockingPrimitive extends FunctionCall, LockOperation {
       this.getTarget().getName().replaceAll("Lock", "Unlock")
   }
 
-  override string say() { result = "call to " + getLocked().getName() }
+  override string say() { result = "call to " + this.getLocked().getName() }
 }
 
 class UnlockingPrimitive extends FunctionCall, UnlockOperation {
   UnlockingPrimitive() { this.getTarget().getName() = ["taskUnlock", "intUnlock", "taskRtpUnlock"] }
 
-  Function getLocked() { result = getMatchingLock().getLocked() }
+  Function getLocked() { result = this.getMatchingLock().getLocked() }
 
   override LockOperation getMatchingLock() { this = result.getMatchingUnlock() }
 }

--- a/cpp/ql/src/external/CodeDuplication.qll
+++ b/cpp/ql/src/external/CodeDuplication.qll
@@ -38,10 +38,10 @@ class Copy extends @duplication_or_similarity {
   int sourceStartColumn() { tokens(this, 0, _, result, _, _) }
 
   /** Gets the line on which the last token in this block ends. */
-  int sourceEndLine() { tokens(this, lastToken(), _, _, result, _) }
+  int sourceEndLine() { tokens(this, this.lastToken(), _, _, result, _) }
 
   /** Gets the column on which the last token in this block ends. */
-  int sourceEndColumn() { tokens(this, lastToken(), _, _, _, result) }
+  int sourceEndColumn() { tokens(this, this.lastToken(), _, _, _, result) }
 
   /** Gets the number of lines containing at least (part of) one token in this block. */
   int sourceLines() { result = this.sourceEndLine() + 1 - this.sourceStartLine() }
@@ -66,11 +66,11 @@ class Copy extends @duplication_or_similarity {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    sourceFile().getAbsolutePath() = filepath and
-    startline = sourceStartLine() and
-    startcolumn = sourceStartColumn() and
-    endline = sourceEndLine() and
-    endcolumn = sourceEndColumn()
+    this.sourceFile().getAbsolutePath() = filepath and
+    startline = this.sourceStartLine() and
+    startcolumn = this.sourceStartColumn() and
+    endline = this.sourceEndLine() and
+    endcolumn = this.sourceEndColumn()
   }
 
   /** Gets a textual representation of this element. */
@@ -79,13 +79,15 @@ class Copy extends @duplication_or_similarity {
 
 /** A block of duplicated code. */
 class DuplicateBlock extends Copy, @duplication {
-  override string toString() { result = "Duplicate code: " + sourceLines() + " duplicated lines." }
+  override string toString() {
+    result = "Duplicate code: " + this.sourceLines() + " duplicated lines."
+  }
 }
 
 /** A block of similar code. */
 class SimilarBlock extends Copy, @similarity {
   override string toString() {
-    result = "Similar code: " + sourceLines() + " almost duplicated lines."
+    result = "Similar code: " + this.sourceLines() + " almost duplicated lines."
   }
 }
 

--- a/cpp/ql/src/external/MetricFilter.qll
+++ b/cpp/ql/src/external/MetricFilter.qll
@@ -67,7 +67,7 @@ class MetricResult extends int {
   /** Gets the URL corresponding to the location of this query result. */
   string getURL() {
     result =
-      "file://" + getFile().getAbsolutePath() + ":" + getStartLine() + ":" + getStartColumn() + ":" +
-        getEndLine() + ":" + getEndColumn()
+      "file://" + this.getFile().getAbsolutePath() + ":" + this.getStartLine() + ":" +
+        this.getStartColumn() + ":" + this.getEndLine() + ":" + this.getEndColumn()
   }
 }


### PR DESCRIPTION
All these have been found by a ql-for-ql query, and the fixes have been automatically generated by a script from @erik-krogh.

How do we feel about merging such a PR?