### PR TITLE
Python: Fix some query-ids

### DIFF
--- a/python/change-notes/2021-11-12-fix-pyhton-query-ids.md
+++ b/python/change-notes/2021-11-12-fix-pyhton-query-ids.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+Fixed the query ids of two queries that are meant for manual exploration: `python/count-untrusted-data-external-api` and `python/untrusted-data-to-external-api` have been changed to `py/count-untrusted-data-external-api` and `py/untrusted-data-to-external-api`.

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/ExternalAPIsUsedWithUntrustedData.ql
@@ -3,7 +3,7 @@
  * @description This reports the external APIs that are used with untrusted data, along with how
  *              frequently the API is called, and how many unique sources of untrusted data flow
  *              to it.
- * @id python/count-untrusted-data-external-api
+ * @id py/count-untrusted-data-external-api
  * @kind table
  * @tags security external/cwe/cwe-20
  */

--- a/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
+++ b/python/ql/src/Security/CWE-020-ExternalAPIs/UntrustedDataToExternalAPI.ql
@@ -1,7 +1,7 @@
 /**
  * @name Untrusted data passed to external API
  * @description Data provided remotely is used in this external API without sanitization, which could be a security risk.
- * @id python/untrusted-data-to-external-api
+ * @id py/untrusted-data-to-external-api
  * @kind path-problem
  * @precision low
  * @problem.severity error

--- a/python/ql/src/analysis/LocalDefinitions.ql
+++ b/python/ql/src/analysis/LocalDefinitions.ql
@@ -3,7 +3,7 @@
  * @description Generates use-definition pairs that provide the data
  *              for jump-to-definition in the code viewer.
  * @kind definitions
- * @id python/ide-jump-to-definition
+ * @id py/ide-jump-to-definition
  * @tags ide-contextual-queries/local-definitions
  */
 

--- a/python/ql/src/analysis/LocalReferences.ql
+++ b/python/ql/src/analysis/LocalReferences.ql
@@ -3,7 +3,7 @@
  * @description Generates use-definition pairs that provide the data
  *              for find-references in the code viewer.
  * @kind definitions
- * @id python/ide-find-references
+ * @id py/ide-find-references
  * @tags ide-contextual-queries/local-references
  */
 


### PR DESCRIPTION
The two queries in CWE-020 are used for manual evaluation (is my
understanding), and the two IDE queries should work based on their tags,
and not on the query-id.

We should get a sign-off on both of them just to be sure though.

- @aeisenberg are you in a position to review IDE part? (or find someone that can)
- @lcartey can you confirm that changing the `id` for the External APIs queries is not going to be a problem?

Thanks :blush: 