### PR TITLE
Java: CWE-266 - Query to detect Intent URI Permission Manipulation in Android applications

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -176,6 +176,8 @@ private predicate localAdditionalTaintExprStep(Expr src, Expr sink) {
   serializationStep(src, sink)
   or
   formatStep(src, sink)
+  or
+  bitwiseStep(src, sink)
 }
 
 /**
@@ -524,6 +526,9 @@ private class FormatterCallable extends TaintPreservingCallable {
     src = [0 .. this.getNumberOfParameters()]
   }
 }
+
+/** Holds if taint may flow from the operand of a bitwise expression to its result. */
+private predicate bitwiseStep(Expr src, BitwiseExpr sink) { sink.(BinaryExpr).getAnOperand() = src }
 
 private import StringBuilderVarModule
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -176,8 +176,6 @@ private predicate localAdditionalTaintExprStep(Expr src, Expr sink) {
   serializationStep(src, sink)
   or
   formatStep(src, sink)
-  or
-  bitwiseStep(src, sink)
 }
 
 /**
@@ -526,9 +524,6 @@ private class FormatterCallable extends TaintPreservingCallable {
     src = [0 .. this.getNumberOfParameters()]
   }
 }
-
-/** Holds if taint may flow from the operand of a bitwise expression to its result. */
-private predicate bitwiseStep(Expr src, BitwiseExpr sink) { sink.(BinaryExpr).getAnOperand() = src }
 
 private import StringBuilderVarModule
 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Android.qll
@@ -67,6 +67,14 @@ class AndroidActivity extends ExportableAndroidComponent {
   AndroidActivity() { getASuperTypeStar(this).hasQualifiedName("android.app", "Activity") }
 }
 
+/** The method `setResult` of the class `android.app.Activity`. */
+class ActivitySetResultMethod extends Method {
+  ActivitySetResultMethod() {
+    this.getDeclaringType().hasQualifiedName("android.app", "Activity") and
+    this.hasName("setResult")
+  }
+}
+
 /** An Android service. */
 class AndroidService extends ExportableAndroidComponent {
   AndroidService() { getASuperTypeStar(this).hasQualifiedName("android.app", "Service") }

--- a/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Intent.qll
@@ -148,6 +148,31 @@ predicate allowIntentExtrasImplicitRead(DataFlow::Node node, DataFlow::Content c
   )
 }
 
