### PR TITLE
Java: CWE-347 Query for detecting Signature Exclusion Attack with SAML assertion

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-347/DOM.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/DOM.qll
@@ -8,19 +8,6 @@ class TypeDomNodeList extends Interface {
   TypeDomNodeList() { this.hasQualifiedName("org.w3c.dom", "NodeList") }
 }
 
-/** The class `javax.xml.crypto.dsig.XMLSignature`. */
-private class TypeXMLSignature extends Interface {
-  TypeXMLSignature() { this.hasQualifiedName("javax.xml.crypto.dsig", "XMLSignature") }
-}
-
-/** The method `validate` of `TypeXMLSignature`. */
-class ValidateSignatureMethod extends Method {
-  ValidateSignatureMethod() {
-    this.hasName("validate") and
-    this.getDeclaringType().getASupertype*() instanceof TypeXMLSignature
-  }
-}
-
 /** Model of handling XML DOM. */
 private class DomDataModel extends SummaryModelCsv {
   override predicate row(string row) {
@@ -28,9 +15,7 @@ private class DomDataModel extends SummaryModelCsv {
       [
         "org.w3c.dom;Document;true;getElementsByTagName" + ["", "NS"] +
           ";;;Argument[-1];ReturnValue;taint",
-        "org.w3c.dom;NodeList;true;item;;;Argument[-1];ReturnValue;taint",
-        "javax.xml.crypto.dsig.dom;DOMValidateContext;false;DOMValidateContext;;;Argument[1];Argument[-1];taint",
-        "javax.xml.crypto.dsig;XMLSignatureFactory;true;unmarshalXMLSignature;;;Argument[0];ReturnValue;taint"
+        "org.w3c.dom;NodeList;true;item;;;Argument[-1];ReturnValue;taint"
       ]
   }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-347/DOM.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/DOM.qll
@@ -1,0 +1,36 @@
+/** Provides classes for working with the W3C Document Object Model (DOM). */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+
+/** The interface `org.w3c.dom.NodeList`. */
+class TypeDomNodeList extends Interface {
+  TypeDomNodeList() { this.hasQualifiedName("org.w3c.dom", "NodeList") }
+}
+
+/** The class `javax.xml.crypto.dsig.XMLSignature`. */
+private class TypeXMLSignature extends Interface {
+  TypeXMLSignature() { this.hasQualifiedName("javax.xml.crypto.dsig", "XMLSignature") }
+}
+
+/** The method `validate` of `TypeXMLSignature`. */
+class ValidateSignatureMethod extends Method {
+  ValidateSignatureMethod() {
+    this.hasName("validate") and
+    this.getDeclaringType().getASupertype*() instanceof TypeXMLSignature
+  }
+}
+
+/** Model of handling XML DOM. */
+private class DomDataModel extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "org.w3c.dom;Document;true;getElementsByTagName" + ["", "NS"] +
+          ";;;Argument[-1];ReturnValue;taint",
+        "org.w3c.dom;NodeList;true;item;;;Argument[-1];ReturnValue;taint",
+        "javax.xml.crypto.dsig.dom;DOMValidateContext;false;DOMValidateContext;;;Argument[1];Argument[-1];taint",
+        "javax.xml.crypto.dsig;XMLSignatureFactory;true;unmarshalXMLSignature;;;Argument[0];ReturnValue;taint"
+      ]
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-347/JavaXml.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/JavaXml.qll
@@ -1,0 +1,28 @@
+/** Provides classes for working with the javax.xml package. */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+
+/** The class `javax.xml.crypto.dsig.XMLSignature`. */
+private class TypeXMLSignature extends Interface {
+  TypeXMLSignature() { this.hasQualifiedName("javax.xml.crypto.dsig", "XMLSignature") }
+}
+
+/** The method `validate` of `TypeXMLSignature`. */
+class ValidateSignatureMethod extends Method {
+  ValidateSignatureMethod() {
+    this.hasName("validate") and
+    this.getDeclaringType().getASupertype*() instanceof TypeXMLSignature
+  }
+}
+
+/** Model of handling XML DOM. */
+private class DomDataModel extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "javax.xml.crypto.dsig.dom;DOMValidateContext;false;DOMValidateContext;;;Argument[1];Argument[-1];taint",
+        "javax.xml.crypto.dsig;XMLSignatureFactory;true;unmarshalXMLSignature;;;Argument[0];ReturnValue;taint"
+      ]
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.java
@@ -1,0 +1,46 @@
+public class MissingSAMLSignatureCheck {
+    public void parseResponse(String encodedResponse, PublicKey key) throws Exception {
+        byte[] decodedResponse = Base64.getDecoder().decode(encodedResponse);
+
+        Document document = null;
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            document = builder.parse(new ByteArrayInputStream(decodedResponse));
+        } catch (Exception e) {
+            throw new Exception("Unable to parse SAML v2.0 authentication response", e);
+        }
+
+        NodeList nl = document.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
+        {
+            // BAD: skip signature validation if there is no signature node.
+            if (nl.getLength() == 0) {
+                return;
+            }
+        }
+
+        { 
+            // GOOD: validate all the signature nodes in the XML document
+            for (int i = 0; i < nl.getLength(); i++) {
+                DOMValidateContext validateContext = new DOMValidateContext(key, nl.item(i));
+                XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+                try {
+                    XMLSignature signature = factory.unmarshalXMLSignature(validateContext);
+                    boolean valid = signature.validate(validateContext);
+                    if (!valid) {
+                        throw new Exception("Invalid SAML v2.0 authentication response. The signature is invalid.");
+                    }
+                } catch (MarshalException e) {
+                    throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response because we couldn't unmarshall the XML Signature element", e);
+                } catch (XMLSignatureException e) {
+                    throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response. The signature was unmarshalled we couldn't validate it for an unknown reason", e);
+                }
+            }
+        }
+
+        ResponseType jaxbResponse = unmarshallFromDocument(document, ResponseType.class);
+        // Access SAML assertions
+        List<Object> assertions = jaxbResponse.getAssertionOrEncryptedAssertion();
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.qhelp
@@ -1,0 +1,41 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>SAML (Security Assertion Markup Language) is an XML-based markup language for exchanging 
+    authentication and authorization data between parties, in particular, between an identity 
+    provider and a service provider. It is used for security assertions, which are statements 
+    that service providers use to make access-control decisions. SAML response messages consist 
+    of issuer, assertion (subject, conditions, and statements), signing key, and signature.
+</p>
+<p>If SAML token does not contain any signature, no protection of integrity or authenticity is 
+    provided. Since no digital signature for the token is required, an attacker can generate tokens 
+    containing arbitrary identities of other users.
+</p>
+<p>Java applications use the JAXB (Java Architecture for XML Binding) API for unmarshalling 
+    (reading) XML instance documents into Java content trees, and then marshalling (writing) Java 
+    content trees back into XML instance documents. The Java XML Digital Signature APIs are specified 
+    in JSR-105 and are implemented in the <code>javax.xml.crypto</code> package, which are used to 
+    verify signature of SAML XML documents. 
+</p>
+</overview>
+
+<recommendation>
+<p>Always verify a SAML XML document has signature and is signed by the issuer's private key.
+</p>
+</recommendation>
+
+<example>
+<p>The following example shows two cases of SAML assertion. In the 'BAD' case, there is no signature 
+    node in the SAML XML document. In the 'GOOD' case, there is a valid signature.
+</p>
+<sample src="MissingSAMLSignatureCheck.java" />
+</example>
+
+<references>
+<li>SSO-Attacks.org: <a href="https://sso-attacks.org/Signature_Exclusion_Attack">Signature Exclusion Attack</a>.</li>
+<li>Packet Storm: <a href="https://packetstormsecurity.com/files/159454/FusionAuth-SAMLv2-0.2.3-Message-Forging.html">FusionAuth-SAMLv2 0.2.3 Message Forging</a></li>
+<li>Fusionauth: <a href="https://github.com/FusionAuth/fusionauth-samlv2/commit/886dbb55613e5c2b99a8b83232f846ba7e5cd5ea#diff-8a2df2671a99b7b052fe464b72e7c8ee04f67aa116345044acfbf2222d2a6a3a">Fixed SAMLv2 signature check</a></li>
+</references>
+
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.ql
@@ -9,6 +9,8 @@
  */
 
 import java
+import DOM
+import JavaXml
 import SAML
 import semmle.code.java.controlflow.Guards
 import semmle.code.java.dataflow.TaintTracking
@@ -21,6 +23,18 @@ class SamlAssertionConf extends TaintTracking::Configuration {
   override predicate isSource(DataFlow::Node source) { source instanceof SamlAssertionSource }
 
   override predicate isSink(DataFlow::Node sink) { sink instanceof SamlAssertionSink }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node prev, DataFlow::Node succ) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof GetElementValueMethod and // jaxbElement.getValue()
+      prev.asExpr() = ma.getQualifier() and
+      succ.asExpr() = ma
+      or
+      ma.getMethod() instanceof UnmarshalElementMethod and // unmarshaller.unmarshal(document, type)
+      prev.asExpr() = ma.getArgument(0) and
+      succ.asExpr() = ma
+    )
+  }
 }
 
 /** Configuration of validating signature in XML file. */

