### PR TITLE
Ruby: QL generator: use qualified imports

### DIFF
--- a/ruby/generator/src/main.rs
+++ b/ruby/generator/src/main.rs
@@ -611,10 +611,10 @@ fn main() -> std::io::Result<()> {
     )?;
     ql::write(
         &mut ql_writer,
-        &[
-            ql::TopLevel::Import("codeql.files.FileSystem"),
-            ql::TopLevel::Import("codeql.Locations"),
-        ],
+        &[ql::TopLevel::Import(ql::Import {
+            module: "codeql.Locations",
+            alias: Some("L"),
+        })],
     )?;
 
     for language in languages {

--- a/ruby/generator/src/ql.rs
+++ b/ruby/generator/src/ql.rs
@@ -4,20 +4,35 @@ use std::fmt;
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub enum TopLevel<'a> {
     Class(Class<'a>),
-    Import(&'a str),
+    Import(Import<'a>),
     Module(Module<'a>),
 }
 
 impl<'a> fmt::Display for TopLevel<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TopLevel::Import(x) => write!(f, "private import {}", x),
+            TopLevel::Import(imp) => write!(f, "{}", imp),
             TopLevel::Class(cls) => write!(f, "{}", cls),
             TopLevel::Module(m) => write!(f, "{}", m),
         }
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct Import<'a> {
+    pub module: &'a str,
+    pub alias: Option<&'a str>,
+}
+
+impl<'a> fmt::Display for Import<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "import {}", &self.module)?;
+        if let Some(name) = &self.alias {
+            write!(f, " as {}", name)?;
+        }
+        Ok(())
+    }
+}
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Class<'a> {
     pub qldoc: Option<String>,

--- a/ruby/generator/src/ql_gen.rs
+++ b/ruby/generator/src/ql_gen.rs
@@ -26,7 +26,7 @@ pub fn create_ast_node_class<'a>(ast_node: &'a str, ast_node_parent: &'a str) ->
         Some(String::from("Gets the location of this element.")),
         "getLocation",
         false,
-        Some(ql::Type::Normal("Location")),
+        Some(ql::Type::Normal("L::Location")),
     );
     let get_a_field_or_child = create_none_predicate(
         Some(String::from("Gets a field or child node of this node.")),
@@ -136,7 +136,7 @@ pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Cl
         qldoc: Some(String::from("Gets the location of this token.")),
         name: "getLocation",
         overridden: true,
-        return_type: Some(ql::Type::Normal("Location")),
+        return_type: Some(ql::Type::Normal("L::Location")),
         formal_parameters: vec![],
         body: create_get_field_expr_for_column_storage("result", tokeninfo, 2, tokeninfo_arity),
     };
@@ -236,7 +236,7 @@ fn create_get_location_predicate(def_table: &str, arity: usize) -> ql::Predicate
         qldoc: Some(String::from("Gets the location of this element.")),
         name: "getLocation",
         overridden: true,
