### PR TITLE
C++: Fix unbound variables in PrivateCleartextWrite.qll.

### DIFF
--- a/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
@@ -52,11 +52,8 @@ module PrivateCleartextWrite {
 
   class WriteSink extends Sink {
     WriteSink() {
-      exists(FileWrite f, BufferWrite b |
-        this.asExpr() = f.getASource()
-        or
-        this.asExpr() = b.getAChild()
-      )
+      this.asExpr() = any(FileWrite f).getASource() or
+      this.asExpr() = any(BufferWrite b).getAChild()
     }
   }
 }


### PR DESCRIPTION
This was pointed out during the hackathon I think, and as far as I can tell nobody has put in a fix for it yet.