--- a/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.ql
@@ -1,0 +1,62 @@
+/**
+ * @name Missing SAMLv2 signature check
+ * @description Failing to verify the SAMLv2 signature allows an attacker to forge SAML assertion and launch Signature Exclusion Attack.
+ * @kind path-problem
+ * @problem.severity error
+ * @id java/missing-samlv2-signature-check
+ * @tags security
+ *       external/cwe/cwe-347
+ */
+
+import java
+import SAML
+import semmle.code.java.controlflow.Guards
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+/** Configuration of handling SAML assertion in XML file. */
+class SamlAssertionConf extends TaintTracking::Configuration {
+  SamlAssertionConf() { this = "SamlAssertionConf" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof SamlAssertionSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof SamlAssertionSink }
+}
+
+/** Configuration of validating signature in XML file. */
+class SamlAssertionSignatureCheckConf extends TaintTracking::Configuration {
+  SamlAssertionSignatureCheckConf() { this = "SamlAssertionSignatureCheckConf" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof SamlAssertionSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof ValidateSignatureMethod and
+      sink.asExpr() = ma.getQualifier()
+    )
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    exists(
+      ConditionBlock cb, EQExpr ee, CompileTimeConstantExpr zero, MethodAccess ma, ReturnStmt stmt
+    |
+      // if (signatureNodeList.getLength() == 0) { return; }
+      cb.getCondition() = ee and
+      zero.(IntegerLiteral).getIntValue() = 0 and
+      ma.getMethod().getDeclaringType().getASupertype*() instanceof TypeDomNodeList and
+      ma.getMethod().hasName("getLength") and
+      ee.hasOperands(ma, zero) and
+      node.asExpr() = ma.getQualifier() and
+      cb.controls(stmt.getBasicBlock(), true)
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, SamlAssertionConf conf
+where
+  conf.hasFlowPath(source, sink) and
+  not exists(SamlAssertionSignatureCheckConf conf2, DataFlow::PathNode sink2 |
+    conf2.hasFlow(source.getNode(), sink2.getNode())
+  )
+select sink.getNode(), source, sink,
+  "SAMLv2 assertion is used $@, but the signature is not verified.", source.getNode(), "here"

--- a/java/ql/src/experimental/Security/CWE/CWE-347/SAML.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-347/SAML.qll
@@ -1,0 +1,71 @@
+/** Provides classes for working with SAML using the JAXB library. */
+
+import java
+import DOM
+
+/** Gets the annotation of the type `typeName` in the package `packageName` on `target`. */
+Annotation getAnnotation(Annotatable target, string packageName, string typeName) {
+  result = target.getAnAnnotation() and
+  exists(AnnotationType at | at = result.getType() |
+    at.nestedName() = typeName and at.getPackage().getName() = packageName
+  )
+}
+
+/** XML element of SAML assertion mapped to a Java class field. */
+class TypeSamlAssertionField extends Field {
+  Annotation xmlElement;
+
+  TypeSamlAssertionField() {
+    this.fromSource() and
+    xmlElement =
+      getAnnotation(this, "javax.xml.bind.annotation", "XmlElements")
+          .getValue("value")
+          .(ArrayInit)
+          .getAnInit() and
+    xmlElement.getValue("name").(CompileTimeConstantExpr).getStringValue() =
+      ["Assertion", "EncryptedAssertion"] and
+    xmlElement.getValue("namespace").(CompileTimeConstantExpr).getStringValue() =
+      "urn:oasis:names:tc:SAML:2.0:assertion"
+  }
+}
+
+/** Source of SAML assertion in an XML document. */
+class SamlAssertionSource extends DataFlow::Node {
+  SamlAssertionSource() { sourceNode(this, "xmldoc") }
+}
+
+/** Holds if `ma` is a getter method call that returns a field of the type `TypeSamlAssertionField`. */
+predicate isSamlAssertionMethodAccess(MethodAccess ma) {
+  exists(TypeSamlAssertionField sf, ReturnStmt ret |
+    ma.getMethod().getDeclaringType() = sf.getDeclaringType() and
+    ret.getEnclosingCallable() = ma.getMethod() and
+    ret.getResult() = sf.getAnAccess()
+  )
+}
+
+/** Sink of the qualifier of a method call to SAML assertion. */
+class SamlAssertionSink extends DataFlow::Node {
+  SamlAssertionSink() {
+    exists(MethodAccess geta |
+      isSamlAssertionMethodAccess(geta) and this.asExpr() = geta.getQualifier()
+    )
+  }
+}
+
+/** Model of XML document builder in the new CSV format. */
+private class XmlDocSource extends SourceModelCsv {
+  override predicate row(string row) {
+    row = ["javax.xml.parsers;DocumentBuilder;true;parse;;;ReturnValue;xmldoc"]
+  }
+}
+
+/** Model of JAXB unmarshalling in the new CSV format. */
+private class JaxbDataModel extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "javax.xml.bind;JAXBElement;false;getValue;;;Argument[-1];ReturnValue;taint",
+        "javax.xml.bind;Unmarshaller;false;unmarshal;;;Argument[0];ReturnValue;taint"
+      ]
+  }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.expected
@@ -1,0 +1,93 @@
+edges
+| MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:29:61:29:68 | document : Document |
+| MissingSAMLSignatureCheckTest.java:29:38:29:75 | unmarshal(...) : JAXBElement | MissingSAMLSignatureCheckTest.java:30:20:30:26 | element : JAXBElement |
+| MissingSAMLSignatureCheckTest.java:29:61:29:68 | document : Document | MissingSAMLSignatureCheckTest.java:29:38:29:75 | unmarshal(...) : JAXBElement |
+| MissingSAMLSignatureCheckTest.java:30:20:30:26 | element : JAXBElement | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object |
+| MissingSAMLSignatureCheckTest.java:69:24:69:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document |
+| MissingSAMLSignatureCheckTest.java:76:37:76:88 | unmarshallFromDocument(...) : Object | MissingSAMLSignatureCheckTest.java:77:35:77:46 | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document |
+| MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document | MissingSAMLSignatureCheckTest.java:76:37:76:88 | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:89:24:89:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:94:60:94:67 | document : Document |
+| MissingSAMLSignatureCheckTest.java:94:37:94:88 | unmarshallFromDocument(...) : Object | MissingSAMLSignatureCheckTest.java:95:35:95:46 | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:94:60:94:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document |
+| MissingSAMLSignatureCheckTest.java:94:60:94:67 | document : Document | MissingSAMLSignatureCheckTest.java:94:37:94:88 | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:98:35:98:51 | document : Document | MissingSAMLSignatureCheckTest.java:99:23:99:30 | document : Document |
+| MissingSAMLSignatureCheckTest.java:99:23:99:30 | document : Document | MissingSAMLSignatureCheckTest.java:99:23:99:104 | getElementsByTagNameNS(...) : NodeList |
+| MissingSAMLSignatureCheckTest.java:99:23:99:104 | getElementsByTagNameNS(...) : NodeList | MissingSAMLSignatureCheckTest.java:105:78:105:79 | nl : NodeList |
+| MissingSAMLSignatureCheckTest.java:105:50:105:88 | new DOMValidateContext(...) : DOMValidateContext | MissingSAMLSignatureCheckTest.java:108:72:108:86 | validateContext : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:105:78:105:79 | nl : NodeList | MissingSAMLSignatureCheckTest.java:105:78:105:87 | item(...) : Node |
+| MissingSAMLSignatureCheckTest.java:105:78:105:87 | item(...) : Node | MissingSAMLSignatureCheckTest.java:105:50:105:88 | new DOMValidateContext(...) : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:108:42:108:87 | unmarshalXMLSignature(...) : XMLSignature | MissingSAMLSignatureCheckTest.java:109:33:109:41 | signature |
+| MissingSAMLSignatureCheckTest.java:108:72:108:86 | validateContext : DOMValidateContext | MissingSAMLSignatureCheckTest.java:108:42:108:87 | unmarshalXMLSignature(...) : XMLSignature |
+| MissingSAMLSignatureCheckTest.java:131:24:131:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:136:26:136:33 | document : Document |
+| MissingSAMLSignatureCheckTest.java:131:24:131:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:138:60:138:67 | document : Document |
+| MissingSAMLSignatureCheckTest.java:136:26:136:33 | document : Document | MissingSAMLSignatureCheckTest.java:98:35:98:51 | document : Document |
+| MissingSAMLSignatureCheckTest.java:138:37:138:88 | unmarshallFromDocument(...) : Object | MissingSAMLSignatureCheckTest.java:139:35:139:46 | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:138:60:138:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document |
+| MissingSAMLSignatureCheckTest.java:138:60:138:67 | document : Document | MissingSAMLSignatureCheckTest.java:138:37:138:88 | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:142:39:142:55 | document : Document | MissingSAMLSignatureCheckTest.java:145:23:145:30 | document : Document |
+| MissingSAMLSignatureCheckTest.java:145:23:145:30 | document : Document | MissingSAMLSignatureCheckTest.java:145:23:145:104 | getElementsByTagNameNS(...) : NodeList |
+| MissingSAMLSignatureCheckTest.java:145:23:145:104 | getElementsByTagNameNS(...) : NodeList | MissingSAMLSignatureCheckTest.java:147:78:147:79 | nl : NodeList |
+| MissingSAMLSignatureCheckTest.java:147:50:147:88 | new DOMValidateContext(...) : DOMValidateContext | MissingSAMLSignatureCheckTest.java:150:72:150:86 | validateContext : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:147:78:147:79 | nl : NodeList | MissingSAMLSignatureCheckTest.java:147:78:147:87 | item(...) : Node |
+| MissingSAMLSignatureCheckTest.java:147:78:147:87 | item(...) : Node | MissingSAMLSignatureCheckTest.java:147:50:147:88 | new DOMValidateContext(...) : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:150:42:150:87 | unmarshalXMLSignature(...) : XMLSignature | MissingSAMLSignatureCheckTest.java:151:37:151:45 | signature |
+| MissingSAMLSignatureCheckTest.java:150:72:150:86 | validateContext : DOMValidateContext | MissingSAMLSignatureCheckTest.java:150:42:150:87 | unmarshalXMLSignature(...) : XMLSignature |
+| MissingSAMLSignatureCheckTest.java:175:24:175:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:180:31:180:38 | document : Document |
+| MissingSAMLSignatureCheckTest.java:175:24:175:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:181:64:181:71 | document : Document |
+| MissingSAMLSignatureCheckTest.java:180:31:180:38 | document : Document | MissingSAMLSignatureCheckTest.java:142:39:142:55 | document : Document |
+| MissingSAMLSignatureCheckTest.java:181:41:181:92 | unmarshallFromDocument(...) : Object | MissingSAMLSignatureCheckTest.java:182:39:182:50 | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:181:64:181:71 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document |
+| MissingSAMLSignatureCheckTest.java:181:64:181:71 | document : Document | MissingSAMLSignatureCheckTest.java:181:41:181:92 | unmarshallFromDocument(...) : Object |
+nodes
+| MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:29:38:29:75 | unmarshal(...) : JAXBElement | semmle.label | unmarshal(...) : JAXBElement |
+| MissingSAMLSignatureCheckTest.java:29:61:29:68 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:30:20:30:26 | element : JAXBElement | semmle.label | element : JAXBElement |
+| MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object | semmle.label | getValue(...) : Object |
+| MissingSAMLSignatureCheckTest.java:69:24:69:79 | parse(...) : Document | semmle.label | parse(...) : Document |
+| MissingSAMLSignatureCheckTest.java:76:37:76:88 | unmarshallFromDocument(...) : Object | semmle.label | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:77:35:77:46 | jaxbResponse | semmle.label | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:89:24:89:79 | parse(...) : Document | semmle.label | parse(...) : Document |
+| MissingSAMLSignatureCheckTest.java:94:37:94:88 | unmarshallFromDocument(...) : Object | semmle.label | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:94:60:94:67 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:95:35:95:46 | jaxbResponse | semmle.label | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:98:35:98:51 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:99:23:99:30 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:99:23:99:104 | getElementsByTagNameNS(...) : NodeList | semmle.label | getElementsByTagNameNS(...) : NodeList |
+| MissingSAMLSignatureCheckTest.java:105:50:105:88 | new DOMValidateContext(...) : DOMValidateContext | semmle.label | new DOMValidateContext(...) : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:105:78:105:79 | nl : NodeList | semmle.label | nl : NodeList |
+| MissingSAMLSignatureCheckTest.java:105:78:105:87 | item(...) : Node | semmle.label | item(...) : Node |
+| MissingSAMLSignatureCheckTest.java:108:42:108:87 | unmarshalXMLSignature(...) : XMLSignature | semmle.label | unmarshalXMLSignature(...) : XMLSignature |
+| MissingSAMLSignatureCheckTest.java:108:72:108:86 | validateContext : DOMValidateContext | semmle.label | validateContext : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:109:33:109:41 | signature | semmle.label | signature |
+| MissingSAMLSignatureCheckTest.java:131:24:131:79 | parse(...) : Document | semmle.label | parse(...) : Document |
+| MissingSAMLSignatureCheckTest.java:131:24:131:79 | parse(...) : Document | semmle.label | parse(...) : Document |
+| MissingSAMLSignatureCheckTest.java:136:26:136:33 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:138:37:138:88 | unmarshallFromDocument(...) : Object | semmle.label | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:138:60:138:67 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:139:35:139:46 | jaxbResponse | semmle.label | jaxbResponse |
+| MissingSAMLSignatureCheckTest.java:142:39:142:55 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:145:23:145:30 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:145:23:145:104 | getElementsByTagNameNS(...) : NodeList | semmle.label | getElementsByTagNameNS(...) : NodeList |
+| MissingSAMLSignatureCheckTest.java:147:50:147:88 | new DOMValidateContext(...) : DOMValidateContext | semmle.label | new DOMValidateContext(...) : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:147:78:147:79 | nl : NodeList | semmle.label | nl : NodeList |
+| MissingSAMLSignatureCheckTest.java:147:78:147:87 | item(...) : Node | semmle.label | item(...) : Node |
+| MissingSAMLSignatureCheckTest.java:150:42:150:87 | unmarshalXMLSignature(...) : XMLSignature | semmle.label | unmarshalXMLSignature(...) : XMLSignature |
+| MissingSAMLSignatureCheckTest.java:150:72:150:86 | validateContext : DOMValidateContext | semmle.label | validateContext : DOMValidateContext |
+| MissingSAMLSignatureCheckTest.java:151:37:151:45 | signature | semmle.label | signature |
+| MissingSAMLSignatureCheckTest.java:175:24:175:79 | parse(...) : Document | semmle.label | parse(...) : Document |
+| MissingSAMLSignatureCheckTest.java:175:24:175:79 | parse(...) : Document | semmle.label | parse(...) : Document |
+| MissingSAMLSignatureCheckTest.java:180:31:180:38 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:181:41:181:92 | unmarshallFromDocument(...) : Object | semmle.label | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:181:64:181:71 | document : Document | semmle.label | document : Document |
+| MissingSAMLSignatureCheckTest.java:182:39:182:50 | jaxbResponse | semmle.label | jaxbResponse |
+subpaths
+| MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object | MissingSAMLSignatureCheckTest.java:76:37:76:88 | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:94:60:94:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object | MissingSAMLSignatureCheckTest.java:94:37:94:88 | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:138:60:138:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object | MissingSAMLSignatureCheckTest.java:138:37:138:88 | unmarshallFromDocument(...) : Object |
+| MissingSAMLSignatureCheckTest.java:181:64:181:71 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object | MissingSAMLSignatureCheckTest.java:181:41:181:92 | unmarshallFromDocument(...) : Object |
+#select
+| MissingSAMLSignatureCheckTest.java:77:35:77:46 | jaxbResponse | MissingSAMLSignatureCheckTest.java:69:24:69:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:77:35:77:46 | jaxbResponse | SAMLv2 assertion is used $@, but the signature is not verified. | MissingSAMLSignatureCheckTest.java:69:24:69:79 | parse(...) | here |
+| MissingSAMLSignatureCheckTest.java:95:35:95:46 | jaxbResponse | MissingSAMLSignatureCheckTest.java:89:24:89:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:95:35:95:46 | jaxbResponse | SAMLv2 assertion is used $@, but the signature is not verified. | MissingSAMLSignatureCheckTest.java:89:24:89:79 | parse(...) | here |

