### PR TITLE
Ruby: Remove `Node::getEnclosingCallable` and `ParameterNode::isParameterOf`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -450,7 +450,7 @@ DataFlowCallable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) { 
  */
 predicate exprNodeReturnedFrom(DataFlow::ExprNode e, Callable c) {
   exists(ReturningNode r |
-    r.getEnclosingCallable().asCallable() = c and
+    nodeGetEnclosingCallable(r).asCallable() = c and
     (
       r.(ExplicitReturnNode).getReturningNode().getReturnedValueNode() = e.asExpr() or
       r.(ExprReturnNode) = e

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -7,12 +7,16 @@ private import SsaImpl as SsaImpl
 private import FlowSummaryImpl as FlowSummaryImpl
 
 /** Gets the callable in which this node occurs. */
-DataFlowCallable nodeGetEnclosingCallable(Node n) { result = n.getEnclosingCallable() }
+DataFlowCallable nodeGetEnclosingCallable(NodeImpl n) { result = n.getEnclosingCallable() }
 
 /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-predicate isParameterNode(ParameterNode p, DataFlowCallable c, int pos) { p.isParameterOf(c, pos) }
+predicate isParameterNode(ParameterNodeImpl p, DataFlowCallable c, int pos) {
+  p.isParameterOf(c, pos)
+}
 
 abstract class NodeImpl extends Node {
+  DataFlowCallable getEnclosingCallable() { result = TCfgScope(this.getCfgScope()) }
+
   /** Do not call: use `getEnclosingCallable()` instead. */
   abstract CfgScope getCfgScope();
 
@@ -312,7 +316,7 @@ private module ParameterNodes {
   abstract class ParameterNodeImpl extends ParameterNode, NodeImpl {
     abstract predicate isSourceParameterOf(Callable c, int i);
 
-    override predicate isParameterOf(DataFlowCallable c, int i) {
+    predicate isParameterOf(DataFlowCallable c, int i) {
       this.isSourceParameterOf(c.asCallable(), i)
     }
   }
@@ -802,7 +806,7 @@ predicate lambdaCall(DataFlowCall call, LambdaCallKind kind, Node receiver) {
     )
   or
   receiver = call.(SummaryCall).getReceiver() and
-  if receiver.(ParameterNode).isParameterOf(_, -2)
+  if receiver.(ParameterNodeImpl).isParameterOf(_, -2)
   then kind = TYieldCallKind()
   else kind = TLambdaCallKind()
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -25,8 +25,6 @@ class Node extends TNode {
   // TODO: cache
   final Location getLocation() { result = this.(NodeImpl).getLocationImpl() }
 
-  DataFlowCallable getEnclosingCallable() { result = TCfgScope(this.(NodeImpl).getCfgScope()) }
-
   /**
    * Holds if this element is at the specified location.
    * The location spans column `startcolumn` of line `startline` to
@@ -85,12 +83,6 @@ class ExprNode extends Node, TExprNode {
 class ParameterNode extends Node, TParameterNode {
   /** Gets the parameter corresponding to this node, if any. */
   Parameter getParameter() { none() }
-
-  /**
-   * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
-   */
-  predicate isParameterOf(DataFlowCallable c, int i) { none() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/UrlRedirectCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UrlRedirectCustomizations.qll
@@ -57,9 +57,9 @@ module UrlRedirect {
         this = e.getRedirectLocation() and
         // As a rough heuristic, assume that methods with these names are handlers for POST/PUT/PATCH/DELETE requests,
         // which are not as vulnerable to URL redirection because browsers will not initiate them from clicking a link.
-        not this.getEnclosingCallable()
-            .asCallable()
-            .(Method)
+        not this.asExpr()
+            .getExpr()
+            .getEnclosingMethod()
             .getName()
             .regexpMatch(".*(create|update|destroy).*")
       )


### PR DESCRIPTION
These predicates no longer need to be user-facing, following https://github.com/github/codeql/pull/7000. 