### PR TITLE
JS: Add insufficient key size query

### DIFF
--- a/javascript/change-notes/2021-11-02-insufficient-key-size.md
+++ b/javascript/change-notes/2021-11-02-insufficient-key-size.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The `js/insufficient-key-size` query has been added. It highlights the creation of cryptographic keys with a short key size.

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -141,14 +141,9 @@ private module NodeJSCrypto {
        *       Also matches `createHash`, `createHmac`, `createSign` instead of `createCipher`.
        */
 
-      exists(DataFlow::SourceNode mod, string createSuffix |
-        createSuffix = "Hash" or
-        createSuffix = "Hmac" or
-        createSuffix = "Sign" or
-        createSuffix = "Cipher"
-      |
+      exists(DataFlow::SourceNode mod |
         mod = DataFlow::moduleImport("crypto") and
-        this = mod.getAMemberCall("create" + createSuffix) and
+        this = mod.getAMemberCall("create" + ["Hash", "Hmac", "Sign", "Cipher"]) and
         algorithm.matchesName(getArgument(0).getStringValue())
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -689,3 +689,28 @@ private module ExpressJwt {
     Key() { this = DataFlow::moduleMember("express-jwt", "sign").getACall().getArgument(1) }
   }
 }
+
+/**
+ * Provides classes for working with the `node-rsa` package (https://www.npmjs.com/package/node-rsa)
+ */
+private module NodeRsa {
+  private class CreateKey extends CryptographicKeyCreation, API::InvokeNode {
+    CryptographicAlgorithm algorithm;
+
+    CreateKey() {
+      this = API::moduleImport("node-rsa").getAnInstantiation()
+      or
+      this = API::moduleImport("node-rsa").getInstance().getMember("generateKeyPair").getACall()
+    }
+
+    override CryptographicAlgorithm getAlgorithm() { result.matchesName("rsa") }
+
+    override int getSize() {
+      result = this.getArgument(0).getIntValue()
+      or
+      result = this.getOptionArgument(0, "b").getIntValue()
+    }
+
+    override predicate isSymmetricKey() { none() }
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -204,6 +204,19 @@ private module NodeJSCrypto {
     override predicate isSymmetricKey() { symmetric = true }
   }
 
+  private class CreateDiffieHellmanKey extends CryptographicKeyCreation, DataFlow::CallNode {
+    // require("crypto").createDiffieHellman(prime_length);
+    CreateDiffieHellmanKey() {
+      this = DataFlow::moduleMember("crypto", "createDiffieHellman").getACall()
+    }
+
+    override CryptographicAlgorithm getAlgorithm() { none() }
+
+    override int getSize() { result = getArgument(0).getIntValue() }
+
+    override predicate isSymmetricKey() { none() }
+  }
+
   private class Apply extends CryptographicOperation, MethodCallExpr {
     InstantiatedAlgorithm instantiation;
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -679,13 +679,13 @@ private module Hasha {
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
+}
 
-  /**
-   * Provides classes for working with the `express-jwt` package (https://github.com/auth0/express-jwt);
-   */
-  module ExpressJwt {
-    private class Key extends CryptographicKey {
-      Key() { this = DataFlow::moduleMember("express-jwt", "sign").getACall().getArgument(1) }
-    }
+/**
+ * Provides classes for working with the `express-jwt` package (https://github.com/auth0/express-jwt);
+ */
+private module ExpressJwt {
+  private class Key extends CryptographicKey {
+    Key() { this = DataFlow::moduleMember("express-jwt", "sign").getACall().getArgument(1) }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
+++ b/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
@@ -89,8 +89,8 @@ abstract class CryptographicAlgorithm extends TCryptographicAlgorithm {
    */
   bindingset[name]
   predicate matchesName(string name) {
-    name.toUpperCase().regexpCapture("^(\\w+)(?:-.*)?$", 1).regexpReplaceAll("[-_ ]", "") =
-      getName()
+    [name.toUpperCase(), name.toUpperCase().regexpCapture("^(\\w+)(?:-.*)?$", 1)]
+        .regexpReplaceAll("[-_ ]", "") = getName()
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
+++ b/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
@@ -46,7 +46,7 @@ private module AlgorithmNames {
     name = ["ARGON2", "PBKDF2", "BCRYPT", "SCRYPT"]
   }
 
-  predicate isWeakPasswordHashingAlgorithm(string name) { none() }
+  predicate isWeakPasswordHashingAlgorithm(string name) { name = "EVPKDF" }
 }
 
 private import AlgorithmNames

--- a/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
+++ b/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
@@ -31,14 +31,22 @@ private module AlgorithmNames {
   }
 
   predicate isStrongEncryptionAlgorithm(string name) {
-    name = ["AES", "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
+    name = [appendMode("AES"), "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
+  }
+
+  /**
+   * Gets the name with a mode of operation added as a suffix.
+   */
+  bindingset[name]
+  private string appendMode(string name) {
+    result = name + ["", "CBC", "ECB", "CFB", "OFB", "CTR", "GCM"]
   }
 
   predicate isWeakEncryptionAlgorithm(string name) {
     name =
       [
-        "DES", "3DES", "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2", "ARC4", "RC4", "ARCFOUR",
-        "ARC5", "RC5"
+        appendMode("DES"), appendMode("3DES"), "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2",
+        "ARC4", "RC4", "ARCFOUR", "ARC5", "RC5"
       ]
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
+++ b/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
@@ -31,22 +31,14 @@ private module AlgorithmNames {
   }
 
   predicate isStrongEncryptionAlgorithm(string name) {
-    name = [appendMode("AES"), "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
-  }
-
-  /**
-   * Gets the name with a mode of operation added as a suffix.
-   */
-  bindingset[name]
-  private string appendMode(string name) {
-    result = name + ["", "CBC", "ECB", "CFB", "OFB", "CTR", "GCM"]
+    name = ["AES", "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
   }
 
   predicate isWeakEncryptionAlgorithm(string name) {
     name =
       [
-        appendMode("DES"), appendMode("3DES"), "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2",
-        "ARC4", "RC4", "ARCFOUR", "ARC5", "RC5"
+        "DES", "3DES", "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2", "ARC4", "RC4", "ARCFOUR",
+        "ARC5", "RC5"
       ]
   }
 
@@ -93,11 +85,12 @@ abstract class CryptographicAlgorithm extends TCryptographicAlgorithm {
 
   /**
    * Holds if the name of this algorithm matches `name` modulo case,
-   * white space, dashes, and underscores.
+   * white space, dashes, underscores, and anything after a dash in the name.
    */
   bindingset[name]
   predicate matchesName(string name) {
-    name.toUpperCase().regexpReplaceAll("[-_ ]", "") = getName()
+    name.toUpperCase().regexpCapture("^(\\w+)(?:-.*)?$", 1).regexpReplaceAll("[-_ ]", "") =
+      getName()
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
+++ b/javascript/ql/lib/semmle/javascript/security/CryptoAlgorithms.qll
@@ -85,7 +85,8 @@ abstract class CryptographicAlgorithm extends TCryptographicAlgorithm {
 
   /**
    * Holds if the name of this algorithm matches `name` modulo case,
-   * white space, dashes, underscores, and anything after a dash in the name.
+   * white space, dashes, underscores, and anything after a dash in the name
+   * (to ignore modes of operation, such as CBC or ECB).
    */
   bindingset[name]
   predicate matchesName(string name) {

--- a/javascript/ql/src/Security/CWE-326/InsufficientKeySize.qhelp
+++ b/javascript/ql/src/Security/CWE-326/InsufficientKeySize.qhelp
@@ -1,0 +1,43 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Modern encryption relies on it being computationally infeasible to break the cipher and decode a message without the key.
+As computational power increases, the ability to break ciphers grows and keys need to become larger.
+</p>
+</overview>
+
+<recommendation>
+<p>
+An encryption key should be at least 2048-bit long when using RSA encryption, and 128-bit long when using 
+symmetric encryption.
+</p>
+</recommendation>
+
+<references>
+<li>
+Wikipedia:
+<a href="https://en.wikipedia.org/wiki/RSA_(cryptosystem)">RSA</a>.
+</li>
+<li>
+Wikipedia:
+<a href="https://en.wikipedia.org/wiki/Advanced_Encryption_Standard">AES</a>.
+</li>
+<li>
+NodeJS: 
+<a href="https://nodejs.org/api/crypto.html">Crypto</a>.
+</li>
+<li>
+NIST:
+<a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf">
+Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths</a>.
+</li>
+<li>
+Wikipedia:
+<a href="https://en.wikipedia.org/wiki/Key_size">Key size</a>
+</li>
+</references>
+</qhelp>

--- a/javascript/ql/src/Security/CWE-326/InsufficientKeySize.ql
+++ b/javascript/ql/src/Security/CWE-326/InsufficientKeySize.ql
@@ -1,0 +1,36 @@
+/**
+ * @name Use of a weak cryptographic key
+ * @description Using a weak cryptographic key can allow an attacker to compromise security.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 7.5
+ * @precision high
+ * @id js/insufficient-key-size
+ * @tags security
+ *       external/cwe/cwe-326
+ */
+
+import javascript
+
+from CryptographicKeyCreation key, int size, string msg, string algo
+where
+  size = key.getSize() and
+  (
+    algo = key.getAlgorithm() + " "
+    or
+    not exists(key.getAlgorithm()) and algo = ""
+  ) and
+  (
+    size < 128 and
+    key.isSymmetricKey() and
+    msg =
+      "Creation of an symmetric " + algo + "key uses " + size +
+        " bits, which is below 128 and considered breakable."
+    or
+    size < 2048 and
+    not key.isSymmetricKey() and
+    msg =
+      "Creation of an asymmetric " + algo + "key uses " + size +
+        " bits, which is below 2048 and considered breakable."
+  )
+select key, msg

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
@@ -4,8 +4,8 @@
 | tst.js:14:14:14:60 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
 | tst.js:15:14:15:60 | CryptoJ ... e: 2 }) | Creation of an symmetric EVPKDF key uses 64 bits, which is below 128 and considered breakable. |
 | tst.js:19:12:19:57 | forge.r ... rd, 64) | Creation of an symmetric RC2 key uses 64 bits, which is below 128 and considered breakable. |
-| tst.js:26:12:26:53 | forge.c ... , key2) | Creation of an symmetric AESCBC key uses 64 bits, which is below 128 and considered breakable. |
-| tst.js:30:12:30:56 | forge.c ... , key3) | Creation of an symmetric 3DESCBC key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:26:12:26:53 | forge.c ... , key2) | Creation of an symmetric AES key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:30:12:30:56 | forge.c ... , key3) | Creation of an symmetric 3DES key uses 64 bits, which is below 128 and considered breakable. |
 | tst.js:35:13:35:43 | crypto. ... an(512) | Creation of an asymmetric key uses 512 bits, which is below 2048 and considered breakable. |
 | tst.js:39:13:39:33 | new Nod ... : 512}) | Creation of an asymmetric RSA key uses 512 bits, which is below 2048 and considered breakable. |
 | tst.js:43:1:43:31 | key.gen ...  65537) | Creation of an asymmetric RSA key uses 512 bits, which is below 2048 and considered breakable. |

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
@@ -6,3 +6,6 @@
 | tst.js:19:12:19:57 | forge.r ... rd, 64) | Creation of an symmetric RC2 key uses 64 bits, which is below 128 and considered breakable. |
 | tst.js:26:12:26:53 | forge.c ... , key2) | Creation of an symmetric AESCBC key uses 64 bits, which is below 128 and considered breakable. |
 | tst.js:30:12:30:56 | forge.c ... , key3) | Creation of an symmetric 3DESCBC key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:35:13:35:43 | crypto. ... an(512) | Creation of an asymmetric key uses 512 bits, which is below 2048 and considered breakable. |
+| tst.js:39:13:39:33 | new Nod ... : 512}) | Creation of an asymmetric RSA key uses 512 bits, which is below 2048 and considered breakable. |
+| tst.js:43:1:43:31 | key.gen ...  65537) | Creation of an asymmetric RSA key uses 512 bits, which is below 2048 and considered breakable. |

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
@@ -1,0 +1,2 @@
+| tst.js:3:14:3:71 | crypto. ... 1024 }) | Creation of an asymmetric RSA key uses 1024 bits, which is below 2048 and considered breakable. |
+| tst.js:7:14:7:59 | crypto. ... : 64 }) | Creation of an symmetric key uses 64 bits, which is below 128 and considered breakable. |

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
@@ -1,5 +1,8 @@
 | tst.js:3:14:3:71 | crypto. ... 1024 }) | Creation of an asymmetric RSA key uses 1024 bits, which is below 2048 and considered breakable. |
 | tst.js:7:14:7:59 | crypto. ... : 64 }) | Creation of an symmetric key uses 64 bits, which is below 128 and considered breakable. |
