### PR TITLE
Java: Deprecate `StringLiteral.getRepresentedString()`

### DIFF
--- a/java/change-notes/2021-10-29-deprecate-String-getRepresentedString.md
+++ b/java/change-notes/2021-10-29-deprecate-String-getRepresentedString.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The predicate `StringLiteral.getRepresentedString()` has been deprecated for removal in a future version because it is just an alias for `getValue()`. That predicate should be used instead.

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -734,6 +734,9 @@ class StringLiteral extends Literal, @stringliteral {
   /**
    * Gets the string represented by this string literal, that is, the content
    * of the literal without enclosing quotes and with escape sequences translated.
+   *
+   * Unpaired Unicode surrogate characters (U+D800 to U+DFFF) are replaced with the
+   * replacement character U+FFFD.
    */
   override string getValue() { result = super.getValue() }
 

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -166,7 +166,7 @@ class CompileTimeConstantExpr extends Expr {
    */
   pragma[nomagic]
   string getStringValue() {
-    result = this.(StringLiteral).getRepresentedString()
+    result = this.(StringLiteral).getValue()
     or
     result =
       this.(AddExpr).getLeftOperand().(CompileTimeConstantExpr).getStringValue() +
@@ -732,9 +732,18 @@ class CharacterLiteral extends Literal, @characterliteral {
  */
 class StringLiteral extends Literal, @stringliteral {
   /**
+   * Gets the string represented by this string literal, that is, the content
+   * of the literal without enclosing quotes and with escape sequences translated.
+   */
+  override string getValue() { result = super.getValue() }
+
+  /**
+   * DEPRECATED: This predicate will be removed in a future version because
+   * it is just an alias for `getValue()`; that predicate should be used instead.
+   *
    * Gets the literal string without the quotes.
    */
-  string getRepresentedString() { result = this.getValue() }
+  deprecated string getRepresentedString() { result = this.getValue() }
 
   /** Holds if this string literal is a text block (`""" ... """`). */
   predicate isTextBlock() { this.getLiteral().matches("\"\"\"%") }

--- a/java/ql/lib/semmle/code/java/JDKAnnotations.qll
+++ b/java/ql/lib/semmle/code/java/JDKAnnotations.qll
@@ -25,9 +25,7 @@ class SuppressWarningsAnnotation extends Annotation {
   }
 
   /** Gets the name of a warning suppressed by this annotation. */
-  string getASuppressedWarning() {
-    result = this.getASuppressedWarningLiteral().getRepresentedString()
-  }
+  string getASuppressedWarning() { result = this.getASuppressedWarningLiteral().getValue() }
 }
 
 /** A `@Target` annotation. */

--- a/java/ql/lib/semmle/code/java/Reflection.qll
+++ b/java/ql/lib/semmle/code/java/Reflection.qll
@@ -75,7 +75,7 @@ class ReflectiveClassIdentifierMethodAccess extends ReflectiveClassIdentifier, M
   /**
    * If the argument to this call is a `StringLiteral`, then return that string.
    */
-  string getTypeName() { result = this.getArgument(0).(StringLiteral).getRepresentedString() }
+  string getTypeName() { result = this.getArgument(0).(StringLiteral).getValue() }
 
   override RefType getReflectivelyIdentifiedClass() {
     // We only handle cases where the class is specified as a string literal to this call.
@@ -360,7 +360,7 @@ class ReflectiveMethodAccess extends ClassMethodAccess {
         this.getInferredClassType().inherits(result)
     ) and
     // Only consider instances where the method name is provided as a `StringLiteral`.
-    result.hasName(this.getArgument(0).(StringLiteral).getRepresentedString())
+    result.hasName(this.getArgument(0).(StringLiteral).getValue())
   }
 }
 
@@ -400,6 +400,6 @@ class ReflectiveFieldAccess extends ClassMethodAccess {
         this.getInferredClassType().inherits(result)
       )
     ) and
-    result.hasName(this.getArgument(0).(StringLiteral).getRepresentedString())
+    result.hasName(this.getArgument(0).(StringLiteral).getValue())
   }
 }

