### PR TITLE
New docs for extractor options

### DIFF
--- a/docs/codeql/codeql-cli/codeql-cli-reference.rst
+++ b/docs/codeql/codeql-cli/codeql-cli-reference.rst
@@ -14,7 +14,7 @@ Learn more about the files you can use when running CodeQL processes and the res
    query-reference-files
    sarif-output
    exit-codes
-
+   extractor-options
 
 - :doc:`About CodeQL packs <about-codeql-packs>`: CodeQL packs are created with the CodeQL CLI and are used to create, depend on, publish, and run CodeQL queries and libraries.
 - :doc:`About QL packs <about-ql-packs>`: QL packs are used to organize the files used in CodeQL analysis. They
@@ -23,3 +23,4 @@ Learn more about the files you can use when running CodeQL processes and the res
 - :doc:`SARIF output <sarif-output>`: CodeQL supports SARIF as an output format for sharing static analysis results.
 - :doc:`Exit codes <exit-codes>`: The CodeQL CLI reports the status of each command it runs as an exit code.
   This exit code provides information for subsequent commands or for other tools that rely on the CodeQL CLI.
+- :doc: `Extractor options <extractor-options`: You can customize the behavior of extractors by setting options through the CodeQL CLI.

--- a/docs/codeql/codeql-cli/codeql-cli-reference.rst
+++ b/docs/codeql/codeql-cli/codeql-cli-reference.rst
@@ -23,4 +23,4 @@ Learn more about the files you can use when running CodeQL processes and the res
 - :doc:`SARIF output <sarif-output>`: CodeQL supports SARIF as an output format for sharing static analysis results.
 - :doc:`Exit codes <exit-codes>`: The CodeQL CLI reports the status of each command it runs as an exit code.
   This exit code provides information for subsequent commands or for other tools that rely on the CodeQL CLI.
-- :doc: `Extractor options <extractor-options`: You can customize the behavior of extractors by setting options through the CodeQL CLI.
+- :doc:`Extractor options <extractor-options>`: You can customize the behavior of extractors by setting options through the CodeQL CLI.

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -63,8 +63,9 @@ more than one language:
 - ``--no-run-unnecessary-builds``: used with ``--db-cluster`` to suppress the build 
   command for languages where the CodeQL CLI does not need to monitor the build 
   (for example, Python and JavaScript/TypeScript).
-- extractor options: used to customize the behavior of extractors that create CodeQL databases. For more information,
-  see the `extractor options documentation <extractor-options>`__. 
+
+You can specify extractor options to customize the behavior of extractors that create CodeQL databases. For more information, see
+":doc:`Extractor options <extractor-options>`."
 
 For full details of all the options you can use when creating databases,
 see the `database create reference documentation <../manual/database-create>`__.  

--- a/docs/codeql/codeql-cli/creating-codeql-databases.rst
+++ b/docs/codeql/codeql-cli/creating-codeql-databases.rst
@@ -63,7 +63,9 @@ more than one language:
 - ``--no-run-unnecessary-builds``: used with ``--db-cluster`` to suppress the build 
   command for languages where the CodeQL CLI does not need to monitor the build 
   (for example, Python and JavaScript/TypeScript).
-   
+- extractor options: used to customize the behavior of extractors that create CodeQL databases. For more information,
+  see the `extractor options documentation <extractor-options>`__. 
+
 For full details of all the options you can use when creating databases,
 see the `database create reference documentation <../manual/database-create>`__.  
 

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -39,36 +39,36 @@ Each extractor defines its own set of configuration options. To find out which o
 
 The extractor option names and descriptions are listed under ``extractor_options``. Each option may contain the following fields::
 
-*   ``title`` (required): The title of the option
-*   ``description`` (required): The description of the option
-*   ``type`` (required): The type of the option, which can be
+* ``title`` (required): The title of the option
+* ``description`` (required): The description of the option
+* ``type`` (required): The type of the option, which can be
 
