### PR TITLE
Ruby: Add `rb/csrf-protection-disabled` query

### DIFF
--- a/ruby/change-notes/2021-11-04-csrf-protection-disabled.md
+++ b/ruby/change-notes/2021-11-04-csrf-protection-disabled.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* A new query (`rb/csrf-protection-disabled`) has been added. The query finds cases where cross-site forgery protection is explictly disabled.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -586,12 +586,15 @@ module OrmInstantiation {
 
 /**
  * A data-flow node that may set or unset Cross-site request forgery protection.
- * `getVerificationSetting() = false` corresponds to disabling verification.
  *
  * Extend this class to refine existing API models. If you want to model new APIs,
  * extend `CSRFProtectionSetting::Range` instead.
  */
 class CSRFProtectionSetting extends DataFlow::Node instanceof CSRFProtectionSetting::Range {
+  /**
+   * Gets the boolean value corresponding to if CSRF protection is enabled
+   * (`true`) or disabled (`false`) by this node.
+   */
   boolean getVerificationSetting() { result = super.getVerificationSetting() }
 }
 
@@ -599,12 +602,15 @@ class CSRFProtectionSetting extends DataFlow::Node instanceof CSRFProtectionSett
 module CSRFProtectionSetting {
   /**
    * A data-flow node that may set or unset Cross-site request forgery protection.
-   * `getVerificationSetting() = false` corresponds to disabling verification.
    *
    * Extend this class to model new APIs. If you want to refine existing API models,
    * extend `CSRFProtectionSetting` instead.
    */
   abstract class Range extends DataFlow::Node {
+    /**
+     * Gets the boolean value corresponding to if CSRF protection is enabled
+     * (`true`) or disabled (`false`) by this node.
+     */
     abstract boolean getVerificationSetting();
   }
 }

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -584,6 +584,31 @@ module OrmInstantiation {
   }
 }
 
+/**
+ * A data-flow node that may set or unset Cross-site request forgery protection.
+ * `getVerificationSetting() = false` corresponds to disabling verification.
+ *
+ * Extend this class to refine existing API models. If you want to model new APIs,
+ * extend `CSRFProtectionSetting::Range` instead.
+ */
+class CSRFProtectionSetting extends DataFlow::Node instanceof CSRFProtectionSetting::Range {
+  boolean getVerificationSetting() { result = super.getVerificationSetting() }
+}
+
+/** Provides a class for modeling new CSRF protection setting APIs. */
+module CSRFProtectionSetting {
+  /**
+   * A data-flow node that may set or unset Cross-site request forgery protection.
+   * `getVerificationSetting() = false` corresponds to disabling verification.
+   *
+   * Extend this class to model new APIs. If you want to refine existing API models,
+   * extend `CSRFProtectionSetting` instead.
+   */
+  abstract class Range extends DataFlow::Node {
+    abstract boolean getVerificationSetting();
+  }
+}
+
 /** Provides classes for modeling path-related APIs. */
 module Path {
   /**

--- a/ruby/ql/lib/codeql/ruby/Frameworks.qll
+++ b/ruby/ql/lib/codeql/ruby/Frameworks.qll
@@ -6,6 +6,7 @@ private import codeql.ruby.frameworks.ActionController
 private import codeql.ruby.frameworks.ActiveRecord
 private import codeql.ruby.frameworks.ActiveStorage
 private import codeql.ruby.frameworks.ActionView
+private import codeql.ruby.frameworks.Rails
 private import codeql.ruby.frameworks.StandardLibrary
 private import codeql.ruby.frameworks.Files
 private import codeql.ruby.frameworks.HttpClients

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -257,3 +257,21 @@ predicate controllerTemplateFile(ActionControllerControllerClass cls, ErbFile te
     )
   )
 }
+
+/**
+ * A call to either `skip_forgery_protection` or
+ * `skip_before_action :verify_authenticity_token` to disable CSRF authenticity
+ * token protection.
+ */
+class ActionControllerSkipForgeryProtectionCall extends CSRFProtectionSetting::Range {
+  ActionControllerSkipForgeryProtectionCall() {
+    exists(MethodCall call | call = this.asExpr().getExpr() |
+      call.getMethodName() = "skip_forgery_protection"
+      or
+      call.getMethodName() = "skip_before_action" and
+      call.getAnArgument().(SymbolLiteral).getValueText() = "verify_authenticity_token"
+    )
+  }
+
+  override boolean getVerificationSetting() { result = false }
+}

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -56,7 +56,11 @@ private class ConfigSourceNode extends DataFlow::LocalSourceNode {
     )
     or
     // `Rails.application.config`
-    this = API::getTopLevelMember("Rails").getReturn("application").getReturn("config").getAnImmediateUse()
+    this =
+      API::getTopLevelMember("Rails")
+          .getReturn("application")
+          .getReturn("config")
+          .getAnImmediateUse()
     or
     // `Rails.application.configure { ... config ... }`
     // `Rails::Application.configure { ... config ... }`

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -32,19 +32,9 @@ private class RailtieClass extends ClassDeclaration {
   }
 }
 
