### PR TITLE
JS: Limited tracking of object literals with methods

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -223,7 +223,7 @@ module CallGraph {
   }
 
   /**
-   * Gets a step summary that object literals we permit when tracking object literals.
+   * Gets a step summary for tracking object literals.
    *
    * To avoid false flow from callbacks passed in via "named parameters", we only track object
    * literals out of returns, not into calls.
@@ -236,6 +236,6 @@ module CallGraph {
     shouldTrackObjectLiteral(node) and
     result = node
     or
-    StepSummary::step(getAnObjectLiteralRef(node), result, [objectLiteralStep()])
+    StepSummary::step(getAnObjectLiteralRef(node), result, objectLiteralStep())
   }
 }

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -79,6 +79,12 @@ module CallGraph {
       cls.getAClassReference(t.continue()) = result
     )
     or
+    exists(DataFlow::ObjectLiteralNode object, string prop |
+      function = object.getAPropertySource(prop) and
+      result = getAnObjectLiteralRef(object).getAPropertyRead(prop) and
+      t.start()
+    )
+    or
     exists(DataFlow::FunctionNode outer |
       result = getAFunctionReference(outer, 0, t.continue()).getAnInvocation() and
       locallyReturnedFunction(outer, function)
@@ -197,11 +203,39 @@ module CallGraph {
     )
     or
     exists(DataFlow::ObjectLiteralNode object, string name |
-      ref = object.getAPropertyRead(name) and
+      ref = getAnObjectLiteralRef(object).getAPropertyRead(name) and
       result = object.getPropertyGetter(name)
       or
-      ref = object.getAPropertyWrite(name) and
+      ref = getAnObjectLiteralRef(object).getAPropertyWrite(name) and
       result = object.getPropertySetter(name)
     )
+  }
+
+  private predicate shouldTrackObjectLiteral(DataFlow::ObjectLiteralNode node) {
+    (
+      node.getAPropertySource() instanceof DataFlow::FunctionNode
+      or
+      exists(node.getPropertyGetter(_))
+      or
+      exists(node.getPropertySetter(_))
+    ) and
+    not node.getTopLevel().isExterns()
+  }
+
+  /**
+   * Gets a step summary that object literals we permit when tracking object literals.
+   *
+   * To avoid false flow from callbacks passed in via "named parameters", we only track object
+   * literals out of returns, not into calls.
+   */
+  private StepSummary objectLiteralStep() { result = LevelStep() or result = ReturnStep() }
+
+  /** Gets a node that refers to the given object literal, via a limited form of type tracking. */
+  cached
+  DataFlow::SourceNode getAnObjectLiteralRef(DataFlow::ObjectLiteralNode node) {
+    shouldTrackObjectLiteral(node) and
+    result = node
+    or
+    StepSummary::step(getAnObjectLiteralRef(node), result, [objectLiteralStep()])
   }
 }


### PR DESCRIPTION
Improves the call graph by tracking object literals with methods on them with a limited form of type tracking. Compared to full type-tracking it is limited in two ways:
- Object literals are not tracked into calls. This is due to risk of false flow when passed in as a "named callback".
- Object literals are not tracked with a type-tracker instance, and so cannot be tracked through properties in as many cases.

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/type-track-obje__default__dist-compare__1/reports) on the default 100 projects shows neutral performance, over 3000 new call edges, and a couple new results.