-| tst.js:14:14:14:56 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
-| tst.js:15:14:15:60 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
-| tst.js:16:14:16:60 | CryptoJ ... e: 2 }) | Creation of an symmetric EVPKDF key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:13:14:13:56 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:14:14:14:60 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:15:14:15:60 | CryptoJ ... e: 2 }) | Creation of an symmetric EVPKDF key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:19:12:19:57 | forge.r ... rd, 64) | Creation of an symmetric RC2 key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:26:12:26:53 | forge.c ... , key2) | Creation of an symmetric AESCBC key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:30:12:30:56 | forge.c ... , key3) | Creation of an symmetric 3DESCBC key uses 64 bits, which is below 128 and considered breakable. |

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.expected
@@ -1,2 +1,5 @@
 | tst.js:3:14:3:71 | crypto. ... 1024 }) | Creation of an asymmetric RSA key uses 1024 bits, which is below 2048 and considered breakable. |
 | tst.js:7:14:7:59 | crypto. ... : 64 }) | Creation of an symmetric key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:14:14:14:56 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:15:14:15:60 | CryptoJ ... e: 2 }) | Creation of an symmetric PBKDF2 key uses 64 bits, which is below 128 and considered breakable. |
+| tst.js:16:14:16:60 | CryptoJ ... e: 2 }) | Creation of an symmetric EVPKDF key uses 64 bits, which is below 128 and considered breakable. |

