### PR TITLE
JS: make array taint-step better

### DIFF
--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
@@ -1,0 +1,25 @@
+| arrays.js:2:16:2:23 | "source" | arrays.js:5:8:5:14 | obj.foo |
+| arrays.js:2:16:2:23 | "source" | arrays.js:11:10:11:15 | arr[i] |
+| arrays.js:2:16:2:23 | "source" | arrays.js:15:27:15:27 | e |
+| arrays.js:2:16:2:23 | "source" | arrays.js:16:23:16:23 | e |
+| arrays.js:2:16:2:23 | "source" | arrays.js:20:8:20:16 | arr.pop() |
+| arrays.js:2:16:2:23 | "source" | arrays.js:49:8:49:13 | arr[0] |
+| arrays.js:2:16:2:23 | "source" | arrays.js:52:10:52:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:56:10:56:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:60:10:60:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:66:10:66:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:71:10:71:10 | x |
+| arrays.js:2:16:2:23 | "source" | arrays.js:74:8:74:29 | arr.fin ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:77:8:77:35 | arrayFi ... llback) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:81:10:81:10 | x |
+| arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
+| arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
+| arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:30:8:30:17 | arr4.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:33:8:33:17 | arr5.pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:35:8:35:26 | arr5.slice(2).pop() |
+| arrays.js:29:21:29:28 | "source" | arrays.js:41:8:41:17 | arr6.pop() |
+| arrays.js:44:4:44:11 | "source" | arrays.js:45:10:45:18 | ary.pop() |
+| arrays.js:44:4:44:11 | "source" | arrays.js:46:10:46:12 | ary |
+| arrays.js:84:9:84:16 | "source" | arrays.js:84:8:84:34 | ["sourc ... ) => x) |
+| arrays.js:85:9:85:16 | "source" | arrays.js:85:8:85:36 | ["sourc ... => !!x) |

--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.ql
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.ql
@@ -1,0 +1,15 @@
+import javascript
+
+class ArrayTaintFlowConfig extends TaintTracking::Configuration {
+    ArrayTaintFlowConfig() { this = "ArrayTaintFlowConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source.asExpr().getStringValue() = "source" }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink = any(DataFlow::CallNode call | call.getCalleeName() = "sink").getAnArgument()
+  }
+}
+
+from ArrayTaintFlowConfig config, DataFlow::Node src, DataFlow::Node snk
+where config.hasFlow(src, snk)
+select src, snk

--- a/javascript/ql/test/library-tests/Arrays/arrays.js
+++ b/javascript/ql/test/library-tests/Arrays/arrays.js
@@ -80,4 +80,7 @@
   for (const x of uniq(arr)) {
     sink(x); // NOT OK
   }
+
+  sink(["source"].filter((x) => x))
+  sink(["source"].filter((x) => !!x))
 });

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -1,9 +1,9 @@
 nodes
-| arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | semmle.label | [ParExpr] (functi ... } }) |
-| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | semmle.label | [ExprStmt] (functi ... } }); |
-| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | semmle.order | 1 |
-| arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | semmle.label | [FunctionExpr] functio ... K } } |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | semmle.label | [BlockStmt] { let ... K } } |
+| arrays.js:1:1:86:2 | [ParExpr] (functi ... !x)) }) | semmle.label | [ParExpr] (functi ... !x)) }) |
+| arrays.js:1:1:86:3 | [ExprStmt] (functi ... x)) }); | semmle.label | [ExprStmt] (functi ... x)) }); |
+| arrays.js:1:1:86:3 | [ExprStmt] (functi ... x)) }); | semmle.order | 1 |
+| arrays.js:1:2:86:1 | [FunctionExpr] functio ... !!x)) } | semmle.label | [FunctionExpr] functio ... !!x)) } |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | semmle.label | [BlockStmt] { let ... !!x)) } |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | [DeclStmt] let source = ... |
 | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | [VarDecl] source |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | [VariableDeclarator] source = "source" |
