### PR TITLE
Add neighborhood scope token feature to ATM library

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CodeToFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CodeToFeatures.qll
@@ -423,15 +423,15 @@ module DatabaseFeatures {
   }
 
   query predicate astNodes(
-    Entity enclosingEntity, EntityOrAstNode parent, int index, AstNode node, string node_type
+    Entity enclosingEntity, EntityOrAstNode parent, int index, AstNode child, string childType
   ) {
-    node = enclosingEntity.getAstRoot(index) and
+    child = enclosingEntity.getAstRoot(index) and
     parent = enclosingEntity and
-    node_type = node.getType()
+    childType = child.getType()
     or
     astNodes(enclosingEntity, _, _, parent, _) and
-    node = parent.(AstNode).getChild(index) and
-    node_type = node.getType()
+    child = parent.(AstNode).getChild(index) and
+    childType = child.getType()
   }
 
   query predicate nodeAttributes(AstNode node, string attr) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CodeToFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CodeToFeatures.qll
@@ -49,6 +49,8 @@ module Raw {
 
     AstNode getParentNode() { result = TAstNode(rawNode.getParent()) }
 
+    raw::ASTNode getNode() { result = rawNode }
+
     raw::StmtContainer getContainer() { result = rawNode.getContainer() }
 
     /**

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -8,12 +8,6 @@ import javascript
 import CodeToFeatures
 import EndpointScoring
 
-DatabaseFeatures::AstNode dbAstNode(ASTNode node, DatabaseFeatures::Entity dbEntity) {
-  result =
-    DatabaseFeatures::astNode(Wrapped::astNode(dbEntity.getWrappedEntity().getDefinedFunction(),
-        Raw::astNode(node)))
-}
-
 /**
  * Gets the value of the token-based feature named `featureName` for the endpoint `endpoint`.
  *
@@ -31,8 +25,10 @@ private string getTokenFeature(DataFlow::Node endpoint, string featureName) {
     result = unique(string x | x = FunctionBodies::getBodyTokenFeatureForEntity(entity))
   )
   or
-  // A feature containing natural language tokens from the neighborhood around the endpoint, in
-  // the order they appear in the source code.
+
+  // A feature containing natural language tokens from the neighborhood around the endpoint 
+  // (limited to within the function that encloses the endpoint), in the order they appear 
+  // in the source code. 
   exists(Raw::AstNode rootNode, DatabaseFeatures::AstNode rootNodeWrapped |
     featureName = "neighborhoodBody" and
     rootNode = NeighborhoodBodies::getNeighborhoodAstNode(Raw::astNode(endpoint.getAstNode())) and
@@ -165,15 +161,13 @@ module FunctionBodies {
   }
 }
 
-/** This module provides functionality for getting the neighborhood scope body feature associated with a neighborhood around an AST node. */
+/** This module provides functionality for getting the local neighborhood around an AST node within its enclosing function body, providing a locally-scoped version of the `enclosingFunctionBody` feature. */
 module NeighborhoodBodies {
   /**
    * Return the ancestor of the input AST node that has the largest number of descendants (i.e. the node nearest the
    * root) but has no more than 128 descendants.
    * TODO: Maybe instead of a threshold on number of descendants, we should instead have a threshold on the number of
-   * leaves in the subtree, which is a closer approximation to the number of tokens in the subtree. If we don't do this,
-   * as an optimization we can remove the sorting by location, since each ancestor of a given node will always have a
-   * different number of descendants.
+   * leaves in the subtree, which is a closer approximation to the number of tokens in the subtree.
    */
   Raw::AstNode getNeighborhoodAstNode(Raw::AstNode node) {
     if getNumDescendents(node.getParentNode()) > 128
@@ -185,22 +179,22 @@ module NeighborhoodBodies {
   int getNumDescendents(Raw::AstNode node) { result = count(node.getAChildNode*()) }
 
   /**
-   * Holds if `node` is an AST node within the entity `entity` and `token` is a node attribute associated with `node`.
+   * Holds if `childNode` is an AST node under `rootNode` and `token` is a node attribute associated with `childNode`. Note that only AST leaves have node attributes.
    *
-   * We restrict `rootNode` to be a neighborhood root to avoid a potentially big result set.
+   * TODO we may need to restrict `rootNode` to be a neighborhood root to avoid a potentially big result set.
    */
   private predicate bodyTokens(
     DatabaseFeatures::AstNode rootNode, DatabaseFeatures::AstNode childNode, string token
   ) {
     childNode = rootNode.getAChild*() and
     token = unique(string t | DatabaseFeatures::nodeAttributes(childNode, t))
-    // and rootNode = getANeighborhoodRoot()
   }
 
   /**
-   * Gets the body token feature for the specified entity.
+   * Gets the body token feature limited to the part of the function body that lies under `rootNode` in the AST.
    *
-   * This is a string containing natural language tokens in the order that they appear in the source code for the entity.
+   * This is a string of space-separated natural language tokens (AST leaves) in the order that they appear in the source code for the AST subtree rooted at `rootNode`. This is equivalent to the portion of the code that falls under
+ * the AST subtree rooted at the given node, except that non-leaf nodes (such as operators) are excluded.
    */
   string getBodyTokenFeatureForNeighborhoodNode(DatabaseFeatures::AstNode rootNode) {
     // If a function has more than 256 body subtokens, then featurize it as absent. This

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -184,13 +184,25 @@ module NeighborhoodBodies {
    * in the subtree.
    */
   Raw::AstNode getNeighborhoodAstNode(Raw::AstNode node) {
-    if getNumDescendents(node.getParentNode()) > maxNumDescendants()
+    if
+      // `node` will always have a parent as we start at and endpoint
+      node.getParentNode() = getOutermostEnclosingFunction(node) or
+      getNumDescendents(node.getParentNode()) > maxNumDescendants()
     then result = node
     else result = getNeighborhoodAstNode(node.getParentNode())
   }
 
   /** Count number of descendants of an AST node */
   int getNumDescendents(Raw::AstNode node) { result = count(node.getAChildNode*()) }
+
+  private ASTNode getContainer(ASTNode node) {
+    result = node.getContainer()
+  }
+
+  /** Return the AST node that is outermost enclosing function (as an AST Node) */
+  Raw::AstNode getOutermostEnclosingFunction(Raw::AstNode node) {
+    result = Raw::astNode(getContainer*(node.getNode())) and result.getContainer() instanceof TopLevel
+  }
 
   /**
    * Holds if `childNode` is an AST node under `rootNode` and `token` is a node attribute associated

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -31,10 +31,9 @@ private string getTokenFeature(DataFlow::Node endpoint, string featureName) {
     result = unique(string x | x = FunctionBodies::getBodyTokenFeatureForEntity(entity))
   )
   or
-
-  // A feature containing natural language tokens from the neighborhood around the endpoint 
-  // (limited to within the function that encloses the endpoint), in the order they appear 
-  // in the source code. 
+  // A feature containing natural language tokens from the neighborhood around the endpoint
+  // (limited to within the function that encloses the endpoint), in the order they appear
+  // in the source code.
   exists(Raw::AstNode rootNode, DatabaseFeatures::AstNode rootNodeWrapped |
     featureName = "neighborhoodBody" and
     rootNode = NeighborhoodBodies::getNeighborhoodAstNode(Raw::astNode(endpoint.getAstNode())) and
@@ -171,13 +170,18 @@ module FunctionBodies {
   }
 }
 
-/** This module provides functionality for getting the local neighborhood around an AST node within its enclosing function body, providing a locally-scoped version of the `enclosingFunctionBody` feature. */
+/**
+ * This module provides functionality for getting the local neighborhood around an AST node within
+ * its enclosing function body, providing a locally-scoped version of the `enclosingFunctionBody` feature.
+ */
 module NeighborhoodBodies {
   /**
-   * Return the ancestor of the input AST node that has the largest number of descendants (i.e. the node nearest the
-   * root) but has no more than 128 descendants.
-   * TODO: Maybe instead of a threshold on number of descendants, we should instead have a threshold on the number of
-   * leaves in the subtree, which is a closer approximation to the number of tokens in the subtree.
+   * Return the ancestor of the input AST node that has the largest number of descendants (i.e. the
+   * node nearest the root) but has no more than `maxNumDescendants` descendants.
+   *
+   * TODO: Maybe instead of a threshold on number of descendants, we should instead have a threshold
+   * on the number of leaves in the subtree, which is a closer approximation to the number of tokens
+   * in the subtree.
    */
   Raw::AstNode getNeighborhoodAstNode(Raw::AstNode node) {
     if getNumDescendents(node.getParentNode()) > maxNumDescendants()
@@ -189,7 +193,8 @@ module NeighborhoodBodies {
   int getNumDescendents(Raw::AstNode node) { result = count(node.getAChildNode*()) }
 
   /**
-   * Holds if `childNode` is an AST node under `rootNode` and `token` is a node attribute associated with `childNode`. Note that only AST leaves have node attributes.
+   * Holds if `childNode` is an AST node under `rootNode` and `token` is a node attribute associated
+   * with `childNode`. Note that only AST leaves have node attributes.
    *
    * TODO we may need to restrict `rootNode` to be a neighborhood root to avoid a potentially big result set.
    */
@@ -279,7 +284,10 @@ private module AccessPaths {
     Boolean() { this = true or this = false }
   }
 
-  /** Get the access path for the node. This includes structural information like `member`, `param`, and `functionalarg` if `includeStructuralInfo` is true. */
+  /**
+  * Get the access path for the node. This includes structural information like `member`, `param`,
+  * and `functionalarg` if `includeStructuralInfo` is true.
+  */
   predicate accessPaths(
     API::Node node, Boolean includeStructuralInfo, string accessPath, string apiName
   ) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -8,6 +8,12 @@ import javascript
 import CodeToFeatures
 import EndpointScoring
 
+DatabaseFeatures::AstNode dbAstNode(ASTNode node, DatabaseFeatures::Entity dbEntity) {
+  result =
+    DatabaseFeatures::astNode(Wrapped::astNode(dbEntity.getWrappedEntity().getDefinedFunction(),
+        Raw::astNode(node)))
+}
+
 /**
  * Gets the value of the token-based feature named `featureName` for the endpoint `endpoint`.
  *
@@ -23,6 +29,18 @@ private string getTokenFeature(DataFlow::Node endpoint, string featureName) {
     // the order that they appear in the source code.
     featureName = "enclosingFunctionBody" and
     result = unique(string x | x = FunctionBodies::getBodyTokenFeatureForEntity(entity))
+  )
+  or
+  // A feature containing natural language tokens from the neighborhood around the endpoint, in
+  // the order they appear in the source code.
+  exists(Raw::AstNode rootNode, DatabaseFeatures::AstNode rootNodeWrapped |
+    featureName = "neighborhoodBody" and
+    rootNode = NeighborhoodBodies::getNeighborhoodAstNode(Raw::astNode(endpoint.getAstNode())) and
+    rootNodeWrapped = DatabaseFeatures::astNode(Wrapped::astNode(endpoint.getContainer(), rootNode)) and
+    result =
+      unique(string x |
+        x = NeighborhoodBodies::getBodyTokenFeatureForNeighborhoodNode(rootNodeWrapped)
+      )
   )
   or
   exists(getACallBasedTokenFeatureComponent(endpoint, _, featureName)) and
@@ -175,7 +193,7 @@ module NeighborhoodBodies {
     DatabaseFeatures::AstNode rootNode, DatabaseFeatures::AstNode childNode, string token
   ) {
     childNode = rootNode.getAChild*() and
-    token = unique(string t | DatabaseFeatures::nodeAttributes(childNode, t)) 
+    token = unique(string t | DatabaseFeatures::nodeAttributes(childNode, t))
     // and rootNode = getANeighborhoodRoot()
   }
 
@@ -330,7 +348,8 @@ private string getASupportedFeatureName() {
   result =
     [
       "enclosingFunctionName", "calleeName", "receiverName", "argumentIndex", "calleeApiName",
-      "calleeAccessPath", "calleeAccessPathWithStructuralInfo", "enclosingFunctionBody"
+      "calleeAccessPath", "calleeAccessPathWithStructuralInfo", "enclosingFunctionBody",
+      "neighborhoodBody"
     ]
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -147,6 +147,67 @@ module FunctionBodies {
   }
 }
 
+/** This module provides functionality for getting the neighborhood scope body feature associated with a neighborhood around an AST node. */
+module NeighborhoodBodies {
+  /**
+   * Return the ancestor of the input AST node that has the largest number of descendants (i.e. the node nearest the
+   * root) but has no more than 128 descendants.
+   * TODO: Maybe instead of a threshold on number of descendants, we should instead have a threshold on the number of
+   * leaves in the subtree, which is a closer approximation to the number of tokens in the subtree. If we don't do this,
+   * as an optimization we can remove the sorting by location, since each ancestor of a given node will always have a
+   * different number of descendants.
+   */
+  Raw::AstNode getNeighborhoodAstNode(Raw::AstNode node) {
+    if getNumDescendents(node.getParentNode()) > 128
+    then result = node
+    else result = getNeighborhoodAstNode(node.getParentNode())
+  }
+
+  /** Count number of descendants of an AST node */
+  int getNumDescendents(Raw::AstNode node) { result = count(node.getAChildNode*()) }
+
+  /**
+   * Holds if `node` is an AST node within the entity `entity` and `token` is a node attribute associated with `node`.
+   *
+   * We restrict `rootNode` to be a neighborhood root to avoid a potentially big result set.
+   */
+  private predicate bodyTokens(
+    DatabaseFeatures::AstNode rootNode, DatabaseFeatures::AstNode childNode, string token
+  ) {
+    childNode = rootNode.getAChild*() and
+    token = unique(string t | DatabaseFeatures::nodeAttributes(childNode, t)) 
+    // and rootNode = getANeighborhoodRoot()
+  }
+
+  /**
+   * Gets the body token feature for the specified entity.
+   *
+   * This is a string containing natural language tokens in the order that they appear in the source code for the entity.
+   */
+  string getBodyTokenFeatureForNeighborhoodNode(DatabaseFeatures::AstNode rootNode) {
+    // If a function has more than 256 body subtokens, then featurize it as absent. This
+    // approximates the behavior of the classifer on non-generic body features where large body
+    // features are replaced by the absent token.
+    if count(DatabaseFeatures::AstNode node, string token | bodyTokens(rootNode, node, token)) > 256
+    then result = ""
+    else
+      result =
+        concat(int i, string rankedToken |
+          rankedToken =
+            rank[i](DatabaseFeatures::AstNode node, string token, Location l |
+              bodyTokens(rootNode, node, token) and l = node.getLocation()
+            |
+              token
+              order by
+                l.getFile().getAbsolutePath(), l.getStartLine(), l.getStartColumn(), l.getEndLine(),
+                l.getEndColumn(), token
+            )
+        |
+          rankedToken, " " order by i
+        )
+  }
+}
+
 /**
  * This module provides functionality for getting a representation of the access path of nodes
  * within the program.


### PR DESCRIPTION
⚠️ This is a replacement of #7148 where the code is on a branch of `codeql`, rather than a fork. This makes testing these changes in `backend` much more straightforward. 

Taking the work in https://github.com/github/ml-ql-adaptive-threat-modeling-backend/tree/annarailton/neighbourhood-features and moving it into the CodeQL library. 

The feature `neighborhoodBody` is now a token feature extracted in `ExctractEndpointData.ql`, alongside the likes of `enclosingFunctionBody`. 

See https://github.com/github/ml-ql-adaptive-threat-modeling/issues/1553
