### PR TITLE
Rewrite qhelp-pr-preview.yml

### DIFF
--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -8,7 +8,7 @@ runs:
       run: |
         LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | grep -v beta | sort --version-sort | tail -1)
         gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-linux64.zip "$LATEST"
-        unzip -q codeql-linux64.zip
-        echo "${{ github.workspace }}/codeql" >> $GITHUB_PATH
+        unzip -q -d "${{ runner.temp }}" codeql-linux64.zip
+        echo "${{ runner.temp  }}/codeql" >> $GITHUB_PATH
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/actions/fetch-codeql/action.yml
+++ b/.github/actions/fetch-codeql/action.yml
@@ -8,7 +8,7 @@ runs:
       run: |
         LATEST=$(gh release list --repo https://github.com/github/codeql-cli-binaries | cut -f 1 | grep -v beta | sort --version-sort | tail -1)
         gh release download --repo https://github.com/github/codeql-cli-binaries --pattern codeql-linux64.zip "$LATEST"
-        unzip -q -d "${{ runner.temp }}" codeql-linux64.zip
-        echo "${{ runner.temp  }}/codeql" >> $GITHUB_PATH
+        unzip -q -d "${RUNNER_TEMP}" codeql-linux64.zip
+        echo "${RUNNER_TEMP}/codeql" >> "${GITHUB_PATH}"
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -1,0 +1,31 @@
+name: Post pull-request comment
+on:
+  workflow_run:
+    workflows: ["Query help preview"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@af92a8455a59214b7b932932f2662fdefbd78126
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          name: comment
+      - run: |
+          PR=$(grep -o '^[0-9]\+$' pr.txt)
+          PR_HEAD_SHA=$(gh api "/repos/${{ github.repository }}/pulls/${PR}" --jq .head.sha)
+          # Check that the pull-request head SHA matches the head SHA of the workflow run
+          if [ "${WORKFLOW_RUN_HEAD_SHA}" != "${PR_HEAD_SHA}" ]; then
+            exit 1
+          fi
+          cat comment.txt | gh pr comment "${PR}" --repo "${{ github.repository }}" -F -
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_commit.id }}

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -13,11 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@af92a8455a59214b7b932932f2662fdefbd78126
-        with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: success
-          name: comment
+        run: gh run download "${{ github.event.workflow_run.id }}" --repo "${{ github.repository }}" --name "comment"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - run: |
           PR=$(grep -o '^[0-9]\+$' pr.txt)
           PR_HEAD_SHA=$(gh api "/repos/${{ github.repository }}/pulls/${PR}" --jq .head.sha)

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -22,6 +22,7 @@ jobs:
           PR_HEAD_SHA="$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .head.sha)"
           # Check that the pull-request head SHA matches the head SHA of the workflow run
           if [ "${WORKFLOW_RUN_HEAD_SHA}" != "${PR_HEAD_SHA}" ]; then
+            echo "PR head SHA ${PR_HEAD_SHA} does not match workflow_run event SHA ${WORKFLOW_RUN_HEAD_SHA}. Stopping." 1>&2
             exit 1
           fi
           gh pr comment "${PR}" --repo "${GITHUB_REPOSITORY}" -F comment.txt

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -13,17 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        run: gh run download "${{ github.event.workflow_run.id }}" --repo "${{ github.repository }}" --name "comment"
+        run: gh run download "${WORKFLOW_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --name "comment"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
       - run: |
-          PR=$(grep -o '^[0-9]\+$' pr.txt)
-          PR_HEAD_SHA=$(gh api "/repos/${{ github.repository }}/pulls/${PR}" --jq .head.sha)
+          PR="$(grep -o '^[0-9]\+$' pr.txt)"
+          PR_HEAD_SHA="$(gh api "/repos/${GITHUB_REPOSITORY}/pulls/${PR}" --jq .head.sha)"
           # Check that the pull-request head SHA matches the head SHA of the workflow run
           if [ "${WORKFLOW_RUN_HEAD_SHA}" != "${PR_HEAD_SHA}" ]; then
             exit 1
           fi