-        return_type: Some(ql::Type::Normal("Location")),
+        return_type: Some(ql::Type::Normal("L::Location")),
         formal_parameters: vec![],
         // body of the form: foo_bar_def(_, _, ..., result)
         body: ql::Expression::Pred(

--- a/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
@@ -3,8 +3,7 @@
  * Automatically generated from the tree-sitter grammar; do not edit
  */
 
-private import codeql.files.FileSystem
-private import codeql.Locations
+import codeql.Locations as L
 
 module Ruby {
   /** The base class for all AST nodes */
@@ -13,7 +12,7 @@ module Ruby {
     string toString() { result = this.getAPrimaryQlClass() }
 
     /** Gets the location of this element. */
-    Location getLocation() { none() }
+    L::Location getLocation() { none() }
 
     /** Gets the parent of this element. */
     AstNode getParent() { ruby_ast_node_parent(this, result, _) }
@@ -37,7 +36,7 @@ module Ruby {
     string getValue() { ruby_tokeninfo(this, _, result, _) }
 
     /** Gets the location of this token. */
-    override Location getLocation() { ruby_tokeninfo(this, _, _, result) }
+    override L::Location getLocation() { ruby_tokeninfo(this, _, _, result) }
 
     /** Gets a string representation of this element. */
     override string toString() { result = this.getValue() }
@@ -70,7 +69,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Alias" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_alias_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_alias_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `alias`. */
     UnderscoreMethodName getAlias() { ruby_alias_def(this, result, _, _) }
@@ -90,7 +89,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "ArgumentList" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_argument_list_def(this, result) }
+    override L::Location getLocation() { ruby_argument_list_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_argument_list_child(this, i, result) }
@@ -105,7 +104,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Array" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_array_def(this, result) }
+    override L::Location getLocation() { ruby_array_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_array_child(this, i, result) }
@@ -120,7 +119,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Assignment" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_assignment_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_assignment_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `left`. */
     AstNode getLeft() { ruby_assignment_def(this, result, _, _) }
@@ -140,7 +139,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "BareString" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_bare_string_def(this, result) }
+    override L::Location getLocation() { ruby_bare_string_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_bare_string_child(this, i, result) }
@@ -155,7 +154,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "BareSymbol" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_bare_symbol_def(this, result) }
+    override L::Location getLocation() { ruby_bare_symbol_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_bare_symbol_child(this, i, result) }
@@ -170,7 +169,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Begin" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_begin_def(this, result) }
+    override L::Location getLocation() { ruby_begin_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_begin_child(this, i, result) }
@@ -185,7 +184,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "BeginBlock" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_begin_block_def(this, result) }
+    override L::Location getLocation() { ruby_begin_block_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_begin_block_child(this, i, result) }
@@ -200,7 +199,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Binary" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_binary_def(this, _, _, _, result) }
+    override L::Location getLocation() { ruby_binary_def(this, _, _, _, result) }
 
     /** Gets the node corresponding to the field `left`. */
     AstNode getLeft() { ruby_binary_def(this, result, _, _, _) }
@@ -275,7 +274,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Block" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_block_def(this, result) }
+    override L::Location getLocation() { ruby_block_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     BlockParameters getParameters() { ruby_block_parameters(this, result) }
@@ -295,7 +294,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "BlockArgument" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_block_argument_def(this, _, result) }
+    override L::Location getLocation() { ruby_block_argument_def(this, _, result) }
 
     /** Gets the child of this node. */
     UnderscoreArg getChild() { ruby_block_argument_def(this, result, _) }
@@ -310,7 +309,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "BlockParameter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_block_parameter_def(this, _, result) }
+    override L::Location getLocation() { ruby_block_parameter_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_block_parameter_def(this, result, _) }
@@ -325,7 +324,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "BlockParameters" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_block_parameters_def(this, result) }
+    override L::Location getLocation() { ruby_block_parameters_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_block_parameters_child(this, i, result) }
@@ -340,7 +339,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Break" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_break_def(this, result) }
+    override L::Location getLocation() { ruby_break_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_break_child(this, result) }
@@ -355,7 +354,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Call" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_call_def(this, _, result) }
+    override L::Location getLocation() { ruby_call_def(this, _, result) }
 
     /** Gets the node corresponding to the field `arguments`. */
     ArgumentList getArguments() { ruby_call_arguments(this, result) }
@@ -384,7 +383,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Case" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_case_def(this, result) }
+    override L::Location getLocation() { ruby_case_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
     UnderscoreStatement getValue() { ruby_case_value(this, result) }
@@ -404,7 +403,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "ChainedString" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_chained_string_def(this, result) }
+    override L::Location getLocation() { ruby_chained_string_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     String getChild(int i) { ruby_chained_string_child(this, i, result) }
@@ -425,7 +424,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Class" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_class_def(this, _, result) }
+    override L::Location getLocation() { ruby_class_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     AstNode getName() { ruby_class_def(this, result, _) }
@@ -468,7 +467,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Conditional" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_conditional_def(this, _, _, _, result) }
+    override L::Location getLocation() { ruby_conditional_def(this, _, _, _, result) }
 
     /** Gets the node corresponding to the field `alternative`. */
     UnderscoreArg getAlternative() { ruby_conditional_def(this, result, _, _, _) }
@@ -499,7 +498,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "DelimitedSymbol" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_delimited_symbol_def(this, result) }
+    override L::Location getLocation() { ruby_delimited_symbol_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_delimited_symbol_child(this, i, result) }
@@ -514,7 +513,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "DestructuredLeftAssignment" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_destructured_left_assignment_def(this, result) }
+    override L::Location getLocation() { ruby_destructured_left_assignment_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_destructured_left_assignment_child(this, i, result) }
@@ -529,7 +528,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "DestructuredParameter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_destructured_parameter_def(this, result) }
+    override L::Location getLocation() { ruby_destructured_parameter_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_destructured_parameter_child(this, i, result) }
@@ -544,7 +543,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Do" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_do_def(this, result) }
+    override L::Location getLocation() { ruby_do_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_do_child(this, i, result) }
@@ -559,7 +558,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "DoBlock" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_do_block_def(this, result) }
+    override L::Location getLocation() { ruby_do_block_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     BlockParameters getParameters() { ruby_do_block_parameters(this, result) }
@@ -579,7 +578,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "ElementReference" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_element_reference_def(this, _, result) }
+    override L::Location getLocation() { ruby_element_reference_def(this, _, result) }
 
     /** Gets the node corresponding to the field `object`. */
     UnderscorePrimary getObject() { ruby_element_reference_def(this, result, _) }
