### PR TITLE
C++: Minor improvements to 'Failure to use HTTPS URLs' query

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -7,6 +7,7 @@
  * @id cpp/non-https-url
  * @tags security
  *       external/cwe/cwe-319
+ *       external/cwe/cwe-345
  */
 
 import cpp

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -62,7 +62,7 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
     // accessed as a URL, for example using it in a network access. Some
     // URLs are only ever displayed or used for data processing.
     exists(FunctionCall fc |
-      fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname", "getaddrinfo"]) and
+      fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname", "gethostbyname2", "gethostbyname_r", "getaddrinfo", "X509_load_http", "X509_CRL_load_http"]) and
       sink.asExpr() = fc.getArgument(0)
       or
       fc.getTarget().hasGlobalOrStdName(["send", "URLDownloadToFile", "URLDownloadToCacheFile"]) and

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -62,7 +62,11 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
     // accessed as a URL, for example using it in a network access. Some
     // URLs are only ever displayed or used for data processing.
     exists(FunctionCall fc |
-      fc.getTarget().hasGlobalOrStdName(["system", "gethostbyname", "gethostbyname2", "gethostbyname_r", "getaddrinfo", "X509_load_http", "X509_CRL_load_http"]) and
+      fc.getTarget()
+          .hasGlobalOrStdName([
+              "system", "gethostbyname", "gethostbyname2", "gethostbyname_r", "getaddrinfo",
+              "X509_load_http", "X509_CRL_load_http"
+            ]) and
       sink.asExpr() = fc.getArgument(0)
       or
       fc.getTarget().hasGlobalOrStdName(["send", "URLDownloadToFile", "URLDownloadToCacheFile"]) and


### PR DESCRIPTION
Minor improvements to the query recently added in https://github.com/github/codeql/pull/7094:
 - add a CWE tag that should effectively associate the query with OWASP A8.
 - add a few more sinks (functions that take a URL as a parameter).