--- a/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-326/InsufficientKeySize.qlref
@@ -1,0 +1,1 @@
+Security/CWE-326/InsufficientKeySize.ql

--- a/javascript/ql/test/query-tests/Security/CWE-326/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-326/tst.js
@@ -7,3 +7,10 @@ const good1 = crypto.generateKeyPairSync("rsa", { modulusLength: 4096 }); // OK
 const bad2 = crypto.generateKeySync("hmac", { length: 64 }); // NOT OK
 
 const good2 = crypto.generateKeySync("aes", { length: 256 }); // OK
+
+var CryptoJS = require("crypto-js");
+
+const bad3 = CryptoJS.algo.PBKDF2.create({ keySize: 2 }); // NOT OK
+const bad4 = CryptoJS.PBKDF2(password, salt, { keySize: 2 }); // NOT OK
+const bad5 = CryptoJS.EvpKDF(password, salt, { keySize: 2 }); // NOT OK
+const bad4 = CryptoJS.PBKDF2(password, salt, { keySize: 8 }); // OK

--- a/javascript/ql/test/query-tests/Security/CWE-326/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-326/tst.js
@@ -31,3 +31,6 @@ var bad9 = forge.cipher.createDecipher('3DES-CBC', key3); // NOT OK
 
 var key4 = myBuffer.getBytes(16);
 var good5 = forge.cipher.createDecipher('AES-CBC', key4); // OK
