### PR TITLE
CPP: Add query for CWE-243 Creation of chroot Jail Without Changing Working Directory

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.cpp
@@ -1,0 +1,24 @@
+...
+  chroot("/myFold/myTmp"); // BAD
+...
+  chdir("/myFold/myTmp"); // BAD
+...
+  int fd = open("/myFold/myTmp", O_RDONLY | O_DIRECTORY);
+  fchdir(fd); // BAD
+...
+  if (chdir("/myFold/myTmp") == -1) {
+    exit(-1);
+  }
+  if (chroot("/myFold/myTmp") == -1) {  // GOOD
+    exit(-1);
+  }
+...
+  if (chdir("/myFold/myTmp") == -1) { // GOOD
+    exit(-1);
+  }
+...
+  int fd = open("/myFold/myTmp", O_RDONLY | O_DIRECTORY);
+  if(fchdir(fd) == -1) { // GOOD
+    exit(-1);
+  }
+...

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.qhelp
@@ -1,0 +1,22 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Working with changing directories, without checking the return value or pinning the directory, may not be safe. Requires the attention of developers.</p>
+
+</recommendation>
+<example>
+<p>The following example demonstrates erroneous and corrected work with changing working directories.</p>
+<sample src="IncorrectChangingWorkingDirectory.cpp" />
+
+</example>
+<references>
+
+<li>
+  CERT C Coding Standard:
+  <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS05-C.+Limit+access+to+files+by+creating+a+jail">POS05-C. Limit access to files by creating a jail</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.qhelp
@@ -15,7 +15,7 @@
 
 <li>
   CERT C Coding Standard:
-  <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS05-C.+Limit+access+to+files+by+creating+a+jail">POS05-C. Limit access to files by creating a jail</a>.
+  <a href="https://wiki.sei.cmu.edu/confluence/display/c/POS05-C.+Limit+access+to+files+by+creating+a+jail">POS05-C. Limit access to files by creating a jail.</a>
 </li>
 
 </references>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.qhelp
@@ -5,7 +5,8 @@
 <overview>
 <p>Working with changing directories, without checking the return value or pinning the directory, may not be safe. Requires the attention of developers.</p>
 
-</recommendation>
+</overview>
+
 <example>
 <p>The following example demonstrates erroneous and corrected work with changing working directories.</p>
 <sample src="IncorrectChangingWorkingDirectory.cpp" />

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -50,6 +50,7 @@ where
   fc.getTarget().hasGlobalOrStdName("chroot") and
   not inExistsChdir(fc) and
   not outExistsChdir(fc) and
