### PR TITLE
Ruby: Downgrade `rb/hardcoded-credentials` precision from high to medium

### DIFF
--- a/ruby/change-notes/2021-11-08-hardcoded-credentials-downgrade.md
+++ b/ruby/change-notes/2021-11-08-hardcoded-credentials-downgrade.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The precision of "Hard-coded credentials" (`rb/hardcoded-credentials`) has been decreased from "high" to "medium". This query will no longer be run and displayed by default on Code Scanning and LGTM.

--- a/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
+++ b/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
@@ -4,7 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @security-severity 9.8
- * @precision high
+ * @precision medium
  * @id rb/hardcoded-credentials
  * @tags security
  *       external/cwe/cwe-259


### PR DESCRIPTION
We've had some feedback around noisy results from this query.

It seems to make sense to downgrade this query so that it's not run as part of the default code scanning suite, as it overlaps with secret scanning functionality. The query will remain in the `security-extended` suite.

@turbo 