### PR TITLE
JS: add pragma[noinline] to predicates where the qldoc mentions join-order

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/AbstractProperties.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/AbstractProperties.qll
@@ -86,6 +86,7 @@ class AbstractProtoProperty extends AbstractProperty {
  * has to be toplevel predicate to avoid a spurious type join with `AbstractProperty`,
  * which in turn introduces a materialization.
  */
+pragma[noinline]
 private AbstractValue getAnAssignedValue(AbstractValue b, string p) {
   exists(AnalyzedPropertyWrite apw | apw.writesValue(b, p, result))
 }

--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -493,6 +493,7 @@ private predicate barrierGuardBlocksEdge(
  *
  * This predicate exists to get a better join-order for the `barrierGuardBlocksEdge` predicate above.
  */
+pragma[noinline]
 private BasicBlock getADominatedBasicBlock(BarrierGuardNode guard, ConditionGuardNode cond) {
   barrierGuardIsRelevant(guard) and
   guard.getEnclosingExpr() = cond.getTest() and
@@ -996,6 +997,7 @@ private predicate exploratoryLoadStep(
  *
  * This private predicate is only used in `exploratoryLoadStep`, and exists as a separate predicate to give the compiler a hint about join-ordering.
  */
+pragma[noinline]
 private string getAForwardRelevantLoadProperty(DataFlow::Configuration cfg) {
   exists(DataFlow::Node previous | isRelevantForward(previous, cfg) |
     basicStoreStep(previous, _, result) or
@@ -1055,6 +1057,7 @@ private predicate exploratoryBackwardStoreStep(
  *
  * This private predicate is only used in `exploratoryBackwardStoreStep`, and exists as a separate predicate to give the compiler a hint about join-ordering.
  */
+pragma[noinline]
 private string getABackwardsRelevantStoreProperty(DataFlow::Configuration cfg) {
   exists(DataFlow::Node mid | isRelevant(mid, cfg) |
     basicLoadStep(mid, _, result) or
@@ -1672,6 +1675,7 @@ private predicate onPath(DataFlow::Node nd, DataFlow::Configuration cfg, PathSum
  *
  * This predicate has been outlined from `onPath` to give the optimizer a hint about join-ordering.
  */
+pragma[noinline]
 private predicate onPathStep(
   DataFlow::Node nd, DataFlow::Configuration cfg, PathSummary summary, PathSummary stepSummary,
   DataFlow::Node mid


### PR DESCRIPTION
The qldoc suggests that the predicate should not be inlined, but that wasn't enforced by a `pragma`.  

[Evaluation looks safe](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-6881-047aee3__default__security-extend/reports). 