### PR TITLE
Python: Model `b32hexencode`/`b32hexdecode`

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -852,7 +852,7 @@ private module StdlibPrivate {
     Base64EncodeCall() {
       name in [
           "b64encode", "standard_b64encode", "urlsafe_b64encode", "b32encode", "b16encode",
-          "encodestring", "a85encode", "b85encode", "encodebytes"
+          "encodestring", "a85encode", "b85encode", "encodebytes", "b32hexencode"
         ] and
       this = base64().getMember(name).getACall()
     }
@@ -867,7 +867,7 @@ private module StdlibPrivate {
         ] and
       result = "Base64"
       or
-      name = "b32encode" and result = "Base32"
+      name in ["b32encode", "b32hexencode"] and result = "Base32"
       or
       name = "b16encode" and result = "Base16"
       or
@@ -884,7 +884,7 @@ private module StdlibPrivate {
     Base64DecodeCall() {
       name in [
           "b64decode", "standard_b64decode", "urlsafe_b64decode", "b32decode", "b16decode",
-          "decodestring", "a85decode", "b85decode", "decodebytes"
+          "decodestring", "a85decode", "b85decode", "decodebytes", "b32hexdecode"
         ] and
       this = base64().getMember(name).getACall()
     }
@@ -901,7 +901,7 @@ private module StdlibPrivate {
         ] and
       result = "Base64"
       or
-      name = "b32decode" and result = "Base32"
+      name in ["b32decode", "b32hexdecode"] and result = "Base32"
       or
       name = "b16decode" and result = "Base16"
       or

--- a/python/ql/test/library-tests/frameworks/stdlib/Decoding.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/Decoding.py
@@ -31,6 +31,7 @@ base64.b64decode(payload)  # $ decodeInput=payload decodeOutput=base64.b64decode
 base64.standard_b64decode(payload)  # $ decodeInput=payload decodeOutput=base64.standard_b64decode(..) decodeFormat=Base64
 base64.urlsafe_b64decode(payload)  # $ decodeInput=payload decodeOutput=base64.urlsafe_b64decode(..) decodeFormat=Base64
 base64.b32decode(payload)  # $ decodeInput=payload decodeOutput=base64.b32decode(..) decodeFormat=Base32
+base64.b32hexdecode(payload)  # $ decodeInput=payload decodeOutput=base64.b32hexdecode(..) decodeFormat=Base32
 base64.b16decode(payload)  # $ decodeInput=payload decodeOutput=base64.b16decode(..) decodeFormat=Base16
 # deprecated since Python 3.1, but still works
 base64.decodestring(payload)  # $ decodeInput=payload decodeOutput=base64.decodestring(..) decodeFormat=Base64

--- a/python/ql/test/library-tests/frameworks/stdlib/Encoding.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/Encoding.py
@@ -10,6 +10,7 @@ base64.b64encode(bs)  # $ encodeInput=bs encodeOutput=base64.b64encode(..) encod
 base64.standard_b64encode(bs)  # $ encodeInput=bs encodeOutput=base64.standard_b64encode(..) encodeFormat=Base64
 base64.urlsafe_b64encode(bs)  # $ encodeInput=bs encodeOutput=base64.urlsafe_b64encode(..) encodeFormat=Base64
 base64.b32encode(bs)  # $ encodeInput=bs encodeOutput=base64.b32encode(..) encodeFormat=Base32
+base64.b32hexencode(bs)  # $ encodeInput=bs encodeOutput=base64.b32hexencode(..) encodeFormat=Base32
 base64.b16encode(bs)  # $ encodeInput=bs encodeOutput=base64.b16encode(..) encodeFormat=Base16
 # deprecated since Python 3.1, but still works
 base64.encodestring(bs)  # $ encodeInput=bs encodeOutput=base64.encodestring(..) encodeFormat=Base64


### PR DESCRIPTION
New in Python 3.10

See
- https://devdocs.io/python~3.10/library/base64#base64.b32hexencode
- https://devdocs.io/python~3.10/library/base64#base64.b32hexdecode


I just forgot in https://github.com/github/codeql/pull/7133 :facepalm: