### PR TITLE
Android: Add ExplicitIntentSanitizer and allowIntentExtrasImplicitRead

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidFileIntentSource.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidFileIntentSource.qll
@@ -48,11 +48,7 @@ class GetContentIntentConfig extends TaintTracking2::Configuration {
     // Allow the wrapped intent created by Intent.getChooser to be consumed
     // by at the sink:
     isSink(node) and
-    (
-      content.(DataFlow::SyntheticFieldContent).getField() = "android.content.Intent.extras"
-      or
-      content instanceof DataFlow::MapValueContent
-    )
+    allowIntentExtrasImplicitRead(node, content)
   }
 }
 


### PR DESCRIPTION
This PR adds some (hopefully quite reusable) classes related to explicit Intent sanitization (which is useful for queries working with implicit Intents, like #6779 and #6963) and Intent extras implicit read steps (also useful for several queries, including #6779).

### Note

The new implicit read step isn't used in `AndroidSensitiveCommunicationQuery.qll` because its scope is more general than only reading extras from an Intent (it aims to read any attribute of any object in those extras too, as is shown in the test case `sendBroadcast4` in `SensitiveCommunication.java`).