### PR TITLE
Python: Add missing `pragma[noinline]`

### DIFF
--- a/python/ql/lib/semmle/python/types/FunctionObject.qll
+++ b/python/ql/lib/semmle/python/types/FunctionObject.qll
@@ -183,6 +183,7 @@ class PyFunctionObject extends FunctionObject {
   }
 
   /** Factored out to help join ordering */
+  pragma[noinline]
   private predicate implicitlyReturns(Object none_, ClassObject noneType) {
     noneType = theNoneType() and
     not this.getFunction().isGenerator() and


### PR DESCRIPTION
Revealed by internal QL-for-QL query. 

I did a performance test (using the query suite for LGTM), but it doesn't look like it has a major impact. (I did not check whether the predicate had been inlined or not).