### PR TITLE
JS: have the aliasPropertyPresenceStep step over extend calls

### DIFF
--- a/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/lib/semmle/javascript/GlobalAccessPaths.qll
@@ -426,6 +426,17 @@ module AccessPath {
       result = AccessPath::getAReferenceTo(root, accessPath)
     )
     or
+    // step over extend calls. Handle aliasing both ways through the extend call.
+    exists(
+      DataFlow::SourceNode rootOne, DataFlow::SourceNode rootTwo, string accessPath,
+      ExtendCall extendCall
+    |
+      rootOne = [extendCall, extendCall.getAnOperand().getALocalSource()] and
+      rootTwo = [extendCall, extendCall.getAnOperand().getALocalSource()] and
+      node = pragma[only_bind_into](AccessPath::getAReferenceTo(rootOne, accessPath)) and
+      result = AccessPath::getAReferenceTo(rootTwo, accessPath)
+    )
+    or
     result = node.getALocalSource()
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginQuery.qll
@@ -76,19 +76,8 @@ private predicate aliasPropertyPresenceStepHelper(
 ) {
   exists(PropertyPresenceSanitizer sanitizer |
     src = sanitizer.getPropRead() and
+    sink = AccessPath::getAnAliasedSourceNode(src) and
     srcBB = src.getBasicBlock() and
-    sinkBB = sink.getBasicBlock() and
-    (
-      sink = AccessPath::getAnAliasedSourceNode(src)
-      or
-      // step over extend calls
-      exists(ExtendCall extendCall, string prop |
-        src = extendCall.getASourceOperand().getALocalSource().getAPropertyReference(prop) and
-        sink =
-          [extendCall, extendCall.getDestinationOperand()]
-              .(DataFlow::SourceNode)
-              .getAPropertyReference(prop)
-      )
-    )
+    sinkBB = sink.getBasicBlock()
   )
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginQuery.qll
@@ -76,8 +76,19 @@ private predicate aliasPropertyPresenceStepHelper(
 ) {
   exists(PropertyPresenceSanitizer sanitizer |
     src = sanitizer.getPropRead() and
-    sink = AccessPath::getAnAliasedSourceNode(src) and
     srcBB = src.getBasicBlock() and
-    sinkBB = sink.getBasicBlock()
+    sinkBB = sink.getBasicBlock() and
+    (
+      sink = AccessPath::getAnAliasedSourceNode(src)
+      or
+      // step over extend calls
+      exists(ExtendCall extendCall, string prop |
+        src = extendCall.getASourceOperand().getALocalSource().getAPropertyReference(prop) and
+        sink =
+          [extendCall, extendCall.getDestinationOperand()]
+              .(DataFlow::SourceNode)
+              .getAPropertyReference(prop)
+      )
+    )
   )
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeJQueryPlugin/UnsafeJQueryPlugin.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeJQueryPlugin/UnsafeJQueryPlugin.expected
@@ -1,3 +1,5 @@
+WARNING: Unused predicate sink (/home/erik/dev/code/ql/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql:30,6-10)
+WARNING: Unused predicate source (/home/erik/dev/code/ql/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql:28,10-16)
 nodes
 | unsafe-jquery-plugin.js:2:38:2:44 | options |
 | unsafe-jquery-plugin.js:2:38:2:44 | options |
@@ -121,6 +123,12 @@ nodes
 | unsafe-jquery-plugin.js:179:5:179:11 | options |
 | unsafe-jquery-plugin.js:179:5:179:18 | options.target |
 | unsafe-jquery-plugin.js:179:5:179:18 | options.target |
+| unsafe-jquery-plugin.js:185:28:185:34 | options |
+| unsafe-jquery-plugin.js:185:28:185:34 | options |
+| unsafe-jquery-plugin.js:186:21:186:27 | options |
+| unsafe-jquery-plugin.js:186:21:186:30 | options.of |
+| unsafe-jquery-plugin.js:192:19:192:28 | options.of |
+| unsafe-jquery-plugin.js:192:19:192:28 | options.of |
 edges
 | unsafe-jquery-plugin.js:2:38:2:44 | options | unsafe-jquery-plugin.js:3:5:3:11 | options |
 | unsafe-jquery-plugin.js:2:38:2:44 | options | unsafe-jquery-plugin.js:3:5:3:11 | options |
@@ -245,6 +253,11 @@ edges
 | unsafe-jquery-plugin.js:178:27:178:33 | options | unsafe-jquery-plugin.js:179:5:179:11 | options |
 | unsafe-jquery-plugin.js:179:5:179:11 | options | unsafe-jquery-plugin.js:179:5:179:18 | options.target |
 | unsafe-jquery-plugin.js:179:5:179:11 | options | unsafe-jquery-plugin.js:179:5:179:18 | options.target |
+| unsafe-jquery-plugin.js:185:28:185:34 | options | unsafe-jquery-plugin.js:186:21:186:27 | options |
+| unsafe-jquery-plugin.js:185:28:185:34 | options | unsafe-jquery-plugin.js:186:21:186:27 | options |
+| unsafe-jquery-plugin.js:186:21:186:27 | options | unsafe-jquery-plugin.js:186:21:186:30 | options.of |
+| unsafe-jquery-plugin.js:186:21:186:30 | options.of | unsafe-jquery-plugin.js:192:19:192:28 | options.of |
+| unsafe-jquery-plugin.js:186:21:186:30 | options.of | unsafe-jquery-plugin.js:192:19:192:28 | options.of |
 #select
 | unsafe-jquery-plugin.js:3:5:3:11 | options | unsafe-jquery-plugin.js:2:38:2:44 | options | unsafe-jquery-plugin.js:3:5:3:11 | options | Potential XSS vulnerability in the $@. | unsafe-jquery-plugin.js:2:19:63:2 | functio ... \\t\\t}\\n\\n\\t} | '$.fn.my_plugin' plugin |
 | unsafe-jquery-plugin.js:5:5:5:18 | options.target | unsafe-jquery-plugin.js:2:38:2:44 | options | unsafe-jquery-plugin.js:5:5:5:18 | options.target | Potential XSS vulnerability in the $@. | unsafe-jquery-plugin.js:2:19:63:2 | functio ... \\t\\t}\\n\\n\\t} | '$.fn.my_plugin' plugin |
