### PR TITLE
Java: Add AsyncTask additional value step

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSteps.qll
@@ -11,6 +11,7 @@ private import semmle.code.java.dataflow.DataFlow
  */
 private module Frameworks {
   private import semmle.code.java.frameworks.jackson.JacksonSerializability
+  private import semmle.code.java.frameworks.android.AsyncTask
   private import semmle.code.java.frameworks.android.Intent
   private import semmle.code.java.frameworks.android.SQLite
   private import semmle.code.java.frameworks.Guice

--- a/java/ql/lib/semmle/code/java/frameworks/android/AsyncTask.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/AsyncTask.qll
@@ -1,0 +1,52 @@
+/** Provides classes and predicates to reason about `AsyncTask`s in Android. */
+
+import java
+private import semmle.code.java.dataflow.DataFlow
+private import semmle.code.java.dataflow.FlowSteps
+
+/**
+ * Models the value-preserving step from `asyncTask.execute(params)` to `AsyncTask::doInBackground(params)`.
+ */
+private class AsyncTaskAdditionalValueStep extends AdditionalValueStep {
+  override predicate step(DataFlow::Node node1, DataFlow::Node node2) {
+    exists(ExecuteAsyncTaskMethodAccess ma, AsyncTaskRunInBackgroundMethod m |
+      DataFlow::getInstanceArgument(ma).getType() = m.getDeclaringType() and
+      node1.asExpr() = ma.getParamsArgument() and
+      node2.asParameter() = m.getParameter(0)
+    )
+  }
+}
+
+/**
+ * The Android class `android.os.AsyncTask`.
+ */
+private class AsyncTask extends RefType {
+  AsyncTask() { this.hasQualifiedName("android.os", "AsyncTask") }
+}
+
+/** A call to the `execute` or `executeOnExecutor` methods of the `android.os.AsyncTask` class. */
+private class ExecuteAsyncTaskMethodAccess extends MethodAccess {
+  Argument paramsArgument;
+
+  ExecuteAsyncTaskMethodAccess() {
+    exists(Method m |
+      this.getMethod() = m and
+      m.getDeclaringType().getSourceDeclaration().getASourceSupertype*() instanceof AsyncTask
+    |
+      m.getName() = "execute" and not m.isStatic() and paramsArgument = this.getArgument(0)
+      or
+      m.getName() = "executeOnExecutor" and paramsArgument = this.getArgument(1)
+    )
+  }
+
+  /** Returns the `params` argument of this call. */
+  Argument getParamsArgument() { result = paramsArgument }
+}
+
+/** The `doInBackground` method of the `android.os.AsyncTask` class. */
+private class AsyncTaskRunInBackgroundMethod extends Method {
+  AsyncTaskRunInBackgroundMethod() {
+    this.getDeclaringType().getSourceDeclaration().getASourceSupertype*() instanceof AsyncTask and
+    this.getName() = "doInBackground"
+  }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-200/SensitiveAndroidFileLeak.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/SensitiveAndroidFileLeak.expected
@@ -4,13 +4,17 @@ edges
 | FileService.java:21:28:21:64 | getStringExtra(...) : Object | FileService.java:25:42:25:50 | localPath : Object |
 | FileService.java:25:13:25:51 | makeParamsToExecute(...) : Object[] | FileService.java:40:41:40:55 | params : Object[] |
 | FileService.java:25:13:25:51 | makeParamsToExecute(...) [[]] : Object | FileService.java:25:13:25:51 | makeParamsToExecute(...) : Object[] |
+| FileService.java:25:13:25:51 | makeParamsToExecute(...) [[]] : Object | FileService.java:40:41:40:55 | params [[]] : Object |
 | FileService.java:25:42:25:50 | localPath : Object | FileService.java:25:13:25:51 | makeParamsToExecute(...) [[]] : Object |
 | FileService.java:25:42:25:50 | localPath : Object | FileService.java:32:13:32:28 | sourceUri : Object |
 | FileService.java:32:13:32:28 | sourceUri : Object | FileService.java:35:17:35:25 | sourceUri : Object |
 | FileService.java:34:20:36:13 | {...} [[]] : Object | FileService.java:34:20:36:13 | new Object[] [[]] : Object |
 | FileService.java:35:17:35:25 | sourceUri : Object | FileService.java:34:20:36:13 | {...} [[]] : Object |
 | FileService.java:40:41:40:55 | params : Object[] | FileService.java:44:33:44:52 | (...)... : Object |
+| FileService.java:40:41:40:55 | params [[]] : Object | FileService.java:44:44:44:49 | params [[]] : Object |
 | FileService.java:44:33:44:52 | (...)... : Object | FileService.java:45:53:45:59 | ...[...] |
+| FileService.java:44:44:44:49 | params [[]] : Object | FileService.java:44:44:44:52 | ...[...] : Object |
+| FileService.java:44:44:44:52 | ...[...] : Object | FileService.java:44:33:44:52 | (...)... : Object |
 | LeakFileActivity2.java:15:13:15:18 | intent : Intent | LeakFileActivity2.java:16:26:16:31 | intent : Intent |
 | LeakFileActivity2.java:16:26:16:31 | intent : Intent | FileService.java:20:31:20:43 | intent : Intent |
 | LeakFileActivity.java:14:35:14:38 | data : Intent | LeakFileActivity.java:18:40:18:59 | contentIntent : Intent |
@@ -30,7 +34,10 @@ nodes
 | FileService.java:34:20:36:13 | {...} [[]] : Object | semmle.label | {...} [[]] : Object |
 | FileService.java:35:17:35:25 | sourceUri : Object | semmle.label | sourceUri : Object |
 | FileService.java:40:41:40:55 | params : Object[] | semmle.label | params : Object[] |
+| FileService.java:40:41:40:55 | params [[]] : Object | semmle.label | params [[]] : Object |
 | FileService.java:44:33:44:52 | (...)... : Object | semmle.label | (...)... : Object |
+| FileService.java:44:44:44:49 | params [[]] : Object | semmle.label | params [[]] : Object |
+| FileService.java:44:44:44:52 | ...[...] : Object | semmle.label | ...[...] : Object |
 | FileService.java:45:53:45:59 | ...[...] | semmle.label | ...[...] |
 | LeakFileActivity2.java:15:13:15:18 | intent : Intent | semmle.label | intent : Intent |
 | LeakFileActivity2.java:16:26:16:31 | intent : Intent | semmle.label | intent : Intent |

--- a/java/ql/test/library-tests/frameworks/android/asynctask/Test.java
+++ b/java/ql/test/library-tests/frameworks/android/asynctask/Test.java
@@ -1,0 +1,34 @@
+import android.os.AsyncTask;
+
+public class Test {
+
+    private static Object source(String kind) {
+        return null;
+    }
+
+    private static void sink(Object o) {}
+
+    public void test() {
+        TestAsyncTask t = new TestAsyncTask();
+        t.execute(source("execute"));
+        t.executeOnExecutor(null, source("executeOnExecutor"));
+        SafeAsyncTask t2 = new SafeAsyncTask();
+        t2.execute("safe");
+    }
+
+    private class TestAsyncTask extends AsyncTask<Object, Object, Object> {
+        @Override
+        protected Object doInBackground(Object... params) {
+            sink(params); // $ hasValueFlow=execute hasValueFlow=executeOnExecutor
+            return null;
+        }
+    }
+
+    private class SafeAsyncTask extends AsyncTask<Object, Object, Object> {
+        @Override
+        protected Object doInBackground(Object... params) {
+            sink(params); // Safe
+            return null;
+        }
+    }
+}

--- a/java/ql/test/library-tests/frameworks/android/asynctask/options
+++ b/java/ql/test/library-tests/frameworks/android/asynctask/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0

--- a/java/ql/test/library-tests/frameworks/android/asynctask/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/asynctask/test.ql
@@ -1,0 +1,6 @@
+import java
+import TestUtilities.InlineFlowTest
+
+class AsyncTaskTest extends InlineFlowTest {
+  override TaintTracking::Configuration getTaintFlowConfig() { none() }
+}


### PR DESCRIPTION
This PR adds a new `AdditionalValueStep` for Android's `AsyncTask`. When `execute` or `executeOnExecutor` are called for a certain `AsyncTask`, their `params` argument flows (preserving value) to the `doInBackground` method of that `AsyncTask` implementation.