### PR TITLE
C#: Handle `Nullable<T>` default parameter values in assemblies

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
@@ -14,7 +14,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             {
                 if (info.Node is null)
                 {
-                    info.Context.ModelError("Attempt to create a null expression");
+                    info.Context.ModelError(info.Location, "Attempt to create a null expression");
                     return new Unknown(info);
                 }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Literal.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Literal.cs
@@ -32,10 +32,10 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             }
 
             var type = info.Type?.Symbol;
-            return GetExprKind(type, info.Node, info.Context);
+            return GetExprKind(type, info.Node, info.Location, info.Context);
         }
 
-        private static ExprKind GetExprKind(ITypeSymbol? type, ExpressionSyntax? expr, Context context)
+        private static ExprKind GetExprKind(ITypeSymbol? type, ExpressionSyntax? expr, Extraction.Entities.Location loc, Context context)
         {
             switch (type?.SpecialType)
             {
@@ -75,10 +75,11 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
                 case null:
                 default:
+                    var kind = type?.SpecialType.ToString() ?? "null";
                     if (expr is not null)
-                        context.ModelError(expr, "Unhandled literal type");
+                        context.ModelError(expr, $"Unhandled literal type {kind}");
                     else
-                        context.ModelError("Unhandled literal type");
+                        context.ModelError(loc, $"Unhandled literal type {kind}");
                     return ExprKind.UNKNOWN;
             }
         }
@@ -86,11 +87,12 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         public static Expression CreateGenerated(Context cx, IExpressionParentEntity parent, int childIndex, ITypeSymbol type, object? value,
             Extraction.Entities.Location location)
         {
+            var kind = value is null ? ExprKind.NULL_LITERAL : GetExprKind(type, null, location, cx);
             var info = new ExpressionInfo(
                 cx,
                 AnnotatedTypeSymbol.CreateNotAnnotated(type),
                 location,
-                GetExprKind(type, null, cx),
+                kind,
                 parent,
                 childIndex,
                 true,

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -429,6 +429,16 @@ namespace Semmle.Extraction
         /// <summary>
         /// Signal an error in the program model.
         /// </summary>
+        /// <param name="loc">The location of the error.</param>
+        /// <param name="msg">The error message.</param>
+        public void ModelError(Entities.Location loc, string msg)
+        {
+            ReportError(new InternalError(loc.ReportingLocation, msg));
+        }
+
+        /// <summary>
+        /// Signal an error in the program model.
+        /// </summary>
         /// <param name="msg">The error message.</param>
         public void ModelError(string msg)
         {

--- a/csharp/extractor/Semmle.Extraction/InternalError.cs
+++ b/csharp/extractor/Semmle.Extraction/InternalError.cs
@@ -23,6 +23,13 @@ namespace Semmle.Extraction
             Location = node.GetLocation();
         }
 
+        public InternalError(Location? loc, string msg)
+        {
+            Text = msg;
+            EntityText = "";
+            Location = loc;
+        }
+
         public InternalError(string msg)
         {
             Text = msg;


### PR DESCRIPTION
Fixes the extractor messages mentioned on https://github.com/github/codeql-action/issues/772.

Very likely also fixes https://github.com/github/codeql-cli-binaries/issues/86 and https://github.com/github/codeql/issues/6874.