### PR TITLE
Add neighborhood scope token feature to ATM library

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CodeToFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CodeToFeatures.qll
@@ -423,15 +423,15 @@ module DatabaseFeatures {
   }
 
   query predicate astNodes(
-    Entity enclosingEntity, EntityOrAstNode parent, int index, AstNode node, string node_type
+    Entity enclosingEntity, EntityOrAstNode parent, int index, AstNode child, string childType
   ) {
-    node = enclosingEntity.getAstRoot(index) and
+    child = enclosingEntity.getAstRoot(index) and
     parent = enclosingEntity and
-    node_type = node.getType()
+    childType = child.getType()
     or
     astNodes(enclosingEntity, _, _, parent, _) and
-    node = parent.(AstNode).getChild(index) and
-    node_type = node.getType()
+    child = parent.(AstNode).getChild(index) and
+    childType = child.getType()
   }
 
   query predicate nodeAttributes(AstNode node, string attr) {


### PR DESCRIPTION
Taking the work in https://github.com/github/ml-ql-adaptive-threat-modeling-backend/tree/annarailton/neighbourhood-features and moving it into the CodeQL library. 

The feature `neighborhoodBody` is now a token feature extracted in `ExctractEndpointData.ql`, alongside the likes of `enclosingFunctionBody`. 

Very much actually the work of @smowton (will amend the commits to add co-author). 

See https://github.com/github/ml-ql-adaptive-threat-modeling/issues/1553