### PR TITLE
JS: Add routing trees library

### DIFF
--- a/javascript/change-notes/2021-11-08-routing-trees.md
+++ b/javascript/change-notes/2021-11-08-routing-trees.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Data flow is now tracked across middleware functions in more cases, leading to more security results in general. Affected packages are `express` and `fastify`.
+* `js/missing-token-validation` has been made more precise, yielding both fewer false positives and more true positives.

--- a/javascript/ql/lib/javascript.qll
+++ b/javascript/ql/lib/javascript.qll
@@ -50,6 +50,7 @@ import semmle.javascript.Promises
 import semmle.javascript.CanonicalNames
 import semmle.javascript.RangeAnalysis
 import semmle.javascript.Regexp
+import semmle.javascript.Routing
 import semmle.javascript.SSA
 import semmle.javascript.StandardLibrary
 import semmle.javascript.Stmt

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -389,6 +389,23 @@ module API {
   }
 
   /**
+   * A class for contributing new steps for tracking uses of an API.
+   */
+  class AdditionalUseStep extends Unit {
+    /**
+     * Holds if use nodes should flow from `pred` to `succ`.
+     */
+    predicate step(DataFlow::SourceNode pred, DataFlow::SourceNode succ) { none() }
+  }
+
+  private module AdditionalUseStep {
+    pragma[nomagic]
+    predicate step(DataFlow::SourceNode pred, DataFlow::SourceNode succ) {
+      any(AdditionalUseStep st).step(pred, succ)
+    }
+  }
+
+  /**
    * Provides the actual implementation of API graphs, cached for performance.
    *
    * Ideally, we'd like nodes to correspond to (global) access paths, with edge labels
@@ -749,6 +766,11 @@ module API {
         prop = "" and
         result = pin.getBoundFunction(pred, boundArgs - predBoundArgs) and
         boundArgs in [0 .. 10]
+      )
+      or
+      exists(DataFlow::SourceNode mid |
+        mid = trackUseNode(nd, promisified, boundArgs, prop, t) and
+        AdditionalUseStep::step(pragma[only_bind_out](mid), result)
       )
       or
       exists(DataFlow::Node pred, string preprop |

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -277,7 +277,7 @@ module Routing {
     }
 
     /** Gets a place where this route node is installed as a route handler. */