-    *   ``string``: indicating that the option can have a single string value
-    *   ``array``: indicating that the option can have a sequence of string values
-    *   ``object``: indicating that it is not an option itself, but a grouping that may contain other options and option groups
+  * ``string``: indicating that the option can have a single string value
+  * ``array``: indicating that the option can have a sequence of string values
+  * ``object``: indicating that it is not an option itself, but a grouping that may contain other options and option groups
 
-*   ``pattern`` (optional): The regular expression patterns that all values of the option should match. Note that the extractor may impose additional constraints on option values that are not or cannot be expressed in this regular expression pattern. Such constraints, if they exist, would be explained under the description field.
-*   ``properties`` (optional): A map from extractor option names in the option group to the corresponding extractor option descriptions. This field can only be present for option groups. For example, options of ``object`` type.
+* ``pattern`` (optional): The regular expression patterns that all values of the option should match. Note that the extractor may impose additional constraints on option values that are not or cannot be expressed in this regular expression pattern. Such constraints, if they exist, would be explained under the description field.
+* ``properties`` (optional): A map from extractor option names in the option group to the corresponding extractor option descriptions. This field can only be present for option groups. For example, options of ``object`` type.
 
 In the example above, the extractor declares two options::
 
-*   ``option1`` is a ``string`` option with value matching ``[a-z]+``
-*   ``group1.option2`` is an ``array`` option with values matching ``[1-9][0-9]*``
+* ``option1`` is a ``string`` option with value matching ``[a-z]+``
+* ``group1.option2`` is an ``array`` option with values matching ``[1-9][0-9]*``
 
 Setting extractor options with the CodeQL CLI
 ---------------------------------------------
 
 The CodeQL CLI supports setting extractor options in subcommands that directly or indirectly invoke extractors. These commands are::
 
-*   ``codeql database create``
-*   ``codeql database start-tracing``
-*   ``codeql database trace-command``
-*   ``codeql database index-files``
+* ``codeql database create``
+* ``codeql database start-tracing``
+* ``codeql database trace-command``
+* ``codeql database index-files``
 
 When running these subcommands, you can set extractor options with the ``--extractor-option`` CLI option. For example::
 
-*   ``codeql database create --extractor-option java.option1=abc ...``
-*   ``codeql database start-tracing --extractor-option java.group1.option2=102 ...``
+* ``codeql database create --extractor-option java.option1=abc ...``
+* ``codeql database start-tracing --extractor-option java.group1.option2=102 ...``
 
 ``--extractor-option`` requires exactly one argument of the form ``extractor_option_name=extractor_option_value``.  ``extractor_option_name`` is the name of the extractor (in this example, ``java``) followed by a period and then the name of the extractor option (in this example, either ``option1`` or ``group1.option2``).  ``extractor_option_value`` is the value being assigned to the extractor option. The value must match the regular expression pattern of the extractor option (if it exists), and it must not contain newline characters.
 
@@ -78,8 +78,8 @@ The CodeQL CLI accepts multiple ``--extractor-option`` options in the same invoc
 
 You can also specify extractor option names without the extractor name. For example::
 
-*   ``codeql database create --extractor-option option1=abc ...``
-*   ``codeql database start-tracing --extractor-option group1.option2=102 ...``
+* ``codeql database create --extractor-option option1=abc ...``
+* ``codeql database start-tracing --extractor-option group1.option2=102 ...``
 
 If you do not specify an extractor name, the extractor option settings will apply to all extractors that declare an option with the given name. In the above example, the first command would set the extractor option ``option1`` to ``abc`` for the ``java`` extractor and every extractor that has an option of ``option1``, for example the ``cpp`` extractor, if the ``option1`` extractor option exists for that extractor.
 
@@ -88,8 +88,8 @@ Setting extractor options from files
 
 You can also set extractor options through a file. The CodeQL CLI subcommands that accept ``--extractor-option`` also accept ``--extractor-options-file``, which has a required argument of the path to a YAML file (with extension ``.yaml`` or ``.yml``) or a JSON file (with extension ``.json``). For example::
 
