### PR TITLE
Python: Port `py/request-without-cert-validation` to use API graphs

### DIFF
--- a/python/ql/test/query-tests/Security/CWE-295-RequestWithoutValidation/RequestWithoutValidation.expected
+++ b/python/ql/test/query-tests/Security/CWE-295-RequestWithoutValidation/RequestWithoutValidation.expected
@@ -1,5 +1,5 @@
-| make_request.py:5:1:5:48 | ControlFlowNode for Attribute() | Call to $@ with verify=$@ | ../lib/requests.py:2:1:2:36 | Function get | requests.get | make_request.py:5:43:5:47 | ControlFlowNode for False | False |
-| make_request.py:7:1:7:49 | ControlFlowNode for Attribute() | Call to $@ with verify=$@ | ../lib/requests.py:11:1:11:46 | Function post | requests.post | make_request.py:7:44:7:48 | ControlFlowNode for False | False |
-| make_request.py:12:1:12:39 | ControlFlowNode for put() | Call to $@ with verify=$@ | ../lib/requests.py:14:1:14:34 | Function put | requests.put | make_request.py:12:34:12:38 | ControlFlowNode for False | False |
-| make_request.py:28:5:28:46 | ControlFlowNode for patch() | Call to $@ with verify=$@ | ../lib/requests.py:17:1:17:36 | Function patch | requests.patch | make_request.py:30:6:30:10 | ControlFlowNode for False | False |
-| make_request.py:34:1:34:45 | ControlFlowNode for Attribute() | Call to $@ with verify=$@ | ../lib/requests.py:11:1:11:46 | Function post | requests.post | make_request.py:34:44:34:44 | ControlFlowNode for IntegerLiteral | False |
+| make_request.py:5:1:5:48 | ControlFlowNode for Attribute() | Call to requests.get with verify=$@ | make_request.py:5:43:5:47 | ControlFlowNode for False | False |
+| make_request.py:7:1:7:49 | ControlFlowNode for Attribute() | Call to requests.post with verify=$@ | make_request.py:7:44:7:48 | ControlFlowNode for False | False |
+| make_request.py:12:1:12:39 | ControlFlowNode for put() | Call to requests.put with verify=$@ | make_request.py:12:34:12:38 | ControlFlowNode for False | False |
+| make_request.py:28:5:28:46 | ControlFlowNode for patch() | Call to requests.patch with verify=$@ | make_request.py:30:6:30:10 | ControlFlowNode for False | False |
+| make_request.py:34:1:34:45 | ControlFlowNode for Attribute() | Call to requests.post with verify=$@ | make_request.py:34:44:34:44 | ControlFlowNode for IntegerLiteral | False |

--- a/python/ql/test/query-tests/Security/CWE-295-RequestWithoutValidation/make_request.py
+++ b/python/ql/test/query-tests/Security/CWE-295-RequestWithoutValidation/make_request.py
@@ -32,3 +32,7 @@ req2("/path/to/cert/") # GOOD
 
 #Falsey value
 requests.post('https://semmle.com', verify=0) # BAD
+
+# requests treat `None` as default value, which means it is turned on
+requests.get('https://semmle.com') # OK
+requests.get('https://semmle.com', verify=None) # OK

--- a/python/ql/test/query-tests/Security/CWE-295-RequestWithoutValidation/options
+++ b/python/ql/test/query-tests/Security/CWE-295-RequestWithoutValidation/options
@@ -1,1 +1,0 @@
-semmle-extractor-options: -p ../lib/ --max-import-depth=3


### PR DESCRIPTION
For my reviewer: I'm don't feel like this should require adding a change note, but happy to do so if you think that's better :blush: (so didn't add the `no-change-note-required` label to the PR yet)