### PR TITLE
Python: Support `flask.blueprints.Blueprint`

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -73,7 +73,11 @@ module Flask {
    */
   module Blueprint {
     /** Gets a reference to the `flask.Blueprint` class. */
-    API::Node classRef() { result = API::moduleImport("flask").getMember("Blueprint") }
+    API::Node classRef() {
+      result = API::moduleImport("flask").getMember("Blueprint")
+      or
+      result = API::moduleImport("flask").getMember("blueprints").getMember("Blueprint")
+    }
 
     /** Gets a reference to an instance of `flask.Blueprint`. */
     API::Node instance() { result = classRef().getReturn() }

--- a/python/ql/test/library-tests/frameworks/flask/routing_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/routing_test.py
@@ -105,8 +105,8 @@ def bp1_example(foo): # $ requestHandler routedParameter=foo
 
 app.register_blueprint(bp1) # by default, URLs of blueprints are not prefixed
 
-
-bp2 = flask.Blueprint("bp2", __name__)
+import flask.blueprints
+bp2 = flask.blueprints.Blueprint("bp2", __name__)
 
 @bp2.route("/example") # $ routeSetup="/example"
 def bp2_example(): # $ requestHandler


### PR DESCRIPTION
Thanks to @haby0 who originally proposed this as part of https://github.com/github/codeql/pull/6977

I don't think this is a big enough change to warrant a change-note