### PR TITLE
Ruby: add `getMethodName` predicate to `DataFlow::CallNode` class

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -60,6 +60,16 @@ class CallNode extends LocalSourceNode {
   Node getKeywordArgument(string name) { result.asExpr() = node.getKeywordArgument(name) }
 }
 
+/** A data-flow node corresponding to a method call in the control-flow graph. */
+class MethodCallNode extends CallNode {
+  private CfgNodes::ExprNodes::MethodCallCfgNode node;
+
+  MethodCallNode() { node = this.asExpr() }
+
+  /** Gets the name of the the method called by the method call corresponding to this data-flow node */
+  string getMethodName() { result = node.getExpr().getMethodName() }
+}
+
 /**
  * An expression, viewed as a node in a data flow graph.
  *

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -58,16 +58,9 @@ class CallNode extends LocalSourceNode {
 
   /** Gets the data-flow node corresponding to the named argument of the call corresponding to this data-flow node */
   Node getKeywordArgument(string name) { result.asExpr() = node.getKeywordArgument(name) }
-}
 
-/** A data-flow node corresponding to a method call in the control-flow graph. */
-class MethodCallNode extends CallNode {
-  private CfgNodes::ExprNodes::MethodCallCfgNode node;
-
-  MethodCallNode() { node = this.asExpr() }
-
-  /** Gets the name of the the method called by the method call corresponding to this data-flow node */
-  string getMethodName() { result = node.getExpr().getMethodName() }
+  /** Gets the name of the the method called by the method call (if any) corresponding to this data-flow node */
+  string getMethodName() { result = node.getExpr().(MethodCall).getMethodName() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
@@ -5,8 +5,7 @@ private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.FlowSummary
 
 /** Defines calls to  `ActiveStorage::Filename#sanitized` as path sanitizers. */
-class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range,
-  DataFlow::MethodCallNode {
+class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range, DataFlow::CallNode {
   ActiveStorageFilenameSanitizedCall() {
     this.getReceiver() =
       API::getTopLevelMember("ActiveStorage").getMember("Filename").getAnInstantiation() and

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
@@ -5,11 +5,12 @@ private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.FlowSummary
 
 /** Defines calls to  `ActiveStorage::Filename#sanitized` as path sanitizers. */
-class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range, DataFlow::CallNode {
+class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range,
+  DataFlow::MethodCallNode {
   ActiveStorageFilenameSanitizedCall() {
     this.getReceiver() =
       API::getTopLevelMember("ActiveStorage").getMember("Filename").getAnInstantiation() and
-    this.asExpr().getExpr().(MethodCall).getMethodName() = "sanitized"
+    this.getMethodName() = "sanitized"
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -99,7 +99,7 @@ module IO {
   }
 
   /**
-   * A `DataFlow::CallNode` that reads data using the `IO` class. For example,
+   * A `DataFlow::MethodCallNode` that reads data using the `IO` class. For example,
    * the `IO.read call in:
    *
    * ```rb
@@ -112,7 +112,7 @@ module IO {
    * filesystem. For working with filesystem accesses specifically, see
    * `IOFileReader` or the `FileSystemReadAccess` concept.
    */
-  class IOReader extends DataFlow::CallNode {
+  class IOReader extends DataFlow::MethodCallNode {
     private boolean classMethodCall;
     private string api;
 
@@ -127,8 +127,7 @@ module IO {
       api = "IO" and
       exists(IOInstanceStrict ii |
         this.getReceiver() = ii and
-        this.asExpr().getExpr().(MethodCall).getMethodName() =
-          ioFileReaderMethodName(classMethodCall)
+        this.getMethodName() = ioFileReaderMethodName(classMethodCall)
       )
       or
       // File instance methods
@@ -136,8 +135,7 @@ module IO {
       api = "File" and
       exists(File::FileInstance fi |
         this.getReceiver() = fi and
-        this.asExpr().getExpr().(MethodCall).getMethodName() =
-          ioFileReaderMethodName(classMethodCall)
+        this.getMethodName() = ioFileReaderMethodName(classMethodCall)
       )
       // TODO: enumeration style methods such as `each`, `foreach`, etc.
     }
@@ -151,7 +149,7 @@ module IO {
   }
 
   /**
-   * A `DataFlow::CallNode` that reads data from the filesystem using the `IO`
+   * A `DataFlow::MethodCallNode` that reads data from the filesystem using the `IO`
    * class. For example, the `IO.read call in:
    *
    * ```rb
@@ -219,7 +217,7 @@ module File {
   /**
    * A call to a `File` method that may return one or more filenames.
    */
-  class FileModuleFilenameSource extends FileNameSource, DataFlow::CallNode {
+  class FileModuleFilenameSource extends FileNameSource, DataFlow::MethodCallNode {
     FileModuleFilenameSource() {
       // Class methods
       this =
@@ -232,13 +230,13 @@ module File {
       // Instance methods
       exists(FileInstance fi |
         this.getReceiver() = fi and
-        this.asExpr().getExpr().(MethodCall).getMethodName() = ["path", "to_path"]
+        this.getMethodName() = ["path", "to_path"]
       )
     }
   }
 
   private class FileModulePermissionModification extends FileSystemPermissionModification::Range,
-    DataFlow::CallNode {
+    DataFlow::MethodCallNode {
     private DataFlow::Node permissionArg;
 
     FileModulePermissionModification() {
@@ -321,7 +319,7 @@ module FileUtils {
   }
 
   private class FileUtilsPermissionModification extends FileSystemPermissionModification::Range,
-    DataFlow::CallNode {
+    DataFlow::MethodCallNode {
     private DataFlow::Node permissionArg;
 
     FileUtilsPermissionModification() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -99,7 +99,7 @@ module IO {
   }
 
   /**
-   * A `DataFlow::MethodCallNode` that reads data using the `IO` class. For example,
+   * A `DataFlow::CallNode` that reads data using the `IO` class. For example,
    * the `IO.read call in:
    *
    * ```rb
@@ -112,7 +112,7 @@ module IO {
    * filesystem. For working with filesystem accesses specifically, see
    * `IOFileReader` or the `FileSystemReadAccess` concept.
    */
-  class IOReader extends DataFlow::MethodCallNode {
+  class IOReader extends DataFlow::CallNode {
     private boolean classMethodCall;
     private string api;
 
@@ -149,7 +149,7 @@ module IO {
   }
 
   /**
-   * A `DataFlow::MethodCallNode` that reads data from the filesystem using the `IO`
+   * A `DataFlow::CallNode` that reads data from the filesystem using the `IO`
    * class. For example, the `IO.read call in:
    *
    * ```rb
@@ -217,7 +217,7 @@ module File {
   /**
    * A call to a `File` method that may return one or more filenames.
    */
-  class FileModuleFilenameSource extends FileNameSource, DataFlow::MethodCallNode {
+  class FileModuleFilenameSource extends FileNameSource, DataFlow::CallNode {
     FileModuleFilenameSource() {
       // Class methods
       this =
@@ -236,7 +236,7 @@ module File {
   }
 
   private class FileModulePermissionModification extends FileSystemPermissionModification::Range,
-    DataFlow::MethodCallNode {
+    DataFlow::CallNode {
     private DataFlow::Node permissionArg;
 
     FileModulePermissionModification() {
@@ -319,7 +319,7 @@ module FileUtils {
   }
 
   private class FileUtilsPermissionModification extends FileSystemPermissionModification::Range,
-    DataFlow::MethodCallNode {
+    DataFlow::CallNode {
     private DataFlow::Node permissionArg;
 
     FileUtilsPermissionModification() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -26,8 +26,6 @@ class KernelMethodCall extends DataFlow::CallNode {
     )
   }
 
-  string getMethodName() { result = methodCall.getMethodName() }
-
   int getNumberOfArguments() { result = methodCall.getNumberOfArguments() }
 }
 


### PR DESCRIPTION
This lets us tidy up a few places where we have a `DataFlow::CallNode` with an underlying `MethodCall`, but have to do a clumsy `node.asExpr().getExpr().(MethodCall)` cast in order to get the name of the called method.