### PR TITLE
Java: Fix bad magic in SynchSetUnsynchGet.

### DIFF
--- a/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
@@ -35,6 +35,7 @@ predicate isSynchronizedByBlock(Method m) {
  * In this case, even if `set` is synchronized and `get` is not, `get` will never see stale
  * values for the field, so synchronization is optional.
  */
+pragma[nomagic]
 predicate bothAccessVolatileField(Method set, Method get) {
   exists(Field f | f.isVolatile() |
     f = get.(GetterMethod).getField() and


### PR DESCRIPTION
Recent optimiser changes appear to have introduced bad magic here, which have been observed to cost more than an hour to evaluate on at least one project. This fix makes the query evaluate in a few seconds.