@@ -599,7 +598,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Else" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_else_def(this, result) }
+    override L::Location getLocation() { ruby_else_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_else_child(this, i, result) }
@@ -614,7 +613,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Elsif" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_elsif_def(this, _, result) }
+    override L::Location getLocation() { ruby_elsif_def(this, _, result) }
 
     /** Gets the node corresponding to the field `alternative`. */
     AstNode getAlternative() { ruby_elsif_alternative(this, result) }
@@ -645,7 +644,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "EndBlock" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_end_block_def(this, result) }
+    override L::Location getLocation() { ruby_end_block_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_end_block_child(this, i, result) }
@@ -660,7 +659,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Ensure" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_ensure_def(this, result) }
+    override L::Location getLocation() { ruby_ensure_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_ensure_child(this, i, result) }
@@ -681,7 +680,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "ExceptionVariable" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_exception_variable_def(this, _, result) }
+    override L::Location getLocation() { ruby_exception_variable_def(this, _, result) }
 
     /** Gets the child of this node. */
     UnderscoreLhs getChild() { ruby_exception_variable_def(this, result, _) }
@@ -696,7 +695,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Exceptions" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_exceptions_def(this, result) }
+    override L::Location getLocation() { ruby_exceptions_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_exceptions_child(this, i, result) }
@@ -723,7 +722,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "For" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_for_def(this, _, _, _, result) }
+    override L::Location getLocation() { ruby_for_def(this, _, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Do getBody() { ruby_for_def(this, result, _, _, _) }
@@ -766,7 +765,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Hash" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_hash_def(this, result) }
+    override L::Location getLocation() { ruby_hash_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_hash_child(this, i, result) }
@@ -787,7 +786,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "HashSplatArgument" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_hash_splat_argument_def(this, _, result) }
+    override L::Location getLocation() { ruby_hash_splat_argument_def(this, _, result) }
 
     /** Gets the child of this node. */
     UnderscoreArg getChild() { ruby_hash_splat_argument_def(this, result, _) }
@@ -802,7 +801,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "HashSplatParameter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_hash_splat_parameter_def(this, result) }
+    override L::Location getLocation() { ruby_hash_splat_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_hash_splat_parameter_name(this, result) }
@@ -823,7 +822,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "HeredocBody" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_heredoc_body_def(this, result) }
+    override L::Location getLocation() { ruby_heredoc_body_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_heredoc_body_child(this, i, result) }
@@ -856,7 +855,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "If" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_if_def(this, _, result) }
+    override L::Location getLocation() { ruby_if_def(this, _, result) }
 
     /** Gets the node corresponding to the field `alternative`. */
     AstNode getAlternative() { ruby_if_alternative(this, result) }
@@ -881,7 +880,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "IfModifier" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_if_modifier_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_if_modifier_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     UnderscoreStatement getBody() { ruby_if_modifier_def(this, result, _, _) }
@@ -901,7 +900,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "In" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_in_def(this, _, result) }
+    override L::Location getLocation() { ruby_in_def(this, _, result) }
 
     /** Gets the child of this node. */
     UnderscoreArg getChild() { ruby_in_def(this, result, _) }