--- a/java/ql/lib/semmle/code/java/StringFormat.qll
+++ b/java/ql/lib/semmle/code/java/StringFormat.qll
@@ -279,7 +279,7 @@ private predicate formatStringFragment(Expr fmt) {
 private predicate formatStringValue(Expr e, string fmtvalue) {
   formatStringFragment(e) and
   (
-    e.(StringLiteral).getRepresentedString() = fmtvalue
+    e.(StringLiteral).getValue() = fmtvalue
     or
     e.getType() instanceof IntegralType and fmtvalue = "1" // dummy value
     or
@@ -318,7 +318,7 @@ private predicate formatStringValue(Expr e, string fmtvalue) {
       getprop.hasName("getProperty") and
       getprop.getDeclaringType().hasQualifiedName("java.lang", "System") and
       getprop.getNumberOfParameters() = 1 and
-      ma.getAnArgument().(StringLiteral).getRepresentedString() = prop and
+      ma.getAnArgument().(StringLiteral).getValue() = prop and
       (prop = "line.separator" or prop = "file.separator" or prop = "path.separator") and
       fmtvalue = "x" // dummy value
     )

--- a/java/ql/lib/semmle/code/java/UnitTests.qll
+++ b/java/ql/lib/semmle/code/java/UnitTests.qll
@@ -162,7 +162,7 @@ class TestNGTestMethod extends Method {
       testAnnotation = this.getAnAnnotation() and
       // The data provider must have the same name as the referenced data provider
       result.getDataProviderName() =
-        testAnnotation.getValue("dataProvider").(StringLiteral).getRepresentedString()
+        testAnnotation.getValue("dataProvider").(StringLiteral).getValue()
     |
       // Either the data provider should be on the current class, or a supertype
       this.getDeclaringType().getAnAncestor() = result.getDeclaringType()
@@ -258,7 +258,7 @@ class TestNGDataProviderMethod extends Method {
           .(TestNGDataProviderAnnotation)
           .getValue("name")
           .(StringLiteral)
-          .getRepresentedString()
+          .getValue()
   }
 }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -300,8 +300,8 @@ private predicate unsafeEscape(MethodAccess ma) {
   // Removing `<script>` tags using a string-replace method is
   // unsafe if such a tag is embedded inside another one (e.g. `<scr<script>ipt>`).
   exists(StringReplaceMethod m | ma.getMethod() = m |
-    ma.getArgument(0).(StringLiteral).getRepresentedString() = "(<script>)" and
-    ma.getArgument(1).(StringLiteral).getRepresentedString() = ""
+    ma.getArgument(0).(StringLiteral).getValue() = "(<script>)" and
+    ma.getArgument(1).(StringLiteral).getValue() = ""
   )
 }
 

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringComponentScan.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringComponentScan.qll
@@ -37,9 +37,9 @@ class SpringComponentScan extends Annotation {
    */
   string getBasePackages() {
     // "value" and "basePackages" are synonymous, and are simple strings
-    result = this.getAValue("basePackages").(StringLiteral).getRepresentedString()
+    result = this.getAValue("basePackages").(StringLiteral).getValue()
     or
-    result = this.getAValue("value").(StringLiteral).getRepresentedString()
+    result = this.getAValue("value").(StringLiteral).getValue()
     or
     exists(TypeLiteral typeLiteral |
       // Base package classes are type literals whose package should be considered a base package.
@@ -201,7 +201,7 @@ class SpringComponent extends RefType {
           .getType()
           .hasQualifiedName("org.springframework.context.annotation", "Profile")
     |
-      result = profileAnnotation.getAValue("value").(StringLiteral).getRepresentedString()
+      result = profileAnnotation.getAValue("value").(StringLiteral).getValue()
     )
   }
 }

--- a/java/ql/lib/semmle/code/java/security/ControlledString.qll
+++ b/java/ql/lib/semmle/code/java/security/ControlledString.qll
@@ -22,7 +22,7 @@ private predicate boxedToString(Method method) {
  * it is better to use a prepared query than to just put single quotes around the string.
  */
 predicate endsInQuote(Expr expr) {
-  exists(string str | str = expr.(StringLiteral).getRepresentedString() | str.matches("%'"))
+  exists(string str | str = expr.(StringLiteral).getValue() | str.matches("%'"))
   or
   exists(Variable var | expr = var.getAnAccess() | endsInQuote(var.getAnAssignedValue()))
   or

--- a/java/ql/lib/semmle/code/java/security/HttpsUrls.qll
+++ b/java/ql/lib/semmle/code/java/security/HttpsUrls.qll
@@ -12,13 +12,13 @@ private import semmle.code.java.frameworks.Networking
  */
 class HttpStringLiteral extends StringLiteral {
   HttpStringLiteral() {
-    exists(string s | this.getRepresentedString() = s |
+    exists(string s | this.getValue() = s |
       s = "http"
       or
       s.matches("http://%") and
       not s.substring(7, s.length()) instanceof PrivateHostName and
       not TaintTracking::localExprTaint(any(StringLiteral p |
-          p.getRepresentedString() instanceof PrivateHostName
+          p.getValue() instanceof PrivateHostName
         ), this.getParent*())
     )
   }

--- a/java/ql/lib/semmle/code/java/security/InsecureBasicAuth.qll
+++ b/java/ql/lib/semmle/code/java/security/InsecureBasicAuth.qll
@@ -41,5 +41,5 @@ private class DefaultInsecureBasicAuthSink extends InsecureBasicAuthSink {
  * String pattern of basic authentication.
  */
 private class BasicAuthString extends StringLiteral {
-  BasicAuthString() { exists(string s | this.getRepresentedString() = s | s.matches("Basic %")) }
+  BasicAuthString() { exists(string s | this.getValue() = s | s.matches("Basic %")) }
 }

--- a/java/ql/lib/semmle/code/java/security/RelativePaths.qll
+++ b/java/ql/lib/semmle/code/java/security/RelativePaths.qll
@@ -5,7 +5,7 @@ import java
  * An element that starts with a relative path.
  */
 predicate relativePath(Element tree, string command) {
-  exists(StringLiteral lit, string text | tree = lit and text = lit.getRepresentedString() |
+  exists(StringLiteral lit, string text | tree = lit and text = lit.getValue() |
     text != "" and
     text.regexpMatch(["[^/\\\\ \t]*", "[^/\\\\ \t]*[ \t].*"]) and
     command = text.replaceAll("\t", " ").splitAt(" ", 0).replaceAll("\"", "")

--- a/java/ql/lib/semmle/code/java/security/SecurityFlag.qll
+++ b/java/ql/lib/semmle/code/java/security/SecurityFlag.qll
@@ -27,7 +27,7 @@ abstract class FlagKind extends string {
         flag.asExpr() = v and v.getType() instanceof FlagType
       )
       or
-      exists(StringLiteral s | s.getRepresentedString() = getAFlagName() | flag.asExpr() = s)
+      exists(StringLiteral s | s.getValue() = getAFlagName() | flag.asExpr() = s)
       or
       exists(MethodAccess ma | ma.getMethod().getName() = getAFlagName() |
         flag.asExpr() = ma and

--- a/java/ql/lib/semmle/code/java/security/SensitiveActions.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveActions.qll
@@ -41,9 +41,7 @@ class SensitiveMethodAccess extends SensitiveExpr, MethodAccess {
     or
     // This is particularly to pick up methods with an argument like "password", which
     // may indicate a lookup.
-    exists(string s |
-      this.getAnArgument().(StringLiteral).getRepresentedString().toLowerCase() = s
-    |
+    exists(string s | this.getAnArgument().(StringLiteral).getValue().toLowerCase() = s |
       s.matches(suspicious()) and
       not s.matches(nonSuspicious())
     )

--- a/java/ql/src/Performance/InefficientEmptyStringTest.ql
+++ b/java/ql/src/Performance/InefficientEmptyStringTest.ql
@@ -16,7 +16,7 @@ where
   mc.getQualifier().getType() instanceof TypeString and
   mc.getMethod().hasName("equals") and
   (
-    mc.getArgument(0).(StringLiteral).getRepresentedString() = "" or
-    mc.getQualifier().(StringLiteral).getRepresentedString() = ""
+    mc.getArgument(0).(StringLiteral).getValue() = "" or
+    mc.getQualifier().(StringLiteral).getValue() = ""
   )
 select mc, "Inefficient comparison to empty string, check for zero length instead."

--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
@@ -17,14 +17,14 @@ import DataFlow
 import PathGraph
 
 private class ShortStringLiteral extends StringLiteral {
-  ShortStringLiteral() { getRepresentedString().length() < 100 }
+  ShortStringLiteral() { getValue().length() < 100 }
 }
 
 class BrokenAlgoLiteral extends ShortStringLiteral {
   BrokenAlgoLiteral() {
-    getRepresentedString().regexpMatch(getInsecureAlgorithmRegex()) and
+    getValue().regexpMatch(getInsecureAlgorithmRegex()) and
     // Exclude German and French sentences.
-    not getRepresentedString().regexpMatch(".*\\p{IsLowercase} des \\p{IsLetter}.*")
+    not getValue().regexpMatch(".*\\p{IsLowercase} des \\p{IsLetter}.*")
   }
 }
 
@@ -48,4 +48,4 @@ where
   source.getNode().asExpr() = s and
   conf.hasFlowPath(source, sink)
 select c, source, sink, "Cryptographic algorithm $@ is weak and should not be used.", s,
-  s.getRepresentedString()
+  s.getValue()

--- a/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
@@ -18,14 +18,14 @@ import semmle.code.java.dispatch.VirtualDispatch
 import PathGraph
 
 private class ShortStringLiteral extends StringLiteral {
-  ShortStringLiteral() { getRepresentedString().length() < 100 }
+  ShortStringLiteral() { getValue().length() < 100 }
 }
 
 class InsecureAlgoLiteral extends ShortStringLiteral {
   InsecureAlgoLiteral() {
     // Algorithm identifiers should be at least two characters.
-    getRepresentedString().length() > 1 and
-    exists(string s | s = getRepresentedString() |
+    getValue().length() > 1 and
+    exists(string s | s = getValue() |
       not s.regexpMatch(getSecureAlgorithmRegex()) and
       // Exclude results covered by another query.
       not s.regexpMatch(getInsecureAlgorithmRegex())
@@ -72,4 +72,4 @@ where
   conf.hasFlowPath(source, sink)
 select c, source, sink,
   "Cryptographic algorithm $@ may not be secure, consider using a different algorithm.", s,
-  s.getRepresentedString()
+  s.getValue()

--- a/java/ql/src/Security/CWE/CWE-798/HardcodedCredentials.qll
+++ b/java/ql/src/Security/CWE/CWE-798/HardcodedCredentials.qll
@@ -31,7 +31,7 @@ private class HardcodedCharArray extends ArrayCreationExpr {
  */
 class HardcodedExpr extends Expr {
   HardcodedExpr() {
-    this.(StringLiteral).getRepresentedString() != "" or
+    this.(StringLiteral).getValue() != "" or
     this instanceof HardcodedByteArray or
     this instanceof HardcodedCharArray
   }

--- a/java/ql/src/Violations of Best Practice/Dead Code/NonAssignedFields.ql
+++ b/java/ql/src/Violations of Best Practice/Dead Code/NonAssignedFields.ql
@@ -34,7 +34,7 @@ predicate subjectToAtomicReferenceFieldUpdater(Field f) {
     c.getMethod().getSourceDeclaration() = newUpdater and
     isClassOf(c.getArgument(0).getType(), f.getDeclaringType()) and
     isClassOf(c.getArgument(1).getType(), f.getType()) and
-    c.getArgument(2).(StringLiteral).getRepresentedString() = f.getName()
+    c.getArgument(2).(StringLiteral).getValue() = f.getName()
   )
 }
 
@@ -45,7 +45,7 @@ predicate lookedUpReflectively(Field f) {
   exists(MethodAccess getDeclaredField |
     isClassOf(getDeclaredField.getQualifier().getType(), f.getDeclaringType()) and
     getDeclaredField.getMethod().hasName("getDeclaredField") and
-    getDeclaredField.getArgument(0).(StringLiteral).getRepresentedString() = f.getName()
+    getDeclaredField.getArgument(0).(StringLiteral).getValue() = f.getName()
   )
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulationLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringViewManipulationLib.qll
@@ -59,7 +59,7 @@ class SpringViewManipulationConfig extends TaintTracking::Configuration {
     exists(AddExpr e, StringLiteral sl |
       node.asExpr() = e.getControlFlowNode().getASuccessor*() and
       sl = e.getLeftOperand*() and
-      sl.getRepresentedString().matches(["redirect:%", "ajaxredirect:%", "forward:%"])
+      sl.getValue().matches(["redirect:%", "ajaxredirect:%", "forward:%"])
     )
     or
     // Block flows like
@@ -79,7 +79,7 @@ class SpringViewManipulationConfig extends TaintTracking::Configuration {
         sl = ca.getQualifier()
       ) and
       ca = getAStringCombiningCall() and
-      sl.getRepresentedString().matches(["redirect:%", "ajaxredirect:%", "forward:%"])
+      sl.getValue().matches(["redirect:%", "ajaxredirect:%", "forward:%"])
     |
       exists(Call cc | DataFlow::localExprFlow(ca.getQualifier(), cc.getQualifier()) |
         cc = node.asExpr()

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -139,7 +139,7 @@ predicate hasShortECKeyPair(MethodAccess ma, string msg) {
     kc.hasFlowPath(source, dest) and
     DataFlow::localExprFlow(cie, ma.getArgument(0)) and
     ma.getArgument(0).getType() instanceof ECGenParameterSpec and
-    getECKeySize(cie.getArgument(0).(StringLiteral).getRepresentedString()) < 256
+    getECKeySize(cie.getArgument(0).(StringLiteral).getValue()) < 256
   ) and
   msg = "Key size should be at least 256 bits for EC encryption."
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInConfigurationClass.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-502/UnsafeSpringExporterInConfigurationClass.ql
@@ -42,7 +42,7 @@ private class UnsafeBeanInitMethod extends Method {
     exists(Annotation a | this.getAnAnnotation() = a |
       a.getType().hasQualifiedName("org.springframework.context.annotation", "Bean") and
       if a.getValue("name") instanceof StringLiteral
-      then identifier = a.getValue("name").(StringLiteral).getRepresentedString()
+      then identifier = a.getValue("name").(StringLiteral).getValue()
       else identifier = this.getName()
     )
   }

--- a/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-522/InsecureLdapAuth.ql
@@ -23,7 +23,7 @@ import DataFlow::PathGraph
 class InsecureLdapUrlLiteral extends StringLiteral {
   InsecureLdapUrlLiteral() {
     // Match connection strings with the LDAP protocol and without private IP addresses to reduce false positives.
-    exists(string s | this.getRepresentedString() = s |
+    exists(string s | this.getValue() = s |
       s.regexpMatch("(?i)ldap://[\\[a-zA-Z0-9].*") and
       not s.substring(7, s.length()) instanceof PrivateHostName
     )

--- a/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-939/IncorrectURLVerification.ql
@@ -54,7 +54,7 @@ class HostVerificationMethodAccess extends MethodAccess {
     ) and
     this.getMethod().getNumberOfParameters() = 1 and
     (
-      this.getArgument(0).(StringLiteral).getRepresentedString().charAt(0) != "." //string constant comparison e.g. uri.getHost().endsWith("example.com")
+      this.getArgument(0).(StringLiteral).getValue().charAt(0) != "." //string constant comparison e.g. uri.getHost().endsWith("example.com")
       or
       this.getArgument(0)
           .(AddExpr)
@@ -63,15 +63,10 @@ class HostVerificationMethodAccess extends MethodAccess {
           .getVariable()
           .getAnAssignedValue()
           .(StringLiteral)
-          .getRepresentedString()
+          .getValue()
           .charAt(0) != "." //var1+var2, check var1 starts with "." e.g. String domainName = "example"; Uri.parse(url).getHost().endsWith(domainName+".com")
       or
-      this.getArgument(0)
-          .(AddExpr)
-          .getLeftOperand()
-          .(StringLiteral)
-          .getRepresentedString()
-          .charAt(0) != "." //"."+var2, check string constant "." e.g. String domainName = "example.com";  Uri.parse(url).getHost().endsWith("www."+domainName)
+      this.getArgument(0).(AddExpr).getLeftOperand().(StringLiteral).getValue().charAt(0) != "." //"."+var2, check string constant "." e.g. String domainName = "example.com";  Uri.parse(url).getHost().endsWith("www."+domainName)
       or
       exists(MethodAccess ma, Method m, Field f |
         this.getArgument(0) = ma and
@@ -87,7 +82,7 @@ class HostVerificationMethodAccess extends MethodAccess {
           .getVariable()
           .getAnAssignedValue()
           .(StringLiteral)
-          .getRepresentedString()
+          .getValue()
           .charAt(0) != "." //check variable starts with "." e.g. String domainName = "example.com";  Uri.parse(url).getHost().endsWith(domainName)
     )
   }

--- a/java/ql/test/library-tests/Encryption/insecure.ql
+++ b/java/ql/test/library-tests/Encryption/insecure.ql
@@ -2,5 +2,5 @@ import default
 import semmle.code.java.security.Encryption
 
 from StringLiteral s
-where s.getRepresentedString().regexpMatch(getInsecureAlgorithmRegex())
+where s.getValue().regexpMatch(getInsecureAlgorithmRegex())
 select s

--- a/java/ql/test/library-tests/Encryption/secure.ql
+++ b/java/ql/test/library-tests/Encryption/secure.ql
@@ -2,5 +2,5 @@ import default
 import semmle.code.java.security.Encryption
 
 from StringLiteral s
-where s.getRepresentedString().regexpMatch(getSecureAlgorithmRegex())
+where s.getValue().regexpMatch(getSecureAlgorithmRegex())
 select s

--- a/java/ql/test/library-tests/literals/stringLiterals/stringLiterals.expected
+++ b/java/ql/test/library-tests/literals/stringLiterals/stringLiterals.expected
@@ -1,48 +1,48 @@
-| StringLiterals.java:7:3:7:4 | "" |  |  |  |
-| StringLiterals.java:8:3:8:17 | "hello,\\tworld" | hello,\tworld | hello,\tworld |  |
-| StringLiterals.java:9:3:9:21 | "hello,\\u0009world" | hello,\tworld | hello,\tworld |  |
-| StringLiterals.java:10:3:10:10 | "\\u0061" | a | a |  |
-| StringLiterals.java:11:3:11:6 | "\\0" | \u0000 | \u0000 |  |
-| StringLiterals.java:12:3:12:10 | "\\uFFFF" | \uffff | \uffff |  |
-| StringLiterals.java:13:3:13:10 | "\\ufFfF" | \uffff | \uffff |  |
-| StringLiterals.java:14:3:14:6 | "\\"" | " | " |  |
-| StringLiterals.java:15:3:15:6 | "\\'" | ' | ' |  |
-| StringLiterals.java:16:3:16:6 | "\\n" | \n | \n |  |
-| StringLiterals.java:17:3:17:6 | "\\\\" | \\ | \\ |  |
-| StringLiterals.java:18:3:18:13 | "test \\123" | test S | test S |  |
-| StringLiterals.java:19:3:19:9 | "\\1234" | S4 | S4 |  |
-| StringLiterals.java:20:3:20:9 | "\\0000" | \u00000 | \u00000 |  |
-| StringLiterals.java:21:3:21:13 | "\\u0061567" | a567 | a567 |  |
-| StringLiterals.java:22:3:22:13 | "\\u1234567" | \u1234567 | \u1234567 |  |
-| StringLiterals.java:23:3:23:18 | "\\uaBcDeF\\u0aB1" | \uabcdeF\u0ab1 | \uabcdeF\u0ab1 |  |
-| StringLiterals.java:24:3:24:16 | "\\uD800\\uDC00" | \ud800\udc00 | \ud800\udc00 |  |
-| StringLiterals.java:25:3:25:16 | "\\uDBFF\\uDFFF" | \udbff\udfff | \udbff\udfff |  |
-| StringLiterals.java:27:3:27:10 | "\\uD800" | \ufffd | \ufffd |  |
-| StringLiterals.java:28:3:28:10 | "\\uDC00" | \ufffd | \ufffd |  |
-| StringLiterals.java:29:3:29:31 | "hello\\uD800hello\\uDC00world" | hello\ufffdhello\ufffdworld | hello\ufffdhello\ufffdworld |  |
-| StringLiterals.java:31:3:31:16 | "\\u005C\\u0022" | " | " |  |
-| StringLiterals.java:32:8:32:20 | 2\\u0061\\u0022 | a | a |  |
-| StringLiterals.java:37:3:39:5 | """      \t  \n\t\ttest "text" and escaped \\u0022\n\t\t""" | test "text" and escaped "\n | test "text" and escaped "\n | text-block |
-| StringLiterals.java:41:3:43:5 | """\n\t\t\tindented\n\t\t""" | \tindented\n | \tindented\n | text-block |
-| StringLiterals.java:44:3:46:5 | """\n\tno indentation last line\n\t\t""" | no indentation last line\n | no indentation last line\n | text-block |
-| StringLiterals.java:47:3:49:7 | """\n\tindentation last line\n\t\t\\s""" | indentation last line\n\t  | indentation last line\n\t  | text-block |
-| StringLiterals.java:50:3:52:6 | """\n\t\t\tnot-indented\n\t\t\t""" | not-indented\n | not-indented\n | text-block |
-| StringLiterals.java:53:3:55:4 | """\n\t\tindented\n\t""" | \tindented\n | \tindented\n | text-block |
-| StringLiterals.java:56:4:58:5 | """\n\t\tnot-indented\n\t\t""" | not-indented\n | not-indented\n | text-block |
-| StringLiterals.java:59:3:62:6 | """\n\t\t    spaces (only single space is trimmed)\n\t\t\ttab\n\t\t\t""" |    spaces (only single space is trimmed)\ntab\n |    spaces (only single space is trimmed)\ntab\n | text-block |
-| StringLiterals.java:63:3:64:22 | """\n\t\t\tend on same line""" | end on same line | end on same line | text-block |
-| StringLiterals.java:65:3:68:5 | """\n\t\ttrailing spaces ignored:  \t \n\t\tnot ignored: \t \\s\n\t\t""" | trailing spaces ignored:\nnot ignored: \t  \n | trailing spaces ignored:\nnot ignored: \t  \n | text-block |
-| StringLiterals.java:69:3:70:18 | """\n\t\t3 quotes:""\\"""" | 3 quotes:""" | 3 quotes:""" | text-block |
-| StringLiterals.java:71:3:74:5 | """\n\t\tline \\\n\t\tcontinuation \\\n\t\t""" | line continuation  | line continuation  | text-block |
-| StringLiterals.java:75:3:79:5 | """\n\t\tExplicit line breaks:\\n\n\t\t\\r\\n\n\t\t\\r\n\t\t""" | Explicit line breaks:\n\n\r\n\n\r\n | Explicit line breaks:\n\n\r\n\n\r\n | text-block |
-| StringLiterals.java:82:10:84:16 | 2"\\u0022\n\t\ttest\n\t\t\\u0022\\uu0022" | test\n | test\n |  |
-| StringLiterals.java:90:3:90:19 | "hello" + "world" | helloworld | helloworld |  |
-| StringLiterals.java:91:3:92:20 | """\n\t\thello""" + "world" | helloworld | helloworld | text-block |
-| StringLiterals.java:93:10:93:12 | "a" | a | a |  |
-| StringLiterals.java:94:3:94:5 | "a" | a | a |  |
-| StringLiterals.java:95:3:95:5 | "a" | a | a |  |
-| StringLiterals.java:96:7:96:9 | "a" | a | a |  |
-| StringLiterals.java:97:3:97:5 | "a" | a | a |  |
-| StringLiterals.java:98:10:98:12 | "a" | a | a |  |
-| StringLiterals.java:99:3:99:5 | "a" | a | a |  |
-| StringLiterals.java:100:9:100:11 | "a" | a | a |  |
+| StringLiterals.java:7:3:7:4 | "" |  |  |
+| StringLiterals.java:8:3:8:17 | "hello,\\tworld" | hello,\tworld |  |
+| StringLiterals.java:9:3:9:21 | "hello,\\u0009world" | hello,\tworld |  |
+| StringLiterals.java:10:3:10:10 | "\\u0061" | a |  |
+| StringLiterals.java:11:3:11:6 | "\\0" | \u0000 |  |
+| StringLiterals.java:12:3:12:10 | "\\uFFFF" | \uffff |  |
+| StringLiterals.java:13:3:13:10 | "\\ufFfF" | \uffff |  |
+| StringLiterals.java:14:3:14:6 | "\\"" | " |  |
+| StringLiterals.java:15:3:15:6 | "\\'" | ' |  |
+| StringLiterals.java:16:3:16:6 | "\\n" | \n |  |
+| StringLiterals.java:17:3:17:6 | "\\\\" | \\ |  |
+| StringLiterals.java:18:3:18:13 | "test \\123" | test S |  |
+| StringLiterals.java:19:3:19:9 | "\\1234" | S4 |  |
+| StringLiterals.java:20:3:20:9 | "\\0000" | \u00000 |  |
+| StringLiterals.java:21:3:21:13 | "\\u0061567" | a567 |  |
+| StringLiterals.java:22:3:22:13 | "\\u1234567" | \u1234567 |  |
+| StringLiterals.java:23:3:23:18 | "\\uaBcDeF\\u0aB1" | \uabcdeF\u0ab1 |  |
+| StringLiterals.java:24:3:24:16 | "\\uD800\\uDC00" | \ud800\udc00 |  |
+| StringLiterals.java:25:3:25:16 | "\\uDBFF\\uDFFF" | \udbff\udfff |  |
+| StringLiterals.java:27:3:27:10 | "\\uD800" | \ufffd |  |
+| StringLiterals.java:28:3:28:10 | "\\uDC00" | \ufffd |  |
+| StringLiterals.java:29:3:29:31 | "hello\\uD800hello\\uDC00world" | hello\ufffdhello\ufffdworld |  |
+| StringLiterals.java:31:3:31:16 | "\\u005C\\u0022" | " |  |
+| StringLiterals.java:32:8:32:20 | 2\\u0061\\u0022 | a |  |
+| StringLiterals.java:37:3:39:5 | """      \t  \n\t\ttest "text" and escaped \\u0022\n\t\t""" | test "text" and escaped "\n | text-block |
+| StringLiterals.java:41:3:43:5 | """\n\t\t\tindented\n\t\t""" | \tindented\n | text-block |
+| StringLiterals.java:44:3:46:5 | """\n\tno indentation last line\n\t\t""" | no indentation last line\n | text-block |
+| StringLiterals.java:47:3:49:7 | """\n\tindentation last line\n\t\t\\s""" | indentation last line\n\t  | text-block |
+| StringLiterals.java:50:3:52:6 | """\n\t\t\tnot-indented\n\t\t\t""" | not-indented\n | text-block |
+| StringLiterals.java:53:3:55:4 | """\n\t\tindented\n\t""" | \tindented\n | text-block |
+| StringLiterals.java:56:4:58:5 | """\n\t\tnot-indented\n\t\t""" | not-indented\n | text-block |
+| StringLiterals.java:59:3:62:6 | """\n\t\t    spaces (only single space is trimmed)\n\t\t\ttab\n\t\t\t""" |    spaces (only single space is trimmed)\ntab\n | text-block |
+| StringLiterals.java:63:3:64:22 | """\n\t\t\tend on same line""" | end on same line | text-block |
+| StringLiterals.java:65:3:68:5 | """\n\t\ttrailing spaces ignored:  \t \n\t\tnot ignored: \t \\s\n\t\t""" | trailing spaces ignored:\nnot ignored: \t  \n | text-block |
+| StringLiterals.java:69:3:70:18 | """\n\t\t3 quotes:""\\"""" | 3 quotes:""" | text-block |
+| StringLiterals.java:71:3:74:5 | """\n\t\tline \\\n\t\tcontinuation \\\n\t\t""" | line continuation  | text-block |
+| StringLiterals.java:75:3:79:5 | """\n\t\tExplicit line breaks:\\n\n\t\t\\r\\n\n\t\t\\r\n\t\t""" | Explicit line breaks:\n\n\r\n\n\r\n | text-block |
+| StringLiterals.java:82:10:84:16 | 2"\\u0022\n\t\ttest\n\t\t\\u0022\\uu0022" | test\n |  |
+| StringLiterals.java:90:3:90:19 | "hello" + "world" | helloworld |  |
+| StringLiterals.java:91:3:92:20 | """\n\t\thello""" + "world" | helloworld | text-block |
+| StringLiterals.java:93:10:93:12 | "a" | a |  |
+| StringLiterals.java:94:3:94:5 | "a" | a |  |
+| StringLiterals.java:95:3:95:5 | "a" | a |  |
+| StringLiterals.java:96:7:96:9 | "a" | a |  |
+| StringLiterals.java:97:3:97:5 | "a" | a |  |
+| StringLiterals.java:98:10:98:12 | "a" | a |  |
+| StringLiterals.java:99:3:99:5 | "a" | a |  |
+| StringLiterals.java:100:9:100:11 | "a" | a |  |

--- a/java/ql/test/library-tests/literals/stringLiterals/stringLiterals.ql
+++ b/java/ql/test/library-tests/literals/stringLiterals/stringLiterals.ql
@@ -4,4 +4,4 @@ from StringLiteral lit, string isTextBlock
 where
   lit.getFile().(CompilationUnit).fromSource() and
   if lit.isTextBlock() then isTextBlock = "text-block" else isTextBlock = ""
-select lit, lit.getValue(), lit.getRepresentedString(), isTextBlock
+select lit, lit.getValue(), isTextBlock


### PR DESCRIPTION
See https://github.com/github/codeql/pull/6614#discussion_r703333882

Its behavior is the same as `getValue()` and it is therefore not needed anymore.