### PR TITLE
Make fetch-codeql/action.yml use the `latest` tag

### DIFF
--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -6,8 +6,7 @@ runs:
     - name: Fetch CodeQL
       shell: bash
       run: |
-        LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | grep -v beta | sort --version-sort | tail -1)
-        gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-linux64.zip "$LATEST"
+        curl -L https://github.com/github/codeql-cli-binaries/releases/latest/download/codeql-linux64.zip -O
         unzip -q codeql-linux64.zip
         echo "${{ github.workspace }}/codeql" >> $GITHUB_PATH
       env:


### PR DESCRIPTION
@aibaars this is subtly different since it uses the `latest` tag rather than the custom sorting.
I only made this PR because I found the `cut -f 1 | grep -v beta | sort --version-sort | tail -1` bit to be a bit too brittle for my taste.