+
+var bad10 = crypto.createDiffieHellman(512);
+var good6 = crypto.createDiffieHellman(2048);

--- a/javascript/ql/test/query-tests/Security/CWE-326/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-326/tst.js
@@ -13,4 +13,21 @@ var CryptoJS = require("crypto-js");
 const bad3 = CryptoJS.algo.PBKDF2.create({ keySize: 2 }); // NOT OK
 const bad4 = CryptoJS.PBKDF2(password, salt, { keySize: 2 }); // NOT OK
 const bad5 = CryptoJS.EvpKDF(password, salt, { keySize: 2 }); // NOT OK
-const bad4 = CryptoJS.PBKDF2(password, salt, { keySize: 8 }); // OK
+const bad6 = CryptoJS.PBKDF2(password, salt, { keySize: 8 }); // OK
+
+const forge = require("node-forge");
+var bad7 = forge.rc2.createEncryptionCipher(password, 64); // NOT OK
+var good3 = forge.rc2.createEncryptionCipher(password, 128); // OK
+
+var key1 = forge.random.getBytesSync(16);
+var good4 = forge.cipher.createCipher('AES-CBC', key1); // OK
+
+var key2 = forge.random.getBytesSync(8);
+var bad8 = forge.cipher.createCipher('AES-CBC', key2); // NOT OK
+
+var myBuffer = forge.util.createBuffer(manyBytes);
+var key3 = myBuffer.getBytes(8);
+var bad9 = forge.cipher.createDecipher('3DES-CBC', key3); // NOT OK
+
+var key4 = myBuffer.getBytes(16);
+var good5 = forge.cipher.createDecipher('AES-CBC', key4); // OK

