### PR TITLE
Language reference: Fix when trailing commas are allowed

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -1333,7 +1333,7 @@ The values of a set literal expression are all the values of all the contained e
 
 Set literals are supported from release 2.1.0 of the CodeQL CLI, and release 1.24 of LGTM Enterprise.
 
-Since release 2.6.3 of the CodeQL CLI, and release 1.28 of LGTM Enterprise, a trailing comma is allowed in a set literal.
+Since release 2.7.0 of the CodeQL CLI, and release 1.28 of LGTM Enterprise, a trailing comma is allowed in a set literal.
 
 Disambiguation of expressions
 -----------------------------


### PR DESCRIPTION
See also this comment: https://github.com/github/codeql-cli-binaries/issues/76#issuecomment-944876419

It appears this change didn't actually make it into 2.6.3 as I thought it did. It will be in 2.7.0 - update the spec accordingly.