-    Node getAUseSite() {
+    Node getRouteInstallation() {
       result = getAUseSiteInRouteSetup()
       or
       not exists(getAUseSiteInRouteSetup()) and

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -288,6 +288,9 @@ module Routing {
      * Gets a node whose value can be accessed via the given access path on the `n`th route handler parameter,
      * from any route handler that follows after this one.
      *
+     * This predicate may be overridden by framework models and only accounts for assignments made by the framework;
+     * not necessarily assignments that are explicit in the application code.
+     *
      * For example, in the context of Express, the `app` object is available as `req.app`:
      * ```js
      * app.get('/', (req, res) => {
@@ -296,10 +299,8 @@ module Routing {
      * ```
      * This can be modelled by mapping `(0, "app")` to the `app` data-flow node (`n=0` corresponds
      * to the `req` parameter).
-     *
-     * This predicate may be overridden by framework models.
      */
-    DataFlow::Node getValueAtAccessPath(int n, string path) { none() }
+    DataFlow::Node getValueImplicitlyStoredInAccessPath(int n, string path) { none() }
   }
 
   /** Holds if `pred` and `succ` are adjacent siblings. */
@@ -875,7 +876,9 @@ module Routing {
     )
     or
     // Implicit assignment contributed by framework model
-    exists(DataFlow::Node value, string path1 | value = base.getValueAtAccessPath(n, path1) |
+    exists(DataFlow::Node value, string path1 |
+      value = base.getValueImplicitlyStoredInAccessPath(n, path1)
+    |
       result = value and path = path1
       or
       exists(string path2 |

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -419,6 +419,8 @@ module Routing {
         or
         HTTP::routeHandlerStep(result, this)
         or
+        RouteHandlerTrackingStep::step(result, this)
+        or
         exists(string prop |
           StepSummary::smallstep(result, getSourceProp(prop).getALocalUse(), StoreStep(prop))
         )
@@ -493,6 +495,22 @@ module Routing {
       ImpliedArrayRoute() { this instanceof ValueNode::UseSite }
 
       override DataFlow::Node getArgumentNode(int n) { result = getElement(n) }
+    }
+  }
+
+  /**
+   * An edge that should be used for tracking route handler definitions to their use-sites.
+   *
+   * This may be subclassed by framework models to contribute additional steps.
+   */
+  class RouteHandlerTrackingStep extends Unit {
+    /** Holds if route handlers should be propagated along the edge `pred -> succ`. */
+    predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
+  }
+
+  private module RouteHandlerTrackingStep {
+    predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      any(RouteHandlerTrackingStep s).step(pred, succ)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -303,7 +303,7 @@ module Routing {
     DataFlow::Node getValueImplicitlyStoredInAccessPath(int n, string path) { none() }
   }
 
-  /** Holds if `pred` and `succ` are adjacent siblings. */
+  /** Holds if `pred` and `succ` are adjacent siblings and `succ` is installed after `pred`. */
   private predicate areSiblings(Node pred, Node succ) {
     exists(ValueNode::Range base, int n |
       pred = base.getChild(n) and

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -144,6 +144,8 @@ module Routing {
       // Leaf nodes that aren't functions are assumed to invoke their continuation
       not exists(getLastChild()) and
       not this instanceof RouteHandler
+      or
+      this instanceof MkRouter
     }
 
     /** Gets the parent of this node, provided that this node may invoke its continuation. */

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -1,0 +1,957 @@
+/**
+ * A model of routing trees, describing the composition of route handlers and middleware functions
+ * in a web server application. See `Routing::Node` for more details.
+ */
+
+private import javascript
+private import semmle.javascript.dataflow.internal.FlowSteps as FlowSteps
+private import semmle.javascript.dataflow.internal.StepSummary
+private import semmle.javascript.DynamicPropertyAccess
+
+/**
+ * A model of routing trees, describing the composition of route handlers and middleware functions
+ * in a web server application. See `Routing::Node` for more details.
+ */
+module Routing {
+  private newtype TNode =
+    /**
+     * A data flow node whose value corresponds to a route node.
+     */
+    MkValueNode(ValueNode::Range range) or
+    /**
+     * A place where a route is installed on a mutable router object, or where a mutable
+     * router object escapes into a function leading to such route setups.
+     *
+     * The call performing the route setup usually returns the router itself, not
+     * the particular route installed here, which is why this is not a value node.
+     */
+    MkRouteSetup(RouteSetup::Base range) or
+    /**
+     * A node representing the state of a mutable router object at the exit of `container`.
+     *
+     * When routers are passed around and mutated from multiple functions, we need to reason about the relative
+     * ordering of route setups in different functions. To simplify this, a separate node is generated for a each
+     * function that mutates the router.
+     */
+    MkRouter(Router::Range range, StmtContainer container) {
+      routerIsLiveInContainer(range, container)
+    }
+
+  private predicate routerIsLiveInContainer(Router::Range router, StmtContainer container) {
+    container = router.getContainer()
+    or
+    exists(RouteSetup::Range setup, ControlFlowNode cfg |
+      setup.isInstalledAt(router, cfg) and
+      container = cfg.getContainer()
+    )
+    or
+    // 'container' contains a call to a function in which 'router' is live
+    exists(DataFlow::InvokeNode invoke, Function f |
+      routerIsLiveInContainer(router, f) and
+      not f = router.getContainer() and // 'f' does not contain the creation of the router
+      FlowSteps::calls(invoke, f) and
+      container = invoke.getContainer()
+    )
+  }
+
+  /** Gets the routing node corresponding to the value of `node`. */
+  Node getNode(DataFlow::Node node) { result = MkValueNode(node) }
+
+  /**
+   * Gets the routing node corresponding to the route installed at the given route setup.
+   *
+   * This is not generally the same as `getNode(call)`, since the route setup method can return a value
+   * that does not correspond to the route that was just installed.
+   * Typically this occurs when the route setup method is chainable and returns the router itself.
+   */
+  Node getRouteSetupNode(DataFlow::CallNode call) { result = MkRouteSetup(call) }
+
+  /**
+   * A node in a routing tree modelling the composition of middleware functions and route handlers.
+   *
+   * More precisely, this is a node in a graph representing a set of possible routing trees, as the
+   * concrete shape of the  routing tree may be depend on branching control flow.
+   *
+   * Each node represents a function that can receive an incoming request, though not necessarily
+   * a function with an explicit body in the source code.
+   *
+   * A node may either consume the request, dispatching to its first child, or pass it on to its successor
+   * in the tree. The successor is the next sibling, or in case there is no next sibling, it is the next sibling
+   * of the first ancestor that has a next sibling.
+   */
+  class Node extends TNode {
+    /** Gets a textual representation of this element. */
+    string toString() { none() } // Overridden in subclass
+
+    /**
+     * Holds if this element is at the specified location.
+     * The location spans column `startcolumn` of line `startline` to
+     * column `endcolumn` of line `endline` in file `filepath`.
+     * For more information, see
+     * [Locations](https://help.semmle.com/QL/learn-ql/ql/locations.html).
+     */
+    predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    ) {
+      none()
+    } // overridden in subclass
+
+    /**
+     * Gets the next sibling of this node in the routing tree.
+     */
+    final Node getNextSibling() { areSiblings(this, result) }
+
+    /**
+     * Gets the previous sibling of this node in the routing tree.
+     */
+    final Node getPreviousSibling() { areSiblings(result, this) }
+
+    /**
+     * Gets a child of this node in the routing tree.
+     */
+    Node getAChild() { none() } // Overridden in subclass
+
+    /**
+     * Gets the parent of this node in the routing tree.
+     */
+    final Node getParent() { result.getAChild() = this }
+
+    /**
+     * Gets the first child of this node in the routing tree.
+     */
+    Node getFirstChild() { none() } // Overridden in subclass
+
+    /**
+     * Gets the last child of this node in the routing tree.
+     */
+    Node getLastChild() { none() } // Overridden in subclass
+
+    /**
+     * Gets the root node of this node in the routing tree.
+     */
+    final RootNode getRootNode() { this = result.getADescendant() }
+
+    /**
+     * Holds if this node may invoke its continuation after having dispatched the
+     * request to its children, that is, the incoming request may be partially processed by
+     * this subtree, and subsequently passed on to the successor.
+     */
+    predicate mayResumeDispatch() {
+      getLastChild().mayResumeDispatch()
+      or
+      exists(this.(RouteHandler).getAContinuationInvocation())
+      or
+      // Leaf nodes that aren't functions are assumed to invoke their continuation
+      not exists(getLastChild()) and
+      not this instanceof RouteHandler
+    }
+
+    /** Gets the parent of this node, provided that this node may invoke its continuation. */
+    private Node getContinuationParent() {
+      result = getParent() and
+      result.mayResumeDispatch()
+    }
+
+    /**
+     * Gets a path prefix to be matched against the path of incoming requests.
+     *
+     * If the prefix matches, the request is dispatched to the first child, with a modified path
+     * where the matched prefix has been removed. For example, if the prefix is `/foo` and the incoming
+     * request has path `/foo/bar`, a request with path `/bar` is dispatched to the first child.
+     *
+     * If the prefix does not match, the request is passed on to the continuation.
+     */
+    string getRelativePath() { none() } // Overridden in subclass
+
+    /**
+     * Holds if this is a node where the request can flow from one child to the next.
+     */
+    private predicate isFork() {
+      exists(Node child |
+        child = getAChild() and
+        child.mayResumeDispatch() and
+        exists(child.getNextSibling())
+      )
+    }
+
+    /**
+     * Gets the path prefix needed to reach this node from the given ancestor, that is, the concatenation
+     * of all relative paths between this node and the ancestor.
+     *
+     * To restrict the size of the predicate, this is only available for the ancestors that are "fork" nodes,
+     * that is, a node that has siblings (i.e. multiple children).
+     */
+    private string getPathFromFork(Node fork) {
+      isFork() and
+      this = fork and
+      result = ""
+      or
+      exists(Node parent | parent = getParent() |
+        not exists(parent.getRelativePath()) and
+        result = parent.getPathFromFork(fork)
+        or
+        result = parent.getPathFromFork(fork) + parent.getRelativePath() and
+        result.length() < 100
+      )
+    }
+
+    /**
+     * Gets an HTTP method required to reach this node from the given ancestor, or `*` if any method
+     * can be used.
+     *
+     * To restrict the size of the predicate, this is only available for the ancestors that are "fork" nodes,
+     * that is, a node that has siblings (i.e. multiple children).
+     */
+    private string getHttpMethodFromFork(Node fork) {
+      isFork() and
+      this = fork and
+      (
+        result = getOwnHttpMethod()
+        or
+        not exists(getOwnHttpMethod()) and
+        result = "*"
+      )
+      or
+      result = getParent().getHttpMethodFromFork(fork) and
+      (
+        // Only the ancestor restricts the HTTP method
+        not exists(getOwnHttpMethod())
+        or
+        // Intersect permitted HTTP methods
+        result = getOwnHttpMethod()
+      )
+      or
+      // The ancestor allows any HTTP method, but this node restricts it
+      getParent().getHttpMethodFromFork(fork) = "*" and
+      result = getOwnHttpMethod()
+    }
+
+    /**
+     * Holds if `node` has processed the incoming request strictly prior to this node.
+     */
+    pragma[inline]
+    private predicate isGuardedByNodeInternal(Node guard) {
+      // Look for a common ancestor `fork` whose child leading to `guard` ("base1") preceeds
+      // the child leading to `this` ("base2").
+      //
+      // Schematically:
+      //      fork
+      //     /    \
+      //   base1  base2
+      //    |       |   <-- (zero or more steps)
+      //   guard   this
+      exists(Node base1, Node base2, Node fork |
+        base1 = guard.getContinuationParent*() and
+        base2 = base1.getNextSibling+() and
+        this = base2.getAChild*() and
+        fork = base1.getParent() and
+        isEitherPrefixOfTheOther(this.getPathFromFork(fork), guard.getPathFromFork(fork)) and
+        areHttpMethodsMatching(base1.getHttpMethodFromFork(fork), base2.getHttpMethodFromFork(fork))
+      )
+    }
+
+    /**
+     * Holds if `node` has processed the incoming request strictly prior to this node.
+     */
+    pragma[inline]
+    predicate isGuardedByNode(Node node) { isGuardedByNodeInternal(pragma[only_bind_out](node)) }
+
+    /**
+     * Holds if the middleware corresponding to `node` has processed the incoming request strictly prior to this node.
+     */
+    pragma[inline]
+    predicate isGuardedBy(DataFlow::Node node) { isGuardedByNode(getNode(node)) }
+
+    /**
+     * Gets an HTTP method name which this node will accept, or nothing if the node accepts all HTTP methods, not
+     * taking into account the context from ancestors or children nodes.
+     */
+    HTTP::RequestMethodName getOwnHttpMethod() { none() } // Overridden in subclass
+
+    private Node getAUseSiteInRouteSetup() {
+      if getParent() instanceof RouteSetup
+      then result = this
+      else result = getParent().getAUseSiteInRouteSetup()
+    }
+
+    /** Gets a place where this route node is installed as a route handler. */
+    Node getAUseSite() {
+      result = getAUseSiteInRouteSetup()
+      or
+      not exists(getAUseSiteInRouteSetup()) and
+      result = this
+    }
+
+    /**
+     * Gets a node whose value can be accessed via the given access path on `n`th route handler input,
+     * from any route handler that follows after this one.
+     *
+     * For example, in the context of Express, the `app` object is available as `req.app`:
+     * ```js
+     * app.get('/', (req, res) => {
+     *   req.app; // alias for 'app'
+     * })
+     * ```
+     * This can be modelled by mapping `(0, "app")` to the `app` data-flow node (`n=0` corresponds
+     * to the `req` parameter).
+     *
+     * This predicate may be overridden by framework models.
+     */
+    DataFlow::Node getValueAtAccessPath(int n, string path) { none() }
+  }
+
+  /** Holds if `pred` and `succ` are adjacent siblings. */
+  private predicate areSiblings(Node pred, Node succ) {
+    exists(ValueNode::Range base, int n |
+      pred = base.getChild(n) and
+      succ = base.getChild(n + 1)
+    )
+    or
+    exists(RouteSetup::Range base, int n |
+      pred = base.getChild(n) and
+      succ = base.getChild(n + 1)
+    )
+    or
+    exists(Router::Range router, ControlFlowNode cfgNode |
+      isInstalledAt(succ, router, cfgNode) and
+      pred = getMostRecentRouteSetupAt(router, cfgNode.getAPredecessor()) and
+      pred != succ // simplify analysis of loops
+    )
+  }
+
+  /** Holds if `a` is a prefix of `b` or the other way around. */
+  bindingset[a, b]
+  private predicate isEitherPrefixOfTheOther(string a, string b) {
+    a = b + any(string s) or b = a + any(string s)
+  }
+
+  /** Holds if `a` and `b` are the same HTTP method name or either of them is `*`. */
+  bindingset[a, b]
+  private predicate areHttpMethodsMatching(string a, string b) { a = "*" or b = "*" or a = b }
+
+  /**
+   * Companion module to the `Node` class, containing abstract classes
+   * that can be used to extend the routing model.
+   */
+  module ValueNode {
+    /**
+     * A node in the routing tree which corresponds to a data-flow node,
+     * and has a linear sequence of children (or no children).
+     *
+     * This class can be extended to contribute new kinds of nodes to tree,
+     * though in common cases it is preferrable to extend one of the more specialized classes:
+     * - `Routing::ValueNode::UseSite` to mark values that are used as a route handler,
+     * - `Routing::ValueNode::WithArguments` for nodes with an indexed sequence of children,
+     * - `Routing::RouteSetup::MethodCall` for nodes manipulating a router object
+     */
+    abstract class Range extends DataFlow::Node {
+      /** Gets the `n`th child of this route node. */
+      Node getChild(int n) { none() }
+
+      /** Gets the number of children of this route node. */
+      final int getNumChild() { result = count(int n | exists(getChild(n))) }
+
+      /**
+       * Gets a path prefix to be matched against the path of incoming requests.
+       *
+       * If the prefix matches, the request is dispatched to the first child, with a modified path
+       * where the matched prefix has been removed. For example, if the prefix is `/foo` and the incoming
+       * request has path `/foo/bar`, a request with path `/bar` is dispatched to the first child.
+       *
+       * If the prefix does not match, the request is passed on to the continuation.
+       */
+      string getRelativePath() { none() }
+
+      /**
+       * Gets an HTTP request method name (in upper case) matched by this node, or nothing
+       * if all HTTP request method names are accepted.
+       */
+      HTTP::RequestMethodName getHttpMethod() { none() }
+    }
+
+    private class ValueNodeImpl extends Node, MkValueNode {
+      Range range;
+
+      ValueNodeImpl() { this = MkValueNode(range) }
+
+      override string toString() { result = range.toString() }
+
+      override predicate hasLocationInfo(
+        string filepath, int startline, int startcolumn, int endline, int endcolumn
+      ) {
+        range.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      }
+
+      override Node getAChild() { result = range.getChild(_) }
+
+      override Node getFirstChild() { result = range.getChild(0) }
+
+      override Node getLastChild() { result = range.getChild(range.getNumChild() - 1) }
+
+      override string getRelativePath() { result = range.getRelativePath() }
+
+      override HTTP::RequestMethodName getOwnHttpMethod() { result = range.getHttpMethod() }
+    }
+
+    private StepSummary routeStepSummary() {
+      // Do not allow call steps as they lead to loss of context.
+      // Such steps are usually handled by the 'ImpliedRouteHandler' class.
+      result = LevelStep() or result = ReturnStep()
+    }
+
+    /**
+     * A node that is used as a route handler.
+     *
+     * Values that flow to this use site are themselves considered use sites, and are
+     * considered children of this one. (Intuitively, requests dispatched to this use-site
+     * are delagated to any node that flows here.)
+     *
+     * Framework models may extend this class to mark nodes as being use sites.
+     */
+    abstract class UseSite extends Range {
+      /**
+       * Gets a data flow ndoe that flows to this use-site in one step.
+       */
+      DataFlow::Node getSource() {
+        result = getALocalSource()
+        or
+        StepSummary::smallstep(result, this, routeStepSummary())
+        or
+        HTTP::routeHandlerStep(result, this)
+        or
+        exists(string prop |
+          StepSummary::smallstep(result, getSourceProp(prop).getALocalUse(), StoreStep(prop))
+        )
+        or
+        this = getAnEnumeratedArrayElement(result)
+      }
+
+      /** Gets a node whose `prop` property flows to this use site. */
+      private DataFlow::SourceNode getSourceProp(string prop) {
+        StepSummary::step(result, this, LoadStep(prop))
+        or
+        StepSummary::step(result, getSourceProp(prop), routeStepSummary())
+        or
+        StepSummary::step(result, getSourceProp(prop), CopyStep(prop))
+        or
+        exists(string oldProp |
+          StepSummary::step(result, getSourceProp(oldProp), LoadStoreStep(prop, oldProp))
+        )
+      }
+
+      private DataFlow::Node getStrictSource() {
+        result = getSource() and
+        result != this
+      }
+
+      final override Routing::Node getChild(int n) {
+        n = 0 and
+        result = MkValueNode(getStrictSource())
+        or
+        // If we cannot find the source of the use-site, but we know it's somehow a reference to a router,
+        // treat the router as the source. This is needed to handle chaining calls on the router, as the
+        // specific framework model knows about chaining steps, but the general `getSource()` predicate doesn't.
+        n = 0 and
+        not exists(getStrictSource()) and
+        exists(Router::Range router |
+          this = router.getAReference().getALocalUse() and
+          result = MkRouter(router, getContainer())
+        )
+      }
+    }
+
+    /**
+     * A node flowing into a use site, modelled as a child of the use site.
+     */
+    private class UseSiteSource extends UseSite {
+      UseSiteSource() { this = any(UseSite use).getSource() }
+    }
+
+    /**
+     * A node that has a linear sequence of children, which should all be marked as route objects.
+     */
+    abstract class WithArguments extends Range {
+      /**
+       * Gets a data flow node that should be seen as the `n`th child of this node.
+       *
+       * Overriding this predicate ensures that a routing node is generated for the child.
+       */
+      abstract DataFlow::Node getArgumentNode(int n);
+
+      final override Node getChild(int n) { result = MkValueNode(getArgumentNode(n)) }
+    }
+
+    /** An argument to a `WithArguments` instance, seen as a use site. */
+    private class Argument extends UseSite {
+      Argument() { this = any(WithArguments n).getArgumentNode(_) }
+    }
+
+    /**
+     * An array which has been determined to be a route node, seen as a route node with arguments.
+     */
+    private class ImpliedArrayRoute extends ValueNode::WithArguments, DataFlow::ArrayCreationNode {
+      ImpliedArrayRoute() { this instanceof ValueNode::UseSite }
+
+      override DataFlow::Node getArgumentNode(int n) { result = getElement(n) }
+    }
+  }
+
+  /**
+   * A node in the routing tree which has no parent.
+   */
+  class RootNode extends Node {
+    RootNode() { not exists(getParent()) }
+
+    /** Gets a node that is part of this subtree. */
+    final Node getADescendant() { result = getAChild*() }
+  }
+
+  /**
+   * A node representing a place where one or more routes are installed onto a mutable
+   * router object.
+   *
+   * The children of this node are the individual route handlers installed here.
+   *
+   * The siblings of this node are the other route setups locally affecting the same router,
+   * in the order in which they are installed.
+   *
+   * In case of branching control flow, the siblings are non-linear, that is, some route setups
+   * will have multiple previous/next siblings, reflecting the different paths the program may take
+   * during setup.
+   */
+  class RouteSetup extends Node, MkRouteSetup {
+    /**
+     * Gets the router affected by this route setup.
+     *
+     * This is an alias for `getParent`, but may be preferred for readability.
+     */
+    final Node getRouter() { result = getParent() }
+  }
+
+  /**
+   * Companion module to the `RouteSetup` class, containing classes that can be use to contribute
+   * new kinds of route setups.
+   */
+  module RouteSetup {
+    // To avoid negative recursion, the route setup range class is split into 'Base' and 'Range', where
+    // 'Range' contains those contributed by frameworks, and 'Base' contains some additional route setups
+    // where the router escapes into a function that contains other route setups.
+    /**
+     * INTERNAL. Use `RouteSetup::Range` instead.
+     *
+     * Class containing explicit route setups in addition to implied route setups, that is,
+     * places where a router escapes into a function containing route setups.
+     */
+    abstract class Base extends DataFlow::Node {
+      /** Gets the `n`th child of this route node. */
+      Node getChild(int n) { none() }
+
+      /** Gets the number of children of this route node. */
+      final int getNumChild() { result = count(int n | exists(getChild(n))) }
+
+      /**
+       * Gets a path prefix to be matched against the path of incoming requests.
+       *
+       * If the prefix matches, the request is dispatched to the first child, with a modified path
+       * where the matched prefix has been removed. For example, if the prefix is `/foo` and the incoming
+       * request has path `/foo/bar`, a request with path `/bar` is dispatched to the first child.
+       *
+       * If the prefix does not match, the request is passed on to the continuation.
+       */
+      string getRelativePath() { none() }
+
+      /**
+       * Gets an HTTP request method name (in upper case) matched by this node, or nothing
+       * if all HTTP request method names are accepted.
+       */
+      HTTP::RequestMethodName getHttpMethod() { none() }
+
+      /**
+       * Holds if this route setup targets `router` and occurs at the given `cfgNode`.
+       */
+      abstract predicate isInstalledAt(Router::Range router, ControlFlowNode cfgNode);
+    }
+
+    /**
+     * This class can be extended to contribute new kinds of route setups.
+     */
+    abstract class Range extends Base {
+      // Note: all member predicates are defined in RouteSetup::Base, declared above.
+    }
+
+    private class RouteSetupImpl extends Node, MkRouteSetup {
+      Base range;
+
+      RouteSetupImpl() { this = MkRouteSetup(range) }
+
+      override string toString() { result = range.toString() }
+
+      override predicate hasLocationInfo(
+        string filepath, int startline, int startcolumn, int endline, int endcolumn
+      ) {
+        range.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      }
+
+      override Node getAChild() { result = range.getChild(_) }
+
+      override Node getFirstChild() { result = range.getChild(0) }
+
+      override Node getLastChild() { result = range.getChild(range.getNumChild() - 1) }
+
+      override string getRelativePath() { result = range.getRelativePath() }
+
+      override HTTP::RequestMethodName getOwnHttpMethod() { result = range.getHttpMethod() }
+    }
+
+    /**
+     * A route setup that is method call on a router object, installing its arguments as route handlers.
+     *
+     * This class can be extended to contribute new kinds of route handlers.
+     */
+    abstract class MethodCall extends RouteSetup::Range, DataFlow::MethodCallNode {
+      override Node getChild(int n) { result = MkValueNode(getChildNode(n)) }
+
+      /** Gets the `n`th child of this route setup. */
+      DataFlow::Node getChildNode(int n) { result = getArgument(n) }
+
+      override predicate isInstalledAt(Router::Range router, ControlFlowNode cfgNode) {
+        this = router.getAReference().getAMethodCall() and cfgNode = getEnclosingExpr()
+      }
+    }
+
+    private class RouteSetupArgument extends ValueNode::UseSite {
+      RouteSetupArgument() { this = any(RouteSetup::MethodCall c).getChildNode(_) }
+    }
+  }
+
+  /**
+   * Provides classes for generating `Router` nodes, to be subclassed by framework models.
+   */
+  module Router {
+    /**
+     * Creation of a mutable router object.
+     */
+    abstract class Range extends DataFlow::Node {
+      /** Gets a reference to this router. */
+      abstract DataFlow::SourceNode getAReference();
+    }
+
+    private class RouterImpl extends Node, MkRouter {
+      Router::Range router;
+      StmtContainer container;
+
+      RouterImpl() { this = MkRouter(router, container) }
+
+      override string toString() {
+        result =
+          router.toString() + " in " +
+            [container.(Function).describe(), container.(TopLevel).getFile().getRelativePath()]
+      }
+
+      override predicate hasLocationInfo(
+        string filepath, int startline, int startcolumn, int endline, int endcolumn
+      ) {
+        router.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      }
+
+      private RouteSetup::Base getARouteSetup() {
+        result.isInstalledAt(router, any(ControlFlowNode cfg | cfg.getContainer() = container))
+      }
+
+      override Node getAChild() { result = MkRouteSetup(getARouteSetup()) }
+
+      override Node getLastChild() {
+        result = getMostRecentRouteSetupAt(router, container.getExit())
+      }
+
+      override Node getFirstChild() {
+        result = getAChild() and not exists(result.getPreviousSibling())
+      }
+    }
+  }
+
+  /**
+   * Like `RouteSetup::Base.isInstalledAt` but with the route setup call mapped to the `MkRouteSetup` node.
+   */
+  private predicate isInstalledAt(
+    RouteSetup setupNode, Router::Range router, ControlFlowNode cfgNode
+  ) {
+    exists(RouteSetup::Base setup |
+      setup.isInstalledAt(router, cfgNode) and
+      setupNode = MkRouteSetup(setup)
+    )
+  }
+
+  /**
+   * Gets the route setup most recently performed on `router` at `node`, or in the case of branching control flow,
+   * gets any route setup that could be the most recent one.
+   */
+  private RouteSetup getMostRecentRouteSetupAt(Router::Range router, ControlFlowNode node) {
+    isInstalledAt(result, router, node)
+    or
+    result = getMostRecentRouteSetupAt(router, node.getAPredecessor()) and
+    not exists(RouteSetup setup | isInstalledAt(setup, router, node))
+  }
+
+  /**
+   * A call where a mutable router object escapes into a parameter or is returned from a function.
+   *
+   * This is modelled as a route setup targeting the "local router" value and having
+   * the "target router" as its only child.
+   *
+   * For example,
+   * ```js
+   * function addMiddleware(r) {
+   *   r.use(bodyParser());
+   *   r.use(auth());
+   * }
+   *
+   * let app = express();
+   * addMiddleware(app); // <-- implied route setup
+   * app.get('/', handleRequest);
+   * ```
+   * here the call to `addMiddleware` is an implied route setup with `app`
+   * as the "local router" and `r` as the "target router".
+   *
+   * The routing tree ends up having the following shape:
+   * - `app`
+   *   - `addMiddleware(app)`
+   *     - `r`
+   *       - `r.use()`
+   *         - `bodyParser()`
+   *       - `r.use()`
+   *         - `auth()`
+   *   - `app.get(...)`
+   *     - `'/'`
+   *     - `handleRequest`
+   */
+  private class ImpliedRouteSetup extends RouteSetup::Base, DataFlow::InvokeNode {
+    Router::Range router;
+    Function target;
+
+    ImpliedRouteSetup() {
+      FlowSteps::calls(this, target) and
+      routerIsLiveInContainer(router, target) and
+      routerIsLiveInContainer(router, getContainer())
+    }
+
+    override Routing::Node getChild(int n) { result = MkRouter(router, target) and n = 0 }
+
+    override predicate isInstalledAt(Router::Range r, ControlFlowNode cfgNode) {
+      r = router and
+      cfgNode = getEnclosingExpr()
+    }
+  }
+
+  /**
+   * A function that handles an incoming request.
+   */
+  class RouteHandler extends Node {
+    DataFlow::FunctionNode function;
+
+    RouteHandler() { this = MkValueNode(function) }
+
+    /**
+     * Gets the `i`th parameter of this route handler.
+     *
+     * This is equivalent to `getParameter(i)` but returns a `RouteHandlerInput`.
+     *
+     * To find all references to this parameter, use `getInput(n).ref()`.
+     */
+    final RouteHandlerInput getInput(int n) { result = function.getParameter(n) }
+
+    /**
+     * Gets a parameter of this route handler.
+     *
+     * This is equivalent to `getAParameter()` but returns a `RouteHandlerInput`.
+     *
+     * To find all references to a parameter, use `getAnInput().ref()`.
+     */
+    final RouteHandlerInput getAnInput() { result = function.getAParameter() }
+
+    /** Gets the function implementing this route handler. */
+    DataFlow::FunctionNode getFunction() { result = function }
+
+    /**
+     * Gets a call that delegates the incoming request to the next route handler in the stack,
+     * usually a call of the form `next()`.
+     *
+     * By default, any 0-argument invocation of one of the route handler's parameters
+     * is considered a continuation invocation, since the other parameters (request and response)
+     * will generally not be invoked as a function. Framework models may override this method
+     * if the default behavior is inadequate for that framework.
+     */
+    DataFlow::CallNode getAContinuationInvocation() {
+      result = getAnInput().ref().getAnInvocation() and
+      result.getNumArgument() = 0
+      or
+      result.(DataFlow::MethodCallNode).getMethodName() = "then" and
+      result.getArgument(0) = getAnInput().ref().getALocalUse()
+    }
+  }
+
+  /**
+   * Gets the `RouteHandler` node corresponding to the given function.
+   *
+   * This has the same result as `getNode(function)` but is declared with a different return type.
+   */
+  RouteHandler getRouteHandler(DataFlow::FunctionNode function) { result.getFunction() = function }
+
+  /**
+   * A parameter to a route handler function.
+   */
+  class RouteHandlerInput extends DataFlow::ParameterNode {
+    RouteHandlerInput() { this = any(RouteHandler h).getFunction().getAParameter() }
+
+    /** Gets a data flow node referring to this route handler input. */
+    private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
+      t.start() and
+      result = this
+      or
+      exists(DataFlow::TypeTracker t2 | result = ref(t2).track(t2, t))
+    }
+
+    /** Gets a data flow node referring to this route handler input. */
+    DataFlow::SourceNode ref() { result = ref(DataFlow::TypeTracker::end()) }
+
+    /**
+     * Gets the corresponding route handler, that is, the function on which this is a parameter.
+     */
+    final RouteHandler getRouteHandler() { result.getFunction().getAParameter() = this }
+
+    /**
+     * Gets a node that is stored in the given access path on this route handler input, either
+     * during execution of this router handler, or in one of the preceding ones.
+     */
+    pragma[inline]
+    DataFlow::Node getValueFromAccessPath(string path) {
+      exists(RouteHandler handler, int i, Node predecessor |
+        pragma[only_bind_out](this) = handler.getFunction().getParameter(i) and
+        result = getAnAccessPathRhs(predecessor, i, path) and
+        (handler.isGuardedByNode(predecessor) or predecessor = handler)
+      )
+    }
+  }
+
+  /**
+   * Gets a value that flows into the given access path of the `n`th route handler input at `base`.
+   *
+   * For example,
+   * ```js
+   * function handler(req, res, next) {
+   *   res.locals.foo = 123;
+   *   next();
+   * }
+   * ```
+   * the node `123` flows into the `locals.foo` access path on the `res` parameter (`n=1`) of `handler`.
+   *
+   * Only route handlers that may invoke the continuation (`next()`) are considered, as the effect
+   * is otherwise not observable by other route handlers.
+   *
+   * In addition to the above, also contains implicit assignments contributed by framework models,
+   * based on `Node::Range::getValueAtAccessPath`.
+   */
+  private DataFlow::Node getAnAccessPathRhs(Node base, int n, string path) {
+    // Assigned in the body of a route handler function, whi
+    exists(RouteHandler handler | base = handler |
+      result = AccessPath::getAnAssignmentTo(handler.getInput(n).ref(), path) and
+      exists(handler.getAContinuationInvocation())
+    )
+    or
+    // Implicit assignment contributed by framework model
+    exists(DataFlow::Node value, string path1 | value = base.getValueAtAccessPath(n, path1) |
+      result = value and path = path1
+      or
+      exists(string path2 |
+        result = AccessPath::getAnAssignmentTo(value.getALocalSource(), path2) and
+        path = path1 + "." + path2
+      )
+    )
+  }
+
+  /**
+   * Gets a value that refers to the given access path of the `n`th route handler input at `base`
+   *
+   * For example,
+   * ```js
+   * function handler2(req, res) {
+   *   res.send(res.locals.foo);
+   * }
+   * ```
+   * here the `res.locals.foo` expression refers to the `locals.foo` path on the `res` parameter (`n=1`)
+   * of `handler2`.
+   */
+  private DataFlow::SourceNode getAnAccessPathRead(RouteHandler base, int n, string path) {
+    result = AccessPath::getAReferenceTo(base.getInput(n).ref(), path) and
+    not AccessPath::DominatingPaths::hasDominatingWrite(result)
+  }
+
+  /**
+   * Like `getAnAccessPathRhs` but with `base` mapped to its root node.
+   */
+  private DataFlow::Node getAnAccessPathRhsUnderRoot(RootNode root, int n, string path) {
+    result = getAnAccessPathRhs(root.getADescendant(), n, path)
+  }
+
+  /**
+   * Like `getAnAccessPathRead` but with `base` mapped to its root node.
+   */
+  private DataFlow::SourceNode getAnAccessPathReadUnderRoot(RootNode root, int n, string path) {
+    result = getAnAccessPathRead(root.getADescendant(), n, path)
+  }
+
+  /**
+   * Holds if `pred -> succ` is an API-graph step between access paths on request input objects.
+   *
+   * Since API graphs are mainly used to propagate type-like information, we do not require
+   * a happens-before relation for this step. We only require that we stay within the same
+   * web application, which is ensured by having a common root node.
+   */
+  private predicate middlewareApiStep(DataFlow::SourceNode pred, DataFlow::SourceNode succ) {
+    exists(RootNode root, int n, string path |
+      pred = getAnAccessPathRhsUnderRoot(root, n, path) and
+      succ = getAnAccessPathReadUnderRoot(root, n, path)
+    )
+    or
+    // We can't augment the call graph as this depends on type tracking, so just
+    // manually add steps out of functions stored on a request input.
+    exists(DataFlow::FunctionNode function, DataFlow::CallNode call |
+      middlewareApiStep(function, call.getCalleeNode().getALocalSource()) and
+      pred = function.getReturnNode() and
+      succ = call
+    )
+  }
+
+  /** Contributes `middlewareApiStep` as an API graph step. */
+  private class MiddlewareApiStep extends API::AdditionalUseStep {
+    override predicate step(DataFlow::SourceNode pred, DataFlow::SourceNode succ) {
+      middlewareApiStep(pred, succ)
+    }
+  }
+
+  /**
+   * Holds if `pred -> succ` is a data-flow step between access paths on request input objects.
+   */
+  private predicate middlewareDataFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(Node writer, Node reader, int n, string path |
+      pred = getAnAccessPathRhs(writer, n, path) and
+      succ = getAnAccessPathRead(reader, n, path) and
+      pragma[only_bind_out](reader).isGuardedByNode(pragma[only_bind_out](writer))
+    )
+    or
+    // Same as in `apiStep`: we can't augment the call graph, so just add flow out
+    // of functions stored on a request input.
+    exists(DataFlow::FunctionNode function, DataFlow::CallNode call |
+      middlewareDataFlowStep(function.getALocalUse(), call.getCalleeNode().getALocalSource()) and
+      pred = function.getReturnNode() and
+      succ = call
+    )
+  }
+
+  /** Contributes `middlewareDataFlowStep` as a value-preserving data flow step. */
+  private class MiddlewareFlowStep extends DataFlow::SharedFlowStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      middlewareDataFlowStep(pred, succ)
+    }
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -285,7 +285,7 @@ module Routing {
     }
 
     /**
-     * Gets a node whose value can be accessed via the given access path on `n`th route handler input,
+     * Gets a node whose value can be accessed via the given access path on the `n`th route handler parameter,
      * from any route handler that follows after this one.
      *
      * For example, in the context of Express, the `app` object is available as `req.app`:
@@ -774,20 +774,16 @@ module Routing {
     /**
      * Gets the `i`th parameter of this route handler.
      *
-     * This is equivalent to `getParameter(i)` but returns a `RouteHandlerInput`.
-     *
-     * To find all references to this parameter, use `getInput(n).ref()`.
+     * To find all references to this parameter, use `getParameter(n).ref()`.
      */
-    final RouteHandlerInput getInput(int n) { result = function.getParameter(n) }
+    final RouteHandlerParameter getParameter(int n) { result = function.getParameter(n) }
 
     /**
      * Gets a parameter of this route handler.
      *
-     * This is equivalent to `getAParameter()` but returns a `RouteHandlerInput`.
-     *
-     * To find all references to a parameter, use `getAnInput().ref()`.
+     * To find all references to a parameter, use `getAParameter().ref()`.
      */
-    final RouteHandlerInput getAnInput() { result = function.getAParameter() }
+    final RouteHandlerParameter getAParameter() { result = function.getAParameter() }
 
     /** Gets the function implementing this route handler. */
     DataFlow::FunctionNode getFunction() { result = function }
@@ -802,11 +798,11 @@ module Routing {
      * if the default behavior is inadequate for that framework.
      */
     DataFlow::CallNode getAContinuationInvocation() {
-      result = getAnInput().ref().getAnInvocation() and
+      result = getAParameter().ref().getAnInvocation() and
       result.getNumArgument() = 0
       or
       result.(DataFlow::MethodCallNode).getMethodName() = "then" and
-      result.getArgument(0) = getAnInput().ref().getALocalUse()
+      result.getArgument(0) = getAParameter().ref().getALocalUse()
     }
   }
 
@@ -820,10 +816,10 @@ module Routing {
   /**
    * A parameter to a route handler function.
    */
-  class RouteHandlerInput extends DataFlow::ParameterNode {
-    RouteHandlerInput() { this = any(RouteHandler h).getFunction().getAParameter() }
+  class RouteHandlerParameter extends DataFlow::ParameterNode {
+    RouteHandlerParameter() { this = any(RouteHandler h).getFunction().getAParameter() }
 
-    /** Gets a data flow node referring to this route handler input. */
+    /** Gets a data flow node referring to this route handler parameter. */
     private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
       t.start() and
       result = this
@@ -831,7 +827,7 @@ module Routing {
       exists(DataFlow::TypeTracker t2 | result = ref(t2).track(t2, t))
     }
 
-    /** Gets a data flow node referring to this route handler input. */
+    /** Gets a data flow node referring to this route handler parameter. */
     DataFlow::SourceNode ref() { result = ref(DataFlow::TypeTracker::end()) }
 
     /**
@@ -840,7 +836,7 @@ module Routing {
     final RouteHandler getRouteHandler() { result.getFunction().getAParameter() = this }
 
     /**
-     * Gets a node that is stored in the given access path on this route handler input, either
+     * Gets a node that is stored in the given access path on this route handler parameter, either
      * during execution of this router handler, or in one of the preceding ones.
      */
     pragma[inline]
@@ -854,7 +850,7 @@ module Routing {
   }
 
   /**
-   * Gets a value that flows into the given access path of the `n`th route handler input at `base`.
+   * Gets a value that flows into the given access path of the `n`th route handler parameter of `base`.
    *
    * For example,
    * ```js
@@ -874,7 +870,7 @@ module Routing {
   private DataFlow::Node getAnAccessPathRhs(Node base, int n, string path) {
     // Assigned in the body of a route handler function, whi
     exists(RouteHandler handler | base = handler |
-      result = AccessPath::getAnAssignmentTo(handler.getInput(n).ref(), path) and
+      result = AccessPath::getAnAssignmentTo(handler.getParameter(n).ref(), path) and
       exists(handler.getAContinuationInvocation())
     )
     or
@@ -890,7 +886,7 @@ module Routing {
   }
 
   /**
-   * Gets a value that refers to the given access path of the `n`th route handler input at `base`
+   * Gets a value that refers to the given access path of the `n`th route handler parameter of `base`.
    *
    * For example,
    * ```js
@@ -902,7 +898,7 @@ module Routing {
    * of `handler2`.
    */
   private DataFlow::SourceNode getAnAccessPathRead(RouteHandler base, int n, string path) {
-    result = AccessPath::getAReferenceTo(base.getInput(n).ref(), path) and
+    result = AccessPath::getAReferenceTo(base.getParameter(n).ref(), path) and
     not AccessPath::DominatingPaths::hasDominatingWrite(result)
   }
 

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -64,13 +64,13 @@ module Routing {
    * that does not correspond to the route that was just installed.
    * Typically this occurs when the route setup method is chainable and returns the router itself.
    */
-  Node getRouteSetupNode(DataFlow::CallNode call) { result = MkRouteSetup(call) }
+  Node getRouteSetupNode(DataFlow::Node call) { result = MkRouteSetup(call) }
 
   /**
    * A node in a routing tree modelling the composition of middleware functions and route handlers.
    *
    * More precisely, this is a node in a graph representing a set of possible routing trees, as the
-   * concrete shape of the  routing tree may be depend on branching control flow.
+   * concrete shape of the routing tree may be depend on branching control flow.
    *
    * Each node represents a function that can receive an incoming request, though not necessarily
    * a function with an explicit body in the source code.
@@ -410,7 +410,7 @@ module Routing {
      */
     abstract class UseSite extends Range {
       /**
-       * Gets a data flow ndoe that flows to this use-site in one step.
+       * Gets a data flow node that flows to this use-site in one step.
        */
       DataFlow::Node getSource() {
         result = getALocalSource()

--- a/javascript/ql/lib/semmle/javascript/Routing.qll
+++ b/javascript/ql/lib/semmle/javascript/Routing.qll
@@ -818,7 +818,9 @@ module Routing {
    * A parameter to a route handler function.
    */
   class RouteHandlerParameter extends DataFlow::ParameterNode {
-    RouteHandlerParameter() { this = any(RouteHandler h).getFunction().getAParameter() }
+    private RouteHandler handler;
+
+    RouteHandlerParameter() { this = handler.getFunction().getAParameter() }
 
     /** Gets a data flow node referring to this route handler parameter. */
     private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
@@ -834,7 +836,7 @@ module Routing {
     /**
      * Gets the corresponding route handler, that is, the function on which this is a parameter.
      */
-    final RouteHandler getRouteHandler() { result.getFunction().getAParameter() = this }
+    final RouteHandler getRouteHandler() { result = handler }
 
     /**
      * Gets a node that is stored in the given access path on this route handler parameter, either
@@ -842,7 +844,7 @@ module Routing {
      */
     pragma[inline]
     DataFlow::Node getValueFromAccessPath(string path) {
-      exists(RouteHandler handler, int i, Node predecessor |
+      exists(int i, Node predecessor |
         pragma[only_bind_out](this) = handler.getFunction().getParameter(i) and
         result = getAnAccessPathRhs(predecessor, i, path) and
         (handler.isGuardedByNode(predecessor) or predecessor = handler)

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -75,6 +75,63 @@ module Express {
     result = "del"
   }
 
+  private class RouterRange extends Routing::Router::Range {
+    RouterDefinition def;
+
+    RouterRange() { this = def.flow() }
+
+    override DataFlow::SourceNode getAReference() { result = def.ref() }
+  }
+
+  private class RoutingTreeSetup extends Routing::RouteSetup::MethodCall {
+    RoutingTreeSetup() { asExpr() instanceof RouteSetup }
+
+    override string getRelativePath() {
+      not getMethodName() = "param" and // do not treat parameter name as a path
+      result = getArgument(0).getStringValue()
+    }
+
+    override HTTP::RequestMethodName getHttpMethod() { result.toLowerCase() = getMethodName() }
+  }
+
+  /**
+   * A route setup performed via `express-limiter`.
+   *
+   * `express-limiter` is unusual in that it can install the middleware on its own,
+   * rather than expecting the caller to install it with `app.use()` or similar.
+   *
+   * For example:
+   * ```js
+   * let app = express();
+   * require('express-limiter')(app, client)({ method: 'get', path: '/foo' });
+   * ```
+   */
+  private class RateLimiterRouteSetup extends Routing::RouteSetup::Range {
+    DataFlow::CallNode limitCall;
+
+    RateLimiterRouteSetup() {
+      limitCall = DataFlow::moduleImport("express-limiter").getACall() and
+      exists(this.(DataFlow::CallNode).getOptionArgument(0, ["path", "method"])) and
+      this = limitCall.getACall()
+    }
+
+    override predicate isInstalledAt(Routing::Router::Range router, ControlFlowNode cfgNode) {
+      router.getAReference().getALocalUse() = limitCall.getArgument(0) and
+      cfgNode = asExpr()
+    }
+  }
+
+  private class AppTree extends Routing::Node {
+    AppTree() { this = Routing::getNode(appCreation()) }
+
+    override DataFlow::Node getValueAtAccessPath(int n, string path) {
+      // req.app and res.app refer to the app object
+      n = [0, 1] and
+      path = "app" and
+      this = Routing::getNode(result)
+    }
+  }
+
   /**
    * A call to an Express router method that sets up a route.
    */
@@ -788,10 +845,13 @@ module Express {
       exists(DataFlow::TypeTracker t2 | result = this.ref(t2).track(t2, t))
     }
 
+    /** Gets a data flow node referring to this router. */
+    DataFlow::SourceNode ref() { result = ref(DataFlow::TypeTracker::end()) }
+
     /**
      * Holds if `sink` may refer to this router.
      */
-    predicate flowsTo(Expr sink) { this.ref(DataFlow::TypeTracker::end()).flowsToExpr(sink) }
+    predicate flowsTo(Expr sink) { this.ref().flowsToExpr(sink) }
 
     /**
      * Gets a `RouteSetup` that was used for setting up a route on this router.
@@ -970,9 +1030,9 @@ module Express {
    */
   private class RenderCallAsTemplateInstantiation extends Templating::TemplateInstantiation::Range,
     DataFlow::CallNode {
-    RenderCallAsTemplateInstantiation() {
-      this = any(ResponseSource res).ref().getAMethodCall("render")
-    }
+    ResponseSource res;
+
+    RenderCallAsTemplateInstantiation() { this = res.ref().getAMethodCall("render") }
 
     override DataFlow::Node getTemplateFileNode() { result = this.getArgument(0) }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -1038,7 +1038,7 @@ module Express {
     override DataFlow::Node getTemplateParamsNode() { result = this.getArgument(1) }
 
     override DataFlow::Node getTemplateParamForValue(string accessPath) {
-      result = res.(Routing::RouteHandlerInput).getValueFromAccessPath("locals." + accessPath)
+      result = res.(Routing::RouteHandlerParameter).getValueFromAccessPath("locals." + accessPath)
     }
 
     override DataFlow::SourceNode getOutput() { result = this.getCallback(2).getParameter(1) }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -613,10 +613,9 @@ module Express {
 
     override predicate isUserControlledObject() {
       kind = "body" and
-      exists(ExpressLibraries::BodyParser bodyParser, RouteHandlerExpr expr |
-        expr.getBody() = request.getRouteHandler() and
-        bodyParser.producesUserControlledObjects() and
-        bodyParser.flowsToExpr(expr.getAMatchingAncestor())
+      exists(ExpressLibraries::BodyParser bodyParser |
+        Routing::getNode(request.getRouteHandler()).isGuardedBy(bodyParser) and
+        bodyParser.producesUserControlledObjects()
       )
       or
       // If we can't find the middlewares for the route handler,

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -1038,6 +1038,10 @@ module Express {
 
     override DataFlow::Node getTemplateParamsNode() { result = this.getArgument(1) }
 
+    override DataFlow::Node getTemplateParamForValue(string accessPath) {
+      result = res.(Routing::RouteHandlerInput).getValueFromAccessPath("locals." + accessPath)
+    }
+
     override DataFlow::SourceNode getOutput() { result = this.getCallback(2).getParameter(1) }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -124,7 +124,7 @@ module Express {
   private class AppTree extends Routing::Node {
     AppTree() { this = Routing::getNode(appCreation()) }
 
-    override DataFlow::Node getValueAtAccessPath(int n, string path) {
+    override DataFlow::Node getValueImplicitlyStoredInAccessPath(int n, string path) {
       // req.app and res.app refer to the app object
       n = [0, 1] and
       path = "app" and

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -106,12 +106,12 @@ module Express {
    * require('express-limiter')(app, client)({ method: 'get', path: '/foo' });
    * ```
    */
-  private class RateLimiterRouteSetup extends Routing::RouteSetup::Range {
+  private class RateLimiterRouteSetup extends Routing::RouteSetup::Range, DataFlow::CallNode {
     DataFlow::CallNode limitCall;
 
     RateLimiterRouteSetup() {
       limitCall = DataFlow::moduleImport("express-limiter").getACall() and
-      exists(this.(DataFlow::CallNode).getOptionArgument(0, ["path", "method"])) and
+      exists(this.getOptionArgument(0, ["path", "method"])) and
       this = limitCall.getACall()
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -132,9 +132,8 @@ module Fastify {
     string methodName;
 
     RouteSetup() {
-      this.getMethodName() = methodName and
-      methodName = ["route", "get", "head", "post", "put", "delete", "options", "patch"] and
-      server.flowsTo(this.getReceiver())
+      this = server(server.flow()).getAMethodCall(methodName).asExpr() and
+      methodName = ["route", "get", "head", "post", "put", "delete", "options", "patch"]
     }
 
     override DataFlow::SourceNode getARouteHandler() {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -194,7 +194,7 @@ module Fastify {
     }
 
     override DataFlow::Node getChildNode(int n) {
-      result = getRawChild(rank[n + 1](int k | exists(getRawChild(k))))
+      result = rank[n + 1](DataFlow::Node child, int k | child = getRawChild(k) | child order by k)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -404,4 +404,14 @@ module Fastify {
       )
     }
   }
+
+  private class RouteHandlerTracking extends Routing::RouteHandlerTrackingStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call |
+        call = DataFlow::moduleImport("fastify-plugin") and
+        pred = call.getArgument(0) and
+        succ = call
+      )
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -96,6 +96,12 @@ module HTTP {
     predicate isSafe() {
       this = ["GET", "HEAD", "OPTIONS", "PRI", "PROPFIND", "REPORT", "SEARCH", "TRACE"]
     }
+
+    /**
+     * Holds if this kind of HTTP request should not generally be considered free of side effects,
+     * such as for `POST` or `PUT` requests.
+     */
+    predicate isUnsafe() { not isSafe() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -234,6 +234,12 @@ module HTTP {
     or
     // references to class methods
     succ = CallGraph::callgraphStep(pred, DataFlow::TypeTracker::end())
+    or
+    exists(DataFlow::CallNode call |
+      call = DataFlow::moduleImport("fastify-plugin") and
+      pred = call.getArgument(0) and
+      succ = call
+    )
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -234,12 +234,6 @@ module HTTP {
     or
     // references to class methods
     succ = CallGraph::callgraphStep(pred, DataFlow::TypeTracker::end())
-    or
-    exists(DataFlow::CallNode call |
-      call = DataFlow::moduleImport("fastify-plugin") and
-      pred = call.getArgument(0) and
-      succ = call
-    )
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
@@ -10,14 +10,9 @@ private module LiveServer {
    * An expression that imports the live-server package, seen as a server-definition.
    */
   class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
-    API::Node imp;
+    ServerDefinition() { this = DataFlow::moduleImport("live-server").asExpr() }
 
-    ServerDefinition() {
-      imp = API::moduleImport("live-server") and
-      this = imp.getAnImmediateUse().asExpr()
-    }
-
-    API::Node getImportNode() { result = imp }
+    API::Node getImportNode() { result.getAnImmediateUse().asExpr() = this }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -29,8 +29,9 @@ private module MongoDB {
   private API::Node getAMongoClient() {
     result = API::moduleImport("mongodb").getMember("MongoClient")
     or
-    result = getAMongoDbCallback().getParameter(1) and
-    not result.getAnImmediateUse().(DataFlow::ParameterNode).getName() = "db" // mongodb v2 provides a `Db` here
+    // The callback parameter is either a MongoClient or Db depending on the mongodb package version,
+    // but we just model it as both.
+    result = getAMongoDbCallback().getParameter(1)
   }
 
   /** Gets an API-graph node that refers to a `connect` callback. */
@@ -44,8 +45,9 @@ private module MongoDB {
   private API::Node getAMongoDb() {
     result = getAMongoClient().getMember("db").getReturn()
     or
-    result = getAMongoDbCallback().getParameter(1) and
-    not result.getAnImmediateUse().(DataFlow::ParameterNode).getName() = "client" // mongodb v3 provides a `Mongoclient` here
+    // The callback parameter is either a MongoClient or Db depending on the mongodb package version,
+    // but we just model it as both.
+    result = getAMongoDbCallback().getParameter(1)
   }
 
   /** Gets a data flow node referring to a MongoDB collection. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
@@ -158,6 +158,17 @@ module Templating {
     DataFlow::SourceNode getAVariableUse(string name) {
       result = this.getScope().getVariable(name).getAnAccess().flow()
     }
+
+    /** Gets a data flow node corresponding to a use of the given template variable within this top-level. */
+    DataFlow::SourceNode getAnAccessPathUse(string accessPath) {
+      result = getAVariableUse(accessPath)
+      or
+      exists(string varName, string suffix |
+        accessPath = varName + "." + suffix and
+        suffix != "" and
+        result = AccessPath::getAReferenceTo(getAVariableUse(varName), suffix)
+      )
+    }
   }
 
   /**
@@ -176,6 +187,11 @@ module Templating {
 
     /** Gets a data flow node that refers to an object whose properties become variables in the template. */
     DataFlow::Node getTemplateParamsNode() { result = range.getTemplateParamsNode() }
+
+    /** Gets a data flow node that provides the value for the template variable at the given access path. */
+    DataFlow::Node getTemplateParamForValue(string accessPath) {
+      result = range.getTemplateParamForValue(accessPath)
+    }
 
     /** Gets the template file instantiated here, if any. */
     TemplateFile getTemplateFile() {
@@ -202,6 +218,9 @@ module Templating {
       /** Gets a data flow node that refers to an object whose properties become variables in the template. */
       abstract DataFlow::Node getTemplateParamsNode();
 
+      /** Gets a data flow node that provides the value for the template variable at the given access path. */
+      DataFlow::Node getTemplateParamForValue(string accessPath) { none() }
+
       /**
        * Gets the template syntax used by this template instantiation, if known.
        *
@@ -222,6 +241,16 @@ module Templating {
             .getAPlaceholder()
             .getInnerTopLevel()
             .getAVariableUse(name)
+    )
+    or
+    exists(TemplateInstantiation inst, string accessPath |
+      result.getARhs() = inst.getTemplateParamForValue(accessPath) and
+      succ =
+        inst.getTemplateFile()
+            .getAnImportedFile*()
+            .getAPlaceholder()
+            .getInnerTopLevel()
+            .getAnAccessPathUse(accessPath)
     )
     or
     exists(string prop, DataFlow::SourceNode prev |

--- a/javascript/ql/lib/semmle/javascript/security/SensitiveActions.qll
+++ b/javascript/ql/lib/semmle/javascript/security/SensitiveActions.qll
@@ -147,8 +147,8 @@ class AuthorizationCall extends SensitiveAction, DataFlow::CallNode {
   AuthorizationCall() {
     exists(string s | s = this.getCalleeName() |
       // name contains `login` or `auth`, but not as part of `loginfo` or `unauth`;
-      // also exclude `author`
-      s.regexpMatch("(?i).*(login(?!fo)|(?<!un)auth(?!or\\b)|verify).*") and
+      // also exclude `author` and words followed by `err` (as in `error`)
+      s.regexpMatch("(?i).*(login(?!fo)|(?<!un)auth(?!or\\b)|verify)(?!err).*") and
       // but it does not start with `get` or `set`
       not s.regexpMatch("(?i)(get|set).*")
     )

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
@@ -30,10 +30,6 @@ private import semmle.javascript.frameworks.ConnectExpressShared::ConnectExpress
  * A route handler that should be rate-limited.
  */
 abstract class ExpensiveRouteHandler extends DataFlow::Node {
-  Express::RouteHandler impl;
-
-  ExpensiveRouteHandler() { this = impl }
-
   /**
    * Holds if `explanation` is a string explaining why this route handler should be rate-limited.
    *
@@ -45,9 +41,15 @@ abstract class ExpensiveRouteHandler extends DataFlow::Node {
 }
 
 /**
- * A route handler expression that is rate limited.
+ * DEPRECATED. Use `RateLimitingMiddleware` instead.
+ *
+ * A route handler expression that is guarded by a rate limiter.
  */
-abstract class RateLimitedRouteHandlerExpr extends Express::RouteHandlerExpr { }
+deprecated class RateLimitedRouteHandlerExpr extends Express::RouteHandlerExpr {
+  RateLimitedRouteHandlerExpr() {
+    Routing::getNode(flow()).isGuardedBy(any(RateLimitingMiddleware m))
+  }
+}
 
 // default implementations
 /**
@@ -106,11 +108,13 @@ class DatabaseAccessAsExpensiveAction extends ExpensiveAction {
 }
 
 /**
+ * DEPRECATED. Use the `Routing::Node` API instead.
+ *
  * A route handler expression that is rate-limited by a rate-limiting middleware.
  */
-class RouteHandlerExpressionWithRateLimiter extends RateLimitedRouteHandlerExpr {
+deprecated class RouteHandlerExpressionWithRateLimiter extends Expr {
   RouteHandlerExpressionWithRateLimiter() {
-    any(RateLimitingMiddleware m).ref().flowsToExpr(this.getAMatchingAncestor())
+    Routing::getNode(this.flow()).isGuardedBy(any(RateLimitingMiddleware m))
   }
 }
 
@@ -139,6 +143,9 @@ abstract class RateLimitingMiddleware extends DataFlow::SourceNode {
 
   /** Gets a data flow node referring to this middleware. */
   DataFlow::SourceNode ref() { result = this.ref(DataFlow::TypeTracker::end()) }
+
+  /** Gets a routing node corresponding to this middleware function. */
+  Routing::Node getRoutingNode() { result = Routing::getNode(this) }
 }
 
 /**
@@ -160,12 +167,21 @@ class BruteForceRateLimit extends RateLimitingMiddleware {
 }
 
 /**
- * A route handler expression that is rate-limited by the `express-limiter` package.
+ * A rate limiter constructed using the `express-limiter` package.
+ *
+ * Note that the `express-limiter` package is unusual in that it may optionally install itself as a middleware.
+ * That aspect is handled by the Express core model.
  */
-class RouteHandlerLimitedByExpressLimiter extends RateLimitedRouteHandlerExpr {
+class RouteHandlerLimitedByExpressLimiter extends RateLimitingMiddleware {
   RouteHandlerLimitedByExpressLimiter() {
-    API::moduleImport("express-limiter").getParameter(0).getARhs().getALocalSource().asExpr() =
-      this.getSetup().getRouter()
+    this = API::moduleImport("express-limiter").getReturn().getReturn().getAnImmediateUse()
+  }
+
+  override Routing::Node getRoutingNode() {
+    result = super.getRoutingNode()
+    or
+    // express-limiter can perform its own route setup
+    result = Routing::getRouteSetupNode(this)
   }
 }
 
@@ -205,4 +221,8 @@ class RateLimiterFlexibleRateLimiter extends DataFlow::FunctionNode {
  */
 class RouteHandlerLimitedByRateLimiterFlexible extends RateLimitingMiddleware {
   RouteHandlerLimitedByRateLimiterFlexible() { this instanceof RateLimiterFlexibleRateLimiter }
+}
+
+private class FastifyRateLimiter extends RateLimitingMiddleware {
+  FastifyRateLimiter() { this = DataFlow::moduleImport("fastify-rate-limit") }
 }

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -130,11 +130,25 @@ predicate isCsrfProtectionRouteHandler(Routing::RouteHandler handler) {
 }
 
 /**
+ * A call of form `passport.authenticate(..., { session: false })`, implying that the incoming
+ * request must carry its credentials rather than relying on cookies.
+ *
+ * In principle such routes should not be preceded by a cookie-parsing middleware, but to
+ * reduce noise we do not want to flag them.
+ */
+API::CallNode nonSessionBasedAuthMiddleware() {
+  result = API::moduleImport("passport").getMember("authenticate").getACall() and
+  result.getParameter(1).getMember("session").getARhs().mayHaveBooleanValue(false)
+}
+
+/**
  * Gets an express route handler expression that is either a custom CSRF protection middleware,
  * or a CSRF protecting library.
  */
 Routing::Node getACsrfMiddleware() {
   result = Routing::getNode(csrfMiddlewareCreation())
+  or
+  result = Routing::getNode(nonSessionBasedAuthMiddleware())
   or
   isCsrfProtectionRouteHandler(result)
 }

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -16,59 +16,27 @@ import javascript
 /** Gets a property name of `req` which refers to data usually derived from cookie data. */
 string cookieProperty() { result = "session" or result = "cookies" or result = "user" }
 
-/** Gets a data flow node that flows to the base of a reference to `cookies`, `session`, or `user`. */
-private DataFlow::SourceNode nodeLeadingToCookieAccess(DataFlow::TypeBackTracker t) {
-  t.start() and
+/**
+ * Holds if `handler` uses cookies.
+ */
+predicate isRouteHandlerUsingCookies(Routing::RouteHandler handler) {
   exists(DataFlow::PropRef value |
-    value = result.getAPropertyRead(cookieProperty()).getAPropertyReference() and
+    value = handler.getAnInput().ref().getAPropertyRead(cookieProperty()).getAPropertyReference() and
     // Ignore accesses to values that are part of a CSRF or captcha check
     not value.getPropertyName().regexpMatch("(?i).*(csrf|xsrf|captcha).*") and
     // Ignore calls like `req.session.save()`
     not value = any(DataFlow::InvokeNode call).getCalleeNode()
   )
-  or
-  exists(DataFlow::TypeBackTracker t2 | result = nodeLeadingToCookieAccess(t2).backtrack(t2, t))
-}
-
-/** Gets a data flow node that flows to the base of an access to `cookies`, `session`, or `user`. */
-DataFlow::SourceNode nodeLeadingToCookieAccess() {
-  result = nodeLeadingToCookieAccess(DataFlow::TypeBackTracker::end())
 }
 
 /**
- * Holds if `handler` uses cookies.
- */
-predicate isRouteHandlerUsingCookies(Express::RouteHandler handler) {
-  DataFlow::parameterNode(handler.getRequestParameter()) = nodeLeadingToCookieAccess()
-}
-
-/** Gets a data flow node referring to a route handler that uses cookies. */
-private DataFlow::SourceNode getARouteUsingCookies(DataFlow::TypeTracker t) {
-  t.start() and
-  isRouteHandlerUsingCookies(result)
-  or
-  exists(DataFlow::TypeTracker t2, DataFlow::SourceNode pred | pred = getARouteUsingCookies(t2) |
-    result = pred.track(t2, t)
-    or
-    t = t2 and
-    HTTP::routeHandlerStep(pred, result)
-  )
-}
-
-/** Gets a data flow node referring to a route handler that uses cookies. */
-DataFlow::SourceNode getARouteUsingCookies() {
-  result = getARouteUsingCookies(DataFlow::TypeTracker::end())
-}
-
-/**
- * Checks if `expr` is preceded by the cookie middleware `cookie`.
+ * Checks if `route` is preceded by the cookie middleware `cookie`.
  *
  * A router handler following after cookie parsing is assumed to depend on
  * cookies, and thus require CSRF protection.
  */
-predicate hasCookieMiddleware(Express::RouteHandlerExpr expr, Express::RouteHandlerExpr cookie) {
-  any(HTTP::CookieMiddlewareInstance i).flowsToExpr(cookie) and
-  expr.getAMatchingAncestor() = cookie
+predicate hasCookieMiddleware(Routing::Node route, HTTP::CookieMiddlewareInstance cookie) {
+  route.isGuardedBy(cookie)
 }
 
 /**
@@ -87,22 +55,26 @@ predicate hasCookieMiddleware(Express::RouteHandlerExpr expr, Express::RouteHand
  * })
  * ```
  */
-DataFlow::CallNode csrfMiddlewareCreation() {
+DataFlow::SourceNode csrfMiddlewareCreation() {
   exists(DataFlow::SourceNode callee | result = callee.getACall() |
     callee = DataFlow::moduleImport("csurf")
     or
     callee = DataFlow::moduleImport("lusca") and
-    exists(result.getOptionArgument(0, "csrf"))
+    exists(result.(DataFlow::CallNode).getOptionArgument(0, "csrf"))
     or
     callee = DataFlow::moduleMember("lusca", "csrf")
     or
     callee = DataFlow::moduleMember("express", "csrf")
   )
+  or
+  // Note: the 'fastify-csrf' plugin enables the 'fastify.csrfProtection' middleware to be installed.
+  // Simply having the plugin registered is not enough, so we look for the 'csrfProtection' middleware.
+  result = Fastify::server().getAPropertyRead("csrfProtection")
 }
 
 /**
  * Gets a data flow node that flows to the base of a reference to `cookies`, `session`, or `user`,
- * where the references property has `csrf` or `xsrf` in its name,
+ * where the referenced property has `csrf` or `xsrf` in its name,
  * and a property is either written or part of a comparison.
  */
 private DataFlow::SourceNode nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTracker t) {
@@ -121,10 +93,10 @@ private DataFlow::SourceNode nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTra
 /**
  * Gets a route handler that sets an CSRF related cookie.
  */
-private Express::RouteHandler getAHandlerSettingCsrfCookie() {
+private Routing::RouteHandler getAHandlerSettingCsrfCookie() {
   exists(HTTP::CookieDefinition setCookie |
     setCookie.getNameArgument().getStringValue().regexpMatch("(?i).*(csrf|xsrf).*") and
-    result = setCookie.getRouteHandler()
+    result = Routing::getRouteHandler(setCookie.getRouteHandler())
   )
 }
 
@@ -133,65 +105,44 @@ private Express::RouteHandler getAHandlerSettingCsrfCookie() {
  * This is indicated either by the request parameter having a CSRF related write to a session variable.
  * Or by the response parameter setting a CSRF related cookie.
  */
-predicate isCsrfProtectionRouteHandler(Express::RouteHandler handler) {
-  DataFlow::parameterNode(handler.getRequestParameter()) =
-    nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTracker::end())
+predicate isCsrfProtectionRouteHandler(Routing::RouteHandler handler) {
+  handler.getAnInput() = nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTracker::end())
   or
   handler = getAHandlerSettingCsrfCookie()
-}
-
-/** Gets a data flow node refering to a route handler that is protecting against CSRF. */
-private DataFlow::SourceNode getACsrfProtectionRouteHandler(DataFlow::TypeTracker t) {
-  t.start() and
-  isCsrfProtectionRouteHandler(result)
-  or
-  exists(DataFlow::TypeTracker t2, DataFlow::SourceNode pred |
-    pred = getACsrfProtectionRouteHandler(t2)
-  |
-    result = pred.track(t2, t)
-    or
-    t = t2 and
-    HTTP::routeHandlerStep(pred, result)
-  )
 }
 
 /**
  * Gets an express route handler expression that is either a custom CSRF protection middleware,
  * or a CSRF protecting library.
  */
-Express::RouteHandlerExpr getACsrfMiddleware() {
-  csrfMiddlewareCreation().flowsToExpr(result)
+Routing::Node getACsrfMiddleware() {
+  result = Routing::getNode(csrfMiddlewareCreation())
   or
-  getACsrfProtectionRouteHandler(DataFlow::TypeTracker::end()).flowsToExpr(result)
+  isCsrfProtectionRouteHandler(result)
 }
 
 /**
  * Holds if the given route handler is protected by CSRF middleware.
  */
-predicate hasCsrfMiddleware(Express::RouteHandlerExpr handler) {
-  getACsrfMiddleware() = handler.getAMatchingAncestor()
+predicate hasCsrfMiddleware(Routing::RouteHandler handler) {
+  handler.isGuardedByNode(getACsrfMiddleware())
 }
 
-from
-  Express::RouterDefinition router, Express::RouteSetup setup, Express::RouteHandlerExpr handler,
-  Express::RouteHandlerExpr cookie
+from Routing::RouteSetup setup, Routing::RouteHandler handler, HTTP::CookieMiddlewareInstance cookie
 where
-  router = setup.getRouter() and
-  handler = setup.getARouteHandlerExpr() and
   // Require that the handler uses cookies and has cookie middleware.
   //
   // In practice, handlers that use cookies always have the cookie middleware or
   // the handler wouldn't work. However, if we can't find the cookie middleware, it
   // indicates that our middleware model is too incomplete, so in that case we
   // don't trust it to detect the presence of CSRF middleware either.
-  getARouteUsingCookies().flowsToExpr(handler) and
+  setup.getAChild*() = handler and
+  isRouteHandlerUsingCookies(handler) and
   hasCookieMiddleware(handler, cookie) and
   // Only flag the cookie parser registered first.
-  not hasCookieMiddleware(cookie, _) and
+  not hasCookieMiddleware(Routing::getNode(cookie), _) and
   not hasCsrfMiddleware(handler) and
-  // Only warn for the last handler in a chain.
-  handler.isLastHandler() and
   // Only warn for dangerous handlers, such as for POST and PUT.
-  not setup.getRequestMethod().isSafe()
+  setup.getOwnHttpMethod().isUnsafe()
 select cookie, "This cookie middleware is serving a request handler $@ without CSRF protection.",
-  handler, "here"
+  setup, "here"

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -21,7 +21,7 @@ string cookieProperty() { result = "session" or result = "cookies" or result = "
  */
 predicate isRouteHandlerUsingCookies(Routing::RouteHandler handler) {
   exists(DataFlow::PropRef value |
-    value = handler.getAnInput().ref().getAPropertyRead(cookieProperty()).getAPropertyReference() and
+    value = handler.getAParameter().ref().getAPropertyRead(cookieProperty()).getAPropertyReference() and
     // Ignore accesses to values that are part of a CSRF or captcha check
     not value.getPropertyName().regexpMatch("(?i).*(csrf|xsrf|captcha).*") and
     // Ignore calls like `req.session.save()`
@@ -124,7 +124,7 @@ private Routing::RouteHandler getAHandlerSettingCsrfCookie() {
  * Or by the response parameter setting a CSRF related cookie.
  */
 predicate isCsrfProtectionRouteHandler(Routing::RouteHandler handler) {
-  handler.getAnInput() = nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTracker::end())
+  handler.getAParameter() = nodeLeadingToCsrfWriteOrCheck(DataFlow::TypeBackTracker::end())
   or
   handler = getAHandlerSettingCsrfCookie()
 }

--- a/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
+++ b/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
@@ -18,7 +18,6 @@ import javascript
 import semmle.javascript.security.dataflow.MissingRateLimiting
 import semmle.javascript.RestrictedLocations
 
-// TODO: Previously we used (FirstLineOf) here, but that doesn't work anymore.
 from
   Routing::Node useSite, ExpensiveRouteHandler r, string explanation, DataFlow::Node reference,
   string referenceLabel

--- a/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
+++ b/javascript/ql/src/Security/CWE-770/MissingRateLimiting.ql
@@ -22,7 +22,7 @@ from
   Routing::Node useSite, ExpensiveRouteHandler r, string explanation, DataFlow::Node reference,
   string referenceLabel
 where
-  useSite = Routing::getNode(r).getAUseSite() and
+  useSite = Routing::getNode(r).getRouteInstallation() and
   r.explain(explanation, reference, referenceLabel) and
   not useSite.isGuardedByNode(any(RateLimitingMiddleware m).getRoutingNode())
 select useSite, "This route handler " + explanation + ", but is not rate-limited.", reference,

--- a/javascript/ql/test/library-tests/Routing/route-setups.js
+++ b/javascript/ql/test/library-tests/Routing/route-setups.js
@@ -1,0 +1,293 @@
+const express = require('express');
+const TestObj = require('@example/test');
+
+function basicTaint() {
+    const app = express();
+    app.use((req, res, next) => {
+        req.tainted = source();
+        req.safe = 'safe';
+        next();
+    });
+    app.get('/', (req, res) => {
+        sink(req.tainted); // NOT OK
+        sink(req.safe); // OK
+    });
+}
+
+function basicApiGraph() {
+    const app = express();
+    app.use((req, res, next) => {
+        req.obj = new TestObj();
+        next();
+    });
+    app.get('/', (req, res) => {
+        sink(req.obj.getSource()); // NOT OK
+        req.obj.getSink(source()); // NOT OK
+    });
+}
+
+function noTaint() {
+    const app = express();
+    function middleware(req, res, next) {
+        req.tainted = source();
+        req.safe = 'safe';
+        next();
+    }
+    app.get('/unsafe', middleware, (req, res) => {
+        sink(req.tainted); // NOT OK
+        sink(req.safe); // OK
+    });
+    app.get('/safe', (req, res) => {
+        sink(req.tainted); // OK - not preceded by middleware
+        sink(req.safe); // OK
+    });
+}
+
+function looseApiGraphStep() {
+    const app = express();
+    function middleware(req, res, next) {
+        req.obj = new TestObj();
+        next();
+    }
+    app.get('/unsafe', middleware, (req, res) => {
+        sink(req.obj.getSource()); // NOT OK
+    });
+    app.get('/safe', (req, res) => {
+        sink(req.obj.getSource()); // NOT OK - we allow API graph steps within the same app
+    });
+}
+
+function chainMiddlewares() {
+    const app = express();
+    function step1(req, res, next) {
+        req.taint = source();
+        next();
+    }
+    function step2(req, res, next) {
+        req.locals.alsoTaint = req.taint;
+        next();
+    }
+    app.get('/', step1, step2, (req, res) => {
+        sink(req.taint); // NOT OK
+        sink(req.locals.alsoTaint); // NOT OK
+    });
+}
+
+function routerEscapesIntoParameter() {
+    const app = express();
+    function setupMiddlewares(router) {
+        router.use((req, res, next) => {
+            req.taint = source();
+            next();
+        });
+    }
+    app.get('/before', (req, res) => {
+        sink(req.taint); // OK
+    });
+    setupMiddlewares(app);
+    app.get('/after', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+}
+
+function routerReturned() {
+    const app = express();
+    function makeMiddlewares() {
+        let router = new express.Router();
+        router.use((req, res, next) => {
+            req.taint = source();
+            next();
+        });
+        return router;
+    }
+    app.get('/before', (req, res) => {
+        sink(req.taint); // OK
+    });
+    app.use(makeMiddlewares());
+    app.get('/after', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+}
+
+function routerCaptured() {
+    const app = express();
+    function addMiddlewares() {
+        app.use((req, res, next) => {
+            req.taint = source();
+            next();
+        });
+    }
+    app.get('/before', (req, res) => {
+        sink(req.taint); // OK
+    });
+    addMiddlewares();
+    app.get('/after', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+}
+
+function withPath() {
+    const app = express();
+    app.use('/foo', (req, res, next) => {
+        req.taint = source();
+        next();
+    });
+    app.get('/foo', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+    app.get('/bar', (req, res) => {
+        sink(req.taint); // OK
+    });
+}
+
+
+function withNestedPath() {
+    const app = express();
+    app.use('/foo/bar', (req, res, next) => {
+        req.taint = source();
+        next();
+    });
+    function makeRouter() {
+        const router = express.Router();
+        router.get('/bar', (req, res) => {
+            sink(req.taint); // NOT OK
+        })
+        router.get('/baz', (req, res) => {
+            sink(req.taint); // OK
+        })
+        return router;
+    }
+    app.get('/foo', makeRouter());
+    app.get('/bar', (req, res) => {
+        sink(req.taint); // OK
+    });
+}
+
+function withHttpMethods() {
+    const app = express();
+    app.get('/foo', (req, res, next) => {
+        req.taintGet = source();
+        next();
+    });
+    app.post('/foo', (req, res, next) => {
+        req.taintPost = source();
+        next();
+    });
+    app.all('/foo', (req, res, next) => {
+        req.taintAll = source();
+        next();
+    });
+    app.get('/foo/a', (req, res) => {
+        sink(req.taintGet); // NOT OK
+        sink(req.taintPost); // OK - not tainted for GET requests
+        sink(req.taintAll); // NOT OK
+    });
+    app.post('/foo/b', (req, res) => {
+        sink(req.taintGet); // OK - not tainted for POST requests
+        sink(req.taintPost); // NOT OK
+        sink(req.taintAll); // NOT OK
+    });
+    app.all('/foo/c', (req, res) => {
+        sink(req.taintGet); // NOT OK
+        sink(req.taintPost); // NOT OK
+        sink(req.taintAll); // NOT OK
+    });
+}
+
+function withChaining() {
+    const app = express();
+    app.use('/', (req, res) => {
+        sink(req.taint); // OK
+    });
+    function middleware() {
+        return express.Router()
+            .use((req, res, next) => {
+                req.taint = source();
+                next();
+            })
+            .use(blah());
+    }
+    app.use(middleware());
+    app.use('/', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+}
+
+function withClass() {
+    class App {
+        constructor(router) {
+            this.router = router;
+            this.earlyRoutes();
+            this.addMiddleware();
+            this.lateRoutes();
+        }
+        earlyRoutes() {
+            this.router.get('/', (req, res) => {
+                sink(req.taint); // OK
+            })
+        }
+        addMiddleware() {
+            this.router.use((req, res, next) => {
+                req.taint = source();
+                next();
+            })
+        }
+        lateRoutes() {
+            this.router.get('/', (req, res) => {
+                sink(req.taint); // NOT OK
+            })
+        }
+    }
+    let app = new App(express());
+}
+
+function withArray() {
+    const app = express();
+    app.get('/before', (req, res) => {
+        sink(req.taint); // OK
+    });
+    app.use([
+        (req, res, next) => {
+            sink(req.taint); // OK
+            next();
+        },
+        (req, res, next) => {
+            req.taint = source();
+            next();
+        },
+        (req, res, next) => {
+            sink(req.taint); // NOT OK
+            next();
+        }
+    ]);
+    app.get('/after', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+}
+
+function withForLoop() {
+    const app = express();
+    let middlewares = [
+        (req, res, next) => {
+            sink(req.taint); // OK
+            next();
+        },
+        (req, res, next) => {
+            req.taint = source();
+            next();
+        },
+        (req, res, next) => {
+            sink(req.taint); // NOT OK
+            next();
+        }
+    ];
+    app.get('/before', (req, res) => {
+        sink(req.taint); // OK
+    });
+    for (let route of middlewares) {
+        app.use(route);
+    }
+    app.get('/after', (req, res) => {
+        sink(req.taint); // NOT OK
+    });
+}

--- a/javascript/ql/test/library-tests/Routing/route-setups.js
+++ b/javascript/ql/test/library-tests/Routing/route-setups.js
@@ -291,3 +291,10 @@ function withForLoop() {
         sink(req.taint); // NOT OK
     });
 }
+
+function routeHandlersInProps() {
+    let routes = require('./routes');
+    const app = express();
+    app.use(routes.first);
+    app.get('/', routes.second);
+}

--- a/javascript/ql/test/library-tests/Routing/routes/first.js
+++ b/javascript/ql/test/library-tests/Routing/routes/first.js
@@ -1,0 +1,6 @@
+export default function first(req, res, next) {
+    req.tainted = source();
+    req.safe = 'safe';
+    next();
+}
+

--- a/javascript/ql/test/library-tests/Routing/routes/index.js
+++ b/javascript/ql/test/library-tests/Routing/routes/index.js
@@ -1,0 +1,4 @@
+export default {
+    first: require('./first'),
+    second: require('./second'),
+};

--- a/javascript/ql/test/library-tests/Routing/routes/second.js
+++ b/javascript/ql/test/library-tests/Routing/routes/second.js
@@ -1,0 +1,4 @@
+export default function second(req, res) {
+    sink(req.tainted); // NOT OK
+    sink(req.safe); // OK
+}

--- a/javascript/ql/test/library-tests/Routing/test.ql
+++ b/javascript/ql/test/library-tests/Routing/test.ql
@@ -1,0 +1,20 @@
+import javascript
+import testUtilities.ConsistencyChecking
+
+API::Node testInstance() { result = API::moduleImport("@example/test").getInstance() }
+
+class Taint extends TaintTracking::Configuration {
+  Taint() { this = "Taint" }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.(DataFlow::CallNode).getCalleeName() = "source"
+    or
+    node = testInstance().getMember("getSource").getReturn().getAnImmediateUse()
+  }
+
+  override predicate isSink(DataFlow::Node node) {
+    node = any(DataFlow::CallNode call | call.getCalleeName() = "sink").getAnArgument()
+    or
+    node = testInstance().getMember("getSink").getAParameter().getARhs()
+  }
+}

--- a/javascript/ql/test/library-tests/frameworks/Express/MiddlewareFlow.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/MiddlewareFlow.qll
@@ -1,0 +1,3 @@
+import javascript
+
+query DataFlow::Node dbUse() { result = API::moduleImport("@example/db").getInstance().getAUse() }

--- a/javascript/ql/test/library-tests/frameworks/Express/src/middleware-flow.js
+++ b/javascript/ql/test/library-tests/frameworks/Express/src/middleware-flow.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const app = express();
+const DB = require('@example/db');
+
+function installDb(req, res, next) {
+    req.db = new DB();
+    req.deep.db = new DB();
+    req.deep.access.db = new DB();
+    next();
+}
+
+function addMiddlewares(router) {
+    router.use(installDb);
+}
+
+function addRoutes(router) {
+    router.get('/foo', (req, res) => {
+        req.db;
+        req.deep.db;
+        req.deep.access.db;
+    });
+    let routers = {
+        '/bar': (req, res) => { req.db; },
+        '/baz': (req, res) => { req.db; },
+    };
+    for (let p in routers) {
+        router.get(p, routers[p]);
+    }
+}
+
+addMiddlewares(app);
+addRoutes(app);
+
+app.listen();
+
+
+const unrelatedApp = express();
+
+unrelatedApp.get('/', (req, res) => {
+    req.db;
+    req.deep.db;
+    req.deep.access.db;
+});

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -18,6 +18,9 @@ test_RouteHandlerExpr_getBody
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:13:16:13:24 | installDb | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -46,6 +49,9 @@ test_RouteSetup
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() | false |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:2:13:2:21 | express() | true |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:2:13:2:21 | express() | false |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:37:22:37:30 | express() | false |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() | false |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
@@ -102,6 +108,10 @@ test_RouteSetup_getLastRouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:13:16:13:24 | installDb |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:27:23:27:32 | routers[p] |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -744,6 +754,8 @@ test_RouterDefinition_getMiddlewareStackAt
 | src/express.js:2:11:2:19 | express() | src/express.js:46:10:46:19 | '/headers' | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:2:11:2:19 | express() | src/express.js:52:1:52:0 | exit node of <toplevel> | src/express.js:44:9:44:25 | getArrowHandler() |
+| src/middleware-flow.js:2:13:2:21 | express() | src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:13:16:13:24 | installDb |
+| src/middleware-flow.js:2:13:2:21 | express() | src/middleware-flow.js:14:2:14:1 | exit node of functio ... lDb);\\n} | src/middleware-flow.js:13:16:13:24 | installDb |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:4:1:4:26 | app.use ... rotect) | src/subrouter.js:4:19:4:25 | protect |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:5:1:5:3 | app | src/subrouter.js:4:19:4:25 | protect |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:5:1:5:7 | app.use | src/subrouter.js:4:19:4:25 | protect |
@@ -841,6 +853,22 @@ test_isRequest
 | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:4:24:4:26 | req |
 | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/middleware-flow.js:5:20:5:22 | req |
+| src/middleware-flow.js:6:5:6:7 | req |
+| src/middleware-flow.js:7:5:7:7 | req |
+| src/middleware-flow.js:8:5:8:7 | req |
+| src/middleware-flow.js:17:25:17:27 | req |
+| src/middleware-flow.js:18:9:18:11 | req |
+| src/middleware-flow.js:19:9:19:11 | req |
+| src/middleware-flow.js:20:9:20:11 | req |
+| src/middleware-flow.js:23:18:23:20 | req |
+| src/middleware-flow.js:23:33:23:35 | req |
+| src/middleware-flow.js:24:18:24:20 | req |
+| src/middleware-flow.js:24:33:24:35 | req |
+| src/middleware-flow.js:39:24:39:26 | req |
+| src/middleware-flow.js:40:5:40:7 | req |
+| src/middleware-flow.js:41:5:41:7 | req |
+| src/middleware-flow.js:42:5:42:7 | req |
 | src/params.js:4:19:4:21 | req |
 | src/params.js:5:17:5:19 | req |
 | src/params.js:6:17:6:19 | req |
@@ -907,6 +935,10 @@ test_RouteSetup_getRouter
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:37:22:37:30 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -951,6 +983,9 @@ test_StandardRouteHandler
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:2:11:2:19 | express() | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:2:11:2:19 | express() | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:2:11:2:19 | express() | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:29:4:31 | res |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:2:13:2:21 | express() | src/middleware-flow.js:5:20:5:22 | req | src/middleware-flow.js:5:25:5:27 | res |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:2:13:2:21 | express() | src/middleware-flow.js:17:25:17:27 | req | src/middleware-flow.js:17:30:17:32 | res |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:37:22:37:30 | express() | src/middleware-flow.js:39:24:39:26 | req | src/middleware-flow.js:39:29:39:31 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:2:11:2:19 | express() | src/params.js:4:19:4:21 | req | src/params.js:4:24:4:26 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:2:11:2:19 | express() | src/params.js:14:33:14:35 | req | src/params.js:14:38:14:40 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
@@ -1118,6 +1153,11 @@ test_ResponseExpr
 | src/inheritedFromNode.js:4:29:4:31 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:5:2:5:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:6:2:6:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:5:25:5:27 | res | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:17:30:17:32 | res | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:23:23:23:25 | res | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:24:23:24:25 | res | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:39:29:39:31 | res | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:24:4:26 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:8:9:8:11 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:8:9:8:23 | res.send(value) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
@@ -1196,6 +1236,9 @@ test_RouterDefinition_getARouteHandler
 | src/express.js:2:11:2:19 | express() | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:2:11:2:19 | express() | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:2:13:2:21 | express() | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:2:13:2:21 | express() | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:37:22:37:30 | express() | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:2:11:2:19 | express() | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:2:11:2:19 | express() | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -1293,6 +1336,9 @@ test_RouteSetup_getServer
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:37:22:37:30 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -1364,6 +1410,10 @@ test_RouteHandlerExpr
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:44:1:44:26 | app.use ... dler()) | false |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | true |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | true |
+| src/middleware-flow.js:13:16:13:24 | installDb | src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | false |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | true |
+| src/middleware-flow.js:27:23:27:32 | routers[p] | src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | true |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | true |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:1:12:2 | app.par ...    }\\n}) | true |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:1:16:2 | app.get ... o");\\n}) | true |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | true |
@@ -1398,6 +1448,7 @@ test_RouteSetup_handlesAllRequestMethods
 | src/express3.js:12:1:12:21 | app.use ... dler()) |
 | src/express.js:39:1:39:21 | app.use ... dler()) |
 | src/express.js:44:1:44:26 | app.use ... dler()) |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) |
 | src/route.js:4:1:5:39 | router. ... xt) {}) |
 | src/routesetups.js:3:1:4:14 | express ... ('', h) |
@@ -1421,6 +1472,8 @@ test_appCreation
 | src/express4.js:2:11:2:19 | express() |
 | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:37:22:37:30 | express() |
 | src/params.js:2:11:2:19 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) |
 | src/responseExprs.js:2:11:2:19 | express() |
@@ -1458,6 +1511,9 @@ test_RouteSetup_getRequestMethod
 | src/express.js:34:1:34:53 | app.get ... andler) | GET |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | POST |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | POST |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | GET |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | GET |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | GET |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | GET |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | GET |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | GET |
@@ -1519,6 +1575,10 @@ test_RouteExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:37:22:37:30 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:1:12:2 | app.par ...    }\\n}) |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
@@ -1637,6 +1697,11 @@ test_RouteHandler_getAResponseExpr
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:6:2:6:4 | res |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:5:25:5:27 | res |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:30:17:32 | res |
+| src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:23:23:25 | res |
+| src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:23:24:25 | res |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:29:39:31 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:24:4:26 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:11 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:23 | res.send(value) |
@@ -1777,6 +1842,11 @@ test_isResponse
 | src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:6:2:6:4 | res |
+| src/middleware-flow.js:5:25:5:27 | res |
+| src/middleware-flow.js:17:30:17:32 | res |
+| src/middleware-flow.js:23:23:23:25 | res |
+| src/middleware-flow.js:24:23:24:25 | res |
+| src/middleware-flow.js:39:29:39:31 | res |
 | src/params.js:4:24:4:26 | res |
 | src/params.js:8:9:8:11 | res |
 | src/params.js:8:9:8:23 | res.send(value) |
@@ -1951,6 +2021,12 @@ test_RouteSetup_getARouteHandler
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:27:23:27:32 | routers[p] |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -2176,6 +2252,8 @@ test_isRouterCreation
 | src/express4.js:2:11:2:19 | express() |
 | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:37:22:37:30 | express() |
 | src/params.js:2:11:2:19 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) |
 | src/responseExprs.js:2:11:2:19 | express() |
@@ -2239,6 +2317,10 @@ test_RouteSetup_getRouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | 0 | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | 0 | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | 0 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | 0 | src/middleware-flow.js:13:16:13:24 | installDb |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | 0 | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | 0 | src/middleware-flow.js:27:23:27:32 | routers[p] |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | 0 | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | 0 | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | 0 | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | 0 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -2267,6 +2349,8 @@ test_RouterDefinition_RouterDefinition
 | src/express4.js:2:11:2:19 | express() |
 | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/middleware-flow.js:2:13:2:21 | express() |
+| src/middleware-flow.js:37:22:37:30 | express() |
 | src/params.js:2:11:2:19 | express() |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) |
 | src/responseExprs.js:2:11:2:19 | express() |
@@ -2330,6 +2414,11 @@ test_RouteHandler
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req | src/express.js:42:18:42:20 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:29:4:31 | res |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:5:20:5:22 | req | src/middleware-flow.js:5:25:5:27 | res |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:25:17:27 | req | src/middleware-flow.js:17:30:17:32 | res |
+| src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:18:23:20 | req | src/middleware-flow.js:23:23:23:25 | res |
+| src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:18:24:20 | req | src/middleware-flow.js:24:23:24:25 | res |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:24:39:26 | req | src/middleware-flow.js:39:29:39:31 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:19:4:21 | req | src/params.js:4:24:4:26 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:33:14:35 | req | src/params.js:14:38:14:40 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
@@ -2394,6 +2483,10 @@ test_RouteSetup_getARouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:13:16:13:24 | installDb |
+| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:27:23:27:32 | routers[p] |
+| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -2552,6 +2645,22 @@ test_RequestExpr
 | src/express.js:50:3:50:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:7:2:7:4 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:5:20:5:22 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:6:5:6:7 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:7:5:7:7 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:8:5:8:7 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
+| src/middleware-flow.js:17:25:17:27 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:18:9:18:11 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:19:9:19:11 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:20:9:20:11 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:23:18:23:20 | req | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:23:33:23:35 | req | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:24:18:24:20 | req | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:24:33:24:35 | req | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:39:24:39:26 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
+| src/middleware-flow.js:40:5:40:7 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
+| src/middleware-flow.js:41:5:41:7 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
+| src/middleware-flow.js:42:5:42:7 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:19:4:21 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:5:17:5:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:6:17:6:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
@@ -2679,6 +2788,22 @@ test_RouteHandler_getARequestExpr
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:5:20:5:22 | req |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:6:5:6:7 | req |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:7:5:7:7 | req |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:8:5:8:7 | req |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:25:17:27 | req |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:18:9:18:11 | req |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:19:9:19:11 | req |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:20:9:20:11 | req |
+| src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:18:23:20 | req |
+| src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:33:23:35 | req |
+| src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:18:24:20 | req |
+| src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:33:24:35 | req |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:24:39:26 | req |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:40:5:40:7 | req |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:41:5:41:7 | req |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:42:5:42:7 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:19:4:21 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:5:17:5:19 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:6:17:6:19 | req |
@@ -2720,7 +2845,21 @@ getRouteHandlerContainerStep
 | src/advanced-routehandler-registration.js:155:18:155:26 | new Map() | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:161:14:161:38 | routesM ... nown()) |
 | src/advanced-routehandler-registration.js:155:18:155:26 | new Map() | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:163:14:163:32 | routesMap2.get("f") |
 | src/controllers/handler-in-bulk-require.js:1:18:1:68 | { path: ... fined } | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined | src/advanced-routehandler-registration.js:139:33:139:57 | bulkReq ... handler |
+| src/middleware-flow.js:22:19:25:5 | {\\n      ... ,\\n    } | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:27:23:27:32 | routers[p] |
+| src/middleware-flow.js:22:19:25:5 | {\\n      ... ,\\n    } | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:27:23:27:32 | routers[p] |
 | src/route-collection.js:1:18:4:1 | {\\n  a:  ... (req)\\n} | src/route-collection.js:2:6:2:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:116:14:116:30 | importedRoutes[p] |
 | src/route-collection.js:1:18:4:1 | {\\n  a:  ... (req)\\n} | src/route-collection.js:2:6:2:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:118:14:118:29 | importedRoutes.a |
 | src/route-collection.js:1:18:4:1 | {\\n  a:  ... (req)\\n} | src/route-collection.js:3:6:3:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:116:14:116:30 | importedRoutes[p] |
 | src/route-collection.js:1:18:4:1 | {\\n  a:  ... (req)\\n} | src/route-collection.js:3:6:3:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:119:14:119:29 | importedRoutes.b |
+dbUse
+| src/middleware-flow.js:6:5:6:21 | req.db = new DB() |
+| src/middleware-flow.js:6:14:6:21 | new DB() |
+| src/middleware-flow.js:7:5:7:26 | req.dee ... ew DB() |
+| src/middleware-flow.js:7:19:7:26 | new DB() |
+| src/middleware-flow.js:8:5:8:33 | req.dee ... ew DB() |
+| src/middleware-flow.js:8:26:8:33 | new DB() |
+| src/middleware-flow.js:18:9:18:14 | req.db |
+| src/middleware-flow.js:19:9:19:19 | req.deep.db |
+| src/middleware-flow.js:20:9:20:26 | req.deep.access.db |
+| src/middleware-flow.js:23:33:23:38 | req.db |
+| src/middleware-flow.js:24:33:24:38 | req.db |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.ql
@@ -47,3 +47,4 @@ import RouteHandlerExpr_getAsSubRouter
 import Credentials
 import RouteHandler_getARequestExpr
 import RouteHandlerContainer
+import MiddlewareFlow

--- a/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
@@ -33,18 +33,18 @@ nodes
 | app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:66:18:66:34 | req.query.rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml |
-| projectA/src/index.js:7:16:7:30 | req.query.sinkA |
-| projectA/src/index.js:7:16:7:30 | req.query.sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
-| projectA/src/index.js:32:16:32:30 | req.query.sinkA |
-| projectA/src/index.js:32:16:32:30 | req.query.sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA |
@@ -57,16 +57,16 @@ nodes
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
-| projectB/src/index.js:8:16:8:30 | req.query.sinkB |
-| projectB/src/index.js:8:16:8:30 | req.query.sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
-| projectB/src/index.js:33:16:33:30 | req.query.sinkB |
-| projectB/src/index.js:33:16:33:30 | req.query.sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB |
@@ -183,18 +183,18 @@ edges
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
-| projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
-| projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
-| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
-| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
-| projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
-| projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
-| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
-| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
@@ -203,16 +203,16 @@ edges
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
-| projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
-| projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
-| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
-| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
-| projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
-| projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
@@ -251,17 +251,17 @@ edges
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 #select
-| projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:7:16:7:30 | req.query.sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:7:16:7:30 | req.query.sinkA | user-provided value |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:12:16:12:30 | req.query.sinkA | user-provided value |
-| projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:17:16:17:30 | req.query.sinkA | user-provided value |
-| projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:32:16:32:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:32:16:32:30 | req.query.sinkA | user-provided value |
+| projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:17:16:17:30 | req.query.sinkA | user-provided value |
+| projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:22:16:22:30 | req.query.sinkA | user-provided value |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:37:16:37:30 | req.query.sinkA | user-provided value |
-| projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:42:16:42:30 | req.query.sinkA | user-provided value |
-| projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:8:16:8:30 | req.query.sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:8:16:8:30 | req.query.sinkB | user-provided value |
+| projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:42:16:42:30 | req.query.sinkA | user-provided value |
+| projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> | projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:47:16:47:30 | req.query.sinkA | user-provided value |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:13:16:13:30 | req.query.sinkB | user-provided value |
-| projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:18:16:18:30 | req.query.sinkB | user-provided value |
-| projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:33:16:33:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:33:16:33:30 | req.query.sinkB | user-provided value |
+| projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:18:16:18:30 | req.query.sinkB | user-provided value |
+| projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:23:16:23:30 | req.query.sinkB | user-provided value |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:38:16:38:30 | req.query.sinkB | user-provided value |
+| projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:43:16:43:30 | req.query.sinkB | user-provided value |
 | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> | Cross-site scripting vulnerability due to $@. | app.js:66:18:66:34 | req.query.rawHtml | user-provided value |
 | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> | Cross-site scripting vulnerability due to $@. | app.js:66:18:66:34 | req.query.rawHtml | user-provided value |
 | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> | Cross-site scripting vulnerability due to $@. | app.js:8:18:8:34 | req.query.rawHtml | user-provided value |

--- a/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
@@ -33,6 +33,8 @@ nodes
 | app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:66:18:66:34 | req.query.rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
@@ -48,6 +50,9 @@ nodes
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
@@ -57,6 +62,8 @@ nodes
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
@@ -70,6 +77,9 @@ nodes
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
@@ -183,6 +193,8 @@ edges
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
@@ -197,12 +209,16 @@ edges
 | projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
@@ -215,6 +231,8 @@ edges
 | projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
@@ -253,12 +271,14 @@ edges
 #select
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:12:16:12:30 | req.query.sinkA | user-provided value |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:17:16:17:30 | req.query.sinkA | user-provided value |
+| projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> | projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:6:38:6:53 | req.query.taintA | user-provided value |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:22:16:22:30 | req.query.sinkA | user-provided value |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:37:16:37:30 | req.query.sinkA | user-provided value |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:42:16:42:30 | req.query.sinkA | user-provided value |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> | projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> | Cross-site scripting vulnerability due to $@. | projectA/src/index.js:47:16:47:30 | req.query.sinkA | user-provided value |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:13:16:13:30 | req.query.sinkB | user-provided value |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:18:16:18:30 | req.query.sinkB | user-provided value |
+| projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> | projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:6:38:6:53 | req.query.taintB | user-provided value |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:23:16:23:30 | req.query.sinkB | user-provided value |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:38:16:38:30 | req.query.sinkB | user-provided value |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> | Cross-site scripting vulnerability due to $@. | projectB/src/index.js:43:16:43:30 | req.query.sinkB | user-provided value |

--- a/javascript/ql/test/library-tests/frameworks/Templating/projectA/src/index.js
+++ b/javascript/ql/test/library-tests/frameworks/Templating/projectA/src/index.js
@@ -2,6 +2,11 @@ const express = require('express');
 
 const app = express();
 
+app.use((req, res, next) => {
+
+
+});
+
 app.get('/fooA', (req, res) => {
     res.render('main', {
         sinkA: req.query.sinkA,

--- a/javascript/ql/test/library-tests/frameworks/Templating/projectA/src/index.js
+++ b/javascript/ql/test/library-tests/frameworks/Templating/projectA/src/index.js
@@ -3,8 +3,8 @@ const express = require('express');
 const app = express();
 
 app.use((req, res, next) => {
-
-
+    res.locals.taintedInMiddleware = req.query.taintA;
+    next();
 });
 
 app.get('/fooA', (req, res) => {

--- a/javascript/ql/test/library-tests/frameworks/Templating/projectA/views/main.ejs
+++ b/javascript/ql/test/library-tests/frameworks/Templating/projectA/views/main.ejs
@@ -1,3 +1,5 @@
 Project A
 <%- sinkA %>
 <%= sinkB %>
+
+<%- taintedInMiddleware %>

--- a/javascript/ql/test/library-tests/frameworks/Templating/projectB/src/index.js
+++ b/javascript/ql/test/library-tests/frameworks/Templating/projectB/src/index.js
@@ -3,8 +3,8 @@ const express = require('express');
 const app = express();
 
 app.use((req, res, next) => {
-
-
+    res.locals.taintedInMiddleware = req.query.taintB;
+    next();
 });
 
 app.get('/fooA', (req, res) => {

--- a/javascript/ql/test/library-tests/frameworks/Templating/projectB/src/index.js
+++ b/javascript/ql/test/library-tests/frameworks/Templating/projectB/src/index.js
@@ -2,6 +2,11 @@ const express = require('express');
 
 const app = express();
 
+app.use((req, res, next) => {
+
+
+});
+
 app.get('/fooA', (req, res) => {
     res.render('main', {
         sinkA: req.query.sinkA,

--- a/javascript/ql/test/library-tests/frameworks/Templating/projectB/views/main.ejs
+++ b/javascript/ql/test/library-tests/frameworks/Templating/projectB/views/main.ejs
@@ -1,3 +1,5 @@
 Project B
 <%= sinkA %>
 <%- sinkB %>
+
+<%- taintedInMiddleware %>

--- a/javascript/ql/test/library-tests/frameworks/Templating/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/test.expected
@@ -40,10 +40,12 @@ getTargetFile
 | views/ejs_sinks.ejs:24:13:24:53 | include ... Html }) | views/ejs_include1.ejs:0:0:0:0 | views/ejs_include1.ejs |
 xssSink
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |

--- a/javascript/ql/test/library-tests/frameworks/Templating/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/test.expected
@@ -26,17 +26,17 @@ getTargetFile
 | app.js:64:5:67:6 | res.ren ... \\n    }) | views/angularjs_sinks.ejs:0:0:0:0 | views/angularjs_sinks.ejs |
 | consolidate.js:3:1:3:83 | consoli ...  => {}) | views/instantiated_as_ejs.html:0:0:0:0 | views/instantiated_as_ejs.html |
 | consolidate.js:4:1:4:90 | consoli ...  => {}) | views/instantiated_as_hbs.html:0:0:0:0 | views/instantiated_as_hbs.html |
-| projectA/src/index.js:6:5:9:6 | res.ren ... \\n    }) | projectA/views/main.ejs:0:0:0:0 | projectA/views/main.ejs |
 | projectA/src/index.js:11:5:14:6 | res.ren ... \\n    }) | projectA/views/main.ejs:0:0:0:0 | projectA/views/main.ejs |
-| projectA/src/index.js:16:5:19:6 | res.ren ... \\n    }) | projectA/views/subfolder/index.ejs:0:0:0:0 | projectA/views/subfolder/index.ejs |
-| projectA/src/index.js:31:5:34:6 | res.ren ... \\n    }) | projectA/views/subfolder/other.ejs:0:0:0:0 | projectA/views/subfolder/other.ejs |
+| projectA/src/index.js:16:5:19:6 | res.ren ... \\n    }) | projectA/views/main.ejs:0:0:0:0 | projectA/views/main.ejs |
+| projectA/src/index.js:21:5:24:6 | res.ren ... \\n    }) | projectA/views/subfolder/index.ejs:0:0:0:0 | projectA/views/subfolder/index.ejs |
 | projectA/src/index.js:36:5:39:6 | res.ren ... \\n    }) | projectA/views/subfolder/other.ejs:0:0:0:0 | projectA/views/subfolder/other.ejs |
-| projectA/src/index.js:41:5:44:6 | res.ren ... \\n    }) | projectA/views/subfolder/subsub/index.ejs:0:0:0:0 | projectA/views/subfolder/subsub/index.ejs |
-| projectB/src/index.js:6:5:9:6 | res.ren ... \\n    }) | projectB/views/main.ejs:0:0:0:0 | projectB/views/main.ejs |
+| projectA/src/index.js:41:5:44:6 | res.ren ... \\n    }) | projectA/views/subfolder/other.ejs:0:0:0:0 | projectA/views/subfolder/other.ejs |
+| projectA/src/index.js:46:5:49:6 | res.ren ... \\n    }) | projectA/views/subfolder/subsub/index.ejs:0:0:0:0 | projectA/views/subfolder/subsub/index.ejs |
 | projectB/src/index.js:11:5:14:6 | res.ren ... \\n    }) | projectB/views/main.ejs:0:0:0:0 | projectB/views/main.ejs |
