### PR TITLE
C#: Replace `localFlow` with `localFlowStep` in recursive predicate

### DIFF
--- a/csharp/ql/src/Bad Practices/Implementation Hiding/ExposeRepresentation.ql
+++ b/csharp/ql/src/Bad Practices/Implementation Hiding/ExposeRepresentation.ql
@@ -29,15 +29,20 @@ predicate returnsCollection(Callable c, Field f) {
   not c.(Modifiable).isStatic()
 }
 
-predicate mayWriteToCollection(Expr modified) {
-  modified instanceof CollectionModificationAccess
+predicate nodeMayWriteToCollection(Node modified) {
+  modified.asExpr() instanceof CollectionModificationAccess
   or
-  exists(Expr mid | mayWriteToCollection(mid) | localExprFlow(modified, mid))
+  exists(Node mid | nodeMayWriteToCollection(mid) | localFlowStep(modified, mid))
   or
-  exists(MethodCall mid, Callable c | mayWriteToCollection(mid) |
-    mid.getTarget() = c and
-    c.canReturn(modified)
+  exists(Node mid, MethodCall mc, Callable c | nodeMayWriteToCollection(mid) |
+    mc = mid.asExpr() and
+    mc.getTarget() = c and
+    c.canReturn(modified.asExpr())
   )
+}
+
+predicate mayWriteToCollection(Expr modified) {
+  nodeMayWriteToCollection(any(ExprNode n | n.getExpr() = modified))
 }
 
 predicate modificationAfter(Expr before, Expr after) {


### PR DESCRIPTION
This change avoids the computation of an expensive transitive closure:
```
	ExposeRepresentation.ql-32:DataFlowPublic::localExprFlow#ff .......................................................................................... 3m50s
	ExposeRepresentation.ql-32:DataFlowPublic::localExprFlow#ff_10#join_rhs .............................................................................. 2m7s
```

Similar to https://github.com/github/codeql/pull/6885.