### PR TITLE
C#: Improve join-order in `defaultDelegateConversion`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Conversion.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Conversion.qll
@@ -552,11 +552,16 @@ private predicate defaultDynamicConversion(Type fromType, Type toType) {
   fromType instanceof RefType and toType instanceof DynamicType
 }
 
+pragma[noinline]
+private predicate systemDelegateBaseType(RefType t) {
+  t = any(SystemDelegateClass c).getABaseType*()
+}
+
 // This is a deliberate, small cartesian product, so we have manually lifted it to force the
 // evaluator to evaluate it in its entirety, rather than trying to optimize it in context.
 pragma[noinline]
 private predicate defaultDelegateConversion(RefType fromType, RefType toType) {
-  fromType instanceof DelegateType and toType = any(SystemDelegateClass c).getABaseType*()
+  fromType instanceof DelegateType and systemDelegateBaseType(toType)
 }
 
 private predicate convRefTypeRefType(RefType fromType, RefType toType) {


### PR DESCRIPTION
Before
```
[2021-10-22 09:16:49] (137s) Tuple counts for Conversion::defaultDelegateConversion#fb/2@58b507 after 27.6s:
                      1        ~0%     {1} r1 = CONSTANT(unique int)[20]
                      130264   ~0%     {1} r2 = JOIN r1 WITH types_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'fromType'
                      94311136 ~0%     {3} r3 = JOIN r2 WITH System::SystemClass#f CARTESIAN PRODUCT OUTPUT Rhs.0, "Delegate", Lhs.0 'fromType'
                      
                      130264   ~3%     {2} r4 = JOIN r3 WITH Element::NamedElement::getName_dispred#ff@staged_ext ON FIRST 2 OUTPUT Lhs.2 'fromType', Lhs.0 'toType'
                      
                      130264   ~3%     {2} r5 = JOIN r3 WITH Element::NamedElement::getName_dispred#ff@staged_ext ON FIRST 2 OUTPUT Lhs.0 'toType', Lhs.2 'fromType'
                      390792   ~0%     {2} r6 = JOIN r5 WITH #Type::ValueOrRefType::getABaseType_dispredPlus#bf ON FIRST 1 OUTPUT Lhs.1 'fromType', Rhs.1 'toType'
                      
                      521056   ~0%     {2} r7 = r4 UNION r6
                                       return r7
```

After
```
[2021-10-22 10:10:09] (0s) Tuple counts for Conversion::systemDelegateBaseType#b/1@c77e87 after 0ms:
                      3 ~0%     {1} r1 = JOIN m##Type::ValueOrRefType::getABaseType_dispredPlus#bf#shared WITH #Type::ValueOrRefType::getABaseType_dispredPlus#bf ON FIRST 1 OUTPUT Rhs.1 't'
                      
                      4 ~0%     {1} r2 = m##Type::ValueOrRefType::getABaseType_dispredPlus#bf#shared UNION r1
                                return r2
[2021-10-22 10:10:09] (0s) Starting to evaluate predicate Conversion::defaultArrayConversion#fb/2@e56f40
[2021-10-22 10:10:09] (0s) Registering Conversion::systemDelegateBaseType#b/1@c77e87 + [] with content 598f0cls835ro797fg9coikrqne
[2021-10-22 10:10:09] (0s)  >>> Created relation Conversion::systemDelegateBaseType#b/1@c77e87 with 4 rows.
[2021-10-22 10:10:09] (0s) Starting to evaluate predicate Conversion::defaultDelegateConversion#fb/2@772ce7
[2021-10-22 10:10:09] (0s) Tuple counts for Conversion::defaultDelegateConversion#fb/2@772ce7 after 69ms:
                      1      ~0%     {1} r1 = CONSTANT(unique int)[20]
                      130264 ~0%     {1} r2 = JOIN r1 WITH types_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'fromType'
                      521056 ~0%     {2} r3 = JOIN r2 WITH Conversion::systemDelegateBaseType#b CARTESIAN PRODUCT OUTPUT Lhs.0 'fromType', Rhs.0
                                     return r3
```