-| projectB/src/index.js:16:5:19:6 | res.ren ... \\n    }) | projectB/views/subfolder/index.ejs:0:0:0:0 | projectB/views/subfolder/index.ejs |
-| projectB/src/index.js:31:5:34:6 | res.ren ... \\n    }) | projectB/views/subfolder/other.ejs:0:0:0:0 | projectB/views/subfolder/other.ejs |
+| projectB/src/index.js:16:5:19:6 | res.ren ... \\n    }) | projectB/views/main.ejs:0:0:0:0 | projectB/views/main.ejs |
+| projectB/src/index.js:21:5:24:6 | res.ren ... \\n    }) | projectB/views/subfolder/index.ejs:0:0:0:0 | projectB/views/subfolder/index.ejs |
 | projectB/src/index.js:36:5:39:6 | res.ren ... \\n    }) | projectB/views/subfolder/other.ejs:0:0:0:0 | projectB/views/subfolder/other.ejs |
+| projectB/src/index.js:41:5:44:6 | res.ren ... \\n    }) | projectB/views/subfolder/other.ejs:0:0:0:0 | projectB/views/subfolder/other.ejs |
 | views/ejs_sinks.ejs:24:13:24:53 | include ... Html }) | views/ejs_include1.ejs:0:0:0:0 | views/ejs_include1.ejs |
 xssSink
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |

