### PR TITLE
Java: CWE-470  - Queries to detect Fragment Injection in Android applications

### DIFF
--- a/java/change-notes/2021-10-20-android-fragment-injection-query.md
+++ b/java/change-notes/2021-10-20-android-fragment-injection-query.md
@@ -1,3 +1,3 @@
 lgtm,codescanning
-* Two new queries, "Android Fragment injection" (`java/android/fragment-injection`) and "Android Fragment injection in PreferenceActivity" (`java/android/fragment-injection-preference-activity`) have been added.
-These queries find exported Android Activities that instantiate and host Fragments created from user-provided data, which can lead to access control bypass and exposes the application to unintended effects.
+* Two new queries, "Android fragment injection" (`java/android/fragment-injection`) and "Android fragment injection in PreferenceActivity" (`java/android/fragment-injection-preference-activity`) have been added.
+These queries find exported Android activities that instantiate and host fragments created from user-provided data. Such activities are vulnerable to access control bypass and expose the Android application to unintended effects.

--- a/java/change-notes/2021-10-20-android-fragment-injection-query.md
+++ b/java/change-notes/2021-10-20-android-fragment-injection-query.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Two new queries, "Android Fragment injection" (`java/android/fragment-injection`) and "Android Fragment injection in PreferenceActivity" (`java/android/fragment-injection-preference-activity`) have been added.
+These queries find exported Android Activities that instantiate and host Fragments created from user-provided data, which can lead to access control bypass and exposes the application to unintended effects.

--- a/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
@@ -1,4 +1,4 @@
-/** Provides classes and predicates related to Android Fragments. */
+/** Provides classes and predicates to track Android fragments. */
 
 import java
 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
@@ -1,3 +1,5 @@
+/** Provides classes and predicates related to Android Fragments. */
+
 import java
 
 /** The class `android.app.Fragment` */

--- a/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Fragment.qll
@@ -1,0 +1,14 @@
+import java
+
+/** The class `android.app.Fragment` */
+class Fragment extends Class {
+  Fragment() { this.hasQualifiedName("android.app", "Fragment") }
+}
+
+/** The method `instantiate` of the class `android.app.Fragment`. */
+class FragmentInstantiateMethod extends Method {
+  FragmentInstantiateMethod() {
+    this.getDeclaringType() instanceof Fragment and
+    this.hasName("instantiate")
+  }
+}

--- a/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
@@ -35,7 +35,7 @@ class IsValidFragmentMethod extends Method {
 
 /**
  * A sink for Fragment injection vulnerabilities,
- * that is, method calls that dynamically add Fragments to Activities.
+ * that is, method calls that dynamically add fragments to activities.
  */
 abstract class FragmentInjectionSink extends DataFlow::Node { }
 

--- a/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
@@ -1,3 +1,5 @@
+/** Provides classes and predicates to reason about Android Fragment injection vulnerabilities. */
+
 import java
 private import semmle.code.java.dataflow.TaintTracking
 private import semmle.code.java.dataflow.ExternalFlow
@@ -43,6 +45,10 @@ abstract class FragmentInjectionSink extends DataFlow::Node { }
  * Extend this class to add additional taint steps that should apply to `FragmentInjectionTaintConf`.
  */
 class FragmentInjectionAdditionalTaintStep extends Unit {
+  /**
+   * Holds if the step from `node1` to `node2` should be considered a taint
+   * step for the `FragmentInjectionTaintConf` configuration.
+   */
   abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);
 }
 

--- a/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
@@ -1,0 +1,60 @@
+import java
+private import semmle.code.java.dataflow.TaintTracking
+private import semmle.code.java.dataflow.ExternalFlow
+private import semmle.code.java.frameworks.android.Android
+private import semmle.code.java.frameworks.android.Fragment
+private import semmle.code.java.Reflection
+
+/**
+ * A sink for Fragment injection vulnerabilities,
+ * that is, method calls that dynamically add Fragments to Activities.
+ */
+abstract class FragmentInjectionSink extends DataFlow::Node { }
+
+/**
+ * A unit class for adding additional taint steps.
+ *
+ * Extend this class to add additional taint steps that should apply to `FragmentInjectionTaintConf`.
+ */
+class FragmentInjectionAdditionalTaintStep extends Unit {
+  abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);
+}
+
+private class FragmentInjectionSinkModels extends SinkModelCsv {
+  override predicate row(string row) {
+    row =
+      ["android.app", "android.support.v4.app", "androidx.fragment.app"] +
+        ";FragmentTransaction;true;" +
+        [
+          "add;(Class,Bundle,String);;Argument[0]", "add;(Fragment,String);;Argument[0]",
+          "add;(int,Class,Bundle);;Argument[1]", "add;(int,Fragment);;Argument[1]",
+          "add;(int,Class,Bundle,String);;Argument[1]", "add;(int,Fragment,String);;Argument[1]",
+          "attach;(Fragment);;Argument[0]", "replace;(int,Class,Bundle);;Argument[1]",
+          "replace;(int,Fragment);;Argument[1]", "replace;(int,Class,Bundle,String);;Argument[1]",
+          "replace;(int,Fragment,String);;Argument[1]",
+        ] + ";fragment-injection"
+  }
+}
+
+private class DefaultFragmentInjectionSink extends FragmentInjectionSink {
+  DefaultFragmentInjectionSink() { sinkNode(this, "fragment-injection") }
+}
+
+private class DefaultFragmentInjectionAdditionalTaintStep extends FragmentInjectionAdditionalTaintStep {
+  override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
+    exists(ReflectiveClassIdentifierMethodAccess ma |
+      ma.getArgument(0) = n1.asExpr() and ma = n2.asExpr()
+    )
+    or
+    exists(NewInstance ni |
+      ni.getQualifier() = n1.asExpr() and
+      ni = n2.asExpr()
+    )
+    or
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof FragmentInstantiateMethod and
+      ma.getArgument(1) = n1.asExpr() and
+      ma = n2.asExpr()
+    )
+  }
+}

