### PR TITLE
C++: Disable the two null termination queries enabled by 6794.

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ImproperNullTermination.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ImproperNullTermination.ql
@@ -5,7 +5,6 @@
  * @kind problem
  * @id cpp/improper-null-termination
  * @problem.severity warning
- * @precision medium
  * @security-severity 7.8
  * @tags security
  *       external/cwe/cwe-170

--- a/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-170/ImproperNullTerminationTainted.ql
@@ -5,7 +5,6 @@
  * @kind problem
  * @id cpp/user-controlled-null-termination-tainted
  * @problem.severity warning
- * @precision medium
  * @security-severity 10.0
  * @tags security
  *       external/cwe/cwe-170


### PR DESCRIPTION
The two queries enabled by https://github.com/github/codeql/pull/6794 are performing badly on `abseil_abseil` (and likely other projects).  I'm working on a fix, but we want the LGTM dist upgrade next week to go smoothly - so to avoid any risks I want to remove those two queries from the suites now, and I'll add them back when I've fixed the performance issue.