### PR TITLE
C#: Fix join order in `inDefDominanceFrontier`

### DIFF
--- a/csharp/ql/lib/semmle/code/cil/internal/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/cil/internal/SsaImplCommon.qll
@@ -156,6 +156,7 @@ private predicate dominatesPredecessor(BasicBlock bb1, BasicBlock bb2) {
 }
 
 /** Holds if `df` is in the dominance frontier of `bb`. */
+pragma[noinline]
 private predicate inDominanceFrontier(BasicBlock bb, BasicBlock df) {
   dominatesPredecessor(bb, df) and
   not strictlyDominates(bb, df)
@@ -169,7 +170,7 @@ pragma[noinline]
 private predicate inDefDominanceFrontier(BasicBlock bb, SourceVariable v) {
   exists(BasicBlock defbb, Definition def |
     def.definesAt(v, defbb, _) and
-    inDominanceFrontier(pragma[only_bind_into](defbb), bb)
+    inDominanceFrontier(defbb, bb)
   )
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/pressa/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/pressa/SsaImplCommon.qll
@@ -156,6 +156,7 @@ private predicate dominatesPredecessor(BasicBlock bb1, BasicBlock bb2) {
 }
 
 /** Holds if `df` is in the dominance frontier of `bb`. */
+pragma[noinline]
 private predicate inDominanceFrontier(BasicBlock bb, BasicBlock df) {
   dominatesPredecessor(bb, df) and
   not strictlyDominates(bb, df)
@@ -169,7 +170,7 @@ pragma[noinline]
 private predicate inDefDominanceFrontier(BasicBlock bb, SourceVariable v) {
   exists(BasicBlock defbb, Definition def |
     def.definesAt(v, defbb, _) and
-    inDominanceFrontier(pragma[only_bind_into](defbb), bb)
+    inDominanceFrontier(defbb, bb)
   )
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImplCommon.qll
@@ -156,6 +156,7 @@ private predicate dominatesPredecessor(BasicBlock bb1, BasicBlock bb2) {
 }
 
 /** Holds if `df` is in the dominance frontier of `bb`. */
+pragma[noinline]
 private predicate inDominanceFrontier(BasicBlock bb, BasicBlock df) {
   dominatesPredecessor(bb, df) and
   not strictlyDominates(bb, df)
@@ -169,7 +170,7 @@ pragma[noinline]
 private predicate inDefDominanceFrontier(BasicBlock bb, SourceVariable v) {
   exists(BasicBlock defbb, Definition def |
     def.definesAt(v, defbb, _) and
-    inDominanceFrontier(pragma[only_bind_into](defbb), bb)
+    inDominanceFrontier(defbb, bb)
   )
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/basessa/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/basessa/SsaImplCommon.qll
@@ -156,6 +156,7 @@ private predicate dominatesPredecessor(BasicBlock bb1, BasicBlock bb2) {
 }
 
 /** Holds if `df` is in the dominance frontier of `bb`. */
+pragma[noinline]
 private predicate inDominanceFrontier(BasicBlock bb, BasicBlock df) {
   dominatesPredecessor(bb, df) and
   not strictlyDominates(bb, df)
@@ -169,7 +170,7 @@ pragma[noinline]
 private predicate inDefDominanceFrontier(BasicBlock bb, SourceVariable v) {
   exists(BasicBlock defbb, Definition def |
     def.definesAt(v, defbb, _) and
-    inDominanceFrontier(pragma[only_bind_into](defbb), bb)
+    inDominanceFrontier(defbb, bb)
   )
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImplCommon.qll
@@ -156,6 +156,7 @@ private predicate dominatesPredecessor(BasicBlock bb1, BasicBlock bb2) {
 }
 
 /** Holds if `df` is in the dominance frontier of `bb`. */
+pragma[noinline]
 private predicate inDominanceFrontier(BasicBlock bb, BasicBlock df) {
   dominatesPredecessor(bb, df) and
   not strictlyDominates(bb, df)
@@ -169,7 +170,7 @@ pragma[noinline]
 private predicate inDefDominanceFrontier(BasicBlock bb, SourceVariable v) {
   exists(BasicBlock defbb, Definition def |
     def.definesAt(v, defbb, _) and
-    inDominanceFrontier(pragma[only_bind_into](defbb), bb)
+    inDominanceFrontier(defbb, bb)
   )
 }
 


### PR DESCRIPTION
While playing around with using the shared SSA library for the C++ IR, I noticed this bad join (in the standard order only, I think):

Before:
```
SsaImplCommon::inDefDominanceFrontier#ff/2@i27#149b1w after 42.6s:
  14178     ~0%     {2} r1 = SCAN SsaImplCommon::Definition::definesAt_dispred#ffff#prev_delta OUTPUT In.2, In.1 'v'
  210081544 ~0%     {3} r2 = JOIN r1 WITH SsaImplCommon::dominatesPredecessor#ff ON FIRST 1 OUTPUT Lhs.1 'v', Lhs.0, Rhs.1 'bb'
  18408     ~2%     {3} r3 = r2 AND NOT #SsaImplSpecific::getImmediateBasicBlockDominatorPlus#ff(Lhs.2 'bb', Lhs.1)
  18408     ~0%     {2} r4 = SCAN r3 OUTPUT In.0 'v', In.2 'bb'
  8850      ~2%     {2} r5 = r4 AND NOT SsaImplCommon::inDefDominanceFrontier#ff#prev(Lhs.1 'bb', Lhs.0 'v')
  8850      ~1%     {2} r6 = SCAN r5 OUTPUT In.1 'bb', In.0 'v'
                    return r6
```

After:
```
Tuple counts for SsaImplCommon::inDefDominanceFrontier#ff#join_rhs/2@77d309 after 1.2s:
  389222  ~0%     {2} r1 = SsaImplCommon::dominatesPredecessor#ff AND NOT #SsaImplSpecific::getImmediateBasicBlockDominatorPlus#ff(Lhs.1 'arg1', Lhs.0 'arg0')
                  return r1
...
Tuple counts for SsaImplCommon::inDefDominanceFrontier#ff/2@i27#149b1w after 7ms:
  14178  ~1%     {2} r1 = SCAN SsaImplCommon::Definition::definesAt_dispred#ffff#prev_delta OUTPUT In.2, In.1 'v'
  18408  ~0%     {2} r2 = JOIN r1 WITH SsaImplCommon::inDefDominanceFrontier#ff#join_rhs ON FIRST 1 OUTPUT Rhs.1 'bb', Lhs.1 'v'
  8850   ~0%     {2} r3 = r2 AND NOT SsaImplCommon::inDefDominanceFrontier#ff#prev(Lhs.0 'bb', Lhs.1 'v')
                  return r3
```