### PR TITLE
Ruby: Cleanup flow through `self`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/Expr.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Expr.qll
@@ -24,21 +24,8 @@ class Expr extends Stmt, TExpr {
   }
 }
 
-/**
- * A reference to the current object. For example:
- * - `self == other`
- * - `self.method_name`
- * - `def self.method_name ... end`
- *
- * This also includes implicit references to the current object in method
- * calls.  For example, the method call `foo(123)` has an implicit `self`
- * receiver, and is equivalent to the explicit `self.foo(123)`.
- */
-class Self extends Expr, TSelf {
-  final override string getAPrimaryQlClass() { result = "Self" }
-
-  final override string toString() { result = "self" }
-}
+/** DEPRECATED: Use `SelfVariableAccess` instead. */
+deprecated class Self = SelfVariableAccess;
 
 /**
  * A sequence of expressions in the right-hand side of an assignment or

--- a/ruby/ql/lib/codeql/ruby/ast/Variable.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Variable.qll
@@ -201,7 +201,16 @@ class ClassVariableWriteAccess extends ClassVariableAccess, VariableWriteAccess 
 /** An access to a class variable where the value is read. */
 class ClassVariableReadAccess extends ClassVariableAccess, VariableReadAccess { }
 
-/** An access to the `self` variable */
+/**
+ * An access to the `self` variable. For example:
+ * - `self == other`
+ * - `self.method_name`
+ * - `def self.method_name ... end`
+ *
+ * This also includes implicit references to the current object in method
+ * calls.  For example, the method call `foo(123)` has an implicit `self`
+ * receiver, and is equivalent to the explicit `self.foo(123)`.
+ */
 class SelfVariableAccess extends LocalVariableAccess instanceof SelfVariableAccessImpl {
   final override string getAPrimaryQlClass() { result = "SelfVariableAccess" }
 }

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Module.qll
@@ -73,7 +73,7 @@ private module Cached {
       m = resolveConstantReadAccess(c.getReceiver())
       or
       m = enclosingModule(c).getModule() and
-      c.getReceiver() instanceof Self
+      c.getReceiver() instanceof SelfVariableAccess
     ) and
     result = resolveConstantReadAccess(c.getAnArgument())
   }
