### PR TITLE
JS: add CWE-497 to js/stack-trace-exposure

### DIFF
--- a/javascript/ql/src/Security/CWE-209/StackTraceExposure.ql
+++ b/javascript/ql/src/Security/CWE-209/StackTraceExposure.ql
@@ -10,6 +10,7 @@
  * @id js/stack-trace-exposure
  * @tags security
  *       external/cwe/cwe-209
+ *       external/cwe/cwe-497
  */
 
 import javascript


### PR DESCRIPTION
This is consistent with [csharp](https://github.com/github/codeql/blob/main/csharp/ql/src/Security%20Features/CWE-209/ExceptionInformationExposure.ql), [go](https://github.com/github/codeql-go/blob/main/ql/src/Security/CWE-209/StackTraceExposure.ql), [java](https://github.com/github/codeql/blob/main/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.ql), and [python](
https://github.com/github/codeql/blob/main/python/ql/src/Security/CWE-209/StackTraceExposure.ql)