### PR TITLE
Ruby: expose TRAP compression option

### DIFF
--- a/ruby/codeql-extractor.yml
+++ b/ruby/codeql-extractor.yml
@@ -7,8 +7,17 @@ file_types:
   - name: ruby
     display_name: Ruby files
     extensions:
-       - .rb
+      - .rb
   - name: erb
     display_name: Ruby templates
     extensions:
-       - .erb
+      - .erb
+options:
+  trap_compression:
+    title: Controls compression for the TRAP files written by the extractor.
+    description: >
+      This option is only intended for use in debugging the extractor. Accepted
+      values are 'gzip' (the default, to write gzip-compressed TRAP) and 'none'
+      (to write uncompressed TRAP).
+    type: string
+    pattern: "^(none|gzip)$"

--- a/ruby/extractor/src/main.rs
+++ b/ruby/extractor/src/main.rs
@@ -16,7 +16,7 @@ enum TrapCompression {
 
 impl TrapCompression {
     fn from_env() -> TrapCompression {
-        match std::env::var("CODEQL_RUBY_TRAP_COMPRESSION") {
+        match std::env::var("CODEQL_EXTRACTOR_RUBY_TRAP_COMPRESSION") {
             Ok(method) => match TrapCompression::from_string(&method) {
                 Some(c) => c,
                 None => {


### PR DESCRIPTION
Draft/placeholder so I don't forget to finish this.

I'm not sure if the env var naming has been finalised, and we discussed changing this to use option groups so the name is `trap.compression`.