### PR TITLE
C++: Add `isFromSystemMacroDefinition` predicate

### DIFF
--- a/cpp/change-notes/2021-11-01-isFromSystemMacroDefinition.md
+++ b/cpp/change-notes/2021-11-01-isFromSystemMacroDefinition.md
@@ -1,0 +1,4 @@
+lgtm,codescanning
+* The QL library `semmle.code.cpp.commons.Exclusions` now contains a predicate
+  `isFromSystemMacroDefinition` for identifying code that originates from a
+  macro outside the project being analyzed.


### PR DESCRIPTION
This PR adds the library routines from https://github.com/github/codeql/pull/6723 without changing the queries. That should be a less controversial change, and hopefully it'll allow interested users to adjust the queries themselves.