### PR TITLE
C#: Use `cs/` prefix in all query IDs

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/PrintAst.ql
+++ b/csharp/ql/lib/semmle/code/csharp/PrintAst.ql
@@ -1,7 +1,7 @@
 /**
  * @name Print AST
  * @description Outputs a representation of the Abstract Syntax Tree.
- * @id csharp/print-ast
+ * @id cs/print-ast
  * @kind graph
  */
 

--- a/csharp/ql/src/Security Features/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
+++ b/csharp/ql/src/Security Features/CWE-020/ExternalAPIsUsedWithUntrustedData.ql
@@ -3,7 +3,7 @@
  * @description This reports the external APIs that are used with untrusted data, along with how
  *              frequently the API is called, and how many unique sources of untrusted data flow
  *              to it.
- * @id csharp/count-untrusted-data-external-api
+ * @id cs/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
  */

--- a/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql
+++ b/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql
@@ -1,7 +1,7 @@
 /**
  * @name Untrusted data passed to external API
  * @description Data provided remotely is used in this external API without sanitization, which could be a security risk.
- * @id csharp/untrusted-data-to-external-api
+ * @id cs/untrusted-data-to-external-api
  * @kind path-problem
  * @precision low
  * @problem.severity error

--- a/csharp/ql/src/experimental/ir/IRConsistency.ql
+++ b/csharp/ql/src/experimental/ir/IRConsistency.ql
@@ -2,7 +2,7 @@
  * @name IR Consistency Check
  * @description Performs consistency checks on the Intermediate Representation. This query should have no results.
  * @kind table
- * @id csharp/ir-consistency-check
+ * @id cs/ir-consistency-check
  */
 
 import implementation.raw.IRConsistency

--- a/csharp/ql/src/experimental/ir/PrintIR.ql
+++ b/csharp/ql/src/experimental/ir/PrintIR.ql
@@ -1,7 +1,7 @@
 /**
  * @name Print IR
  * @description Outputs a representation of the IR graph
- * @id csharp/print-ir
+ * @id cs/print-ir
  * @kind graph
  */
 

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.ql
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRConsistency.ql
@@ -2,7 +2,7 @@
  * @name Raw IR Consistency Check
  * @description Performs consistency checks on the Intermediate Representation. This query should have no results.
  * @kind table
- * @id csharp/raw-ir-consistency-check
+ * @id cs/raw-ir-consistency-check
  */
 
 import IRConsistency

--- a/csharp/ql/src/experimental/ir/implementation/raw/PrintIR.ql
+++ b/csharp/ql/src/experimental/ir/implementation/raw/PrintIR.ql
@@ -1,7 +1,7 @@
 /**
  * @name Print Raw IR
  * @description Outputs a representation of the Raw IR graph
- * @id csharp/print-raw-ir
+ * @id cs/print-raw-ir
  * @kind graph
  */
 

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConsistency.ql
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/SSAConsistency.ql
@@ -2,7 +2,7 @@
  * @name Unaliased SSA Consistency Check
  * @description Performs consistency checks on the SSA construction. This query should have no results.
  * @kind table
- * @id csharp/unaliased-ssa-consistency-check
+ * @id cs/unaliased-ssa-consistency-check
  */
 
 import SSAConsistency

--- a/csharp/ql/src/printAst.ql
+++ b/csharp/ql/src/printAst.ql
@@ -2,7 +2,7 @@
  * @name Print AST
  * @description Outputs a representation of a file's Abstract Syntax Tree. This
  *              query is used by the VS Code extension.
- * @id csharp/print-ast
+ * @id cs/print-ast
  * @kind graph
  * @tags ide-contextual-queries/print-ast
  */


### PR DESCRIPTION
Similar to https://github.com/github/codeql/pull/7026.