### PR TITLE
remove redundant inline casts

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Class.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Class.qll
@@ -237,7 +237,7 @@ class Class extends UserType {
     exists(ClassDerivation cd | cd.getBaseClass() = base |
       result =
         this.accessOfBaseMemberMulti(cd.getDerivedClass(),
-          fieldInBase.accessInDirectDerived(cd.getASpecifier().(AccessSpecifier)))
+          fieldInBase.accessInDirectDerived(cd.getASpecifier()))
     )
   }
 
@@ -261,8 +261,7 @@ class Class extends UserType {
    * includes the case of `base` = `this`.
    */
   AccessSpecifier accessOfBaseMember(Declaration member) {
-    result =
-      this.accessOfBaseMember(member.getDeclaringType(), member.getASpecifier().(AccessSpecifier))
+    result = this.accessOfBaseMember(member.getDeclaringType(), member.getASpecifier())
   }
 
   /**
@@ -319,7 +318,7 @@ class Class extends UserType {
     exists(Type t | t = this.getAFieldSubobjectType().getUnspecifiedType() |
       // Note: Overload resolution is not implemented -- all copy
       // constructors are considered equal.
-      this.cannotAccessCopyConstructorOnAny(t.(Class))
+      this.cannotAccessCopyConstructorOnAny(t)
     )
     or
     // - T has direct or virtual base class that cannot be copied (has deleted,
@@ -392,7 +391,7 @@ class Class extends UserType {
     exists(Type t | t = this.getAFieldSubobjectType().getUnspecifiedType() |
       // Note: Overload resolution is not implemented -- all copy assignment
       // operators are considered equal.
-      this.cannotAccessCopyAssignmentOperatorOnAny(t.(Class))
+      this.cannotAccessCopyAssignmentOperatorOnAny(t)
     )
     or
     exists(Class c | c = this.getADirectOrVirtualBase() |

--- a/cpp/ql/lib/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Declaration.qll
@@ -490,8 +490,7 @@ class AccessHolder extends Declaration, TAccessHolder {
    */
   pragma[inline]
   predicate canAccessMember(Declaration member, Class derived) {
-    this.couldAccessMember(member.getDeclaringType(), member.getASpecifier().(AccessSpecifier),
-      derived)
+    this.couldAccessMember(member.getDeclaringType(), member.getASpecifier(), derived)
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
@@ -307,7 +307,7 @@ private predicate dependsOnFull(DependsSource src, Symbol dest, int category) {
     // dependency from a Variable / Function use -> non-visible definition (link time)
     dependsOnTransitive(src, mid) and
     not mid instanceof EnumConstant and
-    getDeclarationEntries(mid, dest.(DeclarationEntry)) and
+    getDeclarationEntries(mid, dest) and
     not dest instanceof TypeDeclarationEntry and
     // must be definition
     dest.(DeclarationEntry).isDefinition() and

--- a/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Dependency.qll
@@ -275,7 +275,7 @@ private predicate dependsOnDeclarationEntry(Element src, DeclarationEntry dest) 
     dependsOnTransitive(src, mid) and
     not mid instanceof Type and
     not mid instanceof EnumConstant and
-    getDeclarationEntries(mid, dest.(DeclarationEntry)) and
+    getDeclarationEntries(mid, dest) and
     not dest instanceof TypeDeclarationEntry
   )
   or
@@ -283,9 +283,9 @@ private predicate dependsOnDeclarationEntry(Element src, DeclarationEntry dest) 
     // dependency from a Type / Variable / Function use -> any (visible) definition
     dependsOnTransitive(src, mid) and
     not mid instanceof EnumConstant and
-    getDeclarationEntries(mid, dest.(DeclarationEntry)) and
+    getDeclarationEntries(mid, dest) and
     // must be definition
-    dest.(DeclarationEntry).isDefinition()
+    dest.isDefinition()
   )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -175,9 +175,7 @@ class FormattingFunctionCall extends Expr {
   /**
    * Gets the index at which the format string occurs in the argument list.
    */
-  int getFormatParameterIndex() {
-    result = this.getTarget().(FormattingFunction).getFormatParameterIndex()
-  }
+  int getFormatParameterIndex() { result = this.getTarget().getFormatParameterIndex() }
 
   /**
    * Gets the format expression used in this call.
@@ -191,7 +189,7 @@ class FormattingFunctionCall extends Expr {
     exists(int i |
       result = this.getArgument(i) and
       n >= 0 and
-      n = i - this.getTarget().(FormattingFunction).getFirstFormatArgumentIndex()
+      n = i - this.getTarget().getFirstFormatArgumentIndex()
     )
   }
 
@@ -251,7 +249,7 @@ class FormattingFunctionCall extends Expr {
   int getNumFormatArgument() {
     result = count(this.getFormatArgument(_)) and
     // format arguments must be known
-    exists(this.getTarget().(FormattingFunction).getFirstFormatArgumentIndex())
+    exists(this.getTarget().getFirstFormatArgumentIndex())
   }
 
   /**
@@ -289,35 +287,27 @@ class FormatLiteral extends Literal {
    * a `char *` (either way, `%S` will have the opposite meaning).
    * DEPRECATED: Use getDefaultCharType() instead.
    */
-  deprecated predicate isWideCharDefault() {
-    this.getUse().getTarget().(FormattingFunction).isWideCharDefault()
-  }
+  deprecated predicate isWideCharDefault() { this.getUse().getTarget().isWideCharDefault() }
 
   /**
    * Gets the default character type expected for `%s` by this format literal.  Typically
    * `char` or `wchar_t`.
    */
-  Type getDefaultCharType() {
-    result = this.getUse().getTarget().(FormattingFunction).getDefaultCharType()
-  }
+  Type getDefaultCharType() { result = this.getUse().getTarget().getDefaultCharType() }
 
   /**
    * Gets the non-default character type expected for `%S` by this format literal.  Typically
    * `wchar_t` or `char`.  On some snapshots there may be multiple results where we can't tell
    * which is correct for a particular function.
    */
-  Type getNonDefaultCharType() {
-    result = this.getUse().getTarget().(FormattingFunction).getNonDefaultCharType()
-  }
+  Type getNonDefaultCharType() { result = this.getUse().getTarget().getNonDefaultCharType() }
 
   /**
    * Gets the wide character type for this format literal.  This is usually `wchar_t`.  On some
    * snapshots there may be multiple results where we can't tell which is correct for a
    * particular function.
    */
-  Type getWideCharType() {
-    result = this.getUse().getTarget().(FormattingFunction).getWideCharType()
-  }
+  Type getWideCharType() { result = this.getUse().getTarget().getWideCharType() }
 
   /**
    * Holds if this `FormatLiteral` is in a context that supports
@@ -896,7 +886,7 @@ class FormatLiteral extends Literal {
     exists(string len, string conv |
       this.parseConvSpec(n, _, _, _, _, _, len, conv) and
       (len != "l" and len != "w" and len != "h") and
-      this.getUse().getTarget().(FormattingFunction).getFormatCharType().getSize() > 1 and // wide function
+      this.getUse().getTarget().getFormatCharType().getSize() > 1 and // wide function
       (
         conv = "c" and
         result = this.getNonDefaultCharType()

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/DefinitionsAndUses.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/DefinitionsAndUses.qll
@@ -25,7 +25,7 @@ predicate definitionUsePair(SemanticStackVariable var, Expr def, Expr use) {
  * Holds if the definition `def` of some stack variable can reach `node`, which
  * is a definition or use, without crossing definitions of the same variable.
  */
-predicate definitionReaches(Expr def, Expr node) { def.(Def).reaches(true, _, node.(DefOrUse)) }
+predicate definitionReaches(Expr def, Expr node) { def.(Def).reaches(true, _, node) }
 
 private predicate hasAddressOfAccess(SemanticStackVariable var) {
   var.getAnAccess().isAddressOfAccessNonConst()

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSA.qll
@@ -62,7 +62,7 @@ class SsaDefinition extends ControlFlowNodeBase {
   BasicBlock getBasicBlock() { result.contains(this.getDefinition()) }
 
   /** Holds if this definition is a phi node for variable `v`. */
-  predicate isPhiNode(StackVariable v) { exists(StandardSSA x | x.phi_node(v, this.(BasicBlock))) }
+  predicate isPhiNode(StackVariable v) { exists(StandardSSA x | x.phi_node(v, this)) }
 
   /** Gets the location of this definition. */
   Location getLocation() { result = this.(ControlFlowNode).getLocation() }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
@@ -292,7 +292,7 @@ library class SSAHelper extends int {
    */
   cached
   string toString(ControlFlowNode node, StackVariable v) {
-    if phi_node(v, node.(BasicBlock))
+    if phi_node(v, node)
     then result = "SSA phi(" + v.getName() + ")"
     else (
       ssa_defn(v, node, _, _) and result = "SSA def(" + v.getName() + ")"

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/internal/CFG.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/internal/CFG.qll
@@ -231,7 +231,7 @@ private class PostOrderInitializer extends Initializer {
       or
       this.getDeclaration() = for.getRangeVariable()
       or
-      this.getDeclaration() = for.getBeginEndDeclaration().(DeclStmt).getADeclaration()
+      this.getDeclaration() = for.getBeginEndDeclaration().getADeclaration()
     )
   }
 }
@@ -1143,7 +1143,7 @@ private class ExceptionSource extends Node {
       this.reachesParent(mid) and
       not mid = any(TryStmt try).getStmt() and
       not mid = any(MicrosoftTryStmt try).getStmt() and
-      parent = mid.(Node).getParentNode()
+      parent = mid.getParentNode()
     )
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -484,7 +484,7 @@ library class ExprEvaluator extends int {
       this.interestingInternal(e, req, true) and
       (
         result = req.(CompileTimeConstantInt).getIntValue() or
-        result = this.getCompoundValue(e, req.(CompileTimeVariableExpr))
+        result = this.getCompoundValue(e, req)
       ) and
       (
         req.getUnderlyingType().(IntegralType).isSigned() or
@@ -611,7 +611,7 @@ library class ExprEvaluator extends int {
       or
       exists(AssignExpr req | req = val | result = this.getValueInternal(e, req.getRValue()))
       or
-      result = this.getVariableValue(e, val.(VariableAccess))
+      result = this.getVariableValue(e, val)
       or
       exists(FunctionCall call | call = val and not callWithMultipleTargets(call) |
         result = this.getFunctionValue(call.getTarget())
@@ -663,7 +663,7 @@ library class ExprEvaluator extends int {
     this.interestingInternal(_, req, false) and
     (
       result = req.(CompileTimeConstantInt).getIntValue() or
-      result = this.getCompoundValueNonSubExpr(req.(CompileTimeVariableExpr))
+      result = this.getCompoundValueNonSubExpr(req)
     ) and
     (
       req.getUnderlyingType().(IntegralType).isSigned() or
@@ -787,7 +787,7 @@ library class ExprEvaluator extends int {
       or
       exists(AssignExpr req | req = val | result = this.getValueInternalNonSubExpr(req.getRValue()))
       or
-      result = this.getVariableValueNonSubExpr(val.(VariableAccess))
+      result = this.getVariableValueNonSubExpr(val)
       or
       exists(FunctionCall call | call = val and not callWithMultipleTargets(call) |
         result = this.getFunctionValue(call.getTarget())

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Expr.qll
@@ -31,7 +31,7 @@ class Expr extends StmtParent, @expr {
   override Stmt getEnclosingStmt() {
     result = this.getParent().(Expr).getEnclosingStmt()
     or
-    result = this.getParent().(Stmt)
+    result = this.getParent()
     or
     exists(Expr other | result = other.getEnclosingStmt() and other.getConversion() = this)
     or

--- a/cpp/ql/lib/semmle/code/cpp/internal/AddressConstantExpression.qll
+++ b/cpp/ql/lib/semmle/code/cpp/internal/AddressConstantExpression.qll
@@ -31,7 +31,7 @@ private predicate addressConstantVariable(Variable v) {
 private predicate constantAddressLValue(Expr lvalue) {
   lvalue.(VariableAccess).getTarget() =
     any(Variable v |
-      v.(Variable).isStatic()
+      v.isStatic()
       or
       v instanceof GlobalOrNamespaceVariable
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -188,7 +188,7 @@ private predicate fieldStoreStepNoChi(Node node1, FieldContent f, PostUpdateNode
   exists(StoreInstruction store, Class c |
     store = node2.asInstruction() and
     store.getSourceValueOperand() = node1.asOperand() and
-    getWrittenField(store, f.(FieldContent).getAField(), c) and
+    getWrittenField(store, f.getAField(), c) and
     f.hasOffset(c, _, _)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -1305,9 +1305,9 @@ class TranslatedBinaryOperation extends TranslatedSingleInstructionExpr {
   }
 
   override Opcode getOpcode() {
-    result = binaryArithmeticOpcode(expr.(BinaryArithmeticOperation)) or
-    result = binaryBitwiseOpcode(expr.(BinaryBitwiseOperation)) or
-    result = comparisonOpcode(expr.(ComparisonOperation))
+    result = binaryArithmeticOpcode(expr) or
+    result = binaryBitwiseOpcode(expr) or
+    result = comparisonOpcode(expr)
   }
 
   override int getInstructionElementSize(InstructionTag tag) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -1032,7 +1032,7 @@ abstract class TranslatedConversion extends TranslatedNonConstantExpr {
 
   final override TranslatedElement getChild(int id) { id = 0 and result = this.getOperand() }
 
-  final TranslatedExpr getOperand() { result = getTranslatedExpr(expr.(Conversion).getExpr()) }
+  final TranslatedExpr getOperand() { result = getTranslatedExpr(expr.getExpr()) }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -103,9 +103,7 @@ class TranslatedDeclStmt extends TranslatedStmt {
 class TranslatedExprStmt extends TranslatedStmt {
   override ExprStmt stmt;
 
-  TranslatedExpr getExpr() {
-    result = getTranslatedExpr(stmt.(ExprStmt).getExpr().getFullyConverted())
-  }
+  TranslatedExpr getExpr() { result = getTranslatedExpr(stmt.getExpr().getFullyConverted()) }
 
   override TranslatedElement getChild(int id) { id = 0 and result = getExpr() }
 

--- a/cpp/ql/lib/semmle/code/cpp/padding/Padding.qll
+++ b/cpp/ql/lib/semmle/code/cpp/padding/Padding.qll
@@ -88,7 +88,7 @@ abstract class Architecture extends string {
     or
     t instanceof LongLongType and result = this.longLongSize()
     or
-    result = this.enumBitSize(t.(Enum))
+    result = this.enumBitSize(t)
     or
     result = this.integralBitSize(t.(SpecifiedType).getBaseType())
     or
@@ -183,7 +183,7 @@ abstract class Architecture extends string {
     or
     t instanceof ReferenceType and result = this.pointerSize()
     or
-    result = this.enumAlignment(t.(Enum))
+    result = this.enumAlignment(t)
     or
     result = this.alignment(t.(SpecifiedType).getBaseType())
     or
@@ -232,14 +232,14 @@ private Field getAnInitialField(PaddedType t) {
     result = t.getAField()
     or
     // Initial field of the type of a field of the union
-    result = getAnInitialField(t.getAField().getUnspecifiedType().(PaddedType))
+    result = getAnInitialField(t.getAField().getUnspecifiedType())
   else
     exists(Field firstField | t.fieldIndex(firstField) = 1 |
       // The first field of `t`
       result = firstField
       or
       // Initial field of the first field of `t`
-      result = getAnInitialField(firstField.getUnspecifiedType().(PaddedType))
+      result = getAnInitialField(firstField.getUnspecifiedType())
     )
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeSSA.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/RangeSSA.qll
@@ -91,7 +91,7 @@ class RangeSsaDefinition extends ControlFlowNodeBase {
   BasicBlock getBasicBlock() { result.contains(this.getDefinition()) }
 
   /** Whether this definition is a phi node for variable `v`. */
-  predicate isPhiNode(StackVariable v) { exists(RangeSSA x | x.phi_node(v, this.(BasicBlock))) }
+  predicate isPhiNode(StackVariable v) { exists(RangeSSA x | x.phi_node(v, this)) }
 
   /**
    * DEPRECATED: Use isGuardPhi/4 instead

--- a/cpp/ql/lib/semmle/code/cpp/security/FileWrite.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/FileWrite.qll
@@ -173,6 +173,6 @@ private predicate fileWriteWithConvChar(FormattingFunctionCall ffc, Expr source,
     source = ffc.getFormatArgument(n)
   |
     exists(f.getOutputParameterIndex(true)) and
-    conv = ffc.(FormattingFunctionCall).getFormat().(FormatLiteral).getConversionChar(n)
+    conv = ffc.getFormat().(FormatLiteral).getConversionChar(n)
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/valuenumbering/HashCons.qll
+++ b/cpp/ql/lib/semmle/code/cpp/valuenumbering/HashCons.qll
@@ -589,7 +589,7 @@ private predicate mk_HasAlloc(HashCons hc, NewOrNewArrayExpr new) {
 }
 
 private predicate mk_HasExtent(HashCons hc, NewArrayExpr new) {
-  hc = hashCons(new.(NewArrayExpr).getExtent().getFullyConverted())
+  hc = hashCons(new.getExtent().getFullyConverted())
 }
 
 private predicate analyzableNewExpr(NewExpr new) {
@@ -619,7 +619,7 @@ private predicate analyzableNewArrayExpr(NewArrayExpr new) {
   strictcount(new.getAllocatedType().getUnspecifiedType()) = 1 and
   count(new.getAllocatorCall().getFullyConverted()) <= 1 and
   count(new.getInitializer().getFullyConverted()) <= 1 and
-  count(new.(NewArrayExpr).getExtent().getFullyConverted()) <= 1
+  count(new.getExtent().getFullyConverted()) <= 1
 }
 
 private predicate mk_NewArrayExpr(

--- a/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
+++ b/cpp/ql/src/Best Practices/Likely Errors/EmptyBlock.ql
@@ -81,9 +81,8 @@ class BlockOrNonChild extends Element {
 predicate emptyBlockContainsNonchild(BlockStmt b) {
   emptyBlock(_, b) and
   exists(BlockOrNonChild c, AffectedFile file |
-    c.(BlockOrNonChild).getStartRankIn(file) = 1 + b.(BlockOrNonChild).getStartRankIn(file) and
-    c.(BlockOrNonChild).getNonContiguousEndRankIn(file) <
-      b.(BlockOrNonChild).getNonContiguousEndRankIn(file)
+    c.getStartRankIn(file) = 1 + b.(BlockOrNonChild).getStartRankIn(file) and
+    c.getNonContiguousEndRankIn(file) < b.(BlockOrNonChild).getNonContiguousEndRankIn(file)
   )
 }
 

--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticFunctions.ql
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticFunctions.ql
@@ -62,7 +62,7 @@ class Thing extends Locatable {
   }
 
   Thing callsOrAccesses() {
-    this.(Function).calls(result.(Function))
+    this.(Function).calls(result)
     or
     this.(Function).accesses(result.(Function))
     or

--- a/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
+++ b/cpp/ql/src/Likely Bugs/Format/NonConstantFormat.ql
@@ -63,14 +63,14 @@ predicate cannotContainString(Type t) {
 
 predicate isNonConst(DataFlow::Node node) {
   exists(Expr e | e = node.asExpr() |
-    exists(FunctionCall fc | fc = e.(FunctionCall) |
+    exists(FunctionCall fc | fc = e |
       not (
         whitelistFunction(fc.getTarget(), _) or
         fc.getTarget().hasDefinition()
       )
     )
     or
-    exists(Parameter p | p = e.(VariableAccess).getTarget().(Parameter) |
+    exists(Parameter p | p = e.(VariableAccess).getTarget() |
       p.getFunction().getName() = "main" and p.getType() instanceof PointerType
     )
     or

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -10,7 +10,7 @@ import semmle.code.cpp.commons.DateTime
  * Get the top-level `BinaryOperation` enclosing the expression e.
  */
 private BinaryOperation getATopLevelBinaryOperationExpression(Expr e) {
-  result = e.getEnclosingElement().(BinaryOperation)
+  result = e.getEnclosingElement()
   or
   result = getATopLevelBinaryOperationExpression(e.getEnclosingElement())
 }

--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
@@ -66,7 +66,7 @@ predicate functionDefinedInIfDefRecursive(Function f) {
  */
 predicate baseCall(FunctionCall call) {
   call.getNameQualifier().getQualifyingElement() =
-    call.getEnclosingFunction().getDeclaringType().(Class).getABaseClass+()
+    call.getEnclosingFunction().getDeclaringType().getABaseClass+()
 }
 
 from PureExprInVoidContext peivc, Locatable parent, Locatable info, string info_text, string tail

--- a/cpp/ql/src/Metrics/Files/FCyclomaticComplexity.ql
+++ b/cpp/ql/src/Metrics/Files/FCyclomaticComplexity.ql
@@ -15,7 +15,7 @@ import cpp
 from File f, float complexity, float loc
 where
   f.fromSource() and
-  loc = sum(FunctionDeclarationEntry fde | fde.getFile() = f | fde.getNumberOfLines()).(float) and
+  loc = sum(FunctionDeclarationEntry fde | fde.getFile() = f | fde.getNumberOfLines()) and
   if loc > 0
   then
     // Weighted average of complexity by function length

--- a/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
+++ b/cpp/ql/src/Security/CWE/CWE-497/ExposedSystemData.ql
@@ -378,5 +378,5 @@ class SocketOutput extends DataOutput {
 from SystemData sd, DataOutput ow
 where
   sd.getAnExprIndirect() = ow.getASource() or
-  sd.getAnExprIndirect() = ow.getASource().(Expr).getAChild*()
+  sd.getAnExprIndirect() = ow.getASource().getAChild*()
 select ow, "This operation exposes system data from $@.", sd, sd.toString()

--- a/cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBitwiseOrLogicalOperations.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-783/OperatorPrecedenceLogicErrorWhenUseBitwiseOrLogicalOperations.ql
@@ -188,8 +188,7 @@ where
   isBitwiseandBitwise(exp) and
   isDifferentResults(exp.(BinaryBitwiseOperation).getLeftOperand(),
     exp.(BinaryBitwiseOperation).getRightOperand().(BinaryBitwiseOperation).getLeftOperand(),
-    exp.(BinaryBitwiseOperation).getRightOperand().(BinaryBitwiseOperation).getRightOperand(),
-    exp.(BinaryBitwiseOperation),
-    exp.(BinaryBitwiseOperation).getRightOperand().(BinaryBitwiseOperation)) and
+    exp.(BinaryBitwiseOperation).getRightOperand().(BinaryBitwiseOperation).getRightOperand(), exp,
+    exp.(BinaryBitwiseOperation).getRightOperand()) and
   msg = "specify the priority with parentheses."
 select exp, msg

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 79.ql
@@ -142,7 +142,7 @@ class Resource extends MemberVariable {
 
   predicate acquisitionWithRequiredKind(Assignment acquireAssign, string kind) {
     // acquireAssign is an assignment to this resource
-    acquireAssign.(Assignment).getLValue() = this.getAnAccess() and
+    acquireAssign.getLValue() = this.getAnAccess() and
     // Should be in this class, but *any* member method will do
     this.inSameClass(acquireAssign) and
     // Check that it is an acquisition function and return the corresponding kind

--- a/cpp/ql/src/jsf/4.15 Declarations and Definitions/AV Rule 135.ql
+++ b/cpp/ql/src/jsf/4.15 Declarations and Definitions/AV Rule 135.ql
@@ -31,7 +31,7 @@ from Variable v, Variable shadowed
 where
   not v.getParentScope().(BlockStmt).isInMacroExpansion() and
   (
-    v.(LocalVariableOrParameter).shadowsGlobal(shadowed.(GlobalVariable)) or
+    v.(LocalVariableOrParameter).shadowsGlobal(shadowed) or
     localShadowsParameter(v, shadowed) or
     shadowing(v, shadowed)
   )

--- a/cpp/ql/src/jsf/4.22 Pointers and References/AV Rule 173.ql
+++ b/cpp/ql/src/jsf/4.22 Pointers and References/AV Rule 173.ql
@@ -26,7 +26,7 @@ import cpp
 from Assignment a, Variable global, Variable local
 where
   a.fromSource() and
-  global.getAnAccess() = a.getLValue().(VariableAccess) and
+  global.getAnAccess() = a.getLValue() and
   local.getAnAccess() = a.getRValue().(AddressOfExpr).getOperand() and
   local.hasSpecifier("auto") and
   (

--- a/cpp/ql/src/jsf/4.28 Portable Code/AV Rule 210.ql
+++ b/cpp/ql/src/jsf/4.28 Portable Code/AV Rule 210.ql
@@ -49,11 +49,11 @@ class ExposingIntegralUnion extends Union {
     exists(MemberVariable mv1, MemberVariable mv2, IntegralType mv1tp, IntegralType mv2tp |
       mv1 = this.getAMemberVariable() and
       mv2 = this.getAMemberVariable() and
-      mv1tp = mv1.getUnderlyingType().(IntegralType) and
+      mv1tp = mv1.getUnderlyingType() and
       (
-        mv2tp = mv2.getUnderlyingType().(IntegralType)
+        mv2tp = mv2.getUnderlyingType()
         or
-        mv2tp = mv2.getUnderlyingType().(ArrayType).getBaseType().getUnderlyingType().(IntegralType)
+        mv2tp = mv2.getUnderlyingType().(ArrayType).getBaseType().getUnderlyingType()
       ) and
       mv1tp.getSize() > mv2tp.getSize()
     )

--- a/cpp/ql/test/library-tests/controlflow/controlflow/SsaDominance.ql
+++ b/cpp/ql/test/library-tests/controlflow/controlflow/SsaDominance.ql
@@ -14,9 +14,7 @@ import semmle.code.cpp.controlflow.SSA
 
 select count(SsaDefinition d, StackVariable v, Expr u |
     d.getAUse(v) = u and
-    not exists(BasicBlock bd, BasicBlock bu |
-      bd.contains(mkElement(d).(ControlFlowNode)) and bu.contains(u)
-    |
+    not exists(BasicBlock bd, BasicBlock bu | bd.contains(mkElement(d)) and bu.contains(u) |
       bbStrictlyDominates(bd, bu)
       or
       exists(int i, int j |

--- a/cpp/ql/test/library-tests/rangeanalysis/RangeSSA/RangeSsaDominance.ql
+++ b/cpp/ql/test/library-tests/rangeanalysis/RangeSSA/RangeSsaDominance.ql
@@ -14,9 +14,7 @@ import semmle.code.cpp.rangeanalysis.RangeSSA
 
 select count(RangeSsaDefinition d, StackVariable v, Expr u |
     d.getAUse(v) = u and
-    not exists(BasicBlock bd, BasicBlock bu |
-      bd.contains(mkElement(d).(ControlFlowNode)) and bu.contains(u)
-    |
+    not exists(BasicBlock bd, BasicBlock bu | bd.contains(mkElement(d)) and bu.contains(u) |
       bbStrictlyDominates(bd, bu)
       or
       exists(int i, int j |

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -1540,7 +1540,7 @@ module Statements {
       c =
         any(NestedCompletion nc |
           nc.getNestLevel() = 0 and
-          this.throwMayBeUncaught(nc.getOuterCompletion().(ThrowCompletion)) and
+          this.throwMayBeUncaught(nc.getOuterCompletion()) and
           (
             // Incompatible exception type: clause itself
             last = this and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -427,7 +427,7 @@ private Element interpretElement0(
       result = t
       or
       subtypes = true and
-      result = t.(UnboundValueOrRefType).getASubTypeUnbound+()
+      result = t.getASubTypeUnbound+()
     ) and
     result = t and
     name = "" and

--- a/csharp/ql/lib/semmle/code/csharp/security/xml/InsecureXMLQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/xml/InsecureXMLQuery.qll
@@ -209,9 +209,7 @@ module XmlReader {
 /** Provides predicates related to `System.Xml.XmlTextReader`. */
 module XmlTextReader {
   private class InsecureXmlTextReader extends InsecureXmlProcessing, ObjectCreation {
-    InsecureXmlTextReader() {
-      this.getObjectType().(ValueOrRefType).hasQualifiedName("System.Xml.XmlTextReader")
-    }
+    InsecureXmlTextReader() { this.getObjectType().hasQualifiedName("System.Xml.XmlTextReader") }
 
     override predicate isUnsafe(string reason) {
       not exists(Expr xmlResolverVal |

--- a/csharp/ql/src/Stubs/Stubs.qll
+++ b/csharp/ql/src/Stubs/Stubs.qll
@@ -697,7 +697,7 @@ private string stubMethod(Method m, Assembly assembly) {
   if not m.getDeclaringType() instanceof Enum
   then
     result =
-      "    " + stubModifiers(m) + stubClassName(m.(Method).getReturnType()) + " " +
+      "    " + stubModifiers(m) + stubClassName(m.getReturnType()) + " " +
         stubExplicitImplementation(m) + escapeIfKeyword(m.getUndecoratedName()) +
         stubGenericMethodParams(m) + "(" + stubParameters(m) + ")" +
         stubTypeParametersConstraints(m) + stubImplementation(m) + ";\n"

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -1083,7 +1083,7 @@ class TranslatedCast extends TranslatedNonConstantExpr {
     )
   }
 
-  private TranslatedExpr getOperand() { result = getTranslatedExpr(expr.(Cast).getExpr()) }
+  private TranslatedExpr getOperand() { result = getTranslatedExpr(expr.getExpr()) }
 
   private Opcode getOpcode() {
     expr instanceof CastExpr and result instanceof Opcode::CheckedConvertOrThrow

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -1183,9 +1183,9 @@ class TranslatedBinaryOperation extends TranslatedSingleInstructionExpr {
   }
 
   override Opcode getOpcode() {
-    result = binaryArithmeticOpcode(expr.(BinaryArithmeticOperation)) or
-    result = binaryBitwiseOpcode(expr.(BinaryBitwiseOperation)) or
-    result = comparisonOpcode(expr.(ComparisonOperation))
+    result = binaryArithmeticOpcode(expr) or
+    result = binaryBitwiseOpcode(expr) or
+    result = comparisonOpcode(expr)
   }
 
   override int getInstructionElementSize(InstructionTag tag) {

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -89,7 +89,7 @@ class TranslatedDeclStmt extends TranslatedStmt {
 class TranslatedExprStmt extends TranslatedStmt {
   override ExprStmt stmt;
 
-  TranslatedExpr getExpr() { result = getTranslatedExpr(stmt.(ExprStmt).getExpr()) }
+  TranslatedExpr getExpr() { result = getTranslatedExpr(stmt.getExpr()) }
 
   override TranslatedElement getChild(int id) { id = 0 and result = this.getExpr() }
 
@@ -123,7 +123,7 @@ class TranslatedExprStmtAccessorSet extends TranslatedExprStmt {
   }
 
   override TranslatedExpr getExpr() {
-    result = getTranslatedExpr(stmt.(ExprStmt).getExpr().(AssignExpr).getLValue())
+    result = getTranslatedExpr(stmt.getExpr().(AssignExpr).getLValue())
   }
 
   override TranslatedElement getChild(int id) { id = 0 and result = this.getExpr() }

--- a/csharp/ql/src/experimental/ir/internal/IRGuards.qll
+++ b/csharp/ql/src/experimental/ir/internal/IRGuards.qll
@@ -107,7 +107,7 @@ private predicate impliesValue(
     wholeIsTrue = true and partIsTrue = true and part = blo.getAnOperand()
     or
     wholeIsTrue = true and
-    impliesValue(blo.getAnOperand().(BinaryLogicalOperation), part, partIsTrue, true)
+    impliesValue(blo.getAnOperand(), part, partIsTrue, true)
   )
   or
   blo instanceof LogicalOrExpr and
@@ -115,7 +115,7 @@ private predicate impliesValue(
     wholeIsTrue = false and partIsTrue = false and part = blo.getAnOperand()
     or
     wholeIsTrue = false and
-    impliesValue(blo.getAnOperand().(BinaryLogicalOperation), part, partIsTrue, false)
+    impliesValue(blo.getAnOperand(), part, partIsTrue, false)
   )
 }
 
@@ -139,7 +139,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
 
   override predicate comparesLt(Expr left, Expr right, int k, boolean isLessThan, boolean testIsTrue) {
     exists(boolean partIsTrue, GuardCondition part |
-      impliesValue(this.(BinaryLogicalOperation), part, partIsTrue, testIsTrue)
+      impliesValue(this, part, partIsTrue, testIsTrue)
     |
       part.comparesLt(left, right, k, isLessThan, partIsTrue)
     )
@@ -153,7 +153,7 @@ private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
 
   override predicate comparesEq(Expr left, Expr right, int k, boolean areEqual, boolean testIsTrue) {
     exists(boolean partIsTrue, GuardCondition part |
-      impliesValue(this.(BinaryLogicalOperation), part, partIsTrue, testIsTrue)
+      impliesValue(this, part, partIsTrue, testIsTrue)
     |
       part.comparesEq(left, right, k, areEqual, partIsTrue)
     )

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -150,7 +150,7 @@ private module ControlFlowGraphImpl {
      * `TypeThrowable` which results in both `TypeError` and `TypeRuntimeException`.
      */
     UncheckedThrowableType getAnUncheckedSubtype() {
-      result = this.(UncheckedThrowableType)
+      result = this
       or
       result instanceof TypeError and this instanceof TypeThrowable
       or

--- a/java/ql/lib/semmle/code/java/PrintAst.qll
+++ b/java/ql/lib/semmle/code/java/PrintAst.qll
@@ -665,7 +665,7 @@ final class GenericTypeNode extends PrintAstNode, TGenericTypeNode {
   override Location getLocation() { none() }
 
   override ElementNode getChild(int childIndex) {
-    result.getElement().(TypeVariable) = ty.getTypeParameter(childIndex)
+    result.getElement() = ty.getTypeParameter(childIndex)
   }
 
   /**
@@ -686,7 +686,7 @@ final class GenericCallableNode extends PrintAstNode, TGenericCallableNode {
   override string toString() { result = "(Generic Parameters)" }
 
   override ElementNode getChild(int childIndex) {
-    result.getElement().(TypeVariable) = c.getTypeParameter(childIndex)
+    result.getElement() = c.getTypeParameter(childIndex)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/Reflection.qll
+++ b/java/ql/lib/semmle/code/java/Reflection.qll
@@ -150,7 +150,7 @@ private Type parameterForSubTypes(ParameterizedType type) {
       lowerBound = arg.(Wildcard).getLowerBoundType()
     |
       // `T super Foo` implies that `Foo`, or any super-type of `Foo`, may be represented.
-      lowerBound.(RefType).getAnAncestor() = result
+      lowerBound.getAnAncestor() = result
     )
   )
 }

--- a/java/ql/lib/semmle/code/java/Statement.qll
+++ b/java/ql/lib/semmle/code/java/Statement.qll
@@ -567,7 +567,7 @@ class ThrowStmt extends Stmt, @throwstmt {
     or
     exists(Stmt mid |
       mid = this.findEnclosing() and
-      not exists(this.catchClauseForThis(mid.(TryStmt))) and
+      not exists(this.catchClauseForThis(mid)) and
       result = mid.getEnclosingStmt()
     )
   }
@@ -575,7 +575,7 @@ class ThrowStmt extends Stmt, @throwstmt {
   private CatchClause catchClauseForThis(TryStmt try) {
     result = try.getACatchClause() and
     result.getEnclosingCallable() = this.getEnclosingCallable() and
-    this.getExpr().getType().(RefType).hasSupertype*(result.getVariable().getType().(RefType)) and
+    this.getExpr().getType().(RefType).hasSupertype*(result.getVariable().getType()) and
     not this.getEnclosingStmt+() = result
   }
 

--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -511,7 +511,7 @@ class RefType extends Type, Annotatable, Modifiable, @reftype {
       this.getSourceDeclaration().inherits(f)
     )
     or
-    this.hasMethod(m.(Method), _)
+    this.hasMethod(m, _)
   }
 
   /** Holds if this is a top-level type, which is not nested inside any other types. */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -299,7 +299,7 @@ Sign exprSign(Expr e) {
       exists(VarAccess access | access = e |
         not exists(SsaVariable v | getARead(v) = access) and
         (
-          s = fieldSign(getField(access))
+          s = fieldSign(getField(access.(FieldAccess)))
           or
           anySign(s) and not access instanceof FieldAccess
         )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -299,7 +299,7 @@ Sign exprSign(Expr e) {
       exists(VarAccess access | access = e |
         not exists(SsaVariable v | getARead(v) = access) and
         (
-          s = fieldSign(getField(access.(FieldAccess)))
+          s = fieldSign(getField(access))
           or
           anySign(s) and not access instanceof FieldAccess
         )

--- a/java/ql/lib/semmle/code/java/deadcode/DeadCode.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/DeadCode.qll
@@ -18,12 +18,12 @@ predicate isLive(Callable c) {
  * would imply the liveness of `c`.
  */
 Callable possibleLivenessCause(Callable c, string reason) {
-  c.(Method).overridesOrInstantiates(result.(Method)) and
+  c.(Method).overridesOrInstantiates(result) and
   reason = "is overridden or instantiated by"
   or
   result.calls(c) and reason = "calls"
   or
-  result.callsConstructor(c.(Constructor)) and reason = "calls constructor"
+  result.callsConstructor(c) and reason = "calls constructor"
   or
   exists(ClassInstanceExpr e | e.getEnclosingCallable() = result |
     e.getConstructor() = c and reason = "constructs"
@@ -243,7 +243,7 @@ class DeadMethod extends Callable {
     ) and
     not (
       this.(Method).isAbstract() and
-      exists(Method m | m.overridesOrInstantiates+(this.(Method)) | isLive(m))
+      exists(Method m | m.overridesOrInstantiates+(this) | isLive(m))
     ) and
     // A getter or setter associated with a live JPA field.
     //

--- a/java/ql/lib/semmle/code/java/deadcode/DeadCode.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/DeadCode.qll
@@ -93,8 +93,8 @@ class SuppressedConstructor extends Constructor {
     not this.isDefaultConstructor() and
     // Verify that there is only one statement, which is the `super()` call. This exists
     // even for empty constructors.
-    this.getBody().(BlockStmt).getNumStmt() = 1 and
-    this.getBody().(BlockStmt).getAStmt().(SuperConstructorInvocationStmt).getNumArgument() = 0 and
+    this.getBody().getNumStmt() = 1 and
+    this.getBody().getAStmt().(SuperConstructorInvocationStmt).getNumArgument() = 0 and
     // A constructor that is called is not acting to suppress the default constructor. We permit
     // calls from suppressed and default constructors - in both cases, they can only come from
     // sub-class constructors.

--- a/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/EntryPoints.qll
@@ -262,7 +262,7 @@ class ManagedBeanImplEntryPoint extends EntryPoint, RegisteredManagedBeanImpl {
     // Find the method that will be called for each method on each managed bean that this class
     // implements.
     this.inherits(result) and
-    result.(Method).overrides(this.getAnImplementedManagedBean().getAMethod())
+    result.overrides(this.getAnImplementedManagedBean().getAMethod())
   }
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/JAXB.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JAXB.qll
@@ -54,7 +54,7 @@ class JaxbType extends Class {
       this.getAnAnnotation() = a and
       a.getType().(JaxbAnnotationType).hasName("XmlAccessorType")
     |
-      result.getAnAccess() = a.getValue("value").(VarAccess)
+      result.getAnAccess() = a.getValue("value")
     )
   }
 

--- a/java/ql/lib/semmle/code/java/frameworks/javaee/ejb/EJB.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/javaee/ejb/EJB.qll
@@ -668,7 +668,7 @@ Type inheritsMatchingMethodExceptThrows(SessionEJB ejb, Method m) {
     sig = n.getSignature() and
     sig = m.getSignature() and
     exists(Exception ex | ex = n.getAnException() and not throwsExplicitUncheckedException(n, ex) |
-      not ex.getType().(RefType).hasSupertype*(m.getAnException().getType()) and
+      not ex.getType().hasSupertype*(m.getAnException().getType()) and
       result = ex.getType()
     )
   )
@@ -717,7 +717,7 @@ Type inheritsMatchingCreateMethodExceptThrows(StatefulSessionEJB ejb, EjbInterfa
     exists(Exception ex |
       ex = cm.getAnException() and not throwsExplicitUncheckedException(cm, ex)
     |
-      not ex.getType().(RefType).hasSupertype*(icm.getAnException().getType()) and
+      not ex.getType().hasSupertype*(icm.getAnException().getType()) and
       result = ex.getType()
     )
   )
@@ -732,7 +732,7 @@ Type inheritsMatchingCreateMethodExceptThrows(StatefulSessionEJB ejb, EjbInterfa
     exists(Exception ex |
       ex = im.getAnException() and not throwsExplicitUncheckedException(im, ex)
     |
-      not ex.getType().(RefType).hasSupertype*(icm.getAnException().getType()) and
+      not ex.getType().hasSupertype*(icm.getAnException().getType()) and
       result = ex.getType()
     )
   )

--- a/java/ql/lib/semmle/code/java/security/ExternalAPIs.qll
+++ b/java/ql/lib/semmle/code/java/security/ExternalAPIs.qll
@@ -141,8 +141,7 @@ class ExternalAPIUsedWithUntrustedData extends TExternalAPI {
     |
       this = TExternalAPIParameter(m, index) and
       result =
-        m.getDeclaringType().(RefType).getQualifiedName() + "." + m.getSignature() + " [" +
-          indexString + "]"
+        m.getDeclaringType().getQualifiedName() + "." + m.getSignature() + " [" + indexString + "]"
     )
   }
 }

--- a/java/ql/lib/semmle/code/xml/MavenPom.qll
+++ b/java/ql/lib/semmle/code/xml/MavenPom.qll
@@ -395,9 +395,7 @@ class MavenRepo extends Folder {
   /**
    * Gets a Jar file contained within this repository.
    */
-  File getAJarFile() {
-    result = this.getAChildContainer*().(File) and result.getExtension() = "jar"
-  }
+  File getAJarFile() { result = this.getAChildContainer*() and result.getExtension() = "jar" }
 
   /**
    * Gets any jar artifacts in this repository that match the POM project definition. This is an

--- a/java/ql/src/Language Abuse/UselessUpcast.ql
+++ b/java/ql/src/Language Abuse/UselessUpcast.ql
@@ -25,7 +25,7 @@ predicate usefulUpcast(CastExpr e) {
       other.getName() = target.getName() and
       other.getSourceDeclaration() != target.getSourceDeclaration()
     |
-      c.(MethodAccess).getReceiverType().(RefType).inherits(other.(Method)) or
+      c.(MethodAccess).getReceiverType().inherits(other.(Method)) or
       other = target.(Constructor).getDeclaringType().getAConstructor()
     )
   )

--- a/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/InformationLoss.ql
@@ -25,7 +25,7 @@ class DangerousAssignOpExpr extends AssignOp {
   }
 }
 
-predicate problematicCasting(Type t, Expr e) { e.getType().(NumType).widerThan(t.(NumType)) }
+predicate problematicCasting(Type t, Expr e) { e.getType().(NumType).widerThan(t) }
 
 from DangerousAssignOpExpr a, Expr e
 where

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
@@ -45,7 +45,7 @@ private predicate closeableType(RefType t) {
 class SqlResourceOpeningMethodAccess extends MethodAccess {
   SqlResourceOpeningMethodAccess() {
     exists(Method m | this.getMethod() = m |
-      m.getDeclaringType().(RefType).hasQualifiedName("java.sql", _) and
+      m.getDeclaringType().hasQualifiedName("java.sql", _) and
       m.getReturnType().(RefType).hasQualifiedName("java.sql", _) and
       m.getName().regexpMatch("(create|prepare|execute).*") and
       closeableType(m.getReturnType()) and

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
@@ -14,9 +14,7 @@ private import semmle.code.java.controlflow.internal.GuardsLogic
 predicate narrowerThanOrEqualTo(ArithExpr exp, NumType numType) {
   exp.getType().(NumType).widerThan(numType)
   implies
-  exists(CastExpr cast | cast.getAChildExpr() = exp |
-    numType.widerThanOrEqualTo(cast.getType().(NumType))
-  )
+  exists(CastExpr cast | cast.getAChildExpr() = exp | numType.widerThanOrEqualTo(cast.getType()))
 }
 
 private Guard sizeGuard(SsaVariable v, boolean branch, boolean upper) {

--- a/java/ql/src/Security/CWE/CWE-681/NumericCastCommon.qll
+++ b/java/ql/src/Security/CWE/CWE-681/NumericCastCommon.qll
@@ -9,7 +9,7 @@ class NumericNarrowingCastExpr extends CastExpr {
     exists(NumericType sourceType, NumericType targetType |
       sourceType = getExpr().getType() and targetType = getType()
     |
-      not targetType.(NumType).widerThanOrEqualTo(sourceType.(NumType))
+      not targetType.(NumType).widerThanOrEqualTo(sourceType)
     )
   }
 }

--- a/java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
+++ b/java/ql/src/Security/CWE/CWE-833/LockOrderInconsistency.ql
@@ -159,7 +159,7 @@ predicate badMethodAccessLockOrder(
   MethodAccess outerAccess, MethodAccess innerAccess, MethodAccess other
 ) {
   exists(Synched outer, Synched inner |
-    inner.(MethodAccess) = innerAccess and
+    inner = innerAccess and
     inner = outer.getInnerSynch() and
     inner.getLockType() = outer.getLockType() and
     exists(Parameter p, int i | outer.(Method).getAParameter() = p and p.getPosition() = i |

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -126,10 +126,7 @@ DataFlow::Node getASubexpressionWithinQuery(DataFlow::Node query) {
   exists(DataFlow::SourceNode receiver |
     receiver.flowsTo(getASubexpressionWithinQuery*(query.getALocalSource())) and
     result =
-      [
-        receiver.(DataFlow::SourceNode).getAPropertyWrite().getRhs(),
-        receiver.(DataFlow::ArrayCreationNode).getAnElement()
-      ]
+      [receiver.getAPropertyWrite().getRhs(), receiver.(DataFlow::ArrayCreationNode).getAnElement()]
   )
 }
 

--- a/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/lib/semmle/javascript/ES2015Modules.qll
@@ -658,7 +658,7 @@ abstract class ReExportDeclaration extends ExportDeclaration {
   cached
   Module getReExportedModule() {
     Stages::Imports::ref() and
-    result.getFile() = getEnclosingModule().resolve(getImportedPath().(PathExpr))
+    result.getFile() = getEnclosingModule().resolve(getImportedPath())
     or
     result = resolveFromTypeRoot()
   }

--- a/javascript/ql/lib/semmle/javascript/PrintAst.qll
+++ b/javascript/ql/lib/semmle/javascript/PrintAst.qll
@@ -699,7 +699,7 @@ module PrintHTML {
       childIndex = -1 and result.(HTMLAttributesNodes).getElement() = element
       or
       exists(HTML::Element child | result.(HTMLElementNode).getElement() = child |
-        child = element.(HTML::Element).getChild(childIndex)
+        child = element.getChild(childIndex)
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/AnalyzedParameters.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/AnalyzedParameters.qll
@@ -8,7 +8,7 @@ pragma[nomagic]
 predicate isAnalyzedParameter(Parameter p) {
   exists(FunctionWithAnalyzedParameters f, int parmIdx | p = f.getParameter(parmIdx) |
     // we cannot track flow into rest parameters
-    not p.(Parameter).isRestParameter()
+    not p.isRestParameter()
   )
 }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -199,7 +199,7 @@ private class AnalyzedNewExpr extends DataFlow::AnalyzedValueNode {
    */
   private predicate isIndefinite() {
     exists(DataFlow::AnalyzedNode callee, AbstractValue calleeVal |
-      callee = astNode.(NewExpr).getCallee().analyze() and
+      callee = astNode.getCallee().analyze() and
       calleeVal = callee.getALocalValue()
     |
       calleeVal.isIndefinite(_) or
@@ -217,7 +217,7 @@ private class NewInstance extends DataFlow::AnalyzedValueNode {
 
   override AbstractValue getALocalValue() {
     exists(DataFlow::AnalyzedNode callee |
-      callee = astNode.(NewExpr).getCallee().analyze() and
+      callee = astNode.getCallee().analyze() and
       result = TAbstractInstance(callee.getALocalValue())
     )
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/jQuery.qll
@@ -139,7 +139,7 @@ private class JQueryDomElementDefinition extends DOM::ElementDefinition, @call_e
   JQueryDomElementDefinition() {
     this = call and
     call = jquery().getACall().asExpr() and
-    exists(string s | s = call.getArgument(0).(Expr).getStringValue() |
+    exists(string s | s = call.getArgument(0).getStringValue() |
       // match an opening angle bracket followed by a tag name, followed by arbitrary
       // text and a closing angle bracket, potentially with whitespace in between
       tagName = s.regexpCapture("\\s*<\\s*(\\w+)\\b[^>]*>\\s*", 1).toLowerCase()

--- a/javascript/ql/lib/semmle/javascript/security/UselessUseOfCat.qll
+++ b/javascript/ql/lib/semmle/javascript/security/UselessUseOfCat.qll
@@ -317,7 +317,7 @@ module PrettyPrintCatCall {
    */
   string createFileThatIsReadFromCommandList(CommandCall call) {
     exists(DataFlow::ArrayCreationNode array, DataFlow::Node element |
-      array = call.getArgumentList().(DataFlow::ArrayCreationNode) and
+      array = call.getArgumentList() and
       array.getSize() = 1 and
       element = array.getElement(0)
     |

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -526,9 +526,7 @@ module ReflectedXss {
    * ```
    */
   predicate isLocalHeaderDefinition(HTTP::HeaderDefinition header) {
-    exists(ReachableBasicBlock headerBlock |
-      headerBlock = header.getBasicBlock().(ReachableBasicBlock)
-    |
+    exists(ReachableBasicBlock headerBlock | headerBlock = header.getBasicBlock() |
       1 =
         strictcount(HTTP::ResponseSendArgument sender |
           sender.getRouteHandler() = header.getRouteHandler() and

--- a/javascript/ql/test/library-tests/CFG/StaticInit.ql
+++ b/javascript/ql/test/library-tests/CFG/StaticInit.ql
@@ -4,5 +4,5 @@ from ClassDefinition class_, FieldDefinition field
 where
   class_.getAField() = field and
   field.isStatic() and
-  field.getInit().getFirstControlFlowNode().getAPredecessor*() = class_.(ControlFlowNode)
+  field.getInit().getFirstControlFlowNode().getAPredecessor*() = class_
 select field, "Field initializer occurs after its class is created"

--- a/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_inference.ql
+++ b/javascript/ql/test/library-tests/TypeInference/FunctionWithAnalyzedParameters/FunctionWithAnalyzedParameters_inference.ql
@@ -4,4 +4,4 @@ from FunctionWithAnalyzedParameters f, SimpleParameter p, AnalyzedVarDef var
 where
   f.argumentPassing(p, _) and
   var.getAVariable() = p.getVariable()
-select p, var.(AnalyzedVarDef).getAnAssignedValue()
+select p, var.getAnAssignedValue()

--- a/python/ql/lib/semmle/python/SpecialMethods.qll
+++ b/python/ql/lib/semmle/python/SpecialMethods.qll
@@ -107,7 +107,7 @@ class SpecialMethodCallNode extends PotentialSpecialMethodCallNode {
 
   SpecialMethodCallNode() {
     exists(SpecialMethod::Potential pot |
-      this.(SpecialMethod::Potential) = pot and
+      this = pot and
       pot.getSelf().pointsTo().getClass().lookup(pot.getSpecialMethodName()) = resolvedSpecialMethod
     )
   }

--- a/python/ql/lib/semmle/python/Stmts.qll
+++ b/python/ql/lib/semmle/python/Stmts.qll
@@ -94,13 +94,13 @@ class AugAssign extends AugAssign_ {
    * Gets the target of this augmented assignment statement.
    * That is, the `a` in `a += b`.
    */
-  Expr getTarget() { result = this.getOperation().(BinaryExpr).getLeft() }
+  Expr getTarget() { result = this.getOperation().getLeft() }
 
   /**
    * Gets the value of this augmented assignment statement.
    * That is, the `b` in `a += b`.
    */
-  Expr getValue() { result = this.getOperation().(BinaryExpr).getRight() }
+  Expr getValue() { result = this.getOperation().getRight() }
 
   override Stmt getASubStatement() { none() }
 }

--- a/python/ql/lib/semmle/python/essa/Definitions.qll
+++ b/python/ql/lib/semmle/python/essa/Definitions.qll
@@ -221,7 +221,7 @@ class ModuleVariable extends SsaSourceVariable {
   pragma[noinline]
   ImportMemberNode global_variable_import() {
     result.getScope() = this.(GlobalVariable).getScope() and
-    import_from_dot_in_init(result.(ImportMemberNode).getModule(this.getName()))
+    import_from_dot_in_init(result.getModule(this.getName()))
   }
 
   override ControlFlowNode getAnImplicitUse() {
@@ -306,7 +306,7 @@ class EscapingGlobalVariable extends ModuleVariable {
   Scope scope_as_global_variable() { result = this.(GlobalVariable).getScope() }
 
   override CallNode redefinedAtCallSite() {
-    result.(CallNode).getScope().getScope*() = this.scope_as_global_variable()
+    result.getScope().getScope*() = this.scope_as_global_variable()
   }
 }
 
@@ -332,7 +332,7 @@ class SpecialSsaSourceVariable extends SsaSourceVariable {
   Scope scope_as_global_variable() { result = this.(GlobalVariable).getScope() }
 
   override CallNode redefinedAtCallSite() {
-    result.(CallNode).getScope().getScope*() = this.scope_as_global_variable()
+    result.getScope().getScope*() = this.scope_as_global_variable()
   }
 }
 

--- a/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiohttp.qll
@@ -330,8 +330,8 @@ module AiohttpWebModel {
         exists(Await await, DataFlow::CallCfgNode call, DataFlow::AttrRead read |
           this.asExpr() = await
         |
-          read.(DataFlow::AttrRead).getObject() = Request::instance() and
-          read.(DataFlow::AttrRead).getAttributeName() = "post" and
+          read.getObject() = Request::instance() and
+          read.getAttributeName() = "post" and
           call.getFunction() = read and
           await.getValue() = call.asExpr()
         )

--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -1820,7 +1820,7 @@ private module PrivateDjango {
     /** Gets a reference to this class. */
     private DataFlow::TypeTrackingNode getARef(DataFlow::TypeTracker t) {
       t.start() and
-      result.asExpr() = this.getParent()
+      result.asExpr().(ClassExpr) = this.getParent()
       or
       exists(DataFlow::TypeTracker t2 | result = this.getARef(t2).track(t2, t))
     }

--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -1820,7 +1820,7 @@ private module PrivateDjango {
     /** Gets a reference to this class. */
     private DataFlow::TypeTrackingNode getARef(DataFlow::TypeTracker t) {
       t.start() and
-      result.asExpr().(ClassExpr) = this.getParent()
+      result.asExpr() = this.getParent()
       or
       exists(DataFlow::TypeTracker t2 | result = this.getARef(t2).track(t2, t))
     }

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -188,7 +188,7 @@ module Flask {
 
     FlaskViewClass() {
       this.getABase() = Views::View::subclassRef().getAUse().asExpr() and
-      api_node.getAnImmediateUse().asExpr().(ClassExpr) = this.getParent()
+      api_node.getAnImmediateUse().asExpr() = this.getParent()
     }
 
     /** Gets a function that could handle incoming requests, if any. */
@@ -213,7 +213,7 @@ module Flask {
   class FlaskMethodViewClass extends FlaskViewClass {
     FlaskMethodViewClass() {
       this.getABase() = Views::MethodView::subclassRef().getAUse().asExpr() and
-      api_node.getAnImmediateUse().asExpr().(ClassExpr) = this.getParent()
+      api_node.getAnImmediateUse().asExpr() = this.getParent()
     }
 
     override Function getARequestHandler() {
@@ -294,7 +294,7 @@ module Flask {
     override Function getARequestHandler() {
       exists(DataFlow::LocalSourceNode func_src |
         func_src.flowsTo(this.getViewArg()) and
-        func_src.asExpr().(CallableExpr) = result.getDefinition()
+        func_src.asExpr() = result.getDefinition()
       )
       or
       exists(FlaskViewClass vc |

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -188,7 +188,7 @@ module Flask {
 
     FlaskViewClass() {
       this.getABase() = Views::View::subclassRef().getAUse().asExpr() and
-      api_node.getAnImmediateUse().asExpr() = this.getParent()
+      api_node.getAnImmediateUse().asExpr().(ClassExpr) = this.getParent()
     }
 
     /** Gets a function that could handle incoming requests, if any. */
@@ -213,7 +213,7 @@ module Flask {
   class FlaskMethodViewClass extends FlaskViewClass {
     FlaskMethodViewClass() {
       this.getABase() = Views::MethodView::subclassRef().getAUse().asExpr() and
-      api_node.getAnImmediateUse().asExpr() = this.getParent()
+      api_node.getAnImmediateUse().asExpr().(ClassExpr) = this.getParent()
     }
 
     override Function getARequestHandler() {
@@ -294,7 +294,7 @@ module Flask {
     override Function getARequestHandler() {
       exists(DataFlow::LocalSourceNode func_src |
         func_src.flowsTo(this.getViewArg()) and
-        func_src.asExpr() = result.getDefinition()
+        func_src.asExpr().(CallableExpr) = result.getDefinition()
       )
       or
       exists(FlaskViewClass vc |

--- a/python/ql/lib/semmle/python/frameworks/Tornado.qll
+++ b/python/ql/lib/semmle/python/frameworks/Tornado.qll
@@ -102,7 +102,7 @@ private module Tornado {
           /** Gets a reference to this class. */
           private DataFlow::TypeTrackingNode getARef(DataFlow::TypeTracker t) {
             t.start() and
-            result.asExpr().(ClassExpr) = this.getParent()
+            result.asExpr() = this.getParent()
             or
             exists(DataFlow::TypeTracker t2 | result = this.getARef(t2).track(t2, t))
           }

--- a/python/ql/lib/semmle/python/frameworks/Tornado.qll
+++ b/python/ql/lib/semmle/python/frameworks/Tornado.qll
@@ -102,7 +102,7 @@ private module Tornado {
           /** Gets a reference to this class. */
           private DataFlow::TypeTrackingNode getARef(DataFlow::TypeTracker t) {
             t.start() and
-            result.asExpr() = this.getParent()
+            result.asExpr().(ClassExpr) = this.getParent()
             or
             exists(DataFlow::TypeTracker t2 | result = this.getARef(t2).track(t2, t))
           }

--- a/python/ql/lib/semmle/python/objects/Constants.qll
+++ b/python/ql/lib/semmle/python/objects/Constants.qll
@@ -248,7 +248,7 @@ class UnicodeObjectInternal extends ConstantObjectInternal, TUnicode {
   override ObjectInternal getClass() { result = TBuiltinClassObject(Builtin::special("unicode")) }
 
   override Builtin getBuiltin() {
-    result.(Builtin).strValue() = this.strValue() and
+    result.strValue() = this.strValue() and
     result.getClass() = Builtin::special("unicode")
   }
 
@@ -281,7 +281,7 @@ class BytesObjectInternal extends ConstantObjectInternal, TBytes {
   override ObjectInternal getClass() { result = TBuiltinClassObject(Builtin::special("bytes")) }
 
   override Builtin getBuiltin() {
-    result.(Builtin).strValue() = this.strValue() and
+    result.strValue() = this.strValue() and
     result.getClass() = Builtin::special("bytes")
   }
 

--- a/python/ql/lib/semmle/python/types/Properties.qll
+++ b/python/ql/lib/semmle/python/types/Properties.qll
@@ -84,7 +84,7 @@ private predicate property_getter(CallNode decorated, FunctionObject getter) {
 private predicate property_setter(CallNode decorated, FunctionObject setter) {
   property_getter(decorated, _) and
   exists(CallNode setter_call, AttrNode prop_setter |
-    prop_setter.getObject("setter").refersTo(decorated.(Object))
+    prop_setter.getObject("setter").refersTo(decorated)
   |
     setter_call.getArg(0).refersTo(setter) and
     setter_call.getFunction() = prop_setter
@@ -97,7 +97,7 @@ private predicate property_setter(CallNode decorated, FunctionObject setter) {
 private predicate property_deleter(CallNode decorated, FunctionObject deleter) {
   property_getter(decorated, _) and
   exists(CallNode deleter_call, AttrNode prop_deleter |
-    prop_deleter.getObject("deleter").refersTo(decorated.(Object))
+    prop_deleter.getObject("deleter").refersTo(decorated)
   |
     deleter_call.getArg(0).refersTo(deleter) and
     deleter_call.getFunction() = prop_deleter

--- a/python/ql/lib/semmle/python/values/StringAttributes.qll
+++ b/python/ql/lib/semmle/python/values/StringAttributes.qll
@@ -78,5 +78,5 @@ private predicate tracking_step(ControlFlowNode src, ControlFlowNode dest) {
   or
   tracked_call_step(src, dest)
   or
-  dest.refersTo(src.(Object))
+  dest.refersTo(src)
 }

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -99,14 +99,14 @@ private ControlFlowNode get_a_call(Value callable) {
 
 /** Gets the function object corresponding to the given class or function. */
 FunctionObject get_function_or_initializer_objectapi(Object func_or_cls) {
-  result = func_or_cls.(FunctionObject)
+  result = func_or_cls
   or
   result = func_or_cls.(ClassObject).declaredAttribute("__init__")
 }
 
 /** Gets the function object corresponding to the given class or function. */
 FunctionValue get_function_or_initializer(Value func_or_cls) {
-  result = func_or_cls.(FunctionValue)
+  result = func_or_cls
   or
   result = func_or_cls.(ClassValue).declaredAttribute("__init__")
 }

--- a/python/ql/src/Lexical/CommentedOutCode.qll
+++ b/python/ql/src/Lexical/CommentedOutCode.qll
@@ -210,9 +210,9 @@ class CommentedOutCodeBlock extends @py_comment {
 
   /** Whether this commented-out code block is likely to be example code embedded in a larger comment. */
   predicate maybeExampleCode() {
-    exists(CommentBlock block | block.contains(this.(Comment)) |
+    exists(CommentBlock block | block.contains(this) |
       exists(int all_code |
-        all_code = sum(CommentedOutCodeBlock code | block.contains(code.(Comment)) | code.length()) and
+        all_code = sum(CommentedOutCodeBlock code | block.contains(code) | code.length()) and
         /* This ratio may need fine tuning */
         block.length() > all_code * 2
       )

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -74,7 +74,7 @@ class AstCfgNode extends CfgNode, TElementNode {
   override Location getLocation() { result = n.getLocation() }
 
   final override string toString() {
-    exists(string s | s = n.(AstNode).toString() |
+    exists(string s | s = n.toString() |
       result = "[" + this.getSplitsString() + "] " + s
       or
       not exists(this.getSplitsString()) and result = s

--- a/ruby/ql/lib/codeql/ruby/frameworks/XmlParsing.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/XmlParsing.qll
@@ -131,7 +131,7 @@ private DataFlow::LocalSourceNode trackFeature(Feature f, boolean enable, TypeTr
     // same code.
     exists(CfgNodes::ExprNodes::OperationCfgNode operation |
       bitWiseAndOr(operation) and
-      operation = result.asExpr().(CfgNodes::ExprNodes::OperationCfgNode) and
+      operation = result.asExpr() and
       operation.getAnOperand() = trackFeature(f, enable).asExpr()
     )
     or

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -132,7 +132,7 @@ private string getSetterCallAttributeName(AST::SetterMethodCall call) {
 predicate basicLoadStep(Node nodeFrom, Node nodeTo, string content) {
   exists(ExprNodes::MethodCallCfgNode call |
     call.getExpr().getNumberOfArguments() = 0 and
-    content = call.getExpr().(AST::MethodCall).getMethodName() and
+    content = call.getExpr().getMethodName() and
     nodeFrom.asExpr() = call.getReceiver() and
     nodeTo.asExpr() = call
   )


### PR DESCRIPTION
The patch was written automatically by a tool.

Removes inline casts where: 
- the expression is cast to the type the expression already has, or: 
- the inline cast is one side of an equality comparison, where the other side already has the type.