-          cat comment.txt | gh pr comment "${PR}" --repo "${{ github.repository }}" -F -
+          gh pr comment "${PR}" --repo "${GITHUB_REPOSITORY}" -F comment.txt
         env:
           GITHUB_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_commit.id }}

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - "rc/*"
@@ -17,10 +17,16 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - run: echo "${{  github.event.number }}" > pr.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: comment
+          path: pr.txt
+          retention-days: 1
+
       - uses: github/codeql/.github/actions/fetch-codeql@main
       - uses: actions/checkout@v2
         with:
-          ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 2
           persist-credentials: false
 
@@ -33,6 +39,7 @@ jobs:
 
       - name: QHelp preview
         run: |
+          echo "QHelp previews:" > comment.txt
           cat "${{ runner.temp }}/paths.txt" | while read path; do
             if [ ! -f "${path}" ]; then
                exit 1
@@ -41,23 +48,10 @@ jobs:
             echo
             codeql generate query-help --format=markdown -- "./${path}"
             echo "</details>"
-          done > comment.txt
+          done >> comment.txt
 
       - uses: actions/upload-artifact@v2
         with:
-          name: comment.txt
+          name: comment
           path: comment.txt
-
-  post_comment:
-    permissions:
-      pull-requests: write
-    runs-on: ubuntu-latest
-    needs: qhelp
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: comment.txt
-      - run: |
-          (echo "QHelp previews:"; cat comment.txt) | gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" -F -
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          retention-days: 1

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 2
+          persist-credentials: false
       - name: Determine changed files
         id: changes
         run: |

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -16,19 +16,19 @@ jobs:
   qhelp:
     runs-on: ubuntu-latest
     steps:
+      - uses: github/codeql/.github/actions/fetch-codeql@main
       - uses: actions/checkout@v2
         with:
           ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 2
           persist-credentials: false