+/**
+ * The fields to grant URI permissions of the class `android.content.Intent`:
+ *
+ * - `Intent.FLAG_GRANT_READ_URI_PERMISSION`
+ * - `Intent.FLAG_GRANT_WRITE_URI_PERMISSION`
+ * - `Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION`
+ * - `Intent.FLAG_GRANT_PREFIX_URI_PERMISSION`
+ */
+class GrantUriPermissionFlag extends Field {
+  GrantUriPermissionFlag() {
+    this.getDeclaringType() instanceof TypeIntent and
+    this.getName().matches("FLAG_GRANT_%_URI_PERMISSION")
+  }
+}
+
+/** The field `Intent.FLAG_GRANT_READ_URI_PERMISSION`. */
+class GrantReadUriPermissionFlag extends GrantUriPermissionFlag {
+  GrantReadUriPermissionFlag() { this.hasName("FLAG_GRANT_READ_URI_PERMISSION") }
+}
+
+/** The field `Intent.FLAG_GRANT_WRITE_URI_PERMISSION`. */
+class GrantWriteUriPermissionFlag extends GrantUriPermissionFlag {
+  GrantWriteUriPermissionFlag() { this.hasName("FLAG_GRANT_WRITE_URI_PERMISSION") }
+}
+
 private class IntentBundleFlowSteps extends SummaryModelCsv {
   override predicate row(string row) {
     row =

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
@@ -51,9 +51,6 @@ private class IntentFlagsOrDataChangedSanitizer extends IntentUriPermissionManip
       TaintTracking::localExprTaint(any(GrantWriteUriPermissionFlag f).getAnAccess(),
         ma.getArgument(0))
       or
-      ma.getMethod() = m and
-      m.getDeclaringType() instanceof TypeIntent and
-      this.asExpr() = ma.getQualifier() and
       m.hasName("setFlags") and
       not TaintTracking::localExprTaint(any(GrantUriPermissionFlag f).getAnAccess(),
         ma.getArgument(0))

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
@@ -72,6 +72,8 @@ private class IntentFlagsOrDataCheckedGuard extends IntentUriPermissionManipulat
 
   override predicate checks(Expr e, boolean branch) {
     exists(MethodAccess ma, Method m |
+      // This checks `intent` when the result of an `intent.getFlags` or `intent.getData` call flows to `condition`
+      // (i.e., that result is equality-tested)
       ma.getMethod() = m and
       m.getDeclaringType() instanceof TypeIntent and
       m.hasName(["getFlags", "getData"]) and

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
@@ -1,0 +1,101 @@
+/**
+ * Provides classes and predicates to reason about Intent URI permission manipulation
+ * vulnerabilities on Android.
+ */
+
+import java
+private import semmle.code.java.dataflow.DataFlow
+private import semmle.code.java.dataflow.TaintTracking
+private import semmle.code.java.frameworks.android.Android
+private import semmle.code.java.frameworks.android.Intent
+
+/**
+ * A sink for Intent URI permission manipulation vulnerabilities in Android,
+ * that is, method calls that return an Intent as the result of an Activity.
+ */
+abstract class IntentUriPermissionManipulationSink extends DataFlow::Node { }
+
+/**
+ * A sanitizer that makes sure that an Intent is safe to be returned to another Activity.
+ *
+ * Usually, this is done by setting the Intent's data URI and/or its flags to safe values.
+ */
+abstract class IntentUriPermissionManipulationSanitizer extends DataFlow::Node { }
+
+/**
+ * A guard that makes sure that an Intent is safe to be returned to another Activity.
+ *
+ * Usually, this is done by checking that the Intent's data URI and/or its flags contain
+ * expected values.
+ */
+abstract class IntentUriPermissionManipulationGuard extends DataFlow::BarrierGuard { }
+
+private class DefaultIntentUriPermissionManipulationSink extends IntentUriPermissionManipulationSink {
+  DefaultIntentUriPermissionManipulationSink() {
+    exists(MethodAccess ma | ma.getMethod() instanceof ActivitySetResultMethod |
+      ma.getArgument(1) = this.asExpr()
+    )
+  }
+}
+
+private class IntentFlagsOrDataChangedSanitizer extends IntentUriPermissionManipulationSanitizer {
+  IntentFlagsOrDataChangedSanitizer() {
+    exists(MethodAccess ma, Method m |
+      ma.getMethod() = m and
+      m.getDeclaringType() instanceof TypeIntent and
+      this.asExpr() = ma.getQualifier()
+    |
+      m.hasName("removeFlags") and
+      TaintTracking::localExprTaint(any(GrantReadUriPermissionFlag f).getAnAccess(),
+        ma.getArgument(0)) and
+      TaintTracking::localExprTaint(any(GrantWriteUriPermissionFlag f).getAnAccess(),
+        ma.getArgument(0))
+      or
+      ma.getMethod() = m and
+      m.getDeclaringType() instanceof TypeIntent and
+      this.asExpr() = ma.getQualifier() and
+      m.hasName("setFlags") and
+      not TaintTracking::localExprTaint(any(GrantUriPermissionFlag f).getAnAccess(),
+        ma.getArgument(0))
+      or
+      m.hasName("setData")
+    )
+  }
+}
+
+private class IntentFlagsOrDataCheckedGuard extends IntentUriPermissionManipulationGuard {
+  Expr condition;
+
+  IntentFlagsOrDataCheckedGuard() {
+    this.(MethodAccess).getMethod() instanceof EqualsMethod and
+    condition = [this.(MethodAccess).getArgument(0), this.(MethodAccess).getQualifier()]
+    or
+    condition = this.(EqualityTest).getAnOperand().(AndBitwiseExpr)
+  }
+
+  override predicate checks(Expr e, boolean branch) {
+    exists(MethodAccess ma, Method m |
+      ma.getMethod() = m and
+      m.getDeclaringType() instanceof TypeIntent and
+      m.hasName(["getFlags", "getData"]) and
+      TaintTracking::localExprTaint(ma, condition) and
+      ma.getQualifier() = e
+    |
+      bitwiseCheck(branch)
+      or
+      this.(MethodAccess).getMethod() instanceof EqualsMethod and branch = true
+    )
+  }
+
+  /**
+   * Holds if `this` is a bitwise check. `branch` is `true` when the expected value is `0`
+   * and `false` otherwise.
+   */
+  private predicate bitwiseCheck(boolean branch) {
+    exists(CompileTimeConstantExpr operand | operand = this.(EqualityTest).getAnOperand() |
+      if operand.getIntValue() = 0
+      then this.(EqualityTest).polarity() = branch
+      else this.(EqualityTest).polarity().booleanNot() = branch
+    )
+  }
+}

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
@@ -38,6 +38,14 @@ private class DefaultIntentUriPermissionManipulationSink extends IntentUriPermis
   }
 }
 
+/**
+ * Sanitizer that prevents access to arbitrary content providers by modifying the Intent in one of
+ * the following ways:
+ * * Removing the flags `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_WRITE_URI_PERMISSION`.
+ * * Setting the flags to a combination that doesn't include `FLAG_GRANT_READ_URI_PERMISSION` or
+ * `FLAG_GRANT_WRITE_URI_PERMISSION`.
+ * * Replacing the data URI.
+ */
 private class IntentFlagsOrDataChangedSanitizer extends IntentUriPermissionManipulationSanitizer {
   IntentFlagsOrDataChangedSanitizer() {
     exists(MethodAccess ma, Method m |
@@ -60,6 +68,20 @@ private class IntentFlagsOrDataChangedSanitizer extends IntentUriPermissionManip
   }
 }
 
+/**
+ * A guard that checks an Intent's flags or data URI to make sure they are trusted.
+ * It matches the following patterns:
+ *
+ * ```java
+ * if (intent.getData().equals("trustedValue")) {}
+ *
+ * if (intent.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION == 0 &&
+ *      intent.getFlags() & Intent.FLAG_GRANT_WRITE_URI_PERMISSION == 0) {}
+ *
+ * if (intent.getFlags() & Intent.FLAG_GRANT_READ_URI_PERMISSION != 0 ||
+ *      intent.getFlags() & Intent.FLAG_GRANT_WRITE_URI_PERMISSION != 0) {}
+ * ```
+ */
 private class IntentFlagsOrDataCheckedGuard extends IntentUriPermissionManipulationGuard {
   Expr condition;
 

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
@@ -27,4 +27,8 @@ class IntentUriPermissionManipulationConf extends TaintTracking::Configuration {
   override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
     guard instanceof IntentUriPermissionManipulationGuard
   }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    any(IntentUriPermissionManipulationAdditionalTaintStep c).step(node1, node2)
+  }
 }

--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulationQuery.qll
@@ -1,0 +1,30 @@
+/**
+ * Provides taint tracking configurations to be used in queries related to Intent URI permission
+ * manipulation in Android.
+ */
+
+import java
+private import semmle.code.java.dataflow.FlowSources
+private import semmle.code.java.dataflow.DataFlow
+private import IntentUriPermissionManipulation
+
+/**
+ * A taint tracking configuration for user-provided Intents being returned to third party apps.
+ */
+class IntentUriPermissionManipulationConf extends TaintTracking::Configuration {
+  IntentUriPermissionManipulationConf() { this = "UriPermissionManipulationConf" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink instanceof IntentUriPermissionManipulationSink
+  }
+
+  override predicate isSanitizer(DataFlow::Node barrier) {
+    barrier instanceof IntentUriPermissionManipulationSanitizer
+  }
+
+  override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+    guard instanceof IntentUriPermissionManipulationGuard
+  }
+}

--- a/java/ql/lib/semmle/code/xml/AndroidManifest.qll
+++ b/java/ql/lib/semmle/code/xml/AndroidManifest.qll
@@ -75,6 +75,13 @@ class AndroidReceiverXmlElement extends AndroidComponentXmlElement {
 }
 
 /**
+ * An XML attribute with the `android:` prefix.
+ */
+class AndroidXmlAttribute extends XMLAttribute {
+  AndroidXmlAttribute() { this.getNamespace().getPrefix() = "android" }
+}
+
+/**
  * A `<provider>` element in an Android manifest file.
  */
 class AndroidProviderXmlElement extends AndroidComponentXmlElement {
@@ -90,6 +97,14 @@ class AndroidProviderXmlElement extends AndroidComponentXmlElement {
     or
     this.getAnAttribute().(AndroidPermissionXmlAttribute).isWrite() and
     this.getAnAttribute().(AndroidPermissionXmlAttribute).isRead()
+  }
+
+  predicate grantsUriPermissions() {
+    exists(AndroidXmlAttribute attr |
+      this.getAnAttribute() = attr and
+      attr.getName() = "grantUriPermissions" and
+      attr.getValue() = "true"
+    )
   }
 }
 

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.java
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.java
@@ -1,0 +1,25 @@
+public class IntentUriPermissionManipulation extends Activity {
+
+    // BAD: the user-provided Intent is returned as-is
+    public void dangerous() {
+        Intent intent = getIntent();
+        intent.putExtra("result", "resultData");
+        setResult(intent);
+    }
+
+    // GOOD: a new Intent is created and returned
+    public void safe() {
+        Intent intent = new Intent();
+        intent.putExtra("result", "resultData");
+        setResult(intent);
+    }
+
+    // GOOD: the user-provided Intent is sanitized before being returned
+    public void sanitized() {
+        Intent intent = getIntent();
+        intent.putExtra("result", "resultData");
+        intent.removeFlags(
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        setResult(intent);
+    }
+}

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.qhelp
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.qhelp
@@ -6,7 +6,7 @@
 <p>When an Android component expects a result from an Activity, <code>startActivityForResult</code> can be used.
 The started Activity can then use <code>setResult</code> to return the appropriate data to the calling component.</p>
 <p>If an Activity obtains the incoming, user-provided Intent and directly returns it via <code>setResult</code>
-without any checks, the application may be unintentionally giving arbitrary access to its Content Providers, even
+without any checks, the application may be unintentionally giving arbitrary access to its content providers, even
 if they are not exported, as long as they are configured with the attribute <code>android:grantUriPermissions="true"</code>. 
 This happens because the attacker adds the appropriate URI permission flags to the provided Intent, which take effect
 once the Intent is reflected back.</p>

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.qhelp
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.qhelp
@@ -1,0 +1,34 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>When an Android component expects a result from an Activity, <code>startActivityForResult</code> can be used.
+The started Activity can then use <code>setResult</code> to return the appropriate data to the calling component.</p>
+<p>If an Activity obtains the incoming, user-provided Intent and directly returns it via <code>setResult</code>
+without any checks, the application may be unintentionally giving arbitrary access to its Content Providers, even
+if they are not exported, as long as they are configured with the attribute <code>android:grantUriPermissions="true"</code>. 
+This happens because the attacker adds the appropriate URI permission flags to the provided Intent, which take effect
+once the Intent is reflected back.</p>
+</overview>
+
+<recommendation>
+<p>Avoid returning user-provided or untrusted Intents via <code>setResult</code>. Use a new Intent instead.</p>
+<p>If it is required to use the received Intent, make sure that it does not contain URI permission flags, either
+by checking them with <code>Intent.getFlags</code> or removing them with <code>Intent.removeFlags</code>.</p>
+</recommendation>
+
+<example>
+<p>The following sample contains three examples. In the first example, a user-provided Intent is obtained and 
+  directly returned back with <code>setResult</code>, which is dangerous. In the second example, a new Intent
+  is created to safely return the desired data. The third example shows how the obtained Intent can be sanitized
+  by removing dangerous flags before using it to return data to the calling component.
+</p>
+
+<sample src="IntentUriPermissionManipulation.java" />
+</example>
+
+<references>
+<li>Google Help: <a href="https://support.google.com/faqs/answer/9267555?hl=en">Remediation for Intent Redirection Vulnerability</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
@@ -5,6 +5,7 @@
  *              arbitrary Content Providers that are accessible by the vulnerable application.
  * @kind path-problem
  * @problem.severity error
+ * @security-severity 7.8
  * @precision high
  * @id java/android/intent-uri-permission-manipulation
  * @tags security

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Intent URI permission manipulation
+ * @description When an externally provided Intent is returned to an Activity via setResult,
+ *              a malicious application could use this to grant itself permissions to access
+ *              arbitrary Content Providers that are accessible by the vulnerable application.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/android/intent-uri-permission-manipulation
+ * @tags security
+ *       external/cwe/cwe-266
+ *       external/cwe/cwe-926
+ */
+
+import java
+import semmle.code.java.security.IntentUriPermissionManipulationQuery
+import semmle.code.java.dataflow.DataFlow
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink
+where any(IntentUriPermissionManipulationConf c).hasFlowPath(source, sink)
+select sink.getNode(), source, sink,
+  "This Intent can be set with arbitrary flags from $@, " +
+    "and used to give access to internal Content Providers.", source.getNode(), "this user input"

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
@@ -1,7 +1,7 @@
 /**
  * @name Intent URI permission manipulation
- * @description Returning an externally provided Intent via setResult may allow a malicious
- *              application to access arbitrary Content Providers of the vulnerable application.
+ * @description Returning an externally provided Intent via 'setResult' may allow a malicious
+ *              application to access arbitrary content providers of the vulnerable application.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.8
@@ -21,4 +21,4 @@ from DataFlow::PathNode source, DataFlow::PathNode sink
 where any(IntentUriPermissionManipulationConf c).hasFlowPath(source, sink)
 select sink.getNode(), source, sink,
   "This Intent can be set with arbitrary flags from $@, " +
-    "and used to give access to internal Content Providers.", source.getNode(), "this user input"
+    "and used to give access to internal content providers.", source.getNode(), "this user input"

--- a/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
+++ b/java/ql/src/Security/CWE/CWE-266/IntentUriPermissionManipulation.ql
@@ -1,8 +1,7 @@
 /**
  * @name Intent URI permission manipulation
- * @description When an externally provided Intent is returned to an Activity via setResult,
- *              a malicious application could use this to grant itself permissions to access
- *              arbitrary Content Providers that are accessible by the vulnerable application.
+ * @description Returning an externally provided Intent via setResult may allow a malicious
+ *              application to access arbitrary Content Providers of the vulnerable application.
  * @kind path-problem
  * @problem.severity error
  * @security-severity 7.8

--- a/java/ql/src/change-notes/2021-10-27-android-intent-uri-permission-manipulation-query.md
+++ b/java/ql/src/change-notes/2021-10-27-android-intent-uri-permission-manipulation-query.md
@@ -2,5 +2,5 @@
 category: newQuery
 ---
 * A new query "Intent URI permission manipulation" (`java/android/intent-uri-permission-manipulation`) has been added.
-This query finds Android components returning unmodified, received Intents to the calling applications, which
+This query finds Android components that return unmodified, received Intents to the calling applications, which
 can provide unintended access to internal Content Providers of the victim application.

--- a/java/ql/src/change-notes/2021-10-27-android-intent-uri-permission-manipulation-query.md
+++ b/java/ql/src/change-notes/2021-10-27-android-intent-uri-permission-manipulation-query.md
@@ -1,0 +1,6 @@
+---
+category: newQuery
+---
+* A new query "Intent URI permission manipulation" (`java/android/intent-uri-permission-manipulation`) has been added.
+This query finds Android components returning unmodified, received Intents to the calling applications, which
+can provide unintended access to internal Content Providers of the victim application.

--- a/java/ql/src/change-notes/2021-10-27-android-intent-uri-permission-manipulation-query.md
+++ b/java/ql/src/change-notes/2021-10-27-android-intent-uri-permission-manipulation-query.md
@@ -3,4 +3,4 @@ category: newQuery
 ---
 * A new query "Intent URI permission manipulation" (`java/android/intent-uri-permission-manipulation`) has been added.
 This query finds Android components that return unmodified, received Intents to the calling applications, which
-can provide unintended access to internal Content Providers of the victim application.
+can provide unintended access to internal content providers of the victim application.

--- a/java/ql/test/library-tests/frameworks/android/content-provider/Safe.java
+++ b/java/ql/test/library-tests/frameworks/android/content-provider/Safe.java
@@ -11,7 +11,7 @@ import android.os.CancellationSignal;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
 
-// This Content Provider isn't exported, so there shouldn't be any flow
+// This content provider isn't exported, so there shouldn't be any flow
 public class Safe extends ContentProvider {
 
 	void sink(Object o) {}

--- a/java/ql/test/query-tests/security/CWE-266/AndroidManifest.xml
+++ b/java/ql/test/query-tests/security/CWE-266/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.app"
+    android:installLocation="auto"
+    android:versionCode="1"
+    android:versionName="0.1" >
+
+    <application
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme" >
+        <activity
+            android:name=".MainActivity"
+            android:icon="@drawable/ic_launcher"
+			android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/java/ql/test/query-tests/security/CWE-266/IntentUriPermissionManipulationTest.ql
+++ b/java/ql/test/query-tests/security/CWE-266/IntentUriPermissionManipulationTest.ql
@@ -1,0 +1,11 @@
+import java
+import TestUtilities.InlineFlowTest
+import semmle.code.java.security.IntentUriPermissionManipulationQuery
+
+class IntentUriPermissionManipulationTest extends InlineFlowTest {
+  override DataFlow::Configuration getValueFlowConfig() { none() }
+
+  override TaintTracking::Configuration getTaintFlowConfig() {
+    result instanceof IntentUriPermissionManipulationConf
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-266/MainActivity.java
+++ b/java/ql/test/query-tests/security/CWE-266/MainActivity.java
@@ -1,0 +1,85 @@
+package com.example.app;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+public class MainActivity extends Activity {
+
+    public void onCreate(Bundle savedInstance) {
+        {
+            Intent intent = getIntent();
+            setResult(RESULT_OK, intent); // $ hasTaintFlow
+        }
+        {
+            Intent extraIntent = (Intent) getIntent().getParcelableExtra("extraIntent");
+            setResult(RESULT_OK, extraIntent); // $ hasTaintFlow
+        }
+        {
+            Intent intent = getIntent();
+            intent.setData(Uri.parse("content://safe/uri")); // Sanitizer
+            setResult(RESULT_OK, intent); // Safe
+        }
+        {
+            Intent intent = getIntent();
+            intent.setFlags(0); // Sanitizer
+            setResult(RESULT_OK, intent); // Safe
+        }
+        {
+            Intent intent = getIntent();
+            intent.setFlags( // Not properly sanitized
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            setResult(RESULT_OK, intent); // $ hasTaintFlow
+        }
+        {
+            Intent intent = getIntent();
+            intent.removeFlags( // Sanitizer
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            setResult(RESULT_OK, intent); // Safe
+        }
+        {
+            Intent intent = getIntent();
+            // Combined, the following two calls are a sanitizer
+            intent.removeFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.removeFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            setResult(RESULT_OK, intent); // $ SPURIOUS: $ hasTaintFlow
+        }
+        {
+            Intent intent = getIntent();
+            intent.removeFlags( // Not properly sanitized
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            setResult(RESULT_OK, intent); // $ hasTaintFlow
+        }
+        {
+            Intent intent = getIntent();
+            // Good check
+            if (intent.getData().equals(Uri.parse("content://safe/uri"))) {
+                setResult(RESULT_OK, intent); // Safe
+            } else {
+                setResult(RESULT_OK, intent); // $ hasTaintFlow
+            }
+        }
+        {
+            Intent intent = getIntent();
+            int flags = intent.getFlags();
+            // Good check
+            if ((flags & Intent.FLAG_GRANT_READ_URI_PERMISSION) == 0
+                    && (flags & Intent.FLAG_GRANT_WRITE_URI_PERMISSION) == 0) {
+                setResult(RESULT_OK, intent); // Safe
+            } else {
+                setResult(RESULT_OK, intent); // $ hasTaintFlow
+            }
+        }
+        {
+            Intent intent = getIntent();
+            int flags = intent.getFlags();
+            // Insufficient check
+            if ((flags & Intent.FLAG_GRANT_READ_URI_PERMISSION) == 0) {
+                setResult(RESULT_OK, intent); // $ MISSING: $ hasTaintFlow
+            } else {
+                setResult(RESULT_OK, intent); // $ hasTaintFlow
+            }
+        }
+    }
+}

--- a/java/ql/test/query-tests/security/CWE-266/options
+++ b/java/ql/test/query-tests/security/CWE-266/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/google-android-9.0.0


### PR DESCRIPTION
This PR adds a query to detect Intent URI Permission Manipulation in Android applications. The query detects when an exported Activity is obtaining a user-provided Intent and redirecting it back to the calling application. Also, it requires that a non-exported Content Provider with the attribute `android:grantUriPermissions="true"` exists in the project.

## Description

When an externally provided Intent is returned to an Activity with `setResult`, a malicious application could exploit this by manipulating the Intent to grant itself permissions to access arbitrary Content Providers that are accessible by the vulnerable application.

## Evaluation

The query finds 3 TP when run on a set of 1k Android open source projects.

By adding the source defined in #6963, this goes up to 4 TP results (the extra result occurs in an intentionally vulnerable application).
