### PR TITLE
JS: Skip files with unsupported file encoding

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/FileExtractor.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.LinkedHashSet;
@@ -17,6 +17,7 @@ import com.semmle.js.extractor.trapcache.CachingTrapWriter;
 import com.semmle.js.extractor.trapcache.ITrapCache;
 import com.semmle.util.data.StringUtil;
 import com.semmle.util.exception.Exceptions;
+import com.semmle.util.exception.ResourceError;
 import com.semmle.util.extraction.ExtractorOutputConfig;
 import com.semmle.util.files.FileUtil;
 import com.semmle.util.io.WholeIO;
@@ -438,7 +439,16 @@ public class FileExtractor {
     }
 
     // populate source archive
-    String source = new WholeIO(config.getDefaultEncoding()).strictread(f);
+    WholeIO wholeIO = new WholeIO(config.getDefaultEncoding(), true);
+    String source = wholeIO.read(f);
+    if (source == null) {
+      if (wholeIO.getLastException() instanceof CharacterCodingException) {
+        System.err.println("Skipped due to unsupported character encoding: " + f);
+        return 0;
+      } else {
+        throw new ResourceError("Failed to read file " + f, wholeIO.getLastException());
+      }
+    }
     outputConfig.getSourceArchive().add(f, source);
 
     // extract language-independent bits


### PR DESCRIPTION
If the contents of a file cannot be decoded using the expected charset (usually UTF-8) one or more [replacement characters](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) would get inserted, as per the default string-decoding behavior of the Java libraries. We'd then proceed to extract the file with replacement characters and all.

This PR changes it so files with any decoding errors are skipped entirely, but does not fail extraction.

An internal PR must be merged first.