### PR TITLE
Python: model aiopg

### DIFF
--- a/docs/codeql/support/reusables/frameworks.rst
+++ b/docs/codeql/support/reusables/frameworks.rst
@@ -183,6 +183,7 @@ Python built-in support
    pydantic, Utility library
    yarl, Utility library
    aioch, Database
+   aiopg, Database
    asyncpg, Database
    clickhouse-driver, Database
    mysql-connector-python, Database

--- a/python/change-notes/2021-11-09-model-aiopg.md
+++ b/python/change-notes/2021-11-09-model-aiopg.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Added modeling of `aiopg` for sinks executing SQL.

--- a/python/ql/lib/semmle/python/Frameworks.qll
+++ b/python/ql/lib/semmle/python/Frameworks.qll
@@ -6,6 +6,7 @@
 // `docs/codeql/support/reusables/frameworks.rst`
 private import semmle.python.frameworks.Aioch
 private import semmle.python.frameworks.Aiohttp
+private import semmle.python.frameworks.Aiopg
 private import semmle.python.frameworks.Asyncpg
 private import semmle.python.frameworks.ClickhouseDriver
 private import semmle.python.frameworks.Cryptodome

--- a/python/ql/lib/semmle/python/frameworks/Aiopg.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiopg.qll
@@ -14,7 +14,10 @@ private import semmle.python.ApiGraphs
 private module Aiopg {
   private import semmle.python.internal.Awaited
 
-  /** A `ConectionPool` is created when the result of `aiopg.create_pool()` is awaited. */
+  /**
+   * A `ConectionPool` is created when the result of `aiopg.create_pool()` is awaited.
+   * See https://aiopg.readthedocs.io/en/stable/core.html#pool
+   */
   API::Node connectionPool() {
     result = API::moduleImport("aiopg").getMember("create_pool").getReturn().getAwaited()
   }
@@ -23,6 +26,7 @@ private module Aiopg {
    * A `Connection` is created when
    * - the result of `aiopg.connect()` is awaited.
    * - the result of calling `aquire` on a `ConnectionPool` is awaited.
+   * See https://aiopg.readthedocs.io/en/stable/core.html#connection
    */
   API::Node connection() {
     result = API::moduleImport("aiopg").getMember("connect").getReturn().getAwaited()
@@ -34,6 +38,7 @@ private module Aiopg {
    * A `Cursor` is created when
    * - the result of calling `cursor` on a `ConnectionPool` is awaited.
    * - the result of calling `cursor` on a `Connection` is awaited.
+   * See https://aiopg.readthedocs.io/en/stable/core.html#cursor
    */
   API::Node cursor() {
     result = connectionPool().getMember("cursor").getReturn().getAwaited()
@@ -41,7 +46,10 @@ private module Aiopg {
     result = connection().getMember("cursor").getReturn().getAwaited()
   }
 
-  /** Calling `execute` on a `Cursor` constructs a query. */
+  /**
+   * Calling `execute` on a `Cursor` constructs a query.
+   * See https://aiopg.readthedocs.io/en/stable/core.html#aiopg.Cursor.execute
+   */
   class CursorExecuteCall extends SqlConstruction::Range, DataFlow::CallCfgNode {
     CursorExecuteCall() { this = cursor().getMember("execute").getACall() }
 
@@ -64,7 +72,10 @@ private module Aiopg {
     cursorExecuteCall(DataFlow::TypeTracker::end(), sql).flowsTo(result)
   }
 
-  /** Awaiting the result of calling `execute` executes the query. */
+  /**
+   * Awaiting the result of calling `execute` executes the query.
+   * See https://aiopg.readthedocs.io/en/stable/core.html#aiopg.Cursor.execute
+   */
   class AwaitedCursorExecuteCall extends SqlExecution::Range {
     DataFlow::Node sql;
 
@@ -73,7 +84,10 @@ private module Aiopg {
     override DataFlow::Node getSql() { result = sql }
   }
 
-  /** An `Engine` is created when the result of calling `aiopg.sa.create_engine` is awaited. */
+  /**
+   * An `Engine` is created when the result of calling `aiopg.sa.create_engine` is awaited.
+   * See https://aiopg.readthedocs.io/en/stable/sa.html#engine
+   */
   API::Node engine() {
     result =
       API::moduleImport("aiopg").getMember("sa").getMember("create_engine").getReturn().getAwaited()
@@ -81,10 +95,14 @@ private module Aiopg {
 
   /**
    * A `SAConnection` is created when the result of calling `aquire` on an `Engine` is awaited.
+   * See https://aiopg.readthedocs.io/en/stable/sa.html#connection
    */
   API::Node saConnection() { result = engine().getMember("acquire").getReturn().getAwaited() }
 
-  /** Calling `execute` on a `SAConnection` constructs a query. */
+  /**
+   * Calling `execute` on a `SAConnection` constructs a query.
+   * See https://aiopg.readthedocs.io/en/stable/sa.html#aiopg.sa.SAConnection.execute
+   */
   class SAConnectionExecuteCall extends SqlConstruction::Range, DataFlow::CallCfgNode {
     SAConnectionExecuteCall() { this = saConnection().getMember("execute").getACall() }
 
@@ -109,7 +127,10 @@ private module Aiopg {
     saConnectionExecuteCall(DataFlow::TypeTracker::end(), sql).flowsTo(result)
   }
 
-  /** Awaiting the result of calling `execute` executes the query. */
+  /**
+   * Awaiting the result of calling `execute` executes the query.
+   * See https://aiopg.readthedocs.io/en/stable/sa.html#aiopg.sa.SAConnection.execute
+   */
   class AwaitedSAConnectionExecuteCall extends SqlExecution::Range {
     DataFlow::Node sql;
 

--- a/python/ql/lib/semmle/python/frameworks/Aiopg.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiopg.qll
@@ -1,0 +1,74 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `aiopg` PyPI package.
+ * See
+ * - https://aiopg.readthedocs.io/en/stable/index.html
+ * - https://pypi.org/project/aiopg/
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.Concepts
+private import semmle.python.ApiGraphs
+
+/** Provides models for the `aiopg` PyPI package. */
+private module Aiopg {
+  private import semmle.python.internal.Awaited
+
+  /** A `ConectionPool` is created when the result of `aiopg.create_pool()` is awaited. */
+  API::Node connectionPool() {
+    result = API::moduleImport("aiopg").getMember("create_pool").getReturn().getAwaited()
+  }
+
+  /**
+   * A `Connection` is created when
+   * - the result of `aiopg.connect()` is awaited.
+   * - the result of calling `aquire` on a `ConnectionPool` is awaited.
+   */
+  API::Node connection() {
+    result = API::moduleImport("aiopg").getMember("connect").getReturn().getAwaited()
+    or
+    result = connectionPool().getMember("acquire").getReturn().getAwaited()
+  }
+
+  /**
+   * A `Cursor` is created when
+   * - the result of calling `cursor` on a `ConnectionPool` is awaited.
+   * - the result of calling `cursor` on a `Connection` is awaited.
+   */
+  API::Node cursor() {
+    result = connectionPool().getMember("cursor").getReturn().getAwaited()
+    or
+    result = connection().getMember("cursor").getReturn().getAwaited()
+  }
+
+  class CursorExecuteCall extends SqlConstruction::Range, DataFlow::CallCfgNode {
+    CursorExecuteCall() { this = cursor().getMember("execute").getACall() }
+
+    override DataFlow::Node getSql() { result in [this.getArg(0), this.getArgByName("operation")] }
+  }
+
+  /**
+   * This is only needed to connect the argument to the execute call with the subsequnt awaiting.
+   * It should be obsolete once we have `API::CallNode` available.
+   */
+  private DataFlow::TypeTrackingNode cursorExecuteCall(DataFlow::TypeTracker t, DataFlow::Node sql) {
+    // cursor created from connection
+    t.start() and
+    sql = result.(CursorExecuteCall).getSql()
+    or
+    exists(DataFlow::TypeTracker t2 | result = cursorExecuteCall(t2, sql).track(t2, t))
+  }
+
+  DataFlow::Node cursorExecuteCall(DataFlow::Node sql) {
+    cursorExecuteCall(DataFlow::TypeTracker::end(), sql).flowsTo(result)
+  }
+
+  /** Awaiting the result of calling `execute` executes the query. */
+  class AwaitedCursorExecuteCall extends SqlExecution::Range {
+    DataFlow::Node sql;
+
+    AwaitedCursorExecuteCall() { this = awaited(cursorExecuteCall(sql)) }
+
+    override DataFlow::Node getSql() { result = sql }
+  }
+}

--- a/python/ql/test/library-tests/frameworks/aiopg/ConceptsTest.ql
+++ b/python/ql/test/library-tests/frameworks/aiopg/ConceptsTest.ql
@@ -1,0 +1,2 @@
+import python
+import experimental.meta.ConceptsTest

--- a/python/ql/test/library-tests/frameworks/aiopg/test.py
+++ b/python/ql/test/library-tests/frameworks/aiopg/test.py
@@ -17,3 +17,10 @@ async def test_cursor():
         # Create Cursor directly
         async with pool.cursor() as cur:
             await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
+
+from aiopg.sa import create_engine
+
+async def test_engine():
+    engine = await create_engine()
+    conn = await engine.acquire()
+    await conn.execute("sql")  # $ MISSING: getSql="sql" constructedSql="sql"

--- a/python/ql/test/library-tests/frameworks/aiopg/test.py
+++ b/python/ql/test/library-tests/frameworks/aiopg/test.py
@@ -20,7 +20,7 @@ async def test_cursor():
 
     # variants using as few `async with` as possible
     pool = await aiopg.create_pool()
-    conn = pool.acquire()
+    conn = await pool.acquire()
     cur = await conn.cursor()
     await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
 

--- a/python/ql/test/library-tests/frameworks/aiopg/test.py
+++ b/python/ql/test/library-tests/frameworks/aiopg/test.py
@@ -11,13 +11,20 @@ async def test_cursor():
     async with aiopg.create_pool() as pool:
         # Create Cursor via Connection
         async with pool.acquire() as conn:
-            cur = await conn.cursor()
-            await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
+            async with conn.cursor() as cur:
+                await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
 
         # Create Cursor directly
         async with pool.cursor() as cur:
             await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
 
+    # variants using as few `async with` as possible
+    pool = await aiopg.create_pool()
+    conn = pool.acquire()
+    cur = await conn.cursor()
+    await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
+
+# Test SQLAlchemy integration
 from aiopg.sa import create_engine
 
 async def test_engine():

--- a/python/ql/test/library-tests/frameworks/aiopg/test.py
+++ b/python/ql/test/library-tests/frameworks/aiopg/test.py
@@ -23,4 +23,4 @@ from aiopg.sa import create_engine
 async def test_engine():
     engine = await create_engine()
     conn = await engine.acquire()
-    await conn.execute("sql")  # $ MISSING: getSql="sql" constructedSql="sql"
+    await conn.execute("sql")  # $ getSql="sql" constructedSql="sql"

--- a/python/ql/test/library-tests/frameworks/aiopg/test.py
+++ b/python/ql/test/library-tests/frameworks/aiopg/test.py
@@ -5,15 +5,15 @@ async def test_cursor():
     # Create connection directly
     conn = await aiopg.connect()
     cur = await conn.cursor()
-    await cur.execute("sql")  # $ MISSING: getSql="sql"
+    await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
 
     # Create connection via pool
     async with aiopg.create_pool() as pool:
         # Create Cursor via Connection
         async with pool.acquire() as conn:
             cur = await conn.cursor()
-            await cur.execute("sql")  # $ MISSING: getSql="sql"
+            await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"
 
         # Create Cursor directly
         async with pool.cursor() as cur:
-            await cur.execute("sql")  # $ MISSING: getSql="sql"
+            await cur.execute("sql")  # $ getSql="sql" constructedSql="sql"

--- a/python/ql/test/library-tests/frameworks/aiopg/test.py
+++ b/python/ql/test/library-tests/frameworks/aiopg/test.py
@@ -1,0 +1,19 @@
+import aiopg
+
+# Only a cursor can execute sql.
+async def test_cursor():
+    # Create connection directly
+    conn = await aiopg.connect()
+    cur = await conn.cursor()
+    await cur.execute("sql")  # $ MISSING: getSql="sql"
+
+    # Create connection via pool
+    async with aiopg.create_pool() as pool:
+        # Create Cursor via Connection
+        async with pool.acquire() as conn:
+            cur = await conn.cursor()
+            await cur.execute("sql")  # $ MISSING: getSql="sql"
+
+        # Create Cursor directly
+        async with pool.cursor() as cur:
+            await cur.execute("sql")  # $ MISSING: getSql="sql"


### PR DESCRIPTION
Adresses part of https://github.com/github/codeql-python-team/issues/388.

A question is if [`call_proc`](https://aiopg.readthedocs.io/en/stable/core.html#aiopg.Cursor.callproc) should be considered a sink similar to `execute`.