@@ -928,7 +927,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Interpolation" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_interpolation_def(this, result) }
+    override L::Location getLocation() { ruby_interpolation_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_interpolation_child(this, i, result) }
@@ -943,7 +942,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "KeywordParameter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_keyword_parameter_def(this, _, result) }
+    override L::Location getLocation() { ruby_keyword_parameter_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_keyword_parameter_def(this, result, _) }
@@ -963,7 +962,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Lambda" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_lambda_def(this, _, result) }
+    override L::Location getLocation() { ruby_lambda_def(this, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     AstNode getBody() { ruby_lambda_def(this, result, _) }
@@ -983,7 +982,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "LambdaParameters" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_lambda_parameters_def(this, result) }
+    override L::Location getLocation() { ruby_lambda_parameters_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_lambda_parameters_child(this, i, result) }
@@ -998,7 +997,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "LeftAssignmentList" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_left_assignment_list_def(this, result) }
+    override L::Location getLocation() { ruby_left_assignment_list_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_left_assignment_list_child(this, i, result) }
@@ -1013,7 +1012,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Method" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_method_def(this, _, result) }
+    override L::Location getLocation() { ruby_method_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     UnderscoreMethodName getName() { ruby_method_def(this, result, _) }
@@ -1038,7 +1037,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "MethodParameters" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_method_parameters_def(this, result) }
+    override L::Location getLocation() { ruby_method_parameters_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_method_parameters_child(this, i, result) }
@@ -1053,7 +1052,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Module" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_module_def(this, _, result) }
+    override L::Location getLocation() { ruby_module_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     AstNode getName() { ruby_module_def(this, result, _) }
@@ -1073,7 +1072,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Next" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_next_def(this, result) }
+    override L::Location getLocation() { ruby_next_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_next_child(this, result) }
@@ -1100,7 +1099,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "OperatorAssignment" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_operator_assignment_def(this, _, _, _, result) }
+    override L::Location getLocation() { ruby_operator_assignment_def(this, _, _, _, result) }
 
     /** Gets the node corresponding to the field `left`. */
     UnderscoreLhs getLeft() { ruby_operator_assignment_def(this, result, _, _, _) }
@@ -1152,7 +1151,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "OptionalParameter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_optional_parameter_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_optional_parameter_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_optional_parameter_def(this, result, _, _) }
@@ -1173,7 +1172,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Pair" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_pair_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_pair_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `key`. */
     AstNode getKey() { ruby_pair_def(this, result, _, _) }
@@ -1193,7 +1192,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "ParenthesizedStatements" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_parenthesized_statements_def(this, result) }
+    override L::Location getLocation() { ruby_parenthesized_statements_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_parenthesized_statements_child(this, i, result) }
@@ -1208,7 +1207,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Pattern" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_pattern_def(this, _, result) }
+    override L::Location getLocation() { ruby_pattern_def(this, _, result) }
 
     /** Gets the child of this node. */
     AstNode getChild() { ruby_pattern_def(this, result, _) }
@@ -1223,7 +1222,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Program" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_program_def(this, result) }
+    override L::Location getLocation() { ruby_program_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_program_child(this, i, result) }
@@ -1238,7 +1237,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Range" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_range_def(this, _, result) }
+    override L::Location getLocation() { ruby_range_def(this, _, result) }
 
     /** Gets the node corresponding to the field `begin`. */
     UnderscoreArg getBegin() { ruby_range_begin(this, result) }
@@ -1267,7 +1266,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Rational" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_rational_def(this, _, result) }
+    override L::Location getLocation() { ruby_rational_def(this, _, result) }
 
     /** Gets the child of this node. */
     AstNode getChild() { ruby_rational_def(this, result, _) }