--- a/javascript/ql/test/query-tests/Security/CWE-073/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-073/Consistency.expected
@@ -1,1 +1,0 @@
-| query-tests/Security/CWE-073/routes.js:2 | expected an alert, but found none | NOT OK |  |

--- a/javascript/ql/test/query-tests/Security/CWE-073/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-073/Consistency.expected
@@ -1,0 +1,1 @@
+| query-tests/Security/CWE-073/routes.js:2 | expected an alert, but found none | NOT OK |  |

--- a/javascript/ql/test/query-tests/Security/CWE-073/Consistency.ql
+++ b/javascript/ql/test/query-tests/Security/CWE-073/Consistency.ql
@@ -1,0 +1,3 @@
+import javascript
+import semmle.javascript.security.dataflow.TemplateObjectInjectionQuery
+import testUtilities.ConsistencyChecking

--- a/javascript/ql/test/query-tests/Security/CWE-073/TemplateObjectInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-073/TemplateObjectInjection.expected
@@ -1,4 +1,7 @@
 nodes
+| routes.js:2:23:2:30 | req.body |
+| routes.js:2:23:2:30 | req.body |
+| routes.js:2:23:2:30 | req.body |
 | tst2.js:6:9:6:46 | bodyParameter |
 | tst2.js:6:25:6:32 | req.body |
 | tst2.js:6:25:6:32 | req.body |