-#   ``codeql database create --extractor-options-file options.yml ...``
-#   ``codeql database start-tracing --extractor-options-file options.json ...``
+# ``codeql database create --extractor-options-file options.yml ...``
+# ``codeql database start-tracing --extractor-options-file options.json ...``
 
 Each option file contains a tree structure of nested maps. At the root is an extractor map key, and beneath it are map keys that correspond to extractor names. Starting at the third level, there are extractor options and option groups.
 
@@ -116,9 +116,13 @@ In YAML::
              option2: [ 102 ]
 
 The value for a ``string`` extractor option must be a string or a number (which will be converted to a string before further processing).
+
 The value for an ``array`` extractor option must be an array of strings or numbers.
+
 The value for an option group (of type ``object``) must be a map, which may contain nested extractor options and option groups.
+
 Each extractor option value must match the regular expression pattern of the extractor option (if it exists), and it must not contain newline characters.
+
 Assigning an extractor option that does not exist is an error. You can make the CodeQL CLI ignore unknown extractor options by using a special ``__allow_unknown_properties`` Boolean field. For example, the following option file asks the CodeQL CLI to ignore all unknown extractor options and option groups under ``group1``::
 
     extractor:
@@ -130,7 +134,7 @@ Assigning an extractor option that does not exist is an error. You can make the 
 
 You can specify ``--extractor-options-file`` multiple times. The extractor option assignments are processed in the following order::
 
-#   All extractor option files specified by ``--extractor-options-file`` are processed in the order they appear on the command line, then
-#   All extractor option assignments specified by ``--extractor-option`` are processed in the order they appear on the command line
+# All extractor option files specified by ``--extractor-options-file`` are processed in the order they appear on the command line, then
+# All extractor option assignments specified by ``--extractor-option`` are processed in the order they appear on the command line
 
 The same rules govern what happens when the same extractor option is set multiple times, regardless of whether the assignments are done using ``--extractor-option``, using ``--extractor-options-file``, or some combination of the two. If you set a ``string`` extractor option multiple times, the last option value overwrites all previous values. If you set an ``array`` extractor option multiple times, all option values are concatenated in order.

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -37,7 +37,7 @@ Each extractor defines its own set of configuration options. To find out which o
          }
      }
 
-The extractor option names and descriptions are listed under ``extractor_options``. Each description may contain the following fields::
+The extractor option names and descriptions are listed under ``extractor_options``. Each option may contain the following fields::
 
 *   ``title`` (required): The title of the option
 *   ``description`` (required): The description of the option

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -37,11 +37,11 @@ Each extractor defines its own set of configuration options. To find out which o
          }
      }
 
-The extractor option names and descriptions are listed under ``extractor_options``. Each option may contain the following fields::
+The extractor option names and descriptions are listed under ``extractor_options``. Each option may contain the following fields:
 
-- ``title`` (required): The title of the option
-- ``description`` (required): The description of the option
-- ``type`` (required): The type of the option, which can be
+* ``title`` (required): The title of the option
+* ``description`` (required): The description of the option
+* ``type`` (required): The type of the option, which can be
 
   * ``string``: indicating that the option can have a single string value
   * ``array``: indicating that the option can have a sequence of string values
@@ -50,7 +50,7 @@ The extractor option names and descriptions are listed under ``extractor_options
 * ``pattern`` (optional): The regular expression patterns that all values of the option should match. Note that the extractor may impose additional constraints on option values that are not or cannot be expressed in this regular expression pattern. Such constraints, if they exist, would be explained under the description field.
 * ``properties`` (optional): A map from extractor option names in the option group to the corresponding extractor option descriptions. This field can only be present for option groups. For example, options of ``object`` type.
 