@@ -339,6 +339,30 @@ nodes
 | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.label | [CallExpr] sink(x) |
 | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | semmle.label | [ExprStmt] sink(x); |
 | arrays.js:81:10:81:10 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:84:3:84:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | semmle.label | [CallExpr] sink([" ... => x)) |
+| arrays.js:84:3:84:35 | [ExprStmt] sink([" ... => x)) | semmle.label | [ExprStmt] sink([" ... => x)) |
+| arrays.js:84:8:84:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
+| arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | [MethodCallExpr] ["sourc ... ) => x) |
+| arrays.js:84:9:84:16 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:84:19:84:24 | [Label] filter | semmle.label | [Label] filter |
+| arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | semmle.label | [ArrowFunctionExpr] (x) => x |
+| arrays.js:84:27:84:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| arrays.js:84:33:84:33 | [VarRef] x | semmle.label | [VarRef] x |
+| arrays.js:85:3:85:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | [CallExpr] sink([" ... > !!x)) |
+| arrays.js:85:3:85:37 | [ExprStmt] sink([" ... > !!x)) | semmle.label | [ExprStmt] sink([" ... > !!x)) |
+| arrays.js:85:8:85:17 | [ArrayExpr] ["source"] | semmle.label | [ArrayExpr] ["source"] |
+| arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | semmle.label | [DotExpr] ["source"].filter |
+| arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | [MethodCallExpr] ["sourc ... => !!x) |
+| arrays.js:85:9:85:16 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:85:19:85:24 | [Label] filter | semmle.label | [Label] filter |
+| arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | [ArrowFunctionExpr] (x) => !!x |
+| arrays.js:85:27:85:27 | [SimpleParameter] x | semmle.label | [SimpleParameter] x |
+| arrays.js:85:33:85:35 | [UnaryExpr] !!x | semmle.label | [UnaryExpr] !!x |
+| arrays.js:85:34:85:35 | [UnaryExpr] !x | semmle.label | [UnaryExpr] !x |
+| arrays.js:85:35:85:35 | [VarRef] x | semmle.label | [VarRef] x |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
@@ -380,94 +404,104 @@ nodes
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
+| file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 edges
-| arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | semmle.label | 1 |
-| arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | semmle.order | 1 |
-| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | semmle.label | 1 |
-| arrays.js:1:1:83:3 | [ExprStmt] (functi ... } }); | arrays.js:1:1:83:2 | [ParExpr] (functi ... } }) | semmle.order | 1 |
-| arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | semmle.label | 5 |
-| arrays.js:1:2:83:1 | [FunctionExpr] functio ... K } } | arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | semmle.order | 5 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 32 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 32 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 34 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 34 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.label | 35 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.order | 35 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 36 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 36 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.label | 37 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.order | 37 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
-| arrays.js:1:14:83:1 | [BlockStmt] { let ... K } } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
+| arrays.js:1:1:86:2 | [ParExpr] (functi ... !x)) }) | arrays.js:1:2:86:1 | [FunctionExpr] functio ... !!x)) } | semmle.label | 1 |
+| arrays.js:1:1:86:2 | [ParExpr] (functi ... !x)) }) | arrays.js:1:2:86:1 | [FunctionExpr] functio ... !!x)) } | semmle.order | 1 |
+| arrays.js:1:1:86:3 | [ExprStmt] (functi ... x)) }); | arrays.js:1:1:86:2 | [ParExpr] (functi ... !x)) }) | semmle.label | 1 |
+| arrays.js:1:1:86:3 | [ExprStmt] (functi ... x)) }); | arrays.js:1:1:86:2 | [ParExpr] (functi ... !x)) }) | semmle.order | 1 |
+| arrays.js:1:2:86:1 | [FunctionExpr] functio ... !!x)) } | arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | semmle.label | 5 |
+| arrays.js:1:2:86:1 | [FunctionExpr] functio ... !!x)) } | arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | semmle.order | 5 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.label | 18 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:32:3:32:29 | [DeclStmt] var arr5 = ... | semmle.order | 18 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 19 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:33:3:33:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 19 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 20 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:35:3:35:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 20 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.label | 21 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:37:3:37:16 | [DeclStmt] var arr6 = ... | semmle.order | 21 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.label | 22 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:38:3:40:3 | [ForStmt] for (va ... i]; } | semmle.order | 22 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 23 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:41:3:41:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 23 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 24 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:44:3:47:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 24 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.label | 25 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:49:3:49:15 | [ExprStmt] sink(arr[0]); | semmle.order | 25 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.label | 26 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:51:3:53:3 | [ForOfStmt] for (co ... OK } | semmle.order | 26 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.label | 27 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:55:3:57:3 | [ForOfStmt] for (co ... OK } | semmle.order | 27 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.label | 28 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:59:3:61:3 | [ForOfStmt] for (co ... OK } | semmle.order | 28 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.label | 29 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:63:3:63:16 | [DeclStmt] var arr7 = ... | semmle.order | 29 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 30 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:64:3:64:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 30 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.label | 31 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:65:3:67:3 | [ForOfStmt] for (co ... OK } | semmle.order | 31 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 32 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:69:3:69:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 32 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:70:3:72:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 34 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:74:3:74:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 34 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.label | 35 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:76:3:76:42 | [DeclStmt] const arrayFind = ... | semmle.order | 35 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 36 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:77:3:77:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 36 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.label | 37 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:79:3:79:31 | [DeclStmt] const uniq = ... | semmle.order | 37 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:80:3:82:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:84:3:84:35 | [ExprStmt] sink([" ... => x)) | semmle.label | 39 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:84:3:84:35 | [ExprStmt] sink([" ... => x)) | semmle.order | 39 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:85:3:85:37 | [ExprStmt] sink([" ... > !!x)) | semmle.label | 40 |
+| arrays.js:1:14:86:1 | [BlockStmt] { let ... !!x)) } | arrays.js:85:3:85:37 | [ExprStmt] sink([" ... > !!x)) | semmle.order | 40 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -1052,6 +1086,50 @@ edges
 | arrays.js:81:5:81:11 | [CallExpr] sink(x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
 | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.label | 1 |
 | arrays.js:81:5:81:12 | [ExprStmt] sink(x); | arrays.js:81:5:81:11 | [CallExpr] sink(x) | semmle.order | 1 |
+| arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | arrays.js:84:3:84:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | arrays.js:84:3:84:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:84:3:84:35 | [ExprStmt] sink([" ... => x)) | arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | semmle.label | 1 |
+| arrays.js:84:3:84:35 | [ExprStmt] sink([" ... => x)) | arrays.js:84:3:84:35 | [CallExpr] sink([" ... => x)) | semmle.order | 1 |
+| arrays.js:84:8:84:17 | [ArrayExpr] ["source"] | arrays.js:84:9:84:16 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:84:8:84:17 | [ArrayExpr] ["source"] | arrays.js:84:9:84:16 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | arrays.js:84:8:84:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | arrays.js:84:8:84:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | arrays.js:84:19:84:24 | [Label] filter | semmle.label | 2 |
+| arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | arrays.js:84:19:84:24 | [Label] filter | semmle.order | 2 |
+| arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
+| arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | arrays.js:84:8:84:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
+| arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | arrays.js:84:33:84:33 | [VarRef] x | semmle.label | 5 |
+| arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | arrays.js:84:33:84:33 | [VarRef] x | semmle.order | 5 |
+| arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:85:3:85:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | arrays.js:85:3:85:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:85:3:85:37 | [ExprStmt] sink([" ... > !!x)) | arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | semmle.label | 1 |
+| arrays.js:85:3:85:37 | [ExprStmt] sink([" ... > !!x)) | arrays.js:85:3:85:37 | [CallExpr] sink([" ... > !!x)) | semmle.order | 1 |
+| arrays.js:85:8:85:17 | [ArrayExpr] ["source"] | arrays.js:85:9:85:16 | [Literal] "source" | semmle.label | 1 |
+| arrays.js:85:8:85:17 | [ArrayExpr] ["source"] | arrays.js:85:9:85:16 | [Literal] "source" | semmle.order | 1 |
+| arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | arrays.js:85:8:85:17 | [ArrayExpr] ["source"] | semmle.label | 1 |
+| arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | arrays.js:85:8:85:17 | [ArrayExpr] ["source"] | semmle.order | 1 |
+| arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | arrays.js:85:19:85:24 | [Label] filter | semmle.label | 2 |
+| arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | arrays.js:85:19:85:24 | [Label] filter | semmle.order | 2 |
+| arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | semmle.label | 0 |
+| arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | arrays.js:85:8:85:24 | [DotExpr] ["source"].filter | semmle.order | 0 |
+| arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:85:33:85:35 | [UnaryExpr] !!x | semmle.label | 5 |
+| arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | arrays.js:85:33:85:35 | [UnaryExpr] !!x | semmle.order | 5 |
+| arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.label | 1 |
+| arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | file://:0:0:0:0 | (Parameters) | semmle.order | 1 |
+| arrays.js:85:33:85:35 | [UnaryExpr] !!x | arrays.js:85:34:85:35 | [UnaryExpr] !x | semmle.label | 1 |
+| arrays.js:85:33:85:35 | [UnaryExpr] !!x | arrays.js:85:34:85:35 | [UnaryExpr] !x | semmle.order | 1 |
+| arrays.js:85:34:85:35 | [UnaryExpr] !x | arrays.js:85:35:85:35 | [VarRef] x | semmle.label | 1 |
+| arrays.js:85:34:85:35 | [UnaryExpr] !x | arrays.js:85:35:85:35 | [VarRef] x | semmle.order | 1 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:8:12:8:17 | [VarRef] source | semmle.label | 0 |
@@ -1140,6 +1218,14 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:80:24:80:26 | [VarRef] arr | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:81:10:81:10 | [VarRef] x | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:81:10:81:10 | [VarRef] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:84:8:84:34 | [MethodCallExpr] ["sourc ... ) => x) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:84:26:84:33 | [ArrowFunctionExpr] (x) => x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:8:85:36 | [MethodCallExpr] ["sourc ... => !!x) | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:85:26:85:35 | [ArrowFunctionExpr] (x) => !!x | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:16:12:16:12 | [SimpleParameter] e | semmle.label | 0 |
@@ -1154,5 +1240,9 @@ edges
 | file://:0:0:0:0 | (Parameters) | arrays.js:44:26:44:26 | [SimpleParameter] i | semmle.order | 1 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:44:29:44:31 | [SimpleParameter] ary | semmle.label | 2 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:44:29:44:31 | [SimpleParameter] ary | semmle.order | 2 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:84:27:84:27 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:84:27:84:27 | [SimpleParameter] x | semmle.order | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:85:27:85:27 | [SimpleParameter] x | semmle.label | 0 |
+| file://:0:0:0:0 | (Parameters) | arrays.js:85:27:85:27 | [SimpleParameter] x | semmle.order | 0 |
 graphProperties
 | semmle.graphKind | tree |


### PR DESCRIPTION
Hello! 👋

I have met a case when taint tacking was broken on expression like: `filter((x) => !!x)`. Actually it's pretty straightforward taint-step as  `filter((x) => x)`. So i made a PR.

There are also 2 moments to discuss:
1. I didnt found test case for current filter taint-step
2. Why you dont consider cases like `filter((x) => x.name)` as correct taint-step? Because of potential false positives? A have some code:
```
call.(DataFlow::MethodCallNode).getMethodName() = "filter" and
    pred = call.getReceiver() and
    succ = call and
    exists(DataFlow::FunctionNode callback, Expr retexpr, DataFlow::Node retnode |
      callback = call.getArgument(0).getAFunctionValue() and
      retexpr =
        [
          callback.getAReturn().asExpr(),
          callback.getAReturn().asExpr().(LogNotExpr).getOperand().(LogNotExpr).getOperand()
        ] and
      DataFlow::exprNode(retexpr) = AccessPath::getAReferenceTo(retnode, _) and
      retnode = callback.getParameter(0).getALocalUse() and
      (retexpr instanceof DotExpr or retexpr instanceof VarRef)
    )
```
It would be interesting to know what you think about this.

I saw in blame that you removed wide taint-step for any filter. https://github.com/github/codeql/commit/4ac21e9f3ffaacd50392fee6bd665c5d2f15989f. And of course, filter like `(x>5)` or `x.Includes(allowlist)` are incorrect taint steps. But i think that cases like `x => x.name`, `x => !!x`, `x => !!x.name` are points for discussion.

Waiting for your thoughts 😊