### PR TITLE
Java: Extract Commons IO into seperate file

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -83,6 +83,7 @@ private module Frameworks {
   private import semmle.code.java.frameworks.android.XssSinks
   private import semmle.code.java.frameworks.ApacheHttp
   private import semmle.code.java.frameworks.apache.Collections
+  private import semmle.code.java.frameworks.apache.IO
   private import semmle.code.java.frameworks.apache.Lang
   private import semmle.code.java.frameworks.Flexjson
   private import semmle.code.java.frameworks.guava.Guava
@@ -322,33 +323,11 @@ private predicate summaryModelCsv(string row) {
       "org.apache.commons.codec;BinaryDecoder;true;decode;(byte[]);;Argument[0];ReturnValue;taint",
       "org.apache.commons.codec;StringEncoder;true;encode;(String);;Argument[0];ReturnValue;taint",
       "org.apache.commons.codec;StringDecoder;true;decode;(String);;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;buffer;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;readLines;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(InputStream,int);;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;toBufferedInputStream;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;toBufferedReader;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;toByteArray;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;toCharArray;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;toInputStream;;;Argument[0];ReturnValue;taint",
-      "org.apache.commons.io;IOUtils;false;toString;;;Argument[0];ReturnValue;taint",
       "java.net;URLDecoder;false;decode;;;Argument[0];ReturnValue;taint",
       "java.net;URI;false;create;;;Argument[0];ReturnValue;taint",
       "javax.xml.transform.sax;SAXSource;false;sourceToInputSource;;;Argument[0];ReturnValue;taint",
       // arg to arg
       "java.lang;System;false;arraycopy;;;Argument[0];Argument[2];taint",
-      "org.apache.commons.io;IOUtils;false;copy;;;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;copyLarge;;;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;read;;;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(InputStream,byte[]);;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(InputStream,byte[],int,int);;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(InputStream,ByteBuffer);;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(ReadableByteChannel,ByteBuffer);;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(Reader,char[]);;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;readFully;(Reader,char[],int,int);;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;write;;;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;writeChunked;;;Argument[0];Argument[1];taint",
-      "org.apache.commons.io;IOUtils;false;writeLines;;;Argument[0];Argument[2];taint",
-      "org.apache.commons.io;IOUtils;false;writeLines;;;Argument[1];Argument[2];taint",
       // constructor flow
       "java.io;File;false;File;;;Argument[0];Argument[-1];taint",
       "java.io;File;false;File;;;Argument[1];Argument[-1];taint",

--- a/java/ql/lib/semmle/code/java/frameworks/apache/IO.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/apache/IO.qll
@@ -1,0 +1,35 @@
+/** Definitions related to the Apache Commons IO library. */
+
+import java
+private import semmle.code.java.dataflow.FlowSteps
+private import semmle.code.java.dataflow.ExternalFlow
+
+private class CommonsIOSummaryCsv extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "org.apache.commons.io;IOUtils;false;buffer;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;copy;;;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;copyLarge;;;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;read;;;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(InputStream,byte[],int,int);;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(InputStream,byte[]);;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(InputStream,ByteBuffer);;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(InputStream,int);;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(ReadableByteChannel,ByteBuffer);;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(Reader,char[],int,int);;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readFully;(Reader,char[]);;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;readLines;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;toBufferedInputStream;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;toBufferedReader;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;toByteArray;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;toCharArray;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;toInputStream;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;toString;;;Argument[0];ReturnValue;taint",
+        "org.apache.commons.io;IOUtils;false;write;;;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;writeChunked;;;Argument[0];Argument[1];taint",
+        "org.apache.commons.io;IOUtils;false;writeLines;;;Argument[0];Argument[2];taint",
+        "org.apache.commons.io;IOUtils;false;writeLines;;;Argument[1];Argument[2];taint"
+      ]
+  }
+}

--- a/java/ql/lib/semmle/code/java/frameworks/apache/IO.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/apache/IO.qll
@@ -1,7 +1,6 @@
 /** Definitions related to the Apache Commons IO library. */
 
 import java
-private import semmle.code.java.dataflow.FlowSteps
 private import semmle.code.java.dataflow.ExternalFlow
 
 private class CommonsIOSummaryCsv extends SummaryModelCsv {


### PR DESCRIPTION
This makes it easier to regenerate this in the future and see a proper diff.