-In the example above, the extractor declares two options::
+In the example above, the extractor declares two options:
 
 * ``option1`` is a ``string`` option with value matching ``[a-z]+``
 * ``group1.option2`` is an ``array`` option with values matching ``[1-9][0-9]*``
@@ -58,14 +58,14 @@ In the example above, the extractor declares two options::
 Setting extractor options with the CodeQL CLI
 ---------------------------------------------
 
-The CodeQL CLI supports setting extractor options in subcommands that directly or indirectly invoke extractors. These commands are::
+The CodeQL CLI supports setting extractor options in subcommands that directly or indirectly invoke extractors. These commands are:
 
 * ``codeql database create``
 * ``codeql database start-tracing``
 * ``codeql database trace-command``
 * ``codeql database index-files``
 
-When running these subcommands, you can set extractor options with the ``--extractor-option`` CLI option. For example::
+When running these subcommands, you can set extractor options with the ``--extractor-option`` CLI option. For example:
 
 * ``codeql database create --extractor-option java.option1=abc ...``
 * ``codeql database start-tracing --extractor-option java.group1.option2=102 ...``
@@ -76,7 +76,7 @@ Using ``--extractor-option`` to assign an extractor option that does not exist i
 
 The CodeQL CLI accepts multiple ``--extractor-option`` options in the same invocation. If you set a ``string`` extractor option multiple times, the last option value overwrites all previous ones. If you set an `array` extractor option multiple times, all option values are concatenated in order.
 
-You can also specify extractor option names without the extractor name. For example::
+You can also specify extractor option names without the extractor name. For example:
 
 * ``codeql database create --extractor-option option1=abc ...``
 * ``codeql database start-tracing --extractor-option group1.option2=102 ...``
@@ -86,7 +86,7 @@ If you do not specify an extractor name, the extractor option settings will appl
 Setting extractor options from files
 ------------------------------------
 
-You can also set extractor options through a file. The CodeQL CLI subcommands that accept ``--extractor-option`` also accept ``--extractor-options-file``, which has a required argument of the path to a YAML file (with extension ``.yaml`` or ``.yml``) or a JSON file (with extension ``.json``). For example::
+You can also set extractor options through a file. The CodeQL CLI subcommands that accept ``--extractor-option`` also accept ``--extractor-options-file``, which has a required argument of the path to a YAML file (with extension ``.yaml`` or ``.yml``) or a JSON file (with extension ``.json``). For example:
 
 # ``codeql database create --extractor-options-file options.yml ...``
 # ``codeql database start-tracing --extractor-options-file options.json ...``
@@ -132,7 +132,7 @@ Assigning an extractor option that does not exist is an error. You can make the 
              __allow_unknown_properties: true
              option2: [ 102 ]
 
-You can specify ``--extractor-options-file`` multiple times. The extractor option assignments are processed in the following order::
+You can specify ``--extractor-options-file`` multiple times. The extractor option assignments are processed in the following order:
 
 # All extractor option files specified by ``--extractor-options-file`` are processed in the order they appear on the command line, then
 # All extractor option assignments specified by ``--extractor-option`` are processed in the order they appear on the command line

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -31,7 +31,7 @@ Each extractor defines its own set of configuration options. To find out which o
                      "description" : "An example array option for the Java extractor",
                      "type" : "array",
                      "pattern" : "[1-9][0-9]*"
-                 }
+                }
              }
          }
          }

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -88,8 +88,8 @@ Setting extractor options from files
 
 You can also set extractor options through a file. The CodeQL CLI subcommands that accept ``--extractor-option`` also accept ``--extractor-options-file``, which has a required argument of the path to a YAML file (with extension ``.yaml`` or ``.yml``) or a JSON file (with extension ``.json``). For example:
 
-# ``codeql database create --extractor-options-file options.yml ...``
-# ``codeql database start-tracing --extractor-options-file options.json ...``
+* ``codeql database create --extractor-options-file options.yml ...``
+* ``codeql database start-tracing --extractor-options-file options.json ...``
 
 Each option file contains a tree structure of nested maps. At the root is an extractor map key, and beneath it are map keys that correspond to extractor names. Starting at the third level, there are extractor options and option groups.
 