@@ -55,6 +58,7 @@ nodes
 | tst.js:29:28:29:42 | JSON.parse(str) |
 | tst.js:29:39:29:41 | str |
 edges
+| routes.js:2:23:2:30 | req.body | routes.js:2:23:2:30 | req.body |
 | tst2.js:6:9:6:46 | bodyParameter | tst2.js:7:28:7:40 | bodyParameter |
 | tst2.js:6:9:6:46 | bodyParameter | tst2.js:7:28:7:40 | bodyParameter |
 | tst2.js:6:25:6:32 | req.body | tst2.js:6:25:6:46 | req.bod ... rameter |
@@ -104,6 +108,7 @@ edges
 | tst.js:29:39:29:41 | str | tst.js:29:28:29:42 | JSON.parse(str) |
 | tst.js:29:39:29:41 | str | tst.js:29:28:29:42 | JSON.parse(str) |
 #select
+| routes.js:2:23:2:30 | req.body | routes.js:2:23:2:30 | req.body | routes.js:2:23:2:30 | req.body | Template object injection due to $@. | routes.js:2:23:2:30 | req.body | user-provided value |
 | tst2.js:7:28:7:40 | bodyParameter | tst2.js:6:25:6:32 | req.body | tst2.js:7:28:7:40 | bodyParameter | Template object injection due to $@. | tst2.js:6:25:6:32 | req.body | user-provided value |
 | tst2.js:27:28:27:40 | bodyParameter | tst2.js:26:25:26:32 | req.body | tst2.js:27:28:27:40 | bodyParameter | Template object injection due to $@. | tst2.js:26:25:26:32 | req.body | user-provided value |
 | tst2.js:35:28:35:40 | bodyParameter | tst2.js:34:25:34:32 | req.body | tst2.js:35:28:35:40 | bodyParameter | Template object injection due to $@. | tst2.js:34:25:34:32 | req.body | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-073/TemplateObjectInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-073/TemplateObjectInjection.expected