@@ -268,3 +281,4 @@ edges
 | unsafe-jquery-plugin.js:157:44:157:59 | options.target.a | unsafe-jquery-plugin.js:153:38:153:44 | options | unsafe-jquery-plugin.js:157:44:157:59 | options.target.a | Potential XSS vulnerability in the $@. | unsafe-jquery-plugin.js:153:19:158:2 | functio ... NCY]\\n\\t} | '$.fn.my_plugin' plugin |
 | unsafe-jquery-plugin.js:170:6:170:11 | target | unsafe-jquery-plugin.js:160:38:160:44 | options | unsafe-jquery-plugin.js:170:6:170:11 | target | Potential XSS vulnerability in the $@. | unsafe-jquery-plugin.js:160:19:173:2 | functio ... \\t\\t}\\n\\n\\t} | '$.fn.my_plugin' plugin |
 | unsafe-jquery-plugin.js:179:5:179:18 | options.target | unsafe-jquery-plugin.js:178:27:178:33 | options | unsafe-jquery-plugin.js:179:5:179:18 | options.target | Potential XSS vulnerability in the $@. | unsafe-jquery-plugin.js:178:18:180:2 | functio ... T OK\\n\\t} | '$.fn.my_plugin' plugin |
+| unsafe-jquery-plugin.js:192:19:192:28 | options.of | unsafe-jquery-plugin.js:185:28:185:34 | options | unsafe-jquery-plugin.js:192:19:192:28 | options.of | Potential XSS vulnerability in the $@. | unsafe-jquery-plugin.js:185:18:194:2 | functio ... et);\\n\\t} | '$.fn.position' plugin |

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeJQueryPlugin/UnsafeJQueryPlugin.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeJQueryPlugin/UnsafeJQueryPlugin.expected
@@ -1,5 +1,3 @@
-WARNING: Unused predicate sink (/home/erik/dev/code/ql/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql:30,6-10)
-WARNING: Unused predicate source (/home/erik/dev/code/ql/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql:28,10-16)
 nodes
 | unsafe-jquery-plugin.js:2:38:2:44 | options |
 | unsafe-jquery-plugin.js:2:38:2:44 | options |

--- a/javascript/ql/test/query-tests/Security/CWE-079/UnsafeJQueryPlugin/unsafe-jquery-plugin.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/UnsafeJQueryPlugin/unsafe-jquery-plugin.js
@@ -182,4 +182,14 @@
 		$(document).find(options.target); // OK
 	}});
 
+	$.fn.position = function( options ) {
+		if ( !options || !options.of ) {
+			return doSomethingElse( this, arguments );
+		}
+		// extending options
+		options = $.extend( {}, options );
+	
+		var target = $( options.of ); // NOT OK
+		console.log(target);
+	};
 });


### PR DESCRIPTION
Gets a TP for CVE-2021-41184

An alternative solution I tried was to add extend calls to `GlobalAccessPaths.qll::fromReference`.   
However, that caused FNs in other tests (from the analysis mistakenly concluding that a dominating write existed). 