### PR TITLE
Use the `js/` prefix for LdapInjection.ql

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-090/LdapInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-090/LdapInjection.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @precision high
- * @id javascript/ldap-injection
+ * @id js/ldap-injection
  * @tags security
  *       external/cwe/cwe-090
  */


### PR DESCRIPTION
The query is in `/experimental`, so this breaking change should be OK.