--- a/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjection.qll
@@ -22,13 +22,8 @@ class IsValidFragmentMethod extends Method {
    */
   predicate isUnsafe() {
     this.getDeclaringType().(AndroidActivity).isExported() and
-    forex(ReturnStmt retStmt, BooleanLiteral bool |
-      retStmt.getEnclosingCallable() = this and
-      // Using taint tracking to handle logical expressions, like
-      // fragmentName.equals("safe") || true
-      TaintTracking::localExprTaint(bool, retStmt.getResult())
-    |
-      bool.getBooleanValue() = true
+    forex(ReturnStmt retStmt | retStmt.getEnclosingCallable() = this |
+      retStmt.getResult().(BooleanLiteral).getBooleanValue() = true
     )
   }
 }
@@ -39,15 +34,11 @@ class IsValidFragmentMethod extends Method {
  */
 abstract class FragmentInjectionSink extends DataFlow::Node { }
 
-/**
- * A unit class for adding additional taint steps.
- *
- * Extend this class to add additional taint steps that should apply to `FragmentInjectionTaintConf`.
- */
+/** An additional taint step for flows related to Fragment injection vulnerabilites. */
 class FragmentInjectionAdditionalTaintStep extends Unit {
   /**
    * Holds if the step from `node1` to `node2` should be considered a taint
-   * step for the `FragmentInjectionTaintConf` configuration.
+   * step in flows related to Fragment injection vulnerabilites.
    */
   abstract predicate step(DataFlow::Node n1, DataFlow::Node n2);
 }

--- a/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
@@ -1,3 +1,5 @@
+/** Provides classes and predicates to be used in queries related to Android Fragment injection. */
+
 import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking

--- a/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
@@ -7,7 +7,7 @@ import semmle.code.java.security.FragmentInjection
 
 /**
  * A taint-tracking configuration for unsafe user input
- * that is used to create Android Fragments dinamically.
+ * that is used to create Android fragments dynamically.
  */
 class FragmentInjectionTaintConf extends TaintTracking::Configuration {
   FragmentInjectionTaintConf() { this = "FragmentInjectionTaintConf" }

--- a/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/FragmentInjectionQuery.qll
@@ -1,0 +1,20 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.security.FragmentInjection
+
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to create Android Fragments dinamically.
+ */
+class FragmentInjectionTaintConf extends TaintTracking::Configuration {
+  FragmentInjectionTaintConf() { this = "FragmentInjectionTaintConf" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof FragmentInjectionSink }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node n1, DataFlow::Node n2) {
+    any(FragmentInjectionAdditionalTaintStep c).step(n1, n2)
+  }
+}

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.inc.qhelp
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.inc.qhelp
@@ -6,7 +6,7 @@
 When fragments are instantiated with externally provided names, this exposes any exported activity that dynamically
 creates and hosts the fragment to fragment injection. A malicious application could provide the 
 name of an arbitrary fragment, even one not designed to be externally accessible, and inject it into the activity. 
-Thus, effectively bypassing access controls and exposing the application to unintended effects.
+This can bypass access controls and expose the application to unintended effects.
 </p>
 <p>
 Fragments are reusable parts of an Android application's user interface.

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.inc.qhelp
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.inc.qhelp
@@ -1,0 +1,60 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Fragments are reusable parts of an Android application's user interface.
+Even though a Fragment controls its own lifecycle and layout and handles its input events,
+it cannot exist on its own: it must be hosted either by an Activity or another fragment.
+This means that a Fragment will be accessible by third-party applications (that is, exported)
+only if its hosting Activity is itself exported.
+</p>
+<p>
+If an exported Activity dinamically creates and hosts Fragments instantiated with externally
+provided names, a malicious application could provide the name of an arbitrary Fragment, even
+one not designed to be externally accessible, and inject it into the Activity, effectively
+bypassing access controls and exposing the application to unintended effects.
+</p>
+</overview>
+
+<recommendation>
+<p>
+In general, do not instantiate classes (including Fragments) with user-provided names
+without proper validation.
+
+Also, if an exported Activity is extending the <code>PreferenceActivity</code> class, make sure that
+the <code>isValidFragment</code> method is overriden and only returns <code>true</code> when the provided
+<code>fragmentName</code> points to an intended Fragment.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example shows two cases: in the first one, untrusted data is used to instantiate and
+add a Fragment to an Activity, while in the second one, a Fragment is safely added with a static name.
+</p>
+<sample src="FragmentInjection.java" />
+
+<p>
+The next example shows two Activities extending <code>PreferenceActivity</code>. The first one overrides
+<code>isValidFragment</code>, but it wrongly returns <code>true</code> inconditionally. The second Activity
+correctly overrides <code>isValidFragment</code> to only return <code>true</code> when <code>fragmentName</code>
+is a trusted Fragment name.
+</p>
+<sample src="FragmentInjectionInPreferenceActivity.java" />
+</example>
+
+<references>
+<li> Google Help:
+  <a href="https://support.google.com/faqs/answer/7188427?hl=en">How to fix Fragment Injection vulnerability</a>.
+</li>
+<li>
+  IBM Security Systems:
+  <a href="https://securityintelligence.com/wp-content/uploads/2013/12/android-collapses-into-fragments.pdf">Android collapses into Fragments</a>.
+</li>
+<li>
+  Android Developers:
+  <a href="https://developer.android.com/guide/fragments">Fragments</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.inc.qhelp
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.inc.qhelp
@@ -3,43 +3,43 @@
 
 <overview>
 <p>
-Fragments are reusable parts of an Android application's user interface.
-Even though a Fragment controls its own lifecycle and layout and handles its input events,
-it cannot exist on its own: it must be hosted either by an Activity or another fragment.
-This means that a Fragment will be accessible by third-party applications (that is, exported)
-only if its hosting Activity is itself exported.
+When fragments are instantiated with externally provided names, this exposes any exported activity that dynamically
+creates and hosts the fragment to fragment injection. A malicious application could provide the 
+name of an arbitrary fragment, even one not designed to be externally accessible, and inject it into the activity. 
+Thus, effectively bypassing access controls and exposing the application to unintended effects.
 </p>
 <p>
-If an exported Activity dinamically creates and hosts Fragments instantiated with externally
-provided names, a malicious application could provide the name of an arbitrary Fragment, even
-one not designed to be externally accessible, and inject it into the Activity, effectively
-bypassing access controls and exposing the application to unintended effects.
+Fragments are reusable parts of an Android application's user interface.
+Even though a fragment controls its own lifecycle and layout, and handles its input events,
+it cannot exist on its own: it must be hosted either by an activity or another fragment.
+This means that, normally, a fragment will be accessible by third-party applications (that is, exported)
+only if its hosting activity is itself exported.
 </p>
 </overview>
 
 <recommendation>
 <p>
-In general, do not instantiate classes (including Fragments) with user-provided names
-without proper validation.
+In general, do not instantiate classes (including fragments) with user-provided names
+unless the name has been properly validated.
 
-Also, if an exported Activity is extending the <code>PreferenceActivity</code> class, make sure that
+Also, if an exported activity is extending the <code>PreferenceActivity</code> class, make sure that
 the <code>isValidFragment</code> method is overriden and only returns <code>true</code> when the provided
-<code>fragmentName</code> points to an intended Fragment.
+<code>fragmentName</code> points to an intended fragment.
 </p>
 </recommendation>
 
 <example>
 <p>
 The following example shows two cases: in the first one, untrusted data is used to instantiate and
-add a Fragment to an Activity, while in the second one, a Fragment is safely added with a static name.
+add a fragment to an activity, while in the second one, a fragment is safely added with a static name.
 </p>
 <sample src="FragmentInjection.java" />
 
 <p>
-The next example shows two Activities extending <code>PreferenceActivity</code>. The first one overrides
-<code>isValidFragment</code>, but it wrongly returns <code>true</code> inconditionally. The second Activity
-correctly overrides <code>isValidFragment</code> to only return <code>true</code> when <code>fragmentName</code>
-is a trusted Fragment name.
+The next example shows two activities that extend <code>PreferenceActivity</code>. The first activity overrides
+<code>isValidFragment</code>, but it wrongly returns <code>true</code> unconditionally. The second activity
+correctly overrides <code>isValidFragment</code> so that it only returns <code>true</code> when <code>fragmentName</code>
+is a trusted fragment name.
 </p>
 <sample src="FragmentInjectionInPreferenceActivity.java" />
 </example>

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.java
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.java
@@ -1,0 +1,22 @@
+public class MyActivity extends FragmentActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstance) {
+        try {
+            super.onCreate(savedInstance);
+            // BAD: Fragment instantiated from user input
+            {
+                String fName = getIntent().getStringExtra("fragmentName");
+                getFragmentManager().beginTransaction().replace(com.android.internal.R.id.prefs,
+                        Fragment.instantiate(this, fName, null)).commit();
+            }
+            // GOOD: Fragment instantiated statically
+            {
+                getFragmentManager().beginTransaction()
+                        .replace(com.android.internal.R.id.prefs, new MyFragment()).commit();
+            }
+        } catch (Exception e) {
+        }
+    }
+
+}

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.java
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.java
@@ -4,7 +4,7 @@ public class MyActivity extends FragmentActivity {
     protected void onCreate(Bundle savedInstance) {
         try {
             super.onCreate(savedInstance);
-            // BAD: Fragment instantiated from user input
+            // BAD: Fragment instantiated from user input without validation
             {
                 String fName = getIntent().getStringExtra("fragmentName");
                 getFragmentManager().beginTransaction().replace(com.android.internal.R.id.prefs,

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.qhelp
@@ -1,0 +1,4 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+<include src="FragmentInjection.inc.qhelp"></include>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Android Fragment injection
+ * @description Instantiating an Android Fragment from a user-provided value
+ *              may lead to Fragment injection.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 9.8
+ * @precision high
+ * @id java/android/fragment-injection
+ * @tags security
+ *       external/cwe/cwe-470
+ */
+
+import java
+import semmle.code.java.security.FragmentInjectionQuery
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink
+where any(FragmentInjectionTaintConf conf).hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Fragment injection from $@.", source.getNode(),
+  "this user input"

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjection.ql
@@ -1,7 +1,7 @@
 /**
- * @name Android Fragment injection
- * @description Instantiating an Android Fragment from a user-provided value
- *              may lead to Fragment injection.
+ * @name Android fragment injection
+ * @description Instantiating an Android fragment from a user-provided value
+ *              may allow a malicious application to bypass access controls,  exposing the application to unintended effects.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.java
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.java
@@ -1,0 +1,21 @@
+class UnsafeActivity extends PreferenceActivity {
+
+    @Override
+    protected boolean isValidFragment(String fragmentName) {
+        // BAD: any Fragment name can be provided.
+        return true;
+    }
+}
+
+
+class SafeActivity extends PreferenceActivity {
+    @Override
+    protected boolean isValidFragment(String fragmentName) {
+        // Good: only trusted Fragment names are allowed.
+        return SafeFragment1.class.getName().equals(fragmentName)
+                || SafeFragment2.class.getName().equals(fragmentName)
+                || SafeFragment3.class.getName().equals(fragmentName);
+    }
+
+}
+

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.qhelp
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.qhelp
@@ -1,0 +1,4 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+<include src="FragmentInjection.inc.qhelp"></include>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.ql
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Android Fragment injection in PreferenceActivity
+ * @description An insecure implementation of the isValidFragment method
+ *              of the PreferenceActivity class may lead to Fragment injection.
+ * @kind problem
+ * @problem.severity error
+ * @security-severity 9.8
+ * @precision high
+ * @id java/android/fragment-injection-preference-activity
+ * @tags security
+ *       external/cwe/cwe-470
+ */
+
+import java
+import semmle.code.java.security.FragmentInjection
+
+from IsValidFragmentMethod m
+where m.isUnsafe()
+select m,
+  "The 'isValidFragment' method always returns true. This makes the exported Activity $@ vulnerable to Fragment Injection.",
+  m.getDeclaringType(), m.getDeclaringType().getName()

--- a/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.ql
+++ b/java/ql/src/Security/CWE/CWE-470/FragmentInjectionInPreferenceActivity.ql
@@ -1,7 +1,8 @@
 /**
- * @name Android Fragment injection in PreferenceActivity
- * @description An insecure implementation of the isValidFragment method
- *              of the PreferenceActivity class may lead to Fragment injection.
+ * @name Android fragment injection in PreferenceActivity
+ * @description An insecure implementation of the 'isValidFragment' method
+ *              of the 'PreferenceActivity' class may allow a malicious application to bypass access controls,
+ *              exposing the application to unintended effects.
  * @kind problem
  * @problem.severity error
  * @security-severity 9.8

--- a/java/ql/src/change-notes/2021-12-15-android-fragment-injection-query.md
+++ b/java/ql/src/change-notes/2021-12-15-android-fragment-injection-query.md
@@ -1,3 +1,5 @@
-lgtm,codescanning
+---
+category: newQuery
+---
 * Two new queries, "Android fragment injection" (`java/android/fragment-injection`) and "Android fragment injection in PreferenceActivity" (`java/android/fragment-injection-preference-activity`) have been added.
 These queries find exported Android activities that instantiate and host fragments created from user-provided data. Such activities are vulnerable to access control bypass and expose the Android application to unintended effects.

--- a/java/ql/test/query-tests/security/CWE-470/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-470/AndroidManifest.xml
@@ -19,5 +19,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".SafePreferenceActivity" android:exported="true" />
+        <activity android:name=".UnsafePreferenceActivity" android:exported="true" />
+        <activity android:name=".UnexportedPreferenceActivity" android:exported="false" />
     </application>
 </manifest>

--- a/java/ql/test/query-tests/security/CWE-470/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-470/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0"
+    package="com.example.myapp">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/java/ql/test/query-tests/security/CWE-470/FragmentInjectionInPreferenceActivityTest.ql
+++ b/java/ql/test/query-tests/security/CWE-470/FragmentInjectionInPreferenceActivityTest.ql
@@ -1,0 +1,18 @@
+import java
+import semmle.code.java.security.FragmentInjection
+import TestUtilities.InlineExpectationsTest
+
+class FragmentInjectionInPreferenceActivityTest extends InlineExpectationsTest {
+  FragmentInjectionInPreferenceActivityTest() { this = "FragmentInjectionInPreferenceActivityTest" }
+
+  override string getARelevantTag() { result = "hasPreferenceFragmentInjection" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    tag = "hasPreferenceFragmentInjection" and
+    exists(IsValidFragmentMethod isValidFragment | isValidFragment.isUnsafe() |
+      isValidFragment.getLocation() = location and
+      element = isValidFragment.toString() and
+      value = ""
+    )
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-470/FragmentInjectionTest.ql
+++ b/java/ql/test/query-tests/security/CWE-470/FragmentInjectionTest.ql
@@ -1,0 +1,11 @@
+import java
+import semmle.code.java.security.FragmentInjectionQuery
+import TestUtilities.InlineFlowTest
+
+class Test extends InlineFlowTest {
+  override DataFlow::Configuration getValueFlowConfig() { none() }
+
+  override TaintTracking::Configuration getTaintFlowConfig() {
+    result instanceof FragmentInjectionTaintConf
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-470/MainActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/MainActivity.java
@@ -12,7 +12,7 @@ import androidx.fragment.app.FragmentTransaction;
 public class MainActivity extends FragmentActivity {
 
     @Override
-    protected void onCreate(Bundle savedInstance) {
+    public void onCreate(Bundle savedInstance) {
         try {
             super.onCreate(savedInstance);
             final String fname = getIntent().getStringExtra("fname");

--- a/java/ql/test/query-tests/security/CWE-470/MainActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/MainActivity.java
@@ -1,0 +1,39 @@
+package com.example.myapp;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentTransaction;
+
+public class MainActivity extends FragmentActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstance) {
+        try {
+            super.onCreate(savedInstance);
+            final String fname = getIntent().getStringExtra("fname");
+            FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+            Class<Fragment> fClass = (Class<Fragment>) Class.forName(fname);
+            ft.add(fClass.newInstance(), ""); // $ hasTaintFlow
+            ft.add(0, Fragment.instantiate(this, fname), null); // $ hasTaintFlow
+            ft.add(0, Fragment.instantiate(this, fname, null)); // $ hasTaintFlow
+            ft.add(0, fClass, null, ""); // $ hasTaintFlow
+            ft.add(0, fClass.newInstance(), ""); // $ hasTaintFlow
+            ft.attach(fClass.newInstance()); // $ hasTaintFlow
+            ft.replace(0, fClass, null); // $ hasTaintFlow
+            ft.replace(0, fClass.newInstance()); // $ hasTaintFlow
+            ft.replace(0, fClass, null, ""); // $ hasTaintFlow
+            ft.replace(0, fClass.newInstance(), ""); // $ hasTaintFlow
+
+            ft.add(Fragment.class.newInstance(), ""); // Safe
+            ft.attach(Fragment.class.newInstance()); // Safe
+            ft.replace(0, Fragment.class.newInstance(), ""); // Safe
+        } catch (Exception e) {
+        }
+    }
+
+}

--- a/java/ql/test/query-tests/security/CWE-470/SafePreferenceActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/SafePreferenceActivity.java
@@ -1,0 +1,11 @@
+package com.example.myapp;
+
+import android.preference.PreferenceActivity;
+
+public class SafePreferenceActivity extends PreferenceActivity {
+
+    @Override
+    protected boolean isValidFragment(String fragmentName) { // Safe: not all paths return true
+        return fragmentName.equals("MySafeFragment") || fragmentName.equals("MySafeFragment2");
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-470/UnexportedPreferenceActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/UnexportedPreferenceActivity.java
@@ -1,0 +1,11 @@
+package com.example.myapp;
+
+import android.preference.PreferenceActivity;
+
+public class UnexportedPreferenceActivity extends PreferenceActivity {
+
+    @Override
+    protected boolean isValidFragment(String fragmentName) { // Safe: not exported
+        return true;
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-470/UnsafePreferenceActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/UnsafePreferenceActivity.java
@@ -1,0 +1,11 @@
+package com.example.myapp;
+
+import android.preference.PreferenceActivity;
+
+public class UnsafePreferenceActivity extends PreferenceActivity {
+
+    @Override
+    protected boolean isValidFragment(String fragmentName) { // $ hasPreferenceFragmentInjection
+        return fragmentName.equals("MySafeClass") || true;
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-470/UnsafePreferenceActivity.java
+++ b/java/ql/test/query-tests/security/CWE-470/UnsafePreferenceActivity.java
@@ -6,6 +6,6 @@ public class UnsafePreferenceActivity extends PreferenceActivity {
 
     @Override
     protected boolean isValidFragment(String fragmentName) { // $ hasPreferenceFragmentInjection
-        return fragmentName.equals("MySafeClass") || true;
+        return true;
     }
 }

--- a/java/ql/test/query-tests/security/CWE-470/options
+++ b/java/ql/test/query-tests/security/CWE-470/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/google-android-9.0.0

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/Fragment.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/Fragment.java
@@ -65,13 +65,4 @@ public class Fragment {
     return null;
   }
 
-  @Override
-  public void onConfigurationChanged(Configuration p0) {}
-
-  @Override
-  public void onLowMemory() {}
-
-  @Override
-  public void onTrimMemory(int p0) {}
-
 }

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/Fragment.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/Fragment.java
@@ -16,6 +16,7 @@ package android.app;
 
 import android.annotation.Nullable;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -63,5 +64,14 @@ public class Fragment {
   public String toString() {
     return null;
   }
+
+  @Override
+  public void onConfigurationChanged(Configuration p0) {}
+
+  @Override
+  public void onLowMemory() {}
+
+  @Override
+  public void onTrimMemory(int p0) {}
 
 }

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/ListActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/ListActivity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.app;
+
+public class ListActivity extends Activity {
+  public void onContentChanged() {}
+
+  public void setSelection(int position) {}
+
+  public int getSelectedItemPosition() {
+    return 0;
+  }
+
+  public long getSelectedItemId() {
+    return 0;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/content/ComponentCallbacks2.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/content/ComponentCallbacks2.java
@@ -2,10 +2,7 @@
 
 package android.content;
 
-import android.content.ComponentCallbacks;
-
-public interface ComponentCallbacks2 extends ComponentCallbacks
-{
+public interface ComponentCallbacks2 extends ComponentCallbacks {
     static int TRIM_MEMORY_BACKGROUND = 0;
     static int TRIM_MEMORY_COMPLETE = 0;
     static int TRIM_MEMORY_MODERATE = 0;
@@ -13,5 +10,6 @@ public interface ComponentCallbacks2 extends ComponentCallbacks
     static int TRIM_MEMORY_RUNNING_LOW = 0;
     static int TRIM_MEMORY_RUNNING_MODERATE = 0;
     static int TRIM_MEMORY_UI_HIDDEN = 0;
+
     void onTrimMemory(int p0);
 }

--- a/java/ql/test/stubs/google-android-9.0.0/android/preference/PreferenceActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/preference/PreferenceActivity.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.preference;
+
+import java.util.List;
+import android.app.Fragment;
+import android.app.ListActivity;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+public abstract class PreferenceActivity extends ListActivity {
+
+  public static final class Header implements Parcelable {
+    public Header() {}
+
+    public CharSequence getTitle(Resources res) {
+      return null;
+    }
+
+    public CharSequence getSummary(Resources res) {
+      return null;
+    }
+
+    public CharSequence getBreadCrumbTitle(Resources res) {
+      return null;
+    }
+
+    public CharSequence getBreadCrumbShortTitle(Resources res) {
+      return null;
+    }
+
+    public int describeContents() {
+      return 0;
+    }
+
+    public void writeToParcel(Parcel dest, int flags) {}
+
+    public void readFromParcel(Parcel in) {}
+
+    public static final Creator<Header> CREATOR = null;
+
+  }
+
+  public void onBackPressed() {}
+
+  public boolean hasHeaders() {
+    return false;
+  }
+
+  public List<Header> getHeaders() {
+    return null;
+  }
+
+  public boolean isMultiPane() {
+    return false;
+  }
+
+  public boolean onIsMultiPane() {
+    return false;
+  }
+
+  public boolean onIsHidingHeaders() {
+    return false;
+  }
+
+  public Header onGetInitialHeader() {
+    return null;
+  }
+
+  public Header onGetNewHeader() {
+    return null;
+  }
+
+  public void onBuildHeaders(List<Header> target) {}
+
+  public void invalidateHeaders() {}
+
+  public void loadHeadersFromResource(int resid, List<Header> target) {}
+
+  public void setListFooter(View view) {}
+
+  public void onContentChanged() {}
+
+  public void onHeaderClick(Header header, int position) {}
+
+  public Intent onBuildStartFragmentIntent(String fragmentName, Bundle args, int titleRes,
+      int shortTitleRes) {
+    return null;
+  }
+
+  public void startWithFragment(String fragmentName, Bundle args, Fragment resultTo,
+      int resultRequestCode) {}
+
+  public void startWithFragment(String fragmentName, Bundle args, Fragment resultTo,
+      int resultRequestCode, int titleRes, int shortTitleRes) {}
+
+  public void showBreadCrumbs(CharSequence title, CharSequence shortTitle) {}
+
+  public void setParentTitle(CharSequence title, CharSequence shortTitle,
+      OnClickListener listener) {}
+
+  public void switchToHeader(String fragmentName, Bundle args) {}
+
+  public void switchToHeader(Header header) {}
+
+  public void startPreferenceFragment(Fragment fragment, boolean push) {}
+
+  public void startPreferencePanel(String fragmentClass, Bundle args, int titleRes,
+      CharSequence titleText, Fragment resultTo, int resultRequestCode) {}
+
+  public void finishPreferencePanel(Fragment caller, int resultCode, Intent resultData) {}
+
+
+  public void addPreferencesFromIntent(Intent intent) {}
+
+  public void addPreferencesFromResource(int preferencesResId) {}
+
+  protected boolean isValidFragment(String fragmentName) {
+    return false;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/LayoutInflater.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/LayoutInflater.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2007 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.view;
+
+import org.xmlpull.v1.XmlPullParser;
+import android.content.Context;
+import android.util.AttributeSet;
+
+public abstract class LayoutInflater {
+  public interface Filter {
+    boolean onLoadClass(Class clazz);
+
+  }
+  public interface Factory {
+    View onCreateView(String name, Context context, AttributeSet attrs);
+
+  }
+  public interface Factory2 extends Factory {
+    View onCreateView(View parent, String name, Context context, AttributeSet attrs);
+
+  }
+
+  public static LayoutInflater from(Context context) {
+    return null;
+  }
+
+  public abstract LayoutInflater cloneInContext(Context newContext);
+
+  public Context getContext() {
+    return null;
+  }
+
+  public final Factory getFactory() {
+    return null;
+  }
+
+  public final Factory2 getFactory2() {
+    return null;
+  }
+
+  public void setFactory(Factory factory) {}
+
+  public void setFactory2(Factory2 factory) {}
+
+  public void setPrivateFactory(Factory2 factory) {}
+
+  public Filter getFilter() {
+    return null;
+  }
+
+  public void setFilter(Filter filter) {}
+
+  public void setPrecompiledLayoutsEnabledForTesting(boolean enablePrecompiledLayouts) {}
+
+  public View inflate(int resource, ViewGroup root) {
+    return null;
+  }
+
+  public View inflate(XmlPullParser parser, ViewGroup root) {
+    return null;
+  }
+
+  public View inflate(int resource, ViewGroup root, boolean attachToRoot) {
+    return null;
+  }
+
+  public View inflate(XmlPullParser parser, ViewGroup root, boolean attachToRoot) {
+    return null;
+  }
+
+  public final View createView(String name, String prefix, AttributeSet attrs)
+      throws ClassNotFoundException {
+    return null;
+  }
+
+  public final View createView(Context viewContext, String name, String prefix, AttributeSet attrs)
+      throws ClassNotFoundException {
+    return null;
+  }
+
+  public View onCreateView(Context viewContext, View parent, String name, AttributeSet attrs)
+      throws ClassNotFoundException {
+    return null;
+  }
+
+  public final View tryCreateView(View parent, String name, Context context, AttributeSet attrs) {
+    return null;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/View.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/View.java
@@ -1,682 +1,1990 @@
 /*
  * Copyright (C) 2006 The Android Open Source Project
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
+
 package android.view;
 
-import android.content.Context;
-
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+import java.util.function.Predicate;
+import android.annotation.Nullable;
+import android.content.ClipData;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Bitmap;
+import android.graphics.BlendMode;
+import android.graphics.Canvas;
+import android.graphics.Insets;
+import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.Point;
+import android.graphics.PorterDuff;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Region;
+import android.graphics.RenderNode;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.AttributeSet;
+import android.util.SparseArray;
 
-/**
- * <p>
- * This class represents the basic building block for user interface components. A View
- * occupies a rectangular area on the screen and is responsible for drawing and
- * event handling. View is the base class for <em>widgets</em>, which are
- * used to create interactive UI components (buttons, text fields, etc.). The
- * {@link android.view.ViewGroup} subclass is the base class for <em>layouts</em>, which
- * are invisible containers that hold other Views (or other ViewGroups) and define
- * their layout properties.
- * </p>
- *
- * <div class="special reference">
- * <h3>Developer Guides</h3>
- * <p>For information about using this class to develop your application's user interface,
- * read the <a href="{@docRoot}guide/topics/ui/index.html">User Interface</a> developer guide.
- * </div>
- *
- * <a name="Using"></a>
- * <h3>Using Views</h3>
- * <p>
- * All of the views in a window are arranged in a single tree. You can add views
- * either from code or by specifying a tree of views in one or more XML layout
- * files. There are many specialized subclasses of views that act as controls or
- * are capable of displaying text, images, or other content.
- * </p>
- * <p>
- * Once you have created a tree of views, there are typically a few types of
- * common operations you may wish to perform:
- * <ul>
- * <li><strong>Set properties:</strong> for example setting the text of a
- * {@link android.widget.TextView}. The available properties and the methods
- * that set them will vary among the different subclasses of views. Note that
- * properties that are known at build time can be set in the XML layout
- * files.</li>
- * <li><strong>Set focus:</strong> The framework will handle moving focus in
- * response to user input. To force focus to a specific view, call
- * {@link #requestFocus}.</li>
- * <li><strong>Set up listeners:</strong> Views allow clients to set listeners
- * that will be notified when something interesting happens to the view. For
- * example, all views will let you set a listener to be notified when the view
- * gains or loses focus. You can register such a listener using
- * {@link #setOnFocusChangeListener(android.view.View.OnFocusChangeListener)}.
- * Other view subclasses offer more specialized listeners. For example, a Button
- * exposes a listener to notify clients when the button is clicked.</li>
- * <li><strong>Set visibility:</strong> You can hide or show views using
- * {@link #setVisibility(int)}.</li>
- * </ul>
- * </p>
- * <p><em>
- * Note: The Android framework is responsible for measuring, laying out and
- * drawing views. You should not call methods that perform these actions on
- * views yourself unless you are actually implementing a
- * {@link android.view.ViewGroup}.
- * </em></p>
- *
- * <a name="Lifecycle"></a>
- * <h3>Implementing a Custom View</h3>
- *
- * <p>
- * To implement a custom view, you will usually begin by providing overrides for
- * some of the standard methods that the framework calls on all views. You do
- * not need to override all of these methods. In fact, you can start by just
- * overriding {@link #onDraw(android.graphics.Canvas)}.
- * <table border="2" width="85%" align="center" cellpadding="5">
- *     <thead>
- *         <tr><th>Category</th> <th>Methods</th> <th>Description</th></tr>
- *     </thead>
- *
- *     <tbody>
- *     <tr>
- *         <td rowspan="2">Creation</td>
- *         <td>Constructors</td>
- *         <td>There is a form of the constructor that are called when the view
- *         is created from code and a form that is called when the view is
- *         inflated from a layout file. The second form should parse and apply
- *         any attributes defined in the layout file.
- *         </td>
- *     </tr>
- *     <tr>
- *         <td><code>{@link #onFinishInflate()}</code></td>
- *         <td>Called after a view and all of its children has been inflated
- *         from XML.</td>
- *     </tr>
- *
- *     <tr>
- *         <td rowspan="3">Layout</td>
- *         <td><code>{@link #onMeasure(int, int)}</code></td>
- *         <td>Called to determine the size requirements for this view and all
- *         of its children.
- *         </td>
- *     </tr>
- *     <tr>
- *         <td><code>{@link #onLayout(boolean, int, int, int, int)}</code></td>
- *         <td>Called when this view should assign a size and position to all
- *         of its children.
- *         </td>
- *     </tr>
- *     <tr>
- *         <td><code>{@link #onSizeChanged(int, int, int, int)}</code></td>
- *         <td>Called when the size of this view has changed.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td>Drawing</td>
- *         <td><code>{@link #onDraw(android.graphics.Canvas)}</code></td>
- *         <td>Called when the view should render its content.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td rowspan="4">Event processing</td>
- *         <td><code>{@link #onKeyDown(int, KeyEvent)}</code></td>
- *         <td>Called when a new hardware key event occurs.
- *         </td>
- *     </tr>
- *     <tr>
- *         <td><code>{@link #onKeyUp(int, KeyEvent)}</code></td>
- *         <td>Called when a hardware key up event occurs.
- *         </td>
- *     </tr>
- *     <tr>
- *         <td><code>{@link #onTrackballEvent(MotionEvent)}</code></td>
- *         <td>Called when a trackball motion event occurs.
- *         </td>
- *     </tr>
- *     <tr>
- *         <td><code>{@link #onTouchEvent(MotionEvent)}</code></td>
- *         <td>Called when a touch screen motion event occurs.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td rowspan="2">Focus</td>
- *         <td><code>{@link #onFocusChanged(boolean, int, android.graphics.Rect)}</code></td>
- *         <td>Called when the view gains or loses focus.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td><code>{@link #onWindowFocusChanged(boolean)}</code></td>
- *         <td>Called when the window containing the view gains or loses focus.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td rowspan="3">Attaching</td>
- *         <td><code>{@link #onAttachedToWindow()}</code></td>
- *         <td>Called when the view is attached to a window.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td><code>{@link #onDetachedFromWindow}</code></td>
- *         <td>Called when the view is detached from its window.
- *         </td>
- *     </tr>
- *
- *     <tr>
- *         <td><code>{@link #onWindowVisibilityChanged(int)}</code></td>
- *         <td>Called when the visibility of the window containing the view
- *         has changed.
- *         </td>
- *     </tr>
- *     </tbody>
- *
- * </table>
- * </p>
- *
- * <a name="IDs"></a>
- * <h3>IDs</h3>
- * Views may have an integer id associated with them. These ids are typically
- * assigned in the layout XML files, and are used to find specific views within
- * the view tree. A common pattern is to:
- * <ul>
- * <li>Define a Button in the layout file and assign it a unique ID.
- * <pre>
- * &lt;Button
- *     android:id="@+id/my_button"
- *     android:layout_width="wrap_content"
- *     android:layout_height="wrap_content"
- *     android:text="@string/my_button_text"/&gt;
- * </pre></li>
- * <li>From the onCreate method of an Activity, find the Button
- * <pre class="prettyprint">
- *      Button myButton = findViewById(R.id.my_button);
- * </pre></li>
- * </ul>
- * <p>
- * View IDs need not be unique throughout the tree, but it is good practice to
- * ensure that they are at least unique within the part of the tree you are
- * searching.
- * </p>
- *
- * <a name="Position"></a>
- * <h3>Position</h3>
- * <p>
- * The geometry of a view is that of a rectangle. A view has a location,
- * expressed as a pair of <em>left</em> and <em>top</em> coordinates, and
- * two dimensions, expressed as a width and a height. The unit for location
- * and dimensions is the pixel.
- * </p>
- *
- * <p>
- * It is possible to retrieve the location of a view by invoking the methods
- * {@link #getLeft()} and {@link #getTop()}. The former returns the left, or X,
- * coordinate of the rectangle representing the view. The latter returns the
- * top, or Y, coordinate of the rectangle representing the view. These methods
- * both return the location of the view relative to its parent. For instance,
- * when getLeft() returns 20, that means the view is located 20 pixels to the
- * right of the left edge of its direct parent.
- * </p>
- *
- * <p>
- * In addition, several convenience methods are offered to avoid unnecessary
- * computations, namely {@link #getRight()} and {@link #getBottom()}.
- * These methods return the coordinates of the right and bottom edges of the
- * rectangle representing the view. For instance, calling {@link #getRight()}
- * is similar to the following computation: <code>getLeft() + getWidth()</code>
- * (see <a href="#SizePaddingMargins">Size</a> for more information about the width.)
- * </p>
- *
- * <a name="SizePaddingMargins"></a>
- * <h3>Size, padding and margins</h3>
- * <p>
- * The size of a view is expressed with a width and a height. A view actually
- * possess two pairs of width and height values.
- * </p>
- *
- * <p>
- * The first pair is known as <em>measured width</em> and
- * <em>measured height</em>. These dimensions define how big a view wants to be
- * within its parent (see <a href="#Layout">Layout</a> for more details.) The
- * measured dimensions can be obtained by calling {@link #getMeasuredWidth()}
- * and {@link #getMeasuredHeight()}.
- * </p>
- *
- * <p>
- * The second pair is simply known as <em>width</em> and <em>height</em>, or
- * sometimes <em>drawing width</em> and <em>drawing height</em>. These
- * dimensions define the actual size of the view on screen, at drawing time and
- * after layout. These values may, but do not have to, be different from the
- * measured width and height. The width and height can be obtained by calling
- * {@link #getWidth()} and {@link #getHeight()}.
- * </p>
- *
- * <p>
- * To measure its dimensions, a view takes into account its padding. The padding
- * is expressed in pixels for the left, top, right and bottom parts of the view.
- * Padding can be used to offset the content of the view by a specific amount of
- * pixels. For instance, a left padding of 2 will push the view's content by
- * 2 pixels to the right of the left edge. Padding can be set using the
- * {@link #setPadding(int, int, int, int)} or {@link #setPaddingRelative(int, int, int, int)}
- * method and queried by calling {@link #getPaddingLeft()}, {@link #getPaddingTop()},
- * {@link #getPaddingRight()}, {@link #getPaddingBottom()}, {@link #getPaddingStart()},
- * {@link #getPaddingEnd()}.
- * </p>
- *
- * <p>
- * Even though a view can define a padding, it does not provide any support for
- * margins. However, view groups provide such a support. Refer to
- * {@link android.view.ViewGroup} and
- * {@link android.view.ViewGroup.MarginLayoutParams} for further information.
- * </p>
- *
- * <a name="Layout"></a>
- * <h3>Layout</h3>
- * <p>
- * Layout is a two pass process: a measure pass and a layout pass. The measuring
- * pass is implemented in {@link #measure(int, int)} and is a top-down traversal
- * of the view tree. Each view pushes dimension specifications down the tree
- * during the recursion. At the end of the measure pass, every view has stored
- * its measurements. The second pass happens in
- * {@link #layout(int,int,int,int)} and is also top-down. During
- * this pass each parent is responsible for positioning all of its children
- * using the sizes computed in the measure pass.
- * </p>
- *
- * <p>
- * When a view's measure() method returns, its {@link #getMeasuredWidth()} and
- * {@link #getMeasuredHeight()} values must be set, along with those for all of
- * that view's descendants. A view's measured width and measured height values
- * must respect the constraints imposed by the view's parents. This guarantees
- * that at the end of the measure pass, all parents accept all of their
- * children's measurements. A parent view may call measure() more than once on
- * its children. For example, the parent may measure each child once with
- * unspecified dimensions to find out how big they want to be, then call
- * measure() on them again with actual numbers if the sum of all the children's
- * unconstrained sizes is too big or too small.
- * </p>
- *
- * <p>
- * The measure pass uses two classes to communicate dimensions. The
- * {@link MeasureSpec} class is used by views to tell their parents how they
- * want to be measured and positioned. The base LayoutParams class just
- * describes how big the view wants to be for both width and height. For each
- * dimension, it can specify one of:
- * <ul>
- * <li> an exact number
- * <li>MATCH_PARENT, which means the view wants to be as big as its parent
- * (minus padding)
- * <li> WRAP_CONTENT, which means that the view wants to be just big enough to
- * enclose its content (plus padding).
- * </ul>
- * There are subclasses of LayoutParams for different subclasses of ViewGroup.
- * For example, AbsoluteLayout has its own subclass of LayoutParams which adds
- * an X and Y value.
- * </p>
- *
- * <p>
- * MeasureSpecs are used to push requirements down the tree from parent to
- * child. A MeasureSpec can be in one of three modes:
- * <ul>
- * <li>UNSPECIFIED: This is used by a parent to determine the desired dimension
- * of a child view. For example, a LinearLayout may call measure() on its child
- * with the height set to UNSPECIFIED and a width of EXACTLY 240 to find out how
- * tall the child view wants to be given a width of 240 pixels.
- * <li>EXACTLY: This is used by the parent to impose an exact size on the
- * child. The child must use this size, and guarantee that all of its
- * descendants will fit within this size.
- * <li>AT_MOST: This is used by the parent to impose a maximum size on the
- * child. The child must guarantee that it and all of its descendants will fit
- * within this size.
- * </ul>
- * </p>
- *
- * <p>
- * To initiate a layout, call {@link #requestLayout}. This method is typically
- * called by a view on itself when it believes that is can no longer fit within
- * its current bounds.
- * </p>
- *
- * <a name="Drawing"></a>
- * <h3>Drawing</h3>
- * <p>
- * Drawing is handled by walking the tree and recording the drawing commands of
- * any View that needs to update. After this, the drawing commands of the
- * entire tree are issued to screen, clipped to the newly damaged area.
- * </p>
- *
- * <p>
- * The tree is largely recorded and drawn in order, with parents drawn before
- * (i.e., behind) their children, with siblings drawn in the order they appear
- * in the tree. If you set a background drawable for a View, then the View will
- * draw it before calling back to its <code>onDraw()</code> method. The child
- * drawing order can be overridden with
- * {@link ViewGroup#setChildrenDrawingOrderEnabled(boolean) custom child drawing order}
- * in a ViewGroup, and with {@link #setZ(float)} custom Z values} set on Views.
- * </p>
- *
- * <p>
- * To force a view to draw, call {@link #invalidate()}.
- * </p>
- *
- * <a name="EventHandlingThreading"></a>
- * <h3>Event Handling and Threading</h3>
- * <p>
- * The basic cycle of a view is as follows:
- * <ol>
- * <li>An event comes in and is dispatched to the appropriate view. The view
- * handles the event and notifies any listeners.</li>
- * <li>If in the course of processing the event, the view's bounds may need
- * to be changed, the view will call {@link #requestLayout()}.</li>
- * <li>Similarly, if in the course of processing the event the view's appearance
- * may need to be changed, the view will call {@link #invalidate()}.</li>
- * <li>If either {@link #requestLayout()} or {@link #invalidate()} were called,
- * the framework will take care of measuring, laying out, and drawing the tree
- * as appropriate.</li>
- * </ol>
- * </p>
- *
- * <p><em>Note: The entire view tree is single threaded. You must always be on
- * the UI thread when calling any method on any view.</em>
- * If you are doing work on other threads and want to update the state of a view
- * from that thread, you should use a {@link Handler}.
- * </p>
- *
- * <a name="FocusHandling"></a>
- * <h3>Focus Handling</h3>
- * <p>
- * The framework will handle routine focus movement in response to user input.
- * This includes changing the focus as views are removed or hidden, or as new
- * views become available. Views indicate their willingness to take focus
- * through the {@link #isFocusable} method. To change whether a view can take
- * focus, call {@link #setFocusable(boolean)}.  When in touch mode (see notes below)
- * views indicate whether they still would like focus via {@link #isFocusableInTouchMode}
- * and can change this via {@link #setFocusableInTouchMode(boolean)}.
- * </p>
- * <p>
- * Focus movement is based on an algorithm which finds the nearest neighbor in a
- * given direction. In rare cases, the default algorithm may not match the
- * intended behavior of the developer. In these situations, you can provide
- * explicit overrides by using these XML attributes in the layout file:
- * <pre>
- * nextFocusDown
- * nextFocusLeft
- * nextFocusRight
- * nextFocusUp
- * </pre>
- * </p>
- *
- *
- * <p>
- * To get a particular view to take focus, call {@link #requestFocus()}.
- * </p>
- *
- * <a name="TouchMode"></a>
- * <h3>Touch Mode</h3>
- * <p>
- * When a user is navigating a user interface via directional keys such as a D-pad, it is
- * necessary to give focus to actionable items such as buttons so the user can see
- * what will take input.  If the device has touch capabilities, however, and the user
- * begins interacting with the interface by touching it, it is no longer necessary to
- * always highlight, or give focus to, a particular view.  This motivates a mode
- * for interaction named 'touch mode'.
- * </p>
- * <p>
- * For a touch capable device, once the user touches the screen, the device
- * will enter touch mode.  From this point onward, only views for which
- * {@link #isFocusableInTouchMode} is true will be focusable, such as text editing widgets.
- * Other views that are touchable, like buttons, will not take focus when touched; they will
- * only fire the on click listeners.
- * </p>
- * <p>
- * Any time a user hits a directional key, such as a D-pad direction, the view device will
- * exit touch mode, and find a view to take focus, so that the user may resume interacting
- * with the user interface without touching the screen again.
- * </p>
- * <p>
- * The touch mode state is maintained across {@link android.app.Activity}s.  Call
- * {@link #isInTouchMode} to see whether the device is currently in touch mode.
- * </p>
- *
- * <a name="Scrolling"></a>
- * <h3>Scrolling</h3>
- * <p>
- * The framework provides basic support for views that wish to internally
- * scroll their content. This includes keeping track of the X and Y scroll
- * offset as well as mechanisms for drawing scrollbars. See
- * {@link #scrollBy(int, int)}, {@link #scrollTo(int, int)}, and
- * {@link #awakenScrollBars()} for more details.
- * </p>
- *
- * <a name="Tags"></a>
- * <h3>Tags</h3>
- * <p>
- * Unlike IDs, tags are not used to identify views. Tags are essentially an
- * extra piece of information that can be associated with a view. They are most
- * often used as a convenience to store data related to views in the views
- * themselves rather than by putting them in a separate structure.
- * </p>
- * <p>
- * Tags may be specified with character sequence values in layout XML as either
- * a single tag using the {@link android.R.styleable#View_tag android:tag}
- * attribute or multiple tags using the {@code <tag>} child element:
- * <pre>
- *     &lt;View ...
- *           android:tag="@string/mytag_value" /&gt;
- *     &lt;View ...&gt;
- *         &lt;tag android:id="@+id/mytag"
- *              android:value="@string/mytag_value" /&gt;
- *     &lt;/View>
- * </pre>
- * </p>
- * <p>
- * Tags may also be specified with arbitrary objects from code using
- * {@link #setTag(Object)} or {@link #setTag(int, Object)}.
- * </p>
- *
- * <a name="Themes"></a>
- * <h3>Themes</h3>
- * <p>
- * By default, Views are created using the theme of the Context object supplied
- * to their constructor; however, a different theme may be specified by using
- * the {@link android.R.styleable#View_theme android:theme} attribute in layout
- * XML or by passing a {@link ContextThemeWrapper} to the constructor from
- * code.
- * </p>
- * <p>
- * When the {@link android.R.styleable#View_theme android:theme} attribute is
- * used in XML, the specified theme is applied on top of the inflation
- * context's theme (see {@link LayoutInflater}) and used for the view itself as
- * well as any child elements.
- * </p>
- * <p>
- * In the following example, both views will be created using the Material dark
- * color scheme; however, because an overlay theme is used which only defines a
- * subset of attributes, the value of
- * {@link android.R.styleable#Theme_colorAccent android:colorAccent} defined on
- * the inflation context's theme (e.g. the Activity theme) will be preserved.
- * <pre>
- *     &lt;LinearLayout
- *             ...
- *             android:theme="@android:theme/ThemeOverlay.Material.Dark"&gt;
- *         &lt;View ...&gt;
- *     &lt;/LinearLayout&gt;
- * </pre>
- * </p>
- *
- * <a name="Properties"></a>
- * <h3>Properties</h3>
- * <p>
- * The View class exposes an {@link #ALPHA} property, as well as several transform-related
- * properties, such as {@link #TRANSLATION_X} and {@link #TRANSLATION_Y}. These properties are
- * available both in the {@link Property} form as well as in similarly-named setter/getter
- * methods (such as {@link #setAlpha(float)} for {@link #ALPHA}). These properties can
- * be used to set persistent state associated with these rendering-related properties on the view.
- * The properties and methods can also be used in conjunction with
- * {@link android.animation.Animator Animator}-based animations, described more in the
- * <a href="#Animation">Animation</a> section.
- * </p>
- *
- * <a name="Animation"></a>
- * <h3>Animation</h3>
- * <p>
- * Starting with Android 3.0, the preferred way of animating views is to use the
- * {@link android.animation} package APIs. These {@link android.animation.Animator Animator}-based
- * classes change actual properties of the View object, such as {@link #setAlpha(float) alpha} and
- * {@link #setTranslationX(float) translationX}. This behavior is contrasted to that of the pre-3.0
- * {@link android.view.animation.Animation Animation}-based classes, which instead animate only
- * how the view is drawn on the display. In particular, the {@link ViewPropertyAnimator} class
- * makes animating these View properties particularly easy and efficient.
- * </p>
- * <p>
- * Alternatively, you can use the pre-3.0 animation classes to animate how Views are rendered.
- * You can attach an {@link Animation} object to a view using
- * {@link #setAnimation(Animation)} or
- * {@link #startAnimation(Animation)}. The animation can alter the scale,
- * rotation, translation and alpha of a view over time. If the animation is
- * attached to a view that has children, the animation will affect the entire
- * subtree rooted by that node. When an animation is started, the framework will
- * take care of redrawing the appropriate views until the animation completes.
- * </p>
- *
- * <a name="Security"></a>
- * <h3>Security</h3>
- * <p>
- * Sometimes it is essential that an application be able to verify that an action
- * is being performed with the full knowledge and consent of the user, such as
- * granting a permission request, making a purchase or clicking on an advertisement.
- * Unfortunately, a malicious application could try to spoof the user into
- * performing these actions, unaware, by concealing the intended purpose of the view.
- * As a remedy, the framework offers a touch filtering mechanism that can be used to
- * improve the security of views that provide access to sensitive functionality.
- * </p><p>
- * To enable touch filtering, call {@link #setFilterTouchesWhenObscured(boolean)} or set the
- * android:filterTouchesWhenObscured layout attribute to true.  When enabled, the framework
- * will discard touches that are received whenever the view's window is obscured by
- * another visible window.  As a result, the view will not receive touches whenever a
- * toast, dialog or other window appears above the view's window.
- * </p><p>
- * For more fine-grained control over security, consider overriding the
- * {@link #onFilterTouchEventForSecurity(MotionEvent)} method to implement your own
- * security policy. See also {@link MotionEvent#FLAG_WINDOW_IS_OBSCURED}.
- * </p>
- *
- * @attr ref android.R.styleable#View_accessibilityHeading
- * @attr ref android.R.styleable#View_alpha
- * @attr ref android.R.styleable#View_background
- * @attr ref android.R.styleable#View_clickable
- * @attr ref android.R.styleable#View_contentDescription
- * @attr ref android.R.styleable#View_drawingCacheQuality
- * @attr ref android.R.styleable#View_duplicateParentState
- * @attr ref android.R.styleable#View_id
- * @attr ref android.R.styleable#View_requiresFadingEdge
- * @attr ref android.R.styleable#View_fadeScrollbars
- * @attr ref android.R.styleable#View_fadingEdgeLength
- * @attr ref android.R.styleable#View_filterTouchesWhenObscured
- * @attr ref android.R.styleable#View_fitsSystemWindows
- * @attr ref android.R.styleable#View_isScrollContainer
- * @attr ref android.R.styleable#View_focusable
- * @attr ref android.R.styleable#View_focusableInTouchMode
- * @attr ref android.R.styleable#View_focusedByDefault
- * @attr ref android.R.styleable#View_hapticFeedbackEnabled
- * @attr ref android.R.styleable#View_keepScreenOn
- * @attr ref android.R.styleable#View_keyboardNavigationCluster
- * @attr ref android.R.styleable#View_layerType
- * @attr ref android.R.styleable#View_layoutDirection
- * @attr ref android.R.styleable#View_longClickable
- * @attr ref android.R.styleable#View_minHeight
- * @attr ref android.R.styleable#View_minWidth
- * @attr ref android.R.styleable#View_nextClusterForward
- * @attr ref android.R.styleable#View_nextFocusDown
- * @attr ref android.R.styleable#View_nextFocusLeft
- * @attr ref android.R.styleable#View_nextFocusRight
- * @attr ref android.R.styleable#View_nextFocusUp
- * @attr ref android.R.styleable#View_onClick
- * @attr ref android.R.styleable#View_outlineSpotShadowColor
- * @attr ref android.R.styleable#View_outlineAmbientShadowColor
- * @attr ref android.R.styleable#View_padding
- * @attr ref android.R.styleable#View_paddingHorizontal
- * @attr ref android.R.styleable#View_paddingVertical
- * @attr ref android.R.styleable#View_paddingBottom
- * @attr ref android.R.styleable#View_paddingLeft
- * @attr ref android.R.styleable#View_paddingRight
- * @attr ref android.R.styleable#View_paddingTop
- * @attr ref android.R.styleable#View_paddingStart
- * @attr ref android.R.styleable#View_paddingEnd
- * @attr ref android.R.styleable#View_saveEnabled
- * @attr ref android.R.styleable#View_rotation
- * @attr ref android.R.styleable#View_rotationX
- * @attr ref android.R.styleable#View_rotationY
- * @attr ref android.R.styleable#View_scaleX
- * @attr ref android.R.styleable#View_scaleY
- * @attr ref android.R.styleable#View_scrollX
- * @attr ref android.R.styleable#View_scrollY
- * @attr ref android.R.styleable#View_scrollbarSize
- * @attr ref android.R.styleable#View_scrollbarStyle
- * @attr ref android.R.styleable#View_scrollbars
- * @attr ref android.R.styleable#View_scrollbarDefaultDelayBeforeFade
- * @attr ref android.R.styleable#View_scrollbarFadeDuration
- * @attr ref android.R.styleable#View_scrollbarTrackHorizontal
- * @attr ref android.R.styleable#View_scrollbarThumbHorizontal
- * @attr ref android.R.styleable#View_scrollbarThumbVertical
- * @attr ref android.R.styleable#View_scrollbarTrackVertical
- * @attr ref android.R.styleable#View_scrollbarAlwaysDrawHorizontalTrack
- * @attr ref android.R.styleable#View_scrollbarAlwaysDrawVerticalTrack
- * @attr ref android.R.styleable#View_stateListAnimator
- * @attr ref android.R.styleable#View_transitionName
- * @attr ref android.R.styleable#View_soundEffectsEnabled
- * @attr ref android.R.styleable#View_tag
- * @attr ref android.R.styleable#View_textAlignment
- * @attr ref android.R.styleable#View_textDirection
- * @attr ref android.R.styleable#View_transformPivotX
- * @attr ref android.R.styleable#View_transformPivotY
- * @attr ref android.R.styleable#View_translationX
- * @attr ref android.R.styleable#View_translationY
- * @attr ref android.R.styleable#View_translationZ
- * @attr ref android.R.styleable#View_visibility
- * @attr ref android.R.styleable#View_theme
- *
- * @see android.view.ViewGroup
- */
-public class View {
-
-    /**
-     * Simple constructor to use when creating a view from code.
-     *
-     * @param context The Context the view is running in, through which it can
-     *        access the current theme, resources, etc.
-     */
-    public View(Context context) {
+public class View implements Drawable.Callback {
+    public @interface Focusable {
     }
 
+    public @interface Visibility {
+    }
+
+    public @interface AutofillType {
+    }
+    public @interface AutofillImportance {
+    }
+    public @interface AutofillFlags {
+    }
+    public @interface ContentCaptureImportance {
+    }
+    public @interface ScrollCaptureHint {
+    }
+    public @interface DrawingCacheQuality {
+    }
+    public @interface ScrollBarStyle {
+    }
+    public @interface FocusableMode {
+    }
+    public @interface FocusDirection {
+    }
+    public @interface FocusRealDirection {
+    }
+    public @interface LayoutDir {
+    }
+    public @interface ResolvedLayoutDir {
+    }
+    public @interface TextAlignment {
+    }
+    public @interface ScrollIndicators {
+    }
+    public @interface ViewStructureType {
+    }
+    public @interface FindViewFlags {
+    }
+    public @interface LayerType {
+    }
+
+    public View(Context context) {}
+
+    public View(Context context, AttributeSet attrs) {}
+
+    public View(Context context, AttributeSet attrs, int defStyleAttr) {}
+
+    public View(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {}
+
+    public int[] getAttributeResolutionStack(int attribute) {
+        return null;
+    }
+
+    public Map<Integer, Integer> getAttributeSourceResourceMap() {
+        return null;
+    }
+
+    public int getExplicitStyle() {
+        return 0;
+    }
+
+    public final boolean isShowingLayoutBounds() {
+        return false;
+    }
+
+    public final void setShowingLayoutBounds(boolean debugLayout) {}
+
+    public final void saveAttributeDataForStyleable(Context context, int[] styleable,
+            AttributeSet attrs, TypedArray t, int defStyleAttr, int defStyleRes) {}
+
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    public int getVerticalFadingEdgeLength() {
+        return 0;
+    }
+
+    public void setFadingEdgeLength(int length) {}
+
+    public int getHorizontalFadingEdgeLength() {
+        return 0;
+    }
+
+    public int getVerticalScrollbarWidth() {
+        return 0;
+    }
+
+    public void setVerticalScrollbarThumbDrawable(Drawable drawable) {}
+
+    public void setVerticalScrollbarTrackDrawable(Drawable drawable) {}
+
+    public void setHorizontalScrollbarThumbDrawable(Drawable drawable) {}
+
+    public void setHorizontalScrollbarTrackDrawable(Drawable drawable) {}
+
+    public Drawable getVerticalScrollbarThumbDrawable() {
+        return null;
+    }
+
+    public Drawable getVerticalScrollbarTrackDrawable() {
+        return null;
+    }
+
+    public Drawable getHorizontalScrollbarThumbDrawable() {
+        return null;
+    }
+
+    public Drawable getHorizontalScrollbarTrackDrawable() {
+        return null;
+    }
+
+    public void setVerticalScrollbarPosition(int position) {}
+
+    public int getVerticalScrollbarPosition() {
+        return 0;
+    }
+
+    public void setScrollIndicators(int indicators) {}
+
+    public void setScrollIndicators(int indicators, int mask) {}
+
+    public int getScrollIndicators() {
+        return 0;
+    }
+
+    public void setOnScrollChangeListener(OnScrollChangeListener l) {}
+
+    public void setOnFocusChangeListener(OnFocusChangeListener l) {}
+
+    public void addOnLayoutChangeListener(OnLayoutChangeListener listener) {}
+
+    public void removeOnLayoutChangeListener(OnLayoutChangeListener listener) {}
+
+    public void addOnAttachStateChangeListener(OnAttachStateChangeListener listener) {}
+
+    public void removeOnAttachStateChangeListener(OnAttachStateChangeListener listener) {}
+
+    public OnFocusChangeListener getOnFocusChangeListener() {
+        return null;
+    }
+
+    public void setOnClickListener(OnClickListener l) {}
+
+    public boolean hasOnClickListeners() {
+        return false;
+    }
+
+    public void setOnLongClickListener(OnLongClickListener l) {}
+
+    public boolean hasOnLongClickListeners() {
+        return false;
+    }
+
+    public OnLongClickListener getOnLongClickListener() {
+        return null;
+    }
+
+    public void setOnContextClickListener(OnContextClickListener l) {}
+
+    public void setNotifyAutofillManagerOnClick(boolean notify) {}
+
+    public boolean performClick() {
+        return false;
+    }
+
+    public boolean callOnClick() {
+        return false;
+    }
+
+    public boolean performLongClick() {
+        return false;
+    }
+
+    public boolean performLongClick(float x, float y) {
+        return false;
+    }
+
+    public boolean performContextClick(float x, float y) {
+        return false;
+    }
+
+    public boolean performContextClick() {
+        return false;
+    }
+
+    public boolean showContextMenu() {
+        return false;
+    }
+
+    public boolean showContextMenu(float x, float y) {
+        return false;
+    }
+
+    public void startActivityForResult(Intent intent, int requestCode) {}
+
+    public boolean dispatchActivityResult(String who, int requestCode, int resultCode,
+            Intent data) {
+        return false;
+    }
+
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {}
+
+    public final void setRevealOnFocusHint(boolean revealOnFocus) {}
+
+    public final boolean getRevealOnFocusHint() {
+        return false;
+    }
+
+    public void getHotspotBounds(Rect outRect) {}
+
+    public boolean requestRectangleOnScreen(Rect rectangle) {
+        return false;
+    }
+
+    public boolean requestRectangleOnScreen(Rect rectangle, boolean immediate) {
+        return false;
+    }
+
+    public void clearFocus() {}
+
+    public boolean hasFocus() {
+        return false;
+    }
+
+    public boolean hasFocusable() {
+        return false;
+    }
+
+    public boolean hasExplicitFocusable() {
+        return false;
+    }
+
+    public void notifyEnterOrExitForAutoFillIfNeeded(boolean enter) {}
+
+    public void setAccessibilityPaneTitle(CharSequence accessibilityPaneTitle) {}
+
+    public CharSequence getAccessibilityPaneTitle() {
+        return null;
+    }
+
+    public void sendAccessibilityEvent(int eventType) {}
+
+    public void announceForAccessibility(CharSequence text) {}
+
+    public void sendAccessibilityEventInternal(int eventType) {}
+
+    public void getBoundsOnScreen(Rect outRect) {}
+
+    public void getBoundsOnScreen(Rect outRect, boolean clipToParent) {}
+
+    public void mapRectFromViewToScreenCoords(RectF rect, boolean clipToParent) {}
+
+    public CharSequence getAccessibilityClassName() {
+        return null;
+    }
+
+    public int getAutofillType() {
+        return 0;
+    }
+
+    @Nullable
+    public String[] getAutofillHints() {
+        return null;
+    }
+
+    public boolean isAutofilled() {
+        return false;
+    }
+
+    public boolean hideAutofillHighlight() {
+        return false;
+    }
+
+    public int getImportantForAutofill() {
+        return 0;
+    }
+
+    public void setImportantForAutofill(int mode) {}
+
+    public final boolean isImportantForAutofill() {
+        return false;
+    }
+
+    public int getImportantForContentCapture() {
+        return 0;
+    }
+
+    public void setImportantForContentCapture(int mode) {}
+
+    public final boolean isImportantForContentCapture() {
+        return false;
+    }
+
+    public boolean canNotifyAutofillEnterExitEvent() {
+        return false;
+    }
+
+    public void dispatchInitialProvideContentCaptureStructure() {}
+
+    public boolean isVisibleToUserForAutofill(int virtualId) {
+        return false;
+    }
+
+    public boolean isVisibleToUser() {
+        return false;
+    }
+
+    public AccessibilityDelegate getAccessibilityDelegate() {
+        return null;
+    }
+
+    public void setAccessibilityDelegate(AccessibilityDelegate delegate) {}
+
+    public int getAccessibilityViewId() {
+        return 0;
+    }
+
+    public int getAutofillViewId() {
+        return 0;
+    }
+
+    public int getAccessibilityWindowId() {
+        return 0;
+    }
+
+    public final CharSequence getStateDescription() {
+        return null;
+    }
+
+    public CharSequence getContentDescription() {
+        return null;
+    }
+
+    public void setStateDescription(CharSequence stateDescription) {}
+
+    public void setContentDescription(CharSequence contentDescription) {}
+
+    public void setAccessibilityTraversalBefore(int beforeId) {}
+
+    public int getAccessibilityTraversalBefore() {
+        return 0;
+    }
+
+    public void setAccessibilityTraversalAfter(int afterId) {}
+
+    public int getAccessibilityTraversalAfter() {
+        return 0;
+    }
+
+    public int getLabelFor() {
+        return 0;
+    }
+
+    public void setLabelFor(int id) {}
+
+    public boolean isFocused() {
+        return false;
+    }
+
+    public View findFocus() {
+        return null;
+    }
+
+    public boolean isScrollContainer() {
+        return false;
+    }
+
+    public void setScrollContainer(boolean isScrollContainer) {}
+
+    public int getDrawingCacheQuality() {
+        return 0;
+    }
+
+    public void setDrawingCacheQuality(int quality) {}
+
+    public boolean getKeepScreenOn() {
+        return false;
+    }
+
+    public void setKeepScreenOn(boolean keepScreenOn) {}
+
+    public int getNextFocusLeftId() {
+        return 0;
+    }
+
+    public void setNextFocusLeftId(int nextFocusLeftId) {}
+
+    public int getNextFocusRightId() {
+        return 0;
+    }
+
+    public void setNextFocusRightId(int nextFocusRightId) {}
+
+    public int getNextFocusUpId() {
+        return 0;
+    }
+
+    public void setNextFocusUpId(int nextFocusUpId) {}
+
+    public int getNextFocusDownId() {
+        return 0;
+    }
+
+    public void setNextFocusDownId(int nextFocusDownId) {}
+
+    public int getNextFocusForwardId() {
+        return 0;
+    }
+
+    public void setNextFocusForwardId(int nextFocusForwardId) {}
+
+    public int getNextClusterForwardId() {
+        return 0;
+    }
+
+    public void setNextClusterForwardId(int nextClusterForwardId) {}
+
+    public boolean isShown() {
+        return false;
+    }
+
+    public boolean hasWindowInsetsAnimationCallback() {
+        return false;
+    }
+
+    public void setSystemGestureExclusionRects(List<Rect> rects) {}
+
+    public List<Rect> getSystemGestureExclusionRects() {
+        return null;
+    }
+
+    public void getLocationInSurface(int[] location) {}
+
+    public void setFitsSystemWindows(boolean fitSystemWindows) {}
+
+    public boolean getFitsSystemWindows() {
+        return false;
+    }
+
+    public boolean fitsSystemWindows() {
+        return false;
+    }
+
+    public void requestFitSystemWindows() {}
+
+    public void requestApplyInsets() {}
+
+    public void makeOptionalFitsSystemWindows() {}
+
+    public void makeFrameworkOptionalFitsSystemWindows() {}
+
+    public boolean isFrameworkOptionalFitsSystemWindows() {
+        return false;
+    }
+
+    public int getVisibility() {
+        return 0;
+    }
+
+    public void setVisibility(int visibility) {}
+
+    public boolean isEnabled() {
+        return false;
+    }
+
+    public void setEnabled(boolean enabled) {}
+
+    public void setFocusable(boolean focusable) {}
+
+    public void setFocusable(int focusable) {}
+
+    public void setFocusableInTouchMode(boolean focusableInTouchMode) {}
+
+    public void setAutofillHints(String... autofillHints) {}
+
+    public void setAutofilled(boolean isAutofilled, boolean hideHighlight) {}
+
+    public void setSoundEffectsEnabled(boolean soundEffectsEnabled) {}
+
+    public boolean isSoundEffectsEnabled() {
+        return false;
+    }
+
+    public void setHapticFeedbackEnabled(boolean hapticFeedbackEnabled) {}
+
+    public boolean isHapticFeedbackEnabled() {
+        return false;
+    }
+
+    public int getRawLayoutDirection() {
+        return 0;
+    }
+
+    public void setLayoutDirection(int layoutDirection) {}
+
+    public int getLayoutDirection() {
+        return 0;
+    }
+
+    public boolean isLayoutRtl() {
+        return false;
+    }
+
+    public boolean hasTransientState() {
+        return false;
+    }
+
+    public void setHasTransientState(boolean hasTransientState) {}
+
+    public boolean isAttachedToWindow() {
+        return false;
+    }
+
+    public boolean isLaidOut() {
+        return false;
+    }
+
+    public void setWillNotDraw(boolean willNotDraw) {}
+
+    public boolean willNotDraw() {
+        return false;
+    }
+
+    public void setWillNotCacheDrawing(boolean willNotCacheDrawing) {}
+
+    public boolean willNotCacheDrawing() {
+        return false;
+    }
+
+    public boolean isClickable() {
+        return false;
+    }
+
+    public void setClickable(boolean clickable) {}
+
+    public boolean isLongClickable() {
+        return false;
+    }
+
+    public void setLongClickable(boolean longClickable) {}
+
+    public boolean isContextClickable() {
+        return false;
+    }
+
+    public void setContextClickable(boolean contextClickable) {}
+
+    public void setPressed(boolean pressed) {}
+
+    public boolean isPressed() {
+        return false;
+    }
+
+    public boolean isAssistBlocked() {
+        return false;
+    }
+
+    public void setAssistBlocked(boolean enabled) {}
+
+    public boolean isSaveEnabled() {
+        return false;
+    }
+
+    public void setSaveEnabled(boolean enabled) {}
+
+    public boolean getFilterTouchesWhenObscured() {
+        return false;
+    }
+
+    public void setFilterTouchesWhenObscured(boolean enabled) {}
+
+    public boolean isSaveFromParentEnabled() {
+        return false;
+    }
+
+    public void setSaveFromParentEnabled(boolean enabled) {}
+
+    public final boolean isFocusable() {
+        return false;
+    }
+
+    public int getFocusable() {
+        return 0;
+    }
+
+    public final boolean isFocusableInTouchMode() {
+        return false;
+    }
+
+    public boolean isScreenReaderFocusable() {
+        return false;
+    }
+
+    public void setScreenReaderFocusable(boolean screenReaderFocusable) {}
+
+    public boolean isAccessibilityHeading() {
+        return false;
+    }
+
+    public void setAccessibilityHeading(boolean isHeading) {}
+
+    public View focusSearch(int direction) {
+        return null;
+    }
+
+    public final boolean isKeyboardNavigationCluster() {
+        return false;
+    }
+
+    public void setKeyboardNavigationCluster(boolean isCluster) {}
+
+    public final void setFocusedInCluster() {}
+
+    public final boolean isFocusedByDefault() {
+        return false;
+    }
+
+    public void setFocusedByDefault(boolean isFocusedByDefault) {}
+
+    public View keyboardNavigationClusterSearch(View currentCluster, int direction) {
+        return null;
+    }
+
+    public boolean dispatchUnhandledMove(View focused, int direction) {
+        return false;
+    }
+
+    public void setDefaultFocusHighlightEnabled(boolean defaultFocusHighlightEnabled) {}
+
+    public final boolean getDefaultFocusHighlightEnabled() {
+        return false;
+    }
+
+    public ArrayList<View> getFocusables(int direction) {
+        return null;
+    }
+
+    public void addFocusables(ArrayList<View> views, int direction) {}
+
+    public void addFocusables(ArrayList<View> views, int direction, int focusableMode) {}
+
+    public void addKeyboardNavigationClusters(Collection<View> views, int direction) {}
+
+    public void findViewsWithText(ArrayList<View> outViews, CharSequence searched, int flags) {}
+
+    public ArrayList<View> getTouchables() {
+        return null;
+    }
+
+    public void addTouchables(ArrayList<View> views) {}
+
+    public boolean isAccessibilityFocused() {
+        return false;
+    }
+
+    public boolean requestAccessibilityFocus() {
+        return false;
+    }
+
+    public void clearAccessibilityFocus() {}
+
+    public final boolean requestFocus() {
+        return false;
+    }
+
+    public boolean restoreFocusInCluster(int direction) {
+        return false;
+    }
+
+    public boolean restoreFocusNotInCluster() {
+        return false;
+    }
+
+    public boolean restoreDefaultFocus() {
+        return false;
+    }
+
+    public final boolean requestFocus(int direction) {
+        return false;
+    }
+
+    public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
+        return false;
+    }
+
+    public final boolean requestFocusFromTouch() {
+        return false;
+    }
+
+    public int getImportantForAccessibility() {
+        return 0;
+    }
+
+    public void setAccessibilityLiveRegion(int mode) {}
+
+    public int getAccessibilityLiveRegion() {
+        return 0;
+    }
+
+    public void setImportantForAccessibility(int mode) {}
+
+    public boolean isImportantForAccessibility() {
+        return false;
+    }
+
+    public void addChildrenForAccessibility(ArrayList<View> outChildren) {}
+
+    public boolean includeForAccessibility() {
+        return false;
+    }
+
+    public boolean isActionableForAccessibility() {
+        return false;
+    }
+
+    public void notifyViewAccessibilityStateChangedIfNeeded(int changeType) {}
+
+    public void notifySubtreeAccessibilityStateChangedIfNeeded() {}
+
+    public void setTransitionVisibility(int visibility) {}
+
+    public boolean dispatchNestedPrePerformAccessibilityAction(int action, Bundle arguments) {
+        return false;
+    }
+
+    public boolean performAccessibilityAction(int action, Bundle arguments) {
+        return false;
+    }
+
+    public boolean performAccessibilityActionInternal(int action, Bundle arguments) {
+        return false;
+    }
+
+    public CharSequence getIterableTextForAccessibility() {
+        return null;
+    }
+
+    public boolean isAccessibilitySelectionExtendable() {
+        return false;
+    }
+
+    public int getAccessibilitySelectionStart() {
+        return 0;
+    }
+
+    public int getAccessibilitySelectionEnd() {
+        return 0;
+    }
+
+    public void setAccessibilitySelection(int start, int end) {}
+
+    public final boolean isTemporarilyDetached() {
+        return false;
+    }
+
+    public void dispatchStartTemporaryDetach() {}
+
+    public void onStartTemporaryDetach() {}
+
+    public void dispatchFinishTemporaryDetach() {}
+
+    public void onFinishTemporaryDetach() {}
+
+    public void dispatchWindowFocusChanged(boolean hasFocus) {}
+
+    public void onWindowFocusChanged(boolean hasWindowFocus) {}
+
+    public boolean hasWindowFocus() {
+        return false;
+    }
+
+    public boolean hasImeFocus() {
+        return false;
+    }
+
+    public void dispatchDisplayHint(int hint) {}
+
+    public void dispatchWindowVisibilityChanged(int visibility) {}
+
+    public void onVisibilityAggregated(boolean isVisible) {}
+
+    public int getWindowVisibility() {
+        return 0;
+    }
+
+    public void getWindowVisibleDisplayFrame(Rect outRect) {}
+
+    public void getWindowDisplayFrame(Rect outRect) {}
+
+    public void dispatchConfigurationChanged(Configuration newConfig) {}
+
+    public boolean isInTouchMode() {
+        return false;
+    }
+
+    public final Context getContext() {
+        return null;
+    }
+
+    public boolean onCheckIsTextEditor() {
+        return false;
+    }
+
+    public boolean checkInputConnectionProxy(View view) {
+        return false;
+    }
+
+    public boolean isHovered() {
+        return false;
+    }
+
+    public void setHovered(boolean hovered) {}
+
+    public void onHoverChanged(boolean hovered) {}
+
+    public boolean isInScrollingContainer() {
+        return false;
+    }
+
+    public void cancelLongPress() {}
+
+    public final void requestUnbufferedDispatch(int source) {}
+
+    public void bringToFront() {}
+
+    public interface OnScrollChangeListener {
+        void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY);
+
+    }
+    public interface OnLayoutChangeListener {
+        void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft,
+                int oldTop, int oldRight, int oldBottom);
+
+    }
+
+    public void setScrollX(int value) {}
+
+    public void setScrollY(int value) {}
+
+    public final int getScrollX() {
+        return 0;
+    }
+
+    public final int getScrollY() {
+        return 0;
+    }
+
+    public final int getWidth() {
+        return 0;
+    }
+
+    public final int getHeight() {
+        return 0;
+    }
+
+    public void getDrawingRect(Rect outRect) {}
+
+    public final int getMeasuredWidth() {
+        return 0;
+    }
+
+    public final int getMeasuredWidthAndState() {
+        return 0;
+    }
+
+    public final int getMeasuredHeight() {
+        return 0;
+    }
+
+    public final int getMeasuredHeightAndState() {
+        return 0;
+    }
+
+    public final int getMeasuredState() {
+        return 0;
+    }
+
+    public Matrix getMatrix() {
+        return null;
+    }
+
+    public final boolean hasIdentityMatrix() {
+        return false;
+    }
+
+    public final Matrix getInverseMatrix() {
+        return null;
+    }
+
+    public float getCameraDistance() {
+        return 0;
+    }
+
+    public void setCameraDistance(float distance) {}
+
+    public float getRotation() {
+        return 0;
+    }
+
+    public void setRotation(float rotation) {}
+
+    public float getRotationY() {
+        return 0;
+    }
+
+    public void setRotationY(float rotationY) {}
+
+    public float getRotationX() {
+        return 0;
+    }
+
+    public void setRotationX(float rotationX) {}
+
+    public float getScaleX() {
+        return 0;
+    }
+
+    public void setScaleX(float scaleX) {}
+
+    public float getScaleY() {
+        return 0;
+    }
+
+    public void setScaleY(float scaleY) {}
+
+    public float getPivotX() {
+        return 0;
+    }
+
+    public void setPivotX(float pivotX) {}
+
+    public float getPivotY() {
+        return 0;
+    }
+
+    public void setPivotY(float pivotY) {}
+
+    public boolean isPivotSet() {
+        return false;
+    }
+
+    public void resetPivot() {}
+
+    public float getAlpha() {
+        return 0;
+    }
+
+    public void forceHasOverlappingRendering(boolean hasOverlappingRendering) {}
+
+    public final boolean getHasOverlappingRendering() {
+        return false;
+    }
+
+    public boolean hasOverlappingRendering() {
+        return false;
+    }
+
+    public void setAlpha(float alpha) {}
+
+    public void setTransitionAlpha(float alpha) {}
+
+    public float getTransitionAlpha() {
+        return 0;
+    }
+
+    public void setForceDarkAllowed(boolean allow) {}
+
+    public boolean isForceDarkAllowed() {
+        return false;
+    }
+
+    public final int getTop() {
+        return 0;
+    }
+
+    public final void setTop(int top) {}
+
+    public final int getBottom() {
+        return 0;
+    }
+
+    public boolean isDirty() {
+        return false;
+    }
+
+    public final void setBottom(int bottom) {}
+
+    public final int getLeft() {
+        return 0;
+    }
+
+    public final void setLeft(int left) {}
+
+    public final int getRight() {
+        return 0;
+    }
+
+    public final void setRight(int right) {}
+
+    public float getX() {
+        return 0;
+    }
+
+    public void setX(float x) {}
+
+    public float getY() {
+        return 0;
+    }
+
+    public void setY(float y) {}
+
+    public float getZ() {
+        return 0;
+    }
+
+    public void setZ(float z) {}
+
+    public float getElevation() {
+        return 0;
+    }
+
+    public void setElevation(float elevation) {}
+
+    public float getTranslationX() {
+        return 0;
+    }
+
+    public void setTranslationX(float translationX) {}
+
+    public float getTranslationY() {
+        return 0;
+    }
+
+    public void setTranslationY(float translationY) {}
+
+    public float getTranslationZ() {
+        return 0;
+    }
+
+    public void setTranslationZ(float translationZ) {}
+
+    public void setAnimationMatrix(Matrix matrix) {}
+
+    public Matrix getAnimationMatrix() {
+        return null;
+    }
+
+    public final boolean getClipToOutline() {
+        return false;
+    }
+
+    public void setClipToOutline(boolean clipToOutline) {}
+
+    public void invalidateOutline() {}
+
+    public boolean hasShadow() {
+        return false;
+    }
+
+    public void setOutlineSpotShadowColor(int color) {}
+
+    public int getOutlineSpotShadowColor() {
+        return 0;
+    }
+
+    public void setOutlineAmbientShadowColor(int color) {}
+
+    public int getOutlineAmbientShadowColor() {
+        return 0;
+    }
+
+    public void setRevealClip(boolean shouldClip, float x, float y, float radius) {}
+
+    public void getHitRect(Rect outRect) {}
+
+    public boolean pointInView(float localX, float localY, float slop) {
+        return false;
+    }
+
+    public void getFocusedRect(Rect r) {}
+
+    public boolean getGlobalVisibleRect(Rect r, Point globalOffset) {
+        return false;
+    }
+
+    public final boolean getGlobalVisibleRect(Rect r) {
+        return false;
+    }
+
+    public final boolean getLocalVisibleRect(Rect r) {
+        return false;
+    }
+
+    public void offsetTopAndBottom(int offset) {}
+
+    public void offsetLeftAndRight(int offset) {}
+
+    public void resolveLayoutParams() {}
+
+    public void scrollTo(int x, int y) {}
+
+    public void scrollBy(int x, int y) {}
+
+    public void invalidate(Rect dirty) {}
+
+    public void invalidate(int l, int t, int r, int b) {}
+
+    public void invalidate() {}
+
+    public void invalidate(boolean invalidateCache) {}
+
+    public boolean isOpaque() {
+        return false;
+    }
+
+    public Handler getHandler() {
+        return null;
+    }
+
+    public boolean post(Runnable action) {
+        return false;
+    }
+
+    public boolean postDelayed(Runnable action, long delayMillis) {
+        return false;
+    }
+
+    public void postOnAnimation(Runnable action) {}
+
+    public void postOnAnimationDelayed(Runnable action, long delayMillis) {}
+
+    public boolean removeCallbacks(Runnable action) {
+        return false;
+    }
+
+    public void postInvalidate() {}
+
+    public void postInvalidate(int left, int top, int right, int bottom) {}
+
+    public void postInvalidateDelayed(long delayMilliseconds) {}
+
+    public void postInvalidateDelayed(long delayMilliseconds, int left, int top, int right,
+            int bottom) {}
+
+    public void postInvalidateOnAnimation() {}
+
+    public void postInvalidateOnAnimation(int left, int top, int right, int bottom) {}
+
+    public void computeScroll() {}
+
+    public boolean isHorizontalFadingEdgeEnabled() {
+        return false;
+    }
+
+    public void setHorizontalFadingEdgeEnabled(boolean horizontalFadingEdgeEnabled) {}
+
+    public boolean isVerticalFadingEdgeEnabled() {
+        return false;
+    }
+
+    public void setVerticalFadingEdgeEnabled(boolean verticalFadingEdgeEnabled) {}
+
+    public int getFadingEdge() {
+        return 0;
+    }
+
+    public int getFadingEdgeLength() {
+        return 0;
+    }
+
+    public boolean isHorizontalScrollBarEnabled() {
+        return false;
+    }
+
+    public void setHorizontalScrollBarEnabled(boolean horizontalScrollBarEnabled) {}
+
+    public boolean isVerticalScrollBarEnabled() {
+        return false;
+    }
+
+    public void setVerticalScrollBarEnabled(boolean verticalScrollBarEnabled) {}
+
+    public void setScrollbarFadingEnabled(boolean fadeScrollbars) {}
+
+    public boolean isScrollbarFadingEnabled() {
+        return false;
+    }
+
+    public int getScrollBarDefaultDelayBeforeFade() {
+        return 0;
+    }
+
+    public void setScrollBarDefaultDelayBeforeFade(int scrollBarDefaultDelayBeforeFade) {}
+
+    public int getScrollBarFadeDuration() {
+        return 0;
+    }
+
+    public void setScrollBarFadeDuration(int scrollBarFadeDuration) {}
+
+    public int getScrollBarSize() {
+        return 0;
+    }
+
+    public void setScrollBarSize(int scrollBarSize) {}
+
+    public void setScrollBarStyle(int style) {}
+
+    public int getScrollBarStyle() {
+        return 0;
+    }
+
+    public boolean canScrollHorizontally(int direction) {
+        return false;
+    }
+
+    public boolean canScrollVertically(int direction) {
+        return false;
+    }
+
+    public boolean resolveRtlPropertiesIfNeeded() {
+        return false;
+    }
+
+    public void resetRtlProperties() {}
+
+    public void onScreenStateChanged(int screenState) {}
+
+    public void onMovedToDisplay(int displayId, Configuration config) {}
+
+    public void onRtlPropertiesChanged(int layoutDirection) {}
+
+    public boolean resolveLayoutDirection() {
+        return false;
+    }
+
+    public boolean canResolveLayoutDirection() {
+        return false;
+    }
+
+    public void resetResolvedLayoutDirection() {}
+
+    public boolean isLayoutDirectionInherited() {
+        return false;
+    }
+
+    public boolean isLayoutDirectionResolved() {
+        return false;
+    }
+
+    public void resolvePadding() {}
+
+    public void resetResolvedPadding() {}
+
+    public IBinder getWindowToken() {
+        return null;
+    }
+
+    public IBinder getApplicationWindowToken() {
+        return null;
+    }
+
+    public Display getDisplay() {
+        return null;
+    }
+
+    public final void cancelPendingInputEvents() {}
+
+    public void onCancelPendingInputEvents() {}
+
+    public void saveHierarchyState(SparseArray<Parcelable> container) {}
+
+    public void restoreHierarchyState(SparseArray<Parcelable> container) {}
+
+    public long getDrawingTime() {
+        return 0;
+    }
+
+    public void setDuplicateParentStateEnabled(boolean enabled) {}
+
+    public boolean isDuplicateParentStateEnabled() {
+        return false;
+    }
+
+    public void setLayerType(int layerType, Paint paint) {}
+
+    public void setLayerPaint(Paint paint) {}
+
+    public int getLayerType() {
+        return 0;
+    }
+
+    public void buildLayer() {}
+
+    public void setDrawingCacheEnabled(boolean enabled) {}
+
+    public boolean isDrawingCacheEnabled() {
+        return false;
+    }
+
+    public void outputDirtyFlags(String indent, boolean clear, int clearMask) {}
+
+    public boolean canHaveDisplayList() {
+        return false;
+    }
+
+    public RenderNode updateDisplayListIfDirty() {
+        return null;
+    }
+
+    public Bitmap getDrawingCache() {
+        return null;
+    }
+
+    public Bitmap getDrawingCache(boolean autoScale) {
+        return null;
+    }
+
+    public void destroyDrawingCache() {}
+
+    public void setDrawingCacheBackgroundColor(int color) {}
+
+    public int getDrawingCacheBackgroundColor() {
+        return 0;
+    }
+
+    public void buildDrawingCache() {}
+
+    public void buildDrawingCache(boolean autoScale) {}
+
+    public boolean isInEditMode() {
+        return false;
+    }
+
+    public boolean isHardwareAccelerated() {
+        return false;
+    }
+
+    public void setClipBounds(Rect clipBounds) {}
+
+    public Rect getClipBounds() {
+        return null;
+    }
+
+    public boolean getClipBounds(Rect outRect) {
+        return false;
+    }
+
+    public void draw(Canvas canvas) {}
+
+    public int getSolidColor() {
+        return 0;
+    }
+
+    public boolean isLayoutRequested() {
+        return false;
+    }
+
+    public static boolean isLayoutModeOptical(Object o) {
+        return false;
+    }
+
+    public void layout(int l, int t, int r, int b) {}
+
+    public final void setLeftTopRightBottom(int left, int top, int right, int bottom) {}
+
+    public Resources getResources() {
+        return null;
+    }
+
+    @Override
+    public void invalidateDrawable(Drawable drawable) {}
+
+    @Override
+    public void scheduleDrawable(Drawable who, Runnable what, long when) {}
+
+    @Override
+    public void unscheduleDrawable(Drawable who, Runnable what) {}
+
+    public void unscheduleDrawable(Drawable who) {}
+
+    public void onResolveDrawables(int layoutDirection) {}
+
+    public void drawableHotspotChanged(float x, float y) {}
+
+    public void dispatchDrawableHotspotChanged(float x, float y) {}
+
+    public void refreshDrawableState() {}
+
+    public boolean isDefaultFocusHighlightNeeded(Drawable background, Drawable foreground) {
+        return false;
+    }
+
+    public final int[] getDrawableState() {
+        return null;
+    }
+
+    public void jumpDrawablesToCurrentState() {}
+
+    public void setBackgroundColor(int color) {}
+
+    public void setBackgroundResource(int resid) {}
+
+    public void setBackground(Drawable background) {}
+
+    public void setBackgroundDrawable(Drawable background) {}
+
+    public Drawable getBackground() {
+        return null;
+    }
+
+    public void setBackgroundTintList(ColorStateList tint) {}
+
+    public ColorStateList getBackgroundTintList() {
+        return null;
+    }
+
+    public void setBackgroundTintMode(PorterDuff.Mode tintMode) {}
+
+    public void setBackgroundTintBlendMode(BlendMode blendMode) {}
+
+    public PorterDuff.Mode getBackgroundTintMode() {
+        return null;
+    }
+
+    public BlendMode getBackgroundTintBlendMode() {
+        return null;
+    }
+
+    public Drawable getForeground() {
+        return null;
+    }
+
+    public void setForeground(Drawable foreground) {}
+
+    public boolean isForegroundInsidePadding() {
+        return false;
+    }
+
+    public int getForegroundGravity() {
+        return 0;
+    }
+
+    public void setForegroundGravity(int gravity) {}
+
+    public void setForegroundTintList(ColorStateList tint) {}
+
+    public ColorStateList getForegroundTintList() {
+        return null;
+    }
+
+    public void setForegroundTintMode(PorterDuff.Mode tintMode) {}
+
+    public void setForegroundTintBlendMode(BlendMode blendMode) {}
+
+    public PorterDuff.Mode getForegroundTintMode() {
+        return null;
+    }
+
+    public BlendMode getForegroundTintBlendMode() {
+        return null;
+    }
+
+    public void onDrawForeground(Canvas canvas) {}
+
+    public void setPadding(int left, int top, int right, int bottom) {}
+
+    public void setPaddingRelative(int start, int top, int end, int bottom) {}
+
+    public int getSourceLayoutResId() {
+        return 0;
+    }
+
+    public int getPaddingTop() {
+        return 0;
+    }
+
+    public int getPaddingBottom() {
+        return 0;
+    }
+
+    public int getPaddingLeft() {
+        return 0;
+    }
+
+    public int getPaddingStart() {
+        return 0;
+    }
+
+    public int getPaddingRight() {
+        return 0;
+    }
+
+    public int getPaddingEnd() {
+        return 0;
+    }
+
+    public boolean isPaddingRelative() {
+        return false;
+    }
+
+    public void resetPaddingToInitialValues() {}
+
+    public Insets getOpticalInsets() {
+        return null;
+    }
+
+    public void setOpticalInsets(Insets insets) {}
+
+    public void setSelected(boolean selected) {}
+
+    public boolean isSelected() {
+        return false;
+    }
+
+    public void setActivated(boolean activated) {}
+
+    public boolean isActivated() {
+        return false;
+    }
+
+    public View getRootView() {
+        return null;
+    }
+
+    public void transformMatrixToGlobal(Matrix matrix) {}
+
+    public void transformMatrixToLocal(Matrix matrix) {}
+
+    public int[] getLocationOnScreen() {
+        return null;
+    }
+
+    public void getLocationOnScreen(int[] outLocation) {}
+
+    public void getLocationInWindow(int[] outLocation) {}
+
+    public void transformFromViewToWindowSpace(int[] inOutLocation) {}
+
+    public final <T extends View> T findViewById(int id) {
+        return null;
+    }
+
+    public final <T extends View> T requireViewById(int id) {
+        return null;
+    }
+
+    public <T extends View> T findViewByAccessibilityIdTraversal(int accessibilityId) {
+        return null;
+    }
+
+    public <T extends View> T findViewByAutofillIdTraversal(int autofillId) {
+        return null;
+    }
+
+    public final <T extends View> T findViewWithTag(Object tag) {
+        return null;
+    }
+
+    public final <T extends View> T findViewByPredicate(Predicate<View> predicate) {
+        return null;
+    }
+
+    public final <T extends View> T findViewByPredicateInsideOut(View start,
+            Predicate<View> predicate) {
+        return null;
+    }
+
+    public void setId(int id) {}
+
+    public void setIsRootNamespace(boolean isRoot) {}
+
+    public boolean isRootNamespace() {
+        return false;
+    }
+
+    public int getId() {
+        return 0;
+    }
+
+    public long getUniqueDrawingId() {
+        return 0;
+    }
+
+    public Object getTag() {
+        return null;
+    }
+
+    public void setTag(final Object tag) {}
+
+    public Object getTag(int key) {
+        return null;
+    }
+
+    public void setTag(int key, final Object tag) {}
+
+    public void setTagInternal(int key, Object tag) {}
+
+    public void debug() {}
+
+    public int getBaseline() {
+        return 0;
+    }
+
+    public boolean isInLayout() {
+        return false;
+    }
+
+    public void requestLayout() {}
+
+    public void forceLayout() {}
+
+    public final void measure(int widthMeasureSpec, int heightMeasureSpec) {}
+
+    public static int combineMeasuredStates(int curState, int newState) {
+        return 0;
+    }
+
+    public static int resolveSize(int size, int measureSpec) {
+        return 0;
+    }
+
+    public static int resolveSizeAndState(int size, int measureSpec, int childMeasuredState) {
+        return 0;
+    }
+
+    public static int getDefaultSize(int size, int measureSpec) {
+        return 0;
+    }
+
+    public int getMinimumHeight() {
+        return 0;
+    }
+
+    public void setMinimumHeight(int minHeight) {}
+
+    public int getMinimumWidth() {
+        return 0;
+    }
+
+    public void setMinimumWidth(int minWidth) {}
+
+    public void clearAnimation() {}
+
+    public boolean gatherTransparentRegion(Region region) {
+        return false;
+    }
+
+    public void playSoundEffect(int soundConstant) {}
+
+    public boolean performHapticFeedback(int feedbackConstant) {
+        return false;
+    }
+
+    public boolean performHapticFeedback(int feedbackConstant, int flags) {
+        return false;
+    }
+
+    public void setSystemUiVisibility(int visibility) {}
+
+    public int getSystemUiVisibility() {
+        return 0;
+    }
+
+    public int getWindowSystemUiVisibility() {
+        return 0;
+    }
+
+    public void onWindowSystemUiVisibilityChanged(int visible) {}
+
+    public void dispatchWindowSystemUiVisiblityChanged(int visible) {}
+
+    public void setOnSystemUiVisibilityChangeListener(OnSystemUiVisibilityChangeListener l) {}
+
+    public void dispatchSystemUiVisibilityChanged(int visibility) {}
+
+    public void setDisabledSystemUiVisibility(int flags) {}
+
+    public static class DragShadowBuilder {
+        public DragShadowBuilder(View view) {}
+
+        public DragShadowBuilder() {}
+
+        final public View getView() {
+            return null;
+        }
+
+        public void onProvideShadowMetrics(Point outShadowSize, Point outShadowTouchPoint) {}
+
+        public void onDrawShadow(Canvas canvas) {}
+
+    }
+
+    public final boolean startDrag(ClipData data, DragShadowBuilder shadowBuilder,
+            Object myLocalState, int flags) {
+        return false;
+    }
+
+    public final boolean startDragAndDrop(ClipData data, DragShadowBuilder shadowBuilder,
+            Object myLocalState, int flags) {
+        return false;
+    }
+
+    public final void cancelDragAndDrop() {}
+
+    public final void updateDragShadow(DragShadowBuilder shadowBuilder) {}
+
+    public final boolean startMovingTask(float startX, float startY) {
+        return false;
+    }
+
+    public void finishMovingTask() {}
 
 
+    public void onCloseSystemDialogs(String reason) {}
 
+    public void applyDrawableToTransparentRegion(Drawable dr, Region region) {}
 
+    public int getOverScrollMode() {
+        return 0;
+    }
 
+    public void setOverScrollMode(int overScrollMode) {}
 
+    public void setNestedScrollingEnabled(boolean enabled) {}
 
+    public boolean isNestedScrollingEnabled() {
+        return false;
+    }
 
+    public boolean startNestedScroll(int axes) {
+        return false;
+    }
+
+    public void stopNestedScroll() {}
+
+    public boolean hasNestedScrollingParent() {
+        return false;
+    }
+
+    public boolean dispatchNestedScroll(int dxConsumed, int dyConsumed, int dxUnconsumed,
+            int dyUnconsumed, int[] offsetInWindow) {
+        return false;
+    }
+
+    public boolean dispatchNestedPreScroll(int dx, int dy, int[] consumed, int[] offsetInWindow) {
+        return false;
+    }
+
+    public boolean dispatchNestedFling(float velocityX, float velocityY, boolean consumed) {
+        return false;
+    }
+
+    public boolean dispatchNestedPreFling(float velocityX, float velocityY) {
+        return false;
+    }
+
+    public int getRawTextDirection() {
+        return 0;
+    }
+
+    public void setTextDirection(int textDirection) {}
+
+    public int getTextDirection() {
+        return 0;
+    }
+
+    public boolean resolveTextDirection() {
+        return false;
+    }
+
+    public boolean canResolveTextDirection() {
+        return false;
+    }
+
+    public void resetResolvedTextDirection() {}
+
+    public boolean isTextDirectionInherited() {
+        return false;
+    }
+
+    public boolean isTextDirectionResolved() {
+        return false;
+    }
+
+    public int getRawTextAlignment() {
+        return 0;
+    }
+
+    public void setTextAlignment(int textAlignment) {}
+
+    public int getTextAlignment() {
+        return 0;
+    }
+
+    public boolean resolveTextAlignment() {
+        return false;
+    }
+
+    public boolean canResolveTextAlignment() {
+        return false;
+    }
+
+    public void resetResolvedTextAlignment() {}
+
+    public boolean isTextAlignmentInherited() {
+        return false;
+    }
+
+    public boolean isTextAlignmentResolved() {
+        return false;
+    }
+
+    public static int generateViewId() {
+        return 0;
+    }
+
+    public void captureTransitioningViews(List<View> transitioningViews) {}
+
+    public void findNamedViews(Map<String, View> namedElements) {}
+
+    public boolean hasPointerCapture() {
+        return false;
+    }
+
+    public void requestPointerCapture() {}
+
+    public void releasePointerCapture() {}
+
+    public void onPointerCaptureChange(boolean hasCapture) {}
+
+    public void dispatchPointerCaptureChanged(boolean hasCapture) {}
+
+    public static class MeasureSpec {
+        public @interface MeasureSpecMode {
+        }
+
+        public static int makeMeasureSpec(int size, int mode) {
+            return 0;
+        }
+
+        public static int makeSafeMeasureSpec(int size, int mode) {
+            return 0;
+        }
+
+        public static int getMode(int measureSpec) {
+            return 0;
+        }
+
+        public static int getSize(int measureSpec) {
+            return 0;
+        }
+
+        public static String toString(int measureSpec) {
+            return null;
+        }
+
+    }
+
+    public final void setTransitionName(String transitionName) {}
+
+    public String getTransitionName() {
+        return null;
+    }
+
+    public interface OnLongClickListener {
+        boolean onLongClick(View v);
+
+    }
+
+    public interface OnFocusChangeListener {
+        void onFocusChange(View v, boolean hasFocus);
+
+    }
+    public interface OnClickListener {
+        void onClick(View v);
+    }
+    public interface OnContextClickListener {
+        boolean onContextClick(View v);
+
+    }
+
+    public interface OnSystemUiVisibilityChangeListener {
+        public void onSystemUiVisibilityChange(int visibility);
+
+    }
+    public interface OnAttachStateChangeListener {
+        public void onViewAttachedToWindow(View v);
+
+        public void onViewDetachedFromWindow(View v);
+
+    }
+
+    public static class BaseSavedState {
+        public BaseSavedState(Parcel source) {}
+
+        public BaseSavedState(Parcel source, ClassLoader loader) {}
+
+        public BaseSavedState(Parcelable superState) {}
+
+        public void writeToParcel(Parcel out, int flags) {}
+
+    }
+    public static class AccessibilityDelegate {
+        public void sendAccessibilityEvent(View host, int eventType) {}
+
+        public boolean performAccessibilityAction(View host, int action, Bundle args) {
+            return false;
+        }
+    }
+
+    public int getScrollCaptureHint() {
+        return 0;
+    }
+
+    public void setScrollCaptureHint(int hint) {}
+
+    public void setTooltipText(CharSequence tooltipText) {}
+
+    public void setTooltip(CharSequence tooltipText) {}
+
+    public CharSequence getTooltipText() {
+        return null;
+    }
+
+    public CharSequence getTooltip() {
+        return null;
+    }
+
+    public View getTooltipView() {
+        return null;
+    }
+
+    public static boolean isDefaultFocusHighlightEnabled() {
+        return false;
+    }
 }

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/ViewGroup.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/ViewGroup.java
@@ -1,0 +1,522 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.view;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Region;
+import android.os.Bundle;
+import android.util.AttributeSet;
+
+public abstract class ViewGroup extends View {
+  public ViewGroup(Context context) {
+    super(null);
+  }
+
+  public ViewGroup(Context context, AttributeSet attrs) {
+    super(null);
+  }
+
+  public ViewGroup(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(null);
+  }
+
+  public ViewGroup(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    super(null);
+  }
+
+  public int getDescendantFocusability() {
+    return 0;
+  }
+
+  public void setDescendantFocusability(int focusability) {}
+
+  public void requestChildFocus(View child, View focused) {}
+
+  public void focusableViewAvailable(View v) {}
+
+  public boolean showContextMenuForChild(View originalView) {
+    return false;
+  }
+
+  public final boolean isShowingContextMenuWithCoords() {
+    return false;
+  }
+
+  public boolean showContextMenuForChild(View originalView, float x, float y) {
+    return false;
+  }
+
+  public boolean dispatchActivityResult(String who, int requestCode, int resultCode, Intent data) {
+    return false;
+  }
+
+  public View focusSearch(View focused, int direction) {
+    return null;
+  }
+
+  public boolean requestChildRectangleOnScreen(View child, Rect rectangle, boolean immediate) {
+    return false;
+  }
+
+  public void childHasTransientStateChanged(View child, boolean childHasTransientState) {}
+
+  public boolean hasTransientState() {
+    return false;
+  }
+
+  public boolean dispatchUnhandledMove(View focused, int direction) {
+    return false;
+  }
+
+  public void clearChildFocus(View child) {}
+
+  public void clearFocus() {}
+
+  public View getFocusedChild() {
+    return null;
+  }
+
+  public boolean hasFocus() {
+    return false;
+  }
+
+  public View findFocus() {
+    return null;
+  }
+
+  public void addFocusables(ArrayList<View> views, int direction, int focusableMode) {}
+
+  public void addKeyboardNavigationClusters(Collection<View> views, int direction) {}
+
+  public void setTouchscreenBlocksFocus(boolean touchscreenBlocksFocus) {}
+
+  public boolean getTouchscreenBlocksFocus() {
+    return false;
+  }
+
+  public void findViewsWithText(ArrayList<View> outViews, CharSequence text, int flags) {}
+
+  public View findViewByAccessibilityIdTraversal(int accessibilityId) {
+    return null;
+  }
+
+  public View findViewByAutofillIdTraversal(int autofillId) {
+    return null;
+  }
+
+  public void dispatchWindowFocusChanged(boolean hasFocus) {}
+
+  public void addTouchables(ArrayList<View> views) {}
+
+  public void makeOptionalFitsSystemWindows() {}
+
+  public void makeFrameworkOptionalFitsSystemWindows() {}
+
+  public void dispatchDisplayHint(int hint) {}
+
+  public void dispatchWindowVisibilityChanged(int visibility) {}
+
+  public void dispatchConfigurationChanged(Configuration newConfig) {}
+
+  public void recomputeViewAttributes(View child) {}
+
+  public void bringChildToFront(View child) {}
+
+  public void dispatchWindowSystemUiVisiblityChanged(int visible) {}
+
+  public void dispatchSystemUiVisibilityChanged(int visible) {}
+
+  public void dispatchPointerCaptureChanged(boolean hasCapture) {}
+
+  public void addChildrenForAccessibility(ArrayList<View> outChildren) {}
+
+  public ArrayList<View> buildTouchDispatchChildList() {
+    return null;
+  }
+
+  public void transformPointToViewLocal(float[] point, View child) {}
+
+  public void setMotionEventSplittingEnabled(boolean split) {}
+
+  public boolean isMotionEventSplittingEnabled() {
+    return false;
+  }
+
+  public boolean isTransitionGroup() {
+    return false;
+  }
+
+  public void setTransitionGroup(boolean isTransitionGroup) {}
+
+  public void requestDisallowInterceptTouchEvent(boolean disallowIntercept) {}
+
+  public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
+    return false;
+  }
+
+  public boolean restoreDefaultFocus() {
+    return false;
+  }
+
+  public boolean restoreFocusInCluster(int direction) {
+    return false;
+  }
+
+  public boolean restoreFocusNotInCluster() {
+    return false;
+  }
+
+  public void dispatchStartTemporaryDetach() {}
+
+  public void dispatchFinishTemporaryDetach() {}
+
+  public void dispatchProvideContentCaptureStructure() {}
+
+  public CharSequence getAccessibilityClassName() {
+    return null;
+  }
+
+  public void notifySubtreeAccessibilityStateChanged(View child, View source, int changeType) {}
+
+  public void notifySubtreeAccessibilityStateChangedIfNeeded() {}
+
+  public boolean onNestedPrePerformAccessibilityAction(View target, int action, Bundle args) {
+    return false;
+  }
+
+  public final int getChildDrawingOrder(int drawingPosition) {
+    return 0;
+  }
+
+  public boolean getClipChildren() {
+    return false;
+  }
+
+  public void setClipChildren(boolean clipChildren) {}
+
+  public void setClipToPadding(boolean clipToPadding) {}
+
+  public boolean getClipToPadding() {
+    return false;
+  }
+
+  public void dispatchSetSelected(boolean selected) {}
+
+  public void dispatchSetActivated(boolean activated) {}
+
+  public void dispatchDrawableHotspotChanged(float x, float y) {}
+
+  public void addTransientView(View view, int index) {}
+
+  public void removeTransientView(View view) {}
+
+  public int getTransientViewCount() {
+    return 0;
+  }
+
+  public int getTransientViewIndex(int position) {
+    return 0;
+  }
+
+  public View getTransientView(int position) {
+    return null;
+  }
+
+  public void addView(View child) {}
+
+  public void addView(View child, int index) {}
+
+  public void addView(View child, int width, int height) {}
+
+  public void addView(View child, LayoutParams params) {}
+
+  public void addView(View child, int index, LayoutParams params) {}
+
+  public void updateViewLayout(View view, ViewGroup.LayoutParams params) {}
+
+  public interface OnHierarchyChangeListener {
+    void onChildViewAdded(View parent, View child);
+
+    void onChildViewRemoved(View parent, View child);
+
+  }
+
+  public void setOnHierarchyChangeListener(OnHierarchyChangeListener listener) {}
+
+  public void onViewAdded(View child) {}
+
+  public void onViewRemoved(View child) {}
+
+  public void removeView(View view) {}
+
+  public void removeViewInLayout(View view) {}
+
+  public void removeViewsInLayout(int start, int count) {}
+
+  public void removeViewAt(int index) {}
+
+  public void removeViews(int start, int count) {}
+
+  public void removeAllViews() {}
+
+  public void removeAllViewsInLayout() {}
+
+  public void onDescendantInvalidated(View child, View target) {}
+
+  public final void invalidateChild(View child, final Rect dirty) {}
+
+  public final void offsetDescendantRectToMyCoords(View descendant, Rect rect) {}
+
+  public final void offsetRectIntoDescendantCoords(View descendant, Rect rect) {}
+
+  public void offsetChildrenTopAndBottom(int offset) {}
+
+  public boolean getChildVisibleRect(View child, Rect r, android.graphics.Point offset) {
+    return false;
+  }
+
+  public boolean getChildVisibleRect(View child, Rect r, android.graphics.Point offset,
+      boolean forceParentCheck) {
+    return false;
+  }
+
+  public final void layout(int l, int t, int r, int b) {}
+
+  public void startLayoutAnimation() {}
+
+  public void scheduleLayoutAnimation() {}
+
+  public boolean isAnimationCacheEnabled() {
+    return false;
+  }
+
+  public void setAnimationCacheEnabled(boolean enabled) {}
+
+  public boolean isAlwaysDrawnWithCacheEnabled() {
+    return false;
+  }
+
+  public void setAlwaysDrawnWithCacheEnabled(boolean always) {}
+
+  public int getPersistentDrawingCache() {
+    return 0;
+  }
+
+  public void setPersistentDrawingCache(int drawingCacheToKeep) {}
+
+  public int getLayoutMode() {
+    return 0;
+  }
+
+  public void setLayoutMode(int layoutMode) {}
+
+  public LayoutParams generateLayoutParams(AttributeSet attrs) {
+    return null;
+  }
+
+  public int indexOfChild(View child) {
+    return 0;
+  }
+
+  public int getChildCount() {
+    return 0;
+  }
+
+  public View getChildAt(int index) {
+    return null;
+  }
+
+  public static int getChildMeasureSpec(int spec, int padding, int childDimension) {
+    return 0;
+  }
+
+  public void clearDisappearingChildren() {}
+
+  public void startViewTransition(View view) {}
+
+  public void endViewTransition(View view) {}
+
+  public void suppressLayout(boolean suppress) {}
+
+  public boolean isLayoutSuppressed() {
+    return false;
+  }
+
+  public boolean gatherTransparentRegion(Region region) {
+    return false;
+  }
+
+  public void requestTransparentRegion(View child) {}
+
+  public void subtractObscuredTouchableRegion(Region touchableRegion, View view) {}
+
+  public boolean hasWindowInsetsAnimationCallback() {
+    return false;
+  }
+
+  public void jumpDrawablesToCurrentState() {}
+
+  public void setAddStatesFromChildren(boolean addsStates) {}
+
+  public boolean addStatesFromChildren() {
+    return false;
+  }
+
+  public void childDrawableStateChanged(View child) {}
+
+  public boolean resolveRtlPropertiesIfNeeded() {
+    return false;
+  }
+
+  public boolean resolveLayoutDirection() {
+    return false;
+  }
+
+  public boolean resolveTextDirection() {
+    return false;
+  }
+
+  public boolean resolveTextAlignment() {
+    return false;
+  }
+
+  public void resolvePadding() {}
+
+  public void resolveLayoutParams() {}
+
+  public void resetResolvedLayoutDirection() {}
+
+  public void resetResolvedTextDirection() {}
+
+  public void resetResolvedTextAlignment() {}
+
+  public void resetResolvedPadding() {}
+
+  public boolean shouldDelayChildPressedState() {
+    return false;
+  }
+
+  public boolean onStartNestedScroll(View child, View target, int nestedScrollAxes) {
+    return false;
+  }
+
+  public void onNestedScrollAccepted(View child, View target, int axes) {}
+
+  public void onStopNestedScroll(View child) {}
+
+  public void onNestedScroll(View target, int dxConsumed, int dyConsumed, int dxUnconsumed,
+      int dyUnconsumed) {}
+
+  public void onNestedPreScroll(View target, int dx, int dy, int[] consumed) {}
+
+  public boolean onNestedFling(View target, float velocityX, float velocityY, boolean consumed) {
+    return false;
+  }
+
+  public boolean onNestedPreFling(View target, float velocityX, float velocityY) {
+    return false;
+  }
+
+  public int getNestedScrollAxes() {
+    return 0;
+  }
+
+  public void captureTransitioningViews(List<View> transitioningViews) {}
+
+  public void findNamedViews(Map<String, View> namedElements) {}
+
+  public static class LayoutParams {
+    public LayoutParams(Context c, AttributeSet attrs) {}
+
+    public LayoutParams(int width, int height) {}
+
+    public LayoutParams(LayoutParams source) {}
+
+    public void resolveLayoutDirection(int layoutDirection) {}
+
+    public String debug(String output) {
+      return null;
+    }
+
+    public void onDebugDraw(View view, Canvas canvas, Paint paint) {}
+
+  }
+  public static class MarginLayoutParams extends ViewGroup.LayoutParams {
+    public MarginLayoutParams(Context c, AttributeSet attrs) {
+      super(null);
+    }
+
+    public MarginLayoutParams(int width, int height) {
+      super(null);
+    }
+
+    public MarginLayoutParams(MarginLayoutParams source) {
+      super(null);
+    }
+
+    public MarginLayoutParams(LayoutParams source) {
+      super(null);
+    }
+
+    public final void copyMarginsFrom(MarginLayoutParams source) {}
+
+    public void setMargins(int left, int top, int right, int bottom) {}
+
+    public void setMarginsRelative(int start, int top, int end, int bottom) {}
+
+    public void setMarginStart(int start) {}
+
+    public int getMarginStart() {
+      return 0;
+    }
+
+    public void setMarginEnd(int end) {}
+
+    public int getMarginEnd() {
+      return 0;
+    }
+
+    public boolean isMarginRelative() {
+      return false;
+    }
+
+    public void setLayoutDirection(int layoutDirection) {}
+
+    public int getLayoutDirection() {
+      return 0;
+    }
+
+    public void resolveLayoutDirection(int layoutDirection) {}
+
+    public boolean isLayoutRtl() {
+      return false;
+    }
+
+    public void onDebugDraw(View view, Canvas canvas, Paint paint) {}
+
+  }
+
+  public final void onDescendantUnbufferedRequested() {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/widget/Button.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/widget/Button.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+public class Button extends TextView {
+  public Button(Context context) {
+    super(null);
+  }
+
+  public Button(Context context, AttributeSet attrs) {
+    super(null);
+  }
+
+  public Button(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(null);
+  }
+
+  public Button(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    super(null);
+  }
+
+  @Override
+  public CharSequence getAccessibilityClassName() {
+    return null;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/widget/TextView.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/widget/TextView.java
@@ -1,0 +1,816 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package android.widget;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import android.annotation.Nullable;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.TypedArray;
+import android.graphics.BlendMode;
+import android.graphics.PorterDuff;
+import android.graphics.Rect;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.os.LocaleList;
+import android.os.UserHandle;
+import android.util.AttributeSet;
+import android.view.View;
+
+public class TextView extends View {
+  public @interface XMLTypefaceAttr {
+
+  }
+  public @interface AutoSizeTextType {
+  }
+
+  public static void preloadFontCache() {}
+
+  public TextView(Context context) {
+    super(null);
+  }
+
+  public TextView(Context context, AttributeSet attrs) {
+    super(null);
+  }
+
+  public TextView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(null);
+  }
+
+  public TextView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    super(null);
+  }
+
+  public void setAutoSizeTextTypeWithDefaults(int autoSizeTextType) {}
+
+  public void setAutoSizeTextTypeUniformWithConfiguration(int autoSizeMinTextSize,
+      int autoSizeMaxTextSize, int autoSizeStepGranularity, int unit) {}
+
+  public void setAutoSizeTextTypeUniformWithPresetSizes(int[] presetSizes, int unit) {}
+
+  public int getAutoSizeTextType() {
+    return 0;
+  }
+
+  public int getAutoSizeStepGranularity() {
+    return 0;
+  }
+
+  public int getAutoSizeMinTextSize() {
+    return 0;
+  }
+
+  public int getAutoSizeMaxTextSize() {
+    return 0;
+  }
+
+  public int[] getAutoSizeTextAvailableSizes() {
+    return null;
+  }
+
+  public void setTypeface(Typeface tf, int style) {}
+
+  public CharSequence getText() {
+    return null;
+  }
+
+  public int length() {
+    return 0;
+  }
+
+  public CharSequence getTransformed() {
+    return null;
+  }
+
+  public int getLineHeight() {
+    return 0;
+  }
+
+  public int getCompoundPaddingTop() {
+    return 0;
+  }
+
+  public int getCompoundPaddingBottom() {
+    return 0;
+  }
+
+  public int getCompoundPaddingLeft() {
+    return 0;
+  }
+
+  public int getCompoundPaddingRight() {
+    return 0;
+  }
+
+  public int getCompoundPaddingStart() {
+    return 0;
+  }
+
+  public int getCompoundPaddingEnd() {
+    return 0;
+  }
+
+  public int getExtendedPaddingTop() {
+    return 0;
+  }
+
+  public int getExtendedPaddingBottom() {
+    return 0;
+  }
+
+  public int getTotalPaddingLeft() {
+    return 0;
+  }
+
+  public int getTotalPaddingRight() {
+    return 0;
+  }
+
+  public int getTotalPaddingStart() {
+    return 0;
+  }
+
+  public int getTotalPaddingEnd() {
+    return 0;
+  }
+
+  public int getTotalPaddingTop() {
+    return 0;
+  }
+
+  public int getTotalPaddingBottom() {
+    return 0;
+  }
+
+  public void setCompoundDrawables(Drawable left, Drawable top, Drawable right, Drawable bottom) {}
+
+  public void setCompoundDrawablesWithIntrinsicBounds(int left, int top, int right, int bottom) {}
+
+  public void setCompoundDrawablesWithIntrinsicBounds(Drawable left, Drawable top, Drawable right,
+      Drawable bottom) {}
+
+  public void setCompoundDrawablesRelative(Drawable start, Drawable top, Drawable end,
+      Drawable bottom) {}
+
+  public void setCompoundDrawablesRelativeWithIntrinsicBounds(int start, int top, int end,
+      int bottom) {}
+
+  public void setCompoundDrawablesRelativeWithIntrinsicBounds(Drawable start, Drawable top,
+      Drawable end, Drawable bottom) {}
+
+  public Drawable[] getCompoundDrawables() {
+    return null;
+  }
+
+  public Drawable[] getCompoundDrawablesRelative() {
+    return null;
+  }
+
+  public void setCompoundDrawablePadding(int pad) {}
+
+  public int getCompoundDrawablePadding() {
+    return 0;
+  }
+
+  public void setCompoundDrawableTintList(ColorStateList tint) {}
+
+  public ColorStateList getCompoundDrawableTintList() {
+    return null;
+  }
+
+  public void setCompoundDrawableTintMode(PorterDuff.Mode tintMode) {}
+
+  public void setCompoundDrawableTintBlendMode(BlendMode blendMode) {}
+
+  public PorterDuff.Mode getCompoundDrawableTintMode() {
+    return null;
+  }
+
+  public BlendMode getCompoundDrawableTintBlendMode() {
+    return null;
+  }
+
+  public void setFirstBaselineToTopHeight(int firstBaselineToTopHeight) {}
+
+  public void setLastBaselineToBottomHeight(int lastBaselineToBottomHeight) {}
+
+  public int getFirstBaselineToTopHeight() {
+    return 0;
+  }
+
+  public int getLastBaselineToBottomHeight() {
+    return 0;
+  }
+
+  public final int getAutoLinkMask() {
+    return 0;
+  }
+
+  public void setTextSelectHandle(Drawable textSelectHandle) {}
+
+  public void setTextSelectHandle(int textSelectHandle) {}
+
+  @Nullable
+  public Drawable getTextSelectHandle() {
+    return null;
+  }
+
+  public void setTextSelectHandleLeft(Drawable textSelectHandleLeft) {}
+
+  public void setTextSelectHandleLeft(int textSelectHandleLeft) {}
+
+  @Nullable
+  public Drawable getTextSelectHandleLeft() {
+    return null;
+  }
+
+  public void setTextSelectHandleRight(Drawable textSelectHandleRight) {}
+
+  public void setTextSelectHandleRight(int textSelectHandleRight) {}
+
+  @Nullable
+  public Drawable getTextSelectHandleRight() {
+    return null;
+  }
+
+  public void setTextCursorDrawable(Drawable textCursorDrawable) {}
+
+  public void setTextCursorDrawable(int textCursorDrawable) {}
+
+  @Nullable
+  public Drawable getTextCursorDrawable() {
+    return null;
+  }
+
+  public void setTextAppearance(int resId) {}
+
+  public void setTextAppearance(Context context, int resId) {}
+
+  public Locale getTextLocale() {
+    return null;
+  }
+
+  public LocaleList getTextLocales() {
+    return null;
+  }
+
+  public void setTextLocale(Locale locale) {}
+
+  public void setTextLocales(LocaleList locales) {}
+
+  public float getTextSize() {
+    return 0;
+  }
+
+  public float getScaledTextSize() {
+    return 0;
+  }
+
+  public int getTypefaceStyle() {
+    return 0;
+  }
+
+  public void setTextSize(float size) {}
+
+  public void setTextSize(int unit, float size) {}
+
+  public int getTextSizeUnit() {
+    return 0;
+  }
+
+  public float getTextScaleX() {
+    return 0;
+  }
+
+  public void setTextScaleX(float size) {}
+
+  public void setTypeface(Typeface tf) {}
+
+  public Typeface getTypeface() {
+    return null;
+  }
+
+  public void setElegantTextHeight(boolean elegant) {}
+
+  public void setFallbackLineSpacing(boolean enabled) {}
+
+  public boolean isFallbackLineSpacing() {
+    return false;
+  }
+
+  public boolean isElegantTextHeight() {
+    return false;
+  }
+
+  public float getLetterSpacing() {
+    return 0;
+  }
+
+  public void setLetterSpacing(float letterSpacing) {}
+
+  public String getFontFeatureSettings() {
+    return null;
+  }
+
+  public String getFontVariationSettings() {
+    return null;
+  }
+
+  public void setBreakStrategy(int breakStrategy) {}
+
+  public int getBreakStrategy() {
+    return 0;
+  }
+
+  public void setHyphenationFrequency(int hyphenationFrequency) {}
+
+  public int getHyphenationFrequency() {
+    return 0;
+  }
+
+  public void setJustificationMode(int justificationMode) {}
+
+  public int getJustificationMode() {
+    return 0;
+  }
+
+  public void setFontFeatureSettings(String fontFeatureSettings) {}
+
+  public boolean setFontVariationSettings(String fontVariationSettings) {
+    return false;
+  }
+
+  public void setTextColor(int color) {}
+
+  public void setTextColor(ColorStateList colors) {}
+
+  public final ColorStateList getTextColors() {
+    return null;
+  }
+
+  public final int getCurrentTextColor() {
+    return 0;
+  }
+
+  public void setHighlightColor(int color) {}
+
+  public int getHighlightColor() {
+    return 0;
+  }
+
+  public final void setShowSoftInputOnFocus(boolean show) {}
+
+  public final boolean getShowSoftInputOnFocus() {
+    return false;
+  }
+
+  public void setShadowLayer(float radius, float dx, float dy, int color) {}
+
+  public float getShadowRadius() {
+    return 0;
+  }
+
+  public float getShadowDx() {
+    return 0;
+  }
+
+  public float getShadowDy() {
+    return 0;
+  }
+
+  public int getShadowColor() {
+    return 0;
+  }
+
+  public final void setAutoLinkMask(int mask) {}
+
+  public final void setLinksClickable(boolean whether) {}
+
+  public final boolean getLinksClickable() {
+    return false;
+  }
+
+  public final void setHintTextColor(int color) {}
+
+  public final void setHintTextColor(ColorStateList colors) {}
+
+  public final ColorStateList getHintTextColors() {
+    return null;
+  }
+
+  public final int getCurrentHintTextColor() {
+    return 0;
+  }
+
+  public final void setLinkTextColor(int color) {}
+
+  public final void setLinkTextColor(ColorStateList colors) {}
+
+  public final ColorStateList getLinkTextColors() {
+    return null;
+  }
+
+  public void setGravity(int gravity) {}
+
+  public int getGravity() {
+    return 0;
+  }
+
+  public int getPaintFlags() {
+    return 0;
+  }
+
+  public void setPaintFlags(int flags) {}
+
+  public void setHorizontallyScrolling(boolean whether) {}
+
+  public final boolean isHorizontallyScrollable() {
+    return false;
+  }
+
+  public boolean getHorizontallyScrolling() {
+    return false;
+  }
+
+  public void setMinLines(int minLines) {}
+
+  public int getMinLines() {
+    return 0;
+  }
+
+  public void setMinHeight(int minPixels) {}
+
+  public int getMinHeight() {
+    return 0;
+  }
+
+  public void setMaxLines(int maxLines) {}
+
+  public int getMaxLines() {
+    return 0;
+  }
+
+  public void setMaxHeight(int maxPixels) {}
+
+  public int getMaxHeight() {
+    return 0;
+  }
+
+  public void setLines(int lines) {}
+
+  public void setHeight(int pixels) {}
+
+  public void setMinEms(int minEms) {}
+
+  public int getMinEms() {
+    return 0;
+  }
+
+  public void setMinWidth(int minPixels) {}
+
+  public int getMinWidth() {
+    return 0;
+  }
+
+  public void setMaxEms(int maxEms) {}
+
+  public int getMaxEms() {
+    return 0;
+  }
+
+  public void setMaxWidth(int maxPixels) {}
+
+  public int getMaxWidth() {
+    return 0;
+  }
+
+  public void setEms(int ems) {}
+
+  public void setWidth(int pixels) {}
+
+  public void setLineSpacing(float add, float mult) {}
+
+  public float getLineSpacingMultiplier() {
+    return 0;
+  }
+
+  public float getLineSpacingExtra() {
+    return 0;
+  }
+
+  public void setLineHeight(int lineHeight) {}
+
+  public final void append(CharSequence text) {}
+
+  public void append(CharSequence text, int start, int end) {}
+
+
+  public void setFreezesText(boolean freezesText) {}
+
+  public boolean getFreezesText() {
+    return false;
+  }
+
+  public final void setText(CharSequence text) {}
+
+  public final void setTextKeepState(CharSequence text) {}
+
+  public void setText(CharSequence text, BufferType type) {}
+
+  public final void setText(char[] text, int start, int len) {}
+
+  public final void setTextKeepState(CharSequence text, BufferType type) {}
+
+  public final void setText(int resid) {}
+
+  public final void setText(int resid, BufferType type) {}
+
+  public final void setHint(CharSequence hint) {}
+
+  public final void setHint(int resid) {}
+
+  public CharSequence getHint() {
+    return null;
+  }
+
+  public boolean isSingleLine() {
+    return false;
+  }
+
+  public void setInputType(int type) {}
+
+  public boolean isAnyPasswordInputType() {
+    return false;
+  }
+
+  public void setRawInputType(int type) {}
+
+  public int getInputType() {
+    return 0;
+  }
+
+  public void setImeOptions(int imeOptions) {}
+
+  public int getImeOptions() {
+    return 0;
+  }
+
+  public void setImeActionLabel(CharSequence label, int actionId) {}
+
+  public CharSequence getImeActionLabel() {
+    return null;
+  }
+
+  public int getImeActionId() {
+    return 0;
+  }
+
+  public void onEditorAction(int actionCode) {}
+
+  public void setPrivateImeOptions(String type) {}
+
+  public String getPrivateImeOptions() {
+    return null;
+  }
+
+  public Bundle getInputExtras(boolean create) {
+    return null;
+  }
+
+  public void setImeHintLocales(LocaleList hintLocales) {}
+
+  public LocaleList getImeHintLocales() {
+    return null;
+  }
+
+  public CharSequence getError() {
+    return null;
+  }
+
+  public void setError(CharSequence error) {}
+
+  public void setError(CharSequence error, Drawable icon) {}
+
+  public boolean isTextSelectable() {
+    return false;
+  }
+
+  public void setTextIsSelectable(boolean selectable) {}
+
+  public int getHorizontalOffsetForDrawables() {
+    return 0;
+  }
+
+  public int getLineCount() {
+    return 0;
+  }
+
+  public int getLineBounds(int line, Rect bounds) {
+    return 0;
+  }
+
+  public int getBaseline() {
+    return 0;
+  }
+
+  public void resetErrorChangedFlag() {}
+
+  public void hideErrorIfUnchanged() {}
+
+  public boolean onCheckIsTextEditor() {
+    return false;
+  }
+
+  public void beginBatchEdit() {}
+
+  public void endBatchEdit() {}
+
+  public void onBeginBatchEdit() {}
+
+  public void onEndBatchEdit() {}
+
+  public boolean onPrivateIMECommand(String action, Bundle data) {
+    return false;
+  }
+
+  public void nullLayouts() {}
+
+  public boolean useDynamicLayout() {
+    return false;
+  }
+
+  public void setIncludeFontPadding(boolean includepad) {}
+
+  public boolean getIncludeFontPadding() {
+    return false;
+  }
+
+  public boolean bringPointIntoView(int offset) {
+    return false;
+  }
+
+  public boolean moveCursorToVisibleOffset() {
+    return false;
+  }
+
+  public void computeScroll() {}
+
+  public void debug(int depth) {}
+
+  public int getSelectionStart() {
+    return 0;
+  }
+
+  public int getSelectionEnd() {
+    return 0;
+  }
+
+  public boolean hasSelection() {
+    return false;
+  }
+
+  public void setSingleLine() {}
+
+  public void setAllCaps(boolean allCaps) {}
+
+  public boolean isAllCaps() {
+    return false;
+  }
+
+  public void setSingleLine(boolean singleLine) {}
+
+  public void setMarqueeRepeatLimit(int marqueeLimit) {}
+
+  public int getMarqueeRepeatLimit() {
+    return 0;
+  }
+
+  public void setSelectAllOnFocus(boolean selectAllOnFocus) {}
+
+  public void setCursorVisible(boolean visible) {}
+
+  public boolean isCursorVisible() {
+    return false;
+  }
+
+  public void onWindowFocusChanged(boolean hasWindowFocus) {}
+
+  public void clearComposingText() {}
+
+  public void setSelected(boolean selected) {}
+
+  public boolean showContextMenu() {
+    return false;
+  }
+
+  public boolean showContextMenu(float x, float y) {
+    return false;
+  }
+
+  public boolean didTouchFocusSelect() {
+    return false;
+  }
+
+  public void cancelLongPress() {}
+
+  public void findViewsWithText(ArrayList<View> outViews, CharSequence searched, int flags) {}
+
+  public enum BufferType {
+  }
+
+  public static ColorStateList getTextColors(Context context, TypedArray attrs) {
+    return null;
+  }
+
+  public static int getTextColor(Context context, TypedArray attrs, int def) {
+    return 0;
+  }
+
+  public final void setTextOperationUser(UserHandle user) {}
+
+  public Locale getTextServicesLocale() {
+    return null;
+  }
+
+  public boolean isInExtractedMode() {
+    return false;
+  }
+
+  public Locale getSpellCheckerLocale() {
+    return null;
+  }
+
+  public CharSequence getAccessibilityClassName() {
+    return null;
+  }
+
+  public boolean isPositionVisible(final float positionX, final float positionY) {
+    return false;
+  }
+
+  public boolean performAccessibilityActionInternal(int action, Bundle arguments) {
+    return false;
+  }
+
+  public void sendAccessibilityEventInternal(int eventType) {}
+
+  public boolean isInputMethodTarget() {
+    return false;
+  }
+
+  public boolean onTextContextMenuItem(int id) {
+    return false;
+  }
+
+  public boolean performLongClick() {
+    return false;
+  }
+
+  public boolean isSuggestionsEnabled() {
+    return false;
+  }
+
+  public void hideFloatingToolbar(int durationMs) {}
+
+  public int getOffsetForPosition(float x, float y) {
+    return 0;
+  }
+
+  public void onRtlPropertiesChanged(int layoutDirection) {}
+
+  public void onResolveDrawables(int layoutDirection) {}
+
+  public CharSequence getIterableTextForAccessibility() {
+    return null;
+  }
+
+  public int getAccessibilitySelectionStart() {
+    return 0;
+  }
+
+  public boolean isAccessibilitySelectionExtendable() {
+    return false;
+  }
+
+  public int getAccessibilitySelectionEnd() {
+    return 0;
+  }
+
+  public void setAccessibilitySelection(int start, int end) {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/activity/ComponentActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/activity/ComponentActivity.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package androidx.activity;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.os.Bundle;
+import android.view.View;
+
+
+public class ComponentActivity extends androidx.core.app.ComponentActivity {
+  public ComponentActivity() {}
+
+  public ComponentActivity(int contentLayoutId) {}
+
+  public final Object onRetainNonConfigurationInstance() {
+    return null;
+  }
+
+  public Object onRetainCustomNonConfigurationInstance() {
+    return null;
+  }
+
+  public Object getLastCustomNonConfigurationInstance() {
+    return null;
+  }
+
+  @Override
+  public void setContentView(int layoutResID) {}
+
+  @Override
+  public void setContentView(View view) {}
+
+  public Context peekAvailableContext() {
+    return null;
+  }
+
+  public void onBackPressed() {}
+
+  @Override
+  public void startActivityForResult(Intent intent, int requestCode) {}
+
+  public void startActivityForResult(Intent intent, int requestCode, Bundle options) {}
+
+  public void startIntentSenderForResult(IntentSender intent, int requestCode, Intent fillInIntent,
+      int flagsMask, int flagsValues, int extraFlags) throws IntentSender.SendIntentException {}
+
+  public void startIntentSenderForResult(IntentSender intent, int requestCode, Intent fillInIntent,
+      int flagsMask, int flagsValues, int extraFlags, Bundle options)
+      throws IntentSender.SendIntentException {}
+
+  public void onRequestPermissionsResult(int requestCode, String[] permissions,
+      int[] grantResults) {}
+
+
+  public void reportFullyDrawn() {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/ComponentActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/core/app/ComponentActivity.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package androidx.core.app;
+
+import android.app.Activity;
+
+public class ComponentActivity extends Activity {
+
+  public void putExtraData(ExtraData extraData) {}
+
+  public <T extends ExtraData> T getExtraData(Class<T> extraDataClass) {
+    return null;
+  }
+
+  public static class ExtraData {
+  }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentActivity.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentActivity.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package androidx.fragment.app;
+
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+import android.app.Fragment;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.util.AttributeSet;
+import android.view.View;
+import androidx.activity.ComponentActivity;
+
+public class FragmentActivity extends ComponentActivity {
+        public FragmentActivity() {}
+
+        public FragmentActivity(int contentLayoutId) {}
+
+        public void supportFinishAfterTransition() {}
+
+        public void supportPostponeEnterTransition() {}
+
+        public void supportStartPostponedEnterTransition() {}
+
+        public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {}
+
+        public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {}
+
+        public void onConfigurationChanged(Configuration newConfig) {}
+
+        public View onCreateView(View parent, String name, Context context, AttributeSet attrs) {
+                return null;
+        }
+
+        public View onCreateView(String name, Context context, AttributeSet attrs) {
+                return null;
+        }
+
+        public void onLowMemory() {}
+
+        public void onStateNotSaved() {}
+
+        public void supportInvalidateOptionsMenu() {}
+
+        public void dump(String prefix, FileDescriptor fd, PrintWriter writer, String[] args) {}
+
+        public void onAttachFragment(Fragment fragment) {}
+
+        public FragmentManager getSupportFragmentManager() {
+                return null;
+        }
+
+        public final void validateRequestPermissionsRequestCode(int requestCode) {}
+
+        @Override
+        public void onRequestPermissionsResult(int requestCode, String[] permissions,
+                        int[] grantResults) {}
+
+        public void startActivityFromFragment(Fragment fragment, Intent intent, int requestCode) {}
+
+        public void startActivityFromFragment(Fragment fragment, Intent intent, int requestCode,
+                        Bundle options) {}
+
+        public void startIntentSenderFromFragment(Fragment fragment, IntentSender intent,
+                        int requestCode, Intent fillInIntent, int flagsMask, int flagsValues,
+                        int extraFlags, Bundle options) throws IntentSender.SendIntentException {}
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentManager.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentManager.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package androidx.fragment.app;
+
+import java.util.List;
+import android.app.Fragment;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+
+public abstract class FragmentManager {
+  public static void enableDebugLogging(boolean enabled) {}
+
+  public static boolean isLoggingEnabled(int level) {
+    return false;
+  }
+
+  public interface BackStackEntry {
+    int getId();
+
+    String getName();
+
+    int getBreadCrumbTitleRes();
+
+    int getBreadCrumbShortTitleRes();
+
+    CharSequence getBreadCrumbTitle();
+
+    CharSequence getBreadCrumbShortTitle();
+
+  }
+  public interface OnBackStackChangedListener {
+    void onBackStackChanged();
+
+  }
+  public abstract static class FragmentLifecycleCallbacks {
+    public void onFragmentPreAttached(FragmentManager fm, Fragment f, Context context) {}
+
+    public void onFragmentAttached(FragmentManager fm, Fragment f, Context context) {}
+
+    public void onFragmentPreCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {}
+
+    public void onFragmentCreated(FragmentManager fm, Fragment f, Bundle savedInstanceState) {}
+
+    public void onFragmentActivityCreated(FragmentManager fm, Fragment f,
+        Bundle savedInstanceState) {}
+
+    public void onFragmentViewCreated(FragmentManager fm, Fragment f, View v,
+        Bundle savedInstanceState) {}
+
+    public void onFragmentStarted(FragmentManager fm, Fragment f) {}
+
+    public void onFragmentResumed(FragmentManager fm, Fragment f) {}
+
+    public void onFragmentPaused(FragmentManager fm, Fragment f) {}
+
+    public void onFragmentStopped(FragmentManager fm, Fragment f) {}
+
+    public void onFragmentSaveInstanceState(FragmentManager fm, Fragment f, Bundle outState) {}
+
+    public void onFragmentViewDestroyed(FragmentManager fm, Fragment f) {}
+
+    public void onFragmentDestroyed(FragmentManager fm, Fragment f) {}
+
+    public void onFragmentDetached(FragmentManager fm, Fragment f) {}
+
+  }
+
+  public FragmentTransaction openTransaction() {
+    return null;
+  }
+
+  public FragmentTransaction beginTransaction() {
+    return null;
+  }
+
+  public boolean executePendingTransactions() {
+    return false;
+  }
+
+  public void restoreBackStack(String name) {}
+
+  public void saveBackStack(String name) {}
+
+  public void popBackStack() {}
+
+  public boolean popBackStackImmediate() {
+    return false;
+  }
+
+  public void popBackStack(final String name, final int flags) {}
+
+  public boolean popBackStackImmediate(String name, int flags) {
+    return false;
+  }
+
+  public void popBackStack(final int id, final int flags) {}
+
+  public boolean popBackStackImmediate(int id, int flags) {
+    return false;
+  }
+
+  public int getBackStackEntryCount() {
+    return 0;
+  }
+
+  public BackStackEntry getBackStackEntryAt(int index) {
+    return null;
+  }
+
+  public void addOnBackStackChangedListener(OnBackStackChangedListener listener) {}
+
+  public void removeOnBackStackChangedListener(OnBackStackChangedListener listener) {}
+
+  public final void setFragmentResult(String requestKey, Bundle result) {}
+
+  public final void clearFragmentResult(String requestKey) {}
+
+  public final void clearFragmentResultListener(String requestKey) {}
+
+  public void putFragment(Bundle bundle, String key, Fragment fragment) {}
+
+  public Fragment getFragment(Bundle bundle, String key) {
+    return null;
+  }
+
+  public static <F extends Fragment> F findFragment(View view) {
+    return null;
+  }
+
+  public List<Fragment> getFragments() {
+    return null;
+  }
+
+  public Fragment.SavedState saveFragmentInstanceState(Fragment fragment) {
+    return null;
+  }
+
+  public boolean isDestroyed() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return null;
+  }
+
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentTransaction.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/fragment/app/FragmentTransaction.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package androidx.fragment.app;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.view.View;
+
+public abstract class FragmentTransaction {
+  public FragmentTransaction() {}
+
+  public final FragmentTransaction add(Class<? extends Fragment> fragmentClass, Bundle args,
+      String tag) {
+    return null;
+  }
+
+  public FragmentTransaction add(Fragment fragment, String tag) {
+    return null;
+  }
+
+  public final FragmentTransaction add(int containerViewId, Class<? extends Fragment> fragmentClass,
+      Bundle args) {
+    return null;
+  }
+
+  public FragmentTransaction add(int containerViewId, Fragment fragment) {
+    return null;
+  }
+
+  public final FragmentTransaction add(int containerViewId, Class<? extends Fragment> fragmentClass,
+      Bundle args, String tag) {
+    return null;
+  }
+
+  public FragmentTransaction add(int containerViewId, Fragment fragment, String tag) {
+    return null;
+  }
+
+  public final FragmentTransaction replace(int containerViewId,
+      Class<? extends Fragment> fragmentClass, Bundle args) {
+    return null;
+  }
+
+  public FragmentTransaction replace(int containerViewId, Fragment fragment) {
+    return null;
+  }
+
+  public final FragmentTransaction replace(int containerViewId,
+      Class<? extends Fragment> fragmentClass, Bundle args, String tag) {
+    return null;
+  }
+
+  public FragmentTransaction replace(int containerViewId, Fragment fragment, String tag) {
+    return null;
+  }
+
+  public FragmentTransaction remove(Fragment fragment) {
+    return null;
+  }
+
+  public FragmentTransaction hide(Fragment fragment) {
+    return null;
+  }
+
+  public FragmentTransaction show(Fragment fragment) {
+    return null;
+  }
+
+  public FragmentTransaction detach(Fragment fragment) {
+    return null;
+  }
+
+  public FragmentTransaction attach(Fragment fragment) {
+    return null;
+  }
+
+  public FragmentTransaction setPrimaryNavigationFragment(Fragment fragment) {
+    return null;
+  }
+
+  public boolean isEmpty() {
+    return false;
+  }
+
+  public FragmentTransaction setCustomAnimations(int enter, int exit) {
+    return null;
+  }
+
+  public FragmentTransaction setCustomAnimations(int enter, int exit, int popEnter, int popExit) {
+    return null;
+  }
+
+  public FragmentTransaction addSharedElement(View sharedElement, String name) {
+    return null;
+  }
+
+  public FragmentTransaction setTransition(int transition) {
+    return null;
+  }
+
+  public FragmentTransaction setTransitionStyle(int styleRes) {
+    return null;
+  }
+
+  public FragmentTransaction addToBackStack(String name) {
+    return null;
+  }
+
+  public boolean isAddToBackStackAllowed() {
+    return false;
+  }
+
+  public FragmentTransaction disallowAddToBackStack() {
+    return null;
+  }
+
+  public FragmentTransaction setBreadCrumbTitle(int res) {
+    return null;
+  }
+
+  public FragmentTransaction setBreadCrumbTitle(CharSequence text) {
+    return null;
+  }
+
+  public FragmentTransaction setBreadCrumbShortTitle(int res) {
+    return null;
+  }
+
+  public FragmentTransaction setBreadCrumbShortTitle(CharSequence text) {
+    return null;
+  }
+
+  public FragmentTransaction setReorderingAllowed(boolean reorderingAllowed) {
+    return null;
+  }
+
+  public FragmentTransaction setAllowOptimization(boolean allowOptimization) {
+    return null;
+  }
+
+  public FragmentTransaction runOnCommit(Runnable runnable) {
+    return null;
+  }
+
+  public abstract int commit();
+
+  public abstract int commitAllowingStateLoss();
+
+  public abstract void commitNow();
+
+  public abstract void commitNowAllowingStateLoss();
+
+}


### PR DESCRIPTION
This PR adds two new queries:

* **Fragment injection**, which looks for Fragments being instantiated from user-provided input (either using reflection or `Fragment.instantiate`) that are then added to an Activity.
* **Fragment injection in PreferenceActivity**, which looks for exported Activities extending `PreferenceActivity` and insecurely implementing `isValidFragment` (i.e. always returning `true` independently of the value of `fragmentName`).

## Description

Fragment injection is an instance of unsafe reflection that allows malicious applications to inject arbitrary Fragments in an exported Activity of the victim application. This can lead to access control bypass and exposes the application to unintended effects.

## Evaluation

When run on a set of 1k Android open source projects:

* **Fragment injection** finds 1 TP result.
* **Fragment injection in PreferenceActivity** finds 1 TP result.

## References

* [How to fix Fragment Injection vulnerability](https://support.google.com/faqs/answer/7188427?hl=en)
* [Android collapses into Fragments](https://securityintelligence.com/wp-content/uploads/2013/12/android-collapses-into-fragments.pdf)
* [Android Developers: Fragments](https://developer.android.com/guide/fragments)