### PR TITLE
JS: add cwe-297 to `js/disabling-certificate-validation`

### DIFF
--- a/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
+++ b/javascript/ql/src/Security/CWE-295/DisablingCertificateValidation.ql
@@ -8,6 +8,7 @@
  * @id js/disabling-certificate-validation
  * @tags security
  *       external/cwe/cwe-295
+ *       external/cwe/cwe-297
  */
 
 import javascript


### PR DESCRIPTION
[CWE-297: Improper Validation of Certificate with Host Mismatch](https://cwe.mitre.org/data/definitions/297.html). 

The CWE was already used in [this similar Java query](https://github.com/github/codeql/blob/main/java/ql/src/Security/CWE/CWE-297/UnsafeHostnameVerification.ql). 