### PR TITLE
JS: [Internal only] Rename ATM query pack for consistency with other packs

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -1,4 +1,4 @@
-name: codeql/javascript-experimental-atm-src
+name: codeql/javascript-experimental-atm-queries
 language: javascript
 version: 0.0.0
 suites: codeql-suites


### PR DESCRIPTION
This PR renames the ATM query pack from `codeql/javascript-experimental-atm-src` to `codeql/javascript-experimental-atm-queries` for consistency with other query packs.