+
       - name: Determine changed files
         id: changes
         run: |
           (git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.qhelp$' | grep -v '.inc.qhelp';
            git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.inc.qhelp$' | xargs -d '\n' -rn1 basename | xargs -d '\n' -rn1 git grep -l) |
            sort -u > "${{ runner.temp }}/paths.txt"
-
-      - uses: ./.github/actions/fetch-codeql
 
       - name: QHelp preview
         run: |

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -2,7 +2,6 @@ name: Query help preview
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   pull_request_target:
@@ -14,6 +13,8 @@ on:
 
 jobs:
   qhelp:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: github/codeql/.github/actions/fetch-codeql@main
@@ -32,14 +33,28 @@ jobs:
 
       - name: QHelp preview
         run: |
-          if [ -s "${{ runner.temp }}/paths.txt" ]; then
-            ( echo "QHelp previews:";
-            cat "${{ runner.temp }}/paths.txt" | while read path; do
-              echo "<details> <summary>${path}</summary>"
-              echo
-              codeql generate query-help --format=markdown "${path}"
-              echo "</details>"
-            done) | gh pr comment "${{ github.event.pull_request.number }}" -F -
-          fi
+          cat "${{ runner.temp }}/paths.txt" | while read path; do
+            echo "<details> <summary>${path}</summary>"
+            echo
+            codeql generate query-help --format=markdown "${path}"
+            echo "</details>"
+          done > comment.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: comment.txt
+          path: comment.txt
+
+  post_comment:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: qhelp
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: comment.txt
+      - run: |
+          (echo "QHelp previews:"; cat comment.txt) | gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" -F -
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -29,14 +29,17 @@ jobs:
         run: |
           (git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.qhelp$' | grep -v '.inc.qhelp';
            git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.inc.qhelp$' | xargs -d '\n' -rn1 basename | xargs -d '\n' -rn1 git grep -l) |
-           grep '.qhelp$' | sort -u > "${{ runner.temp }}/paths.txt"
+           grep '.qhelp$' | grep -v '^-' | sort -u > "${{ runner.temp }}/paths.txt"
 
       - name: QHelp preview
         run: |
           cat "${{ runner.temp }}/paths.txt" | while read path; do
+            if [ ! -f "${path}" ]; then
+               exit 1
+            fi
             echo "<details> <summary>${path}</summary>"
             echo
-            codeql generate query-help --format=markdown "${path}"
+            codeql generate query-help --format=markdown -- "./${path}"
             echo "</details>"
           done > comment.txt
 

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -23,13 +23,11 @@ jobs:
           name: comment
           path: pr.txt
           retention-days: 1
-
-      - uses: github/codeql/.github/actions/fetch-codeql@main
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
           persist-credentials: false
-
+      - uses: ./.github/actions/fetch-codeql
       - name: Determine changed files
         id: changes
         run: |

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -30,14 +30,15 @@ jobs:
       - uses: ./.github/actions/fetch-codeql
 
       - name: QHelp preview
-        if: ${{ steps.changes.outputs.qhelp_files }}
         run: |
-          ( echo "QHelp previews:";
-          cat "${{ runner.temp }}/paths.txt" | while read path; do
-            echo "<details> <summary>${path}</summary>"
-            echo
-            codeql generate query-help --format=markdown "${path}"
-            echo "</details>"
-          done) | gh pr comment "${{ github.event.pull_request.number }}" -F -
+          if [ -s "${{ runner.temp }}/paths.txt" ]; then
+            ( echo "QHelp previews:";
+            cat "${{ runner.temp }}/paths.txt" | while read path; do
+              echo "<details> <summary>${path}</summary>"
+              echo
+              codeql generate query-help --format=markdown "${path}"
+              echo "</details>"
+            done) | gh pr comment "${{ github.event.pull_request.number }}" -F -
+          fi
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           (git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.qhelp$' | grep -v '.inc.qhelp';
            git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.inc.qhelp$' | xargs -d '\n' -rn1 basename | xargs -d '\n' -rn1 git grep -l) |
-           sort -u > "${{ runner.temp }}/paths.txt"
+           grep '.qhelp$' | sort -u > "${{ runner.temp }}/paths.txt"
 
       - name: QHelp preview
         run: |

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -1,10 +1,14 @@
 name: Query help preview
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
-      - 'rc/*'
+      - "rc/*"
     paths:
       - "ruby/**/*.qhelp"
 
@@ -14,14 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 2
       - name: Determine changed files
         id: changes
         run: |
-          echo -n "::set-output name=qhelp_files::"
-          (git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep .qhelp$ | grep -v .inc.qhelp;
-           git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep .inc.qhelp$ | xargs -d '\n' -rn1 basename | xargs -d '\n' -rn1 git grep -l) |
-           sort -u | xargs -d '\n' -n1 printf "'%s' "
+          (git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.qhelp$' | grep -v '.inc.qhelp';
+           git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.inc.qhelp$' | xargs -d '\n' -rn1 basename | xargs -d '\n' -rn1 git grep -l) |
+           sort -u > "${{ runner.temp }}/paths.txt"
 
       - uses: ./.github/actions/fetch-codeql
 
@@ -29,10 +33,10 @@ jobs:
         if: ${{ steps.changes.outputs.qhelp_files }}
         run: |
           ( echo "QHelp previews:";
-          for path in ${{ steps.changes.outputs.qhelp_files }} ; do
+          cat "${{ runner.temp }}/paths.txt" | while read path; do
             echo "<details> <summary>${path}</summary>"
             echo
-            codeql generate query-help --format=markdown ${path}
+            codeql generate query-help --format=markdown "${path}"
             echo "</details>"
           done) | gh pr comment "${{ github.event.pull_request.number }}" -F -
         env:

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -37,18 +37,28 @@ jobs:
 
       - name: QHelp preview
         run: |
+          EXIT_CODE=0
           echo "QHelp previews:" > comment.txt
-          cat "${{ runner.temp }}/paths.txt" | while read path; do
+          while read path; do
             if [ ! -f "${path}" ]; then
                exit 1
             fi
             echo "<details> <summary>${path}</summary>"
             echo
-            codeql generate query-help --format=markdown -- "./${path}"
+            codeql generate query-help --format=markdown -- "./${path}" 2> errors.txt || EXIT_CODE="$?"
+            if [ -s errors.txt ]; then
+               echo "# errors/warnings:"
+               echo '```'
+               cat errors.txt
+               cat errors.txt 1>&2
+               echo '```'
+            fi
             echo "</details>"
-          done >> comment.txt
+          done < "${{ runner.temp }}/paths.txt" >> comment.txt
+          exit "${EXIT_CODE}"
 
-      - uses: actions/upload-artifact@v2
+      - if: always()
+        uses: actions/upload-artifact@v2
         with:
           name: comment
           path: comment.txt

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -31,15 +31,15 @@ jobs:
       - name: Determine changed files
         id: changes
         run: |
-          (git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.qhelp$' | grep -v '.inc.qhelp';
-           git diff --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep '.inc.qhelp$' | xargs -d '\n' -rn1 basename | xargs -d '\n' -rn1 git grep -l) |
-           grep '.qhelp$' | grep -v '^-' | sort -u > "${{ runner.temp }}/paths.txt"
+          (git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.qhelp$' | grep -z -v '.inc.qhelp';
+           git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.inc.qhelp$' | xargs --null -rn1 basename | xargs --null -rn1 git grep -z -l) |
+           grep -z '.qhelp$' | grep -z -v '^-' | sort -z -u > "${{ runner.temp }}/paths.txt"
 
       - name: QHelp preview
         run: |
           EXIT_CODE=0
           echo "QHelp previews:" > comment.txt
-          while read path; do
+          while read -r -d $'\0' path; do
             if [ ! -f "${path}" ]; then
                exit 1
             fi

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -13,8 +13,6 @@ on:
 
 jobs:
   qhelp:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - run: echo "${{  github.event.number }}" > pr.txt

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           (git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.qhelp$' | grep -z -v '.inc.qhelp';
            git diff -z --name-only --diff-filter=ACMRT HEAD~1 HEAD | grep -z '.inc.qhelp$' | xargs --null -rn1 basename | xargs --null -rn1 git grep -z -l) |
-           grep -z '.qhelp$' | grep -z -v '^-' | sort -z -u > "${{ runner.temp }}/paths.txt"
+           grep -z '.qhelp$' | grep -z -v '^-' | sort -z -u > "${RUNNER_TEMP}/paths.txt"
 
       - name: QHelp preview
         run: |
@@ -52,7 +52,7 @@ jobs:
                echo '```'
             fi
             echo "</details>"
-          done < "${{ runner.temp }}/paths.txt" >> comment.txt
+          done < "${RUNNER_TEMP}/paths.txt" >> comment.txt
           exit "${EXIT_CODE}"
 
       - if: always()


### PR DESCRIPTION
This pull request makes the `qhelp-pr-preview` workflow suitable to be run on pull requests from forks. Actions jobs on pull requests from forks are run with limited privileges and as a result the workflow was not allowed to post a comment containing the QHelp previews. To make this work I split the workflow in two, the first generates the query help in markdown format and uploads the result as an artefact. The second workflow uses a `workflow_run` trigger and takes care of downloading the generated markdown and posting it to the pull request. The first workflow is completely user controlled and runs with read-only permissions. The second workflow has elevated permissions `pull-request: write` to post the comment. However, this workflow is not user controlled and its inputs (a pull-request number and contents of the comment to be posted) are not used in dangerous ways. In addition the workflow double checks that the commit SHA of the head of the pull request and the one from the triggering workflow run match. This prevents a malicious user from writing spam comments on arbitrary pull requests.

An example run can be found at https://github.com/aibaars/codeql/pull/5#issuecomment-959211119