### PR TITLE
Add Ruby to generate-code-scanning-query-list.py and make the script faster

### DIFF
--- a/misc/scripts/generate-code-scanning-query-list.py
+++ b/misc/scripts/generate-code-scanning-query-list.py
@@ -28,7 +28,7 @@ arguments = parser.parse_args()
 assert hasattr(arguments, "ignore_missing_query_packs")
 
 # Define which languages and query packs to consider
-languages = [ "cpp", "csharp", "go", "java", "javascript", "python"]
+languages = [ "cpp", "csharp", "go", "java", "javascript", "python", "ruby"]
 packs = [ "code-scanning", "security-and-quality", "security-extended" ]
 
 class CodeQL:


### PR DESCRIPTION
The script used to take 20 minutes to run, which should be reduced to less that 1 minute using `codeql execute cli-server`

For easy reviewing view diff ignoring white space: https://github.com/github/codeql/pull/6952/files?w=1

@RasmusWL @turbo @sj 