### PR TITLE
JS: add cwe-942 to `js/cors-misconfiguration-for-credentials`

### DIFF
--- a/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.ql
+++ b/javascript/ql/src/Security/CWE-346/CorsMisconfigurationForCredentials.ql
@@ -9,6 +9,7 @@
  * @tags security
  *       external/cwe/cwe-346
  *       external/cwe/cwe-639
+ *       external/cwe/cwe-942
  */
 
 import javascript


### PR DESCRIPTION
[CWE-942: Permissive Cross-domain Policy with Untrusted Domains](https://cwe.mitre.org/data/definitions/942.html).  

The CWE was already used in [this similar experimental go query](https://github.com/github/codeql-go/blob/main/ql/src/experimental/CWE-942/CorsMisconfiguration.ql). 