### PR TITLE
C++: New query 'Failure to use HTTPS URLs'

### DIFF
--- a/cpp/change-notes/2021-11-09-use-of-http.md
+++ b/cpp/change-notes/2021-11-09-use-of-http.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* A new query `cpp/non-https-url` has been added for C/C++. The query flags uses of `http` URLs that might be better replaced with `https`.

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.cpp
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.cpp
@@ -1,0 +1,9 @@
+
+void openUrl(char *url)
+{
+	// ...
+}
+
+openUrl("http://example.com"); // BAD
+
+openUrl("https://example.com"); // GOOD: Opening a connection to a URL using HTTPS enforces SSL.

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.qhelp
@@ -1,0 +1,35 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+
+<p>Constructing URLs with the HTTP protocol can lead to unsecured connections.</p>
+
+</overview>
+<recommendation>
+
+<p>When you construct a URL, ensure that you use an HTTPS URL rather than an HTTP URL. Then, any connections that are made using that URL are secure SSL connections.</p>
+
+</recommendation>
+<example>
+
+<p>The following example shows two ways of opening a connection using a URL. When the connection is 
+opened using an HTTP URL rather than an HTTPS URL, the connection is unsecured. When the connection is opened using an HTTPS URL, the connection is a secure SSL connection.</p>
+
+<sample src="HttpsUrls.cpp" />
+
+</example>
+<references>
+
+<li>
+OWASP:
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html">Transport Layer Protection Cheat Sheet</a>.
+</li>
+<li>
+OWASP Top 10:
+<a href="https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/">A08:2021 – Software and Data Integrity Failures</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.qhelp
@@ -28,7 +28,7 @@ OWASP:
 </li>
 <li>
 OWASP Top 10:
-<a href="https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/">A08:2021 – Software and Data Integrity Failures</a>.
+<a href="https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/">A08:2021 - Software and Data Integrity Failures</a>.
 </li>
 
 </references>

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.qhelp
@@ -17,7 +17,7 @@
 <p>The following example shows two ways of opening a connection using a URL. When the connection is 
 opened using an HTTP URL rather than an HTTPS URL, the connection is unsecured. When the connection is opened using an HTTPS URL, the connection is a secure SSL connection.</p>
 
-<sample src="HttpsUrls.cpp" />
+<sample src="UseOfHttp.cpp" />
 
 </example>
 <references>

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -60,6 +60,9 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
       fc.getTarget().getName() = ["send", "URLDownloadToFile"] and
       sink.asExpr() = fc.getArgument(1)
       or
