### PR TITLE
Ruby: Fix performance problem in `Definitions.ql`

### DIFF
--- a/ruby/ql/src/queries/analysis/Definitions.ql
+++ b/ruby/ql/src/queries/analysis/Definitions.ql
@@ -65,6 +65,13 @@ newtype DefLoc =
     not exists(MethodBase m | m.getAChild+() = write)
   }
 
+pragma[noinline]
+ConstantWriteAccess definitionOf0(string fqn) {
+  fqn = resolveConstant(_) and
+  result =
+    min(ConstantWriteAccess w | w.getQualifiedName() = fqn | w order by w.getLocation().toString())
+}
+
 /**
  * Gets the constant write that defines the given constant.
  *  Modules often don't have a unique definition, as they are opened multiple times in different
@@ -72,10 +79,5 @@ newtype DefLoc =
  *  location.
  */
 ConstantWriteAccess definitionOf(ConstantReadAccess r) {
-  result =
-    min(ConstantWriteAccess w |
-      w.getQualifiedName() = resolveConstant(r)
-    |
-      w order by w.getLocation().toString()
-    )
+  result = definitionOf0(resolveConstant(r))
 }


### PR DESCRIPTION
Avoids computing this large set:

```
[2021-11-12 14:31:11] (542s) Tuple counts for Definitions::definitionOf#ff#min_term/5@cc3ffc after 2m10s:
                      337397265 ~3%     {5} r1 = JOIN Definitions::definitionOf#ff#shared WITH Module::Cached::resolveConstant#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'arg0', Lhs.2 'arg3', Lhs.1 'arg4', Lhs.2 'arg3', Lhs.1 'arg4'
                                        return r1
```