### PR TITLE
C++: Further performance improvement for the null termination queries

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/NullTermination.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/NullTermination.qll
@@ -5,13 +5,12 @@ import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * Holds if the expression `e` assigns something including `va` to a
- * stack variable that is later null terminated at `e0`.
+ * stack variable `v0` that is later null terminated at `e0`.
  */
-private predicate mayAddNullTerminatorHelper(Expr e, VariableAccess va, Expr e0) {
-  exists(StackVariable v0, Expr val |
+private predicate mayAddNullTerminatorHelper(Expr e, VariableAccess va, StackVariable v0) {
+  exists(Expr val |
     exprDefinition(v0, e, val) and // `e` is `v0 := val`
-    val.getAChild*() = va and
-    mayAddNullTerminator(e0, v0.getAnAccess())
+    val.getAChild*() = va
   )
 }
 
@@ -47,8 +46,9 @@ predicate mayAddNullTerminator(Expr e, VariableAccess va) {
   )
   or
   // Assignment to another stack variable
-  exists(Expr e0 |
-    mayAddNullTerminatorHelper(pragma[only_bind_into](e), va, pragma[only_bind_into](e0)) and
+  exists(StackVariable v0, Expr e0 |
+    mayAddNullTerminatorHelper(e, va, v0) and
+    mayAddNullTerminator(pragma[only_bind_into](e0), pragma[only_bind_into](v0.getAnAccess())) and
     controlFlowNodeSuccessorTransitive(e, e0)
   )
   or

--- a/cpp/ql/lib/semmle/code/cpp/commons/NullTermination.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/NullTermination.qll
@@ -3,9 +3,13 @@ private import semmle.code.cpp.models.interfaces.ArrayFunction
 private import semmle.code.cpp.models.implementations.Strcat
 import semmle.code.cpp.dataflow.DataFlow
 
+/**
+ * Holds if the expression `e` assigns something including `va` to a
+ * stack variable that is later null terminated at `e0`.
+ */
 private predicate mayAddNullTerminatorHelper(Expr e, VariableAccess va, Expr e0) {
   exists(StackVariable v0, Expr val |
-    exprDefinition(v0, e, val) and
+    exprDefinition(v0, e, val) and // `e` is `v0 := val`
     val.getAChild*() = va and
     mayAddNullTerminator(e0, v0.getAnAccess())
   )
@@ -25,8 +29,8 @@ private predicate controlFlowNodeSuccessorTransitive(ControlFlowNode n1, Control
 }
 
 /**
- * Holds if the expression `e` may add a null terminator to the string in
- * variable `v`.
+ * Holds if the expression `e` may add a null terminator to the string
+ * accessed by `va`.
  */
 predicate mayAddNullTerminator(Expr e, VariableAccess va) {
   // Assignment: dereferencing or array access

--- a/cpp/ql/lib/semmle/code/cpp/commons/NullTermination.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/NullTermination.qll
@@ -5,7 +5,7 @@ import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * Holds if the expression `e` assigns something including `va` to a
- * stack variable `v0` that is later null terminated at `e0`.
+ * stack variable `v0`.
  */
 private predicate mayAddNullTerminatorHelper(Expr e, VariableAccess va, StackVariable v0) {
   exists(Expr val |


### PR DESCRIPTION
Follow-up to https://github.com/github/codeql/pull/6915.

The goal here was to eliminate the mutual recursion between `mayAddNullTerminator` and `mayAddNullTerminatorHelper`, which was still causing unnecessarily slow performance on a few projects.  I'm not sure if I've found the best solution to this - in particular `mayAddNullTerminatorHelper` looks quite large to me, though I haven't seen it blow up in practice.  Happy to take further suggestions.

The change has a *small* positive effect on performance locally.  I ran [DCA](https://github.com/github/codeql-dca-main/issues/969) on this (actually a variant with the two queries enabled) and only saw a 29s overall improvement there, which is likely not statistically significant.

@MathiasVP 