+      fc.getTarget().getName() = "curl_easy_setopt" and
+      sink.asExpr() = fc.getArgument(2)
+      or
       fc.getTarget().getName() = "ShellExecute" and
       sink.asExpr() = fc.getArgument(3)
     )

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -35,8 +35,9 @@ class HttpStringLiteral extends StringLiteral {
     exists(string s | this.getValue() = s |
       s = "http"
       or
-      s.matches("http://%") and
-      not s.substring(7, s.length()) instanceof PrivateHostName and
+      exists(string tail |
+        tail = s.regexpCapture("http://(.*)", 1) and not tail instanceof PrivateHostName
+      ) and
       not TaintTracking::localExprTaint(any(StringLiteral p |
           p.getValue() instanceof PrivateHostName
         ), this.getParent*())

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -1,0 +1,75 @@
+/**
+ * @name Failure to use HTTPS URLs
+ * @description Non-HTTPS connections can be intercepted by third parties.
+ * @kind path-problem
+ * @problem.severity warning
+ * @precision medium
+ * @id cpp/non-https-url
+ * @tags security
+ *       external/cwe/cwe-319
+ */
+
+import cpp
+import semmle.code.cpp.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+/**
+ * A string matching private host names of IPv4 and IPv6, which only matches
+ * the host portion therefore checking for port is not necessary.
+ * Several examples are localhost, reserved IPv4 IP addresses including
+ * 127.0.0.1, 10.x.x.x, 172.16.x,x, 192.168.x,x, and reserved IPv6 addresses
+ * including [0:0:0:0:0:0:0:1] and [::1]
+ */
+class PrivateHostName extends string {
+  bindingset[this]
+  PrivateHostName() {
+    this.regexpMatch("(?i)localhost(?:[:/?#].*)?|127\\.0\\.0\\.1(?:[:/?#].*)?|10(?:\\.[0-9]+){3}(?:[:/?#].*)?|172\\.16(?:\\.[0-9]+){2}(?:[:/?#].*)?|192.168(?:\\.[0-9]+){2}(?:[:/?#].*)?|\\[?0:0:0:0:0:0:0:1\\]?(?:[:/?#].*)?|\\[?::1\\]?(?:[:/?#].*)?")
+  }
+}
+
+/**
+ * A string containing an HTTP URL not in a private domain.
+ */
+class HttpStringLiteral extends StringLiteral {
+  HttpStringLiteral() {
+    exists(string s | this.getValue() = s |
+      s = "http"
+      or
+      s.matches("http://%") and
+      not s.substring(7, s.length()) instanceof PrivateHostName and
+      not TaintTracking::localExprTaint(any(StringLiteral p |
+          p.getValue() instanceof PrivateHostName
+        ), this.getParent*())
+    )
+  }
+}
+
+/**
+ * Taint tracking configuration for HTTP connections.
+ */
+class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
+  HttpStringToUrlOpenConfig() { this = "HttpStringToUrlOpenConfig" }
+
+  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof HttpStringLiteral }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(FunctionCall fc |
+      fc.getTarget().getName() = ["system", "gethostbyname"] and
+      sink.asExpr() = fc.getArgument(0)
+      or
+      fc.getTarget().getName() = ["send", "URLDownloadToFile"] and
+      sink.asExpr() = fc.getArgument(1)
+      or
+      fc.getTarget().getName() = "ShellExecute" and
+      sink.asExpr() = fc.getArgument(3)
+    )
+  }
+}
+
+from
+  HttpStringToUrlOpenConfig config, DataFlow::PathNode source, DataFlow::PathNode sink,
+  HttpStringLiteral str
+where
+  config.hasFlowPath(source, sink) and
+  str = source.getNode().asExpr()
+select str, source, sink, "A URL may be constructed with the HTTP protocol."

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -54,16 +54,16 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
 
   override predicate isSink(DataFlow::Node sink) {
     exists(FunctionCall fc |
-      fc.getTarget().getName() = ["system", "gethostbyname"] and
+      fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname"]) and
       sink.asExpr() = fc.getArgument(0)
       or
-      fc.getTarget().getName() = ["send", "URLDownloadToFile"] and
+      fc.getTarget().hasGlobalOrStdName(["send", "URLDownloadToFile"]) and
       sink.asExpr() = fc.getArgument(1)
       or
-      fc.getTarget().getName() = "curl_easy_setopt" and
+      fc.getTarget().hasGlobalOrStdName("curl_easy_setopt") and
       sink.asExpr() = fc.getArgument(2)
       or
-      fc.getTarget().getName() = "ShellExecute" and
+      fc.getTarget().hasGlobalOrStdName("ShellExecute") and
       sink.asExpr() = fc.getArgument(3)
     )
   }

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -54,16 +54,16 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
 
   override predicate isSink(DataFlow::Node sink) {
     exists(FunctionCall fc |
-      fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname"]) and
+      fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname", "getaddrinfo"]) and
       sink.asExpr() = fc.getArgument(0)
       or
-      fc.getTarget().hasGlobalOrStdName(["send", "URLDownloadToFile"]) and
+      fc.getTarget().hasGlobalOrStdName(["send", "URLDownloadToFile", "URLDownloadToCacheFile"]) and
       sink.asExpr() = fc.getArgument(1)
       or
-      fc.getTarget().hasGlobalOrStdName("curl_easy_setopt") and
+      fc.getTarget().hasGlobalOrStdName(["curl_easy_setopt", "getnameinfo"]) and
       sink.asExpr() = fc.getArgument(2)
       or
-      fc.getTarget().hasGlobalOrStdName("ShellExecute") and
+      fc.getTarget().hasGlobalOrStdName(["ShellExecute", "ShellExecuteA", "ShellExecuteW"]) and
       sink.asExpr() = fc.getArgument(3)
     )
   }

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -51,9 +51,15 @@ class HttpStringLiteral extends StringLiteral {
 class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
   HttpStringToUrlOpenConfig() { this = "HttpStringToUrlOpenConfig" }
 
-  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof HttpStringLiteral }
+  override predicate isSource(DataFlow::Node src) {
+    // Sources are strings containing an HTTP URL not in a private domain.
+    src.asExpr() instanceof HttpStringLiteral
+  }
 
   override predicate isSink(DataFlow::Node sink) {
+    // Sinks can be anything that demonstrates the string is likely to be
+    // accessed as a URL, for example using it in a network access. Some
+    // URLs are only ever displayed or used for data processing.
     exists(FunctionCall fc |
       fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname", "getaddrinfo"]) and
       sink.asExpr() = fc.getArgument(0)

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -1,15 +1,25 @@
 edges
-| test.cpp:11:20:11:22 | url | test.cpp:15:30:15:32 | url |
-| test.cpp:28:10:28:29 | http://example.com | test.cpp:11:20:11:22 | url |
-| test.cpp:38:18:38:26 | http:// | test.cpp:41:11:41:16 | buffer |
-| test.cpp:41:11:41:16 | buffer | test.cpp:11:20:11:22 | url |
+| test.cpp:11:26:11:28 | url | test.cpp:15:30:15:32 | url |
+| test.cpp:28:10:28:29 | http://example.com | test.cpp:11:26:11:28 | url |
+| test.cpp:35:23:35:42 | http://example.com | test.cpp:39:11:39:15 | url_l |
+| test.cpp:36:26:36:45 | http://example.com | test.cpp:40:11:40:17 | access to array |
+| test.cpp:39:11:39:15 | url_l | test.cpp:11:26:11:28 | url |
+| test.cpp:40:11:40:17 | access to array | test.cpp:11:26:11:28 | url |
+| test.cpp:46:18:46:26 | http:// | test.cpp:49:11:49:16 | buffer |
+| test.cpp:49:11:49:16 | buffer | test.cpp:11:26:11:28 | url |
 nodes
-| test.cpp:11:20:11:22 | url | semmle.label | url |
+| test.cpp:11:26:11:28 | url | semmle.label | url |
 | test.cpp:15:30:15:32 | url | semmle.label | url |
 | test.cpp:28:10:28:29 | http://example.com | semmle.label | http://example.com |
-| test.cpp:38:18:38:26 | http:// | semmle.label | http:// |
-| test.cpp:41:11:41:16 | buffer | semmle.label | buffer |
+| test.cpp:35:23:35:42 | http://example.com | semmle.label | http://example.com |
+| test.cpp:36:26:36:45 | http://example.com | semmle.label | http://example.com |
+| test.cpp:39:11:39:15 | url_l | semmle.label | url_l |
+| test.cpp:40:11:40:17 | access to array | semmle.label | access to array |
+| test.cpp:46:18:46:26 | http:// | semmle.label | http:// |
+| test.cpp:49:11:49:16 | buffer | semmle.label | buffer |
 subpaths
 #select
 | test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
-| test.cpp:38:18:38:26 | http:// | test.cpp:38:18:38:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -1,0 +1,15 @@
+edges
+| test.cpp:11:20:11:22 | url | test.cpp:15:30:15:32 | url |
+| test.cpp:28:10:28:29 | http://example.com | test.cpp:11:20:11:22 | url |
+| test.cpp:38:18:38:26 | http:// | test.cpp:41:11:41:16 | buffer |
+| test.cpp:41:11:41:16 | buffer | test.cpp:11:20:11:22 | url |
+nodes
+| test.cpp:11:20:11:22 | url | semmle.label | url |
+| test.cpp:15:30:15:32 | url | semmle.label | url |
+| test.cpp:28:10:28:29 | http://example.com | semmle.label | http://example.com |
+| test.cpp:38:18:38:26 | http:// | semmle.label | http:// |
+| test.cpp:41:11:41:16 | buffer | semmle.label | buffer |
+subpaths
+#select
+| test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:38:18:38:26 | http:// | test.cpp:38:18:38:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-319/UseOfHttp.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
@@ -4,11 +4,11 @@ struct host
 	// ...
 };
 
-host gethostbyname(char *str);
+host gethostbyname(const char *str);
 char *strcpy(char *s1, const char *s2);
 char *strcat(char *s1, const char *s2);
 
-void openUrl(char *url)
+void openUrl(const char *url)
 {
 	// ...
 
@@ -21,7 +21,7 @@ void doNothing(char *url)
 {
 }
 
-char *urls[] = { "http://example.com" };
+const char *url_g = "http://example.com"; // BAD [NOT DETECTED]
 
 void test()
 {
@@ -30,7 +30,15 @@ void test()
 	openUrl("http://localhost/example"); // GOOD (localhost)
 	openUrl("https://localhost/example"); // GOOD (https, localhost)
 	doNothing("http://example.com"); // GOOD (URL not used)
-	openUrl(urls[0]); // BAD [NOT DETECTED]
+
+	{
+		const char *url_l = "http://example.com"; // BAD
+		const char *urls[] = { "http://example.com" }; // BAD
+
+		openUrl(url_g);
+		openUrl(url_l);
+		openUrl(urls[0]);
+	}
 
 	{
 		char buffer[1024];

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
@@ -1,0 +1,52 @@
+
+struct host
+{
+	// ...
+};
+
+host gethostbyname(char *str);
+char *strcpy(char *s1, const char *s2);
+char *strcat(char *s1, const char *s2);
+
+void openUrl(char *url)
+{
+	// ...
+
+	host myHost = gethostbyname(url);
+
+	// ...
+}
+
+void doNothing(char *url)
+{
+}
+
+char *urls[] = { "http://example.com" };
+
+void test()
+{
+	openUrl("http://example.com"); // BAD
+	openUrl("https://example.com"); // GOOD (https)
+	openUrl("http://localhost/example"); // GOOD (localhost)
+	openUrl("https://localhost/example"); // GOOD (https, localhost)
+	doNothing("http://example.com"); // GOOD (URL not used)
+	openUrl(urls[0]); // BAD [NOT DETECTED]
+
+	{
+		char buffer[1024];
+
+		strcpy(buffer, "http://"); // BAD
+		strcat(buffer, "example.com");
+
+		openUrl(buffer);
+	}
+
+	{
+		char buffer[1024];
+
+		strcpy(buffer, "https://"); // GOOD (https)
+		strcat(buffer, "example.com");
+
+		openUrl(buffer);
+	}
+}


### PR DESCRIPTION
This is a new query for spotting uses of `http` (rather than `https`), which along with another query will provide us a basis to claim partial coverage of [OWASP A08:2021](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/).  The code and `qhelp` is derived from `java/non-https-url` but simplified in several places.

In addition to the tests you can view some results on LGTM at: https://lgtm.com/query/1597019895252712493/

Performance seems fine locally and I have no reason to be concerned about it.

I'm keen to discuss the right precision and severity (and other tags) for this query in addition to any suggestions you have for the query itself.