@@ -29,31 +29,31 @@ nodes
 | tst2.js:51:25:51:46 | req.bod ... rameter |
 | tst2.js:52:28:52:40 | bodyParameter |
 | tst2.js:52:28:52:40 | bodyParameter |
-| tst.js:5:9:5:46 | bodyParameter |
-| tst.js:5:25:5:32 | req.body |
-| tst.js:5:25:5:32 | req.body |
-| tst.js:5:25:5:46 | req.bod ... rameter |
-| tst.js:6:9:6:49 | queryParameter |
-| tst.js:6:9:6:49 | queryParameter |
-| tst.js:6:26:6:49 | req.que ... rameter |
-| tst.js:6:26:6:49 | req.que ... rameter |
-| tst.js:6:26:6:49 | req.que ... rameter |
-| tst.js:8:28:8:40 | bodyParameter |
-| tst.js:8:28:8:40 | bodyParameter |
-| tst.js:9:28:9:41 | queryParameter |
-| tst.js:9:28:9:41 | queryParameter |
-| tst.js:18:19:18:32 | queryParameter |
-| tst.js:18:19:18:32 | queryParameter |
-| tst.js:21:24:21:26 | obj |
-| tst.js:21:24:21:26 | obj |
-| tst.js:22:28:22:30 | obj |
-| tst.js:22:28:22:30 | obj |
-| tst.js:24:11:24:24 | str |
-| tst.js:24:17:24:19 | obj |
-| tst.js:24:17:24:24 | obj + "" |
-| tst.js:27:28:27:42 | JSON.parse(str) |
-| tst.js:27:28:27:42 | JSON.parse(str) |
-| tst.js:27:39:27:41 | str |
+| tst.js:7:9:7:46 | bodyParameter |
+| tst.js:7:25:7:32 | req.body |
+| tst.js:7:25:7:32 | req.body |
+| tst.js:7:25:7:46 | req.bod ... rameter |
+| tst.js:8:9:8:49 | queryParameter |
+| tst.js:8:9:8:49 | queryParameter |
+| tst.js:8:26:8:49 | req.que ... rameter |
+| tst.js:8:26:8:49 | req.que ... rameter |
+| tst.js:8:26:8:49 | req.que ... rameter |
+| tst.js:10:28:10:40 | bodyParameter |
+| tst.js:10:28:10:40 | bodyParameter |
+| tst.js:11:28:11:41 | queryParameter |
+| tst.js:11:28:11:41 | queryParameter |
+| tst.js:20:19:20:32 | queryParameter |
+| tst.js:20:19:20:32 | queryParameter |
+| tst.js:23:24:23:26 | obj |
+| tst.js:23:24:23:26 | obj |
+| tst.js:24:28:24:30 | obj |
+| tst.js:24:28:24:30 | obj |
+| tst.js:26:11:26:24 | str |
+| tst.js:26:17:26:19 | obj |
+| tst.js:26:17:26:24 | obj + "" |
+| tst.js:29:28:29:42 | JSON.parse(str) |
+| tst.js:29:28:29:42 | JSON.parse(str) |
+| tst.js:29:39:29:41 | str |
 edges
 | tst2.js:6:9:6:46 | bodyParameter | tst2.js:7:28:7:40 | bodyParameter |
 | tst2.js:6:9:6:46 | bodyParameter | tst2.js:7:28:7:40 | bodyParameter |