--- a/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.expected
@@ -1,8 +1,5 @@
 edges
-| MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:29:61:29:68 | document : Document |
-| MissingSAMLSignatureCheckTest.java:29:38:29:75 | unmarshal(...) : JAXBElement | MissingSAMLSignatureCheckTest.java:30:20:30:26 | element : JAXBElement |
-| MissingSAMLSignatureCheckTest.java:29:61:29:68 | document : Document | MissingSAMLSignatureCheckTest.java:29:38:29:75 | unmarshal(...) : JAXBElement |
-| MissingSAMLSignatureCheckTest.java:30:20:30:26 | element : JAXBElement | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object |
+| MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object |
 | MissingSAMLSignatureCheckTest.java:69:24:69:79 | parse(...) : Document | MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document |
 | MissingSAMLSignatureCheckTest.java:76:37:76:88 | unmarshallFromDocument(...) : Object | MissingSAMLSignatureCheckTest.java:77:35:77:46 | jaxbResponse |
 | MissingSAMLSignatureCheckTest.java:76:60:76:67 | document : Document | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document |
@@ -41,9 +38,6 @@ edges
 | MissingSAMLSignatureCheckTest.java:181:64:181:71 | document : Document | MissingSAMLSignatureCheckTest.java:181:41:181:92 | unmarshallFromDocument(...) : Object |
 nodes
 | MissingSAMLSignatureCheckTest.java:25:42:25:58 | document : Document | semmle.label | document : Document |
