### PR TITLE
JavaScript: Improve support for copied properties in API graphs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/Promises.qll
+++ b/javascript/ql/lib/semmle/javascript/Promises.qll
@@ -425,6 +425,14 @@ module PromiseFlow {
       prop = errorProp() and
       pred = call.getCallback(0).getAReturn()
     )
+    or
+    // return from `async` function
+    exists(DataFlow::FunctionNode f | f.getFunction().isAsync() |
+      // ordinary return
+      prop = valueProp() and
+      pred = f.getAReturn() and
+      succ = f.getReturnNode()
+    )
   }
 }
 

--- a/javascript/ql/test/ApiGraphs/async-await/tst.ts
+++ b/javascript/ql/test/ApiGraphs/async-await/tst.ts
@@ -1,0 +1,9 @@
+import { readFile } from 'fs/promises';
+
+async function readFileUtf8(path: string): Promise<string> {
+    return readFile(path, { encoding: 'utf8' });
+}
+
+async function test(path: string) {
+    await readFileUtf8(path); /* use (promised (return (member readFile (member exports (module fs/promises))))) */
+}


### PR DESCRIPTION
The original motivation for this PR was to teach the API-graphs library to properly handle promises being returned from an `async` function. These don't get double-wrapped into another layer of promises, but are copied into the result object. Our library already provides a way of modelling that via a `loadStoreStep`, but such steps were not previously taken into account by the API-graphs library.

With this PR, they are respected when computing use nodes, not just for the promise-related pseudo-properties but for all properties (though I'm not sure to what extent that matters in practice). I haven't looked into the corresponding change for def nodes yet.

@erik-krogh has kindly done a performance evaluation, which looks reasonable (after the second commit anyway).