@@ -1282,7 +1281,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Redo" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_redo_def(this, result) }
+    override L::Location getLocation() { ruby_redo_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_redo_child(this, result) }
@@ -1297,7 +1296,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Regex" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_regex_def(this, result) }
+    override L::Location getLocation() { ruby_regex_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_regex_child(this, i, result) }
@@ -1312,7 +1311,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Rescue" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_rescue_def(this, result) }
+    override L::Location getLocation() { ruby_rescue_def(this, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Then getBody() { ruby_rescue_body(this, result) }
@@ -1337,7 +1336,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "RescueModifier" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_rescue_modifier_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_rescue_modifier_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     UnderscoreStatement getBody() { ruby_rescue_modifier_def(this, result, _, _) }
@@ -1357,7 +1356,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "RestAssignment" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_rest_assignment_def(this, result) }
+    override L::Location getLocation() { ruby_rest_assignment_def(this, result) }
 
     /** Gets the child of this node. */
     UnderscoreLhs getChild() { ruby_rest_assignment_child(this, result) }
@@ -1372,7 +1371,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Retry" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_retry_def(this, result) }
+    override L::Location getLocation() { ruby_retry_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_retry_child(this, result) }
@@ -1387,7 +1386,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Return" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_return_def(this, result) }
+    override L::Location getLocation() { ruby_return_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_return_child(this, result) }
@@ -1402,7 +1401,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "RightAssignmentList" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_right_assignment_list_def(this, result) }
+    override L::Location getLocation() { ruby_right_assignment_list_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_right_assignment_list_child(this, i, result) }
@@ -1417,7 +1416,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "ScopeResolution" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_scope_resolution_def(this, _, result) }
+    override L::Location getLocation() { ruby_scope_resolution_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     AstNode getName() { ruby_scope_resolution_def(this, result, _) }
@@ -1443,7 +1442,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Setter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_setter_def(this, _, result) }
+    override L::Location getLocation() { ruby_setter_def(this, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_setter_def(this, result, _) }
@@ -1464,7 +1463,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "SingletonClass" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_singleton_class_def(this, _, result) }
+    override L::Location getLocation() { ruby_singleton_class_def(this, _, result) }
 
     /** Gets the node corresponding to the field `value`. */
     UnderscoreArg getValue() { ruby_singleton_class_def(this, result, _) }
@@ -1484,7 +1483,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "SingletonMethod" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_singleton_method_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_singleton_method_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `name`. */
     UnderscoreMethodName getName() { ruby_singleton_method_def(this, result, _, _) }
@@ -1513,7 +1512,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "SplatArgument" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_splat_argument_def(this, _, result) }
+    override L::Location getLocation() { ruby_splat_argument_def(this, _, result) }
 
     /** Gets the child of this node. */
     UnderscoreArg getChild() { ruby_splat_argument_def(this, result, _) }