@@ -80,36 +80,36 @@ edges
 | tst2.js:51:25:51:32 | req.body | tst2.js:51:25:51:46 | req.bod ... rameter |
 | tst2.js:51:25:51:32 | req.body | tst2.js:51:25:51:46 | req.bod ... rameter |
 | tst2.js:51:25:51:46 | req.bod ... rameter | tst2.js:51:9:51:46 | bodyParameter |
-| tst.js:5:9:5:46 | bodyParameter | tst.js:8:28:8:40 | bodyParameter |
-| tst.js:5:9:5:46 | bodyParameter | tst.js:8:28:8:40 | bodyParameter |
-| tst.js:5:25:5:32 | req.body | tst.js:5:25:5:46 | req.bod ... rameter |
-| tst.js:5:25:5:32 | req.body | tst.js:5:25:5:46 | req.bod ... rameter |
-| tst.js:5:25:5:46 | req.bod ... rameter | tst.js:5:9:5:46 | bodyParameter |
-| tst.js:6:9:6:49 | queryParameter | tst.js:9:28:9:41 | queryParameter |
-| tst.js:6:9:6:49 | queryParameter | tst.js:9:28:9:41 | queryParameter |
-| tst.js:6:9:6:49 | queryParameter | tst.js:18:19:18:32 | queryParameter |
-| tst.js:6:9:6:49 | queryParameter | tst.js:18:19:18:32 | queryParameter |
-| tst.js:6:26:6:49 | req.que ... rameter | tst.js:6:9:6:49 | queryParameter |
-| tst.js:6:26:6:49 | req.que ... rameter | tst.js:6:9:6:49 | queryParameter |
-| tst.js:6:26:6:49 | req.que ... rameter | tst.js:6:9:6:49 | queryParameter |
-| tst.js:6:26:6:49 | req.que ... rameter | tst.js:6:9:6:49 | queryParameter |
-| tst.js:18:19:18:32 | queryParameter | tst.js:21:24:21:26 | obj |
-| tst.js:18:19:18:32 | queryParameter | tst.js:21:24:21:26 | obj |
-| tst.js:21:24:21:26 | obj | tst.js:22:28:22:30 | obj |
-| tst.js:21:24:21:26 | obj | tst.js:22:28:22:30 | obj |
-| tst.js:21:24:21:26 | obj | tst.js:24:17:24:19 | obj |
-| tst.js:24:11:24:24 | str | tst.js:27:39:27:41 | str |
-| tst.js:24:17:24:19 | obj | tst.js:24:17:24:24 | obj + "" |
-| tst.js:24:17:24:24 | obj + "" | tst.js:24:11:24:24 | str |
-| tst.js:27:39:27:41 | str | tst.js:27:28:27:42 | JSON.parse(str) |
-| tst.js:27:39:27:41 | str | tst.js:27:28:27:42 | JSON.parse(str) |
+| tst.js:7:9:7:46 | bodyParameter | tst.js:10:28:10:40 | bodyParameter |
+| tst.js:7:9:7:46 | bodyParameter | tst.js:10:28:10:40 | bodyParameter |
+| tst.js:7:25:7:32 | req.body | tst.js:7:25:7:46 | req.bod ... rameter |
+| tst.js:7:25:7:32 | req.body | tst.js:7:25:7:46 | req.bod ... rameter |
+| tst.js:7:25:7:46 | req.bod ... rameter | tst.js:7:9:7:46 | bodyParameter |
+| tst.js:8:9:8:49 | queryParameter | tst.js:11:28:11:41 | queryParameter |
+| tst.js:8:9:8:49 | queryParameter | tst.js:11:28:11:41 | queryParameter |
+| tst.js:8:9:8:49 | queryParameter | tst.js:20:19:20:32 | queryParameter |
+| tst.js:8:9:8:49 | queryParameter | tst.js:20:19:20:32 | queryParameter |
+| tst.js:8:26:8:49 | req.que ... rameter | tst.js:8:9:8:49 | queryParameter |
+| tst.js:8:26:8:49 | req.que ... rameter | tst.js:8:9:8:49 | queryParameter |
+| tst.js:8:26:8:49 | req.que ... rameter | tst.js:8:9:8:49 | queryParameter |
+| tst.js:8:26:8:49 | req.que ... rameter | tst.js:8:9:8:49 | queryParameter |
+| tst.js:20:19:20:32 | queryParameter | tst.js:23:24:23:26 | obj |
+| tst.js:20:19:20:32 | queryParameter | tst.js:23:24:23:26 | obj |
+| tst.js:23:24:23:26 | obj | tst.js:24:28:24:30 | obj |
+| tst.js:23:24:23:26 | obj | tst.js:24:28:24:30 | obj |
+| tst.js:23:24:23:26 | obj | tst.js:26:17:26:19 | obj |
+| tst.js:26:11:26:24 | str | tst.js:29:39:29:41 | str |
+| tst.js:26:17:26:19 | obj | tst.js:26:17:26:24 | obj + "" |
+| tst.js:26:17:26:24 | obj + "" | tst.js:26:11:26:24 | str |
+| tst.js:29:39:29:41 | str | tst.js:29:28:29:42 | JSON.parse(str) |
+| tst.js:29:39:29:41 | str | tst.js:29:28:29:42 | JSON.parse(str) |
 #select
 | tst2.js:7:28:7:40 | bodyParameter | tst2.js:6:25:6:32 | req.body | tst2.js:7:28:7:40 | bodyParameter | Template object injection due to $@. | tst2.js:6:25:6:32 | req.body | user-provided value |
 | tst2.js:27:28:27:40 | bodyParameter | tst2.js:26:25:26:32 | req.body | tst2.js:27:28:27:40 | bodyParameter | Template object injection due to $@. | tst2.js:26:25:26:32 | req.body | user-provided value |
 | tst2.js:35:28:35:40 | bodyParameter | tst2.js:34:25:34:32 | req.body | tst2.js:35:28:35:40 | bodyParameter | Template object injection due to $@. | tst2.js:34:25:34:32 | req.body | user-provided value |
 | tst2.js:43:28:43:40 | bodyParameter | tst2.js:42:25:42:32 | req.body | tst2.js:43:28:43:40 | bodyParameter | Template object injection due to $@. | tst2.js:42:25:42:32 | req.body | user-provided value |
 | tst2.js:52:28:52:40 | bodyParameter | tst2.js:51:25:51:32 | req.body | tst2.js:52:28:52:40 | bodyParameter | Template object injection due to $@. | tst2.js:51:25:51:32 | req.body | user-provided value |