-| MissingSAMLSignatureCheckTest.java:29:38:29:75 | unmarshal(...) : JAXBElement | semmle.label | unmarshal(...) : JAXBElement |
-| MissingSAMLSignatureCheckTest.java:29:61:29:68 | document : Document | semmle.label | document : Document |
-| MissingSAMLSignatureCheckTest.java:30:20:30:26 | element : JAXBElement | semmle.label | element : JAXBElement |
 | MissingSAMLSignatureCheckTest.java:30:20:30:37 | getValue(...) : Object | semmle.label | getValue(...) : Object |
 | MissingSAMLSignatureCheckTest.java:69:24:69:79 | parse(...) : Document | semmle.label | parse(...) : Document |
 | MissingSAMLSignatureCheckTest.java:76:37:76:88 | unmarshallFromDocument(...) : Object | semmle.label | unmarshallFromDocument(...) : Object |

--- a/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.java
@@ -1,0 +1,185 @@
+package com.example;
+
+import java.io.ByteArrayInputStream;
+import java.security.Key;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.crypto.MarshalException;
+import javax.xml.crypto.dsig.dom.DOMValidateContext;
+import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.XMLSignatureException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+public class MissingSAMLSignatureCheckTest {
+    private <T> T unmarshallFromDocument(Document document, Class<T> type) throws Exception {
+        try {
+            JAXBContext context = JAXBContext.newInstance(type);
+            Unmarshaller unmarshaller = context.createUnmarshaller();
+            JAXBElement<T> element = unmarshaller.unmarshal(document, type);
+            return element.getValue();
+        } catch (Exception e) {
+            throw new Exception("Unable to unmarshall SAML response", e);
+        }
+    }
+
+    private void verifySignature1(Document document, Key key) throws Exception {
+        NodeList nl = document.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
+        // skip signature validation if there is no signature node.
+        if (nl.getLength() == 0) {
+            return;
+        }
+
+        for (int i = 0; i < nl.getLength(); i++) {
+            DOMValidateContext validateContext = new DOMValidateContext(key, nl.item(i));
+            XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+            try {
+                XMLSignature signature = factory.unmarshalXMLSignature(validateContext);
+                boolean valid = signature.validate(validateContext);
+                if (!valid) {
+                    throw new Exception("Invalid SAML v2.0 authentication response. The signature is invalid.");
+                }
+            } catch (MarshalException e) {
+                throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response because we couldn't unmarshall the XML Signature element", e);
+            } catch (XMLSignatureException e) {
+                throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response. The signature was unmarshalled we couldn't validate it for an unknown reason", e);
+            }
+        }
+    }
+
+    // BAD: allow SAMLv2 assertion with signature check skipped.
+    public void parseResponse1(String encodedResponse, PublicKey key) throws Exception {
+        byte[] decodedResponse = Base64.getDecoder().decode(encodedResponse);
+
+        Document document = null;
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            document = builder.parse(new ByteArrayInputStream(decodedResponse));
+        } catch (Exception e) {
+            throw new Exception("Unable to parse SAML v2.0 authentication response", e);
+        }
+
+        verifySignature1(document, key);
+    
+        ResponseType jaxbResponse = unmarshallFromDocument(document, ResponseType.class);
+        List<Object> assertions = jaxbResponse.getAssertionOrEncryptedAssertion();
+    }
+
+    // BAD: does not validate signature of SAMLv2 assertion.
+    public void parseResponse2(String encodedResponse, PublicKey key) throws Exception {
+        byte[] decodedResponse = Base64.getDecoder().decode(encodedResponse);
+
+        Document document = null;
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            document = builder.parse(new ByteArrayInputStream(decodedResponse));
+        } catch (Exception e) {
+            throw new Exception("Unable to parse SAML v2.0 authentication response", e);
+        }
+
+        ResponseType jaxbResponse = unmarshallFromDocument(document, ResponseType.class);
+        List<Object> assertions = jaxbResponse.getAssertionOrEncryptedAssertion();
+    }
+
+    private void verifySignature2(Document document, Key key) throws Exception {
+        NodeList nl = document.getElementsByTagNameNS("http://www.w3.org/2000/09/xmldsig#", "Signature");
+        if (nl.getLength() == 0) {
+            throw new Exception("Invalid SAML v2.0 operation. The signature is missing from the XML but is required.");
+        }
+
+        for (int i = 0; i < nl.getLength(); i++) {
+            DOMValidateContext validateContext = new DOMValidateContext(key, nl.item(i));
+            XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+            try {
+                XMLSignature signature = factory.unmarshalXMLSignature(validateContext);
+                boolean valid = signature.validate(validateContext);
+                // throw an exception if the signature is not valid.
+                if (!valid) {
+                    throw new Exception("Invalid SAML v2.0 authentication response. The signature is invalid.");
+                }
+            } catch (MarshalException e) {
+                throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response because we couldn't unmarshall the XML Signature element", e);
+            } catch (XMLSignatureException e) {
+                throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response. The signature was unmarshalled we couldn't validate it for an unknown reason", e);
+            }
+        }
+    }
+
+    // GOOD: handle SAMLv2 assertion with proper signature verification.
+    public void parseResponse3(String encodedResponse, PublicKey key) throws Exception {
+        byte[] decodedResponse = Base64.getDecoder().decode(encodedResponse);
+
+        Document document = null;
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            document = builder.parse(new ByteArrayInputStream(decodedResponse));
+        } catch (Exception e) {
+            throw new Exception("Unable to parse SAML v2.0 authentication response", e);
+        }
+
+        verifySignature2(document, key);
+
+        ResponseType jaxbResponse = unmarshallFromDocument(document, ResponseType.class);
+        List<Object> assertions = jaxbResponse.getAssertionOrEncryptedAssertion();
+    }
+
+    private boolean hasValidSignature(Document document, Key key) throws Exception {
+        boolean hasValidSignature = false;
+
+        NodeList nl = document.getElementsByTagNameNS("http://www.w3.org/2000/09/xmldsig#", "Signature");
+        for (int i = 0; i < nl.getLength(); i++) {
+            DOMValidateContext validateContext = new DOMValidateContext(key, nl.item(i));
+            XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+            try {
+                XMLSignature signature = factory.unmarshalXMLSignature(validateContext);
+                hasValidSignature = signature.validate(validateContext);
+                // verification fails as long as one signature is invalid.
+                if (!hasValidSignature) {
+                    break;
+                }
+            } catch (MarshalException e) {
+                throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response because we couldn't unmarshall the XML Signature element", e);
+            } catch (XMLSignatureException e) {
+                throw new Exception("Unable to verify XML signature in the SAML v2.0 authentication response. The signature was unmarshalled we couldn't validate it for an unknown reason", e);
+            }
+        }
+
+        return hasValidSignature;
+    }
+
+    // GOOD: handle SAMLv2 assertion with proper signature verification.
+    public void parseResponse4(String encodedResponse, PublicKey key) throws Exception {
+        byte[] decodedResponse = Base64.getDecoder().decode(encodedResponse);
+
+        Document document = null;
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        try {
+            DocumentBuilder builder = documentBuilderFactory.newDocumentBuilder();
+            document = builder.parse(new ByteArrayInputStream(decodedResponse));
+        } catch (Exception e) {
+            throw new Exception("Unable to parse SAML v2.0 authentication response", e);
+        }
+
+        if (hasValidSignature(document, key)) {
+            ResponseType jaxbResponse = unmarshallFromDocument(document, ResponseType.class);
+            List<Object> assertions = jaxbResponse.getAssertionOrEncryptedAssertion();
+        }
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-347/MissingSAMLSignatureCheckTest.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-347/MissingSAMLSignatureCheck.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-347/ResponseType.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-347/ResponseType.java
@@ -1,0 +1,196 @@
+package com.example;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlID;
+import javax.xml.bind.annotation.XmlSchemaType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ResponseType", propOrder = {
+    "assertionOrEncryptedAssertion"
+})
+public class ResponseType {
+    @XmlElements({
+        @XmlElement(name = "EncryptedAssertion", namespace = "urn:oasis:names:tc:SAML:2.0:assertion", type = EncryptedDataType.class),
+        @XmlElement(name = "Assertion", namespace = "urn:oasis:names:tc:SAML:2.0:assertion", type = AssertionType.class)
+    })
+    protected List<Object> assertionOrEncryptedAssertion;
+
+    public List<Object> getAssertionOrEncryptedAssertion() {
+        if (assertionOrEncryptedAssertion == null) {
+            assertionOrEncryptedAssertion = new ArrayList<Object>();
+        }
+        return this.assertionOrEncryptedAssertion;
+    }
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "EncryptedDataType")
+class EncryptedDataType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "NameIDType", propOrder = {
+    "value"
+})
+class NameIDType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SignatureType", propOrder = {
+    "signedInfo",
+    "signatureValue",
+    "keyInfo",
+    "object"
+})
+class SignatureType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "SubjectType", propOrder = {
+    "content"
+})
+class SubjectType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ConditionsType", propOrder = {
+    "conditionOrAudienceRestrictionOrOneTimeUse"
+})
+class ConditionsType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "StatementAbstractType")
+class StatementAbstractType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AdviceType", propOrder = {
+    "assertionIDRefOrAssertionURIRefOrAssertion"
+})
+class AdviceType {
+    // Leave as blank
+}
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "AssertionType", propOrder = {
+    "issuer",
+    "signature",
+    "subject",
+    "conditions",
+    "advice",
+    "statementOrAuthnStatementOrAuthzDecisionStatement"
+})
+class AssertionType {
+    @XmlElement(name = "Issuer", required = true)
+    protected NameIDType issuer;
+    @XmlElement(name = "Signature", namespace = "http://www.w3.org/2000/09/xmldsig#")
+    protected SignatureType signature;
+    @XmlElement(name = "Subject")
+    protected SubjectType subject;
+    @XmlElement(name = "Conditions")
+    protected ConditionsType conditions;
+    @XmlElement(name = "Advice")
+    protected AdviceType advice;
+    @XmlElements({
+        @XmlElement(name = "AuthnStatement", type = Object.class), // Not implemented
+        @XmlElement(name = "Statement"),
+        @XmlElement(name = "AttributeStatement", type = Object.class), // Not implemented
+        @XmlElement(name = "AuthzDecisionStatement", type = Object.class) // Not implemented
+    })
+    protected List<StatementAbstractType> statementOrAuthnStatementOrAuthzDecisionStatement;
+    @XmlAttribute(name = "Version", required = true)
+    protected String version;
+    @XmlAttribute(name = "ID", required = true)
+    @XmlSchemaType(name = "ID")
+    protected String id;
+    @XmlAttribute(name = "IssueInstant", required = true)
+    @XmlSchemaType(name = "dateTime")
+    protected XMLGregorianCalendar issueInstant;
+
+    public NameIDType getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(NameIDType value) {
+        this.issuer = value;
+    }
+
+    public SignatureType getSignature() {
+        return signature;
+    }
+
+    public void setSignature(SignatureType value) {
+        this.signature = value;
+    }
+
+    public SubjectType getSubject() {
+        return subject;
+    }
+
+    public void setSubject(SubjectType value) {
+        this.subject = value;
+    }
+
+    public ConditionsType getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(ConditionsType value) {
+        this.conditions = value;
+    }
+
+    public AdviceType getAdvice() {
+        return advice;
+    }
+
+    public void setAdvice(AdviceType value) {
+        this.advice = value;
+    }
+
+    public List<StatementAbstractType> getStatementOrAuthnStatementOrAuthzDecisionStatement() {
+        if (statementOrAuthnStatementOrAuthzDecisionStatement == null) {
+            statementOrAuthnStatementOrAuthzDecisionStatement = new ArrayList<StatementAbstractType>();
+        }
+        return this.statementOrAuthnStatementOrAuthzDecisionStatement;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String value) {
+        this.version = value;
+    }
+
+    public String getID() {
+        return id;
+    }
+
+    public void setID(String value) {
+        this.id = value;
+    }
+
+    public XMLGregorianCalendar getIssueInstant() {
+        return issueInstant;
+    }
+
+    public void setIssueInstant(XMLGregorianCalendar value) {
+        this.issueInstant = value;
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-347/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-347/options
@@ -1,0 +1,1 @@
+// semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/jsr105-api:${testdir}/../../../../stubs/jaxb-api-2.3.1

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/JAXBElement.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/JAXBElement.java
@@ -1,0 +1,10 @@
+package javax.xml.bind;
+
+public class JAXBElement<T> {
+    public void setValue(T t) {
+    }
+
+    public T getValue() {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/Unmarshaller.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/Unmarshaller.java
@@ -1,5 +1,7 @@
 package javax.xml.bind;
 
+import org.w3c.dom.Node;
+
 import java.net.URL;
 import java.io.Reader;
 import java.io.InputStream;
@@ -68,8 +70,8 @@ abstract public interface Unmarshaller {
 //  abstract public JAXBElement<T> unmarshal(Source p0, Class<T> p1);
 //
 //  abstract public Object unmarshal(Node p0);
-//
-//  abstract public JAXBElement<T> unmarshal(Node p0, Class<T> p1);
+
+  abstract public <T> JAXBElement<T> unmarshal(Node p0, Class<T> p1);
 //
 //  abstract public Object unmarshal(InputSource p0);
 }

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlAccessType.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlAccessType.java
@@ -1,0 +1,8 @@
+package javax.xml.bind.annotation;
+
+public enum XmlAccessType {
+    PROPERTY,
+    FIELD,
+    PUBLIC_MEMBER,
+    NONE
+}

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlAccessorType.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlAccessorType.java
@@ -1,0 +1,5 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlAccessorType {
+    XmlAccessType value() default XmlAccessType.PUBLIC_MEMBER;
+}

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlAttribute.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlAttribute.java
@@ -1,0 +1,9 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlAttribute {
+    String name() default "##default";
+ 
+     boolean required() default false;
+
+    String namespace() default "##default" ;
+}

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlElement.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlElement.java
@@ -1,0 +1,17 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlElement {
+    String name() default "##default";
+
+    boolean nillable() default false;
+
+    boolean required() default false;
+
+    String namespace() default "##default";
+
+    String defaultValue() default "\u0000";
+
+    Class type() default DEFAULT.class;
+
+    static final class DEFAULT {};
+}

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlElements.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlElements.java
@@ -1,0 +1,5 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlElements {
+    XmlElement[] value();
+}

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlID.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlID.java
@@ -1,0 +1,5 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlID { }
+
+

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlSchemaType.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlSchemaType.java
@@ -1,0 +1,13 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlSchemaType {
+    String name();
+
+    String namespace() default "http://www.w3.org/2001/XMLSchema";
+
+    Class type() default DEFAULT.class;
+
+    static final class DEFAULT {};
+}
+
+

--- a/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlType.java
+++ b/java/ql/test/stubs/jaxb-api-2.3.1/javax/xml/bind/annotation/XmlType.java
@@ -1,0 +1,16 @@
+package javax.xml.bind.annotation;
+
+public @interface XmlType {
+    String name() default "##default" ;
+ 
+    String[] propOrder() default {""};
+
+    String namespace() default "##default" ;
+   
+    Class factoryClass() default DEFAULT.class;
+
+    static final class DEFAULT {}
+
+    String factoryMethod() default "";
+}
+

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/MarshalException.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/MarshalException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * $Id: MarshalException.java,v 1.5 2005/05/10 15:47:42 mullan Exp $
+ */
+package javax.xml.crypto;
+
+/**
+ * Indicates an exceptional condition that occurred during the XML
+ * marshalling or unmarshalling process.
+ *
+ * <p>A {@code MarshalException} can contain a cause: another
+ * throwable that caused this {@code MarshalException} to get thrown.
+ *
+ * @author Sean Mullan
+ * @author JSR 105 Expert Group
+ * @since 1.6
+ * @see XMLSignature#sign(XMLSignContext)
+ * @see XMLSignatureFactory#unmarshalXMLSignature(XMLValidateContext)
+ */
+public class MarshalException extends Exception {
+}

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/XMLStructure.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/XMLStructure.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * $Id: XMLStructure.java,v 1.3 2005/05/10 15:47:42 mullan Exp $
+ */
+package javax.xml.crypto;
+
+/**
+ * A representation of an XML structure from any namespace. The purpose of
+ * this interface is to group (and provide type safety for) all
+ * representations of XML structures.
+ *
+ * @author Sean Mullan
+ * @author JSR 105 Expert Group
+ * @since 1.6
+ */
+public interface XMLStructure {
+
+    /**
+     * Indicates whether a specified feature is supported.
+     *
+     * @param feature the feature name (as an absolute URI)
+     * @return <code>true</code> if the specified feature is supported,
+     *    <code>false</code> otherwise
+     * @throws NullPointerException if <code>feature</code> is <code>null</code>
+     */
+    boolean isFeatureSupported(String feature);
+}

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLSignature.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLSignature.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ *
+ * (C) Copyright IBM Corp. 2003 All Rights Reserved.
+ *
+ * ===========================================================================
+ */
+/*
+ * $Id: XMLSignature.java,v 1.10 2005/05/10 16:03:48 mullan Exp $
+ */
+package javax.xml.crypto.dsig;
+
+import javax.xml.crypto.MarshalException;
+import javax.xml.crypto.XMLStructure;
+
+/**
+ * A representation of the XML <code>Signature</code> element as
+ * defined in the <a href="http://www.w3.org/TR/xmldsig-core/">
+ * W3C Recommendation for XML-Signature Syntax and Processing</a>.
+ * This class contains methods for signing and validating XML signatures
+ * with behavior as defined by the W3C specification. The XML Schema Definition
+ * is defined as:
+ * <pre><code>
+ * &lt;element name="Signature" type="ds:SignatureType"/&gt;
+ * &lt;complexType name="SignatureType"&gt;
+ *    &lt;sequence&gt;
+ *      &lt;element ref="ds:SignedInfo"/&gt;
+ *      &lt;element ref="ds:SignatureValue"/&gt;
+ *      &lt;element ref="ds:KeyInfo" minOccurs="0"/&gt;
+ *      &lt;element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/&gt;
+ *    &lt;/sequence&gt;
+ *    &lt;attribute name="Id" type="ID" use="optional"/&gt;
+ * &lt;/complexType&gt;
+ * </code></pre>
+ * <p>
+ * An <code>XMLSignature</code> instance may be created by invoking one of the
+ * {@link XMLSignatureFactory#newXMLSignature newXMLSignature} methods of the
+ * {@link XMLSignatureFactory} class.
+ *
+ * <p>If the contents of the underlying document containing the
+ * <code>XMLSignature</code> are subsequently modified, the behavior is
+ * undefined.
+ *
+ * <p>Note that this class is named <code>XMLSignature</code> rather than
+ * <code>Signature</code> to avoid naming clashes with the existing
+ * {@link Signature java.security.Signature} class.
+ *
+ * @see XMLSignatureFactory#newXMLSignature(SignedInfo, KeyInfo)
+ * @see XMLSignatureFactory#newXMLSignature(SignedInfo, KeyInfo, List, String, String)
+ * @author Joyce L. Leung
+ * @author Sean Mullan
+ * @author Erwin van der Koogh
+ * @author JSR 105 Expert Group
+ * @since 1.6
+ */
+public interface XMLSignature extends XMLStructure {
+
+    /**
+     * The XML Namespace URI of the W3C Recommendation for XML-Signature
+     * Syntax and Processing.
+     */
+    final static String XMLNS = "http://www.w3.org/2000/09/xmldsig#";
+
+    /**
+     * Validates the signature according to the
+     * <a href="http://www.w3.org/TR/xmldsig-core/#sec-CoreValidation">
+     * core validation processing rules</a>. This method validates the
+     * signature using the existing state, it does not unmarshal and
+     * reinitialize the contents of the <code>XMLSignature</code> using the
+     * location information specified in the context.
+     *
+     * <p>This method only validates the signature the first time it is
+     * invoked. On subsequent invocations, it returns a cached result.
+     *
+     * @param validateContext the validating context
+     * @return <code>true</code> if the signature passed core validation,
+     *    otherwise <code>false</code>
+     * @throws ClassCastException if the type of <code>validateContext</code>
+     *    is not compatible with this <code>XMLSignature</code>
+     * @throws NullPointerException if <code>validateContext</code> is
+     *    <code>null</code>
+     * @throws XMLSignatureException if an unexpected error occurs during
+     *    validation that prevented the validation operation from completing
+     */
+    boolean validate(XMLValidateContext validateContext)
+        throws XMLSignatureException;
+}

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLSignatureException.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLSignatureException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * $Id: XMLSignatureException.java,v 1.5 2005/05/10 16:03:48 mullan Exp $
+ */
+package javax.xml.crypto.dsig;
+
+/**
+ * Indicates an exceptional condition that occurred during the XML
+ * signature generation or validation process.
+ *
+ * <p>An {@code XMLSignatureException} can contain a cause: another
+ * throwable that caused this {@code XMLSignatureException} to get thrown.
+ *
+ * @since 1.6
+ */
+public class XMLSignatureException extends Exception {
+}

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLSignatureFactory.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLSignatureFactory.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * $Id: XMLSignatureFactory.java,v 1.14 2005/09/15 14:29:01 mullan Exp $
+ */
+package javax.xml.crypto.dsig;
+
+import javax.xml.crypto.MarshalException;
+import javax.xml.crypto.XMLStructure;
+import javax.xml.crypto.dsig.dom.DOMValidateContext;
+
+/**
+ * A factory for creating {@link XMLSignature} objects from scratch or
+ * for unmarshalling an <code>XMLSignature</code> object from a corresponding
+ * XML representation.
+ *
+ * <h2>XMLSignatureFactory Type</h2>
+ *
+ * <p>Each instance of <code>XMLSignatureFactory</code> supports a specific
+ * XML mechanism type. To create an <code>XMLSignatureFactory</code>, call one
+ * of the static {@link #getInstance getInstance} methods, passing in the XML
+ * mechanism type desired, for example:
+ *
+ * <blockquote><code>
+ * XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+ * </code></blockquote>
+ *
+ * <p>The objects that this factory produces will be based
+ * on DOM and abide by the DOM interoperability requirements as defined in the
+ * {@extLink security_guide_xmldsig_rqmts DOM Mechanism Requirements} section
+ * of the API overview. See the
+ * {@extLink security_guide_xmldsig_provider Service Providers} section of
+ * the API overview for a list of standard mechanism types.
+ *
+ * <p><code>XMLSignatureFactory</code> implementations are registered and loaded
+ * using the {@link java.security.Provider} mechanism.
+ * For example, a service provider that supports the
+ * DOM mechanism would be specified in the <code>Provider</code> subclass as:
+ * <pre>
+ *     put("XMLSignatureFactory.DOM", "org.example.DOMXMLSignatureFactory");
+ * </pre>
+ *
+ * <p>An implementation MUST minimally support the default mechanism type: DOM.
+ *
+ * <p>Note that a caller must use the same <code>XMLSignatureFactory</code>
+ * instance to create the <code>XMLStructure</code>s of a particular
+ * <code>XMLSignature</code> that is to be generated. The behavior is
+ * undefined if <code>XMLStructure</code>s from different providers or
+ * different mechanism types are used together.
+ *
+ * <p>Also, the <code>XMLStructure</code>s that are created by this factory
+ * may contain state specific to the <code>XMLSignature</code> and are not
+ * intended to be reusable.
+ *
+ * <h2>Creating XMLSignatures from scratch</h2>
+ *
+ * <p>Once the <code>XMLSignatureFactory</code> has been created, objects
+ * can be instantiated by calling the appropriate method. For example, a
+ * {@link Reference} instance may be created by invoking one of the
+ * {@link #newReference newReference} methods.
+ *
+ * <h2>Unmarshalling XMLSignatures from XML</h2>
+ *
+ * <p>Alternatively, an <code>XMLSignature</code> may be created from an
+ * existing XML representation by invoking the {@link #unmarshalXMLSignature
+ * unmarshalXMLSignature} method and passing it a mechanism-specific
+ * {@link XMLValidateContext} instance containing the XML content:
+ *
+ * <pre>
+ * DOMValidateContext context = new DOMValidateContext(key, signatureElement);
+ * XMLSignature signature = factory.unmarshalXMLSignature(context);
+ * </pre>
+ *
+ * Each <code>XMLSignatureFactory</code> must support the required
+ * <code>XMLValidateContext</code> types for that factory type, but may support
+ * others. A DOM <code>XMLSignatureFactory</code> must support {@link
+ * DOMValidateContext} objects.
+ *
+ * <h2>Signing and marshalling XMLSignatures to XML</h2>
+ *
+ * Each <code>XMLSignature</code> created by the factory can also be
+ * marshalled to an XML representation and signed, by invoking the
+ * {@link XMLSignature#sign sign} method of the
+ * {@link XMLSignature} object and passing it a mechanism-specific
+ * {@link XMLSignContext} object containing the signing key and
+ * marshalling parameters (see {@link DOMSignContext}).
+ * For example:
+ *
+ * <pre>
+ *    DOMSignContext context = new DOMSignContext(privateKey, document);
+ *    signature.sign(context);
+ * </pre>
+ *
+ * <b>Concurrent Access</b>
+ * <p>The static methods of this class are guaranteed to be thread-safe.
+ * Multiple threads may concurrently invoke the static methods defined in this
+ * class with no ill effects.
+ *
+ * <p>However, this is not true for the non-static methods defined by this
+ * class. Unless otherwise documented by a specific provider, threads that
+ * need to access a single <code>XMLSignatureFactory</code> instance
+ * concurrently should synchronize amongst themselves and provide the
+ * necessary locking. Multiple threads each manipulating a different
+ * <code>XMLSignatureFactory</code> instance need not synchronize.
+ *
+ * @author Sean Mullan
+ * @author JSR 105 Expert Group
+ * @since 1.6
+ */
+public abstract class XMLSignatureFactory {
+    /**
+     * Default constructor, for invocation by subclasses.
+     */
+    protected XMLSignatureFactory() {}
+
+    /**
+     * Returns an <code>XMLSignatureFactory</code> that supports the
+     * specified XML processing mechanism and representation type (ex: "DOM").
+     *
+     * <p>This method uses the standard JCA provider lookup mechanism to
+     * locate and instantiate an <code>XMLSignatureFactory</code>
+     * implementation of the desired mechanism type. It traverses the list of
+     * registered security <code>Provider</code>s, starting with the most
+     * preferred <code>Provider</code>.  A new <code>XMLSignatureFactory</code>
+     * object from the first <code>Provider</code> that supports the specified
+     * mechanism is returned.
+     *
+     * <p>Note that the list of registered providers may be retrieved via
+     * the {@link Security#getProviders() Security.getProviders()} method.
+     *
+     * @implNote
+     * The JDK Reference Implementation additionally uses the
+     * {@code jdk.security.provider.preferred}
+     * {@link Security#getProperty(String) Security} property to determine
+     * the preferred provider order for the specified algorithm. This
+     * may be different than the order of providers returned by
+     * {@link Security#getProviders() Security.getProviders()}.
+     *
+     * @param mechanismType the type of the XML processing mechanism and
+     *    representation. See the {@extLink security_guide_xmldsig_provider
+     *    Service Providers} section of the API overview for a list of
+     *    standard mechanism types.
+     * @return a new <code>XMLSignatureFactory</code>
+     * @throws NullPointerException if <code>mechanismType</code> is
+     *    <code>null</code>
+     * @throws NoSuchMechanismException if no <code>Provider</code> supports an
+     *    <code>XMLSignatureFactory</code> implementation for the specified
+     *    mechanism
+     * @see Provider
+     */
+    public static XMLSignatureFactory getInstance(String mechanismType) {
+        return null;
+    }
+
+    /**
+     * Returns an <code>XMLSignatureFactory</code> that supports the
+     * default XML processing mechanism and representation type ("DOM").
+     *
+     * <p>This method uses the standard JCA provider lookup mechanism to
+     * locate and instantiate an <code>XMLSignatureFactory</code>
+     * implementation of the default mechanism type. It traverses the list of
+     * registered security <code>Provider</code>s, starting with the most
+     * preferred <code>Provider</code>.  A new <code>XMLSignatureFactory</code>
+     * object from the first <code>Provider</code> that supports the DOM
+     * mechanism is returned.
+     *
+     * <p>Note that the list of registered providers may be retrieved via
+     * the {@link Security#getProviders() Security.getProviders()} method.
+     *
+     * @return a new <code>XMLSignatureFactory</code>
+     * @throws NoSuchMechanismException if no <code>Provider</code> supports an
+     *    <code>XMLSignatureFactory</code> implementation for the DOM
+     *    mechanism
+     * @see Provider
+     */
+    public static XMLSignatureFactory getInstance() {
+        return null;
+    }
+
+    /**
+     * Unmarshals a new <code>XMLSignature</code> instance from a
+     * mechanism-specific <code>XMLValidateContext</code> instance.
+     *
+     * @param context a mechanism-specific context from which to unmarshal the
+     *    signature from
+     * @return the <code>XMLSignature</code>
+     * @throws NullPointerException if <code>context</code> is
+     *    <code>null</code>
+     * @throws ClassCastException if the type of <code>context</code> is
+     *    inappropriate for this factory
+     * @throws MarshalException if an unrecoverable exception occurs
+     *    during unmarshalling
+     */
+    public abstract XMLSignature unmarshalXMLSignature
+        (XMLValidateContext context) throws MarshalException;
+
+    /**
+     * Unmarshals a new <code>XMLSignature</code> instance from a
+     * mechanism-specific <code>XMLStructure</code> instance.
+     * This method is useful if you only want to unmarshal (and not
+     * validate) an <code>XMLSignature</code>.
+     *
+     * @param xmlStructure a mechanism-specific XML structure from which to
+     *    unmarshal the signature from
+     * @return the <code>XMLSignature</code>
+     * @throws NullPointerException if <code>xmlStructure</code> is
+     *    <code>null</code>
+     * @throws ClassCastException if the type of <code>xmlStructure</code> is
+     *    inappropriate for this factory
+     * @throws MarshalException if an unrecoverable exception occurs
+     *    during unmarshalling
+     */
+    public abstract XMLSignature unmarshalXMLSignature
+        (XMLStructure xmlStructure) throws MarshalException;
+}

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLValidateContext.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/XMLValidateContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * $Id: XMLValidateContext.java,v 1.8 2005/05/10 16:03:49 mullan Exp $
+ */
+package javax.xml.crypto.dsig;
+
+/**
+ * Contains context information for validating XML Signatures. This interface
+ * is primarily intended for type-safety.
+ *
+ * <p>Note that <code>XMLValidateContext</code> instances can contain
+ * information and state specific to the XML signature structure it is
+ * used with. The results are unpredictable if an
+ * <code>XMLValidateContext</code> is used with different signature structures
+ * (for example, you should not use the same <code>XMLValidateContext</code>
+ * instance to validate two different {@link XMLSignature} objects).
+ * <p>
+ * <b><a id="SupportedProperties"></a>Supported Properties</b>
+ * <p>The following properties can be set by an application using the
+ * {@link #setProperty setProperty} method.
+ * <ul>
+ *   <li><code>javax.xml.crypto.dsig.cacheReference</code>: value must be a
+ *      {@link Boolean}. This property controls whether or not the
+ *      {@link Reference#validate Reference.validate} method will cache the
+ *      dereferenced content and pre-digested input for subsequent retrieval via
+ *      the {@link Reference#getDereferencedData Reference.getDereferencedData}
+ *      and {@link Reference#getDigestInputStream
+ *      Reference.getDigestInputStream} methods. The default value if not
+ *      specified is <code>Boolean.FALSE</code>.
+ * </ul>
+ *
+ * @author Sean Mullan
+ * @author JSR 105 Expert Group
+ * @since 1.6
+ * @see XMLSignature#validate(XMLValidateContext)
+ * @see Reference#validate(XMLValidateContext)
+ */
+public interface XMLValidateContext {}

--- a/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/dom/DOMValidateContext.java
+++ b/java/ql/test/stubs/jsr105-api/javax/xml/crypto/dsig/dom/DOMValidateContext.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * $Id: DOMValidateContext.java,v 1.8 2005/05/10 16:31:14 mullan Exp $
+ */
+package javax.xml.crypto.dsig.dom;
+
+import java.security.Key;
+import org.w3c.dom.Node;
+import javax.xml.crypto.dsig.XMLValidateContext;
+
+/**
+ * A DOM-specific {@link XMLValidateContext}. This class contains additional
+ * methods to specify the location in a DOM tree where an {@link XMLSignature}
+ * is to be unmarshalled and validated from.
+ *
+ * <p>Note that the behavior of an unmarshalled <code>XMLSignature</code>
+ * is undefined if the contents of the underlying DOM tree are modified by the
+ * caller after the <code>XMLSignature</code> is created.
+ *
+ * <p>Also, note that <code>DOMValidateContext</code> instances can contain
+ * information and state specific to the XML signature structure it is
+ * used with. The results are unpredictable if a
+ * <code>DOMValidateContext</code> is used with different signature structures
+ * (for example, you should not use the same <code>DOMValidateContext</code>
+ * instance to validate two different {@link XMLSignature} objects).
+ *
+ * @author Sean Mullan
+ * @author JSR 105 Expert Group
+ * @since 1.6
+ * @see XMLSignatureFactory#unmarshalXMLSignature(XMLValidateContext)
+ */
+public class DOMValidateContext implements XMLValidateContext {
+    /**
+     * Creates a <code>DOMValidateContext</code> containing the specified key
+     * and node. The validating key will be stored in a
+     * {@link KeySelector#singletonKeySelector singleton KeySelector} that
+     * is returned when the {@link #getKeySelector getKeySelector}
+     * method is called.
+     *
+     * @param validatingKey the validating key
+     * @param node the node
+     * @throws NullPointerException if <code>validatingKey</code> or
+     *    <code>node</code> is <code>null</code>
+     */
+    public DOMValidateContext(Key validatingKey, Node node) {
+    }
+}


### PR DESCRIPTION
SAML (Security Assertion Markup Language) is an XML-based markup language for exchanging  authentication and authorization data between parties, in particular, between an identity provider and a service provider. It is used for security assertions, which are statements that service providers use to make access-control decisions. SAML response messages consist of issuer, assertion (subject, conditions, and statements), signing key, and signature.

If SAML token does not contain any signature, no protection of integrity or authenticity is provided. Since no digital signature for the token is required, an attacker can generate tokens containing arbitrary identities of other users.

Java applications use the JAXB (Java Architecture for XML Binding) API for unmarshalling (reading) XML instance documents into Java content trees, and then marshalling (writing) Java content trees back into XML instance documents. The Java XML Digital Signature APIs are specified in JSR-105 and are implemented in the <code>javax.xml.crypto</code> package, which are used to verify signature of SAML XML documents. 

The query detects missing signature check against SAML assertion XML documents. Please consider to merge the PR. Thanks.