@@ -437,7 +437,7 @@ private module ResolveImpl {
         encl = enclosingModule(this) and
         result = [qualifiedModuleNameNonRec(encl, _, _), qualifiedModuleNameRec(encl, _, _)]
       |
-        this.getReceiver() instanceof Self
+        this.getReceiver() instanceof SelfVariableAccess
         or
         not exists(this.getReceiver())
       )

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Variable.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Variable.qll
@@ -366,7 +366,23 @@ private module Cached {
 
   cached
   predicate isCapturedAccess(LocalVariableAccess access) {
-    access.getVariable().getDeclaringScope() != access.getCfgScope()
+    exists(Scope scope1, Scope scope2 |
+      scope1 = access.getVariable().getDeclaringScope() and
+      scope2 = access.getCfgScope() and
+      scope1 != scope2
+    |
+      if access instanceof SelfVariableAccess
+      then
+        // ```
+        // class C
+        //   def self.m // not a captured access
+        //   end
+        // end
+        // ```
+        not scope2 instanceof Toplevel or
+        not access = any(SingletonMethod m).getObject()
+      else any()
+    )
   }
 
   cached

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -14,7 +14,7 @@ class EntryNode extends CfgNode, TEntryNode {
 
   EntryNode() { this = TEntryNode(scope) }
 
-  final override EntryBasicBlock getBasicBlock() { result = CfgNode.super.getBasicBlock() }
+  final override EntryBasicBlock getBasicBlock() { result = super.getBasicBlock() }
 
   final override Location getLocation() { result = scope.getLocation() }
 
@@ -31,7 +31,7 @@ class AnnotatedExitNode extends CfgNode, TAnnotatedExitNode {
   /** Holds if this node represent a normal exit. */
   final predicate isNormal() { normal = true }
 
-  final override AnnotatedExitBasicBlock getBasicBlock() { result = CfgNode.super.getBasicBlock() }
+  final override AnnotatedExitBasicBlock getBasicBlock() { result = super.getBasicBlock() }
 
   final override Location getLocation() { result = scope.getLocation() }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
@@ -316,7 +316,7 @@ module Ssa {
     CapturedCallDefinition() {
       exists(Variable v, BasicBlock bb, int i |
         this.definesAt(v, bb, i) and
-        SsaImpl::capturedCallWrite(bb, i, v)
+        SsaImpl::capturedCallWrite(_, bb, i, v)
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/SSA.qll
@@ -233,6 +233,8 @@ module Ssa {
       )
     }
 
+    override SelfVariable getSourceVariable() { result = v }
+
     final override string toString() { result = "self (" + v.getDeclaringScope() + ")" }
 
     final override Location getLocation() { result = this.getControlFlowNode().getLocation() }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -232,6 +232,18 @@ private module Cached {
     )
   }
 
+  /** Gets a viable run-time target for the call `call`. */
+  cached
+  DataFlowCallable viableCallable(DataFlowCall call) {
+    result = TCfgScope(getTarget(call.asCall())) and
+    not call.asCall().getExpr() instanceof YieldCall // handled by `lambdaCreation`/`lambdaCall`
+    or
+    exists(LibraryCallable callable |
+      result = TLibraryCallable(callable) and
+      call.asCall().getExpr() = callable.getACall()
+    )
+  }
+
   cached
   newtype TArgumentPosition =
     TSelfArgumentPosition() or
@@ -421,17 +433,6 @@ private DataFlow::LocalSourceNode trackModuleRec(Module tp, TypeTracker t, StepS
 
 private DataFlow::LocalSourceNode trackModule(Module tp) {
   result = trackModule(tp, TypeTracker::end())
-}
-
-/** Gets a viable run-time target for the call `call`. */
-DataFlowCallable viableCallable(DataFlowCall call) {
-  result = TCfgScope(getTarget(call.asCall())) and
-  not call.asCall().getExpr() instanceof YieldCall // handled by `lambdaCreation`/`lambdaCall`
-  or
-  exists(LibraryCallable callable |
-    result = TLibraryCallable(callable) and
-    call.asCall().getExpr() = callable.getACall()
-  )
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -203,7 +203,7 @@ private module Cached {
           result = lookupMethod(tp, method) and
           if result.(Method).isPrivate()
           then
-            exists(Self self |
+            exists(SelfVariableAccess self |
               self = call.getReceiver().getExpr() and
               pragma[only_bind_out](self.getEnclosingModule().getModule().getSuperClass*()) =
                 pragma[only_bind_out](result.getEnclosingModule().getModule())
@@ -300,28 +300,14 @@ private DataFlow::LocalSourceNode trackInstance(Module tp, TypeTracker t) {
     )
     or
     // `self` in method
-    exists(Self self, Method enclosing |
-      self = result.asExpr().getExpr() and
-      enclosing = self.getEnclosingMethod() and
-      tp = enclosing.getEnclosingModule().getModule() and
-      not self.getEnclosingModule().getEnclosingMethod() = enclosing
-    )
+    tp = result.(SsaSelfDefinitionNode).getSelfScope().(Method).getEnclosingModule().getModule()
     or
     // `self` in singleton method
-    exists(Self self, MethodBase enclosing |
-      self = result.asExpr().getExpr() and
-      flowsToSingletonMethodObject(trackInstance(tp), enclosing) and
-      enclosing = self.getEnclosingMethod() and
-      not self.getEnclosingModule().getEnclosingMethod() = enclosing
-    )
+    flowsToSingletonMethodObject(trackInstance(tp), result.(SsaSelfDefinitionNode).getSelfScope())
     or
     // `self` in top-level
-    exists(Self self, Toplevel enclosing |
-      self = result.asExpr().getExpr() and
-      enclosing = self.getEnclosingModule() and
-      tp = TResolved("Object") and
-      not self.getEnclosingMethod().getEnclosingModule() = enclosing
-    )
+    result.(SsaSelfDefinitionNode).getSelfScope() instanceof Toplevel and
+    tp = TResolved("Object")
     or
     // a module or class
     exists(Module m |
@@ -371,7 +357,7 @@ private predicate singletonMethod(MethodBase method, Expr object) {
 
 pragma[nomagic]
 private predicate flowsToSingletonMethodObject(DataFlow::LocalSourceNode nodeFrom, MethodBase method) {
-  exists(DataFlow::LocalSourceNode nodeTo |
+  exists(DataFlow::Node nodeTo |
     nodeFrom.flowsTo(nodeTo) and
     singletonMethod(method, nodeTo.asExpr().getExpr())
   )
@@ -409,13 +395,8 @@ private DataFlow::LocalSourceNode trackSingletonMethod(MethodBase m, string name
   name = m.getName()
 }
 
-private DataFlow::Node selfInModule(Module tp) {
-  exists(Self self, ModuleBase enclosing |
-    self = result.asExpr().getExpr() and
-    enclosing = self.getEnclosingModule() and
-    tp = enclosing.getModule() and
-    not self.getEnclosingMethod().getEnclosingModule() = enclosing
-  )
+private SsaSelfDefinitionNode selfInModule(Module tp) {
+  tp = result.getSelfScope().(ModuleBase).getModule()
 }
 
 private DataFlow::LocalSourceNode trackModule(Module tp, TypeTracker t) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -70,6 +70,20 @@ module LocalFlow {
     )
   }
 
+  /** Gets the SSA definition node corresponding to the implicit `self` parameter for `m`. */
+  private SsaDefinitionNode getSelfParameterDefNode(MethodBase m) {
+    result.getDefinition().(Ssa::SelfDefinition).getSourceVariable().getDeclaringScope() = m
+  }
+
+  /**
+   * Holds if `nodeFrom` is a parameter node, and `nodeTo` is a corresponding SSA node.
+   */
+  predicate localFlowSsaParamInput(Node nodeFrom, Node nodeTo) {
+    nodeTo = getParameterDefNode(nodeFrom.(ParameterNode).getParameter())
+    or
+    nodeTo = getSelfParameterDefNode(nodeFrom.(SelfParameterNode).getMethod())
+  }
+
   /**
    * Holds if there is a local use-use flow step from `nodeFrom` to `nodeTo`
    * involving SSA definition `def`.
@@ -114,9 +128,6 @@ module LocalFlow {
 
   predicate localFlowStepCommon(Node nodeFrom, Node nodeTo) {
     localSsaFlowStep(nodeFrom, nodeTo)
-    or
-    nodeFrom.(SelfParameterNode).getMethod() = nodeTo.asExpr().getExpr().getEnclosingCallable() and
-    nodeTo.asExpr().getExpr() instanceof Self
     or
     nodeFrom.asExpr() = nodeTo.asExpr().(CfgNodes::ExprNodes::AssignExprCfgNode).getRhs()
     or
@@ -236,7 +247,7 @@ private module Cached {
     or
     defaultValueFlow(nodeTo.(ParameterNode).getParameter(), nodeFrom)
     or
-    nodeTo = LocalFlow::getParameterDefNode(nodeFrom.(ParameterNode).getParameter())
+    LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
     or
     nodeTo.(SynthReturnNode).getAnInput() = nodeFrom
     or
@@ -253,7 +264,7 @@ private module Cached {
     or
     defaultValueFlow(nodeTo.(ParameterNode).getParameter(), nodeFrom)
     or
-    nodeTo = LocalFlow::getParameterDefNode(nodeFrom.(ParameterNode).getParameter())
+    LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
     or
     LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo)
     or
@@ -275,27 +286,34 @@ private module Cached {
     LocalFlow::localSsaFlowStepUseUse(_, nodeFrom, nodeTo)
   }
 
+  private predicate entrySsaDefinition(SsaDefinitionNode n) {
+    n = LocalFlow::getParameterDefNode(_)
+    or
+    exists(Ssa::Definition def | def = n.getDefinition() |
+      def instanceof Ssa::SelfDefinition
+      or
+      def instanceof Ssa::CapturedEntryDefinition
+    )
+  }
+
   cached
   predicate isLocalSourceNode(Node n) {
     n instanceof ParameterNode
     or
-    // This case should not be needed once we have proper use-use flow
-    // for `self`. At that point, the `self`s returned by `trackInstance`
-    // in `DataFlowDispatch.qll` should refer to the post-update node,
-    // and we can remove this case.
-    n.asExpr().getExpr() instanceof Self
+    n instanceof PostUpdateNodes::ExprPostUpdateNode
     or
-    // Nodes that can't be reached from another parameter or expression.
-    not localFlowStepTypeTracker+(any(Node e |
-        e instanceof ExprNode
+    // Expressions that can't be reached from another entry definition or expression.
+    not localFlowStepTypeTracker+(any(Node n0 |
+        n0 instanceof ExprNode
         or
-        e instanceof ParameterNode
-      ), n)
+        entrySsaDefinition(n0)
+      ), n.(ExprNode))
     or
-    // Ensure all parameter SSA nodes are local sources -- this is needed by type tracking.
-    // Note that when the parameter has a default value, it will be reachable from an
-    // expression (the default value) and therefore won't be caught by the rule above.
-    n = LocalFlow::getParameterDefNode(_)
+    // Ensure all entry SSA definitions are local sources -- for parameters, this
+    // is needed by type tracking. Note that when the parameter has a default value,
+    // it will be reachable from an expression (the default value) and therefore
+    // won't be caught by the rule above.
+    entrySsaDefinition(n)
   }
 
   cached
@@ -356,6 +374,16 @@ class SsaDefinitionNode extends NodeImpl, TSsaDefinitionNode {
   override Location getLocationImpl() { result = def.getLocation() }
 
   override string toStringImpl() { result = def.toString() }
+}
+
+/** An SSA definition for a `self` variable. */
+class SsaSelfDefinitionNode extends LocalSourceNode, SsaDefinitionNode {
+  private SelfVariable self;
+
+  SsaSelfDefinitionNode() { self = def.getSourceVariable() }
+
+  /** Gets the scope in which the `self` variable is declared. */
+  Scope getSelfScope() { result = self.getDeclaringScope() }
 }
 
 /**
@@ -744,13 +772,6 @@ predicate jumpStep(Node pred, Node succ) {
   or
   SsaImpl::captureFlowOut(pred.(SsaDefinitionNode).getDefinition(),
     succ.(SsaDefinitionNode).getDefinition())
-  or
-  exists(Self s, Method m |
-    s = succ.asExpr().getExpr() and
-    pred.(SelfParameterNode).getMethod() = m and
-    m = s.getEnclosingMethod() and
-    m != s.getEnclosingCallable()
-  )
   or
   succ.asExpr().getExpr().(ConstantReadAccess).getValue() = pred.asExpr().getExpr()
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -1,4 +1,5 @@
 private import SsaImplCommon
+private import SsaImplSpecific as SsaImplSpecific
 private import codeql.ruby.AST
 private import codeql.ruby.CFG
 private import codeql.ruby.ast.Variable
@@ -58,13 +59,15 @@ private predicate hasCapturedRead(Variable v, CfgScope scope) {
 }
 
 pragma[noinline]
+private predicate variableWriteInOuterScope(BasicBlock bb, LocalVariable v, CfgScope scope) {
+  SsaImplSpecific::variableWrite(bb, _, v, _) and
+  scope.getOuterCfgScope() = bb.getScope()
+}
+
+pragma[noinline]
 private predicate hasVariableWriteWithCapturedRead(BasicBlock bb, LocalVariable v, CfgScope scope) {
   hasCapturedRead(v, scope) and
-  exists(VariableWriteAccess write |
-    write = bb.getANode().getNode() and
-    write.getVariable() = v and
-    bb.getScope() = scope.getOuterCfgScope()
-  )
+  variableWriteInOuterScope(bb, v, scope)
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -41,23 +41,21 @@ private predicate capturedExitRead(AnnotatedExitBasicBlock bb, int i, LocalVaria
   i = bb.length()
 }
 
-private CfgScope getCaptureOuterCfgScope(CfgScope scope) {
-  result = scope.getOuterCfgScope() and
-  (
-    scope instanceof Block
-    or
-    scope instanceof Lambda
-  )
-}
-
-/** Holds if captured variable `v` is read inside `scope`. */
+/**
+ * Holds if captured variable `v` is read directly inside `scope`,
+ * or inside a (transitively) nested scope of `scope`.
+ */
 pragma[noinline]
 private predicate hasCapturedRead(Variable v, CfgScope scope) {
   any(LocalVariableReadAccess read |
-    read.getVariable() = v and scope = getCaptureOuterCfgScope*(read.getCfgScope())
+    read.getVariable() = v and scope = read.getCfgScope().getOuterCfgScope*()
   ).isCapturedAccess()
 }
 
+/**
+ * Holds if `v` is written inside basic block `bb`, which is in the immediate
+ * outer scope of `scope`.
+ */
 pragma[noinline]
 private predicate variableWriteInOuterScope(BasicBlock bb, LocalVariable v, CfgScope scope) {
   SsaImplSpecific::variableWrite(bb, _, v, _) and
@@ -71,28 +69,20 @@ private predicate hasVariableWriteWithCapturedRead(BasicBlock bb, LocalVariable 
 }
 
 /**
- * Holds if the call at index `i` in basic block `bb` may reach a callable
- * that reads captured variable `v`.
+ * Holds if the call `call` at index `i` in basic block `bb` may reach
+ * a callable that reads captured variable `v`.
  */
-private predicate capturedCallRead(BasicBlock bb, int i, LocalVariable v) {
+private predicate capturedCallRead(Call call, BasicBlock bb, int i, LocalVariable v) {
   exists(CfgScope scope |
     hasVariableWriteWithCapturedRead(bb.getAPredecessor*(), v, scope) and
-    bb.getNode(i).getNode() instanceof Call
+    call = bb.getNode(i).getNode()
   |
-    not scope instanceof Block
-    or
     // If the read happens inside a block, we restrict to the call that
     // contains the block
-    scope = any(MethodCall c | bb.getNode(i) = c.getAControlFlowNode()).getBlock()
+    not scope instanceof Block
+    or
+    scope = call.(MethodCall).getBlock()
   )
-}
-
-/** Holds if captured variable `v` is written inside `scope`. */
-pragma[noinline]
-private predicate hasCapturedWrite(Variable v, CfgScope scope) {
-  any(LocalVariableWriteAccess write |
-    write.getVariable() = v and scope = getCaptureOuterCfgScope*(write.getCfgScope())
-  ).isCapturedAccess()
 }
 
 /** Holds if `v` is read at index `i` in basic block `bb`. */
@@ -107,21 +97,38 @@ predicate variableRead(BasicBlock bb, int i, LocalVariable v, boolean certain) {
   variableReadActual(bb, i, v) and
   certain = true
   or
-  capturedCallRead(bb, i, v) and
+  capturedCallRead(_, bb, i, v) and
   certain = false
   or
   capturedExitRead(bb, i, v) and
   certain = false
 }
 
+/**
+ * Holds if captured variable `v` is written directly inside `scope`,
+ * or inside a (transitively) nested scope of `scope`.
+ */
+pragma[noinline]
+private predicate hasCapturedWrite(Variable v, CfgScope scope) {
+  any(LocalVariableWriteAccess write |
+    write.getVariable() = v and scope = write.getCfgScope().getOuterCfgScope*()
+  ).isCapturedAccess()
+}
+
+/**
+ * Holds if `v` is read inside basic block `bb`, which is in the immediate
+ * outer scope of `scope`.
+ */
+pragma[noinline]
+private predicate variableReadActualInOuterScope(BasicBlock bb, LocalVariable v, CfgScope scope) {
+  variableReadActual(bb, _, v) and
+  bb.getScope() = scope.getOuterCfgScope()
+}
+
 pragma[noinline]
 private predicate hasVariableReadWithCapturedWrite(BasicBlock bb, LocalVariable v, CfgScope scope) {
   hasCapturedWrite(v, scope) and
-  exists(VariableReadAccess read |
-    read = bb.getANode().getNode() and
-    read.getVariable() = v and
-    bb.getScope() = scope.getOuterCfgScope()
-  )
+  variableReadActualInOuterScope(bb, v, scope)
 }
 
 cached
@@ -137,20 +144,20 @@ private module Cached {
   }
 
   /**
-   * Holds if the call at index `i` in basic block `bb` may reach a callable
+   * Holds if the call `call` at index `i` in basic block `bb` may reach a callable
    * that writes captured variable `v`.
    */
   cached
-  predicate capturedCallWrite(BasicBlock bb, int i, LocalVariable v) {
+  predicate capturedCallWrite(Call call, BasicBlock bb, int i, LocalVariable v) {
     exists(CfgScope scope |
       hasVariableReadWithCapturedWrite(bb.getASuccessor*(), v, scope) and
-      bb.getNode(i).getNode() instanceof Call
+      call = bb.getNode(i).getNode()
     |
-      not scope instanceof Block
-      or
       // If the write happens inside a block, we restrict to the call that
       // contains the block
-      scope = any(MethodCall c | bb.getNode(i) = c.getAControlFlowNode()).getBlock()
+      not scope instanceof Block
+      or
+      scope = call.(MethodCall).getBlock()
     )
   }
 
@@ -180,6 +187,26 @@ private module Cached {
     )
   }
 
+  pragma[noinline]
+  private predicate defReachesCallReadInOuterScope(
+    Definition def, Call call, LocalVariable v, CfgScope scope
+  ) {
+    exists(BasicBlock bb, int i |
+      ssaDefReachesRead(v, def, bb, i) and
+      capturedCallRead(call, bb, i, v) and
+      scope.getOuterCfgScope() = bb.getScope()
+    )
+  }
+
+  pragma[noinline]
+  private predicate hasCapturedEntryWrite(Definition entry, LocalVariable v, CfgScope scope) {
+    exists(BasicBlock bb, int i |
+      capturedEntryWrite(bb, i, v) and
+      entry.definesAt(v, bb, i) and
+      bb.getScope().getOuterCfgScope*() = scope
+    )
+  }
+
   /**
    * Holds if there is flow for a captured variable from the enclosing scope into a block.
    * ```rb
@@ -191,13 +218,35 @@ private module Cached {
    */
   cached
   predicate captureFlowIn(Definition def, Definition entry) {
-    exists(LocalVariable v, BasicBlock bb, int i |
+    exists(Call call, LocalVariable v, CfgScope scope |
+      defReachesCallReadInOuterScope(def, call, v, scope) and
+      hasCapturedEntryWrite(entry, v, scope)
+    |
+      // If the read happens inside a block, we restrict to the call that
+      // contains the block
+      not scope instanceof Block
+      or
+      scope = call.(MethodCall).getBlock()
+    )
+  }
+
+  private import codeql.ruby.dataflow.SSA
+
+  pragma[noinline]
+  private predicate defReachesExitReadInInnerScope(Definition def, LocalVariable v, CfgScope scope) {
+    exists(BasicBlock bb, int i |
       ssaDefReachesRead(v, def, bb, i) and
-      capturedCallRead(bb, i, v) and
-      exists(BasicBlock bb2, int i2 |
-        capturedEntryWrite(bb2, i2, v) and
-        entry.definesAt(v, bb2, i2)
-      )
+      capturedExitRead(bb, i, v) and
+      scope = bb.getScope().getOuterCfgScope*()
+    )
+  }
+
+  pragma[noinline]
+  private predicate hasCapturedExitRead(Definition exit, Call call, LocalVariable v, CfgScope scope) {
+    exists(BasicBlock bb, int i |
+      capturedCallWrite(call, bb, i, v) and
+      exit.definesAt(v, bb, i) and
+      bb.getScope() = scope.getOuterCfgScope()
     )
   }
 
@@ -213,13 +262,15 @@ private module Cached {
    */
   cached
   predicate captureFlowOut(Definition def, Definition exit) {
-    exists(LocalVariable v, BasicBlock bb, int i |
-      ssaDefReachesRead(v, def, bb, i) and
-      capturedExitRead(bb, i, v) and
-      exists(BasicBlock bb2, int i2 |
-        capturedCallWrite(bb2, i2, v) and
-        exit.definesAt(v, bb2, i2)
-      )
+    exists(Call call, LocalVariable v, CfgScope scope |
+      defReachesExitReadInInnerScope(def, v, scope) and
+      hasCapturedExitRead(exit, call, v, _)
+    |
+      // If the read happens inside a block, we restrict to the call that
+      // contains the block
+      not scope instanceof Block
+      or
+      scope = call.(MethodCall).getBlock()
     )
   }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImplSpecific.qll
@@ -40,7 +40,7 @@ predicate variableWrite(BasicBlock bb, int i, SourceVariable v, boolean certain)
   ) and
   certain = true
   or
-  SsaImpl::capturedCallWrite(bb, i, v) and
+  SsaImpl::capturedCallWrite(_, bb, i, v) and
   certain = false
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPublic.qll
@@ -20,14 +20,4 @@ predicate localExprTaint(CfgNodes::ExprCfgNode e1, CfgNodes::ExprCfgNode e2) {
   localTaint(DataFlow::exprNode(e1), DataFlow::exprNode(e2))
 }
 
-/**
- * Holds if taint propagates from `nodeFrom` to `nodeTo` in exactly one local
- * (intra-procedural) step.
- */
-predicate localTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-  defaultAdditionalTaintStep(nodeFrom, nodeTo)
-  or
-  // Simple flow through library code is included in the exposed local
-  // step relation, even though flow is technically inter-procedural
-  FlowSummaryImpl::Private::Steps::summaryThroughStep(nodeFrom, nodeTo, false)
-}
+predicate localTaintStep = localTaintStepCached/2;

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -105,7 +105,7 @@ private class ActionControllerContextCall extends MethodCall {
   private ActionControllerControllerClass controllerClass;
 
   ActionControllerContextCall() {
-    this.getReceiver() instanceof Self and
+    this.getReceiver() instanceof SelfVariableAccess and
     this.getEnclosingModule() = controllerClass
   }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
@@ -61,7 +61,7 @@ private class ActionViewHtmlEscapeCall extends HtmlEscapeCall {
 // A call in a context where some commonly used `ActionView` methods are available.
 private class ActionViewContextCall extends MethodCall {
   ActionViewContextCall() {
-    this.getReceiver() instanceof Self and
+    this.getReceiver() instanceof SelfVariableAccess and
     inActionViewContext(this)
   }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
@@ -221,7 +221,7 @@ private class GraphqlSchemaObjectClassMethodCall extends MethodCall {
     recvCls.getModule() = resolveConstantReadAccess(this.getReceiver())
     or
     // e.g. self.some_method(...) within a graphql Object or Interface
-    this.getReceiver() instanceof Self and
+    this.getReceiver() instanceof SelfVariableAccess and
     this.getEnclosingModule() = recvCls
   }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Kernel.qll
@@ -27,7 +27,7 @@ module Kernel {
         or
         methodCall instanceof UnknownMethodCall and
         (
-          this.getReceiver().asExpr().getExpr() instanceof Self and
+          this.getReceiver().asExpr().getExpr() instanceof SelfVariableAccess and
           isPrivateKernelMethod(methodCall.getMethodName())
           or
           isPublicKernelMethod(methodCall.getMethodName())

--- a/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/typetracking/TypeTrackerSpecific.qll
@@ -88,10 +88,7 @@ predicate callStep(Node nodeFrom, Node nodeTo) {
   // we model it as a call step, in order to avoid computing a potential
   // self-cross product of all calls to a function that returns one of its parameters
   // (only to later filter that flow out using `TypeTracker::append`).
-  nodeTo =
-    DataFlowPrivate::LocalFlow::getParameterDefNode(nodeFrom
-          .(DataFlowPublic::ParameterNode)
-          .getParameter())
+  DataFlowPrivate::LocalFlow::localFlowSsaParamInput(nodeFrom, nodeTo)
 }
 
 /**

--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -1,28 +1,28 @@
 gems/Gemfile:
 #    1| [Toplevel] Gemfile
 #    1|   getStmt: [MethodCall] call to source
-#    1|     getReceiver: [Self, SelfVariableAccess] self
+#    1|     getReceiver: [SelfVariableAccess] self
 #    1|     getArgument: [StringLiteral] "https://rubygems.org"
 #    1|       getComponent: [StringTextComponent] https://rubygems.org
 #    3|   getStmt: [MethodCall] call to gem
-#    3|     getReceiver: [Self, SelfVariableAccess] self
+#    3|     getReceiver: [SelfVariableAccess] self
 #    3|     getArgument: [StringLiteral] "foo_gem"
 #    3|       getComponent: [StringTextComponent] foo_gem
 #    3|     getArgument: [StringLiteral] "~> 2.0"
 #    3|       getComponent: [StringTextComponent] ~> 2.0
 #    5|   getStmt: [MethodCall] call to source
-#    5|     getReceiver: [Self, SelfVariableAccess] self
+#    5|     getReceiver: [SelfVariableAccess] self
 #    5|     getArgument: [StringLiteral] "https://gems.example.com"
 #    5|       getComponent: [StringTextComponent] https://gems.example.com
 #    5|     getBlock: [DoBlock] do ... end
 #    6|       getStmt: [MethodCall] call to gem
-#    6|         getReceiver: [Self, SelfVariableAccess] self
+#    6|         getReceiver: [SelfVariableAccess] self
 #    6|         getArgument: [StringLiteral] "my_gem"
 #    6|           getComponent: [StringTextComponent] my_gem
 #    6|         getArgument: [StringLiteral] "1.0"
 #    6|           getComponent: [StringTextComponent] 1.0
 #    7|       getStmt: [MethodCall] call to gem
-#    7|         getReceiver: [Self, SelfVariableAccess] self
+#    7|         getReceiver: [SelfVariableAccess] self
 #    7|         getArgument: [StringLiteral] "another_gem"
 #    7|           getComponent: [StringTextComponent] another_gem
 #    7|         getArgument: [StringLiteral] "3.1.4"
@@ -30,20 +30,20 @@ gems/Gemfile:
 calls/calls.rb:
 #    1| [Toplevel] calls.rb
 #    2|   getStmt: [MethodCall] call to foo
-#    2|     getReceiver: [Self, SelfVariableAccess] self
+#    2|     getReceiver: [SelfVariableAccess] self
 #    5|   getStmt: [MethodCall] call to bar
 #    5|     getReceiver: [ConstantReadAccess] Foo
 #    8|   getStmt: [MethodCall] call to bar
-#    8|     getReceiver: [Self, SelfVariableAccess] self
+#    8|     getReceiver: [SelfVariableAccess] self
 #   11|   getStmt: [MethodCall] call to bar
 #   11|     getReceiver: [IntegerLiteral] 123
 #   14|   getStmt: [MethodCall] call to foo
-#   14|     getReceiver: [Self, SelfVariableAccess] self
+#   14|     getReceiver: [SelfVariableAccess] self
 #   14|     getArgument: [IntegerLiteral] 0
 #   14|     getArgument: [IntegerLiteral] 1
 #   14|     getArgument: [IntegerLiteral] 2
 #   17|   getStmt: [MethodCall] call to foo
-#   17|     getReceiver: [Self, SelfVariableAccess] self
+#   17|     getReceiver: [SelfVariableAccess] self
 #   17|     getBlock: [BraceBlock] { ... }
 #   17|       getParameter: [SimpleParameter] x
 #   17|         getDefiningAccess: [LocalVariableAccess] x
@@ -51,7 +51,7 @@ calls/calls.rb:
 #   17|         getAnOperand/getLeftOperand/getReceiver: [LocalVariableAccess] x
 #   17|         getAnOperand/getArgument/getRightOperand: [IntegerLiteral] 1
 #   20|   getStmt: [MethodCall] call to foo
-#   20|     getReceiver: [Self, SelfVariableAccess] self
+#   20|     getReceiver: [SelfVariableAccess] self
 #   20|     getBlock: [DoBlock] do ... end
 #   20|       getParameter: [SimpleParameter] x
 #   20|         getDefiningAccess: [LocalVariableAccess] x
@@ -75,33 +75,33 @@ calls/calls.rb:
 #   36|       getArgument: [IntegerLiteral] 100
 #   36|       getArgument: [IntegerLiteral] 200
 #   46|   getStmt: [MethodCall] call to foo
-#   46|     getReceiver: [Self, SelfVariableAccess] self
+#   46|     getReceiver: [SelfVariableAccess] self
 #   47|   getStmt: [MethodCall] call to foo
 #   47|     getReceiver: [ConstantReadAccess] X
 #   50|   getStmt: [ParenthesizedExpr] ( ... )
 #   50|     getStmt: [MethodCall] call to foo
-#   50|       getReceiver: [Self, SelfVariableAccess] self
+#   50|       getReceiver: [SelfVariableAccess] self
 #   51|   getStmt: [ParenthesizedExpr] ( ... )
 #   51|     getStmt: [MethodCall] call to foo
 #   51|       getReceiver: [ConstantReadAccess] X
 #   54|   getStmt: [MethodCall] call to some_func
-#   54|     getReceiver: [Self, SelfVariableAccess] self
+#   54|     getReceiver: [SelfVariableAccess] self
 #   54|     getArgument: [MethodCall] call to foo
-#   54|       getReceiver: [Self, SelfVariableAccess] self
+#   54|       getReceiver: [SelfVariableAccess] self
 #   55|   getStmt: [MethodCall] call to some_func
-#   55|     getReceiver: [Self, SelfVariableAccess] self
+#   55|     getReceiver: [SelfVariableAccess] self
 #   55|     getArgument: [MethodCall] call to foo
 #   55|       getReceiver: [ConstantReadAccess] X
 #   58|   getStmt: [ArrayLiteral] [...]
 #   58|     getElement: [MethodCall] call to foo
-#   58|       getReceiver: [Self, SelfVariableAccess] self
+#   58|       getReceiver: [SelfVariableAccess] self
 #   59|   getStmt: [ArrayLiteral] [...]
 #   59|     getElement: [MethodCall] call to foo
 #   59|       getReceiver: [ConstantReadAccess] X
 #   62|   getStmt: [AssignExpr] ... = ...
 #   62|     getAnOperand/getLeftOperand: [LocalVariableAccess] var1
 #   62|     getAnOperand/getRightOperand: [MethodCall] call to foo
-#   62|       getReceiver: [Self, SelfVariableAccess] self
+#   62|       getReceiver: [SelfVariableAccess] self
 #   63|   getStmt: [AssignExpr] ... = ...
 #   63|     getAnOperand/getLeftOperand: [LocalVariableAccess] var1
 #   63|     getAnOperand/getRightOperand: [MethodCall] call to foo
@@ -109,7 +109,7 @@ calls/calls.rb:
 #   66|   getStmt: [AssignAddExpr] ... += ...
 #   66|     getAnOperand/getLeftOperand: [LocalVariableAccess] var1
 #   66|     getAnOperand/getRightOperand: [MethodCall] call to bar
-#   66|       getReceiver: [Self, SelfVariableAccess] self
+#   66|       getReceiver: [SelfVariableAccess] self
 #   67|   getStmt: [AssignAddExpr] ... += ...
 #   67|     getAnOperand/getLeftOperand: [LocalVariableAccess] var1
 #   67|     getAnOperand/getRightOperand: [MethodCall] call to bar
@@ -118,64 +118,64 @@ calls/calls.rb:
 #   70|     getAnOperand/getLeftOperand: [LocalVariableAccess] var1
 #   70|     getAnOperand/getRightOperand: [ArgumentList] ..., ...
 #   70|       getElement: [MethodCall] call to foo
-#   70|         getReceiver: [Self, SelfVariableAccess] self
+#   70|         getReceiver: [SelfVariableAccess] self
 #   70|       getElement: [MethodCall] call to bar
 #   70|         getReceiver: [ConstantReadAccess] X
 #   73|   getStmt: [BeginExpr] begin ... 
 #   74|     getStmt: [MethodCall] call to foo
-#   74|       getReceiver: [Self, SelfVariableAccess] self
+#   74|       getReceiver: [SelfVariableAccess] self
 #   75|     getStmt: [MethodCall] call to foo
 #   75|       getReceiver: [ConstantReadAccess] X
 #   79|   getBeginBlock: [BeginBlock] BEGIN { ... }
 #   79|     getStmt: [MethodCall] call to foo
-#   79|       getReceiver: [Self, SelfVariableAccess] self
+#   79|       getReceiver: [SelfVariableAccess] self
 #   79|     getStmt: [MethodCall] call to bar
 #   79|       getReceiver: [ConstantReadAccess] X
 #   82|   getStmt: [EndBlock] END { ... }
 #   82|     getStmt: [MethodCall] call to foo
-#   82|       getReceiver: [Self, SelfVariableAccess] self
+#   82|       getReceiver: [SelfVariableAccess] self
 #   82|     getStmt: [MethodCall] call to bar
 #   82|       getReceiver: [ConstantReadAccess] X
 #   85|   getStmt: [AddExpr] ... + ...
 #   85|     getAnOperand/getLeftOperand/getReceiver: [MethodCall] call to foo
-#   85|       getReceiver: [Self, SelfVariableAccess] self
+#   85|       getReceiver: [SelfVariableAccess] self
 #   85|     getAnOperand/getArgument/getRightOperand: [MethodCall] call to bar
 #   85|       getReceiver: [ConstantReadAccess] X
 #   88|   getStmt: [NotExpr] ! ...
 #   88|     getAnOperand/getOperand/getReceiver: [MethodCall] call to foo
-#   88|       getReceiver: [Self, SelfVariableAccess] self
+#   88|       getReceiver: [SelfVariableAccess] self
 #   89|   getStmt: [ComplementExpr] ~ ...
 #   89|     getAnOperand/getOperand/getReceiver: [MethodCall] call to bar
 #   89|       getReceiver: [ConstantReadAccess] X
 #   92|   getStmt: [MethodCall] call to foo
-#   92|     getReceiver: [Self, SelfVariableAccess] self
+#   92|     getReceiver: [SelfVariableAccess] self
 #   92|     getBlock: [BraceBlock] { ... }
 #   92|       getStmt: [MethodCall] call to bar
-#   92|         getReceiver: [Self, SelfVariableAccess] self
+#   92|         getReceiver: [SelfVariableAccess] self
 #   92|       getStmt: [MethodCall] call to baz
 #   92|         getReceiver: [ConstantReadAccess] X
 #   95|   getStmt: [MethodCall] call to foo
-#   95|     getReceiver: [Self, SelfVariableAccess] self
+#   95|     getReceiver: [SelfVariableAccess] self
 #   95|     getBlock: [DoBlock] do ... end
 #   96|       getStmt: [MethodCall] call to bar
-#   96|         getReceiver: [Self, SelfVariableAccess] self
+#   96|         getReceiver: [SelfVariableAccess] self
 #   97|       getStmt: [MethodCall] call to baz
 #   97|         getReceiver: [ConstantReadAccess] X
 #  101|   getStmt: [MethodCall] call to bar
 #  101|     getReceiver: [MethodCall] call to foo
-#  101|       getReceiver: [Self, SelfVariableAccess] self
+#  101|       getReceiver: [SelfVariableAccess] self
 #  102|   getStmt: [MethodCall] call to baz
 #  102|     getReceiver: [MethodCall] call to bar
-#  102|       getReceiver: [Self, SelfVariableAccess] self
+#  102|       getReceiver: [SelfVariableAccess] self
 #  106|   getStmt: [CaseExpr] case ...
 #  106|     getValue: [MethodCall] call to foo
-#  106|       getReceiver: [Self, SelfVariableAccess] self
+#  106|       getReceiver: [SelfVariableAccess] self
 #  107|     getBranch: [WhenClause] when ...
 #  107|       getPattern: [MethodCall] call to bar
-#  107|         getReceiver: [Self, SelfVariableAccess] self
+#  107|         getReceiver: [SelfVariableAccess] self
 #  107|       getBody: [StmtSequence] then ...
 #  108|         getStmt: [MethodCall] call to baz
-#  108|           getReceiver: [Self, SelfVariableAccess] self
+#  108|           getReceiver: [SelfVariableAccess] self
 #  110|   getStmt: [CaseExpr] case ...
 #  110|     getValue: [MethodCall] call to foo
 #  110|       getReceiver: [ConstantReadAccess] X
@@ -187,20 +187,20 @@ calls/calls.rb:
 #  112|           getReceiver: [ConstantReadAccess] X
 #  116|   getStmt: [ClassDeclaration] MyClass
 #  117|     getStmt: [MethodCall] call to foo
-#  117|       getReceiver: [Self, SelfVariableAccess] self
+#  117|       getReceiver: [SelfVariableAccess] self
 #  118|     getStmt: [MethodCall] call to bar
 #  118|       getReceiver: [ConstantReadAccess] X
 #  122|   getStmt: [ClassDeclaration] MyClass
 #  122|     getSuperclassExpr: [MethodCall] call to foo
-#  122|       getReceiver: [Self, SelfVariableAccess] self
+#  122|       getReceiver: [SelfVariableAccess] self
 #  124|   getStmt: [ClassDeclaration] MyClass2
 #  124|     getSuperclassExpr: [MethodCall] call to foo
 #  124|       getReceiver: [ConstantReadAccess] X
 #  128|   getStmt: [SingletonClass] class << ...
 #  128|     getValue: [MethodCall] call to foo
-#  128|       getReceiver: [Self, SelfVariableAccess] self
+#  128|       getReceiver: [SelfVariableAccess] self
 #  129|     getStmt: [MethodCall] call to bar
-#  129|       getReceiver: [Self, SelfVariableAccess] self
+#  129|       getReceiver: [SelfVariableAccess] self
 #  131|   getStmt: [SingletonClass] class << ...
 #  131|     getValue: [MethodCall] call to foo
 #  131|       getReceiver: [ConstantReadAccess] X
@@ -208,21 +208,21 @@ calls/calls.rb:
 #  132|       getReceiver: [ConstantReadAccess] X
 #  136|   getStmt: [Method] some_method
 #  137|     getStmt: [MethodCall] call to foo
-#  137|       getReceiver: [Self, SelfVariableAccess] self
+#  137|       getReceiver: [SelfVariableAccess] self
 #  138|     getStmt: [MethodCall] call to bar
 #  138|       getReceiver: [ConstantReadAccess] X
 #  142|   getStmt: [SingletonMethod] some_method
 #  142|     getObject: [MethodCall] call to foo
-#  142|       getReceiver: [Self, SelfVariableAccess] self
+#  142|       getReceiver: [SelfVariableAccess] self
 #  143|     getStmt: [MethodCall] call to bar
-#  143|       getReceiver: [Self, SelfVariableAccess] self
+#  143|       getReceiver: [SelfVariableAccess] self
 #  144|     getStmt: [MethodCall] call to baz
 #  144|       getReceiver: [ConstantReadAccess] X
 #  148|   getStmt: [Method] method_with_keyword_param
 #  148|     getParameter: [KeywordParameter] keyword
 #  148|       getDefiningAccess: [LocalVariableAccess] keyword
 #  148|       getDefaultValue: [MethodCall] call to foo
-#  148|         getReceiver: [Self, SelfVariableAccess] self
+#  148|         getReceiver: [SelfVariableAccess] self
 #  150|   getStmt: [Method] method_with_keyword_param2
 #  150|     getParameter: [KeywordParameter] keyword
 #  150|       getDefiningAccess: [LocalVariableAccess] keyword
@@ -232,7 +232,7 @@ calls/calls.rb:
 #  154|     getParameter: [OptionalParameter] param
 #  154|       getDefiningAccess: [LocalVariableAccess] param
 #  154|       getDefaultValue: [MethodCall] call to foo
-#  154|         getReceiver: [Self, SelfVariableAccess] self
+#  154|         getReceiver: [SelfVariableAccess] self
 #  156|   getStmt: [Method] method_with_optional_param2
 #  156|     getParameter: [OptionalParameter] param
 #  156|       getDefiningAccess: [LocalVariableAccess] param
@@ -240,16 +240,16 @@ calls/calls.rb:
 #  156|         getReceiver: [ConstantReadAccess] X
 #  160|   getStmt: [ModuleDeclaration] SomeModule
 #  161|     getStmt: [MethodCall] call to foo
-#  161|       getReceiver: [Self, SelfVariableAccess] self
+#  161|       getReceiver: [SelfVariableAccess] self
 #  162|     getStmt: [MethodCall] call to bar
 #  162|       getReceiver: [ConstantReadAccess] X
 #  166|   getStmt: [TernaryIfExpr] ... ? ... : ...
 #  166|     getCondition: [MethodCall] call to foo
-#  166|       getReceiver: [Self, SelfVariableAccess] self
+#  166|       getReceiver: [SelfVariableAccess] self
 #  166|     getBranch/getThen: [MethodCall] call to bar
-#  166|       getReceiver: [Self, SelfVariableAccess] self
+#  166|       getReceiver: [SelfVariableAccess] self
 #  166|     getBranch/getElse: [MethodCall] call to baz
-#  166|       getReceiver: [Self, SelfVariableAccess] self
+#  166|       getReceiver: [SelfVariableAccess] self
 #  167|   getStmt: [TernaryIfExpr] ... ? ... : ...
 #  167|     getCondition: [MethodCall] call to foo
 #  167|       getReceiver: [ConstantReadAccess] X
@@ -259,19 +259,19 @@ calls/calls.rb:
 #  167|       getReceiver: [ConstantReadAccess] X
 #  170|   getStmt: [IfExpr] if ...
 #  170|     getCondition: [MethodCall] call to foo
-#  170|       getReceiver: [Self, SelfVariableAccess] self
+#  170|       getReceiver: [SelfVariableAccess] self
 #  170|     getBranch/getThen: [StmtSequence] then ...
 #  171|       getStmt: [MethodCall] call to wibble
-#  171|         getReceiver: [Self, SelfVariableAccess] self
+#  171|         getReceiver: [SelfVariableAccess] self
 #  172|     getBranch/getElse: [IfExpr] elsif ...
 #  172|       getCondition: [MethodCall] call to bar
-#  172|         getReceiver: [Self, SelfVariableAccess] self
+#  172|         getReceiver: [SelfVariableAccess] self
 #  172|       getBranch/getThen: [StmtSequence] then ...
 #  173|         getStmt: [MethodCall] call to wobble
-#  173|           getReceiver: [Self, SelfVariableAccess] self
+#  173|           getReceiver: [SelfVariableAccess] self
 #  174|       getBranch/getElse: [StmtSequence] else ...
 #  175|         getStmt: [MethodCall] call to wabble
-#  175|           getReceiver: [Self, SelfVariableAccess] self
+#  175|           getReceiver: [SelfVariableAccess] self
 #  177|   getStmt: [IfExpr] if ...
 #  177|     getCondition: [MethodCall] call to foo
 #  177|       getReceiver: [ConstantReadAccess] X
@@ -289,9 +289,9 @@ calls/calls.rb:
 #  182|           getReceiver: [ConstantReadAccess] X
 #  186|   getStmt: [IfModifierExpr] ... if ...
 #  186|     getBody/getBranch: [MethodCall] call to bar
-#  186|       getReceiver: [Self, SelfVariableAccess] self
+#  186|       getReceiver: [SelfVariableAccess] self
 #  186|     getCondition: [MethodCall] call to foo
-#  186|       getReceiver: [Self, SelfVariableAccess] self
+#  186|       getReceiver: [SelfVariableAccess] self
 #  187|   getStmt: [IfModifierExpr] ... if ...
 #  187|     getBody/getBranch: [MethodCall] call to bar
 #  187|       getReceiver: [ConstantReadAccess] X
@@ -299,10 +299,10 @@ calls/calls.rb:
 #  187|       getReceiver: [ConstantReadAccess] X
 #  190|   getStmt: [UnlessExpr] unless ...
 #  190|     getCondition: [MethodCall] call to foo
-#  190|       getReceiver: [Self, SelfVariableAccess] self
+#  190|       getReceiver: [SelfVariableAccess] self
 #  190|     getBranch/getThen: [StmtSequence] then ...
 #  191|       getStmt: [MethodCall] call to bar
-#  191|         getReceiver: [Self, SelfVariableAccess] self
+#  191|         getReceiver: [SelfVariableAccess] self
 #  193|   getStmt: [UnlessExpr] unless ...
 #  193|     getCondition: [MethodCall] call to foo
 #  193|       getReceiver: [ConstantReadAccess] X
@@ -311,9 +311,9 @@ calls/calls.rb:
 #  194|         getReceiver: [ConstantReadAccess] X
 #  198|   getStmt: [UnlessModifierExpr] ... unless ...
 #  198|     getBody/getBranch: [MethodCall] call to bar
-#  198|       getReceiver: [Self, SelfVariableAccess] self
+#  198|       getReceiver: [SelfVariableAccess] self
 #  198|     getCondition: [MethodCall] call to foo
-#  198|       getReceiver: [Self, SelfVariableAccess] self
+#  198|       getReceiver: [SelfVariableAccess] self
 #  199|   getStmt: [UnlessModifierExpr] ... unless ...
 #  199|     getBody/getBranch: [MethodCall] call to bar
 #  199|       getReceiver: [ConstantReadAccess] X
@@ -321,10 +321,10 @@ calls/calls.rb:
 #  199|       getReceiver: [ConstantReadAccess] X
 #  202|   getStmt: [WhileExpr] while ...
 #  202|     getCondition: [MethodCall] call to foo
-#  202|       getReceiver: [Self, SelfVariableAccess] self
+#  202|       getReceiver: [SelfVariableAccess] self
 #  202|     getBody: [StmtSequence] do ...
 #  203|       getStmt: [MethodCall] call to bar
-#  203|         getReceiver: [Self, SelfVariableAccess] self
+#  203|         getReceiver: [SelfVariableAccess] self
 #  205|   getStmt: [WhileExpr] while ...
 #  205|     getCondition: [MethodCall] call to foo
 #  205|       getReceiver: [ConstantReadAccess] X
@@ -333,9 +333,9 @@ calls/calls.rb:
 #  206|         getReceiver: [ConstantReadAccess] X
 #  210|   getStmt: [WhileModifierExpr] ... while ...
 #  210|     getBody: [MethodCall] call to bar
-#  210|       getReceiver: [Self, SelfVariableAccess] self
+#  210|       getReceiver: [SelfVariableAccess] self
 #  210|     getCondition: [MethodCall] call to foo
-#  210|       getReceiver: [Self, SelfVariableAccess] self
+#  210|       getReceiver: [SelfVariableAccess] self
 #  211|   getStmt: [WhileModifierExpr] ... while ...
 #  211|     getBody: [MethodCall] call to bar
 #  211|       getReceiver: [ConstantReadAccess] X
@@ -343,10 +343,10 @@ calls/calls.rb:
 #  211|       getReceiver: [ConstantReadAccess] X
 #  214|   getStmt: [UntilExpr] until ...
 #  214|     getCondition: [MethodCall] call to foo
-#  214|       getReceiver: [Self, SelfVariableAccess] self
+#  214|       getReceiver: [SelfVariableAccess] self
 #  214|     getBody: [StmtSequence] do ...
 #  215|       getStmt: [MethodCall] call to bar
-#  215|         getReceiver: [Self, SelfVariableAccess] self
+#  215|         getReceiver: [SelfVariableAccess] self
 #  217|   getStmt: [UntilExpr] until ...
 #  217|     getCondition: [MethodCall] call to foo
 #  217|       getReceiver: [ConstantReadAccess] X
@@ -355,9 +355,9 @@ calls/calls.rb:
 #  218|         getReceiver: [ConstantReadAccess] X
 #  222|   getStmt: [UntilModifierExpr] ... until ...
 #  222|     getBody: [MethodCall] call to bar
-#  222|       getReceiver: [Self, SelfVariableAccess] self
+#  222|       getReceiver: [SelfVariableAccess] self
 #  222|     getCondition: [MethodCall] call to foo
-#  222|       getReceiver: [Self, SelfVariableAccess] self
+#  222|       getReceiver: [SelfVariableAccess] self
 #  223|   getStmt: [UntilModifierExpr] ... until ...
 #  223|     getBody: [MethodCall] call to bar
 #  223|       getReceiver: [ConstantReadAccess] X
@@ -366,10 +366,10 @@ calls/calls.rb:
 #  226|   getStmt: [ForExpr] for ... in ...
 #  226|     getPattern: [LocalVariableAccess] x
 #  226|     getValue: [MethodCall] call to bar
-#  226|       getReceiver: [Self, SelfVariableAccess] self
+#  226|       getReceiver: [SelfVariableAccess] self
 #  226|     getBody: [StmtSequence] do ...
 #  227|       getStmt: [MethodCall] call to baz
-#  227|         getReceiver: [Self, SelfVariableAccess] self
+#  227|         getReceiver: [SelfVariableAccess] self
 #  229|   getStmt: [ForExpr] for ... in ...
 #  229|     getPattern: [LocalVariableAccess] x
 #  229|     getValue: [MethodCall] call to bar
@@ -379,9 +379,9 @@ calls/calls.rb:
 #  230|         getReceiver: [ConstantReadAccess] X
 #  234|   getStmt: [ElementReference] ...[...]
 #  234|     getReceiver: [MethodCall] call to foo
-#  234|       getReceiver: [Self, SelfVariableAccess] self
+#  234|       getReceiver: [SelfVariableAccess] self
 #  234|     getArgument: [MethodCall] call to bar
-#  234|       getReceiver: [Self, SelfVariableAccess] self
+#  234|       getReceiver: [SelfVariableAccess] self
 #  235|   getStmt: [ElementReference] ...[...]
 #  235|     getReceiver: [MethodCall] call to foo
 #  235|       getReceiver: [ConstantReadAccess] X
@@ -391,22 +391,22 @@ calls/calls.rb:
 #  238|     getComponent: [StringTextComponent] foo-
 #  238|     getComponent: [StringInterpolationComponent] #{...}
 #  238|       getStmt: [MethodCall] call to bar
-#  238|         getReceiver: [Self, SelfVariableAccess] self
+#  238|         getReceiver: [SelfVariableAccess] self
 #  238|     getComponent: [StringTextComponent] -
 #  238|     getComponent: [StringInterpolationComponent] #{...}
 #  238|       getStmt: [MethodCall] call to baz
 #  238|         getReceiver: [ConstantReadAccess] X
 #  241|   getStmt: [ConstantReadAccess] Bar
 #  241|     getScopeExpr: [MethodCall] call to foo
-#  241|       getReceiver: [Self, SelfVariableAccess] self
+#  241|       getReceiver: [SelfVariableAccess] self
 #  242|   getStmt: [ConstantReadAccess] Bar
 #  242|     getScopeExpr: [MethodCall] call to foo
 #  242|       getReceiver: [ConstantReadAccess] X
 #  245|   getStmt: [RangeLiteral] _ .. _
 #  245|     getBegin: [MethodCall] call to foo
-#  245|       getReceiver: [Self, SelfVariableAccess] self
+#  245|       getReceiver: [SelfVariableAccess] self
 #  245|     getEnd: [MethodCall] call to bar
-#  245|       getReceiver: [Self, SelfVariableAccess] self
+#  245|       getReceiver: [SelfVariableAccess] self
 #  246|   getStmt: [RangeLiteral] _ .. _
 #  246|     getBegin: [MethodCall] call to foo
 #  246|       getReceiver: [ConstantReadAccess] X
@@ -415,9 +415,9 @@ calls/calls.rb:
 #  249|   getStmt: [HashLiteral] {...}
 #  249|     getElement: [Pair] Pair
 #  249|       getKey: [MethodCall] call to foo
-#  249|         getReceiver: [Self, SelfVariableAccess] self
+#  249|         getReceiver: [SelfVariableAccess] self
 #  249|       getValue: [MethodCall] call to bar
-#  249|         getReceiver: [Self, SelfVariableAccess] self
+#  249|         getReceiver: [SelfVariableAccess] self
 #  249|     getElement: [Pair] Pair
 #  249|       getKey: [MethodCall] call to foo
 #  249|         getReceiver: [ConstantReadAccess] X
@@ -426,10 +426,10 @@ calls/calls.rb:
 #  252|   getStmt: [BeginExpr] begin ... 
 #  253|     getRescue: [RescueClause] rescue ...
 #  253|       getException: [MethodCall] call to foo
-#  253|         getReceiver: [Self, SelfVariableAccess] self
+#  253|         getReceiver: [SelfVariableAccess] self
 #  254|     getEnsure: [StmtSequence] ensure ...
 #  254|       getStmt: [MethodCall] call to bar
-#  254|         getReceiver: [Self, SelfVariableAccess] self
+#  254|         getReceiver: [SelfVariableAccess] self
 #  256|   getStmt: [BeginExpr] begin ... 
 #  257|     getRescue: [RescueClause] rescue ...
 #  257|       getException: [MethodCall] call to foo
@@ -439,55 +439,55 @@ calls/calls.rb:
 #  258|         getReceiver: [ConstantReadAccess] X
 #  262|   getStmt: [RescueModifierExpr] ... rescue ...
 #  262|     getBody: [MethodCall] call to foo
-#  262|       getReceiver: [Self, SelfVariableAccess] self
+#  262|       getReceiver: [SelfVariableAccess] self
 #  262|     getHandler: [MethodCall] call to bar
-#  262|       getReceiver: [Self, SelfVariableAccess] self
+#  262|       getReceiver: [SelfVariableAccess] self
 #  263|   getStmt: [RescueModifierExpr] ... rescue ...
 #  263|     getBody: [MethodCall] call to foo
 #  263|       getReceiver: [ConstantReadAccess] X
 #  263|     getHandler: [MethodCall] call to bar
 #  263|       getReceiver: [ConstantReadAccess] X
 #  266|   getStmt: [MethodCall] call to foo
-#  266|     getReceiver: [Self, SelfVariableAccess] self
+#  266|     getReceiver: [SelfVariableAccess] self
 #  266|     getArgument: [BlockArgument] &...
 #  266|       getValue: [MethodCall] call to bar
-#  266|         getReceiver: [Self, SelfVariableAccess] self
+#  266|         getReceiver: [SelfVariableAccess] self
 #  267|   getStmt: [MethodCall] call to foo
-#  267|     getReceiver: [Self, SelfVariableAccess] self
+#  267|     getReceiver: [SelfVariableAccess] self
 #  267|     getArgument: [BlockArgument] &...
 #  267|       getValue: [MethodCall] call to bar
 #  267|         getReceiver: [ConstantReadAccess] X
 #  268|   getStmt: [MethodCall] call to foo
-#  268|     getReceiver: [Self, SelfVariableAccess] self
+#  268|     getReceiver: [SelfVariableAccess] self
 #  268|     getArgument: [BlockArgument] &...
 #  270|   getStmt: [MethodCall] call to foo
-#  270|     getReceiver: [Self, SelfVariableAccess] self
+#  270|     getReceiver: [SelfVariableAccess] self
 #  270|     getArgument: [SplatExpr] * ...
 #  270|       getAnOperand/getOperand/getReceiver: [MethodCall] call to bar
-#  270|         getReceiver: [Self, SelfVariableAccess] self
+#  270|         getReceiver: [SelfVariableAccess] self
 #  271|   getStmt: [MethodCall] call to foo
-#  271|     getReceiver: [Self, SelfVariableAccess] self
+#  271|     getReceiver: [SelfVariableAccess] self
 #  271|     getArgument: [SplatExpr] * ...
 #  271|       getAnOperand/getOperand/getReceiver: [MethodCall] call to bar
 #  271|         getReceiver: [ConstantReadAccess] X
 #  274|   getStmt: [MethodCall] call to foo
-#  274|     getReceiver: [Self, SelfVariableAccess] self
+#  274|     getReceiver: [SelfVariableAccess] self
 #  274|     getArgument: [HashSplatExpr] ** ...
 #  274|       getAnOperand/getOperand/getReceiver: [MethodCall] call to bar
-#  274|         getReceiver: [Self, SelfVariableAccess] self
+#  274|         getReceiver: [SelfVariableAccess] self
 #  275|   getStmt: [MethodCall] call to foo
-#  275|     getReceiver: [Self, SelfVariableAccess] self
+#  275|     getReceiver: [SelfVariableAccess] self
 #  275|     getArgument: [HashSplatExpr] ** ...
 #  275|       getAnOperand/getOperand/getReceiver: [MethodCall] call to bar
 #  275|         getReceiver: [ConstantReadAccess] X
 #  278|   getStmt: [MethodCall] call to foo
-#  278|     getReceiver: [Self, SelfVariableAccess] self
+#  278|     getReceiver: [SelfVariableAccess] self
 #  278|     getArgument: [Pair] Pair
 #  278|       getKey: [SymbolLiteral] :blah
 #  278|       getValue: [MethodCall] call to bar
-#  278|         getReceiver: [Self, SelfVariableAccess] self
+#  278|         getReceiver: [SelfVariableAccess] self
 #  279|   getStmt: [MethodCall] call to foo
-#  279|     getReceiver: [Self, SelfVariableAccess] self
+#  279|     getReceiver: [SelfVariableAccess] self
 #  279|     getArgument: [Pair] Pair
 #  279|       getKey: [SymbolLiteral] :blah
 #  279|       getValue: [MethodCall] call to bar
@@ -539,37 +539,37 @@ calls/calls.rb:
 #  302|     getStmt: [Method] another_method
 #  303|       getStmt: [MethodCall] call to super
 #  303|         getReceiver: [MethodCall] call to foo
-#  303|           getReceiver: [Self, SelfVariableAccess] self
+#  303|           getReceiver: [SelfVariableAccess] self
 #  304|       getStmt: [MethodCall] call to super
-#  304|         getReceiver: [Self, SelfVariableAccess] self
+#  304|         getReceiver: [SelfVariableAccess] self
 #  305|       getStmt: [MethodCall] call to super
 #  305|         getReceiver: [SuperCall] call to super
 #  310|   getStmt: [MethodCall] call to call
 #  310|     getReceiver: [MethodCall] call to foo
-#  310|       getReceiver: [Self, SelfVariableAccess] self
+#  310|       getReceiver: [SelfVariableAccess] self
 #  311|   getStmt: [MethodCall] call to call
 #  311|     getReceiver: [MethodCall] call to foo
-#  311|       getReceiver: [Self, SelfVariableAccess] self
+#  311|       getReceiver: [SelfVariableAccess] self
 #  311|     getArgument: [IntegerLiteral] 1
 #  314|   getStmt: [AssignExpr] ... = ...
 #  314|     getAnOperand/getLeftOperand: [MethodCall] call to foo
-#  314|       getReceiver: [Self, SelfVariableAccess] self
+#  314|       getReceiver: [SelfVariableAccess] self
 #  314|     getAnOperand/getRightOperand: [IntegerLiteral] 10
 #  315|   getStmt: [AssignExpr] ... = ...
 #  315|     getAnOperand/getLeftOperand: [ElementReference] ...[...]
 #  315|       getReceiver: [MethodCall] call to foo
-#  315|         getReceiver: [Self, SelfVariableAccess] self
+#  315|         getReceiver: [SelfVariableAccess] self
 #  315|       getArgument: [IntegerLiteral] 0
 #  315|     getAnOperand/getRightOperand: [IntegerLiteral] 10
 #  316|   getStmt: [AssignExpr] ... = ...
 #  316|     getAnOperand/getLeftOperand: [DestructuredLhsExpr] (..., ...)
 #  316|       getElement: [MethodCall] call to foo
-#  316|         getReceiver: [Self, SelfVariableAccess] self
+#  316|         getReceiver: [SelfVariableAccess] self
 #  316|       getElement: [MethodCall] call to bar
-#  316|         getReceiver: [Self, SelfVariableAccess] self
+#  316|         getReceiver: [SelfVariableAccess] self
 #  316|       getElement: [ElementReference] ...[...]
 #  316|         getReceiver: [MethodCall] call to foo
-#  316|           getReceiver: [Self, SelfVariableAccess] self
+#  316|           getReceiver: [SelfVariableAccess] self
 #  316|         getArgument: [IntegerLiteral] 4
 #  316|     getAnOperand/getRightOperand: [ArrayLiteral] [...]
 #  316|       getElement: [IntegerLiteral] 1
@@ -581,7 +581,7 @@ calls/calls.rb:
 #  317|       getElement: [LocalVariableAccess] a
 #  317|       getElement: [ElementReference] ...[...]
 #  317|         getReceiver: [MethodCall] call to foo
-#  317|           getReceiver: [Self, SelfVariableAccess] self
+#  317|           getReceiver: [SelfVariableAccess] self
 #  317|         getArgument: [IntegerLiteral] 5
 #  317|     getAnOperand/getRightOperand: [ArrayLiteral] [...]
 #  317|       getElement: [IntegerLiteral] 1
@@ -589,57 +589,57 @@ calls/calls.rb:
 #  317|       getElement: [IntegerLiteral] 3
 #  318|   getStmt: [AssignAddExpr] ... += ...
 #  318|     getAnOperand/getLeftOperand: [MethodCall] call to count
-#  318|       getReceiver: [Self, SelfVariableAccess] self
+#  318|       getReceiver: [SelfVariableAccess] self
 #  318|     getAnOperand/getRightOperand: [IntegerLiteral] 1
 #  319|   getStmt: [AssignAddExpr] ... += ...
 #  319|     getAnOperand/getLeftOperand: [ElementReference] ...[...]
 #  319|       getReceiver: [MethodCall] call to foo
-#  319|         getReceiver: [Self, SelfVariableAccess] self
+#  319|         getReceiver: [SelfVariableAccess] self
 #  319|       getArgument: [IntegerLiteral] 0
 #  319|     getAnOperand/getRightOperand: [IntegerLiteral] 1
 #  320|   getStmt: [AssignMulExpr] ... *= ...
 #  320|     getAnOperand/getLeftOperand: [ElementReference] ...[...]
 #  320|       getReceiver: [MethodCall] call to bar
 #  320|         getReceiver: [MethodCall] call to foo
-#  320|           getReceiver: [Self, SelfVariableAccess] self
+#  320|           getReceiver: [SelfVariableAccess] self
 #  320|       getArgument: [IntegerLiteral] 0
 #  320|       getArgument: [MethodCall] call to baz
 #  320|         getReceiver: [MethodCall] call to foo
-#  320|           getReceiver: [Self, SelfVariableAccess] self
+#  320|           getReceiver: [SelfVariableAccess] self
 #  320|       getArgument: [AddExpr] ... + ...
 #  320|         getAnOperand/getLeftOperand/getReceiver: [MethodCall] call to boo
 #  320|           getReceiver: [MethodCall] call to foo
-#  320|             getReceiver: [Self, SelfVariableAccess] self
+#  320|             getReceiver: [SelfVariableAccess] self
 #  320|         getAnOperand/getArgument/getRightOperand: [IntegerLiteral] 1
 #  320|     getAnOperand/getRightOperand: [IntegerLiteral] 2
 #  323|   getStmt: [Method] foo
 #  323|     getStmt: [MethodCall] call to bar
-#  323|       getReceiver: [Self, SelfVariableAccess] self
+#  323|       getReceiver: [SelfVariableAccess] self
 #  324|   getStmt: [Method] foo
 #  324|     getStmt: [MethodCall] call to bar
-#  324|       getReceiver: [Self, SelfVariableAccess] self
+#  324|       getReceiver: [SelfVariableAccess] self
 #  325|   getStmt: [Method] foo
 #  325|     getParameter: [SimpleParameter] x
 #  325|       getDefiningAccess: [LocalVariableAccess] x
 #  325|     getStmt: [MethodCall] call to bar
-#  325|       getReceiver: [Self, SelfVariableAccess] self
+#  325|       getReceiver: [SelfVariableAccess] self
 #  326|   getStmt: [SingletonMethod] foo
 #  326|     getObject: [ConstantReadAccess] Object
 #  326|     getStmt: [MethodCall] call to bar
-#  326|       getReceiver: [Self, SelfVariableAccess] self
+#  326|       getReceiver: [SelfVariableAccess] self
 #  327|   getStmt: [SingletonMethod] foo
 #  327|     getObject: [ConstantReadAccess] Object
 #  327|     getParameter: [SimpleParameter] x
 #  327|       getDefiningAccess: [LocalVariableAccess] x
 #  327|     getStmt: [MethodCall] call to bar
-#  327|       getReceiver: [Self, SelfVariableAccess] self
+#  327|       getReceiver: [SelfVariableAccess] self
 #  328|   getStmt: [Method] foo
 #  328|     getStmt: [RescueModifierExpr] ... rescue ...
 #  328|       getBody: [MethodCall] call to bar
-#  328|         getReceiver: [Self, SelfVariableAccess] self
+#  328|         getReceiver: [SelfVariableAccess] self
 #  328|       getHandler: [ParenthesizedExpr] ( ... )
 #  328|         getStmt: [MethodCall] call to print
-#  328|           getReceiver: [Self, SelfVariableAccess] self
+#  328|           getReceiver: [SelfVariableAccess] self
 #  328|           getArgument: [StringLiteral] "error"
 #  328|             getComponent: [StringTextComponent] error
 #  331|   getStmt: [Method] foo
@@ -653,7 +653,7 @@ calls/calls.rb:
 #  335|       getDefiningAccess: [LocalVariableAccess] b
 #  335|     getParameter: [ForwardParameter] ...
 #  336|     getStmt: [MethodCall] call to bar
-#  336|       getReceiver: [Self, SelfVariableAccess] self
+#  336|       getReceiver: [SelfVariableAccess] self
 #  336|       getArgument: [LocalVariableAccess] b
 #  336|       getArgument: [ForwardedArguments] ...
 #  340|   getStmt: [ForExpr] for ... in ...
@@ -672,17 +672,17 @@ calls/calls.rb:
 #  340|         getElement: [IntegerLiteral] 6
 #  340|     getBody: [StmtSequence] do ...
 #  341|       getStmt: [MethodCall] call to foo
-#  341|         getReceiver: [Self, SelfVariableAccess] self
+#  341|         getReceiver: [SelfVariableAccess] self
 #  341|         getArgument: [LocalVariableAccess] x
 #  341|         getArgument: [LocalVariableAccess] y
 #  341|         getArgument: [LocalVariableAccess] z
 #  344|   getStmt: [MethodCall] call to foo
-#  344|     getReceiver: [Self, SelfVariableAccess] self
+#  344|     getReceiver: [SelfVariableAccess] self
 #  344|     getArgument: [Pair] Pair
 #  344|       getKey: [SymbolLiteral] :x
 #  344|       getValue: [IntegerLiteral] 42
 #  345|   getStmt: [MethodCall] call to foo
-#  345|     getReceiver: [Self, SelfVariableAccess] self
+#  345|     getReceiver: [SelfVariableAccess] self
 #  345|     getArgument: [Pair] Pair
 #  345|       getKey: [SymbolLiteral] :x
 #  345|       getValue: [LocalVariableAccess] x
@@ -690,12 +690,12 @@ calls/calls.rb:
 #  345|       getKey: [SymbolLiteral] :novar
 #  345|       getValue: [MethodCall] call to novar
 #  346|   getStmt: [MethodCall] call to foo
-#  346|     getReceiver: [Self, SelfVariableAccess] self
+#  346|     getReceiver: [SelfVariableAccess] self
 #  346|     getArgument: [Pair] Pair
 #  346|       getKey: [SymbolLiteral] :X
 #  346|       getValue: [IntegerLiteral] 42
 #  347|   getStmt: [MethodCall] call to foo
-#  347|     getReceiver: [Self, SelfVariableAccess] self
+#  347|     getReceiver: [SelfVariableAccess] self
 #  347|     getArgument: [Pair] Pair
 #  347|       getKey: [SymbolLiteral] :X
 #  347|       getValue: [ConstantReadAccess] X
@@ -747,7 +747,7 @@ control/cases.rb:
 #   21|         getStmt: [IntegerLiteral] 30
 #   26|   getStmt: [CaseExpr] case ...
 #   26|     getValue: [MethodCall] call to expr
-#   26|       getReceiver: [Self, SelfVariableAccess] self
+#   26|       getReceiver: [SelfVariableAccess] self
 #   27|     getBranch: [InClause] in ... then ...
 #   27|       getPattern: [IntegerLiteral] 5
 #   27|       getBody: [StmtSequence] then ...
@@ -756,7 +756,7 @@ control/cases.rb:
 #   28|       getStmt: [BooleanLiteral] false
 #   31|   getStmt: [CaseExpr] case ...
 #   31|     getValue: [MethodCall] call to expr
-#   31|       getReceiver: [Self, SelfVariableAccess] self
+#   31|       getReceiver: [SelfVariableAccess] self
 #   32|     getBranch: [InClause] in ... then ...
 #   32|       getPattern: [LocalVariableAccess] x
 #   32|       getCondition: [LTExpr] ... < ...
@@ -775,7 +775,7 @@ control/cases.rb:
 #   36|       getStmt: [BooleanLiteral] false
 #   39|   getStmt: [CaseExpr] case ...
 #   39|     getValue: [MethodCall] call to expr
-#   39|       getReceiver: [Self, SelfVariableAccess] self
+#   39|       getReceiver: [SelfVariableAccess] self
 #   40|     getBranch: [InClause] in ... then ...
 #   40|       getPattern: [IntegerLiteral] 5
 #   41|     getBranch: [InClause] in ... then ...
@@ -947,7 +947,7 @@ control/cases.rb:
 #   84|     getAnOperand/getRightOperand: [IntegerLiteral] 42
 #   86|   getStmt: [CaseExpr] case ...
 #   86|     getValue: [MethodCall] call to expr
-#   86|       getReceiver: [Self, SelfVariableAccess] self
+#   86|       getReceiver: [SelfVariableAccess] self
 #   87|     getBranch: [InClause] in ... then ...
 #   87|       getPattern: [IntegerLiteral] 5
 #   88|     getBranch: [InClause] in ... then ...
@@ -1004,7 +1004,7 @@ control/cases.rb:
 #  100|     getBranch: [InClause] in ... then ...
 #  100|       getPattern: [AlternativePattern] ... | ...
 #  100|         getAlternative: [NilLiteral] nil
-#  100|         getAlternative: [Self, SelfVariableAccess] self
+#  100|         getAlternative: [SelfVariableAccess] self
 #  100|         getAlternative: [BooleanLiteral] true
 #  100|         getAlternative: [BooleanLiteral] false
 #  100|         getAlternative: [LineLiteral] __LINE__
@@ -1043,7 +1043,7 @@ control/cases.rb:
 #  107|       getPattern: [LocalVariableAccess] var
 #  110|   getStmt: [CaseExpr] case ...
 #  110|     getValue: [MethodCall] call to expr
-#  110|       getReceiver: [Self, SelfVariableAccess] self
+#  110|       getReceiver: [SelfVariableAccess] self
 #  111|     getBranch: [InClause] in ... then ...
 #  111|       getPattern: [AlternativePattern] ... | ...
 #  111|         getAlternative: [IntegerLiteral] 5
@@ -1054,7 +1054,7 @@ control/cases.rb:
 #  111|         getAlternative: [LocalVariableAccess] var
 #  116|   getStmt: [CaseExpr] case ...
 #  116|     getValue: [MethodCall] call to expr
-#  116|       getReceiver: [Self, SelfVariableAccess] self
+#  116|       getReceiver: [SelfVariableAccess] self
 #  117|     getBranch: [InClause] in ... then ...
 #  117|       getPattern: [ArrayPattern] [ ..., * ]
 #  118|     getBranch: [InClause] in ... then ...
@@ -1083,7 +1083,7 @@ control/cases.rb:
 #  123|         getSuffixElement: [LocalVariableAccess] e
 #  128|   getStmt: [CaseExpr] case ...
 #  128|     getValue: [MethodCall] call to expr
-#  128|       getReceiver: [Self, SelfVariableAccess] self
+#  128|       getReceiver: [SelfVariableAccess] self
 #  129|     getBranch: [InClause] in ... then ...
 #  129|       getPattern: [FindPattern] [ *,...,* ]
 #  129|         getElement: [LocalVariableAccess] x
@@ -1104,7 +1104,7 @@ control/cases.rb:
 #  132|         getElement: [ConstantReadAccess] Bar
 #  137|   getStmt: [CaseExpr] case ...
 #  137|     getValue: [MethodCall] call to expr
-#  137|       getReceiver: [Self, SelfVariableAccess] self
+#  137|       getReceiver: [SelfVariableAccess] self
 #  138|     getBranch: [InClause] in ... then ...
 #  138|       getPattern: [HashPattern] { ..., ** }
 #  139|     getBranch: [InClause] in ... then ...
@@ -1141,7 +1141,7 @@ control/cases.rb:
 #  144|         getValue: [IntegerLiteral] 1
 #  147|   getStmt: [CaseExpr] case ...
 #  147|     getValue: [MethodCall] call to expr
-#  147|       getReceiver: [Self, SelfVariableAccess] self
+#  147|       getReceiver: [SelfVariableAccess] self
 #  148|     getBranch: [InClause] in ... then ...
 #  148|       getPattern: [ReferencePattern] ^...
 #  148|         getExpr: [LocalVariableAccess] foo
@@ -1156,7 +1156,7 @@ control/cases.rb:
 #  151|         getExpr: [ClassVariableAccess] @@foo
 #  154|   getStmt: [CaseExpr] case ...
 #  154|     getValue: [MethodCall] call to expr
-#  154|       getReceiver: [Self, SelfVariableAccess] self
+#  154|       getReceiver: [SelfVariableAccess] self
 #  155|     getBranch: [InClause] in ... then ...
 #  155|       getPattern: [ReferencePattern] ^...
 #  155|         getExpr: [LocalVariableAccess] foo
@@ -1175,7 +1175,7 @@ modules/classes.rb:
 #    7|     getSuperclassExpr: [ConstantReadAccess] BaseClass
 #   11|   getStmt: [ClassDeclaration] Baz
 #   11|     getSuperclassExpr: [MethodCall] call to superclass_for
-#   11|       getReceiver: [Self, SelfVariableAccess] self
+#   11|       getReceiver: [SelfVariableAccess] self
 #   11|       getArgument: [SymbolLiteral] :baz
 #   15|   getStmt: [ModuleDeclaration] MyModule
 #   16|   getStmt: [ClassDeclaration] MyClass
@@ -1183,16 +1183,16 @@ modules/classes.rb:
 #   20|   getStmt: [ClassDeclaration] Wibble
 #   21|     getStmt: [Method] method_a
 #   22|       getStmt: [MethodCall] call to puts
-#   22|         getReceiver: [Self, SelfVariableAccess] self
+#   22|         getReceiver: [SelfVariableAccess] self
 #   22|         getArgument: [StringLiteral] "a"
 #   22|           getComponent: [StringTextComponent] a
 #   25|     getStmt: [Method] method_b
 #   26|       getStmt: [MethodCall] call to puts
-#   26|         getReceiver: [Self, SelfVariableAccess] self
+#   26|         getReceiver: [SelfVariableAccess] self
 #   26|         getArgument: [StringLiteral] "b"
 #   26|           getComponent: [StringTextComponent] b
 #   29|     getStmt: [MethodCall] call to some_method_call
-#   29|       getReceiver: [Self, SelfVariableAccess] self
+#   29|       getReceiver: [SelfVariableAccess] self
 #   30|     getStmt: [AssignExpr] ... = ...
 #   30|       getAnOperand/getLeftOperand: [GlobalVariableAccess] $global_var
 #   30|       getAnOperand/getRightOperand: [IntegerLiteral] 123
@@ -1210,11 +1210,11 @@ modules/classes.rb:
 #   43|         getAnOperand/getArgument/getRightOperand: [SuperCall] call to super
 #   46|     getStmt: [Method] wibble
 #   47|       getStmt: [MethodCall] call to puts
-#   47|         getReceiver: [Self, SelfVariableAccess] self
+#   47|         getReceiver: [SelfVariableAccess] self
 #   47|         getArgument: [StringLiteral] "wibble"
 #   47|           getComponent: [StringTextComponent] wibble
 #   50|     getStmt: [MethodCall] call to another_method_call
-#   50|       getReceiver: [Self, SelfVariableAccess] self
+#   50|       getReceiver: [SelfVariableAccess] self
 #   51|     getStmt: [AssignExpr] ... = ...
 #   51|       getAnOperand/getLeftOperand: [GlobalVariableAccess] $global_var2
 #   51|       getAnOperand/getRightOperand: [IntegerLiteral] 456
@@ -1385,7 +1385,7 @@ constants/constants.rb:
 #   22|         getParameter: [SimpleParameter] name
 #   22|           getDefiningAccess: [LocalVariableAccess] name
 #   23|         getStmt: [MethodCall] call to puts
-#   23|           getReceiver: [Self, SelfVariableAccess] self
+#   23|           getReceiver: [SelfVariableAccess] self
 #   23|           getArgument: [StringLiteral] "#{...} #{...}"
 #   23|             getComponent: [StringInterpolationComponent] #{...}
 #   23|               getStmt: [ConstantReadAccess] GREETING
@@ -1393,7 +1393,7 @@ constants/constants.rb:
 #   23|             getComponent: [StringInterpolationComponent] #{...}
 #   23|               getStmt: [LocalVariableAccess] name
 #   28|     getStmt: [MethodCall] call to Array
-#   28|       getReceiver: [Self, SelfVariableAccess] self
+#   28|       getReceiver: [SelfVariableAccess] self
 #   28|       getArgument: [StringLiteral] "foo"
 #   28|         getComponent: [StringTextComponent] foo
 #   31|   getStmt: [ClassDeclaration] ClassD
@@ -1414,15 +1414,15 @@ constants/constants.rb:
 #   39|         getScopeExpr: [ConstantReadAccess] ModuleA
 #   39|     getAnOperand/getRightOperand: [IntegerLiteral] 1024
 #   41|   getStmt: [MethodCall] call to puts
-#   41|     getReceiver: [Self, SelfVariableAccess] self
+#   41|     getReceiver: [SelfVariableAccess] self
 #   41|     getArgument: [ConstantReadAccess] MAX_SIZE
 #   41|       getScopeExpr: [ConstantReadAccess] ModuleB
 #   41|         getScopeExpr: [ConstantReadAccess] ModuleA
 #   43|   getStmt: [MethodCall] call to puts
-#   43|     getReceiver: [Self, SelfVariableAccess] self
+#   43|     getReceiver: [SelfVariableAccess] self
 #   43|     getArgument: [ConstantReadAccess] GREETING
 #   44|   getStmt: [MethodCall] call to puts
-#   44|     getReceiver: [Self, SelfVariableAccess] self
+#   44|     getReceiver: [SelfVariableAccess] self
 #   44|     getArgument: [ConstantReadAccess] GREETING
 #   46|   getStmt: [ModuleDeclaration] ModuleB
 #   46|     getScopeExpr: [ConstantReadAccess] ModuleA
@@ -1459,7 +1459,7 @@ constants/constants.rb:
 #   65|         getScopeExpr: [ConstantReadAccess] Mod3
 #   68|   getStmt: [ModuleDeclaration] Mod4
 #   69|     getStmt: [MethodCall] call to include
-#   69|       getReceiver: [Self, SelfVariableAccess] self
+#   69|       getReceiver: [SelfVariableAccess] self
 #   69|       getArgument: [ConstantReadAccess] Mod1
 #   70|     getStmt: [ModuleDeclaration] Mod5
 #   70|       getScopeExpr: [ConstantReadAccess] Mod3
@@ -1578,7 +1578,7 @@ literals/literals.rb:
 #   66|     getComponent: [StringTextComponent] foo 
 #   66|     getComponent: [StringInterpolationComponent] #{...}
 #   66|       getStmt: [MethodCall] call to blah
-#   66|         getReceiver: [Self, SelfVariableAccess] self
+#   66|         getReceiver: [SelfVariableAccess] self
 #   66|       getStmt: [AddExpr] ... + ...
 #   66|         getAnOperand/getLeftOperand/getReceiver: [IntegerLiteral] 1
 #   66|         getAnOperand/getArgument/getRightOperand: [IntegerLiteral] 9
@@ -1766,7 +1766,7 @@ literals/literals.rb:
 #  118|       getValue: [IntegerLiteral] 7
 #  118|     getElement: [HashSplatExpr] ** ...
 #  118|       getAnOperand/getOperand/getReceiver: [MethodCall] call to baz
-#  118|         getReceiver: [Self, SelfVariableAccess] self
+#  118|         getReceiver: [SelfVariableAccess] self
 #  121|   getStmt: [ParenthesizedExpr] ( ... )
 #  121|     getStmt: [RangeLiteral] _ .. _
 #  121|       getBegin: [IntegerLiteral] 1
@@ -1782,7 +1782,7 @@ literals/literals.rb:
 #  124|   getStmt: [ParenthesizedExpr] ( ... )
 #  124|     getStmt: [RangeLiteral] _ .. _
 #  124|       getBegin: [MethodCall] call to start
-#  124|         getReceiver: [Self, SelfVariableAccess] self
+#  124|         getReceiver: [SelfVariableAccess] self
 #  124|       getEnd: [AddExpr] ... + ...
 #  124|         getAnOperand/getLeftOperand/getReceiver: [IntegerLiteral] 2
 #  124|         getAnOperand/getArgument/getRightOperand: [IntegerLiteral] 3
@@ -1900,7 +1900,7 @@ literals/literals.rb:
 #  152|     getComponent: [StringEscapeSequenceComponent] \\
 #  152|     getComponent: [StringTextComponent] foobar
 #  155|   getStmt: [MethodCall] call to run_sql
-#  155|     getReceiver: [Self, SelfVariableAccess] self
+#  155|     getReceiver: [SelfVariableAccess] self
 #  155|     getArgument: [HereDoc] <<SQL
 #  155|       getComponent: [StringTextComponent] 
 #  155|       select * from table
@@ -1910,7 +1910,7 @@ literals/literals.rb:
 #  157|       where name = 
 #  158|       getComponent: [StringInterpolationComponent] #{...}
 #  158|         getStmt: [MethodCall] call to name
-#  158|           getReceiver: [Self, SelfVariableAccess] self
+#  158|           getReceiver: [SelfVariableAccess] self
 #  158|       getComponent: [StringTextComponent] 
 #  158|       
 #  161|   getStmt: [Method] m
@@ -1935,7 +1935,7 @@ literals/literals.rb:
 #  171|        text with 
 #  172|       getComponent: [StringInterpolationComponent] #{...}
 #  172|         getStmt: [MethodCall] call to interpolation
-#  172|           getReceiver: [Self, SelfVariableAccess] self
+#  172|           getReceiver: [SelfVariableAccess] self
 #  172|       getComponent: [StringTextComponent]  !
 #  172|       
 #  176|   getStmt: [AssignExpr] ... = ...
@@ -1945,7 +1945,7 @@ literals/literals.rb:
 #  176|        text without 
 #  177|       getComponent: [StringInterpolationComponent] #{...}
 #  177|         getStmt: [MethodCall] call to interpolation
-#  177|           getReceiver: [Self, SelfVariableAccess] self
+#  177|           getReceiver: [SelfVariableAccess] self
 #  177|       getComponent: [StringTextComponent]  !
 #  177|       
 #  180|   getStmt: [AssignExpr] ... = ...
@@ -2116,7 +2116,7 @@ control/loops.rb:
 misc/misc.erb:
 #    2| [Toplevel] misc.erb
 #    2|   getStmt: [MethodCall] call to require_asset
-#    2|     getReceiver: [Self, SelfVariableAccess] self
+#    2|     getReceiver: [SelfVariableAccess] self
 #    2|     getArgument: [StringLiteral] "main_include_admin.js"
 #    2|       getComponent: [StringTextComponent] main_include_admin.js
 misc/misc.rb:
@@ -2166,7 +2166,7 @@ modules/modules.rb:
 #    6|       getStmt: [ClassDeclaration] ClassInFooBar
 #    9|       getStmt: [Method] method_in_foo_bar
 #   12|       getStmt: [MethodCall] call to puts
-#   12|         getReceiver: [Self, SelfVariableAccess] self
+#   12|         getReceiver: [SelfVariableAccess] self
 #   12|         getArgument: [StringLiteral] "module Foo::Bar"
 #   12|           getComponent: [StringTextComponent] module Foo::Bar
 #   13|       getStmt: [AssignExpr] ... = ...
@@ -2175,7 +2175,7 @@ modules/modules.rb:
 #   16|     getStmt: [Method] method_in_foo
 #   19|     getStmt: [ClassDeclaration] ClassInFoo
 #   22|     getStmt: [MethodCall] call to puts
-#   22|       getReceiver: [Self, SelfVariableAccess] self
+#   22|       getReceiver: [SelfVariableAccess] self
 #   22|       getArgument: [StringLiteral] "module Foo"
 #   22|         getComponent: [StringTextComponent] module Foo
 #   23|     getStmt: [AssignExpr] ... = ...
@@ -2185,7 +2185,7 @@ modules/modules.rb:
 #   27|     getStmt: [Method] method_in_another_definition_of_foo
 #   30|     getStmt: [ClassDeclaration] ClassInAnotherDefinitionOfFoo
 #   33|     getStmt: [MethodCall] call to puts
-#   33|       getReceiver: [Self, SelfVariableAccess] self
+#   33|       getReceiver: [SelfVariableAccess] self
 #   33|       getArgument: [StringLiteral] "module Foo again"
 #   33|         getComponent: [StringTextComponent] module Foo again
 #   34|     getStmt: [AssignExpr] ... = ...
@@ -2195,7 +2195,7 @@ modules/modules.rb:
 #   38|     getStmt: [Method] method_a
 #   41|     getStmt: [Method] method_b
 #   44|     getStmt: [MethodCall] call to puts
-#   44|       getReceiver: [Self, SelfVariableAccess] self
+#   44|       getReceiver: [SelfVariableAccess] self
 #   44|       getArgument: [StringLiteral] "module Bar"
 #   44|         getComponent: [StringTextComponent] module Bar
 #   45|     getStmt: [AssignExpr] ... = ...
@@ -2206,7 +2206,7 @@ modules/modules.rb:
 #   49|     getStmt: [ClassDeclaration] ClassInAnotherDefinitionOfFooBar
 #   52|     getStmt: [Method] method_in_another_definition_of_foo_bar
 #   55|     getStmt: [MethodCall] call to puts
-#   55|       getReceiver: [Self, SelfVariableAccess] self
+#   55|       getReceiver: [SelfVariableAccess] self
 #   55|       getArgument: [StringLiteral] "module Foo::Bar again"
 #   55|         getComponent: [StringTextComponent] module Foo::Bar again
 #   56|     getStmt: [AssignExpr] ... = ...
@@ -2231,25 +2231,25 @@ modules/modules.rb:
 #   84|     getStmt: [ModuleDeclaration] Foo1
 #   88|   getStmt: [ModuleDeclaration] IncludeTest
 #   89|     getStmt: [MethodCall] call to include
-#   89|       getReceiver: [Self, SelfVariableAccess] self
+#   89|       getReceiver: [SelfVariableAccess] self
 #   89|       getArgument: [ConstantReadAccess] Test
 #   90|     getStmt: [MethodCall] call to module_eval
 #   90|       getReceiver: [ConstantReadAccess] Object
 #   90|       getBlock: [BraceBlock] { ... }
 #   90|         getStmt: [MethodCall] call to prepend
-#   90|           getReceiver: [Self, SelfVariableAccess] self
+#   90|           getReceiver: [SelfVariableAccess] self
 #   90|           getArgument: [ConstantReadAccess] Other
 #   91|     getStmt: [ModuleDeclaration] Y
 #   91|       getScopeExpr: [ConstantReadAccess] Foo1
 #   95|   getStmt: [ModuleDeclaration] IncludeTest2
 #   96|     getStmt: [MethodCall] call to include
-#   96|       getReceiver: [Self, SelfVariableAccess] self
+#   96|       getReceiver: [SelfVariableAccess] self
 #   96|       getArgument: [ConstantReadAccess] Test
 #   97|     getStmt: [ModuleDeclaration] Z
 #   97|       getScopeExpr: [ConstantReadAccess] Foo1
 #  101|   getStmt: [ModuleDeclaration] PrependTest
 #  102|     getStmt: [MethodCall] call to prepend
-#  102|       getReceiver: [Self, SelfVariableAccess] self
+#  102|       getReceiver: [SelfVariableAccess] self
 #  102|       getArgument: [ConstantReadAccess] Test
 #  103|     getStmt: [ModuleDeclaration] Y
 #  103|       getScopeExpr: [ConstantReadAccess] Foo2
@@ -2513,7 +2513,7 @@ params/params.rb:
 #    9|       getParameter: [SimpleParameter] value
 #    9|         getDefiningAccess: [LocalVariableAccess] value
 #   10|       getStmt: [MethodCall] call to puts
-#   10|         getReceiver: [Self, SelfVariableAccess] self
+#   10|         getReceiver: [SelfVariableAccess] self
 #   10|         getArgument: [StringLiteral] "#{...} -> #{...}"
 #   10|           getComponent: [StringInterpolationComponent] #{...}
 #   10|             getStmt: [LocalVariableAccess] key
@@ -2545,7 +2545,7 @@ params/params.rb:
 #   22|         getElement: [LocalVariableAccess] a
 #   22|         getElement: [LocalVariableAccess] b
 #   22|       getStmt: [MethodCall] call to puts
-#   22|         getReceiver: [Self, SelfVariableAccess] self
+#   22|         getReceiver: [SelfVariableAccess] self
 #   22|         getArgument: [AddExpr] ... + ...
 #   22|           getAnOperand/getLeftOperand/getReceiver: [LocalVariableAccess] a
 #   22|           getAnOperand/getArgument/getRightOperand: [LocalVariableAccess] b
@@ -2607,7 +2607,7 @@ params/params.rb:
 #   46|     getParameter: [BlockParameter] &block
 #   46|       getDefiningAccess: [LocalVariableAccess] block
 #   47|     getStmt: [MethodCall] call to puts
-#   47|       getReceiver: [Self, SelfVariableAccess] self
+#   47|       getReceiver: [SelfVariableAccess] self
 #   47|       getArgument: [MethodCall] call to call
 #   47|         getReceiver: [LocalVariableAccess] block
 #   47|         getArgument: [Pair] Pair
@@ -2617,7 +2617,7 @@ params/params.rb:
 #   47|           getKey: [SymbolLiteral] :foo
 #   47|           getValue: [IntegerLiteral] 3
 #   49|   getStmt: [MethodCall] call to use_block_with_keyword
-#   49|     getReceiver: [Self, SelfVariableAccess] self
+#   49|     getReceiver: [SelfVariableAccess] self
 #   49|     getBlock: [DoBlock] do ... end
 #   49|       getParameter: [KeywordParameter] xx
 #   49|         getDefiningAccess: [LocalVariableAccess] xx
@@ -2659,7 +2659,7 @@ params/params.rb:
 #   63|       getArgument: [StringLiteral] "Zeus"
 #   63|         getComponent: [StringTextComponent] Zeus
 #   65|   getStmt: [MethodCall] call to use_block_with_optional
-#   65|     getReceiver: [Self, SelfVariableAccess] self
+#   65|     getReceiver: [SelfVariableAccess] self
 #   65|     getBlock: [DoBlock] do ... end
 #   65|       getParameter: [SimpleParameter] name
 #   65|         getDefiningAccess: [LocalVariableAccess] name
@@ -2667,7 +2667,7 @@ params/params.rb:
 #   65|         getDefiningAccess: [LocalVariableAccess] age
 #   65|         getDefaultValue: [IntegerLiteral] 99
 #   66|       getStmt: [MethodCall] call to puts
-#   66|         getReceiver: [Self, SelfVariableAccess] self
+#   66|         getReceiver: [SelfVariableAccess] self
 #   66|         getArgument: [StringLiteral] "#{...} is #{...} years old"
 #   66|           getComponent: [StringInterpolationComponent] #{...}
 #   66|             getStmt: [LocalVariableAccess] name
@@ -2707,7 +2707,7 @@ params/params.rb:
 #   81|     getParameter: [BlockParameter] &
 #   81|       getDefiningAccess: [LocalVariableAccess] __synth__0
 #   82|     getStmt: [MethodCall] call to proc
-#   82|       getReceiver: [Self, SelfVariableAccess] self
+#   82|       getReceiver: [SelfVariableAccess] self
 #   82|       getArgument: [BlockArgument] &...
 #   82|         getValue: [LocalVariableAccess] __synth__0
 #   83|     getStmt: [MethodCall] call to each
@@ -2789,24 +2789,24 @@ gems/lib/test.rb:
 #    1| [Toplevel] test.rb
 #    1|   getStmt: [ClassDeclaration] Foo
 #    2|     getStmt: [SingletonMethod] greet
-#    2|       getObject: [Self, SelfVariableAccess] self
+#    2|       getObject: [SelfVariableAccess] self
 #    3|       getStmt: [MethodCall] call to puts
-#    3|         getReceiver: [Self, SelfVariableAccess] self
+#    3|         getReceiver: [SelfVariableAccess] self
 #    3|         getArgument: [StringLiteral] "Hello"
 #    3|           getComponent: [StringTextComponent] Hello
 modules/toplevel.rb:
 #    1| [Toplevel] toplevel.rb
 #    1|   getStmt: [MethodCall] call to puts
-#    1|     getReceiver: [Self, SelfVariableAccess] self
+#    1|     getReceiver: [SelfVariableAccess] self
 #    1|     getArgument: [StringLiteral] "world"
 #    1|       getComponent: [StringTextComponent] world
 #    3|   getStmt: [EndBlock] END { ... }
 #    3|     getStmt: [MethodCall] call to puts
-#    3|       getReceiver: [Self, SelfVariableAccess] self
+#    3|       getReceiver: [SelfVariableAccess] self
 #    3|       getArgument: [StringLiteral] "!!!"
 #    3|         getComponent: [StringTextComponent] !!!
 #    5|   getBeginBlock: [BeginBlock] BEGIN { ... }
 #    5|     getStmt: [MethodCall] call to puts
-#    5|       getReceiver: [Self, SelfVariableAccess] self
+#    5|       getReceiver: [SelfVariableAccess] self
 #    5|       getArgument: [StringLiteral] "hello"
 #    5|         getComponent: [StringTextComponent] hello

--- a/ruby/ql/test/library-tests/ast/AstDesugar.expected
+++ b/ruby/ql/test/library-tests/ast/AstDesugar.expected
@@ -3,7 +3,7 @@ calls/calls.rb:
 #   58|   getDesugared: [MethodCall] call to []
 #   58|     getReceiver: [ConstantReadAccess] Array
 #   58|     getArgument: [MethodCall] call to foo
-#   58|       getReceiver: [Self, SelfVariableAccess] self
+#   58|       getReceiver: [SelfVariableAccess] self
 #   59| [ArrayLiteral] [...]
 #   59|   getDesugared: [MethodCall] call to []
 #   59|     getReceiver: [ConstantReadAccess] Array
@@ -15,7 +15,7 @@ calls/calls.rb:
 #   66|     getAnOperand/getRightOperand: [AddExpr] ... + ...
 #   66|       getAnOperand/getLeftOperand/getReceiver: [LocalVariableAccess] var1
 #   66|       getAnOperand/getArgument/getRightOperand: [MethodCall] call to bar
-#   66|         getReceiver: [Self, SelfVariableAccess] self
+#   66|         getReceiver: [SelfVariableAccess] self
 #   67| [AssignAddExpr] ... += ...
 #   67|   getDesugared: [AssignExpr] ... = ...
 #   67|     getAnOperand/getLeftOperand: [LocalVariableAccess] var1
@@ -32,9 +32,9 @@ calls/calls.rb:
 #  226|         getAnOperand/getRightOperand: [LocalVariableAccess] __synth__0__1
 #  226|         getAnOperand/getLeftOperand: [LocalVariableAccess] x
 #  227|       getStmt: [MethodCall] call to baz
-#  227|         getReceiver: [Self, SelfVariableAccess] self
+#  227|         getReceiver: [SelfVariableAccess] self
 #  226|     getReceiver: [MethodCall] call to bar
-#  226|       getReceiver: [Self, SelfVariableAccess] self
+#  226|       getReceiver: [SelfVariableAccess] self
 #  229| [ForExpr] for ... in ...
 #  229|   getDesugared: [MethodCall] call to each
 #  229|     getBlock: [BraceBlock] { ... }
@@ -52,9 +52,9 @@ calls/calls.rb:
 #  249|     getReceiver: [ConstantReadAccess] Hash
 #  249|     getArgument: [Pair] Pair
 #  249|       getKey: [MethodCall] call to foo
-#  249|         getReceiver: [Self, SelfVariableAccess] self
+#  249|         getReceiver: [SelfVariableAccess] self
 #  249|       getValue: [MethodCall] call to bar
-#  249|         getReceiver: [Self, SelfVariableAccess] self
+#  249|         getReceiver: [SelfVariableAccess] self
 #  249|     getArgument: [Pair] Pair
 #  249|       getKey: [MethodCall] call to foo
 #  249|         getReceiver: [ConstantReadAccess] X
@@ -63,7 +63,7 @@ calls/calls.rb:
 #  314| [AssignExpr] ... = ...
 #  314|   getDesugared: [StmtSequence] ...
 #  314|     getStmt: [SetterMethodCall] call to foo=
-#  314|       getReceiver: [Self, SelfVariableAccess] self
+#  314|       getReceiver: [SelfVariableAccess] self
 #  314|       getArgument: [AssignExpr] ... = ...
 #  314|         getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__0
 #  314|         getAnOperand/getRightOperand: [IntegerLiteral] 10
@@ -72,7 +72,7 @@ calls/calls.rb:
 #  315|   getDesugared: [StmtSequence] ...
 #  315|     getStmt: [SetterMethodCall] call to []=
 #  315|       getReceiver: [MethodCall] call to foo
-#  315|         getReceiver: [Self, SelfVariableAccess] self
+#  315|         getReceiver: [SelfVariableAccess] self
 #  315|       getArgument: [AssignExpr] ... = ...
 #  315|         getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__0
 #  315|         getAnOperand/getRightOperand: [IntegerLiteral] 10
@@ -84,7 +84,7 @@ calls/calls.rb:
 #  316|       getAnOperand/getLeftOperand: [MethodCall] call to foo
 #  316|       getDesugared: [StmtSequence] ...
 #  316|         getStmt: [SetterMethodCall] call to foo=
-#  316|           getReceiver: [Self, SelfVariableAccess] self
+#  316|           getReceiver: [SelfVariableAccess] self
 #  316|           getArgument: [AssignExpr] ... = ...
 #  316|             getAnOperand/getRightOperand: [MethodCall] call to []
 #  316|               getArgument: [IntegerLiteral] 0
@@ -95,7 +95,7 @@ calls/calls.rb:
 #  316|       getAnOperand/getLeftOperand: [MethodCall] call to bar
 #  316|       getDesugared: [StmtSequence] ...
 #  316|         getStmt: [SetterMethodCall] call to bar=
-#  316|           getReceiver: [Self, SelfVariableAccess] self
+#  316|           getReceiver: [SelfVariableAccess] self
 #  316|           getArgument: [AssignExpr] ... = ...
 #  316|             getAnOperand/getRightOperand: [MethodCall] call to []
 #  316|               getArgument: [RangeLiteral] _ .. _
@@ -109,7 +109,7 @@ calls/calls.rb:
 #  316|       getDesugared: [StmtSequence] ...
 #  316|         getStmt: [SetterMethodCall] call to []=
 #  316|           getReceiver: [MethodCall] call to foo
-#  316|             getReceiver: [Self, SelfVariableAccess] self
+#  316|             getReceiver: [SelfVariableAccess] self
 #  316|           getArgument: [AssignExpr] ... = ...
 #  316|             getAnOperand/getRightOperand: [MethodCall] call to []
 #  316|               getArgument: [IntegerLiteral] -1
@@ -139,7 +139,7 @@ calls/calls.rb:
 #  317|       getDesugared: [StmtSequence] ...
 #  317|         getStmt: [SetterMethodCall] call to []=
 #  317|           getReceiver: [MethodCall] call to foo
-#  317|             getReceiver: [Self, SelfVariableAccess] self
+#  317|             getReceiver: [SelfVariableAccess] self
 #  317|           getArgument: [AssignExpr] ... = ...
 #  317|             getAnOperand/getRightOperand: [MethodCall] call to []
 #  317|               getArgument: [RangeLiteral] _ .. _
@@ -161,7 +161,7 @@ calls/calls.rb:
 #  318| [AssignAddExpr] ... += ...
 #  318|   getDesugared: [StmtSequence] ...
 #  318|     getStmt: [AssignExpr] ... = ...
-#  318|       getAnOperand/getRightOperand: [Self, SelfVariableAccess] self
+#  318|       getAnOperand/getRightOperand: [SelfVariableAccess] self
 #  318|       getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__0
 #  318|     getStmt: [SetterMethodCall] call to count=
 #  318|       getReceiver: [LocalVariableAccess] __synth__0
@@ -177,7 +177,7 @@ calls/calls.rb:
 #  319|   getDesugared: [StmtSequence] ...
 #  319|     getStmt: [AssignExpr] ... = ...
 #  319|       getAnOperand/getRightOperand: [MethodCall] call to foo
-#  319|         getReceiver: [Self, SelfVariableAccess] self
+#  319|         getReceiver: [SelfVariableAccess] self
 #  319|       getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__0
 #  319|     getStmt: [SetterMethodCall] call to []=
 #  319|       getReceiver: [LocalVariableAccess] __synth__0
@@ -199,7 +199,7 @@ calls/calls.rb:
 #  320|     getStmt: [AssignExpr] ... = ...
 #  320|       getAnOperand/getRightOperand: [MethodCall] call to bar
 #  320|         getReceiver: [MethodCall] call to foo
-#  320|           getReceiver: [Self, SelfVariableAccess] self
+#  320|           getReceiver: [SelfVariableAccess] self
 #  320|       getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__0
 #  320|     getStmt: [SetterMethodCall] call to []=
 #  320|       getReceiver: [LocalVariableAccess] __synth__0
@@ -213,13 +213,13 @@ calls/calls.rb:
 #  320|     getStmt: [AssignExpr] ... = ...
 #  320|       getAnOperand/getRightOperand: [MethodCall] call to baz
 #  320|         getReceiver: [MethodCall] call to foo
-#  320|           getReceiver: [Self, SelfVariableAccess] self
+#  320|           getReceiver: [SelfVariableAccess] self
 #  320|       getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__2
 #  320|     getStmt: [AssignExpr] ... = ...
 #  320|       getAnOperand/getRightOperand: [AddExpr] ... + ...
 #  320|         getAnOperand/getLeftOperand/getReceiver: [MethodCall] call to boo
 #  320|           getReceiver: [MethodCall] call to foo
-#  320|             getReceiver: [Self, SelfVariableAccess] self
+#  320|             getReceiver: [SelfVariableAccess] self
 #  320|         getAnOperand/getArgument/getRightOperand: [IntegerLiteral] 1
 #  320|       getAnOperand/getLeftOperand: [LocalVariableAccess] __synth__3
 #  320|     getStmt: [AssignExpr] ... = ...
@@ -260,7 +260,7 @@ calls/calls.rb:
 #  340|               getReceiver: [LocalVariableAccess] __synth__0__1
 #  340|         getAnOperand/getLeftOperand: [DestructuredLhsExpr] (..., ...)
 #  341|       getStmt: [MethodCall] call to foo
-#  341|         getReceiver: [Self, SelfVariableAccess] self
+#  341|         getReceiver: [SelfVariableAccess] self
 #  341|         getArgument: [LocalVariableAccess] x
 #  341|         getArgument: [LocalVariableAccess] y
 #  341|         getArgument: [LocalVariableAccess] z
@@ -476,7 +476,7 @@ literals/literals.rb:
 #  118|       getValue: [IntegerLiteral] 7
 #  118|     getArgument: [HashSplatExpr] ** ...
 #  118|       getAnOperand/getOperand/getReceiver: [MethodCall] call to baz
-#  118|         getReceiver: [Self, SelfVariableAccess] self
+#  118|         getReceiver: [SelfVariableAccess] self
 #  185| [HashLiteral] {...}
 #  185|   getDesugared: [MethodCall] call to []
 #  185|     getReceiver: [ConstantReadAccess] Hash

--- a/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
+++ b/ruby/ql/test/library-tests/dataflow/local/DataflowStep.expected
@@ -1,6 +1,6 @@
 | local_dataflow.rb:1:1:7:3 | self (foo) | local_dataflow.rb:3:8:3:10 | self |
 | local_dataflow.rb:1:1:7:3 | self (local_dataflow.rb) | local_dataflow.rb:49:1:53:3 | self |
-| local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:3:8:3:10 | self |
+| local_dataflow.rb:1:1:7:3 | self in foo | local_dataflow.rb:1:1:7:3 | self (foo) |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:1:9:1:9 | a |
 | local_dataflow.rb:1:9:1:9 | a | local_dataflow.rb:2:7:2:7 | a |
 | local_dataflow.rb:2:3:2:7 | ... = ... | local_dataflow.rb:3:13:3:13 | b |
@@ -71,16 +71,7 @@
 | local_dataflow.rb:50:18:50:18 | x | local_dataflow.rb:51:20:51:20 | x |
 | local_dataflow.rb:51:9:51:15 | "break" | local_dataflow.rb:51:3:51:15 | break |
 | local_dataflow.rb:60:1:90:3 | self (test_case) | local_dataflow.rb:78:12:78:20 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:78:12:78:20 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:79:20:79:26 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:80:24:80:30 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:82:7:82:13 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:83:7:83:13 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:84:7:84:13 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:85:22:85:28 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:86:28:86:34 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:87:20:87:26 | self |
-| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:89:3:89:9 | self |
+| local_dataflow.rb:60:1:90:3 | self in test_case | local_dataflow.rb:60:1:90:3 | self (test_case) |
 | local_dataflow.rb:60:15:60:15 | x | local_dataflow.rb:60:15:60:15 | x |
 | local_dataflow.rb:60:15:60:15 | x | local_dataflow.rb:61:12:61:12 | x |
 | local_dataflow.rb:61:7:68:5 | case ... | local_dataflow.rb:61:3:68:5 | ... = ... |

--- a/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/string-flow/string-flow.expected
@@ -201,7 +201,6 @@ edges
 | string_flow.rb:241:10:241:10 | b [array element] :  | string_flow.rb:241:10:241:13 | ...[...] |
 | string_flow.rb:242:10:242:10 | b [array element] :  | string_flow.rb:242:10:242:13 | ...[...] |
 | string_flow.rb:246:5:246:18 | ... = ... :  | string_flow.rb:250:26:250:26 | a :  |
-| string_flow.rb:246:5:246:18 | ... = ... :  | string_flow.rb:258:27:258:27 | a :  |
 | string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:246:5:246:18 | ... = ... :  |
 | string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:247:10:247:10 | a :  |
 | string_flow.rb:246:9:246:18 | call to source :  | string_flow.rb:248:20:248:20 | a :  |
@@ -215,7 +214,6 @@ edges
 | string_flow.rb:250:26:250:26 | a :  | string_flow.rb:250:10:250:28 | call to scrub |
 | string_flow.rb:252:10:252:10 | a :  | string_flow.rb:252:10:252:22 | call to scrub! |
 | string_flow.rb:253:21:253:21 | a :  | string_flow.rb:253:10:253:22 | call to scrub! |
-| string_flow.rb:255:5:255:18 | ... = ... :  | string_flow.rb:250:26:250:26 | a :  |
 | string_flow.rb:255:5:255:18 | ... = ... :  | string_flow.rb:258:27:258:27 | a :  |
 | string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:255:5:255:18 | ... = ... :  |
 | string_flow.rb:255:9:255:18 | call to source :  | string_flow.rb:256:5:256:5 | a :  |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -5,6 +5,7 @@ track
 | type_tracker.rb:2:5:5:7 | return return in field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:2:5:5:7 | self (field=) | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self (field=) | type tracker without call steps | type_tracker.rb:2:5:5:7 | self (field=) |
+| type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:2:5:5:7 | self in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | self in field= |
 | type_tracker.rb:2:16:2:18 | val | type tracker with call steps | type_tracker.rb:2:16:2:18 | val |
@@ -16,17 +17,10 @@ track
 | type_tracker.rb:3:9:3:23 | [post] self | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:3:9:3:23 | [post] self | type tracker without call steps | type_tracker.rb:3:9:3:23 | [post] self |
 | type_tracker.rb:3:9:3:23 | call to puts | type tracker without call steps | type_tracker.rb:3:9:3:23 | call to puts |
-| type_tracker.rb:3:9:3:23 | self | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:3:9:3:23 | self | type tracker without call steps | type_tracker.rb:3:9:3:23 | self |
 | type_tracker.rb:3:14:3:17 | [post] self | type tracker without call steps | type_tracker.rb:3:14:3:17 | [post] self |
-| type_tracker.rb:3:14:3:17 | self | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:3:14:3:17 | self | type tracker without call steps | type_tracker.rb:3:14:3:17 | self |
 | type_tracker.rb:3:14:3:23 | [post] call to field | type tracker without call steps | type_tracker.rb:3:14:3:23 | [post] call to field |
 | type_tracker.rb:3:14:3:23 | call to field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:4:9:4:14 | @field | type tracker without call steps | type_tracker.rb:4:9:4:14 | @field |
-| type_tracker.rb:4:18:4:20 | val | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:4:18:4:20 | val | type tracker without call steps | type_tracker.rb:4:18:4:20 | val |
-| type_tracker.rb:4:18:4:20 | val | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:7:5:9:7 | &block | type tracker without call steps | type_tracker.rb:7:5:9:7 | &block |
 | type_tracker.rb:7:5:9:7 | field | type tracker without call steps | type_tracker.rb:7:5:9:7 | field |
 | type_tracker.rb:7:5:9:7 | return return in field | type tracker without call steps | type_tracker.rb:3:14:3:23 | call to field |
@@ -41,15 +35,22 @@ track
 | type_tracker.rb:12:1:16:3 | m | type tracker without call steps | type_tracker.rb:12:1:16:3 | m |
 | type_tracker.rb:12:1:16:3 | return return in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | return return in m |
 | type_tracker.rb:12:1:16:3 | self (m) | type tracker without call steps | type_tracker.rb:12:1:16:3 | self (m) |
+| type_tracker.rb:12:1:16:3 | self in m | type tracker with call steps | type_tracker.rb:12:1:16:3 | self (m) |
 | type_tracker.rb:12:1:16:3 | self in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | self in m |
 | type_tracker.rb:13:5:13:7 | var | type tracker without call steps | type_tracker.rb:13:5:13:7 | var |
+| type_tracker.rb:13:5:13:23 | ... = ... | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
+| type_tracker.rb:13:5:13:23 | ... = ... | type tracker with call steps | type_tracker.rb:2:5:5:7 | self in field= |
+| type_tracker.rb:13:5:13:23 | ... = ... | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
+| type_tracker.rb:13:5:13:23 | ... = ... | type tracker without call steps | type_tracker.rb:13:5:13:23 | ... = ... |
 | type_tracker.rb:13:11:13:19 | Container | type tracker without call steps | type_tracker.rb:13:11:13:19 | Container |
 | type_tracker.rb:13:11:13:19 | [post] Container | type tracker without call steps | type_tracker.rb:13:11:13:19 | [post] Container |
+| type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:2:5:5:7 | self in field= |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker without call steps | type_tracker.rb:13:11:13:23 | call to new |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:5:14:7 | [post] var | type tracker without call steps | type_tracker.rb:14:5:14:7 | [post] var |
+| type_tracker.rb:14:5:14:13 | ... = ... | type tracker without call steps | type_tracker.rb:14:5:14:13 | ... = ... |
 | type_tracker.rb:14:5:14:13 | [post] ... = ... | type tracker without call steps | type_tracker.rb:14:5:14:13 | [post] ... = ... |
 | type_tracker.rb:14:5:14:13 | __synth__0 | type tracker without call steps | type_tracker.rb:14:5:14:13 | __synth__0 |
 | type_tracker.rb:14:5:14:13 | call to field= | type tracker without call steps | type_tracker.rb:14:5:14:13 | call to field= |
@@ -63,7 +64,6 @@ track
 | type_tracker.rb:15:5:15:18 | [post] self | type tracker without call steps | type_tracker.rb:15:5:15:18 | [post] self |
 | type_tracker.rb:15:5:15:18 | call to puts | type tracker without call steps | type_tracker.rb:12:1:16:3 | return return in m |
 | type_tracker.rb:15:5:15:18 | call to puts | type tracker without call steps | type_tracker.rb:15:5:15:18 | call to puts |
-| type_tracker.rb:15:5:15:18 | self | type tracker without call steps | type_tracker.rb:15:5:15:18 | self |
 | type_tracker.rb:15:10:15:12 | [post] var | type tracker without call steps | type_tracker.rb:15:10:15:12 | [post] var |
 | type_tracker.rb:15:10:15:18 | [post] call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | [post] call to field |
 | type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
@@ -76,6 +76,7 @@ trackEnd
 | type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:3:9:3:23 | self |
 | type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:3:14:3:17 | self |
 | type_tracker.rb:2:5:5:7 | self (field=) | type_tracker.rb:7:5:9:7 | self in field |
+| type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:2:5:5:7 | self (field=) |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:2:5:5:7 | self in field= |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:3:9:3:23 | self |
 | type_tracker.rb:2:5:5:7 | self in field= | type_tracker.rb:3:14:3:17 | self |
@@ -94,19 +95,10 @@ trackEnd
 | type_tracker.rb:3:9:3:23 | [post] self | type_tracker.rb:3:14:3:17 | self |
 | type_tracker.rb:3:9:3:23 | [post] self | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:3:9:3:23 | call to puts | type_tracker.rb:3:9:3:23 | call to puts |
-| type_tracker.rb:3:9:3:23 | self | type_tracker.rb:3:9:3:23 | self |
-| type_tracker.rb:3:9:3:23 | self | type_tracker.rb:3:14:3:17 | self |
-| type_tracker.rb:3:9:3:23 | self | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:3:14:3:17 | [post] self | type_tracker.rb:3:14:3:17 | [post] self |
-| type_tracker.rb:3:14:3:17 | self | type_tracker.rb:3:14:3:17 | self |
-| type_tracker.rb:3:14:3:17 | self | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:3:14:3:23 | [post] call to field | type_tracker.rb:3:14:3:23 | [post] call to field |
 | type_tracker.rb:3:14:3:23 | call to field | type_tracker.rb:3:14:3:23 | call to field |
 | type_tracker.rb:4:9:4:14 | @field | type_tracker.rb:4:9:4:14 | @field |
-| type_tracker.rb:4:18:4:20 | val | type_tracker.rb:2:5:5:7 | return return in field= |
-| type_tracker.rb:4:18:4:20 | val | type_tracker.rb:4:9:4:20 | ... = ... |
-| type_tracker.rb:4:18:4:20 | val | type_tracker.rb:4:18:4:20 | val |
-| type_tracker.rb:4:18:4:20 | val | type_tracker.rb:14:5:14:13 | call to field= |
 | type_tracker.rb:7:5:9:7 | &block | type_tracker.rb:7:5:9:7 | &block |
 | type_tracker.rb:7:5:9:7 | field | type_tracker.rb:1:1:10:3 | Container |
 | type_tracker.rb:7:5:9:7 | field | type_tracker.rb:7:5:9:7 | field |
@@ -123,11 +115,21 @@ trackEnd
 | type_tracker.rb:12:1:16:3 | return return in m | type_tracker.rb:12:1:16:3 | return return in m |
 | type_tracker.rb:12:1:16:3 | self (m) | type_tracker.rb:12:1:16:3 | self (m) |
 | type_tracker.rb:12:1:16:3 | self (m) | type_tracker.rb:15:5:15:18 | self |
+| type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:12:1:16:3 | self (m) |
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:12:1:16:3 | self in m |
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:15:5:15:18 | self |
 | type_tracker.rb:13:5:13:7 | var | type_tracker.rb:13:5:13:7 | var |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:2:5:5:7 | self (field=) |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:2:5:5:7 | self in field= |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:3:9:3:23 | self |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:3:14:3:17 | self |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:7:5:9:7 | self in field |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:13:5:13:23 | ... = ... |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:14:5:14:7 | var |
+| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:15:10:15:12 | var |
 | type_tracker.rb:13:11:13:19 | Container | type_tracker.rb:13:11:13:19 | Container |
 | type_tracker.rb:13:11:13:19 | [post] Container | type_tracker.rb:13:11:13:19 | [post] Container |
+| type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:2:5:5:7 | self (field=) |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:2:5:5:7 | self in field= |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:3:9:3:23 | self |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:3:14:3:17 | self |
@@ -140,6 +142,9 @@ trackEnd
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:7:5:9:7 | self in field |
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:14:5:14:7 | [post] var |
 | type_tracker.rb:14:5:14:7 | [post] var | type_tracker.rb:15:10:15:12 | var |
+| type_tracker.rb:14:5:14:13 | ... = ... | type_tracker.rb:14:5:14:13 | ... = ... |
+| type_tracker.rb:14:5:14:13 | ... = ... | type_tracker.rb:14:5:14:13 | __synth__0 |
+| type_tracker.rb:14:5:14:13 | ... = ... | type_tracker.rb:14:5:14:23 | ... |
 | type_tracker.rb:14:5:14:13 | [post] ... = ... | type_tracker.rb:14:5:14:13 | [post] ... = ... |
 | type_tracker.rb:14:5:14:13 | __synth__0 | type_tracker.rb:14:5:14:13 | __synth__0 |
 | type_tracker.rb:14:5:14:13 | call to field= | type_tracker.rb:14:5:14:13 | call to field= |
@@ -157,7 +162,6 @@ trackEnd
 | type_tracker.rb:15:5:15:18 | [post] self | type_tracker.rb:15:5:15:18 | [post] self |
 | type_tracker.rb:15:5:15:18 | call to puts | type_tracker.rb:12:1:16:3 | return return in m |
 | type_tracker.rb:15:5:15:18 | call to puts | type_tracker.rb:15:5:15:18 | call to puts |
-| type_tracker.rb:15:5:15:18 | self | type_tracker.rb:15:5:15:18 | self |
 | type_tracker.rb:15:10:15:12 | [post] var | type_tracker.rb:15:10:15:12 | [post] var |
 | type_tracker.rb:15:10:15:18 | [post] call to field | type_tracker.rb:15:10:15:18 | [post] call to field |
 | type_tracker.rb:15:10:15:18 | call to field | type_tracker.rb:15:10:15:18 | call to field |

--- a/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
@@ -45,9 +45,9 @@ potentiallyUnsafeSqlExecutingMethodCall
 | ActiveRecordInjection.rb:75:5:75:29 | call to order |
 | ActiveRecordInjection.rb:80:7:80:40 | call to find_by |
 activeRecordModelInstantiations
-| ActiveRecordInjection.rb:10:5:10:68 | self | ActiveRecordInjection.rb:5:1:17:3 | User |
+| ActiveRecordInjection.rb:8:3:11:5 | self (authenticate) | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:15:5:15:40 | call to find_by | ActiveRecordInjection.rb:1:1:3:3 | UserGroup |
-| ActiveRecordInjection.rb:23:5:23:25 | self | ActiveRecordInjection.rb:19:1:25:3 | Admin |
+| ActiveRecordInjection.rb:20:3:24:5 | self (delete_by) | ActiveRecordInjection.rb:19:1:25:3 | Admin |
 | ActiveRecordInjection.rb:80:7:80:40 | call to find_by | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:85:5:85:33 | call to find_by | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:88:5:88:34 | call to find | ActiveRecordInjection.rb:5:1:17:3 | User |

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -29,12 +29,14 @@ definition
 | nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self |
 | nested_scopes.rb:31:11:31:16 | ... = ... | nested_scopes.rb:31:11:31:11 | a |
 | nested_scopes.rb:40:1:40:18 | ... = ... | nested_scopes.rb:40:1:40:1 | d |
+| parameters.rb:1:1:1:1 | self (parameters.rb) | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:9:5:3 | <captured> | parameters.rb:1:1:62:1 | self |
 | parameters.rb:1:14:1:14 | x | parameters.rb:1:14:1:14 | x |
 | parameters.rb:2:4:2:8 | ... = ... | parameters.rb:1:18:1:18 | y |
 | parameters.rb:7:1:13:3 | self (order_pizza) | parameters.rb:7:1:13:3 | self |
 | parameters.rb:7:17:7:22 | client | parameters.rb:7:17:7:22 | client |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas |
+| parameters.rb:15:1:19:3 | self (print_map) | parameters.rb:15:1:19:3 | self |
 | parameters.rb:15:17:15:19 | map | parameters.rb:15:17:15:19 | map |
 | parameters.rb:16:12:18:5 | <captured> | parameters.rb:15:1:19:3 | self |
 | parameters.rb:16:16:16:18 | key | parameters.rb:16:16:16:18 | key |
@@ -110,6 +112,7 @@ definition
 | ssa.rb:26:3:28:5 | <captured> | ssa.rb:25:1:30:3 | self |
 | ssa.rb:26:3:28:5 | __synth__0__1 | ssa.rb:26:3:28:5 | __synth__0__1 |
 | ssa.rb:26:3:28:5 | call to each | ssa.rb:26:7:26:10 | elem |
+| ssa.rb:32:1:36:3 | self (m3) | ssa.rb:32:1:36:3 | self |
 | ssa.rb:33:16:35:5 | <captured> | ssa.rb:32:1:36:3 | self |
 | ssa.rb:33:20:33:20 | x | ssa.rb:33:20:33:20 | x |
 | ssa.rb:38:1:42:3 | self (m4) | ssa.rb:38:1:42:3 | self |


### PR DESCRIPTION
Since @hmac's https://github.com/github/codeql-ruby/pull/335, `self` is handled in the SSA library as any other variable (except we were missing support for captured variables, which required using `SsaImplSpecific::variableWrite` instead of `VariableWriteAccess` in `hasVariableWriteWithCapturedRead`). Consequently, we no longer need explicit flow from `self` parameters to all accesses, as this is now covered by normal parameter-to-first-use flow, followed by adjacent-use-use flow. 

The last two commits are unrelated performance tweaks (though the performance problem fixed by the latter commit was amplified by letting the SSA library handle flow through captured `self` variables).