### PR TITLE
C#: Remove macos compatibility stanzas from tracing config.

### DIFF
--- a/csharp/tools/osx64/compiler-tracing.spec
+++ b/csharp/tools/osx64/compiler-tracing.spec
@@ -14,18 +14,3 @@
   replace yes
   invoke ${compiler}
   append /p:UseSharedCompilation=false
-/usr/bin/codesign:
-  replace yes
-  invoke /usr/bin/env
-  prepend /usr/bin/codesign
-  trace no
-/usr/bin/pkill:
-  replace yes
-  invoke /usr/bin/env
-  prepend /usr/bin/pkill
-  trace no
-/usr/bin/pgrep:
-  replace yes
-  invoke /usr/bin/env
-  prepend /usr/bin/pgrep
-  trace no


### PR DESCRIPTION
As outlined in github/semmle-code#40797, we do not need these stanzas anymore.