### PR TITLE
Use the new instanceof syntax everywhere

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
+++ b/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
@@ -324,10 +324,8 @@ abstract class DataOutput extends Element {
 /**
  * Data that is output via standard output or standard error.
  */
-class StandardOutput extends DataOutput {
-  StandardOutput() { this instanceof OutputWrite }
-
-  override Expr getASource() { result = this.(OutputWrite).getASource() }
+class StandardOutput extends DataOutput instanceof OutputWrite {
+  override Expr getASource() { result = OutputWrite.super.getASource() }
 }
 
 private predicate socketCallOrIndirect(FunctionCall call) {

--- a/javascript/ql/lib/semmle/javascript/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/DOM.qll
@@ -63,29 +63,25 @@ module DOM {
   /**
    * An HTML element, viewed as an `ElementDefinition`.
    */
-  private class HtmlElementDefinition extends ElementDefinition, @xmlelement {
-    HtmlElementDefinition() { this instanceof HTML::Element }
-
-    override string getName() { result = this.(HTML::Element).getName() }
+  private class HtmlElementDefinition extends ElementDefinition, @xmlelement instanceof HTML::Element {
+    override string getName() { result = HTML::Element.super.getName() }
 
     override AttributeDefinition getAttribute(int i) {
-      result = this.(HTML::Element).getAttribute(i)
+      result = HTML::Element.super.getAttribute(i)
     }
 
-    override ElementDefinition getParent() { result = this.(HTML::Element).getParent() }
+    override ElementDefinition getParent() { result = HTML::Element.super.getParent() }
   }
 
   /**
    * A JSX element, viewed as an `ElementDefinition`.
    */
-  private class JsxElementDefinition extends ElementDefinition, @jsx_element {
-    JsxElementDefinition() { this instanceof JSXElement }
+  private class JsxElementDefinition extends ElementDefinition, @jsx_element instanceof JSXElement {
+    override string getName() { result = JSXElement.super.getName() }
 
-    override string getName() { result = this.(JSXElement).getName() }
+    override AttributeDefinition getAttribute(int i) { result = JSXElement.super.getAttribute(i) }
 
-    override AttributeDefinition getAttribute(int i) { result = this.(JSXElement).getAttribute(i) }
-
-    override ElementDefinition getParent() { result = this.(JSXElement).getJsxParent() }
+    override ElementDefinition getParent() { result = super.getJsxParent() }
   }
 
   /**
@@ -131,14 +127,12 @@ module DOM {
   /**
    * An HTML attribute, viewed as an `AttributeDefinition`.
    */
-  private class HtmlAttributeDefinition extends AttributeDefinition, @xmlattribute {
-    HtmlAttributeDefinition() { this instanceof HTML::Attribute }
+  private class HtmlAttributeDefinition extends AttributeDefinition, @xmlattribute instanceof HTML::Attribute {
+    override string getName() { result = HTML::Attribute.super.getName() }
 
-    override string getName() { result = this.(HTML::Attribute).getName() }
+    override string getStringValue() { result = super.getValue() }
 
-    override string getStringValue() { result = this.(HTML::Attribute).getValue() }
-
-    override ElementDefinition getElement() { result = this.(HTML::Attribute).getElement() }
+    override ElementDefinition getElement() { result = HTML::Attribute.super.getElement() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -61,17 +61,15 @@ class ParameterNode extends DataFlow::SourceNode {
  * new Array(16)
  * ```
  */
-class InvokeNode extends DataFlow::SourceNode {
-  InvokeNode() { this instanceof DataFlow::Impl::InvokeNodeDef }
-
+class InvokeNode extends DataFlow::SourceNode instanceof DataFlow::Impl::InvokeNodeDef {
   /** Gets the syntactic invoke expression underlying this function invocation. */
-  InvokeExpr getInvokeExpr() { result = this.(DataFlow::Impl::InvokeNodeDef).getInvokeExpr() }
+  InvokeExpr getInvokeExpr() { result = super.getInvokeExpr() }
 
   /** Gets the name of the function or method being invoked, if it can be determined. */
-  string getCalleeName() { result = this.(DataFlow::Impl::InvokeNodeDef).getCalleeName() }
+  string getCalleeName() { result = super.getCalleeName() }
 
   /** Gets the data flow node specifying the function to be called. */
-  DataFlow::Node getCalleeNode() { result = this.(DataFlow::Impl::InvokeNodeDef).getCalleeNode() }
+  DataFlow::Node getCalleeNode() { result = super.getCalleeNode() }
 
   /**
    * Gets the data flow node corresponding to the `i`th argument of this invocation.
@@ -92,10 +90,10 @@ class InvokeNode extends DataFlow::SourceNode {
    * but the position of `z` cannot be determined, hence there are no first and second
    * argument nodes.
    */
-  DataFlow::Node getArgument(int i) { result = this.(DataFlow::Impl::InvokeNodeDef).getArgument(i) }
+  DataFlow::Node getArgument(int i) { result = super.getArgument(i) }
 
   /** Gets the data flow node corresponding to an argument of this invocation. */
-  DataFlow::Node getAnArgument() { result = this.(DataFlow::Impl::InvokeNodeDef).getAnArgument() }
+  DataFlow::Node getAnArgument() { result = super.getAnArgument() }
 
   /** Gets the data flow node corresponding to the last argument of this invocation. */
   DataFlow::Node getLastArgument() { result = getArgument(getNumArgument() - 1) }
@@ -112,12 +110,10 @@ class InvokeNode extends DataFlow::SourceNode {
    * ```
    *  .
    */
-  DataFlow::Node getASpreadArgument() {
-    result = this.(DataFlow::Impl::InvokeNodeDef).getASpreadArgument()
-  }
+  DataFlow::Node getASpreadArgument() { result = super.getASpreadArgument() }
 
   /** Gets the number of arguments of this invocation, if it can be determined. */
-  int getNumArgument() { result = this.(DataFlow::Impl::InvokeNodeDef).getNumArgument() }
+  int getNumArgument() { result = super.getNumArgument() }
 
   Function getEnclosingFunction() { result = getBasicBlock().getContainer() }
 
@@ -258,15 +254,13 @@ class InvokeNode extends DataFlow::SourceNode {
  * Math.abs(x)
  * ```
  */
-class CallNode extends InvokeNode {
-  CallNode() { this instanceof DataFlow::Impl::CallNodeDef }
-
+class CallNode extends InvokeNode instanceof DataFlow::Impl::CallNodeDef {
   /**
    * Gets the data flow node corresponding to the receiver expression of this method call.
    *
    * For example, the receiver of `x.m()` is `x`.
    */
-  DataFlow::Node getReceiver() { result = this.(DataFlow::Impl::CallNodeDef).getReceiver() }
+  DataFlow::Node getReceiver() { result = super.getReceiver() }
 }
 
 /**
@@ -279,11 +273,9 @@ class CallNode extends InvokeNode {
  * Math.abs(x)
  * ```
  */
-class MethodCallNode extends CallNode {
-  MethodCallNode() { this instanceof DataFlow::Impl::MethodCallNodeDef }
-
+class MethodCallNode extends CallNode instanceof DataFlow::Impl::MethodCallNodeDef {
   /** Gets the name of the invoked method, if it can be determined. */
-  string getMethodName() { result = this.(DataFlow::Impl::MethodCallNodeDef).getMethodName() }
+  string getMethodName() { result = super.getMethodName() }
 
   /**
    * Holds if this data flow node calls method `methodName` on receiver node `receiver`.

--- a/javascript/ql/lib/semmle/javascript/dataflow/Refinements.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Refinements.qll
@@ -53,21 +53,18 @@ abstract class RefinementCandidate extends Expr {
  * A refinement candidate that references at most one variable, and hence
  * can be used to refine the abstract values inferred for that variable.
  */
-class Refinement extends Expr {
-  Refinement() {
-    this instanceof RefinementCandidate and
-    count(this.(RefinementCandidate).getARefinedVar()) <= 1
-  }
+class Refinement extends Expr instanceof RefinementCandidate {
+  Refinement() { count(this.(RefinementCandidate).getARefinedVar()) <= 1 }
 
   /**
    * Gets the variable refined by this expression, if any.
    */
-  SsaSourceVariable getRefinedVar() { result = this.(RefinementCandidate).getARefinedVar() }
+  SsaSourceVariable getRefinedVar() { result = super.getARefinedVar() }
 
   /**
    * Gets a refinement value inferred for this expression in context `ctxt`.
    */
-  RefinementValue eval(RefinementContext ctxt) { result = this.(RefinementCandidate).eval(ctxt) }
+  RefinementValue eval(RefinementContext ctxt) { result = super.eval(ctxt) }
 }
 
 /** A literal, viewed as a refinement expression. */

--- a/javascript/ql/lib/semmle/javascript/security/performance/PolynomialReDoSCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/performance/PolynomialReDoSCustomizations.qll
@@ -47,10 +47,8 @@ module PolynomialReDoS {
    * A remote input to a server, seen as a source for polynomial
    * regular expression denial-of-service vulnerabilities.
    */
-  class RequestInputAccessAsSource extends Source {
-    RequestInputAccessAsSource() { this instanceof HTTP::RequestInputAccess }
-
-    override string getKind() { result = this.(HTTP::RequestInputAccess).getKind() }
+  class RequestInputAccessAsSource extends Source instanceof HTTP::RequestInputAccess {
+    override string getKind() { result = HTTP::RequestInputAccess.super.getKind() }
   }
 
   /**

--- a/javascript/ql/src/experimental/Security/CWE-090/LdapInjectionCustomizations.qll
+++ b/javascript/ql/src/experimental/Security/CWE-090/LdapInjectionCustomizations.qll
@@ -39,21 +39,17 @@ module LdapInjection {
   /**
    * An LDAP filter for an API call that executes an operation against the LDAP server.
    */
-  class LdapjsSearchFilterAsSink extends Sink {
-    LdapjsSearchFilterAsSink() { this instanceof LdapjsSearchFilter }
-
+  class LdapjsSearchFilterAsSink extends Sink instanceof LdapjsSearchFilter {
     override DataFlow::InvokeNode getQueryCall() {
-      result = this.(LdapjsSearchFilter).getQueryCall()
+      result = LdapjsSearchFilter.super.getQueryCall()
     }
   }
 
   /**
    * An LDAP DN argument for an API call that executes an operation against the LDAP server.
    */
-  class LdapjsDNArgumentAsSink extends Sink {
-    LdapjsDNArgumentAsSink() { this instanceof LdapjsDNArgument }
-
-    override DataFlow::InvokeNode getQueryCall() { result = this.(LdapjsDNArgument).getQueryCall() }
+  class LdapjsDNArgumentAsSink extends Sink instanceof LdapjsDNArgument {
+    override DataFlow::InvokeNode getQueryCall() { result = LdapjsDNArgument.super.getQueryCall() }
   }
 
   /**

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -1345,10 +1345,8 @@ module IterableUnpacking {
   }
 
   /** A (possibly recursive) target of an unpacking assignment which is also a sequence. */
-  class UnpackingAssignmentSequenceTarget extends UnpackingAssignmentTarget {
-    UnpackingAssignmentSequenceTarget() { this instanceof SequenceNode }
-
-    ControlFlowNode getElement(int i) { result = this.(SequenceNode).getElement(i) }
+  class UnpackingAssignmentSequenceTarget extends UnpackingAssignmentTarget instanceof SequenceNode {
+    ControlFlowNode getElement(int i) { result = super.getElement(i) }
 
     ControlFlowNode getAnElement() { result = this.getElement(_) }
   }

--- a/python/ql/lib/semmle/python/dataflow/old/TaintTracking.qll
+++ b/python/ql/lib/semmle/python/dataflow/old/TaintTracking.qll
@@ -639,16 +639,14 @@ module DataFlow {
     }
   }
 
-  deprecated private class ConfigurationAdapter extends TaintTracking::Configuration {
-    ConfigurationAdapter() { this instanceof Configuration }
-
+  deprecated private class ConfigurationAdapter extends TaintTracking::Configuration instanceof Configuration {
     override predicate isSource(DataFlow::Node node, TaintKind kind) {
-      this.(Configuration).isSource(node.asCfgNode()) and
+      Configuration.super.isSource(node.asCfgNode()) and
       kind instanceof DataFlowType
     }
 
     override predicate isSink(DataFlow::Node node, TaintKind kind) {
-      this.(Configuration).isSink(node.asCfgNode()) and
+      Configuration.super.isSink(node.asCfgNode()) and
       kind instanceof DataFlowType
     }
   }

--- a/python/ql/lib/semmle/python/dependencies/TechInventory.qll
+++ b/python/ql/lib/semmle/python/dependencies/TechInventory.qll
@@ -14,16 +14,14 @@ string munge(File sourceFile, ExternalPackage package) {
   result = "/" + sourceFile.getRelativePath() + "<|>" + package.getName() + "<|>unknown"
 }
 
-abstract class ExternalPackage extends Object {
-  ExternalPackage() { this instanceof ModuleObject }
-
+abstract class ExternalPackage extends Object instanceof ModuleObject {
   abstract string getName();
 
   abstract string getVersion();
 
-  Object getAttribute(string name) { result = this.(ModuleObject).attr(name) }
+  Object getAttribute(string name) { result = super.attr(name) }
 
-  PackageObject getPackage() { result = this.(ModuleObject).getPackage() }
+  PackageObject getPackage() { result = super.getPackage() }
 }
 
 bindingset[text]

--- a/python/ql/lib/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/lib/semmle/python/objects/ObjectAPI.qll
@@ -343,21 +343,25 @@ module Value {
  * Callables include Python functions, built-in functions and bound-methods,
  * but not classes.
  */
-class CallableValue extends Value instanceof CallableObjectInternal {
+class CallableValue extends Value {
+  CallableValue() { this instanceof CallableObjectInternal }
+
   /**
    * Holds if this callable never returns once called.
    * For example, `sys.exit`
    */
-  predicate neverReturns() { super.neverReturns() }
+  predicate neverReturns() { this.(CallableObjectInternal).neverReturns() }
 
   /** Gets the scope for this function, provided that it is a Python function. */
   FunctionScope getScope() { result = this.(PythonFunctionObjectInternal).getScope() }
 
   /** Gets the `n`th parameter node of this callable. */
-  NameNode getParameter(int n) { result = super.getParameter(n) }
+  NameNode getParameter(int n) { result = this.(CallableObjectInternal).getParameter(n) }
 
   /** Gets the `name`d parameter node of this callable. */
-  NameNode getParameterByName(string name) { result = super.getParameterByName(name) }
+  NameNode getParameterByName(string name) {
+    result = this.(CallableObjectInternal).getParameterByName(name)
+  }
 
   /**
    * Gets the argument in `call` corresponding to the `n`'th positional parameter of this callable.

--- a/python/ql/lib/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/lib/semmle/python/objects/ObjectAPI.qll
@@ -147,9 +147,7 @@ class Value extends TObject {
  * Class representing modules in the Python program
  * Each `ModuleValue` represents a module object in the Python program.
  */
-class ModuleValue extends Value {
-  ModuleValue() { this instanceof ModuleObjectInternal }
-
+class ModuleValue extends Value instanceof ModuleObjectInternal {
   /**
    * Holds if this module "exports" name.
    * That is, does it define `name` in `__all__` or is
@@ -159,7 +157,7 @@ class ModuleValue extends Value {
   predicate exports(string name) { PointsTo::moduleExports(this, name) }
 
   /** Gets the scope for this module, provided that it is a Python module. */
-  ModuleScope getScope() { result = this.(ModuleObjectInternal).getSourceModule() }
+  ModuleScope getScope() { result = super.getSourceModule() }
 
   /**
    * Gets the container path for this module. Will be the file for a Python module,
@@ -181,7 +179,7 @@ class ModuleValue extends Value {
   predicate isPackage() { this instanceof PackageObjectInternal }
 
   /** Whether the complete set of names "exported" by this module can be accurately determined */
-  predicate hasCompleteExportInfo() { this.(ModuleObjectInternal).hasCompleteExportInfo() }
+  predicate hasCompleteExportInfo() { super.hasCompleteExportInfo() }
 
   /** Get a module that this module imports */
   ModuleValue getAnImportedModule() { result.importedAs(this.getScope().getAnImportedModuleName()) }
@@ -345,25 +343,21 @@ module Value {
  * Callables include Python functions, built-in functions and bound-methods,
  * but not classes.
  */
-class CallableValue extends Value {
-  CallableValue() { this instanceof CallableObjectInternal }
-
+class CallableValue extends Value instanceof CallableObjectInternal {
   /**
    * Holds if this callable never returns once called.
    * For example, `sys.exit`
    */
-  predicate neverReturns() { this.(CallableObjectInternal).neverReturns() }
+  predicate neverReturns() { super.neverReturns() }
 
   /** Gets the scope for this function, provided that it is a Python function. */
   FunctionScope getScope() { result = this.(PythonFunctionObjectInternal).getScope() }
 
   /** Gets the `n`th parameter node of this callable. */
-  NameNode getParameter(int n) { result = this.(CallableObjectInternal).getParameter(n) }
+  NameNode getParameter(int n) { result = super.getParameter(n) }
 
   /** Gets the `name`d parameter node of this callable. */
-  NameNode getParameterByName(string name) {
-    result = this.(CallableObjectInternal).getParameterByName(name)
-  }
+  NameNode getParameterByName(string name) { result = super.getParameterByName(name) }
 
   /**
    * Gets the argument in `call` corresponding to the `n`'th positional parameter of this callable.
@@ -452,23 +446,21 @@ class CallableValue extends Value {
  * Class representing bound-methods, such as `o.func`, where `o` is an instance
  * of a class that has a callable attribute `func`.
  */
-class BoundMethodValue extends CallableValue {
-  BoundMethodValue() { this instanceof BoundMethodObjectInternal }
-
+class BoundMethodValue extends CallableValue instanceof BoundMethodObjectInternal {
   /**
    * Gets the callable that will be used when `this` is called.
    * The actual callable for `func` in `o.func`.
    */
-  CallableValue getFunction() { result = this.(BoundMethodObjectInternal).getFunction() }
+  CallableValue getFunction() { result = super.getFunction() }
 
   /**
    * Gets the value that will be used for the `self` parameter when `this` is called.
    * The value for `o` in `o.func`.
    */
-  Value getSelf() { result = this.(BoundMethodObjectInternal).getSelf() }
+  Value getSelf() { result = super.getSelf() }
 
   /** Gets the parameter node that will be used for `self`. */
-  NameNode getSelfParameter() { result = this.(BoundMethodObjectInternal).getSelfParameter() }
+  NameNode getSelfParameter() { result = super.getSelfParameter() }
 }
 
 /**
@@ -831,12 +823,10 @@ class BuiltinMethodValue extends FunctionValue {
 /**
  * A class representing sequence objects with a length and tracked items.
  */
-class SequenceValue extends Value {
-  SequenceValue() { this instanceof SequenceObjectInternal }
+class SequenceValue extends Value instanceof SequenceObjectInternal {
+  Value getItem(int n) { result = super.getItem(n) }
 
-  Value getItem(int n) { result = this.(SequenceObjectInternal).getItem(n) }
-
-  int length() { result = this.(SequenceObjectInternal).length() }
+  int length() { result = super.length() }
 }
 
 /** A class representing tuple objects */
@@ -887,14 +877,12 @@ class NumericValue extends Value {
  * https://docs.python.org/3/howto/descriptor.html#properties
  * https://docs.python.org/3/library/functions.html#property
  */
-class PropertyValue extends Value {
-  PropertyValue() { this instanceof PropertyInternal }
+class PropertyValue extends Value instanceof PropertyInternal {
+  CallableValue getGetter() { result = super.getGetter() }
 
-  CallableValue getGetter() { result = this.(PropertyInternal).getGetter() }
+  CallableValue getSetter() { result = super.getSetter() }
 
-  CallableValue getSetter() { result = this.(PropertyInternal).getSetter() }
-
-  CallableValue getDeleter() { result = this.(PropertyInternal).getDeleter() }
+  CallableValue getDeleter() { result = super.getDeleter() }
 }
 
 /** A method-resolution-order sequence of classes */

--- a/python/ql/lib/semmle/python/types/Extensions.qll
+++ b/python/ql/lib/semmle/python/types/Extensions.qll
@@ -151,12 +151,10 @@ class ReModulePointToExtension extends PointsToExtension {
   private predicate pointsTo_helper(Context context) { context.appliesTo(this) }
 }
 
-deprecated private class BackwardCompatiblePointToExtension extends PointsToExtension {
-  BackwardCompatiblePointToExtension() { this instanceof CustomPointsToFact }
-
+deprecated private class BackwardCompatiblePointToExtension extends PointsToExtension instanceof CustomPointsToFact {
   override predicate pointsTo(Context context, ObjectInternal value, ControlFlowNode origin) {
     exists(Object obj, ClassObject cls |
-      this.(CustomPointsToFact).pointsTo(context, obj, cls, origin)
+      CustomPointsToFact.super.pointsTo(context, obj, cls, origin)
     |
       value.getBuiltin() = obj
       or


### PR DESCRIPTION
The patch was written automatically by a tool. 

The patch finds nothing in the languages not mentioned here. 

Evaluations look good: [C++](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-6934-e117659__PR__PR/reports), [JavaScript](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-6934-e117659__PR__PR__1/reports), [Python](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-6934-e117659__PR__PR__2/reports). 