@@ -1528,7 +1527,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "SplatParameter" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_splat_parameter_def(this, result) }
+    override L::Location getLocation() { ruby_splat_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_splat_parameter_name(this, result) }
@@ -1543,7 +1542,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "String" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_string_def(this, result) }
+    override L::Location getLocation() { ruby_string_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_string_child(this, i, result) }
@@ -1558,7 +1557,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "StringArray" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_string_array_def(this, result) }
+    override L::Location getLocation() { ruby_string_array_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     BareString getChild(int i) { ruby_string_array_child(this, i, result) }
@@ -1579,7 +1578,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Subshell" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_subshell_def(this, result) }
+    override L::Location getLocation() { ruby_subshell_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_subshell_child(this, i, result) }
@@ -1600,7 +1599,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Superclass" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_superclass_def(this, _, result) }
+    override L::Location getLocation() { ruby_superclass_def(this, _, result) }
 
     /** Gets the child of this node. */
     AstNode getChild() { ruby_superclass_def(this, result, _) }
@@ -1615,7 +1614,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "SymbolArray" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_symbol_array_def(this, result) }
+    override L::Location getLocation() { ruby_symbol_array_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     BareSymbol getChild(int i) { ruby_symbol_array_child(this, i, result) }
@@ -1630,7 +1629,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Then" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_then_def(this, result) }
+    override L::Location getLocation() { ruby_then_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_then_child(this, i, result) }
@@ -1651,7 +1650,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Unary" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_unary_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_unary_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `operand`. */
     AstNode getOperand() { ruby_unary_def(this, result, _, _) }
@@ -1683,7 +1682,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Undef" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_undef_def(this, result) }
+    override L::Location getLocation() { ruby_undef_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     UnderscoreMethodName getChild(int i) { ruby_undef_child(this, i, result) }
@@ -1704,7 +1703,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Unless" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_unless_def(this, _, result) }
+    override L::Location getLocation() { ruby_unless_def(this, _, result) }
 
     /** Gets the node corresponding to the field `alternative`. */
     AstNode getAlternative() { ruby_unless_alternative(this, result) }
@@ -1729,7 +1728,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "UnlessModifier" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_unless_modifier_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_unless_modifier_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     UnderscoreStatement getBody() { ruby_unless_modifier_def(this, result, _, _) }
@@ -1749,7 +1748,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Until" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_until_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_until_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Do getBody() { ruby_until_def(this, result, _, _) }
@@ -1769,7 +1768,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "UntilModifier" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_until_modifier_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_until_modifier_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     UnderscoreStatement getBody() { ruby_until_modifier_def(this, result, _, _) }
@@ -1789,7 +1788,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "When" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_when_def(this, result) }
+    override L::Location getLocation() { ruby_when_def(this, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Then getBody() { ruby_when_body(this, result) }
@@ -1809,7 +1808,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "While" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_while_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_while_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Do getBody() { ruby_while_def(this, result, _, _) }
@@ -1829,7 +1828,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "WhileModifier" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_while_modifier_def(this, _, _, result) }
+    override L::Location getLocation() { ruby_while_modifier_def(this, _, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     UnderscoreStatement getBody() { ruby_while_modifier_def(this, result, _, _) }
@@ -1849,7 +1848,7 @@ module Ruby {
     override string getAPrimaryQlClass() { result = "Yield" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { ruby_yield_def(this, result) }
+    override L::Location getLocation() { ruby_yield_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_yield_child(this, result) }
@@ -1866,7 +1865,7 @@ module Erb {
     string toString() { result = this.getAPrimaryQlClass() }
 
     /** Gets the location of this element. */
-    Location getLocation() { none() }
+    L::Location getLocation() { none() }
 
     /** Gets the parent of this element. */
     AstNode getParent() { erb_ast_node_parent(this, result, _) }
@@ -1890,7 +1889,7 @@ module Erb {
     string getValue() { erb_tokeninfo(this, _, result, _) }
 
     /** Gets the location of this token. */
-    override Location getLocation() { erb_tokeninfo(this, _, _, result) }
+    override L::Location getLocation() { erb_tokeninfo(this, _, _, result) }
 
     /** Gets a string representation of this element. */
     override string toString() { result = this.getValue() }
@@ -1923,7 +1922,7 @@ module Erb {
     override string getAPrimaryQlClass() { result = "CommentDirective" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { erb_comment_directive_def(this, _, result) }
+    override L::Location getLocation() { erb_comment_directive_def(this, _, result) }
 
     /** Gets the child of this node. */
     Comment getChild() { erb_comment_directive_def(this, result, _) }
@@ -1944,7 +1943,7 @@ module Erb {
     override string getAPrimaryQlClass() { result = "Directive" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { erb_directive_def(this, _, result) }
+    override L::Location getLocation() { erb_directive_def(this, _, result) }
 
     /** Gets the child of this node. */
     Code getChild() { erb_directive_def(this, result, _) }
@@ -1959,7 +1958,7 @@ module Erb {
     override string getAPrimaryQlClass() { result = "GraphqlDirective" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { erb_graphql_directive_def(this, _, result) }
+    override L::Location getLocation() { erb_graphql_directive_def(this, _, result) }
 
     /** Gets the child of this node. */
     Code getChild() { erb_graphql_directive_def(this, result, _) }
@@ -1974,7 +1973,7 @@ module Erb {
     override string getAPrimaryQlClass() { result = "OutputDirective" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { erb_output_directive_def(this, _, result) }
+    override L::Location getLocation() { erb_output_directive_def(this, _, result) }
 
     /** Gets the child of this node. */
     Code getChild() { erb_output_directive_def(this, result, _) }
@@ -1989,7 +1988,7 @@ module Erb {
     override string getAPrimaryQlClass() { result = "Template" }
 
     /** Gets the location of this element. */
-    override Location getLocation() { erb_template_def(this, result) }
+    override L::Location getLocation() { erb_template_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { erb_template_child(this, i, result) }


### PR DESCRIPTION
This avoids name clashes in case the tree-sitter grammar contains rules with the same name as the classes exported by the Locations module (e.g. `File`, `Location`, etc.).