--- a/javascript/ql/test/query-tests/Security/CWE-326/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-326/tst.js
@@ -34,3 +34,11 @@ var good5 = forge.cipher.createDecipher('AES-CBC', key4); // OK
 
 var bad10 = crypto.createDiffieHellman(512);
 var good6 = crypto.createDiffieHellman(2048);
+
+const NodeRSA = require('node-rsa');
+var bad11 = new NodeRSA({b: 512}); // NOT OK
+var good7 = new NodeRSA({b: 4096}); // OK
+
+var key = new NodeRSA(); // OK
+key.generateKeyPair(512, 65537); // NOT OK
+key.generateKeyPair(4096, 65537); // OK

--- a/javascript/ql/test/query-tests/Security/CWE-326/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-326/tst.js
@@ -1,0 +1,9 @@
+const crypto = require("crypto");
+
+const bad1 = crypto.generateKeyPairSync("rsa", { modulusLength: 1024 }); // NOT OK
+
+const good1 = crypto.generateKeyPairSync("rsa", { modulusLength: 4096 }); // OK
+
+const bad2 = crypto.generateKeySync("hmac", { length: 64 }); // NOT OK
+
+const good2 = crypto.generateKeySync("aes", { length: 256 }); // OK

--- a/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
+++ b/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
@@ -89,8 +89,8 @@ abstract class CryptographicAlgorithm extends TCryptographicAlgorithm {
    */
   bindingset[name]
   predicate matchesName(string name) {
-    name.toUpperCase().regexpCapture("^(\\w+)(?:-.*)?$", 1).regexpReplaceAll("[-_ ]", "") =
-      getName()
+    [name.toUpperCase(), name.toUpperCase().regexpCapture("^(\\w+)(?:-.*)?$", 1)]
+        .regexpReplaceAll("[-_ ]", "") = getName()
   }
 
   /**

--- a/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
+++ b/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
@@ -31,14 +31,22 @@ private module AlgorithmNames {
   }
 
   predicate isStrongEncryptionAlgorithm(string name) {
-    name = ["AES", "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
+    name = [appendMode("AES"), "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
+  }
+
+  /**
+   * Gets the name with a mode of operation added as a suffix.
+   */
+  bindingset[name]
+  private string appendMode(string name) {
+    result = name + ["", "CBC", "ECB", "CFB", "OFB", "CTR", "GCM"]
   }
 
   predicate isWeakEncryptionAlgorithm(string name) {
     name =
       [
-        "DES", "3DES", "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2", "ARC4", "RC4", "ARCFOUR",
-        "ARC5", "RC5"
+        appendMode("DES"), appendMode("3DES"), "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2",
+        "ARC4", "RC4", "ARCFOUR", "ARC5", "RC5"
       ]
   }
 
@@ -46,7 +54,7 @@ private module AlgorithmNames {
     name = ["ARGON2", "PBKDF2", "BCRYPT", "SCRYPT"]
   }
 
-  predicate isWeakPasswordHashingAlgorithm(string name) { none() }
+  predicate isWeakPasswordHashingAlgorithm(string name) { name = "EVPKDF" }
 }
 
 private import AlgorithmNames