@@ -134,7 +134,7 @@ Assigning an extractor option that does not exist is an error. You can make the 
 
 You can specify ``--extractor-options-file`` multiple times. The extractor option assignments are processed in the following order:
 
-# All extractor option files specified by ``--extractor-options-file`` are processed in the order they appear on the command line, then
-# All extractor option assignments specified by ``--extractor-option`` are processed in the order they appear on the command line
+1. All extractor option files specified by ``--extractor-options-file`` are processed in the order they appear on the command line, then
+2. All extractor option assignments specified by ``--extractor-option`` are processed in the order they appear on the command line
 
 The same rules govern what happens when the same extractor option is set multiple times, regardless of whether the assignments are done using ``--extractor-option``, using ``--extractor-options-file``, or some combination of the two. If you set a ``string`` extractor option multiple times, the last option value overwrites all previous values. If you set an ``array`` extractor option multiple times, all option values are concatenated in order.

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -81,7 +81,7 @@ You can also specify extractor option names without the extractor name. For exam
 *   ``codeql database create --extractor-option option1=abc ...``
 *   ``codeql database start-tracing --extractor-option group1.option2=102 ...``
 
-If you do not specify an extractor name, the extractor option settings will apply to all extractors that declare an option with the given name. In the above example, the first command would set the extractor option ``option1`` to ``abc`` for the ``java`` extractor and every extractor that has an option of ``option1``, for example the ``cpp`` extractor, if the ``option1` extractor option exists for that extractor.
+If you do not specify an extractor name, the extractor option settings will apply to all extractors that declare an option with the given name. In the above example, the first command would set the extractor option ``option1`` to ``abc`` for the ``java`` extractor and every extractor that has an option of ``option1``, for example the ``cpp`` extractor, if the ``option1`` extractor option exists for that extractor.
 
 Setting extractor options from files
 ------------------------------------

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -4,7 +4,7 @@ Extractor options
 =================
 
 The CodeQL CLI uses special programs, called extractors, to extract information from the source code of a
-software system into a database that can be queried.  You can customize the behavior of extractors by
+software system into a database that can be queried. You can customize the behavior of extractors by
 setting extractor configuration options through the CodeQL CLI.
 
 About extractor options

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -39,9 +39,9 @@ Each extractor defines its own set of configuration options. To find out which o
 
 The extractor option names and descriptions are listed under ``extractor_options``. Each option may contain the following fields::
 
-* ``title`` (required): The title of the option
-* ``description`` (required): The description of the option
-* ``type`` (required): The type of the option, which can be
+- ``title`` (required): The title of the option
+- ``description`` (required): The description of the option
+- ``type`` (required): The type of the option, which can be
 
   * ``string``: indicating that the option can have a single string value
   * ``array``: indicating that the option can have a sequence of string values

--- a/docs/codeql/codeql-cli/extractor-options.rst
+++ b/docs/codeql/codeql-cli/extractor-options.rst
@@ -1,0 +1,136 @@
+.. extractor-options:
+
+Extractor options
+=================
+
+The CodeQL CLI uses special programs, called extractors, to extract information from the source code of a
+software system into a database that can be queried.  You can customize the behavior of extractors by
+setting extractor configuration options through the CodeQL CLI.
+
+About extractor options
+-----------------------
+
+Each extractor defines its own set of configuration options. To find out which options are available for a particular extractor, you can run ``codeql resolve languages`` or ``codeql resolve extractor`` with the ``--format=betterjson`` option. The ``betterjson`` output format provides the root paths of extractors and additional information. The output of ``codeql resolve extractor --format=betterjson`` will often be formatted like the following example::
+
+    {
+         "extractor_root" : "/home/user/codeql/java",
+         "extractor_options" : {
+             "option1" : {
+             "title" : "Java extractor option 1",
+             "description" : "An example string option for the Java extractor.",
+             "type" : "string",
+             "pattern" : "[a-z]+"
+             },
+         "group1" : {
+             "title" : "Java extractor group 1",
+             "description" : "An example option group for the Java extractor.",
+             "type" : "object",
+             "properties" : {
+                 "option2" : {
+                     "title" : "Java extractor option 2",
+                     "description" : "An example array option for the Java extractor",
+                     "type" : "array",
+                     "pattern" : "[1-9][0-9]*"
+                 }
+             }
+         }
+         }
+     }
+
+The extractor option names and descriptions are listed under ``extractor_options``. Each description may contain the following fields::
+
+*   ``title`` (required): The title of the option
+*   ``description`` (required): The description of the option
+*   ``type`` (required): The type of the option, which can be
+
+    *   ``string``: indicating that the option can have a single string value
+    *   ``array``: indicating that the option can have a sequence of string values
+    *   ``object``: indicating that it is not an option itself, but a grouping that may contain other options and option groups
+
+*   ``pattern`` (optional): The regular expression patterns that all values of the option should match. Note that the extractor may impose additional constraints on option values that are not or cannot be expressed in this regular expression pattern. Such constraints, if they exist, would be explained under the description field.
+*   ``properties`` (optional): A map from extractor option names in the option group to the corresponding extractor option descriptions. This field can only be present for option groups. For example, options of ``object`` type.
+
+In the example above, the extractor declares two options::
+
+*   ``option1`` is a ``string`` option with value matching ``[a-z]+``
+*   ``group1.option2`` is an ``array`` option with values matching ``[1-9][0-9]*``
+
+Setting extractor options with the CodeQL CLI
+---------------------------------------------
+
+The CodeQL CLI supports setting extractor options in subcommands that directly or indirectly invoke extractors. These commands are::
+
+*   ``codeql database create``
+*   ``codeql database start-tracing``
+*   ``codeql database trace-command``
+*   ``codeql database index-files``
+
+When running these subcommands, you can set extractor options with the ``--extractor-option`` CLI option. For example::
+
+*   ``codeql database create --extractor-option java.option1=abc ...``
+*   ``codeql database start-tracing --extractor-option java.group1.option2=102 ...``
+
+``--extractor-option`` requires exactly one argument of the form ``extractor_option_name=extractor_option_value``.  ``extractor_option_name`` is the name of the extractor (in this example, ``java``) followed by a period and then the name of the extractor option (in this example, either ``option1`` or ``group1.option2``).  ``extractor_option_value`` is the value being assigned to the extractor option. The value must match the regular expression pattern of the extractor option (if it exists), and it must not contain newline characters.
+
+Using ``--extractor-option`` to assign an extractor option that does not exist is an error.
+
+The CodeQL CLI accepts multiple ``--extractor-option`` options in the same invocation. If you set a ``string`` extractor option multiple times, the last option value overwrites all previous ones. If you set an `array` extractor option multiple times, all option values are concatenated in order.
+
+You can also specify extractor option names without the extractor name. For example::
+
+*   ``codeql database create --extractor-option option1=abc ...``
+*   ``codeql database start-tracing --extractor-option group1.option2=102 ...``
+
+If you do not specify an extractor name, the extractor option settings will apply to all extractors that declare an option with the given name. In the above example, the first command would set the extractor option ``option1`` to ``abc`` for the ``java`` extractor and every extractor that has an option of ``option1``, for example the ``cpp`` extractor, if the ``option1` extractor option exists for that extractor.
+
+Setting extractor options from files
+------------------------------------
+
+You can also set extractor options through a file. The CodeQL CLI subcommands that accept ``--extractor-option`` also accept ``--extractor-options-file``, which has a required argument of the path to a YAML file (with extension ``.yaml`` or ``.yml``) or a JSON file (with extension ``.json``). For example::
+
+#   ``codeql database create --extractor-options-file options.yml ...``
+#   ``codeql database start-tracing --extractor-options-file options.json ...``
+
+Each option file contains a tree structure of nested maps. At the root is an extractor map key, and beneath it are map keys that correspond to extractor names. Starting at the third level, there are extractor options and option groups.
+
+In JSON::
+
+    {
+         "extractor" : {
+             “java”: {
+                 "option1" : “abc”,
+                 "group1" : {
+                 "option2" : [ 102 ]
+                 }
+             }
+         }
+     }
+
+
+In YAML::
+
+    extractor:
+     java:
+         option1: “abc”
+         group1:
+             option2: [ 102 ]
+
+The value for a ``string`` extractor option must be a string or a number (which will be converted to a string before further processing).
+The value for an ``array`` extractor option must be an array of strings or numbers.
+The value for an option group (of type ``object``) must be a map, which may contain nested extractor options and option groups.
+Each extractor option value must match the regular expression pattern of the extractor option (if it exists), and it must not contain newline characters.
+Assigning an extractor option that does not exist is an error. You can make the CodeQL CLI ignore unknown extractor options by using a special ``__allow_unknown_properties`` Boolean field. For example, the following option file asks the CodeQL CLI to ignore all unknown extractor options and option groups under ``group1``::
+
+    extractor:
+     java:
+         option1: “abc”
+         group1:
+             __allow_unknown_properties: true
+             option2: [ 102 ]
+
+You can specify ``--extractor-options-file`` multiple times. The extractor option assignments are processed in the following order::
+
+#   All extractor option files specified by ``--extractor-options-file`` are processed in the order they appear on the command line, then
+#   All extractor option assignments specified by ``--extractor-option`` are processed in the order they appear on the command line
+
+The same rules govern what happens when the same extractor option is set multiple times, regardless of whether the assignments are done using ``--extractor-option``, using ``--extractor-options-file``, or some combination of the two. If you set a ``string`` extractor option multiple times, the last option value overwrites all previous values. If you set an ``array`` extractor option multiple times, all option values are concatenated in order.