-| tst.js:8:28:8:40 | bodyParameter | tst.js:5:25:5:32 | req.body | tst.js:8:28:8:40 | bodyParameter | Template object injection due to $@. | tst.js:5:25:5:32 | req.body | user-provided value |
-| tst.js:9:28:9:41 | queryParameter | tst.js:6:26:6:49 | req.que ... rameter | tst.js:9:28:9:41 | queryParameter | Template object injection due to $@. | tst.js:6:26:6:49 | req.que ... rameter | user-provided value |
-| tst.js:22:28:22:30 | obj | tst.js:6:26:6:49 | req.que ... rameter | tst.js:22:28:22:30 | obj | Template object injection due to $@. | tst.js:6:26:6:49 | req.que ... rameter | user-provided value |
-| tst.js:27:28:27:42 | JSON.parse(str) | tst.js:6:26:6:49 | req.que ... rameter | tst.js:27:28:27:42 | JSON.parse(str) | Template object injection due to $@. | tst.js:6:26:6:49 | req.que ... rameter | user-provided value |
+| tst.js:10:28:10:40 | bodyParameter | tst.js:7:25:7:32 | req.body | tst.js:10:28:10:40 | bodyParameter | Template object injection due to $@. | tst.js:7:25:7:32 | req.body | user-provided value |
+| tst.js:11:28:11:41 | queryParameter | tst.js:8:26:8:49 | req.que ... rameter | tst.js:11:28:11:41 | queryParameter | Template object injection due to $@. | tst.js:8:26:8:49 | req.que ... rameter | user-provided value |
+| tst.js:24:28:24:30 | obj | tst.js:8:26:8:49 | req.que ... rameter | tst.js:24:28:24:30 | obj | Template object injection due to $@. | tst.js:8:26:8:49 | req.que ... rameter | user-provided value |
+| tst.js:29:28:29:42 | JSON.parse(str) | tst.js:8:26:8:49 | req.que ... rameter | tst.js:29:28:29:42 | JSON.parse(str) | Template object injection due to $@. | tst.js:8:26:8:49 | req.que ... rameter | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-073/routes.js
+++ b/javascript/ql/test/query-tests/Security/CWE-073/routes.js
@@ -1,0 +1,3 @@
+exports.foo = function(req, res) {
+    res.render('foo', req.body); // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-073/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-073/tst.js
@@ -1,6 +1,8 @@
 var app = require('express')();
 app.set('view engine', 'hbs');
 
+
+
 app.post('/path', function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     var queryParameter = req.query.queryParameter;

--- a/javascript/ql/test/query-tests/Security/CWE-073/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-073/tst.js
@@ -1,8 +1,8 @@
 var app = require('express')();
 app.set('view engine', 'hbs');
 
-
-
+app.use(require('body-parser').json());
+app.use(require('body-parser').urlencoded({ extended: false }));
 app.post('/path', function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     var queryParameter = req.query.queryParameter;

--- a/javascript/ql/test/query-tests/Security/CWE-073/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-073/tst.js
@@ -28,3 +28,6 @@ function indirect(res, obj) {
 
     res.render("template", JSON.parse(str)); // NOT OK
 }
+
+let routes = require('./routes');
+app.post('/foo', routes.foo);

--- a/javascript/ql/test/query-tests/Security/CWE-073/tst2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-073/tst2.js
@@ -2,27 +2,27 @@ const handlebars = require("express-handlebars");
 var app = require('express')();
 app.engine( '.hbs', handlebars({ defaultLayout: 'main', extname: '.hbs' }) ); 
 app.set('view engine', '.hbs')
-app.post('/path', function(req, res) {
+app.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // NOT OK
 }); 
 
 var app2 = require('express')();
-app2.post('/path', function(req, res) {
+app2.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // OK
 }); 
 
 var app3 = require('express')();
 app3.set('view engine', 'pug');
-app3.post('/path', function(req, res) {
+app3.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // OK
 }); 
 
 var app4 = require('express')();
 app4.set('view engine', 'ejs');
-app4.post('/path', function(req, res) {
+app4.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // NOT OK
 }); 
@@ -30,7 +30,7 @@ app4.post('/path', function(req, res) {
 var app5 = require('express')();
 app5.engine("foobar", require("consolidate").whiskers);
 app5.set('view engine', 'foobar');
-app5.post('/path', function(req, res) {
+app5.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // NOT OK
 }); 
@@ -38,7 +38,7 @@ app5.post('/path', function(req, res) {
 var app6 = require('express')();
 app6.register(".html", require("consolidate").whiskers);
 app6.set('view engine', 'html');
-app6.post('/path', function(req, res) {
+app6.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // NOT OK
 }); 
@@ -47,7 +47,7 @@ const express = require('express');
 var router = express.Router();
 var app7 = express();
 app7.set('view engine', 'ejs');
-router.post('/path', function(req, res) {
+router.post('/path', require('body-parser').json(), function(req, res) {
     var bodyParameter = req.body.bodyParameter;
     res.render('template', bodyParameter); // NOT OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
@@ -4,6 +4,7 @@
 | MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:45:31:47:6 | errorCa ... \\n    }) | here |
 | csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:53:45:3 | functio ... e')\\n  } | here |
 | csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:40:34:1 | functio ... sed')\\n} | here |
+| fastify2.js:7:16:7:40 | require ... ookie') | This cookie middleware is serving a request handler $@ without CSRF protection. | fastify2.js:24:12:27:3 | async ( ... ody\\n  } | here |
 | fastify.js:5:14:5:38 | require ... ookie') | This cookie middleware is serving a request handler $@ without CSRF protection. | fastify.js:20:12:23:3 | async ( ... ody\\n  } | here |
 | lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:42:29:1 | functio ... sed')\\n} | here |
 | lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:31:40:34:1 | functio ... sed')\\n} | here |

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
@@ -1,13 +1,13 @@
-| MissingCsrfMiddlewareBad.js:7:9:7:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:10:1:12:2 | app.pos ... l"];\\n}) | here |
-| MissingCsrfMiddlewareBad.js:17:13:17:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:25:5:27:7 | app.pos ...     })) | here |
-| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:41:5:43:7 | app.pos ...     })) | here |
-| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:45:5:47:7 | app.pos ...     })) | here |
-| csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:3:45:4 | router. ... ')\\n  }) | here |
-| csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:1:34:2 | app.pos ... ed')\\n}) | here |
-| fastify.js:5:14:5:38 | require ... ookie') | This cookie middleware is serving a request handler $@ without CSRF protection. | fastify.js:17:1:24:2 | app.rou ... \\n  }\\n}) | here |
-| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:1:29:2 | app.pos ... ed')\\n}) | here |
-| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:31:1:34:2 | app.pos ... ed')\\n}) | here |
-| tst.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | tst.js:8:1:10:2 | app.pos ... s.x;\\n}) | here |
-| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:8:1:13:2 | app.pos ... k');\\n}) | here |
-| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:29:1:32:2 | app.pos ... k');\\n}) | here |
-| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:34:1:37:2 | app.pos ... k');\\n}) | here |
+| MissingCsrfMiddlewareBad.js:7:9:7:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:10:26:12:1 | functio ... il"];\\n} | here |
+| MissingCsrfMiddlewareBad.js:17:13:17:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:25:30:27:6 | errorCa ... \\n    }) | here |
+| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:41:30:43:6 | errorCa ... \\n    }) | here |
+| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:45:31:47:6 | errorCa ... \\n    }) | here |
+| csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:53:45:3 | functio ... e')\\n  } | here |
+| csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:40:34:1 | functio ... sed')\\n} | here |
+| fastify.js:5:14:5:38 | require ... ookie') | This cookie middleware is serving a request handler $@ without CSRF protection. | fastify.js:20:12:23:3 | async ( ... ody\\n  } | here |
+| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:42:29:1 | functio ... sed')\\n} | here |
+| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:31:40:34:1 | functio ... sed')\\n} | here |
+| tst.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | tst.js:8:21:10:1 | (req, r ... es.x;\\n} | here |
+| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:8:34:13:1 | (req, r ... Ok');\\n} | here |
+| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:29:19:32:1 | (req, r ... Ok');\\n} | here |
+| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:34:22:37:1 | (req, r ... Ok');\\n} | here |

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
@@ -1,11 +1,13 @@
-| MissingCsrfMiddlewareBad.js:7:9:7:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:10:26:12:1 | functio ... il"];\\n} | here |
-| MissingCsrfMiddlewareBad.js:17:13:17:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:25:30:27:6 | errorCa ... \\n    }) | here |
-| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:41:30:43:6 | errorCa ... \\n    }) | here |
-| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:45:31:47:6 | errorCa ... \\n    }) | here |
-| csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:53:45:3 | functio ... e')\\n  } | here |
-| csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:40:34:1 | functio ... sed')\\n} | here |
-| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:42:29:1 | functio ... sed')\\n} | here |
-| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:31:40:34:1 | functio ... sed')\\n} | here |
-| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:8:34:13:1 | (req, r ... Ok');\\n} | here |
-| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:29:19:32:1 | (req, r ... Ok');\\n} | here |
-| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:34:22:37:1 | (req, r ... Ok');\\n} | here |
+| MissingCsrfMiddlewareBad.js:7:9:7:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:10:1:12:2 | app.pos ... l"];\\n}) | here |
+| MissingCsrfMiddlewareBad.js:17:13:17:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:25:5:27:7 | app.pos ...     })) | here |
+| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:41:5:43:7 | app.pos ...     })) | here |
+| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:45:5:47:7 | app.pos ...     })) | here |
+| csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:3:45:4 | router. ... ')\\n  }) | here |
+| csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:1:34:2 | app.pos ... ed')\\n}) | here |
+| fastify.js:5:14:5:38 | require ... ookie') | This cookie middleware is serving a request handler $@ without CSRF protection. | fastify.js:17:1:24:2 | app.rou ... \\n  }\\n}) | here |
+| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:1:29:2 | app.pos ... ed')\\n}) | here |
+| lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:31:1:34:2 | app.pos ... ed')\\n}) | here |
+| tst.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | tst.js:8:1:10:2 | app.pos ... s.x;\\n}) | here |
+| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:8:1:13:2 | app.pos ... k');\\n}) | here |
+| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:29:1:32:2 | app.pos ... k');\\n}) | here |
+| unused_cookies.js:6:9:6:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | unused_cookies.js:34:1:37:2 | app.pos ... k');\\n}) | here |

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
@@ -98,10 +98,11 @@ var passport = require('passport');
     app.use(cookieParser())
     app.use(passport.authorize({ session: true }))
 
-    function checkToken(req) {
+    function checkToken(req, res, next) {
         if (req.headers.xsrfToken !== req.session.xsrfToken) {
             throw new Error("Halt and catch fire!")
         }
+        next();
     }
 
     function setCsrfToken(req, response, next) {

--- a/javascript/ql/test/query-tests/Security/CWE-352/fastify.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/fastify.js
@@ -1,0 +1,34 @@
+const fastify = require('fastify')
+
+const app = fastify();
+
+app.register(require('fastify-cookie'));
+app.register(require('fastify-csrf'));
+
+app.route({
+  method: 'GET',
+  path: '/getter',
+  handler: async (req, reply) => { // OK
+    return 'hello';
+  }
+})
+
+// unprotected route
+app.route({
+  method: 'POST',
+  path: '/',
+  handler: async (req, reply) => { // NOT OK - lacks CSRF protection
+    req.session.blah;
+    return req.body
+  }
+})
+
+
+app.route({
+  method: 'POST',
+  path: '/',
+  onRequest: app.csrfProtection,
+  handler: async (req, reply) => { // OK - has CSRF protection
+    return req.body
+  }
+})

--- a/javascript/ql/test/query-tests/Security/CWE-352/fastify2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/fastify2.js
@@ -1,0 +1,38 @@
+const fastify = require('fastify')
+const fp = require('fastify-plugin');
+
+const app = fastify();
+
+function plugin(app) {
+  app.register(require('fastify-cookie'));
+  app.register(require('fastify-csrf'));
+}
+app.register(fp(plugin));
+
+app.route({
+  method: 'GET',
+  path: '/getter',
+  handler: async (req, reply) => { // OK
+    return 'hello';
+  }
+})
+
+// unprotected route
+app.route({
+  method: 'POST',
+  path: '/',
+  handler: async (req, reply) => { // NOT OK - lacks CSRF protection
+    req.session.blah;
+    return req.body
+  }
+})
+
+
+app.route({
+  method: 'POST',
+  path: '/',
+  onRequest: app.csrfProtection,
+  handler: async (req, reply) => { // OK - has CSRF protection
+    return req.body
+  }
+})

--- a/javascript/ql/test/query-tests/Security/CWE-352/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/tst.js
@@ -1,0 +1,22 @@
+const express = require('express')
+const cookieParser = require('cookie-parser')
+const csrf = require('csurf')
+
+const app = express()
+app.use(cookieParser())
+
+app.post('/unsafe', (req, res) => { // NOT OK
+  req.cookies.x;
+});
+
+function middlewares() {
+  return express.Router()
+    .use(csrf({ cookie: true}))
+    .use('/', express.bodyParser());
+}
+
+app.use(middlewares());
+
+app.post('/safe', (req, res) => { // OK
+  req.cookies.x;
+});

--- a/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimiting.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimiting.expected
@@ -8,3 +8,4 @@
 | tst.js:38:20:38:36 | expensiveHandler4 | This route handler performs $@, but is not rate-limited. | tst.js:17:40:17:83 | connect ... ution') | a database access |
 | tst.js:64:25:64:63 | functio ... req); } | This route handler performs $@, but is not rate-limited. | tst.js:64:46:64:60 | verifyUser(req) | authorization |
 | tst.js:76:25:76:53 | catchAs ... ndler1) | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |
+| tst.js:88:24:88:40 | expensiveHandler1 | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |

--- a/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimiting.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-770/MissingRateLimiting.expected
@@ -1,4 +1,4 @@
-| MissingRateLimiting.js:4:19:4:38 | functio ... ath);\\n} | This route handler performs $@, but is not rate-limited. | MissingRateLimiting.js:7:5:7:22 | res.sendFile(path) | a file system access |
+| MissingRateLimiting.js:4:19:8:1 | functio ... ath);\\n} | This route handler performs $@, but is not rate-limited. | MissingRateLimiting.js:7:5:7:22 | res.sendFile(path) | a file system access |
 | MissingRateLimiting.js:25:19:25:20 | f1 | This route handler performs $@, but is not rate-limited. | MissingRateLimiting.js:13:5:13:22 | res.sendFile(path) | a file system access |
 | MissingRateLimiting.js:25:27:25:28 | f3 | This route handler performs $@, but is not rate-limited. | MissingRateLimiting.js:22:5:22:22 | res.sendFile(path) | a file system access |
 | tst.js:22:24:22:40 | expensiveHandler1 | This route handler performs $@, but is not rate-limited. | tst.js:14:40:14:46 | login() | authorization |

--- a/javascript/ql/test/query-tests/Security/CWE-770/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-770/tst.js
@@ -58,7 +58,7 @@ app2.get('/:path', bruteforce.prevent, expensiveHandler1); // OK
 
 // rate limiting using express-limiter
 var app3 = express();
-var limiter = require('express-limiter')(app3);
+require('express-limiter')(app3)({ method: 'get', path: '/' });
 app3.get('/:path', expensiveHandler1); // OK
 
 express().get('/:path', function(req, res) { verifyUser(req); });  // NOT OK

--- a/javascript/ql/test/query-tests/Security/CWE-770/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-770/tst.js
@@ -77,3 +77,8 @@ express().get('/:path', catchAsync(expensiveHandler1)); // NOT OK
 express().get('/:path', rateLimiterMiddleware, catchAsync(expensiveHandler1)); // OK
 express().get('/:path', catchAsync(rateLimiterMiddleware), expensiveHandler1); // OK
 express().get('/:path', catchAsync(rateLimiterMiddleware), catchAsync(expensiveHandler1)); // OK
+
+function errorHandler(req, res, next) {
+  next(makeOAuthError(req, res));
+}
+express().use(errorHandler); // OK - does not perform authentication

--- a/javascript/ql/test/query-tests/Security/CWE-770/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-770/tst.js
@@ -82,3 +82,9 @@ function errorHandler(req, res, next) {
   next(makeOAuthError(req, res));
 }
 express().use(errorHandler); // OK - does not perform authentication
+
+const fastifyApp = require('fastify')();
+
+fastifyApp.get('/foo', expensiveHandler1); // NOT OK
+fastifyApp.register(require('fastify-rate-limit'));
+fastifyApp.get('/bar', expensiveHandler1); // OK


### PR DESCRIPTION
This introduces the `Routing` library, modeling the composition of middleware functions and route handlers, and helps reason about data flow between these.

Previously we were missing data flow in cases like this:
```js
app.use((req, res) => {
  req.data = req.query.x;
});
app.get('/', (req, res) => {
  let x = req.data; // <-- missed flow from req.query.x
});
```
Data-flow configurations as well as API graphs can now track flow between the two functions above.

## What's in this PR

- The `Routing` library with a bunch of abstract classes for framework models to extend.
- It is instantiated for Express and Fastify for now. There are more framework models, but I had to stop creeping the scope of the PR.
- The framework models themselves haven't changed much; they just contribute to the routing tree model, which then contributes new data-flow and API graph steps.
- The CSRF and rate limiting queries now use the routing tree model.
- `req.body` is now seen as a deeply tainted object in more cases, as the logic for detecting the body parser is now based on routing trees. We get some new results because of this.


## Routing tree examples
The structure of the router hierarchy is seen as a tree, with each node being a function that can dispatch the incoming request to its children, or pass it on to its next sibling. We a graph-structure used to represent the possible trees that can be constructed at runtime. (Branching control-flow can cause the graph to be non-tree shaped)

For example:
```js
app.use(foo());
app.get(bar());
app.get('/', a, b, c);
```
would generate a tree of form:
- `app`
  - `app.use()`
    - `foo()`
  - `app.get()`
    - `bar()`
  - `app.get('/)`
    - `a`
    - `b`
    - `c`

Now suppose `foo()` is defined to return another router:
```js
function foo() {
  let router = express.Router();
  router.use(...);
  return router;
}
```
The inner router would appear as a child in the overall routing tree:
- `app`
  - `app.use()`
    - `foo()`
      - `router`
        - `router.use(...)`
  - ...

In general, if there is flow from A to B, then A becomes a child of B. For example,
```js
function A(req, res) {}
let B1 = A;
app.use(B1);
let B2 = A;
app.use(B2);
```
The hierarchy would be as follows, with `A` occurring in two different places, but their corresponding use-sites (`B1`, `B2`) still explicit in the tree.
- `app`
  -  `app.use()`
      - `B1`
        - `A`
  - `app.use()`
    - `B2`
      - `A`

(In this example, the explicit `let` bindings were just there to make it easier to refer to the use-sites, but separate use-site nodes would exist even if the `let` bindings were inlined)

If a router is returned, the data-flow rule wires things up nicely:
```js
function makeRouter() {
  let router = express.Router();
  router.use(A);
  return router;
}
app.use(makeRouter());
```
- `app`
  - `app.use()`
    - `makeRouter()`
      - `router`
        - `router.use()`
          - `A`

An interesting case is when a mutable router object escapes into another function. In this case, we need interprocedural reasoning about side effects, since ordering of middlewares reflects the order in which certain calls are made. We simplify this by creating a separate node for each function that touches the router object, and at the point where the router escapes, we add a child relationship between caller and callee. For example:
```js
function addMiddlewares(router) {
  router.use(A);
  router.use(B);
}
app.use(cookie());
addMiddlewares(app);
app.get('/', ...)
```
- `app`
  - `app.use(cookie())`
  - `addMiddlewares(app)` (point of escape)
    - `router` (callee's view of router)
      - `router.use(A)`
      - `router.use(B)`
  - `app.get('/', ...)`

With the above tree, we can see that `A,B` come after `cookie()` but before the `get('/')` handler.

## Evaluations (internal links)

- [On EJS slugs](https://github.com/github/codeql-dca-main/tree/data/asgerf/routing-trees__ejs__dist-compare__9/reports) we get 17 new alerts, not counting the 465 missing rate-limiting alerts which is a bit ridiculous. Mostly TPs as far as I can tell, although some of them are existing alerts with a new source detected through middleware-flow.
- [Default slugs](https://github.com/github/codeql-dca-main/tree/data/asgerf/routing-trees__default__dist-compare__2/reports) shows good performance and some new SQL injections, and both new TPs and fixed FPs for missing CSRF middleware