### PR TITLE
Ruby: Add missing CFG entry for `ForwardParameter`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
@@ -608,6 +608,8 @@ module Trees {
     }
   }
 
+  private class ForwardParameterTree extends LeafTree, ForwardParameter { }
+
   private class ForInTree extends LeafTree, ForIn { }
 
   /**

--- a/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -2432,10 +2432,28 @@ cfg.rb:
 #  196| forward_param
 #-----|  -> exit cfg.rb (normal)
 
+#  196| exit forward_param
+
+#  196| exit forward_param (normal)
+#-----|  -> exit forward_param
+
 #  196| a
 #-----|  -> b
 
 #  196| b
+#-----|  -> ...
+
+#  196| ...
+#-----|  -> self
+
+#  197| call to bar
+#-----|  -> exit forward_param (normal)
+
+#  197| self
+#-----|  -> b
+
+#  197| b
+#-----|  -> call to bar
 
 desugar.rb:
 #    1| enter m1

--- a/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -2398,7 +2398,7 @@ cfg.rb:
 #-----|  -> yield ...
 
 #  194| call to run_block
-#-----|  -> exit cfg.rb (normal)
+#-----|  -> forward_param
 
 #  194| self
 #-----|  -> { ... }
@@ -2425,6 +2425,17 @@ cfg.rb:
 
 #  194| x
 #-----|  -> call to puts
+
+#  196| enter forward_param
+#-----|  -> a
+
+#  196| forward_param
+#-----|  -> exit cfg.rb (normal)
+
+#  196| a
+#-----|  -> b
+
+#  196| b
 
 desugar.rb:
 #    1| enter m1

--- a/ruby/ql/test/library-tests/controlflow/graph/cfg.rb
+++ b/ruby/ql/test/library-tests/controlflow/graph/cfg.rb
@@ -193,6 +193,10 @@ end
 
 run_block { |x|puts x }
 
+def forward_param(a, b, ...)
+  bar(b, ...)
+end
+
 __END__
 
 Some ignored nonsense


### PR DESCRIPTION
Found by https://github.com/github/codeql/pull/7130.