### PR TITLE
Python/Ruby: Remove owasp tags

### DIFF
--- a/python/ql/src/Security/CWE-022/PathInjection.ql
+++ b/python/ql/src/Security/CWE-022/PathInjection.ql
@@ -9,7 +9,6 @@
  * @id py/path-injection
  * @tags correctness
  *       security
- *       external/owasp/owasp-a1
  *       external/cwe/cwe-022
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036

--- a/python/ql/src/Security/CWE-078/CommandInjection.ql
+++ b/python/ql/src/Security/CWE-078/CommandInjection.ql
@@ -10,7 +10,6 @@
  * @id py/command-line-injection
  * @tags correctness
  *       security
- *       external/owasp/owasp-a1
  *       external/cwe/cwe-078
  *       external/cwe/cwe-088
  */

--- a/python/ql/src/Security/CWE-089/SqlInjection.ql
+++ b/python/ql/src/Security/CWE-089/SqlInjection.ql
@@ -9,7 +9,6 @@
  * @id py/sql-injection
  * @tags security
  *       external/cwe/cwe-089
- *       external/owasp/owasp-a1
  */
 
 import python

--- a/python/ql/src/Security/CWE-094/CodeInjection.ql
+++ b/python/ql/src/Security/CWE-094/CodeInjection.ql
@@ -9,7 +9,6 @@
  * @precision high
  * @id py/code-injection
  * @tags security
- *       external/owasp/owasp-a1
  *       external/cwe/cwe-094
  *       external/cwe/cwe-095
  *       external/cwe/cwe-116

--- a/ruby/ql/src/queries/security/cwe-089/SqlInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-089/SqlInjection.ql
@@ -9,7 +9,6 @@
  * @id rb/sql-injection
  * @tags security
  *       external/cwe/cwe-089
- *       external/owasp/owasp-a1
  */
 
 import ruby

--- a/ruby/ql/src/queries/security/cwe-094/CodeInjection.ql
+++ b/ruby/ql/src/queries/security/cwe-094/CodeInjection.ql
@@ -9,7 +9,6 @@
  * @precision high
  * @id rb/code-injection
  * @tags security
- *       external/owasp/owasp-a1
  *       external/cwe/cwe-094
  *       external/cwe/cwe-095
  *       external/cwe/cwe-116


### PR DESCRIPTION
These are no longer correct, since the A1 category changed from 2017 to
2021, see https://owasp.org/Top10/#whats-changed-in-the-top-10-for-2021

Since only a very few queries had these tags, I think we're much better
off having them removed.