--- a/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
+++ b/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
@@ -31,22 +31,14 @@ private module AlgorithmNames {
   }
 
   predicate isStrongEncryptionAlgorithm(string name) {
-    name = [appendMode("AES"), "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
-  }
-
-  /**
-   * Gets the name with a mode of operation added as a suffix.
-   */
-  bindingset[name]
-  private string appendMode(string name) {
-    result = name + ["", "CBC", "ECB", "CFB", "OFB", "CTR", "GCM"]
+    name = ["AES", "AES128", "AES192", "AES256", "AES512", "RSA", "RABBIT", "BLOWFISH"]
   }
 
   predicate isWeakEncryptionAlgorithm(string name) {
     name =
       [
-        appendMode("DES"), appendMode("3DES"), "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2",
-        "ARC4", "RC4", "ARCFOUR", "ARC5", "RC5"
+        "DES", "3DES", "TRIPLEDES", "TDEA", "TRIPLEDEA", "ARC2", "RC2", "ARC4", "RC4", "ARCFOUR",
+        "ARC5", "RC5"
       ]
   }
 
@@ -93,11 +85,12 @@ abstract class CryptographicAlgorithm extends TCryptographicAlgorithm {
 
   /**
    * Holds if the name of this algorithm matches `name` modulo case,
-   * white space, dashes, and underscores.
+   * white space, dashes, underscores, and anything after a dash in the name.
    */
   bindingset[name]
   predicate matchesName(string name) {
-    name.toUpperCase().regexpReplaceAll("[-_ ]", "") = getName()
+    name.toUpperCase().regexpCapture("^(\\w+)(?:-.*)?$", 1).regexpReplaceAll("[-_ ]", "") =
+      getName()
   }
 
   /**

--- a/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
+++ b/python/ql/lib/semmle/python/concepts/CryptoAlgorithms.qll
@@ -85,7 +85,8 @@ abstract class CryptographicAlgorithm extends TCryptographicAlgorithm {
 
   /**
    * Holds if the name of this algorithm matches `name` modulo case,
-   * white space, dashes, underscores, and anything after a dash in the name.
+   * white space, dashes, underscores, and anything after a dash in the name
+   * (to ignore modes of operation, such as CBC or ECB).
    */
   bindingset[name]
   predicate matchesName(string name) {


### PR DESCRIPTION
[Evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/cwe326-eval/reports) looks fine.  
It finds a few results among the test-cases of NodeJS.   

Heavily inspired by: [csharp query](https://github.com/github/codeql/blob/main/csharp/ql/src/Security%20Features/InsufficientKeySize.ql), [go query](https://github.com/github/codeql-go/blob/main/ql/src/Security/CWE-326/InsufficientKeySize.ql), [python query](https://github.com/github/codeql/blob/main/python/ql/src/Security/CWE-326/WeakCryptoKey.ql). 

There aren't that many projects that generate their own keys, but I managed to [find a few](https://lgtm.com/query/8376072927259659767/).   
None of them look that serious, so I've set the severity to `warning`.