### PR TITLE
Java: Fix bad join-order.

### DIFF
--- a/java/ql/lib/semmle/code/java/dispatch/WrappedInvocation.qll
+++ b/java/ql/lib/semmle/code/java/dispatch/WrappedInvocation.qll
@@ -39,7 +39,10 @@ private Expr getRunnerArgument(MethodAccess ma, Method runmethod) {
   or
   getRunnerArgument(ma, runmethod).(CastExpr).getExpr() = result
   or
-  getRunnerArgument(ma, runmethod).(VarAccess).getVariable().getAnAssignedValue() = result
+  pragma[only_bind_out](getRunnerArgument(ma, runmethod))
+      .(VarAccess)
+      .getVariable()
+      .getAnAssignedValue() = result
 }
 
 /**


### PR DESCRIPTION
This puts the delta first and avoids the variable-to-double-varaccess cartesian blowup.