--- a/docs/codeql/codeql-cli/using-the-codeql-cli.rst
+++ b/docs/codeql/codeql-cli/using-the-codeql-cli.rst
@@ -18,6 +18,10 @@ See the following links to learn how to get set up and run CodeQL commands:
   <creating-codeql-databases>`: Create relational
   representations of source code that can be queried like any other database.
   
+- :doc:`Extractor options
+  <extractor-options>`: Set options for the 
+  behavior of extractors that create CodeQL databases.
+
 - :doc:`Analyzing CodeQL databases with the CodeQL CLI
   <analyzing-databases-with-the-codeql-cli>`: Analyze your code using queries
   written in a specially-designed, object-oriented query language.
@@ -57,6 +61,7 @@ See the following links to learn how to get set up and run CodeQL commands:
    about-the-codeql-cli
    getting-started-with-the-codeql-cli
    creating-codeql-databases
+   extractor-options
    analyzing-databases-with-the-codeql-cli
    upgrading-codeql-databases
    using-custom-queries-with-the-codeql-cli


### PR DESCRIPTION
This PR creates a new article that describes extractor options and how to invoke them. It also adds a link to this new article in the [Creating CodeQL databases](https://codeql.github.com/docs/codeql-cli/creating-codeql-databases/) article.

To the docs team member who reviews this, the current examples are a bit vague because whats shipping in this CodeQL CLI release is the ability for CodeQL CLI to accept extractor options from CLI users and pass the options to the extractors. No extractor has declared any options yet, so this may be as specific as we can be for now. As time goes on, each extractor will gradually introduce its own set of extractor options. When this happens, we can revisit these examples and add additional information like which options might be helpful for specific troubleshooting situations.

cc @cklin, would it now be possible to write an example that uses existing extractor options or is that still a ways out? I'd like to have an example that someone could try running to test out extractor options on their own, but I also know this might not be possible yet. Thanks!