-// `Rails.application.config` calls
-private API::Node getConfigApiNode() {
-  result = API::getTopLevelMember("Rails").getReturn("application").getReturn("config")
-}
-
-// `Rails.application.configure`
-private DataFlow::CallNode getConfigureApiNode() {
-  result = API::getTopLevelMember("Rails").getReturn("application").getAMethodCall("configure")
-}
-
 private DataFlow::CallNode getAConfigureCallNode() {
   // `Rails.application.configure`
-  result = getConfigureApiNode()
+  result = API::getTopLevelMember("Rails").getReturn("application").getAMethodCall("configure")
   or
   // `Rails::Application.configure`
   exists(ConstantReadAccess read, RailtieClass cls |
@@ -66,7 +56,7 @@ private class ConfigSourceNode extends DataFlow::LocalSourceNode {
     )
     or
     // `Rails.application.config`
-    this = getConfigApiNode().getAnImmediateUse()
+    this = API::getTopLevelMember("Rails").getReturn("application").getReturn("config").getAnImmediateUse()
     or
     // `Rails.application.configure { ... config ... }`
     // `Rails::Application.configure { ... config ... }`

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -102,16 +102,14 @@ private predicate hasBooleanValue(DataFlow::Node node, boolean value) {
 
 // `<actionControllerConfig>.allow_forgery_protection = <verificationSetting>`
 private DataFlow::CallNode getAnAllowForgeryProtectionCall(boolean verificationSetting) {
-  exists(ActionControllerConfigNode recv |
-    // exclude some test and development configuration
-    not (
-      result.getLocation().getFile().getRelativePath().matches("%test/%") or
-      result.getLocation().getFile().getStem() = ["test", "development"]
-    ) and
-    result.getReceiver() = recv and
-    result.asExpr().getExpr().(MethodCall).getMethodName() = "allow_forgery_protection=" and
-    hasBooleanValue(result.getArgument(0), verificationSetting)
-  )
+  // exclude some test and development configuration
+  not (
+    result.getLocation().getFile().getRelativePath().matches("%test/%") or
+    result.getLocation().getFile().getStem() = ["test", "development"]
+  ) and
+  result.getReceiver() instanceof ActionControllerConfigNode and
+  result.asExpr().getExpr().(MethodCall).getMethodName() = "allow_forgery_protection=" and
+  hasBooleanValue(result.getArgument(0), verificationSetting)
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -1,0 +1,139 @@
+/**
+ * Provides classes for working with Rails.
+ */
+
+private import codeql.files.FileSystem
+private import codeql.ruby.AST
+private import codeql.ruby.Concepts
+private import codeql.ruby.DataFlow
+private import codeql.ruby.frameworks.ActionController
+private import codeql.ruby.frameworks.ActionView
+private import codeql.ruby.frameworks.ActiveRecord
+private import codeql.ruby.frameworks.ActiveStorage
+private import codeql.ruby.ast.internal.Module
+private import codeql.ruby.ApiGraphs
+
+/**
+ * A reference to either `Rails::Railtie`, `Rails::Engine`, or `Rails::Application`.
+ * `Engine` and `Application` extend `Railtie`, but may not have definitions present in the database.
+ */
+private class RailtieClassAccess extends ConstantReadAccess {
+  RailtieClassAccess() {
+    this.getScopeExpr().(ConstantAccess).getName() = "Rails" and
+    this.getName() = ["Railtie", "Engine", "Application"]
+  }
+}
+
+// A `ClassDeclaration` that (transitively) extends `Rails::Railtie`
+private class RailtieClass extends ClassDeclaration {
+  RailtieClass() {
+    this.getSuperclassExpr() instanceof RailtieClassAccess or
+    exists(RailtieClass other | other.getModule() = resolveScopeExpr(this.getSuperclassExpr()))
+  }
+}
+
+// `Rails.application.config` calls
+private API::Node getConfigApiNode() {
+  result = API::getTopLevelMember("Rails").getReturn("application").getReturn("config")
+}
+
+// `Rails.application.configure`
+private DataFlow::CallNode getConfigureApiNode() {
+  result = API::getTopLevelMember("Rails").getReturn("application").getAMethodCall("configure")
+}
+
+private DataFlow::CallNode getAConfigureCallNode() {
+  // `Rails.application.configure`
+  result = getConfigureApiNode()
+  or
+  // `Rails::Application.configure`
+  exists(ConstantReadAccess read, RailtieClass cls |
+    read = result.getReceiver().asExpr().getExpr() and
+    resolveScopeExpr(read) = cls.getModule() and
+    result.asExpr().getExpr().(MethodCall).getMethodName() = "configure"
+  )
+}
+
+/**
+ * An access to a Rails config object.
+ */
+private class ConfigSourceNode extends DataFlow::LocalSourceNode {
+  ConfigSourceNode() {
+    // `Foo < Rails::Application ... config ...`
+    exists(MethodCall configCall | this.asExpr().getExpr() = configCall |
+      configCall.getMethodName() = "config" and
+      configCall.getEnclosingModule() instanceof RailtieClass
+    )
+    or
+    // `Rails.application.config`
+    this = getConfigApiNode().getAnImmediateUse()
+    or
+    // `Rails.application.configure { ... config ... }`
+    // `Rails::Application.configure { ... config ... }`
+    exists(DataFlow::CallNode configureCallNode, Block block, MethodCall configCall |
+      configCall = this.asExpr().getExpr()
+    |
+      configureCallNode = getAConfigureCallNode() and
+      block = configureCallNode.asExpr().getExpr().(MethodCall).getBlock() and
+      configCall.getParent+() = block and
+      configCall.getMethodName() = "config"
+    )
+  }
+}
+
+private class ConfigNode extends DataFlow::Node {
+  ConfigNode() { exists(ConfigSourceNode src | src.flowsTo(this)) }
+}
+
+// A call where the Rails application config is the receiver
+private class CallAgainstConfig extends DataFlow::CallNode {
+  CallAgainstConfig() { this.getReceiver() instanceof ConfigNode }
+
+  MethodCall getCall() { result = this.asExpr().getExpr() }
+
+  Block getBlock() { result = this.getCall().getBlock() }
+}
+
+private class ActionControllerConfigNode extends DataFlow::Node {
+  ActionControllerConfigNode() {
+    exists(CallAgainstConfig source | source.getCall().getMethodName() = "action_controller" |
+      source.flowsTo(this)
+    )
+  }
+}
+
+/** Holds if `node` can contain `value`. */
+private predicate hasBooleanValue(DataFlow::Node node, boolean value) {
+  exists(DataFlow::LocalSourceNode literal |
+    literal.asExpr().getExpr().(BooleanLiteral).getValue() = value and
+    literal.flowsTo(node)
+  )
+}
+
+// `<actionControllerConfig>.allow_forgery_protection = <verificationSetting>`
+private DataFlow::CallNode getAnAllowForgeryProtectionCall(boolean verificationSetting) {
+  exists(ActionControllerConfigNode recv |
+    // exclude some test and development configuration
+    not (
+      result.getLocation().getFile().getRelativePath().matches("%test/%") or
+      result.getLocation().getFile().getStem() = ["test", "development"]
+    ) and
+    result.getReceiver() = recv and
+    result.asExpr().getExpr().(MethodCall).getMethodName() = "allow_forgery_protection=" and
+    hasBooleanValue(result.getArgument(0), verificationSetting)
+  )
+}
+
+/**
+ * A `DataFlow::Node` that may enable or disable Rails CSRF protection in
+ * production code.
+ */
+private class AllowForgeryProtectionSetting extends CSRFProtectionSetting::Range {
+  private boolean verificationSetting;
+
+  AllowForgeryProtectionSetting() { this = getAnAllowForgeryProtectionCall(verificationSetting) }
+
+  override boolean getVerificationSetting() { result = verificationSetting }
+}
+// TODO: initialization hooks, e.g. before_configuration, after_initialize...
+// TODO: initializers

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -106,10 +106,10 @@ private predicate hasBooleanValue(DataFlow::Node node, boolean value) {
 
 // `<actionControllerConfig>.allow_forgery_protection = <verificationSetting>`
 private DataFlow::CallNode getAnAllowForgeryProtectionCall(boolean verificationSetting) {
-  // exclude some test and development configuration
+  // exclude some test configuration
   not (
     result.getLocation().getFile().getRelativePath().matches("%test/%") or
-    result.getLocation().getFile().getStem() = ["test", "development"]
+    result.getLocation().getFile().getStem() = "test"
   ) and
   result.getReceiver() instanceof ActionControllerConfigNode and
   result.asExpr().getExpr().(MethodCall).getMethodName() = "allow_forgery_protection=" and

--- a/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
+++ b/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
@@ -6,7 +6,7 @@
   <overview>
     <p>
       Cross-site request forgery (CSRF) is a type of vulnerability in which an
-      attacker  is able to force a user carry out an action that the user did
+      attacker is able to force a user carry out an action that the user did
       not intend. This may allow the attacker to perform actions on behalf of
       the targeted user.
     </p>
@@ -40,7 +40,7 @@
 
   <example>
     <p>
-      The following example shows a case where forgery protection is disabled by
+      The following example shows a case where CSRF protection is disabled by
       skipping token verification.
     </p>
 

--- a/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
+++ b/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
@@ -1,0 +1,62 @@
+<!DOCTYPE qhelp PUBLIC
+ "-//Semmle//qhelp//EN"
+ "qhelp.dtd">
+<qhelp>
+
+  <overview>
+    <p>
+      Cross-site request forgery (CSRF) is a type of vulnerability in which an
+      attacker  is able to force a user carry out an action that the user did
+      not intend. This may allow the attacker to perform actions on behalf of
+      the targeted user.
+    </p>
+
+    <p>
+      The attacker tricks an authenticated user into submitting a request to the
+      web application. Typically this request will result in a state change on
+      the server, such as changing the user's password. The request can be
+      initiated when the user visits a site controlled by the attacker. If the
+      web application relies only on cookies for authentication, or on other
+      credentials that are automatically included in the request, then this
+      request will appear as legitimate to the server.
+    </p>
+
+    <p>
+      A common countermeasure for CSRF is to generate a unique token to be
+      included in the HTML sent from the server to a user. This token can be
+      used as a hidden field to be sent back with requests to the server, where
+      the server can then check that the token is valid and associated with the
+      relevant user session.
+    </p>
+  </overview>
+
+  <recommendation>
+    <p>
+      In many web frameworks, CSRF protection is enabled by default. In these
+      cases, using the default configuration is sufficient to guard against most
+      CSRF attacks.
+    </p>
+  </recommendation>
+
+  <example>
+    <p>
+      The following example shows a case where forgery protection is disabled by
+      skipping token verification.
+    </p>
+
+    <sample src="examples/UsersController.rb"/>
+
+    <p>
+      Verification can be re-enabled by removing the call to
+      <code>skip_before_action</code>.
+    </p>
+
+  </example>
+
+  <references>
+    <li>Wikipedia: <a href="https://en.wikipedia.org/wiki/Cross-site_request_forgery">Cross-site request forgery</a></li>
+    <li>OWASP: <a href="https://owasp.org/www-community/attacks/csrf">Cross-site request forgery</a></li>
+    <li>Securing Rails Applications: <a href="https://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf">Cross-Site Request Forgery (CSRF)</a></li>
+  </references>
+
+</qhelp>

--- a/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
+++ b/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp
@@ -7,8 +7,7 @@
     <p>
       Cross-site request forgery (CSRF) is a type of vulnerability in which an
       attacker is able to force a user carry out an action that the user did
-      not intend. This may allow the attacker to perform actions on behalf of
-      the targeted user.
+      not intend.
     </p>
 
     <p>

--- a/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.ql
+++ b/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.ql
@@ -1,0 +1,19 @@
+/**
+ * @name CSRF protection disabled
+ * @description Disabling CSRF protection makes the application vulnerable to
+ *              a Cross-Site Request Forgery (CSRF) attack.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 8.8
+ * @precision high
+ * @id rb/csrf-protection-disabled
+ * @tags security
+ *       external/cwe/cwe-352
+ */
+
+import ruby
+import codeql.ruby.Concepts
+
+from CSRFProtectionSetting s
+where s.getVerificationSetting() = false
+select s, "Potential CSRF vulnerability due to forgery protection being disabled."

--- a/ruby/ql/src/queries/security/cwe-352/examples/UsersController.rb
+++ b/ruby/ql/src/queries/security/cwe-352/examples/UsersController.rb
@@ -1,0 +1,3 @@
+class UsersController < ApplicationController
+  skip_before_action :verify_authenticity_token
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/CSRFProtectionDisabled.expected
+++ b/ruby/ql/test/query-tests/security/cwe-352/CSRFProtectionDisabled.expected
@@ -1,3 +1,4 @@
 | railsapp/app/controllers/users_controller.rb:4:3:4:47 | call to skip_before_action | Potential CSRF vulnerability due to forgery protection being disabled. |
 | railsapp/config/application.rb:15:5:15:53 | call to allow_forgery_protection= | Potential CSRF vulnerability due to forgery protection being disabled. |
+| railsapp/config/environments/development.rb:5:3:5:51 | call to allow_forgery_protection= | Potential CSRF vulnerability due to forgery protection being disabled. |
 | railsapp/config/environments/production.rb:5:3:5:51 | call to allow_forgery_protection= | Potential CSRF vulnerability due to forgery protection being disabled. |

--- a/ruby/ql/test/query-tests/security/cwe-352/CSRFProtectionDisabled.expected
+++ b/ruby/ql/test/query-tests/security/cwe-352/CSRFProtectionDisabled.expected
@@ -1,0 +1,3 @@
+| railsapp/app/controllers/users_controller.rb:4:3:4:47 | call to skip_before_action | Potential CSRF vulnerability due to forgery protection being disabled. |
+| railsapp/config/application.rb:15:5:15:53 | call to allow_forgery_protection= | Potential CSRF vulnerability due to forgery protection being disabled. |
+| railsapp/config/environments/production.rb:5:3:5:51 | call to allow_forgery_protection= | Potential CSRF vulnerability due to forgery protection being disabled. |

--- a/ruby/ql/test/query-tests/security/cwe-352/CSRFProtectionDisabled.qlref
+++ b/ruby/ql/test/query-tests/security/cwe-352/CSRFProtectionDisabled.qlref
@@ -1,0 +1,1 @@
+queries/security/cwe-352/CSRFProtectionDisabled.ql

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/app/controllers/application_controller.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/app/controllers/users_controller.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+class UsersController < ApplicationController
+
+  # BAD: Disabling forgery protection may open the application to CSRF attacks
+  skip_before_action :verify_authenticity_token
+
+  def change_email
+    user = User.find_by(name: params[:user_name])
+    user.email = params[:new_email]
+    user.save!
+  end
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/application.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/application.rb
@@ -1,0 +1,17 @@
+require_relative 'boot'
+
+require 'rails/all'
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module Railsapp
+  class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 6.0
+
+    # BAD: Disabling forgery protection may open the application to CSRF attacks
+    config.action_controller.allow_forgery_protection = false
+  end
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environment.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environment.rb
@@ -1,0 +1,5 @@
+# Load the Rails application.
+require_relative 'application'
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environments/development.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environments/development.rb
@@ -1,0 +1,6 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # GOOD: disabling CSRF protection in the development environment should not be flagged
+  config.action_controller.allow_forgery_protection = false
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environments/production.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environments/production.rb
@@ -1,0 +1,6 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # BAD: Disabling forgery protection may open the application to CSRF attacks
+  config.action_controller.allow_forgery_protection = false
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environments/test.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/config/environments/test.rb
@@ -1,0 +1,11 @@
+# The test environment is used exclusively to run your application's
+# test suite. You never need to work with it otherwise. Remember that
+# your test database is "scratch space" for the test suite and is wiped
+# and recreated between test runs. Don't rely on the data there!
+
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # GOOD: disabling CSRF protection in the test environment should not be flagged
+  config.action_controller.allow_forgery_protection = false
+end

--- a/ruby/ql/test/query-tests/security/cwe-352/railsapp/test/controllers/users_controller_test.rb
+++ b/ruby/ql/test/query-tests/security/cwe-352/railsapp/test/controllers/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UsersControllerTest < ActiveSupport::TestCase
+  setup do
+    # GOOD: disabling CSRF protection in tests should not be flagged
+    config.action_controller.allow_forgery_protection = false
+  end
+end


### PR DESCRIPTION
Finds cases in Rails apps where either `config.action_controller.allow_forgery_protection` is set to `false`, or where token verification is disabled in a controller through `skip_forgery_protection` or `skip_before_action :verify_authenticity_token`.

The bulk of this PR is modelling some core Rails classes and methods. This is separated out from the rest of the `ActiveRecord`, `ActionController`, etc. modelling as it's not generally specific to any one of them.

I suspect that the `@security-severity` on this may be a bit high - since CSRF protection is enabled by default in Rails, the cases where it's explicitly turned off tend to be deliberate, and there are often custom protections in place that this query can't detect. 

Despite this, I think the query is worth including. Because CSRF protection is enabled by default, cases where it's disabled are relatively uncommon and shouldn't be too overwhelming to review and fix or dismiss on most codebases.

I've made some basic efforts to exclude configuration for test and development environments from the results here. A possible refinement could be to look at the control flow graph leading up places where forgery protection is disabled and to see if this is guarded by a check on the current Rails environment.