+  // in this section I want to exclude calls to functions containing chroot that have a direct path to chdir, or to a function containing chdir
   exists(FunctionCall fctmp |
     fc.getEnclosingStmt().getParentStmt*() = fctmp.getTarget().getEntryPoint().getChildStmt*() and
     not inExistsChdir(fctmp) and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -1,0 +1,70 @@
+/**
+ * @name Find work with changing working directories, with security errors.
+ * @description Not validating the return value or pinning the directory can be unsafe.
+ * @kind problem
+ * @id cpp/work-with-changing-working-directories
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-243
+ *       external/cwe/cwe-252
+ */
+
+import cpp
+
+/** Holds if a `fc` function call is available before or before a `chdir` function call. */
+predicate inExistsChdir(FunctionCall fcp) {
+  exists(FunctionCall fctmp |
+    (
+      fctmp.getTarget().hasGlobalOrStdName("chdir") or
+      fctmp.getTarget().hasGlobalOrStdName("fchdir")
+    ) and
+    (
+      fctmp.getASuccessor*() = fcp or
+      fcp.getASuccessor*() = fctmp
+    )
+  )
+}
+
+/** Holds if a `fc` function call is available before or before a function call containing a `chdir` call. */
+predicate outExistsChdir(FunctionCall fcp) {
+  exists(FunctionCall fctmp |
+    exists(FunctionCall fctmp2 |
+      (
+        fctmp2.getTarget().hasGlobalOrStdName("chdir") or
+        fctmp2.getTarget().hasGlobalOrStdName("fchdir")
+      ) and
+      fctmp2.getEnclosingStmt().getParentStmt*() = fctmp.getTarget().getEntryPoint().getChildStmt*()
+    ) and
+    (
+      fctmp.getASuccessor*() = fcp or
+      fcp.getASuccessor*() = fctmp
+    )
+  )
+}
+
+from FunctionCall fc, string msg
+where
+  fc.getTarget().hasGlobalOrStdName("chroot") and
+  not inExistsChdir(fc) and
+  not outExistsChdir(fc) and
+  exists(FunctionCall fctmp |
+    fc.getEnclosingStmt().getParentStmt*() = fctmp.getTarget().getEntryPoint().getChildStmt*() and
+    not inExistsChdir(fctmp) and
+    not outExistsChdir(fctmp)
+  ) and
+  msg = "Creation of chroot Jail Without Changing Working Directory out"
+  or
+  (
+    fc.getTarget().hasGlobalOrStdName("chdir") or
+    fc.getTarget().hasGlobalOrStdName("fchdir")
+  ) and
+  not exists(ConditionalStmt cotmp | cotmp.getControllingExpr().getAChild*() = fc) and
+  not exists(Loop lptmp | lptmp.getCondition().getAChild*() = fc) and
+  not exists(ReturnStmt rttmp | rttmp.getExpr().getAChild*() = fc) and
+  not exists(Assignment astmp | astmp.getAChild*() = fc) and
+  not exists(Initializer ittmp | ittmp.getExpr().getAChild*() = fc) and
+  not fc.isInMacroExpansion() and
+  msg = fc.getTarget().getName() + " unchecked return value."
+select fc, msg

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -36,6 +36,7 @@ predicate outExistsChdir(FunctionCall fcp) {
         fctmp2.getTarget().hasGlobalOrStdName("chdir") or
         fctmp2.getTarget().hasGlobalOrStdName("fchdir")
       ) and
+      // we are looking for a call containing calls chdir and fchdir
       fctmp2.getEnclosingStmt().getParentStmt*() = fctmp.getTarget().getEntryPoint().getChildStmt*()
     ) and
     (

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -13,7 +13,7 @@
 
 import cpp
 
-/** Holds if a `fc` function call is available before or before a `chdir` function call. */
+/** Holds if a `fc` function call is available before or after a `chdir` function call. */
 predicate inExistsChdir(FunctionCall fcp) {
   exists(FunctionCall fctmp |
     (
@@ -54,7 +54,7 @@ where
     not inExistsChdir(fctmp) and
     not outExistsChdir(fctmp)
   ) and
-  msg = "Creation of chroot Jail Without Changing Working Directory out"
+  msg = "Creation of 'chroot' jail without changing the working directory"
   or
   (
     fc.getTarget().hasGlobalOrStdName("chdir") or
@@ -65,6 +65,6 @@ where
   not exists(ReturnStmt rttmp | rttmp.getExpr().getAChild*() = fc) and
   not exists(Assignment astmp | astmp.getAChild*() = fc) and
   not exists(Initializer ittmp | ittmp.getExpr().getAChild*() = fc) and
-  not fc.isInMacroExpansion() and
-  msg = fc.getTarget().getName() + " unchecked return value."
+  not isFromMacroDefinition(fc)
+  msg = "Unchecked return value for call to '" + fc.getTarget().getName() + "'."
 select fc, msg

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -12,6 +12,7 @@
  */
 
 import cpp
+import semmle.code.cpp.commons.Exclusions
 
 /** Holds if a `fc` function call is available before or after a `chdir` function call. */
 predicate inExistsChdir(FunctionCall fcp) {
@@ -27,7 +28,7 @@ predicate inExistsChdir(FunctionCall fcp) {
   )
 }
 
-/** Holds if a `fc` function call is available before or before a function call containing a `chdir` call. */
+/** Holds if a `fc` function call is available before or after a function call containing a `chdir` call. */
 predicate outExistsChdir(FunctionCall fcp) {
   exists(FunctionCall fctmp |
     exists(FunctionCall fctmp2 |

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -63,7 +63,7 @@ where
     fc.getTarget().hasGlobalOrStdName("chdir") or
     fc.getTarget().hasGlobalOrStdName("fchdir")
   ) and
-  fc instanceof ExprInVoidContext
+  fc instanceof ExprInVoidContext and
   not isFromMacroDefinition(fc) and
   msg = "Unchecked return value for call to '" + fc.getTarget().getName() + "'."
 select fc, msg

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -68,6 +68,6 @@ where
   not exists(ReturnStmt rttmp | rttmp.getExpr().getAChild*() = fc) and
   not exists(Assignment astmp | astmp.getAChild*() = fc) and
   not exists(Initializer ittmp | ittmp.getExpr().getAChild*() = fc) and
-  not isFromMacroDefinition(fc)
+  not isFromMacroDefinition(fc) and
   msg = "Unchecked return value for call to '" + fc.getTarget().getName() + "'."
 select fc, msg

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -22,8 +22,8 @@ predicate inExistsChdir(FunctionCall fcp) {
       fctmp.getTarget().hasGlobalOrStdName("fchdir")
     ) and
     (
-      fctmp.getASuccessor*() = fcp or
-      fcp.getASuccessor*() = fctmp
+      fcp.getBasicBlock().getASuccessor*() = fctmp.getBasicBlock() or
+      fctmp.getBasicBlock().getASuccessor*() = fcp.getBasicBlock()
     )
   )
 }
@@ -40,8 +40,8 @@ predicate outExistsChdir(FunctionCall fcp) {
       fctmp2.getEnclosingStmt().getParentStmt*() = fctmp.getTarget().getEntryPoint().getChildStmt*()
     ) and
     (
-      fctmp.getASuccessor*() = fcp or
-      fcp.getASuccessor*() = fctmp
+      fcp.getBasicBlock().getASuccessor*() = fctmp.getBasicBlock() or
+      fctmp.getBasicBlock().getASuccessor*() = fcp.getBasicBlock()
     )
   )
 }

--- a/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql
@@ -63,11 +63,7 @@ where
     fc.getTarget().hasGlobalOrStdName("chdir") or
     fc.getTarget().hasGlobalOrStdName("fchdir")
   ) and
-  not exists(ConditionalStmt cotmp | cotmp.getControllingExpr().getAChild*() = fc) and
-  not exists(Loop lptmp | lptmp.getCondition().getAChild*() = fc) and
-  not exists(ReturnStmt rttmp | rttmp.getExpr().getAChild*() = fc) and
-  not exists(Assignment astmp | astmp.getAChild*() = fc) and
-  not exists(Initializer ittmp | ittmp.getExpr().getAChild*() = fc) and
+  fc instanceof ExprInVoidContext
   not isFromMacroDefinition(fc) and
   msg = "Unchecked return value for call to '" + fc.getTarget().getName() + "'."
 select fc, msg

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/IncorrectChangingWorkingDirectory.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/IncorrectChangingWorkingDirectory.expected
@@ -1,0 +1,2 @@
+| test.cpp:12:7:12:12 | call to chroot | Creation of chroot Jail Without Changing Working Directory out |
+| test.cpp:29:3:29:7 | call to chdir | chdir unchecked return value. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/IncorrectChangingWorkingDirectory.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/IncorrectChangingWorkingDirectory.expected
@@ -1,2 +1,2 @@
-| test.cpp:12:7:12:12 | call to chroot | Creation of chroot Jail Without Changing Working Directory out |
-| test.cpp:29:3:29:7 | call to chdir | chdir unchecked return value. |
+| test.cpp:12:7:12:12 | call to chroot | Creation of 'chroot' jail without changing the working directory |
+| test.cpp:29:3:29:7 | call to chdir | Unchecked return value for call to 'chdir'. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/IncorrectChangingWorkingDirectory.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/IncorrectChangingWorkingDirectory.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-243/IncorrectChangingWorkingDirectory.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-243/semmle/tests/test.cpp
@@ -1,0 +1,46 @@
+typedef int FILE;
+#define size_t int
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+FILE *fopen(const char *filename, const char *mode);
+int fread(char *buf, int size, int count, FILE *fp);
+int fclose(FILE *fp);
+int chroot(char *path);
+int chdir(char *path);
+void exit(int status);
+
+int funTest1(){
+  if (chroot("/myFold/myTmp") == -1) {  // BAD
+    exit(-1);
+  }
+  return 0;
+}
+
+int funTest2(){  
+  if (chdir("/myFold/myTmp") == -1) { // GOOD
+    exit(-1);
+  }
+  if (chroot("/myFold/myTmp") == -1) {  // GOOD
+    exit(-1);
+  }
+  return 0;
+}
+
+int funTest3(){  
+  chdir("/myFold/myTmp"); // BAD
+  return 0;
+}
+int main(int argc, char *argv[])
+{
+  if(argc = 0) {
+    funTest3();
+    return 2;
+  }
+  if(argc = 1)
+    funTest1();
+  else
+    funTest2();
+  FILE *fp = fopen(argv[1], "w");
+  fwrite("12345", 5, 1, fp);
+  fclose(fp);
+  return 0;
+}


### PR DESCRIPTION
The request looks for situations of incorrect work with the setting of the working directory. first of all, this is the lack of checking the return value by the set function, secondly, it is the lack of setting after using the chroot call.

CVE-2008-5110

links to real work results, I will add later. I am currently working on them with developers.