### PR TITLE
C++: Always recognize pointers as iterators

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
@@ -35,6 +35,16 @@ private class IteratorByTraits extends Iterator {
 }
 
 /**
+ * The C++ standard includes an `std::iterator_traits` specialization for pointer types. When
+ * this specialization is included in the database, a pointer type `T*` will be an instance
+ * of the `IteratorByTraits` class. However, if the `T*` specialization is not in the database,
+ * we need to explicitly include them with this class.
+ */
+private class IteratorByPointer extends Iterator instanceof PointerType {
+  IteratorByPointer() { not this instanceof IteratorByTraits }
+}
+
+/**
  * A type which has the typedefs expected for an iterator.
  */
 private class IteratorByTypedefs extends Iterator, Class {

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -1,3 +1,4 @@
+| example.c:15:37:15:37 | b | example.c:15:37:15:37 | b |
 | example.c:15:37:15:37 | b | example.c:19:6:19:6 | b |
 | example.c:15:44:15:46 | pos | example.c:24:24:24:26 | pos |
 | example.c:15:44:15:46 | pos | example.c:28:23:28:25 | pos |
@@ -70,8 +71,10 @@
 | test.cpp:391:11:391:13 | tmp | test.cpp:391:10:391:13 | & ... |
 | test.cpp:391:17:391:23 | source1 | test.cpp:391:10:391:13 | ref arg & ... |
 | test.cpp:391:17:391:23 | source1 | test.cpp:391:16:391:23 | & ... |
+| test.cpp:480:67:480:67 | s | test.cpp:480:67:480:67 | s |
 | test.cpp:480:67:480:67 | s | test.cpp:481:21:481:21 | s |
 | test.cpp:480:67:480:67 | s | test.cpp:482:20:482:20 | s |
+| test.cpp:481:21:481:21 | s [post update] | test.cpp:480:67:480:67 | s |
 | test.cpp:481:21:481:21 | s [post update] | test.cpp:482:20:482:20 | s |
 | test.cpp:481:24:481:30 | ref arg content | test.cpp:482:23:482:29 | content |
 | test.cpp:482:23:482:29 | content | test.cpp:483:9:483:17 | p_content |

--- a/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
@@ -10,29 +10,35 @@ edges
 | A.cpp:31:20:31:20 | c | A.cpp:23:10:23:10 | c |
 | A.cpp:31:20:31:20 | c | A.cpp:31:14:31:21 | call to B [c] |
 | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... |
+| A.cpp:43:10:43:12 | & ... | A.cpp:173:26:173:26 | o |
 | A.cpp:47:12:47:18 | new | A.cpp:48:20:48:20 | c |
 | A.cpp:48:12:48:18 | call to make [c] | A.cpp:49:10:49:10 | b [c] |
 | A.cpp:48:20:48:20 | c | A.cpp:29:23:29:23 | c |
 | A.cpp:48:20:48:20 | c | A.cpp:48:12:48:18 | call to make [c] |
 | A.cpp:49:10:49:10 | b [c] | A.cpp:49:13:49:13 | c |
+| A.cpp:49:13:49:13 | c | A.cpp:173:26:173:26 | o |
 | A.cpp:55:5:55:5 | ref arg b [c] | A.cpp:56:10:56:10 | b [c] |
 | A.cpp:55:12:55:19 | new | A.cpp:27:17:27:17 | c |
 | A.cpp:55:12:55:19 | new | A.cpp:55:5:55:5 | ref arg b [c] |
 | A.cpp:56:10:56:10 | b [c] | A.cpp:28:8:28:10 | this [c] |
 | A.cpp:56:10:56:10 | b [c] | A.cpp:56:13:56:15 | call to get |
+| A.cpp:56:13:56:15 | call to get | A.cpp:173:26:173:26 | o |
 | A.cpp:57:11:57:24 | call to B [c] | A.cpp:57:11:57:24 | new [c] |
 | A.cpp:57:11:57:24 | new [c] | A.cpp:28:8:28:10 | this [c] |
 | A.cpp:57:11:57:24 | new [c] | A.cpp:57:28:57:30 | call to get |
 | A.cpp:57:17:57:23 | new | A.cpp:23:10:23:10 | c |
 | A.cpp:57:17:57:23 | new | A.cpp:57:11:57:24 | call to B [c] |
+| A.cpp:57:28:57:30 | call to get | A.cpp:173:26:173:26 | o |
 | A.cpp:64:10:64:15 | call to setOnB [c] | A.cpp:66:10:66:11 | b2 [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:64:10:64:15 | call to setOnB [c] |
 | A.cpp:64:21:64:28 | new | A.cpp:85:26:85:26 | c |
 | A.cpp:66:10:66:11 | b2 [c] | A.cpp:66:14:66:14 | c |
+| A.cpp:66:14:66:14 | c | A.cpp:173:26:173:26 | o |
 | A.cpp:73:10:73:19 | call to setOnBWrap [c] | A.cpp:75:10:75:11 | b2 [c] |
 | A.cpp:73:25:73:32 | new | A.cpp:73:10:73:19 | call to setOnBWrap [c] |
 | A.cpp:73:25:73:32 | new | A.cpp:78:27:78:27 | c |
 | A.cpp:75:10:75:11 | b2 [c] | A.cpp:75:14:75:14 | c |
+| A.cpp:75:14:75:14 | c | A.cpp:173:26:173:26 | o |
 | A.cpp:78:27:78:27 | c | A.cpp:81:21:81:21 | c |
 | A.cpp:81:10:81:15 | call to setOnB [c] | A.cpp:82:12:82:24 | ... ? ... : ... [c] |
 | A.cpp:81:21:81:21 | c | A.cpp:81:10:81:15 | call to setOnB [c] |
@@ -48,13 +54,20 @@ edges
 | A.cpp:103:14:103:14 | c [a] | A.cpp:107:12:107:13 | c1 [a] |
 | A.cpp:103:14:103:14 | c [a] | A.cpp:120:12:120:13 | c1 [a] |
 | A.cpp:107:12:107:13 | c1 [a] | A.cpp:107:16:107:16 | a |
+| A.cpp:107:16:107:16 | a | A.cpp:173:26:173:26 | o |
 | A.cpp:120:12:120:13 | c1 [a] | A.cpp:120:16:120:16 | a |
+| A.cpp:120:16:120:16 | a | A.cpp:173:26:173:26 | o |
+| A.cpp:124:14:124:14 | b [c] | A.cpp:131:8:131:8 | ref arg b [c] |
+| A.cpp:126:5:126:5 | ref arg b [c] | A.cpp:124:14:124:14 | b [c] |
 | A.cpp:126:5:126:5 | ref arg b [c] | A.cpp:131:8:131:8 | ref arg b [c] |
 | A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c |
 | A.cpp:126:12:126:18 | new | A.cpp:126:5:126:5 | ref arg b [c] |
 | A.cpp:131:8:131:8 | ref arg b [c] | A.cpp:132:10:132:10 | b [c] |
 | A.cpp:132:10:132:10 | b [c] | A.cpp:132:13:132:13 | c |
+| A.cpp:132:13:132:13 | c | A.cpp:173:26:173:26 | o |
 | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:31 | ... = ... |
+| A.cpp:140:13:140:13 | b [c] | A.cpp:151:18:151:18 | ref arg b [c] |
+| A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:140:13:140:13 | b [c] |
 | A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:143:7:143:31 | ... = ... [c] |
 | A.cpp:142:7:142:7 | b [post update] [c] | A.cpp:151:18:151:18 | ref arg b [c] |
 | A.cpp:142:7:142:20 | ... = ... | A.cpp:142:7:142:7 | b [post update] [c] |
@@ -66,15 +79,24 @@ edges
 | A.cpp:143:7:143:31 | ... = ... [c] | A.cpp:143:7:143:10 | this [post update] [b, c] |
 | A.cpp:143:25:143:31 | new | A.cpp:143:7:143:31 | ... = ... |
 | A.cpp:150:12:150:18 | new | A.cpp:151:18:151:18 | b |
+| A.cpp:151:12:151:24 | call to D [b, c] | A.cpp:152:10:152:10 | d [b, c] |
 | A.cpp:151:12:151:24 | call to D [b, c] | A.cpp:153:10:153:10 | d [b, c] |
 | A.cpp:151:12:151:24 | call to D [b] | A.cpp:152:10:152:10 | d [b] |
 | A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b |
 | A.cpp:151:18:151:18 | b | A.cpp:151:12:151:24 | call to D [b] |
 | A.cpp:151:18:151:18 | ref arg b [c] | A.cpp:154:10:154:10 | b [c] |
+| A.cpp:152:10:152:10 | d [b, c] | A.cpp:152:13:152:13 | b [c] |
 | A.cpp:152:10:152:10 | d [b] | A.cpp:152:13:152:13 | b |
+| A.cpp:152:10:152:10 | d [post update] [b, c] | A.cpp:153:10:153:10 | d [b, c] |
+| A.cpp:152:13:152:13 | b | A.cpp:173:26:173:26 | o |
+| A.cpp:152:13:152:13 | b [c] | A.cpp:152:13:152:13 | ref arg b [c] |
+| A.cpp:152:13:152:13 | b [c] | A.cpp:173:26:173:26 | o [c] |
+| A.cpp:152:13:152:13 | ref arg b [c] | A.cpp:152:10:152:10 | d [post update] [b, c] |
 | A.cpp:153:10:153:10 | d [b, c] | A.cpp:153:13:153:13 | b [c] |
 | A.cpp:153:13:153:13 | b [c] | A.cpp:153:16:153:16 | c |
+| A.cpp:153:16:153:16 | c | A.cpp:173:26:173:26 | o |
 | A.cpp:154:10:154:10 | b [c] | A.cpp:154:13:154:13 | c |
+| A.cpp:154:13:154:13 | c | A.cpp:173:26:173:26 | o |
 | A.cpp:159:12:159:18 | new | A.cpp:160:29:160:29 | b |
 | A.cpp:160:18:160:60 | call to MyList [head] | A.cpp:161:38:161:39 | l1 [head] |
 | A.cpp:160:29:160:29 | b | A.cpp:160:18:160:60 | call to MyList [head] |
@@ -87,13 +109,23 @@ edges
 | A.cpp:162:38:162:39 | l2 [next, head] | A.cpp:162:18:162:40 | call to MyList [next, next, head] |
 | A.cpp:162:38:162:39 | l2 [next, head] | A.cpp:181:32:181:35 | next [next, head] |
 | A.cpp:165:10:165:11 | l3 [next, next, head] | A.cpp:165:14:165:17 | next [next, head] |
+| A.cpp:165:10:165:11 | l3 [post update] [next, next, head] | A.cpp:167:44:167:44 | l [next, next, head] |
 | A.cpp:165:14:165:17 | next [next, head] | A.cpp:165:20:165:23 | next [head] |
+| A.cpp:165:14:165:17 | next [post update] [next, head] | A.cpp:165:10:165:11 | l3 [post update] [next, next, head] |
 | A.cpp:165:20:165:23 | next [head] | A.cpp:165:26:165:29 | head |
+| A.cpp:165:20:165:23 | next [head] | A.cpp:165:26:165:29 | head |
+| A.cpp:165:20:165:23 | next [post update] [head] | A.cpp:165:14:165:17 | next [post update] [next, head] |
+| A.cpp:165:26:165:29 | head | A.cpp:165:26:165:29 | ref arg head |
+| A.cpp:165:26:165:29 | head | A.cpp:173:26:173:26 | o |
+| A.cpp:165:26:165:29 | ref arg head | A.cpp:165:20:165:23 | next [post update] [head] |
 | A.cpp:167:44:167:44 | l [next, head] | A.cpp:167:47:167:50 | next [head] |
 | A.cpp:167:44:167:44 | l [next, next, head] | A.cpp:167:47:167:50 | next [next, head] |
 | A.cpp:167:47:167:50 | next [head] | A.cpp:169:12:169:12 | l [head] |
 | A.cpp:167:47:167:50 | next [next, head] | A.cpp:167:44:167:44 | l [next, head] |
 | A.cpp:169:12:169:12 | l [head] | A.cpp:169:15:169:18 | head |
+| A.cpp:169:15:169:18 | head | A.cpp:173:26:173:26 | o |
+| A.cpp:173:26:173:26 | o | A.cpp:173:26:173:26 | o |
+| A.cpp:173:26:173:26 | o [c] | A.cpp:173:26:173:26 | o [c] |
 | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:20 | ... = ... |
 | A.cpp:181:32:181:35 | next [head] | A.cpp:184:7:184:23 | ... = ... [head] |
 | A.cpp:181:32:181:35 | next [next, head] | A.cpp:184:7:184:23 | ... = ... [next, head] |
@@ -150,6 +182,7 @@ edges
 | D.cpp:22:10:22:11 | b2 [box, elem] | D.cpp:22:14:22:20 | call to getBox1 [elem] |
 | D.cpp:22:14:22:20 | call to getBox1 [elem] | D.cpp:10:11:10:17 | this [elem] |
 | D.cpp:22:14:22:20 | call to getBox1 [elem] | D.cpp:22:25:22:31 | call to getElem |
+| D.cpp:22:25:22:31 | call to getElem | realistic.cpp:41:17:41:17 | o |
 | D.cpp:28:15:28:24 | new | D.cpp:30:5:30:20 | ... = ... |
 | D.cpp:30:5:30:5 | b [post update] [box, elem] | D.cpp:31:14:31:14 | b [box, elem] |
 | D.cpp:30:5:30:20 | ... = ... | D.cpp:30:8:30:10 | box [post update] [elem] |
@@ -182,17 +215,23 @@ edges
 | D.cpp:64:10:64:17 | boxfield [box, elem] | D.cpp:64:20:64:22 | box [elem] |
 | D.cpp:64:10:64:17 | this [boxfield, box, elem] | D.cpp:64:10:64:17 | boxfield [box, elem] |
 | D.cpp:64:20:64:22 | box [elem] | D.cpp:64:25:64:28 | elem |
+| D.cpp:64:25:64:28 | elem | realistic.cpp:41:17:41:17 | o |
 | E.cpp:19:27:19:27 | p [data, buffer] | E.cpp:21:10:21:10 | p [data, buffer] |
 | E.cpp:21:10:21:10 | p [data, buffer] | E.cpp:21:13:21:16 | data [buffer] |
 | E.cpp:21:13:21:16 | data [buffer] | E.cpp:21:18:21:23 | buffer |
+| E.cpp:21:18:21:23 | buffer | realistic.cpp:41:17:41:17 | o |
 | E.cpp:28:21:28:23 | ref arg raw | E.cpp:31:10:31:12 | raw |
 | E.cpp:29:21:29:21 | b [post update] [buffer] | E.cpp:32:10:32:10 | b [buffer] |
 | E.cpp:29:24:29:29 | ref arg buffer | E.cpp:29:21:29:21 | b [post update] [buffer] |
 | E.cpp:30:21:30:21 | p [post update] [data, buffer] | E.cpp:33:18:33:19 | & ... [data, buffer] |
 | E.cpp:30:23:30:26 | data [post update] [buffer] | E.cpp:30:21:30:21 | p [post update] [data, buffer] |
 | E.cpp:30:28:30:33 | ref arg buffer | E.cpp:30:23:30:26 | data [post update] [buffer] |
+| E.cpp:31:10:31:12 | raw | realistic.cpp:41:17:41:17 | o |
 | E.cpp:32:10:32:10 | b [buffer] | E.cpp:32:13:32:18 | buffer |
+| E.cpp:32:13:32:18 | buffer | realistic.cpp:41:17:41:17 | o |
 | E.cpp:33:18:33:19 | & ... [data, buffer] | E.cpp:19:27:19:27 | p [data, buffer] |
+| aliasing.cpp:8:23:8:23 | s [m1] | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] |
+| aliasing.cpp:9:3:9:3 | s [post update] [m1] | aliasing.cpp:8:23:8:23 | s [m1] |
 | aliasing.cpp:9:3:9:3 | s [post update] [m1] | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | aliasing.cpp:9:3:9:3 | s [post update] [m1] |
 | aliasing.cpp:9:11:9:20 | call to user_input | aliasing.cpp:9:3:9:22 | ... = ... |
@@ -204,30 +243,42 @@ edges
 | aliasing.cpp:25:17:25:19 | ref arg & ... [m1] | aliasing.cpp:29:8:29:9 | s1 [m1] |
 | aliasing.cpp:26:19:26:20 | ref arg s2 [m1] | aliasing.cpp:30:8:30:9 | s2 [m1] |
 | aliasing.cpp:29:8:29:9 | s1 [m1] | aliasing.cpp:29:11:29:12 | m1 |
+| aliasing.cpp:29:11:29:12 | m1 | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:30:8:30:9 | s2 [m1] | aliasing.cpp:30:11:30:12 | m1 |
+| aliasing.cpp:30:11:30:12 | m1 | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:60:3:60:4 | s2 [post update] [m1] | aliasing.cpp:62:8:62:12 | copy2 [m1] |
 | aliasing.cpp:60:3:60:22 | ... = ... | aliasing.cpp:60:3:60:4 | s2 [post update] [m1] |
 | aliasing.cpp:60:11:60:20 | call to user_input | aliasing.cpp:60:3:60:22 | ... = ... |
 | aliasing.cpp:62:8:62:12 | copy2 [m1] | aliasing.cpp:62:14:62:15 | m1 |
+| aliasing.cpp:62:14:62:15 | m1 | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:92:3:92:3 | w [post update] [s, m1] | aliasing.cpp:93:8:93:8 | w [s, m1] |
 | aliasing.cpp:92:3:92:23 | ... = ... | aliasing.cpp:92:5:92:5 | s [post update] [m1] |
 | aliasing.cpp:92:5:92:5 | s [post update] [m1] | aliasing.cpp:92:3:92:3 | w [post update] [s, m1] |
 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:92:3:92:23 | ... = ... |
 | aliasing.cpp:93:8:93:8 | w [s, m1] | aliasing.cpp:93:10:93:10 | s [m1] |
 | aliasing.cpp:93:10:93:10 | s [m1] | aliasing.cpp:93:12:93:13 | m1 |
+| aliasing.cpp:93:12:93:13 | m1 | realistic.cpp:41:17:41:17 | o |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:158:17:158:20 | ref arg data |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:164:17:164:20 | ref arg data |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:175:15:175:22 | ref arg & ... |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:187:15:187:22 | ref arg & ... |
+| aliasing.cpp:105:23:105:24 | pa | aliasing.cpp:200:15:200:24 | ref arg & ... |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:158:17:158:20 | ref arg data |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:164:17:164:20 | ref arg data |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:175:15:175:22 | ref arg & ... |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:187:15:187:22 | ref arg & ... |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:200:15:200:24 | ref arg & ... |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:105:23:105:24 | pa |
 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:4:106:5 | pa [inner post update] |
 | aliasing.cpp:158:15:158:15 | s [post update] [data] | aliasing.cpp:159:9:159:9 | s [data] |
 | aliasing.cpp:158:17:158:20 | ref arg data | aliasing.cpp:158:15:158:15 | s [post update] [data] |
+| aliasing.cpp:159:8:159:14 | * ... | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:159:9:159:9 | s [data] | aliasing.cpp:159:11:159:14 | data |
 | aliasing.cpp:159:11:159:14 | data | aliasing.cpp:159:8:159:14 | * ... |
 | aliasing.cpp:164:15:164:15 | s [post update] [data] | aliasing.cpp:165:8:165:8 | s [data] |
 | aliasing.cpp:164:17:164:20 | ref arg data | aliasing.cpp:164:15:164:15 | s [post update] [data] |
 | aliasing.cpp:165:8:165:8 | s [data] | aliasing.cpp:165:10:165:13 | data |
+| aliasing.cpp:165:8:165:16 | access to array | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:165:10:165:13 | data | aliasing.cpp:165:8:165:16 | access to array |
 | aliasing.cpp:175:15:175:22 | ref arg & ... | aliasing.cpp:175:21:175:22 | m1 [inner post update] |
 | aliasing.cpp:175:16:175:17 | s2 [post update] [s, m1] | aliasing.cpp:176:8:176:9 | s2 [s, m1] |
@@ -235,24 +286,33 @@ edges
 | aliasing.cpp:175:21:175:22 | m1 [inner post update] | aliasing.cpp:175:19:175:19 | s [post update] [m1] |
 | aliasing.cpp:176:8:176:9 | s2 [s, m1] | aliasing.cpp:176:11:176:11 | s [m1] |
 | aliasing.cpp:176:11:176:11 | s [m1] | aliasing.cpp:176:13:176:14 | m1 |
+| aliasing.cpp:176:13:176:14 | m1 | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:187:15:187:22 | ref arg & ... | aliasing.cpp:187:21:187:22 | m1 [inner post update] |
 | aliasing.cpp:187:16:187:17 | s2 [post update] [s, m1] | aliasing.cpp:189:8:189:11 | s2_2 [s, m1] |
 | aliasing.cpp:187:19:187:19 | s [post update] [m1] | aliasing.cpp:187:16:187:17 | s2 [post update] [s, m1] |
 | aliasing.cpp:187:21:187:22 | m1 [inner post update] | aliasing.cpp:187:19:187:19 | s [post update] [m1] |
 | aliasing.cpp:189:8:189:11 | s2_2 [s, m1] | aliasing.cpp:189:13:189:13 | s [m1] |
 | aliasing.cpp:189:13:189:13 | s [m1] | aliasing.cpp:189:15:189:16 | m1 |
+| aliasing.cpp:189:15:189:16 | m1 | realistic.cpp:41:17:41:17 | o |
 | aliasing.cpp:200:15:200:24 | ref arg & ... | aliasing.cpp:200:23:200:24 | m1 [inner post update] |
 | aliasing.cpp:200:16:200:18 | ps2 [post update] [s, m1] | aliasing.cpp:201:8:201:10 | ps2 [s, m1] |
 | aliasing.cpp:200:21:200:21 | s [post update] [m1] | aliasing.cpp:200:16:200:18 | ps2 [post update] [s, m1] |
 | aliasing.cpp:200:23:200:24 | m1 [inner post update] | aliasing.cpp:200:21:200:21 | s [post update] [m1] |
 | aliasing.cpp:201:8:201:10 | ps2 [s, m1] | aliasing.cpp:201:13:201:13 | s [m1] |
 | aliasing.cpp:201:13:201:13 | s [m1] | aliasing.cpp:201:15:201:16 | m1 |
+| aliasing.cpp:201:15:201:16 | m1 | realistic.cpp:41:17:41:17 | o |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
+| arrays.cpp:7:8:7:13 | access to array | realistic.cpp:41:17:41:17 | o |
+| arrays.cpp:8:8:8:13 | access to array | realistic.cpp:41:17:41:17 | o |
+| arrays.cpp:9:8:9:11 | * ... | realistic.cpp:41:17:41:17 | o |
+| arrays.cpp:10:8:10:15 | * ... | realistic.cpp:41:17:41:17 | o |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:16:8:16:13 | access to array |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:17:8:17:13 | access to array |
+| arrays.cpp:16:8:16:13 | access to array | realistic.cpp:41:17:41:17 | o |
+| arrays.cpp:17:8:17:13 | access to array | realistic.cpp:41:17:41:17 | o |
 | arrays.cpp:36:3:36:3 | o [post update] [nested, arr, data] | arrays.cpp:37:8:37:8 | o [nested, arr, data] |
 | arrays.cpp:36:3:36:3 | o [post update] [nested, arr, data] | arrays.cpp:38:8:38:8 | o [nested, arr, data] |
 | arrays.cpp:36:3:36:17 | access to array [post update] [data] | arrays.cpp:36:12:36:14 | arr [inner post update] [data] |
@@ -261,13 +321,22 @@ edges
 | arrays.cpp:36:12:36:14 | arr [inner post update] [data] | arrays.cpp:36:5:36:10 | nested [post update] [arr, data] |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:36:3:36:37 | ... = ... |
 | arrays.cpp:37:8:37:8 | o [nested, arr, data] | arrays.cpp:37:10:37:15 | nested [arr, data] |
+| arrays.cpp:37:8:37:8 | o [post update] [nested, arr, data] | arrays.cpp:38:8:38:8 | o [nested, arr, data] |
 | arrays.cpp:37:8:37:22 | access to array [data] | arrays.cpp:37:24:37:27 | data |
+| arrays.cpp:37:8:37:22 | access to array [data] | arrays.cpp:37:24:37:27 | data |
+| arrays.cpp:37:8:37:22 | access to array [post update] [data] | arrays.cpp:37:17:37:19 | arr [inner post update] [data] |
 | arrays.cpp:37:10:37:15 | nested [arr, data] | arrays.cpp:37:17:37:19 | arr [data] |
+| arrays.cpp:37:10:37:15 | nested [post update] [arr, data] | arrays.cpp:37:8:37:8 | o [post update] [nested, arr, data] |
 | arrays.cpp:37:17:37:19 | arr [data] | arrays.cpp:37:8:37:22 | access to array [data] |
+| arrays.cpp:37:17:37:19 | arr [inner post update] [data] | arrays.cpp:37:10:37:15 | nested [post update] [arr, data] |
+| arrays.cpp:37:24:37:27 | data | arrays.cpp:37:24:37:27 | ref arg data |
+| arrays.cpp:37:24:37:27 | data | realistic.cpp:41:17:41:17 | o |
+| arrays.cpp:37:24:37:27 | ref arg data | arrays.cpp:37:8:37:22 | access to array [post update] [data] |
 | arrays.cpp:38:8:38:8 | o [nested, arr, data] | arrays.cpp:38:10:38:15 | nested [arr, data] |
 | arrays.cpp:38:8:38:22 | access to array [data] | arrays.cpp:38:24:38:27 | data |
 | arrays.cpp:38:10:38:15 | nested [arr, data] | arrays.cpp:38:17:38:19 | arr [data] |
 | arrays.cpp:38:17:38:19 | arr [data] | arrays.cpp:38:8:38:22 | access to array [data] |
+| arrays.cpp:38:24:38:27 | data | realistic.cpp:41:17:41:17 | o |
 | arrays.cpp:42:3:42:3 | o [post update] [indirect, arr, data] | arrays.cpp:43:8:43:8 | o [indirect, arr, data] |
 | arrays.cpp:42:3:42:3 | o [post update] [indirect, arr, data] | arrays.cpp:44:8:44:8 | o [indirect, arr, data] |
 | arrays.cpp:42:3:42:20 | access to array [post update] [data] | arrays.cpp:42:15:42:17 | arr [inner post update] [data] |
@@ -276,14 +345,24 @@ edges
 | arrays.cpp:42:15:42:17 | arr [inner post update] [data] | arrays.cpp:42:5:42:12 | indirect [post update] [arr, data] |
 | arrays.cpp:42:29:42:38 | call to user_input | arrays.cpp:42:3:42:40 | ... = ... |
 | arrays.cpp:43:8:43:8 | o [indirect, arr, data] | arrays.cpp:43:10:43:17 | indirect [arr, data] |
+| arrays.cpp:43:8:43:8 | o [post update] [indirect, arr, data] | arrays.cpp:44:8:44:8 | o [indirect, arr, data] |
 | arrays.cpp:43:8:43:25 | access to array [data] | arrays.cpp:43:27:43:30 | data |
+| arrays.cpp:43:8:43:25 | access to array [data] | arrays.cpp:43:27:43:30 | data |
+| arrays.cpp:43:8:43:25 | access to array [post update] [data] | arrays.cpp:43:20:43:22 | arr [inner post update] [data] |
 | arrays.cpp:43:10:43:17 | indirect [arr, data] | arrays.cpp:43:20:43:22 | arr [data] |
+| arrays.cpp:43:10:43:17 | indirect [post update] [arr, data] | arrays.cpp:43:8:43:8 | o [post update] [indirect, arr, data] |
 | arrays.cpp:43:20:43:22 | arr [data] | arrays.cpp:43:8:43:25 | access to array [data] |
+| arrays.cpp:43:20:43:22 | arr [inner post update] [data] | arrays.cpp:43:10:43:17 | indirect [post update] [arr, data] |
+| arrays.cpp:43:27:43:30 | data | arrays.cpp:43:27:43:30 | ref arg data |
+| arrays.cpp:43:27:43:30 | data | realistic.cpp:41:17:41:17 | o |
+| arrays.cpp:43:27:43:30 | ref arg data | arrays.cpp:43:8:43:25 | access to array [post update] [data] |
 | arrays.cpp:44:8:44:8 | o [indirect, arr, data] | arrays.cpp:44:10:44:17 | indirect [arr, data] |
 | arrays.cpp:44:8:44:25 | access to array [data] | arrays.cpp:44:27:44:30 | data |
 | arrays.cpp:44:10:44:17 | indirect [arr, data] | arrays.cpp:44:20:44:22 | arr [data] |
 | arrays.cpp:44:20:44:22 | arr [data] | arrays.cpp:44:8:44:25 | access to array [data] |
+| arrays.cpp:44:27:44:30 | data | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:16 | ... = ... |
+| by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:11:39:11:39 | s [a] |
 | by_reference.cpp:12:5:12:16 | ... = ... | by_reference.cpp:12:5:12:5 | s [post update] [a] |
 | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:19 | ... = ... |
 | by_reference.cpp:16:5:16:19 | ... = ... | by_reference.cpp:16:5:16:8 | this [post update] [a] |
@@ -308,21 +387,30 @@ edges
 | by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:50:3:50:3 | ref arg s [a] |
 | by_reference.cpp:51:8:51:8 | s [a] | by_reference.cpp:35:9:35:19 | this [a] |
 | by_reference.cpp:51:8:51:8 | s [a] | by_reference.cpp:51:10:51:20 | call to getDirectly |
+| by_reference.cpp:51:10:51:20 | call to getDirectly | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:56:3:56:3 | ref arg s [a] | by_reference.cpp:57:8:57:8 | s [a] |
 | by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:19:28:19:32 | value |
 | by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:56:3:56:3 | ref arg s [a] |
 | by_reference.cpp:57:8:57:8 | s [a] | by_reference.cpp:39:9:39:21 | this [a] |
 | by_reference.cpp:57:8:57:8 | s [a] | by_reference.cpp:57:10:57:22 | call to getIndirectly |
+| by_reference.cpp:57:10:57:22 | call to getIndirectly | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:62:3:62:3 | ref arg s [a] | by_reference.cpp:63:8:63:8 | s [a] |
 | by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value |
 | by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:62:3:62:3 | ref arg s [a] |
 | by_reference.cpp:63:8:63:8 | s [a] | by_reference.cpp:43:9:43:27 | this [a] |
 | by_reference.cpp:63:8:63:8 | s [a] | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:63:10:63:28 | call to getThroughNonMember | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:68:17:68:18 | ref arg & ... [a] | by_reference.cpp:69:22:69:23 | & ... [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:68:17:68:18 | ref arg & ... [a] |
+| by_reference.cpp:69:8:69:20 | call to nonMemberGetA | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:69:22:69:23 | & ... [a] | by_reference.cpp:31:46:31:46 | s [a] |
 | by_reference.cpp:69:22:69:23 | & ... [a] | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
+| by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:102:21:102:39 | ref arg & ... [a] |
+| by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:103:27:103:35 | ref arg inner_ptr [a] |
+| by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:106:21:106:41 | ref arg & ... [a] |
+| by_reference.cpp:83:31:83:35 | inner [a] | by_reference.cpp:107:29:107:37 | ref arg inner_ptr [a] |
+| by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:83:31:83:35 | inner [a] |
 | by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:102:21:102:39 | ref arg & ... [a] |
 | by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:103:27:103:35 | ref arg inner_ptr [a] |
 | by_reference.cpp:84:3:84:7 | inner [post update] [a] | by_reference.cpp:106:21:106:41 | ref arg & ... [a] |
@@ -340,8 +428,11 @@ edges
 | by_reference.cpp:88:3:88:7 | inner [post update] [a] | by_reference.cpp:127:21:127:38 | ref arg * ... [a] |
 | by_reference.cpp:88:3:88:24 | ... = ... | by_reference.cpp:88:3:88:7 | inner [post update] [a] |
 | by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:88:3:88:24 | ... = ... |
+| by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:104:15:104:22 | ref arg & ... |
+| by_reference.cpp:91:25:91:26 | pa | by_reference.cpp:108:15:108:24 | ref arg & ... |
 | by_reference.cpp:92:4:92:5 | pa [inner post update] | by_reference.cpp:104:15:104:22 | ref arg & ... |
 | by_reference.cpp:92:4:92:5 | pa [inner post update] | by_reference.cpp:108:15:108:24 | ref arg & ... |
+| by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:91:25:91:26 | pa |
 | by_reference.cpp:92:9:92:18 | call to user_input | by_reference.cpp:92:4:92:5 | pa [inner post update] |
 | by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:124:21:124:21 | ref arg a |
 | by_reference.cpp:95:25:95:26 | pa | by_reference.cpp:128:23:128:23 | ref arg a |
@@ -364,14 +455,20 @@ edges
 | by_reference.cpp:108:24:108:24 | a [inner post update] | by_reference.cpp:108:16:108:21 | pouter [post update] [a] |
 | by_reference.cpp:110:8:110:12 | outer [inner_nested, a] | by_reference.cpp:110:14:110:25 | inner_nested [a] |
 | by_reference.cpp:110:14:110:25 | inner_nested [a] | by_reference.cpp:110:27:110:27 | a |
+| by_reference.cpp:110:27:110:27 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:111:8:111:12 | outer [inner_ptr, a] | by_reference.cpp:111:14:111:22 | inner_ptr [a] |
 | by_reference.cpp:111:14:111:22 | inner_ptr [a] | by_reference.cpp:111:25:111:25 | a |
+| by_reference.cpp:111:25:111:25 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:112:8:112:12 | outer [a] | by_reference.cpp:112:14:112:14 | a |
+| by_reference.cpp:112:14:112:14 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:114:8:114:13 | pouter [inner_nested, a] | by_reference.cpp:114:16:114:27 | inner_nested [a] |
 | by_reference.cpp:114:16:114:27 | inner_nested [a] | by_reference.cpp:114:29:114:29 | a |
+| by_reference.cpp:114:29:114:29 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:115:8:115:13 | pouter [inner_ptr, a] | by_reference.cpp:115:16:115:24 | inner_ptr [a] |
 | by_reference.cpp:115:16:115:24 | inner_ptr [a] | by_reference.cpp:115:27:115:27 | a |
+| by_reference.cpp:115:27:115:27 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:116:8:116:13 | pouter [a] | by_reference.cpp:116:16:116:16 | a |
+| by_reference.cpp:116:16:116:16 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:122:21:122:25 | outer [post update] [inner_nested, a] | by_reference.cpp:130:8:130:12 | outer [inner_nested, a] |
 | by_reference.cpp:122:27:122:38 | ref arg inner_nested [a] | by_reference.cpp:122:21:122:25 | outer [post update] [inner_nested, a] |
 | by_reference.cpp:123:21:123:36 | ref arg * ... [a] | by_reference.cpp:123:28:123:36 | inner_ptr [inner post update] [a] |
@@ -388,14 +485,20 @@ edges
 | by_reference.cpp:128:23:128:23 | ref arg a | by_reference.cpp:128:15:128:20 | pouter [post update] [a] |
 | by_reference.cpp:130:8:130:12 | outer [inner_nested, a] | by_reference.cpp:130:14:130:25 | inner_nested [a] |
 | by_reference.cpp:130:14:130:25 | inner_nested [a] | by_reference.cpp:130:27:130:27 | a |
+| by_reference.cpp:130:27:130:27 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:131:8:131:12 | outer [inner_ptr, a] | by_reference.cpp:131:14:131:22 | inner_ptr [a] |
 | by_reference.cpp:131:14:131:22 | inner_ptr [a] | by_reference.cpp:131:25:131:25 | a |
+| by_reference.cpp:131:25:131:25 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:132:8:132:12 | outer [a] | by_reference.cpp:132:14:132:14 | a |
+| by_reference.cpp:132:14:132:14 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:134:8:134:13 | pouter [inner_nested, a] | by_reference.cpp:134:16:134:27 | inner_nested [a] |
 | by_reference.cpp:134:16:134:27 | inner_nested [a] | by_reference.cpp:134:29:134:29 | a |
+| by_reference.cpp:134:29:134:29 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:135:8:135:13 | pouter [inner_ptr, a] | by_reference.cpp:135:16:135:24 | inner_ptr [a] |
 | by_reference.cpp:135:16:135:24 | inner_ptr [a] | by_reference.cpp:135:27:135:27 | a |
+| by_reference.cpp:135:27:135:27 | a | realistic.cpp:41:17:41:17 | o |
 | by_reference.cpp:136:8:136:13 | pouter [a] | by_reference.cpp:136:16:136:16 | a |
+| by_reference.cpp:136:16:136:16 | a | realistic.cpp:41:17:41:17 | o |
 | complex.cpp:9:7:9:7 | this [a_] | complex.cpp:9:20:9:21 | this [a_] |
 | complex.cpp:9:20:9:21 | this [a_] | complex.cpp:9:20:9:21 | a_ |
 | complex.cpp:10:7:10:7 | this [b_] | complex.cpp:10:20:10:21 | this [b_] |
@@ -439,26 +542,31 @@ edges
 | complex.cpp:65:7:65:8 | b3 [inner, f, a_] | complex.cpp:40:17:40:17 | b [inner, f, a_] |
 | complex.cpp:65:7:65:8 | b3 [inner, f, b_] | complex.cpp:40:17:40:17 | b [inner, f, b_] |
 | conflated.cpp:19:19:19:21 | ref arg raw | conflated.cpp:20:8:20:10 | raw |
+| conflated.cpp:20:8:20:10 | raw | realistic.cpp:41:17:41:17 | o |
 | conflated.cpp:29:3:29:4 | pa [post update] [x] | conflated.cpp:30:8:30:9 | pa [x] |
 | conflated.cpp:29:3:29:22 | ... = ... | conflated.cpp:29:3:29:4 | pa [post update] [x] |
 | conflated.cpp:29:11:29:20 | call to user_input | conflated.cpp:29:3:29:22 | ... = ... |
 | conflated.cpp:30:8:30:9 | pa [x] | conflated.cpp:30:12:30:12 | x |
+| conflated.cpp:30:12:30:12 | x | realistic.cpp:41:17:41:17 | o |
 | conflated.cpp:36:3:36:4 | pa [post update] [x] | conflated.cpp:37:8:37:9 | pa [x] |
 | conflated.cpp:36:3:36:22 | ... = ... | conflated.cpp:36:3:36:4 | pa [post update] [x] |
 | conflated.cpp:36:11:36:20 | call to user_input | conflated.cpp:36:3:36:22 | ... = ... |
 | conflated.cpp:37:8:37:9 | pa [x] | conflated.cpp:37:12:37:12 | x |
+| conflated.cpp:37:12:37:12 | x | realistic.cpp:41:17:41:17 | o |
 | conflated.cpp:54:3:54:4 | ll [post update] [next, y] | conflated.cpp:55:8:55:9 | ll [next, y] |
 | conflated.cpp:54:3:54:28 | ... = ... | conflated.cpp:54:7:54:10 | next [post update] [y] |
 | conflated.cpp:54:7:54:10 | next [post update] [y] | conflated.cpp:54:3:54:4 | ll [post update] [next, y] |
 | conflated.cpp:54:17:54:26 | call to user_input | conflated.cpp:54:3:54:28 | ... = ... |
 | conflated.cpp:55:8:55:9 | ll [next, y] | conflated.cpp:55:12:55:15 | next [y] |
 | conflated.cpp:55:12:55:15 | next [y] | conflated.cpp:55:18:55:18 | y |
+| conflated.cpp:55:18:55:18 | y | realistic.cpp:41:17:41:17 | o |
 | conflated.cpp:60:3:60:4 | ll [post update] [next, y] | conflated.cpp:61:8:61:9 | ll [next, y] |
 | conflated.cpp:60:3:60:28 | ... = ... | conflated.cpp:60:7:60:10 | next [post update] [y] |
 | conflated.cpp:60:7:60:10 | next [post update] [y] | conflated.cpp:60:3:60:4 | ll [post update] [next, y] |
 | conflated.cpp:60:17:60:26 | call to user_input | conflated.cpp:60:3:60:28 | ... = ... |
 | conflated.cpp:61:8:61:9 | ll [next, y] | conflated.cpp:61:12:61:15 | next [y] |
 | conflated.cpp:61:12:61:15 | next [y] | conflated.cpp:61:18:61:18 | y |
+| conflated.cpp:61:18:61:18 | y | realistic.cpp:41:17:41:17 | o |
 | constructors.cpp:18:9:18:9 | this [a_] | constructors.cpp:18:22:18:23 | this [a_] |
 | constructors.cpp:18:22:18:23 | this [a_] | constructors.cpp:18:22:18:23 | a_ |
 | constructors.cpp:19:9:19:9 | this [b_] | constructors.cpp:19:22:19:23 | this [b_] |
@@ -492,6 +600,7 @@ edges
 | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:44 | ... = ... |
 | qualifiers.cpp:9:30:9:44 | ... = ... | qualifiers.cpp:9:30:9:33 | this [post update] [a] |
 | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:64 | ... = ... |
+| qualifiers.cpp:12:49:12:53 | inner [post update] [a] | qualifiers.cpp:12:27:12:31 | inner [a] |
 | qualifiers.cpp:12:49:12:64 | ... = ... | qualifiers.cpp:12:49:12:53 | inner [post update] [a] |
 | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:65 | ... = ... |
 | qualifiers.cpp:13:51:13:55 | inner [post update] [a] | qualifiers.cpp:13:29:13:33 | inner [a] |
@@ -502,18 +611,21 @@ edges
 | qualifiers.cpp:22:27:22:36 | call to user_input | qualifiers.cpp:22:5:22:38 | ... = ... |
 | qualifiers.cpp:23:10:23:14 | outer [inner, a] | qualifiers.cpp:23:16:23:20 | inner [a] |
 | qualifiers.cpp:23:16:23:20 | inner [a] | qualifiers.cpp:23:23:23:23 | a |
+| qualifiers.cpp:23:23:23:23 | a | realistic.cpp:41:17:41:17 | o |
 | qualifiers.cpp:27:5:27:9 | ref arg outer [inner, a] | qualifiers.cpp:28:10:28:14 | outer [inner, a] |
 | qualifiers.cpp:27:11:27:18 | ref arg call to getInner [a] | qualifiers.cpp:27:5:27:9 | ref arg outer [inner, a] |
 | qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value |
 | qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:27:11:27:18 | ref arg call to getInner [a] |
 | qualifiers.cpp:28:10:28:14 | outer [inner, a] | qualifiers.cpp:28:16:28:20 | inner [a] |
 | qualifiers.cpp:28:16:28:20 | inner [a] | qualifiers.cpp:28:23:28:23 | a |
+| qualifiers.cpp:28:23:28:23 | a | realistic.cpp:41:17:41:17 | o |
 | qualifiers.cpp:32:17:32:21 | ref arg outer [inner, a] | qualifiers.cpp:33:10:33:14 | outer [inner, a] |
 | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] | qualifiers.cpp:32:17:32:21 | ref arg outer [inner, a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] |
 | qualifiers.cpp:33:10:33:14 | outer [inner, a] | qualifiers.cpp:33:16:33:20 | inner [a] |
 | qualifiers.cpp:33:16:33:20 | inner [a] | qualifiers.cpp:33:23:33:23 | a |
+| qualifiers.cpp:33:23:33:23 | a | realistic.cpp:41:17:41:17 | o |
 | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] | qualifiers.cpp:37:26:37:33 | call to getInner [inner post update] [a] |
 | qualifiers.cpp:37:20:37:24 | ref arg outer [inner, a] | qualifiers.cpp:38:10:38:14 | outer [inner, a] |
 | qualifiers.cpp:37:26:37:33 | call to getInner [inner post update] [a] | qualifiers.cpp:37:20:37:24 | ref arg outer [inner, a] |
@@ -521,6 +633,7 @@ edges
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] |
 | qualifiers.cpp:38:10:38:14 | outer [inner, a] | qualifiers.cpp:38:16:38:20 | inner [a] |
 | qualifiers.cpp:38:16:38:20 | inner [a] | qualifiers.cpp:38:23:38:23 | a |
+| qualifiers.cpp:38:23:38:23 | a | realistic.cpp:41:17:41:17 | o |
 | qualifiers.cpp:42:5:42:40 | ... = ... | qualifiers.cpp:42:6:42:22 | * ... [post update] [a] |
 | qualifiers.cpp:42:6:42:22 | * ... [post update] [a] | qualifiers.cpp:42:13:42:20 | call to getInner [inner post update] [a] |
 | qualifiers.cpp:42:7:42:11 | ref arg outer [inner, a] | qualifiers.cpp:43:10:43:14 | outer [inner, a] |
@@ -528,12 +641,15 @@ edges
 | qualifiers.cpp:42:29:42:38 | call to user_input | qualifiers.cpp:42:5:42:40 | ... = ... |
 | qualifiers.cpp:43:10:43:14 | outer [inner, a] | qualifiers.cpp:43:16:43:20 | inner [a] |
 | qualifiers.cpp:43:16:43:20 | inner [a] | qualifiers.cpp:43:23:43:23 | a |
+| qualifiers.cpp:43:23:43:23 | a | realistic.cpp:41:17:41:17 | o |
 | qualifiers.cpp:47:5:47:42 | ... = ... | qualifiers.cpp:47:15:47:22 | call to getInner [post update] [a] |
 | qualifiers.cpp:47:6:47:11 | ref arg & ... [inner, a] | qualifiers.cpp:48:10:48:14 | outer [inner, a] |
 | qualifiers.cpp:47:15:47:22 | call to getInner [post update] [a] | qualifiers.cpp:47:6:47:11 | ref arg & ... [inner, a] |
 | qualifiers.cpp:47:31:47:40 | call to user_input | qualifiers.cpp:47:5:47:42 | ... = ... |
 | qualifiers.cpp:48:10:48:14 | outer [inner, a] | qualifiers.cpp:48:16:48:20 | inner [a] |
 | qualifiers.cpp:48:16:48:20 | inner [a] | qualifiers.cpp:48:23:48:23 | a |
+| qualifiers.cpp:48:23:48:23 | a | realistic.cpp:41:17:41:17 | o |
+| realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o |
 | realistic.cpp:53:9:53:11 | foo [post update] [bar, baz, userInput, bufferLen] | realistic.cpp:61:21:61:23 | foo [bar, baz, userInput, bufferLen] |
 | realistic.cpp:53:9:53:18 | access to array [post update] [baz, userInput, bufferLen] | realistic.cpp:53:13:53:15 | bar [inner post update] [baz, userInput, bufferLen] |
 | realistic.cpp:53:9:53:66 | ... = ... | realistic.cpp:53:25:53:33 | userInput [post update] [bufferLen] |
@@ -542,10 +658,19 @@ edges
 | realistic.cpp:53:25:53:33 | userInput [post update] [bufferLen] | realistic.cpp:53:20:53:22 | baz [post update] [userInput, bufferLen] |
 | realistic.cpp:53:55:53:64 | call to user_input | realistic.cpp:53:9:53:66 | ... = ... |
 | realistic.cpp:61:21:61:23 | foo [bar, baz, userInput, bufferLen] | realistic.cpp:61:25:61:27 | bar [baz, userInput, bufferLen] |
+| realistic.cpp:61:21:61:23 | foo [post update] [bar, baz, userInput, bufferLen] | realistic.cpp:61:21:61:23 | foo [bar, baz, userInput, bufferLen] |
 | realistic.cpp:61:21:61:30 | access to array [baz, userInput, bufferLen] | realistic.cpp:61:32:61:34 | baz [userInput, bufferLen] |
+| realistic.cpp:61:21:61:30 | access to array [post update] [baz, userInput, bufferLen] | realistic.cpp:61:25:61:27 | bar [inner post update] [baz, userInput, bufferLen] |
 | realistic.cpp:61:25:61:27 | bar [baz, userInput, bufferLen] | realistic.cpp:61:21:61:30 | access to array [baz, userInput, bufferLen] |
+| realistic.cpp:61:25:61:27 | bar [inner post update] [baz, userInput, bufferLen] | realistic.cpp:61:21:61:23 | foo [post update] [bar, baz, userInput, bufferLen] |
+| realistic.cpp:61:32:61:34 | baz [post update] [userInput, bufferLen] | realistic.cpp:61:21:61:30 | access to array [post update] [baz, userInput, bufferLen] |
 | realistic.cpp:61:32:61:34 | baz [userInput, bufferLen] | realistic.cpp:61:37:61:45 | userInput [bufferLen] |
 | realistic.cpp:61:37:61:45 | userInput [bufferLen] | realistic.cpp:61:47:61:55 | bufferLen |
+| realistic.cpp:61:37:61:45 | userInput [bufferLen] | realistic.cpp:61:47:61:55 | bufferLen |
+| realistic.cpp:61:37:61:45 | userInput [post update] [bufferLen] | realistic.cpp:61:32:61:34 | baz [post update] [userInput, bufferLen] |
+| realistic.cpp:61:47:61:55 | bufferLen | realistic.cpp:41:17:41:17 | o |
+| realistic.cpp:61:47:61:55 | bufferLen | realistic.cpp:61:47:61:55 | ref arg bufferLen |
+| realistic.cpp:61:47:61:55 | ref arg bufferLen | realistic.cpp:61:37:61:45 | userInput [post update] [bufferLen] |
 | simple.cpp:18:9:18:9 | this [a_] | simple.cpp:18:22:18:23 | this [a_] |
 | simple.cpp:18:22:18:23 | this [a_] | simple.cpp:18:22:18:23 | a_ |
 | simple.cpp:19:9:19:9 | this [b_] | simple.cpp:19:22:19:23 | this [b_] |
@@ -593,14 +718,28 @@ edges
 | simple.cpp:92:5:92:22 | ... = ... | simple.cpp:92:5:92:5 | a [post update] [i] |
 | simple.cpp:92:11:92:20 | call to user_input | simple.cpp:92:5:92:22 | ... = ... |
 | simple.cpp:94:10:94:11 | a2 [i] | simple.cpp:94:13:94:13 | i |
+| struct_init.c:14:24:14:25 | ab [a] | struct_init.c:14:24:14:25 | ab [a] |
 | struct_init.c:14:24:14:25 | ab [a] | struct_init.c:15:8:15:9 | ab [a] |
 | struct_init.c:15:8:15:9 | ab [a] | struct_init.c:15:12:15:12 | a |
+| struct_init.c:15:8:15:9 | ab [a] | struct_init.c:15:12:15:12 | a |
+| struct_init.c:15:8:15:9 | ab [post update] [a] | struct_init.c:14:24:14:25 | ab [a] |
+| struct_init.c:15:12:15:12 | a | realistic.cpp:41:17:41:17 | o |
+| struct_init.c:15:12:15:12 | a | struct_init.c:15:12:15:12 | ref arg a |
+| struct_init.c:15:12:15:12 | ref arg a | struct_init.c:15:8:15:9 | ab [post update] [a] |
 | struct_init.c:20:17:20:36 | {...} [a] | struct_init.c:22:8:22:9 | ab [a] |
 | struct_init.c:20:17:20:36 | {...} [a] | struct_init.c:24:10:24:12 | & ... [a] |
 | struct_init.c:20:17:20:36 | {...} [a] | struct_init.c:28:5:28:7 | & ... [a] |
 | struct_init.c:20:20:20:29 | call to user_input | struct_init.c:20:17:20:36 | {...} [a] |
 | struct_init.c:22:8:22:9 | ab [a] | struct_init.c:22:11:22:11 | a |
+| struct_init.c:22:8:22:9 | ab [a] | struct_init.c:22:11:22:11 | a |
+| struct_init.c:22:8:22:9 | ab [post update] [a] | struct_init.c:24:10:24:12 | & ... [a] |
+| struct_init.c:22:8:22:9 | ab [post update] [a] | struct_init.c:28:5:28:7 | & ... [a] |
+| struct_init.c:22:11:22:11 | a | realistic.cpp:41:17:41:17 | o |
+| struct_init.c:22:11:22:11 | a | struct_init.c:22:11:22:11 | ref arg a |
+| struct_init.c:22:11:22:11 | ref arg a | struct_init.c:22:8:22:9 | ab [post update] [a] |
 | struct_init.c:24:10:24:12 | & ... [a] | struct_init.c:14:24:14:25 | ab [a] |
+| struct_init.c:24:10:24:12 | & ... [a] | struct_init.c:24:10:24:12 | ref arg & ... [a] |
+| struct_init.c:24:10:24:12 | ref arg & ... [a] | struct_init.c:28:5:28:7 | & ... [a] |
 | struct_init.c:26:23:29:3 | {...} [nestedAB, a] | struct_init.c:31:8:31:12 | outer [nestedAB, a] |
 | struct_init.c:26:23:29:3 | {...} [nestedAB, a] | struct_init.c:36:11:36:15 | outer [nestedAB, a] |
 | struct_init.c:26:23:29:3 | {...} [pointerAB, a] | struct_init.c:33:8:33:12 | outer [pointerAB, a] |
@@ -608,9 +747,16 @@ edges
 | struct_init.c:27:7:27:16 | call to user_input | struct_init.c:27:5:27:23 | {...} [a] |
 | struct_init.c:28:5:28:7 | & ... [a] | struct_init.c:26:23:29:3 | {...} [pointerAB, a] |
 | struct_init.c:31:8:31:12 | outer [nestedAB, a] | struct_init.c:31:14:31:21 | nestedAB [a] |
+| struct_init.c:31:8:31:12 | outer [post update] [nestedAB, a] | struct_init.c:36:11:36:15 | outer [nestedAB, a] |
 | struct_init.c:31:14:31:21 | nestedAB [a] | struct_init.c:31:23:31:23 | a |
+| struct_init.c:31:14:31:21 | nestedAB [a] | struct_init.c:31:23:31:23 | a |
+| struct_init.c:31:14:31:21 | nestedAB [post update] [a] | struct_init.c:31:8:31:12 | outer [post update] [nestedAB, a] |
+| struct_init.c:31:23:31:23 | a | realistic.cpp:41:17:41:17 | o |
+| struct_init.c:31:23:31:23 | a | struct_init.c:31:23:31:23 | ref arg a |
+| struct_init.c:31:23:31:23 | ref arg a | struct_init.c:31:14:31:21 | nestedAB [post update] [a] |
 | struct_init.c:33:8:33:12 | outer [pointerAB, a] | struct_init.c:33:14:33:22 | pointerAB [a] |
 | struct_init.c:33:14:33:22 | pointerAB [a] | struct_init.c:33:25:33:25 | a |
+| struct_init.c:33:25:33:25 | a | realistic.cpp:41:17:41:17 | o |
 | struct_init.c:36:10:36:24 | & ... [a] | struct_init.c:14:24:14:25 | ab [a] |
 | struct_init.c:36:11:36:15 | outer [nestedAB, a] | struct_init.c:36:17:36:24 | nestedAB [a] |
 | struct_init.c:36:17:36:24 | nestedAB [a] | struct_init.c:36:10:36:24 | & ... [a] |
@@ -674,12 +820,14 @@ nodes
 | A.cpp:107:16:107:16 | a | semmle.label | a |
 | A.cpp:120:12:120:13 | c1 [a] | semmle.label | c1 [a] |
 | A.cpp:120:16:120:16 | a | semmle.label | a |
+| A.cpp:124:14:124:14 | b [c] | semmle.label | b [c] |
 | A.cpp:126:5:126:5 | ref arg b [c] | semmle.label | ref arg b [c] |
 | A.cpp:126:12:126:18 | new | semmle.label | new |
 | A.cpp:131:8:131:8 | ref arg b [c] | semmle.label | ref arg b [c] |
 | A.cpp:132:10:132:10 | b [c] | semmle.label | b [c] |
 | A.cpp:132:13:132:13 | c | semmle.label | c |
 | A.cpp:140:13:140:13 | b | semmle.label | b |
+| A.cpp:140:13:140:13 | b [c] | semmle.label | b [c] |
 | A.cpp:142:7:142:7 | b [post update] [c] | semmle.label | b [post update] [c] |
 | A.cpp:142:7:142:20 | ... = ... | semmle.label | ... = ... |
 | A.cpp:142:14:142:20 | new | semmle.label | new |
@@ -695,8 +843,12 @@ nodes
 | A.cpp:151:12:151:24 | call to D [b] | semmle.label | call to D [b] |
 | A.cpp:151:18:151:18 | b | semmle.label | b |
 | A.cpp:151:18:151:18 | ref arg b [c] | semmle.label | ref arg b [c] |
+| A.cpp:152:10:152:10 | d [b, c] | semmle.label | d [b, c] |
 | A.cpp:152:10:152:10 | d [b] | semmle.label | d [b] |
+| A.cpp:152:10:152:10 | d [post update] [b, c] | semmle.label | d [post update] [b, c] |
 | A.cpp:152:13:152:13 | b | semmle.label | b |
+| A.cpp:152:13:152:13 | b [c] | semmle.label | b [c] |
+| A.cpp:152:13:152:13 | ref arg b [c] | semmle.label | ref arg b [c] |
 | A.cpp:153:10:153:10 | d [b, c] | semmle.label | d [b, c] |
 | A.cpp:153:13:153:13 | b [c] | semmle.label | b [c] |
 | A.cpp:153:16:153:16 | c | semmle.label | c |
@@ -710,15 +862,24 @@ nodes
 | A.cpp:162:18:162:40 | call to MyList [next, next, head] | semmle.label | call to MyList [next, next, head] |
 | A.cpp:162:38:162:39 | l2 [next, head] | semmle.label | l2 [next, head] |
 | A.cpp:165:10:165:11 | l3 [next, next, head] | semmle.label | l3 [next, next, head] |
+| A.cpp:165:10:165:11 | l3 [post update] [next, next, head] | semmle.label | l3 [post update] [next, next, head] |
 | A.cpp:165:14:165:17 | next [next, head] | semmle.label | next [next, head] |
+| A.cpp:165:14:165:17 | next [post update] [next, head] | semmle.label | next [post update] [next, head] |
 | A.cpp:165:20:165:23 | next [head] | semmle.label | next [head] |
+| A.cpp:165:20:165:23 | next [post update] [head] | semmle.label | next [post update] [head] |
 | A.cpp:165:26:165:29 | head | semmle.label | head |
+| A.cpp:165:26:165:29 | head | semmle.label | head |
+| A.cpp:165:26:165:29 | ref arg head | semmle.label | ref arg head |
 | A.cpp:167:44:167:44 | l [next, head] | semmle.label | l [next, head] |
 | A.cpp:167:44:167:44 | l [next, next, head] | semmle.label | l [next, next, head] |
 | A.cpp:167:47:167:50 | next [head] | semmle.label | next [head] |
 | A.cpp:167:47:167:50 | next [next, head] | semmle.label | next [next, head] |
 | A.cpp:169:12:169:12 | l [head] | semmle.label | l [head] |
 | A.cpp:169:15:169:18 | head | semmle.label | head |
+| A.cpp:173:26:173:26 | o | semmle.label | o |
+| A.cpp:173:26:173:26 | o | semmle.label | o |
+| A.cpp:173:26:173:26 | o [c] | semmle.label | o [c] |
+| A.cpp:173:26:173:26 | o [c] | semmle.label | o [c] |
 | A.cpp:181:15:181:21 | newHead | semmle.label | newHead |
 | A.cpp:181:32:181:35 | next [head] | semmle.label | next [head] |
 | A.cpp:181:32:181:35 | next [next, head] | semmle.label | next [next, head] |
@@ -829,6 +990,7 @@ nodes
 | E.cpp:32:10:32:10 | b [buffer] | semmle.label | b [buffer] |
 | E.cpp:32:13:32:18 | buffer | semmle.label | buffer |
 | E.cpp:33:18:33:19 | & ... [data, buffer] | semmle.label | & ... [data, buffer] |
+| aliasing.cpp:8:23:8:23 | s [m1] | semmle.label | s [m1] |
 | aliasing.cpp:9:3:9:3 | s [post update] [m1] | semmle.label | s [post update] [m1] |
 | aliasing.cpp:9:3:9:22 | ... = ... | semmle.label | ... = ... |
 | aliasing.cpp:9:11:9:20 | call to user_input | semmle.label | call to user_input |
@@ -854,6 +1016,7 @@ nodes
 | aliasing.cpp:93:8:93:8 | w [s, m1] | semmle.label | w [s, m1] |
 | aliasing.cpp:93:10:93:10 | s [m1] | semmle.label | s [m1] |
 | aliasing.cpp:93:12:93:13 | m1 | semmle.label | m1 |
+| aliasing.cpp:105:23:105:24 | pa | semmle.label | pa |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | semmle.label | pa [inner post update] |
 | aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:158:15:158:15 | s [post update] [data] | semmle.label | s [post update] [data] |
@@ -902,10 +1065,16 @@ nodes
 | arrays.cpp:36:12:36:14 | arr [inner post update] [data] | semmle.label | arr [inner post update] [data] |
 | arrays.cpp:36:26:36:35 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:37:8:37:8 | o [nested, arr, data] | semmle.label | o [nested, arr, data] |
+| arrays.cpp:37:8:37:8 | o [post update] [nested, arr, data] | semmle.label | o [post update] [nested, arr, data] |
 | arrays.cpp:37:8:37:22 | access to array [data] | semmle.label | access to array [data] |
+| arrays.cpp:37:8:37:22 | access to array [post update] [data] | semmle.label | access to array [post update] [data] |
 | arrays.cpp:37:10:37:15 | nested [arr, data] | semmle.label | nested [arr, data] |
+| arrays.cpp:37:10:37:15 | nested [post update] [arr, data] | semmle.label | nested [post update] [arr, data] |
 | arrays.cpp:37:17:37:19 | arr [data] | semmle.label | arr [data] |
+| arrays.cpp:37:17:37:19 | arr [inner post update] [data] | semmle.label | arr [inner post update] [data] |
 | arrays.cpp:37:24:37:27 | data | semmle.label | data |
+| arrays.cpp:37:24:37:27 | data | semmle.label | data |
+| arrays.cpp:37:24:37:27 | ref arg data | semmle.label | ref arg data |
 | arrays.cpp:38:8:38:8 | o [nested, arr, data] | semmle.label | o [nested, arr, data] |
 | arrays.cpp:38:8:38:22 | access to array [data] | semmle.label | access to array [data] |
 | arrays.cpp:38:10:38:15 | nested [arr, data] | semmle.label | nested [arr, data] |
@@ -918,15 +1087,22 @@ nodes
 | arrays.cpp:42:15:42:17 | arr [inner post update] [data] | semmle.label | arr [inner post update] [data] |
 | arrays.cpp:42:29:42:38 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:43:8:43:8 | o [indirect, arr, data] | semmle.label | o [indirect, arr, data] |
+| arrays.cpp:43:8:43:8 | o [post update] [indirect, arr, data] | semmle.label | o [post update] [indirect, arr, data] |
 | arrays.cpp:43:8:43:25 | access to array [data] | semmle.label | access to array [data] |
+| arrays.cpp:43:8:43:25 | access to array [post update] [data] | semmle.label | access to array [post update] [data] |
 | arrays.cpp:43:10:43:17 | indirect [arr, data] | semmle.label | indirect [arr, data] |
+| arrays.cpp:43:10:43:17 | indirect [post update] [arr, data] | semmle.label | indirect [post update] [arr, data] |
 | arrays.cpp:43:20:43:22 | arr [data] | semmle.label | arr [data] |
+| arrays.cpp:43:20:43:22 | arr [inner post update] [data] | semmle.label | arr [inner post update] [data] |
 | arrays.cpp:43:27:43:30 | data | semmle.label | data |
+| arrays.cpp:43:27:43:30 | data | semmle.label | data |
+| arrays.cpp:43:27:43:30 | ref arg data | semmle.label | ref arg data |
 | arrays.cpp:44:8:44:8 | o [indirect, arr, data] | semmle.label | o [indirect, arr, data] |
 | arrays.cpp:44:8:44:25 | access to array [data] | semmle.label | access to array [data] |
 | arrays.cpp:44:10:44:17 | indirect [arr, data] | semmle.label | indirect [arr, data] |
 | arrays.cpp:44:20:44:22 | arr [data] | semmle.label | arr [data] |
 | arrays.cpp:44:27:44:30 | data | semmle.label | data |
+| by_reference.cpp:11:39:11:39 | s [a] | semmle.label | s [a] |
 | by_reference.cpp:11:48:11:52 | value | semmle.label | value |
 | by_reference.cpp:12:5:12:5 | s [post update] [a] | semmle.label | s [post update] [a] |
 | by_reference.cpp:12:5:12:16 | ... = ... | semmle.label | ... = ... |
@@ -967,6 +1143,7 @@ nodes
 | by_reference.cpp:68:21:68:30 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:69:8:69:20 | call to nonMemberGetA | semmle.label | call to nonMemberGetA |
 | by_reference.cpp:69:22:69:23 | & ... [a] | semmle.label | & ... [a] |
+| by_reference.cpp:83:31:83:35 | inner [a] | semmle.label | inner [a] |
 | by_reference.cpp:84:3:84:7 | inner [post update] [a] | semmle.label | inner [post update] [a] |
 | by_reference.cpp:84:3:84:25 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:84:14:84:23 | call to user_input | semmle.label | call to user_input |
@@ -974,6 +1151,7 @@ nodes
 | by_reference.cpp:88:3:88:7 | inner [post update] [a] | semmle.label | inner [post update] [a] |
 | by_reference.cpp:88:3:88:24 | ... = ... | semmle.label | ... = ... |
 | by_reference.cpp:88:13:88:22 | call to user_input | semmle.label | call to user_input |
+| by_reference.cpp:91:25:91:26 | pa | semmle.label | pa |
 | by_reference.cpp:92:4:92:5 | pa [inner post update] | semmle.label | pa [inner post update] |
 | by_reference.cpp:92:9:92:18 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:95:25:95:26 | pa | semmle.label | pa |
@@ -1141,6 +1319,7 @@ nodes
 | qualifiers.cpp:9:21:9:25 | value | semmle.label | value |
 | qualifiers.cpp:9:30:9:33 | this [post update] [a] | semmle.label | this [post update] [a] |
 | qualifiers.cpp:9:30:9:44 | ... = ... | semmle.label | ... = ... |
+| qualifiers.cpp:12:27:12:31 | inner [a] | semmle.label | inner [a] |
 | qualifiers.cpp:12:40:12:44 | value | semmle.label | value |
 | qualifiers.cpp:12:49:12:53 | inner [post update] [a] | semmle.label | inner [post update] [a] |
 | qualifiers.cpp:12:49:12:64 | ... = ... | semmle.label | ... = ... |
@@ -1189,6 +1368,8 @@ nodes
 | qualifiers.cpp:48:10:48:14 | outer [inner, a] | semmle.label | outer [inner, a] |
 | qualifiers.cpp:48:16:48:20 | inner [a] | semmle.label | inner [a] |
 | qualifiers.cpp:48:23:48:23 | a | semmle.label | a |
+| realistic.cpp:41:17:41:17 | o | semmle.label | o |
+| realistic.cpp:41:17:41:17 | o | semmle.label | o |
 | realistic.cpp:53:9:53:11 | foo [post update] [bar, baz, userInput, bufferLen] | semmle.label | foo [post update] [bar, baz, userInput, bufferLen] |
 | realistic.cpp:53:9:53:18 | access to array [post update] [baz, userInput, bufferLen] | semmle.label | access to array [post update] [baz, userInput, bufferLen] |
 | realistic.cpp:53:9:53:66 | ... = ... | semmle.label | ... = ... |
@@ -1197,11 +1378,18 @@ nodes
 | realistic.cpp:53:25:53:33 | userInput [post update] [bufferLen] | semmle.label | userInput [post update] [bufferLen] |
 | realistic.cpp:53:55:53:64 | call to user_input | semmle.label | call to user_input |
 | realistic.cpp:61:21:61:23 | foo [bar, baz, userInput, bufferLen] | semmle.label | foo [bar, baz, userInput, bufferLen] |
+| realistic.cpp:61:21:61:23 | foo [post update] [bar, baz, userInput, bufferLen] | semmle.label | foo [post update] [bar, baz, userInput, bufferLen] |
 | realistic.cpp:61:21:61:30 | access to array [baz, userInput, bufferLen] | semmle.label | access to array [baz, userInput, bufferLen] |
+| realistic.cpp:61:21:61:30 | access to array [post update] [baz, userInput, bufferLen] | semmle.label | access to array [post update] [baz, userInput, bufferLen] |
 | realistic.cpp:61:25:61:27 | bar [baz, userInput, bufferLen] | semmle.label | bar [baz, userInput, bufferLen] |
+| realistic.cpp:61:25:61:27 | bar [inner post update] [baz, userInput, bufferLen] | semmle.label | bar [inner post update] [baz, userInput, bufferLen] |
+| realistic.cpp:61:32:61:34 | baz [post update] [userInput, bufferLen] | semmle.label | baz [post update] [userInput, bufferLen] |
 | realistic.cpp:61:32:61:34 | baz [userInput, bufferLen] | semmle.label | baz [userInput, bufferLen] |
 | realistic.cpp:61:37:61:45 | userInput [bufferLen] | semmle.label | userInput [bufferLen] |
+| realistic.cpp:61:37:61:45 | userInput [post update] [bufferLen] | semmle.label | userInput [post update] [bufferLen] |
 | realistic.cpp:61:47:61:55 | bufferLen | semmle.label | bufferLen |
+| realistic.cpp:61:47:61:55 | bufferLen | semmle.label | bufferLen |
+| realistic.cpp:61:47:61:55 | ref arg bufferLen | semmle.label | ref arg bufferLen |
 | simple.cpp:18:9:18:9 | this [a_] | semmle.label | this [a_] |
 | simple.cpp:18:22:18:23 | a_ | semmle.label | a_ |
 | simple.cpp:18:22:18:23 | this [a_] | semmle.label | this [a_] |
@@ -1253,21 +1441,33 @@ nodes
 | simple.cpp:94:10:94:11 | a2 [i] | semmle.label | a2 [i] |
 | simple.cpp:94:13:94:13 | i | semmle.label | i |
 | struct_init.c:14:24:14:25 | ab [a] | semmle.label | ab [a] |
+| struct_init.c:14:24:14:25 | ab [a] | semmle.label | ab [a] |
 | struct_init.c:15:8:15:9 | ab [a] | semmle.label | ab [a] |
+| struct_init.c:15:8:15:9 | ab [post update] [a] | semmle.label | ab [post update] [a] |
 | struct_init.c:15:12:15:12 | a | semmle.label | a |
+| struct_init.c:15:12:15:12 | a | semmle.label | a |
+| struct_init.c:15:12:15:12 | ref arg a | semmle.label | ref arg a |
 | struct_init.c:20:17:20:36 | {...} [a] | semmle.label | {...} [a] |
 | struct_init.c:20:20:20:29 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:22:8:22:9 | ab [a] | semmle.label | ab [a] |
+| struct_init.c:22:8:22:9 | ab [post update] [a] | semmle.label | ab [post update] [a] |
 | struct_init.c:22:11:22:11 | a | semmle.label | a |
+| struct_init.c:22:11:22:11 | a | semmle.label | a |
+| struct_init.c:22:11:22:11 | ref arg a | semmle.label | ref arg a |
 | struct_init.c:24:10:24:12 | & ... [a] | semmle.label | & ... [a] |
+| struct_init.c:24:10:24:12 | ref arg & ... [a] | semmle.label | ref arg & ... [a] |
 | struct_init.c:26:23:29:3 | {...} [nestedAB, a] | semmle.label | {...} [nestedAB, a] |
 | struct_init.c:26:23:29:3 | {...} [pointerAB, a] | semmle.label | {...} [pointerAB, a] |
 | struct_init.c:27:5:27:23 | {...} [a] | semmle.label | {...} [a] |
 | struct_init.c:27:7:27:16 | call to user_input | semmle.label | call to user_input |
 | struct_init.c:28:5:28:7 | & ... [a] | semmle.label | & ... [a] |
 | struct_init.c:31:8:31:12 | outer [nestedAB, a] | semmle.label | outer [nestedAB, a] |
+| struct_init.c:31:8:31:12 | outer [post update] [nestedAB, a] | semmle.label | outer [post update] [nestedAB, a] |
 | struct_init.c:31:14:31:21 | nestedAB [a] | semmle.label | nestedAB [a] |
+| struct_init.c:31:14:31:21 | nestedAB [post update] [a] | semmle.label | nestedAB [post update] [a] |
 | struct_init.c:31:23:31:23 | a | semmle.label | a |
+| struct_init.c:31:23:31:23 | a | semmle.label | a |
+| struct_init.c:31:23:31:23 | ref arg a | semmle.label | ref arg a |
 | struct_init.c:33:8:33:12 | outer [pointerAB, a] | semmle.label | outer [pointerAB, a] |
 | struct_init.c:33:14:33:22 | pointerAB [a] | semmle.label | pointerAB [a] |
 | struct_init.c:33:25:33:25 | a | semmle.label | a |
@@ -1293,9 +1493,11 @@ subpaths
 | A.cpp:90:15:90:15 | c | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this [post update] [c] | A.cpp:90:7:90:8 | ref arg b2 [c] |
 | A.cpp:126:12:126:18 | new | A.cpp:27:17:27:17 | c | A.cpp:27:22:27:25 | this [post update] [c] | A.cpp:126:5:126:5 | ref arg b [c] |
 | A.cpp:151:18:151:18 | b | A.cpp:140:13:140:13 | b | A.cpp:143:7:143:10 | this [post update] [b] | A.cpp:151:12:151:24 | call to D [b] |
+| A.cpp:152:13:152:13 | b [c] | A.cpp:173:26:173:26 | o [c] | A.cpp:173:26:173:26 | o [c] | A.cpp:152:13:152:13 | ref arg b [c] |
 | A.cpp:160:29:160:29 | b | A.cpp:181:15:181:21 | newHead | A.cpp:183:7:183:10 | this [post update] [head] | A.cpp:160:18:160:60 | call to MyList [head] |
 | A.cpp:161:38:161:39 | l1 [head] | A.cpp:181:32:181:35 | next [head] | A.cpp:184:7:184:10 | this [post update] [next, head] | A.cpp:161:18:161:40 | call to MyList [next, head] |
 | A.cpp:162:38:162:39 | l2 [next, head] | A.cpp:181:32:181:35 | next [next, head] | A.cpp:184:7:184:10 | this [post update] [next, next, head] | A.cpp:162:18:162:40 | call to MyList [next, next, head] |
+| A.cpp:165:26:165:29 | head | A.cpp:173:26:173:26 | o | A.cpp:173:26:173:26 | o | A.cpp:165:26:165:29 | ref arg head |
 | B.cpp:7:25:7:25 | e | B.cpp:33:16:33:17 | e1 | B.cpp:35:7:35:10 | this [post update] [elem1] | B.cpp:7:16:7:35 | call to Box1 [elem1] |
 | B.cpp:8:25:8:26 | b1 [elem1] | B.cpp:44:16:44:17 | b1 [elem1] | B.cpp:46:7:46:10 | this [post update] [box1, elem1] | B.cpp:8:16:8:27 | call to Box2 [box1, elem1] |
 | B.cpp:16:37:16:37 | e | B.cpp:33:26:33:27 | e2 | B.cpp:36:7:36:10 | this [post update] [elem2] | B.cpp:16:16:16:38 | call to Box1 [elem2] |
@@ -1304,7 +1506,10 @@ subpaths
 | D.cpp:22:14:22:20 | call to getBox1 [elem] | D.cpp:10:11:10:17 | this [elem] | D.cpp:10:30:10:33 | elem | D.cpp:22:25:22:31 | call to getElem |
 | D.cpp:37:21:37:21 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this [post update] [elem] | D.cpp:37:8:37:10 | ref arg box [elem] |
 | D.cpp:51:27:51:27 | e | D.cpp:11:24:11:24 | e | D.cpp:11:29:11:32 | this [post update] [elem] | D.cpp:51:8:51:14 | ref arg call to getBox1 [elem] |
+| arrays.cpp:37:24:37:27 | data | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | arrays.cpp:37:24:37:27 | ref arg data |
+| arrays.cpp:43:27:43:30 | data | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | arrays.cpp:43:27:43:30 | ref arg data |
 | by_reference.cpp:20:23:20:27 | value | by_reference.cpp:15:26:15:30 | value | by_reference.cpp:16:5:16:8 | this [post update] [a] | by_reference.cpp:20:5:20:8 | ref arg this [a] |
+| by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | s [a] | by_reference.cpp:24:19:24:22 | ref arg this [a] |
 | by_reference.cpp:24:25:24:29 | value | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:24:19:24:22 | ref arg this [a] |
 | by_reference.cpp:40:12:40:15 | this [a] | by_reference.cpp:35:9:35:19 | this [a] | by_reference.cpp:36:18:36:18 | a | by_reference.cpp:40:18:40:28 | call to getDirectly |
 | by_reference.cpp:44:26:44:29 | this [a] | by_reference.cpp:31:46:31:46 | s [a] | by_reference.cpp:32:15:32:15 | a | by_reference.cpp:44:12:44:24 | call to nonMemberGetA |
@@ -1314,6 +1519,7 @@ subpaths
 | by_reference.cpp:57:8:57:8 | s [a] | by_reference.cpp:39:9:39:21 | this [a] | by_reference.cpp:40:18:40:28 | call to getDirectly | by_reference.cpp:57:10:57:22 | call to getIndirectly |
 | by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:23:34:23:38 | value | by_reference.cpp:24:19:24:22 | ref arg this [a] | by_reference.cpp:62:3:62:3 | ref arg s [a] |
 | by_reference.cpp:63:8:63:8 | s [a] | by_reference.cpp:43:9:43:27 | this [a] | by_reference.cpp:44:12:44:24 | call to nonMemberGetA | by_reference.cpp:63:10:63:28 | call to getThroughNonMember |
+| by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:11:39:11:39 | s [a] | by_reference.cpp:68:17:68:18 | ref arg & ... [a] |
 | by_reference.cpp:68:21:68:30 | call to user_input | by_reference.cpp:11:48:11:52 | value | by_reference.cpp:12:5:12:5 | s [post update] [a] | by_reference.cpp:68:17:68:18 | ref arg & ... [a] |
 | by_reference.cpp:69:22:69:23 | & ... [a] | by_reference.cpp:31:46:31:46 | s [a] | by_reference.cpp:32:15:32:15 | a | by_reference.cpp:69:8:69:20 | call to nonMemberGetA |
 | complex.cpp:42:16:42:16 | f [a_] | complex.cpp:9:7:9:7 | this [a_] | complex.cpp:9:20:9:21 | a_ | complex.cpp:42:18:42:18 | call to a |
@@ -1329,9 +1535,11 @@ subpaths
 | constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:23:13:23:13 | a | constructors.cpp:23:25:23:29 | constructor init of field a_ [post-this] [a_] | constructors.cpp:36:11:36:37 | call to Foo [a_] |
 | constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:23:20:23:20 | b | constructors.cpp:23:32:23:36 | constructor init of field b_ [post-this] [b_] | constructors.cpp:36:11:36:37 | call to Foo [b_] |
 | qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:9:21:9:25 | value | qualifiers.cpp:9:30:9:33 | this [post update] [a] | qualifiers.cpp:27:11:27:18 | ref arg call to getInner [a] |
+| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:27:12:31 | inner [a] | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] |
 | qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:12:40:12:44 | value | qualifiers.cpp:12:49:12:53 | inner [post update] [a] | qualifiers.cpp:32:23:32:30 | ref arg call to getInner [a] |
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:29:13:33 | inner [a] | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] |
 | qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:13:42:13:46 | value | qualifiers.cpp:13:51:13:55 | inner [post update] [a] | qualifiers.cpp:37:19:37:35 | ref arg * ... [a] |
+| realistic.cpp:61:47:61:55 | bufferLen | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | realistic.cpp:61:47:61:55 | ref arg bufferLen |
 | simple.cpp:28:10:28:10 | f [a_] | simple.cpp:18:9:18:9 | this [a_] | simple.cpp:18:22:18:23 | a_ | simple.cpp:28:12:28:12 | call to a |
 | simple.cpp:29:10:29:10 | f [b_] | simple.cpp:19:9:19:9 | this [b_] | simple.cpp:19:22:19:23 | b_ | simple.cpp:29:12:29:12 | call to b |
 | simple.cpp:39:12:39:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | this [post update] [a_] | simple.cpp:39:5:39:5 | ref arg f [a_] |
@@ -1339,6 +1547,10 @@ subpaths
 | simple.cpp:41:12:41:21 | call to user_input | simple.cpp:20:19:20:19 | a | simple.cpp:20:24:20:25 | this [post update] [a_] | simple.cpp:41:5:41:5 | ref arg h [a_] |
 | simple.cpp:42:12:42:21 | call to user_input | simple.cpp:21:19:21:19 | b | simple.cpp:21:24:21:25 | this [post update] [b_] | simple.cpp:42:5:42:5 | ref arg h [b_] |
 | simple.cpp:84:14:84:20 | this [f2, f1] | simple.cpp:78:9:78:15 | this [f2, f1] | simple.cpp:79:19:79:20 | f1 | simple.cpp:84:14:84:20 | call to getf2f1 |
+| struct_init.c:15:12:15:12 | a | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | struct_init.c:15:12:15:12 | ref arg a |
+| struct_init.c:22:11:22:11 | a | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | struct_init.c:22:11:22:11 | ref arg a |
+| struct_init.c:24:10:24:12 | & ... [a] | struct_init.c:14:24:14:25 | ab [a] | struct_init.c:14:24:14:25 | ab [a] | struct_init.c:24:10:24:12 | ref arg & ... [a] |
+| struct_init.c:31:23:31:23 | a | realistic.cpp:41:17:41:17 | o | realistic.cpp:41:17:41:17 | o | struct_init.c:31:23:31:23 | ref arg a |
 #select
 | A.cpp:43:10:43:12 | & ... | A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... | & ... flows from $@ | A.cpp:41:15:41:21 | new | new |
 | A.cpp:49:13:49:13 | c | A.cpp:47:12:47:18 | new | A.cpp:49:13:49:13 | c | c flows from $@ | A.cpp:47:12:47:18 | new | new |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -299,12 +299,15 @@
 | file://:0:0:0:0 | (unnamed parameter 0) | file://:0:0:0:0 | (unnamed parameter 0) |  |
 | file://:0:0:0:0 | (unnamed parameter 0) | file://:0:0:0:0 | (unnamed parameter 0) |  |
 | file://:0:0:0:0 | (unnamed parameter 0) | file://:0:0:0:0 | (unnamed parameter 0) |  |
+| format.cpp:16:21:16:21 | s | format.cpp:16:21:16:21 | s |  |
 | format.cpp:16:21:16:21 | s | format.cpp:22:22:22:22 | s |  |
 | format.cpp:16:31:16:31 | n | format.cpp:22:25:22:25 | n |  |
+| format.cpp:16:46:16:51 | format | format.cpp:16:46:16:51 | format |  |
 | format.cpp:16:46:16:51 | format | format.cpp:22:28:22:33 | format |  |
 | format.cpp:20:10:20:13 | args | format.cpp:22:36:22:39 | args |  |
 | format.cpp:22:12:22:20 | call to vsnprintf | format.cpp:22:3:22:40 | ... = ... |  |
 | format.cpp:22:12:22:20 | call to vsnprintf | format.cpp:25:9:25:14 | result |  |
+| format.cpp:22:22:22:22 | ref arg s | format.cpp:16:21:16:21 | s |  |
 | format.cpp:50:21:50:24 | {...} | format.cpp:51:17:51:22 | buffer |  |
 | format.cpp:50:21:50:24 | {...} | format.cpp:52:8:52:13 | buffer |  |
 | format.cpp:50:23:50:23 | 0 | format.cpp:50:21:50:24 | {...} | TAINT |
@@ -3344,7 +3347,9 @@
 | smart_pointer.cpp:93:8:93:8 | ref arg q | smart_pointer.cpp:94:8:94:8 | q |  |
 | smart_pointer.cpp:94:8:94:8 | q | smart_pointer.cpp:94:9:94:9 | call to operator-> |  |
 | smart_pointer.cpp:94:8:94:8 | ref arg q | smart_pointer.cpp:86:67:86:67 | q |  |
+| smart_pointer.cpp:97:17:97:18 | pa | smart_pointer.cpp:97:17:97:18 | pa |  |
 | smart_pointer.cpp:97:17:97:18 | pa | smart_pointer.cpp:98:5:98:6 | pa |  |
+| smart_pointer.cpp:98:5:98:6 | pa [post update] | smart_pointer.cpp:97:17:97:18 | pa |  |
 | smart_pointer.cpp:98:5:98:20 | ... = ... | smart_pointer.cpp:98:9:98:9 | x [post update] |  |
 | smart_pointer.cpp:98:13:98:18 | call to source | smart_pointer.cpp:98:5:98:20 | ... = ... |  |
 | smart_pointer.cpp:102:25:102:50 | call to unique_ptr | smart_pointer.cpp:103:11:103:11 | p |  |
@@ -5923,11 +5928,13 @@
 | taint.cpp:172:10:172:15 | buffer | taint.cpp:172:10:172:15 | ref arg buffer | TAINT |
 | taint.cpp:172:10:172:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:172:18:172:24 | tainted | taint.cpp:172:10:172:15 | ref arg buffer | TAINT |
+| taint.cpp:180:19:180:19 | p | taint.cpp:180:19:180:19 | p |  |
 | taint.cpp:180:19:180:19 | p | taint.cpp:181:9:181:9 | p |  |
 | taint.cpp:181:9:181:9 | p | taint.cpp:181:8:181:9 | * ... | TAINT |
 | taint.cpp:185:11:185:16 | call to source | taint.cpp:186:11:186:11 | x |  |
 | taint.cpp:186:10:186:11 | ref arg & ... | taint.cpp:186:11:186:11 | x [inner post update] |  |
 | taint.cpp:186:11:186:11 | x | taint.cpp:186:10:186:11 | & ... |  |
+| taint.cpp:192:23:192:28 | source | taint.cpp:192:23:192:28 | source |  |
 | taint.cpp:192:23:192:28 | source | taint.cpp:194:13:194:18 | source |  |
 | taint.cpp:193:6:193:6 | x | taint.cpp:194:10:194:10 | x |  |
 | taint.cpp:193:6:193:6 | x | taint.cpp:195:7:195:7 | x |  |
@@ -5935,6 +5942,7 @@
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:194:10:194:10 | x [inner post update] |  |
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... |  |
+| taint.cpp:194:13:194:18 | ref arg source | taint.cpp:192:23:192:28 | source |  |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:2:194:7 | call to memcpy | TAINT |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
 | taint.cpp:207:6:207:11 | call to source | taint.cpp:207:2:207:13 | ... = ... |  |
@@ -6040,18 +6048,22 @@
 | taint.cpp:304:2:304:6 | ... = ... | taint.cpp:304:2:304:2 | a [post update] |  |
 | taint.cpp:304:6:304:6 | b | taint.cpp:302:21:302:21 | a |  |
 | taint.cpp:304:6:304:6 | b | taint.cpp:304:2:304:6 | ... = ... |  |
+| taint.cpp:307:21:307:21 | a | taint.cpp:307:21:307:21 | a |  |
 | taint.cpp:307:21:307:21 | a | taint.cpp:309:3:309:3 | a |  |
 | taint.cpp:307:28:307:28 | b | taint.cpp:309:7:309:7 | b |  |
+| taint.cpp:309:2:309:3 | * ... [post update] | taint.cpp:307:21:307:21 | a |  |
 | taint.cpp:309:2:309:3 | * ... [post update] | taint.cpp:309:3:309:3 | a [inner post update] |  |
 | taint.cpp:309:2:309:7 | ... = ... | taint.cpp:309:2:309:3 | * ... [post update] |  |
 | taint.cpp:309:3:309:3 | a | taint.cpp:309:2:309:3 | * ... | TAINT |
 | taint.cpp:309:7:309:7 | b | taint.cpp:309:2:309:7 | ... = ... |  |
+| taint.cpp:312:21:312:21 | a | taint.cpp:312:21:312:21 | a |  |
 | taint.cpp:312:21:312:21 | a | taint.cpp:317:3:317:3 | a |  |
 | taint.cpp:312:28:312:28 | b | taint.cpp:316:6:316:6 | b |  |
 | taint.cpp:316:6:316:6 | b | taint.cpp:316:6:316:10 | ... + ... | TAINT |
 | taint.cpp:316:6:316:10 | ... + ... | taint.cpp:316:2:316:10 | ... = ... |  |
 | taint.cpp:316:6:316:10 | ... + ... | taint.cpp:317:7:317:7 | c |  |
 | taint.cpp:316:10:316:10 | 1 | taint.cpp:316:6:316:10 | ... + ... | TAINT |
+| taint.cpp:317:2:317:3 | * ... [post update] | taint.cpp:312:21:312:21 | a |  |
 | taint.cpp:317:2:317:3 | * ... [post update] | taint.cpp:317:3:317:3 | a [inner post update] |  |
 | taint.cpp:317:2:317:7 | ... = ... | taint.cpp:317:2:317:3 | * ... [post update] |  |
 | taint.cpp:317:3:317:3 | a | taint.cpp:317:2:317:3 | * ... | TAINT |
@@ -6113,6 +6125,7 @@
 | taint.cpp:347:13:347:13 | d | taint.cpp:347:12:347:13 | & ... |  |
 | taint.cpp:348:14:348:14 | ref arg e | taint.cpp:355:7:355:7 | e |  |
 | taint.cpp:348:17:348:17 | ref arg t | taint.cpp:350:7:350:7 | t |  |
+| taint.cpp:367:24:367:29 | source | taint.cpp:367:24:367:29 | source |  |
 | taint.cpp:367:24:367:29 | source | taint.cpp:371:13:371:18 | source |  |
 | taint.cpp:367:24:367:29 | source | taint.cpp:373:14:373:19 | source |  |
 | taint.cpp:371:6:371:11 | call to strdup | taint.cpp:371:2:371:19 | ... = ... |  |
@@ -6130,6 +6143,7 @@
 | taint.cpp:383:6:383:12 | call to strndup | taint.cpp:384:7:384:7 | a |  |
 | taint.cpp:383:14:383:27 | hello, world | taint.cpp:383:6:383:12 | call to strndup | TAINT |
 | taint.cpp:383:30:383:35 | source | taint.cpp:383:6:383:12 | call to strndup | TAINT |
+| taint.cpp:387:27:387:32 | source | taint.cpp:387:27:387:32 | source |  |
 | taint.cpp:387:27:387:32 | source | taint.cpp:391:13:391:18 | source |  |
 | taint.cpp:391:6:391:11 | call to wcsdup | taint.cpp:391:2:391:19 | ... = ... |  |
 | taint.cpp:391:6:391:11 | call to wcsdup | taint.cpp:393:7:393:7 | a |  |
@@ -6137,6 +6151,7 @@
 | taint.cpp:392:6:392:11 | call to wcsdup | taint.cpp:392:2:392:28 | ... = ... |  |
 | taint.cpp:392:6:392:11 | call to wcsdup | taint.cpp:394:7:394:7 | b |  |
 | taint.cpp:392:13:392:27 | hello, world | taint.cpp:392:6:392:11 | call to wcsdup | TAINT |
+| taint.cpp:397:25:397:30 | source | taint.cpp:397:25:397:30 | source |  |
 | taint.cpp:397:25:397:30 | source | taint.cpp:401:14:401:19 | source |  |
 | taint.cpp:397:25:397:30 | source | taint.cpp:403:15:403:20 | source |  |
 | taint.cpp:401:6:401:12 | call to strdupa | taint.cpp:401:2:401:20 | ... = ... |  |
@@ -6239,6 +6254,7 @@
 | taint.cpp:485:6:485:6 | 0 | taint.cpp:493:7:493:7 | y |  |
 | taint.cpp:490:7:490:7 | ref arg x | taint.cpp:492:7:492:7 | x |  |
 | taint.cpp:490:10:490:10 | ref arg y | taint.cpp:493:7:493:7 | y |  |
+| taint.cpp:502:26:502:32 | source1 | taint.cpp:502:26:502:32 | source1 |  |
 | taint.cpp:502:26:502:32 | source1 | taint.cpp:505:28:505:34 | source1 |  |
 | taint.cpp:503:15:503:21 | 0 | taint.cpp:505:12:505:15 | line |  |
 | taint.cpp:503:15:503:21 | 0 | taint.cpp:507:7:507:10 | line |  |
@@ -6248,29 +6264,39 @@
 | taint.cpp:505:12:505:15 | line | taint.cpp:505:11:505:15 | & ... |  |
 | taint.cpp:505:18:505:19 | ref arg & ... | taint.cpp:505:19:505:19 | n [inner post update] |  |
 | taint.cpp:505:19:505:19 | n | taint.cpp:505:18:505:19 | & ... |  |
+| taint.cpp:505:28:505:34 | ref arg source1 | taint.cpp:502:26:502:32 | source1 |  |
 | taint.cpp:505:28:505:34 | source1 | taint.cpp:505:11:505:15 | ref arg & ... | TAINT |
+| taint.cpp:514:24:514:29 | source | taint.cpp:514:24:514:29 | source |  |
 | taint.cpp:514:24:514:29 | source | taint.cpp:516:27:516:32 | source |  |
 | taint.cpp:515:22:515:29 | ,.-;:_ | taint.cpp:516:35:516:39 | delim |  |
 | taint.cpp:515:22:515:29 | ,.-;:_ | taint.cpp:518:7:518:11 | delim |  |
 | taint.cpp:516:20:516:25 | call to strtok | taint.cpp:517:7:517:15 | tokenized |  |
+| taint.cpp:516:27:516:32 | ref arg source | taint.cpp:514:24:514:29 | source |  |
 | taint.cpp:516:27:516:32 | source | taint.cpp:516:20:516:25 | call to strtok | TAINT |
+| taint.cpp:525:26:525:28 | ptr | taint.cpp:525:26:525:28 | ptr |  |
 | taint.cpp:525:26:525:28 | ptr | taint.cpp:526:10:526:12 | ptr |  |
 | taint.cpp:525:26:525:28 | ptr | taint.cpp:527:7:527:9 | ptr |  |
 | taint.cpp:525:26:525:28 | ptr | taint.cpp:528:8:528:10 | ptr |  |
 | taint.cpp:525:36:525:41 | source | taint.cpp:526:15:526:20 | source |  |
 | taint.cpp:526:10:526:12 | ptr | taint.cpp:526:2:526:8 | call to _strset |  |
+| taint.cpp:526:10:526:12 | ref arg ptr | taint.cpp:525:26:525:28 | ptr |  |
 | taint.cpp:526:10:526:12 | ref arg ptr | taint.cpp:527:7:527:9 | ptr |  |
 | taint.cpp:526:10:526:12 | ref arg ptr | taint.cpp:528:8:528:10 | ptr |  |
 | taint.cpp:526:15:526:20 | source | taint.cpp:526:2:526:8 | call to _strset | TAINT |
 | taint.cpp:526:15:526:20 | source | taint.cpp:526:10:526:12 | ref arg ptr |  |
+| taint.cpp:527:7:527:9 | ref arg ptr | taint.cpp:525:26:525:28 | ptr |  |
 | taint.cpp:527:7:527:9 | ref arg ptr | taint.cpp:528:8:528:10 | ptr |  |
 | taint.cpp:528:8:528:10 | ptr | taint.cpp:528:7:528:10 | * ... | TAINT |
+| taint.cpp:531:26:531:31 | source | taint.cpp:531:26:531:31 | source |  |
 | taint.cpp:531:26:531:31 | source | taint.cpp:532:10:532:15 | source |  |
 | taint.cpp:531:26:531:31 | source | taint.cpp:533:7:533:12 | source |  |
+| taint.cpp:532:10:532:15 | ref arg source | taint.cpp:531:26:531:31 | source |  |
 | taint.cpp:532:10:532:15 | ref arg source | taint.cpp:533:7:533:12 | source |  |
 | taint.cpp:532:10:532:15 | source | taint.cpp:532:2:532:8 | call to _strset |  |
 | taint.cpp:532:18:532:18 | 0 | taint.cpp:532:2:532:8 | call to _strset | TAINT |
 | taint.cpp:532:18:532:18 | 0 | taint.cpp:532:10:532:15 | ref arg source |  |
+| taint.cpp:533:7:533:12 | ref arg source | taint.cpp:531:26:531:31 | source |  |
+| taint.cpp:540:24:540:29 | source | taint.cpp:540:24:540:29 | source |  |
 | taint.cpp:540:24:540:29 | source | taint.cpp:542:14:542:19 | source |  |
 | taint.cpp:541:6:541:6 | x | taint.cpp:542:11:542:11 | x |  |
 | taint.cpp:541:6:541:6 | x | taint.cpp:543:7:543:7 | x |  |
@@ -6280,6 +6306,7 @@
 | taint.cpp:542:11:542:11 | x | taint.cpp:542:10:542:11 | & ... |  |
 | taint.cpp:542:14:542:19 | source | taint.cpp:542:2:542:8 | call to mempcpy | TAINT |
 | taint.cpp:542:14:542:19 | source | taint.cpp:542:10:542:11 | ref arg & ... | TAINT |
+| taint.cpp:550:24:550:29 | source | taint.cpp:550:24:550:29 | source |  |
 | taint.cpp:550:24:550:29 | source | taint.cpp:552:16:552:21 | source |  |
 | taint.cpp:551:6:551:9 | dest | taint.cpp:552:10:552:13 | dest |  |
 | taint.cpp:551:6:551:9 | dest | taint.cpp:552:35:552:38 | dest |  |
@@ -6288,29 +6315,42 @@
 | taint.cpp:552:10:552:13 | ref arg dest | taint.cpp:553:7:553:10 | dest |  |
 | taint.cpp:552:16:552:21 | source | taint.cpp:552:2:552:8 | call to memccpy | TAINT |
 | taint.cpp:552:16:552:21 | source | taint.cpp:552:10:552:13 | ref arg dest | TAINT |
+| taint.cpp:560:24:560:28 | dest1 | taint.cpp:560:24:560:28 | dest1 |  |
 | taint.cpp:560:24:560:28 | dest1 | taint.cpp:561:9:561:13 | dest1 |  |
 | taint.cpp:560:24:560:28 | dest1 | taint.cpp:562:7:562:11 | dest1 |  |
+| taint.cpp:560:37:560:41 | dest2 | taint.cpp:560:37:560:41 | dest2 |  |
 | taint.cpp:560:37:560:41 | dest2 | taint.cpp:564:9:564:13 | dest2 |  |
 | taint.cpp:560:37:560:41 | dest2 | taint.cpp:565:7:565:11 | dest2 |  |
+| taint.cpp:560:50:560:54 | clean | taint.cpp:560:50:560:54 | clean |  |
 | taint.cpp:560:50:560:54 | clean | taint.cpp:564:16:564:20 | clean |  |
+| taint.cpp:560:63:560:68 | source | taint.cpp:560:63:560:68 | source |  |
 | taint.cpp:560:63:560:68 | source | taint.cpp:561:16:561:21 | source |  |
 | taint.cpp:561:9:561:13 | dest1 | taint.cpp:561:2:561:7 | call to strcat |  |
 | taint.cpp:561:9:561:13 | dest1 | taint.cpp:561:9:561:13 | ref arg dest1 | TAINT |
+| taint.cpp:561:9:561:13 | ref arg dest1 | taint.cpp:560:24:560:28 | dest1 |  |
 | taint.cpp:561:9:561:13 | ref arg dest1 | taint.cpp:562:7:562:11 | dest1 |  |
 | taint.cpp:561:16:561:21 | source | taint.cpp:561:9:561:13 | ref arg dest1 | TAINT |
+| taint.cpp:562:7:562:11 | ref arg dest1 | taint.cpp:560:24:560:28 | dest1 |  |
 | taint.cpp:564:9:564:13 | dest2 | taint.cpp:564:2:564:7 | call to strcat |  |
 | taint.cpp:564:9:564:13 | dest2 | taint.cpp:564:9:564:13 | ref arg dest2 | TAINT |
+| taint.cpp:564:9:564:13 | ref arg dest2 | taint.cpp:560:37:560:41 | dest2 |  |
 | taint.cpp:564:9:564:13 | ref arg dest2 | taint.cpp:565:7:565:11 | dest2 |  |
 | taint.cpp:564:16:564:20 | clean | taint.cpp:564:9:564:13 | ref arg dest2 | TAINT |
+| taint.cpp:565:7:565:11 | ref arg dest2 | taint.cpp:560:37:560:41 | dest2 |  |
+| taint.cpp:572:37:572:41 | dest1 | taint.cpp:572:37:572:41 | dest1 |  |
 | taint.cpp:572:37:572:41 | dest1 | taint.cpp:574:36:574:40 | dest1 |  |
 | taint.cpp:572:37:572:41 | dest1 | taint.cpp:575:7:575:11 | dest1 |  |
 | taint.cpp:572:37:572:41 | dest1 | taint.cpp:576:8:576:12 | dest1 |  |
+| taint.cpp:572:65:572:67 | ptr | taint.cpp:572:65:572:67 | ptr |  |
 | taint.cpp:572:65:572:67 | ptr | taint.cpp:574:43:574:45 | ptr |  |
 | taint.cpp:572:65:572:67 | ptr | taint.cpp:580:43:580:45 | ptr |  |
+| taint.cpp:572:85:572:89 | dest3 | taint.cpp:572:85:572:89 | dest3 |  |
 | taint.cpp:572:85:572:89 | dest3 | taint.cpp:580:36:580:40 | dest3 |  |
 | taint.cpp:572:85:572:89 | dest3 | taint.cpp:581:7:581:11 | dest3 |  |
 | taint.cpp:572:85:572:89 | dest3 | taint.cpp:582:8:582:12 | dest3 |  |
+| taint.cpp:573:32:573:36 | clean | taint.cpp:573:32:573:36 | clean |  |
 | taint.cpp:573:32:573:36 | clean | taint.cpp:580:51:580:55 | clean |  |
+| taint.cpp:573:49:573:54 | source | taint.cpp:573:49:573:54 | source |  |
 | taint.cpp:573:49:573:54 | source | taint.cpp:574:51:574:56 | source |  |
 | taint.cpp:573:61:573:61 | n | taint.cpp:574:48:574:48 | n |  |
 | taint.cpp:573:61:573:61 | n | taint.cpp:580:48:580:48 | n |  |
@@ -6318,11 +6358,14 @@
 | taint.cpp:574:25:574:34 | call to _mbsncat_l | taint.cpp:578:8:578:12 | dest2 |  |
 | taint.cpp:574:36:574:40 | dest1 | taint.cpp:574:25:574:34 | call to _mbsncat_l |  |
 | taint.cpp:574:36:574:40 | dest1 | taint.cpp:574:36:574:40 | ref arg dest1 | TAINT |
+| taint.cpp:574:36:574:40 | ref arg dest1 | taint.cpp:572:37:572:41 | dest1 |  |
 | taint.cpp:574:36:574:40 | ref arg dest1 | taint.cpp:575:7:575:11 | dest1 |  |
 | taint.cpp:574:36:574:40 | ref arg dest1 | taint.cpp:576:8:576:12 | dest1 |  |
 | taint.cpp:574:43:574:45 | ptr | taint.cpp:574:36:574:40 | ref arg dest1 | TAINT |
 | taint.cpp:574:48:574:48 | n | taint.cpp:574:36:574:40 | ref arg dest1 | TAINT |
+| taint.cpp:574:51:574:56 | ref arg source | taint.cpp:573:49:573:54 | source |  |
 | taint.cpp:574:51:574:56 | source | taint.cpp:574:36:574:40 | ref arg dest1 | TAINT |
+| taint.cpp:575:7:575:11 | ref arg dest1 | taint.cpp:572:37:572:41 | dest1 |  |
 | taint.cpp:575:7:575:11 | ref arg dest1 | taint.cpp:576:8:576:12 | dest1 |  |
 | taint.cpp:576:8:576:12 | dest1 | taint.cpp:576:7:576:12 | * ... | TAINT |
 | taint.cpp:577:7:577:11 | ref arg dest2 | taint.cpp:578:8:578:12 | dest2 |  |
@@ -6331,15 +6374,19 @@
 | taint.cpp:580:25:580:34 | call to _mbsncat_l | taint.cpp:584:8:584:12 | dest4 |  |
 | taint.cpp:580:36:580:40 | dest3 | taint.cpp:580:25:580:34 | call to _mbsncat_l |  |
 | taint.cpp:580:36:580:40 | dest3 | taint.cpp:580:36:580:40 | ref arg dest3 | TAINT |
+| taint.cpp:580:36:580:40 | ref arg dest3 | taint.cpp:572:85:572:89 | dest3 |  |
 | taint.cpp:580:36:580:40 | ref arg dest3 | taint.cpp:581:7:581:11 | dest3 |  |
 | taint.cpp:580:36:580:40 | ref arg dest3 | taint.cpp:582:8:582:12 | dest3 |  |
 | taint.cpp:580:43:580:45 | ptr | taint.cpp:580:36:580:40 | ref arg dest3 | TAINT |
 | taint.cpp:580:48:580:48 | n | taint.cpp:580:36:580:40 | ref arg dest3 | TAINT |
 | taint.cpp:580:51:580:55 | clean | taint.cpp:580:36:580:40 | ref arg dest3 | TAINT |
+| taint.cpp:580:51:580:55 | ref arg clean | taint.cpp:573:32:573:36 | clean |  |
+| taint.cpp:581:7:581:11 | ref arg dest3 | taint.cpp:572:85:572:89 | dest3 |  |
 | taint.cpp:581:7:581:11 | ref arg dest3 | taint.cpp:582:8:582:12 | dest3 |  |
 | taint.cpp:582:8:582:12 | dest3 | taint.cpp:582:7:582:12 | * ... | TAINT |
 | taint.cpp:583:7:583:11 | ref arg dest4 | taint.cpp:584:8:584:12 | dest4 |  |
 | taint.cpp:584:8:584:12 | dest4 | taint.cpp:584:7:584:12 | * ... | TAINT |
+| taint.cpp:591:24:591:29 | source | taint.cpp:591:24:591:29 | source |  |
 | taint.cpp:591:24:591:29 | source | taint.cpp:594:29:594:34 | source |  |
 | taint.cpp:592:23:592:30 | ,.-;:_ | taint.cpp:594:37:594:41 | delim |  |
 | taint.cpp:594:9:594:17 | tokenized | taint.cpp:594:9:594:42 | ... = ... |  |
@@ -6347,6 +6394,7 @@
 | taint.cpp:594:21:594:26 | call to strsep | taint.cpp:595:10:595:18 | tokenized |  |
 | taint.cpp:594:21:594:26 | call to strsep | taint.cpp:596:11:596:19 | tokenized |  |
 | taint.cpp:594:28:594:34 | & ... | taint.cpp:594:21:594:26 | call to strsep | TAINT |
+| taint.cpp:594:28:594:34 | ref arg & ... | taint.cpp:591:24:591:29 | source |  |
 | taint.cpp:594:28:594:34 | ref arg & ... | taint.cpp:594:29:594:34 | source |  |
 | taint.cpp:594:28:594:34 | ref arg & ... | taint.cpp:594:29:594:34 | source [inner post update] |  |
 | taint.cpp:594:29:594:34 | source | taint.cpp:594:21:594:26 | call to strsep | TAINT |
@@ -6354,45 +6402,63 @@
 | taint.cpp:594:37:594:41 | delim | taint.cpp:594:21:594:26 | call to strsep | TAINT |
 | taint.cpp:595:10:595:18 | ref arg tokenized | taint.cpp:596:11:596:19 | tokenized |  |
 | taint.cpp:596:11:596:19 | tokenized | taint.cpp:596:10:596:19 | * ... | TAINT |
+| taint.cpp:606:25:606:30 | source | taint.cpp:606:25:606:30 | source |  |
 | taint.cpp:606:25:606:30 | source | taint.cpp:607:18:607:23 | source |  |
+| taint.cpp:606:39:606:43 | clean | taint.cpp:606:39:606:43 | clean |  |
 | taint.cpp:606:39:606:43 | clean | taint.cpp:611:18:611:22 | clean |  |
+| taint.cpp:606:82:606:87 | locale | taint.cpp:606:82:606:87 | locale |  |
 | taint.cpp:606:82:606:87 | locale | taint.cpp:607:26:607:31 | locale |  |
 | taint.cpp:606:82:606:87 | locale | taint.cpp:611:25:611:30 | locale |  |
+| taint.cpp:607:10:607:16 | call to _strinc | taint.cpp:606:52:606:56 | dest1 |  |
 | taint.cpp:607:10:607:16 | call to _strinc | taint.cpp:607:2:607:32 | ... = ... |  |
 | taint.cpp:607:10:607:16 | call to _strinc | taint.cpp:608:7:608:11 | dest1 |  |
 | taint.cpp:607:10:607:16 | call to _strinc | taint.cpp:609:8:609:12 | dest1 |  |
 | taint.cpp:607:18:607:23 | source | taint.cpp:607:10:607:16 | call to _strinc | TAINT |
 | taint.cpp:607:26:607:31 | locale | taint.cpp:607:10:607:16 | call to _strinc | TAINT |
+| taint.cpp:607:26:607:31 | ref arg locale | taint.cpp:606:82:606:87 | locale |  |
 | taint.cpp:607:26:607:31 | ref arg locale | taint.cpp:611:25:611:30 | locale |  |
+| taint.cpp:608:7:608:11 | ref arg dest1 | taint.cpp:606:52:606:56 | dest1 |  |
 | taint.cpp:608:7:608:11 | ref arg dest1 | taint.cpp:609:8:609:12 | dest1 |  |
 | taint.cpp:609:8:609:12 | dest1 | taint.cpp:609:7:609:12 | * ... | TAINT |
+| taint.cpp:611:10:611:16 | call to _strinc | taint.cpp:606:65:606:69 | dest2 |  |
 | taint.cpp:611:10:611:16 | call to _strinc | taint.cpp:611:2:611:31 | ... = ... |  |
 | taint.cpp:611:10:611:16 | call to _strinc | taint.cpp:612:7:612:11 | dest2 |  |
 | taint.cpp:611:10:611:16 | call to _strinc | taint.cpp:613:8:613:12 | dest2 |  |
 | taint.cpp:611:18:611:22 | clean | taint.cpp:611:10:611:16 | call to _strinc | TAINT |
 | taint.cpp:611:25:611:30 | locale | taint.cpp:611:10:611:16 | call to _strinc | TAINT |
+| taint.cpp:611:25:611:30 | ref arg locale | taint.cpp:606:82:606:87 | locale |  |
+| taint.cpp:612:7:612:11 | ref arg dest2 | taint.cpp:606:65:606:69 | dest2 |  |
 | taint.cpp:612:7:612:11 | ref arg dest2 | taint.cpp:613:8:613:12 | dest2 |  |
 | taint.cpp:613:8:613:12 | dest2 | taint.cpp:613:7:613:12 | * ... | TAINT |
+| taint.cpp:616:34:616:48 | source_unsigned | taint.cpp:616:34:616:48 | source_unsigned |  |
 | taint.cpp:616:34:616:48 | source_unsigned | taint.cpp:617:26:617:40 | source_unsigned |  |
+| taint.cpp:616:57:616:62 | source | taint.cpp:616:57:616:62 | source |  |
 | taint.cpp:616:57:616:62 | source | taint.cpp:621:40:621:45 | source |  |
+| taint.cpp:617:18:617:24 | call to _mbsinc | taint.cpp:616:80:616:92 | dest_unsigned |  |
 | taint.cpp:617:18:617:24 | call to _mbsinc | taint.cpp:617:2:617:41 | ... = ... |  |
 | taint.cpp:617:18:617:24 | call to _mbsinc | taint.cpp:618:7:618:19 | dest_unsigned |  |
 | taint.cpp:617:18:617:24 | call to _mbsinc | taint.cpp:619:8:619:20 | dest_unsigned |  |
 | taint.cpp:617:26:617:40 | source_unsigned | taint.cpp:617:18:617:24 | call to _mbsinc | TAINT |
+| taint.cpp:618:7:618:19 | ref arg dest_unsigned | taint.cpp:616:80:616:92 | dest_unsigned |  |
 | taint.cpp:618:7:618:19 | ref arg dest_unsigned | taint.cpp:619:8:619:20 | dest_unsigned |  |
 | taint.cpp:619:8:619:20 | dest_unsigned | taint.cpp:619:7:619:20 | * ... | TAINT |
+| taint.cpp:621:16:621:22 | call to _mbsinc | taint.cpp:616:101:616:104 | dest |  |
 | taint.cpp:621:16:621:22 | call to _mbsinc | taint.cpp:621:2:621:46 | ... = ... |  |
 | taint.cpp:621:16:621:22 | call to _mbsinc | taint.cpp:622:7:622:10 | dest |  |
 | taint.cpp:621:16:621:22 | call to _mbsinc | taint.cpp:623:8:623:11 | dest |  |
 | taint.cpp:621:40:621:45 | source | taint.cpp:621:16:621:22 | call to _mbsinc | TAINT |
+| taint.cpp:622:7:622:10 | ref arg dest | taint.cpp:616:101:616:104 | dest |  |
 | taint.cpp:622:7:622:10 | ref arg dest | taint.cpp:623:8:623:11 | dest |  |
 | taint.cpp:623:8:623:11 | dest | taint.cpp:623:7:623:11 | * ... | TAINT |
+| taint.cpp:626:40:626:45 | source | taint.cpp:626:40:626:45 | source |  |
 | taint.cpp:626:40:626:45 | source | taint.cpp:627:18:627:23 | source |  |
 | taint.cpp:626:40:626:45 | source | taint.cpp:627:31:627:36 | source |  |
 | taint.cpp:626:40:626:45 | source | taint.cpp:633:25:633:30 | source |  |
 | taint.cpp:626:40:626:45 | source | taint.cpp:638:18:638:23 | source |  |
+| taint.cpp:626:63:626:67 | clean | taint.cpp:626:63:626:67 | clean |  |
 | taint.cpp:626:63:626:67 | clean | taint.cpp:633:18:633:22 | clean |  |
 | taint.cpp:626:63:626:67 | clean | taint.cpp:638:26:638:30 | clean |  |
+| taint.cpp:627:10:627:16 | call to _strdec | taint.cpp:626:85:626:89 | dest1 |  |
 | taint.cpp:627:10:627:16 | call to _strdec | taint.cpp:627:2:627:37 | ... = ... |  |
 | taint.cpp:627:10:627:16 | call to _strdec | taint.cpp:628:7:628:11 | dest1 |  |
 | taint.cpp:627:10:627:16 | call to _strdec | taint.cpp:629:8:629:12 | dest1 |  |
@@ -6400,20 +6466,25 @@
 | taint.cpp:627:18:627:28 | ... + ... | taint.cpp:627:10:627:16 | call to _strdec | TAINT |
 | taint.cpp:627:27:627:28 | 12 | taint.cpp:627:18:627:28 | ... + ... | TAINT |
 | taint.cpp:627:31:627:36 | source | taint.cpp:627:10:627:16 | call to _strdec | TAINT |
+| taint.cpp:628:7:628:11 | ref arg dest1 | taint.cpp:626:85:626:89 | dest1 |  |
 | taint.cpp:628:7:628:11 | ref arg dest1 | taint.cpp:629:8:629:12 | dest1 |  |
 | taint.cpp:629:8:629:12 | dest1 | taint.cpp:629:7:629:12 | * ... | TAINT |
+| taint.cpp:633:10:633:16 | call to _strdec | taint.cpp:626:107:626:111 | dest2 |  |
 | taint.cpp:633:10:633:16 | call to _strdec | taint.cpp:633:2:633:31 | ... = ... |  |
 | taint.cpp:633:10:633:16 | call to _strdec | taint.cpp:634:7:634:11 | dest2 |  |
 | taint.cpp:633:10:633:16 | call to _strdec | taint.cpp:635:8:635:12 | dest2 |  |
 | taint.cpp:633:18:633:22 | clean | taint.cpp:633:10:633:16 | call to _strdec | TAINT |
 | taint.cpp:633:25:633:30 | source | taint.cpp:633:10:633:16 | call to _strdec | TAINT |
+| taint.cpp:634:7:634:11 | ref arg dest2 | taint.cpp:626:107:626:111 | dest2 |  |
 | taint.cpp:634:7:634:11 | ref arg dest2 | taint.cpp:635:8:635:12 | dest2 |  |
 | taint.cpp:635:8:635:12 | dest2 | taint.cpp:635:7:635:12 | * ... | TAINT |
+| taint.cpp:638:10:638:16 | call to _strdec | taint.cpp:626:129:626:133 | dest3 |  |
 | taint.cpp:638:10:638:16 | call to _strdec | taint.cpp:638:2:638:31 | ... = ... |  |
 | taint.cpp:638:10:638:16 | call to _strdec | taint.cpp:639:7:639:11 | dest3 |  |
 | taint.cpp:638:10:638:16 | call to _strdec | taint.cpp:640:8:640:12 | dest3 |  |
 | taint.cpp:638:18:638:23 | source | taint.cpp:638:10:638:16 | call to _strdec | TAINT |
 | taint.cpp:638:26:638:30 | clean | taint.cpp:638:10:638:16 | call to _strdec | TAINT |
+| taint.cpp:639:7:639:11 | ref arg dest3 | taint.cpp:626:129:626:133 | dest3 |  |
 | taint.cpp:639:7:639:11 | ref arg dest3 | taint.cpp:640:8:640:12 | dest3 |  |
 | taint.cpp:640:8:640:12 | dest3 | taint.cpp:640:7:640:12 | * ... | TAINT |
 | taint.cpp:647:33:647:38 | source | taint.cpp:650:17:650:22 | source |  |
@@ -6427,19 +6498,23 @@
 | taint.cpp:653:6:653:14 | call to _strnextc | taint.cpp:654:7:654:7 | c |  |
 | taint.cpp:653:16:653:17 |  | taint.cpp:653:6:653:14 | call to _strnextc | TAINT |
 | taint.cpp:662:9:662:12 | this | taint.cpp:662:25:662:29 | this |  |
+| taint.cpp:665:33:665:38 | source | taint.cpp:665:33:665:38 | source |  |
 | taint.cpp:665:33:665:38 | source | taint.cpp:667:20:667:25 | source |  |
 | taint.cpp:666:30:666:30 | c | taint.cpp:667:10:667:10 | c |  |
 | taint.cpp:666:30:666:30 | c | taint.cpp:668:8:668:8 | c |  |
 | taint.cpp:667:10:667:10 | ref arg c | taint.cpp:668:8:668:8 | c |  |
 | taint.cpp:667:12:667:15 | call to data | taint.cpp:667:3:667:8 | call to memcpy |  |
+| taint.cpp:667:20:667:25 | ref arg source | taint.cpp:665:33:665:38 | source |  |
 | taint.cpp:667:20:667:25 | source | taint.cpp:667:3:667:8 | call to memcpy | TAINT |
 | taint.cpp:667:20:667:25 | source | taint.cpp:667:12:667:15 | ref arg call to data | TAINT |
 | taint.cpp:674:9:674:12 | this | taint.cpp:674:31:674:35 | this |  |
+| taint.cpp:677:35:677:40 | source | taint.cpp:677:35:677:40 | source |  |
 | taint.cpp:677:35:677:40 | source | taint.cpp:679:20:679:25 | source |  |
 | taint.cpp:678:27:678:27 | c | taint.cpp:679:10:679:10 | c |  |
 | taint.cpp:678:27:678:27 | c | taint.cpp:680:8:680:8 | c |  |
 | taint.cpp:679:10:679:10 | ref arg c | taint.cpp:680:8:680:8 | c |  |
 | taint.cpp:679:12:679:15 | call to data | taint.cpp:679:3:679:8 | call to memcpy |  |
+| taint.cpp:679:20:679:25 | ref arg source | taint.cpp:677:35:677:40 | source |  |
 | taint.cpp:679:20:679:25 | source | taint.cpp:679:3:679:8 | call to memcpy | TAINT |
 | taint.cpp:679:20:679:25 | source | taint.cpp:679:12:679:15 | ref arg call to data | TAINT |
 | taint.cpp:690:14:690:14 | s | taint.cpp:691:18:691:18 | s |  |
@@ -7782,6 +7857,7 @@
 | vector.cpp:413:11:413:16 | call to source | vector.cpp:413:2:413:2 | call to operator* [post update] | TAINT |
 | vector.cpp:413:11:413:16 | call to source | vector.cpp:413:2:413:18 | ... = ... |  |
 | vector.cpp:414:7:414:9 | ref arg v14 | vector.cpp:415:1:415:1 | v14 |  |
+| vector.cpp:417:33:417:45 | source_string | vector.cpp:417:33:417:45 | source_string |  |
 | vector.cpp:417:33:417:45 | source_string | vector.cpp:421:23:421:35 | source_string |  |
 | vector.cpp:417:33:417:45 | source_string | vector.cpp:428:23:428:35 | source_string |  |
 | vector.cpp:417:33:417:45 | source_string | vector.cpp:442:23:442:35 | source_string |  |

--- a/cpp/ql/test/library-tests/types/__wchar_t/wchar_t.expected
+++ b/cpp/ql/test/library-tests/types/__wchar_t/wchar_t.expected
@@ -1,3 +1,3 @@
-| file://:0:0:0:0 | __wchar_t * | PointerType | Wchar_t, WideCharType |
+| file://:0:0:0:0 | __wchar_t * | IteratorByPointer, PointerType | Wchar_t, WideCharType |
 | file://:0:0:0:0 | const __wchar_t | SpecifiedType | Wchar_t, WideCharType |
 | file://:0:0:0:0 | wchar_t | Wchar_t, WideCharType |  |

--- a/cpp/ql/test/library-tests/types/wchar_t_typedef/wchar_t.expected
+++ b/cpp/ql/test/library-tests/types/wchar_t_typedef/wchar_t.expected
@@ -1,3 +1,3 @@
 | file://:0:0:0:0 | wchar_t | Wchar_t, WideCharType |  |
-| file://:0:0:0:0 | wchar_t * | PointerType | CTypedefType, Wchar_t |
+| file://:0:0:0:0 | wchar_t * | IteratorByPointer, PointerType | CTypedefType, Wchar_t |
 | ms.c:2:24:2:30 | wchar_t | CTypedefType, Wchar_t |  |

--- a/cpp/ql/test/library-tests/variables/variables/types.expected
+++ b/cpp/ql/test/library-tests/variables/variables/types.expected
@@ -30,7 +30,7 @@
 | char8_t | Char8Type |  |  |  |  |
 | char16_t | Char16Type |  |  |  |  |
 | char32_t | Char32Type |  |  |  |  |
-| char * | CharPointerType |  | char |  |  |
+| char * | CharPointerType, IteratorByPointer |  | char |  |  |
 | char *[3] | ArrayType | char * | char * |  |  |
 | char *[32] | ArrayType | char * | char * |  |  |
 | char *[] | ArrayType | char * | char * |  |  |
@@ -48,7 +48,7 @@
 | const address | SpecifiedType |  | address |  |  |
 | const address & | LValueReferenceType |  | const address |  |  |
 | const char | SpecifiedType |  | char |  |  |
-| const char * | PointerType |  | const char |  |  |
+| const char * | IteratorByPointer, PointerType |  | const char |  |  |
 | const char *[3] | ArrayType | const char * | const char * |  |  |
 | const char *[] | ArrayType | const char * | const char * |  |  |
 | const char[5] | ArrayType | const char | const char |  |  |
@@ -65,7 +65,7 @@
 | float | FloatType |  |  |  |  |
 | float[3] | ArrayType | float | float |  |  |
 | int | IntType, MicrosoftInt32Type |  |  |  |  |
-| int * | IntPointerType |  | int |  |  |
+| int * | IntPointerType, IteratorByPointer |  | int |  |  |
 | int[4] | ArrayType | int | int |  |  |
 | int[8] | ArrayType | int | int |  |  |
 | int[10] | ArrayType | int | int |  |  |
@@ -90,5 +90,5 @@
 | unsigned long long | LongLongType |  |  |  | unsigned integral |
 | unsigned short | ShortType |  |  |  | unsigned integral |
 | void | VoidType |  |  |  |  |
-| void * | VoidPointerType |  | void |  |  |
+| void * | IteratorByPointer, VoidPointerType |  | void |  |  |
 | wchar_t | Wchar_t, WideCharType |  |  |  |  |

--- a/cpp/ql/test/query-tests/Likely Bugs/Conversion/CastArrayPointerArithmetic/CastArrayPointerArithmetic.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Conversion/CastArrayPointerArithmetic/CastArrayPointerArithmetic.expected
@@ -1,47 +1,137 @@
 edges
+| test.cpp:26:29:26:29 | b | test.cpp:26:29:26:29 | b |
 | test.cpp:26:29:26:29 | b | test.cpp:27:2:27:2 | b |
 | test.cpp:30:34:30:34 | b | test.cpp:31:2:31:2 | b |
+| test.cpp:34:31:34:31 | b | test.cpp:34:31:34:31 | b |
 | test.cpp:34:31:34:31 | b | test.cpp:35:2:35:2 | b |
+| test.cpp:38:35:38:35 | d | test.cpp:38:35:38:35 | d |
+| test.cpp:38:35:38:35 | d | test.cpp:39:2:39:2 | d |
+| test.cpp:42:40:42:40 | d | test.cpp:43:2:43:2 | d |
+| test.cpp:46:37:46:37 | d | test.cpp:46:37:46:37 | d |
+| test.cpp:46:37:46:37 | d | test.cpp:47:2:47:2 | d |
 | test.cpp:50:31:50:31 | b | test.cpp:51:11:51:11 | b |
 | test.cpp:57:19:57:19 | d | test.cpp:26:29:26:29 | b |
+| test.cpp:57:19:57:19 | d | test.cpp:57:19:57:19 | ref arg d |
+| test.cpp:57:19:57:19 | ref arg d | test.cpp:58:25:58:25 | d |
+| test.cpp:57:19:57:19 | ref arg d | test.cpp:59:21:59:21 | d |
+| test.cpp:57:19:57:19 | ref arg d | test.cpp:61:22:61:22 | d |
+| test.cpp:57:19:57:19 | ref arg d | test.cpp:62:28:62:28 | d |
+| test.cpp:57:19:57:19 | ref arg d | test.cpp:63:24:63:24 | d |
+| test.cpp:57:19:57:19 | ref arg d | test.cpp:95:21:95:21 | d |
 | test.cpp:58:25:58:25 | d | test.cpp:30:34:30:34 | b |
 | test.cpp:59:21:59:21 | d | test.cpp:34:31:34:31 | b |
+| test.cpp:59:21:59:21 | d | test.cpp:59:21:59:21 | ref arg d |
+| test.cpp:59:21:59:21 | ref arg d | test.cpp:61:22:61:22 | d |
+| test.cpp:59:21:59:21 | ref arg d | test.cpp:62:28:62:28 | d |
+| test.cpp:59:21:59:21 | ref arg d | test.cpp:63:24:63:24 | d |
+| test.cpp:59:21:59:21 | ref arg d | test.cpp:95:21:95:21 | d |
+| test.cpp:61:22:61:22 | d | test.cpp:38:35:38:35 | d |
+| test.cpp:61:22:61:22 | d | test.cpp:61:22:61:22 | ref arg d |
+| test.cpp:61:22:61:22 | ref arg d | test.cpp:62:28:62:28 | d |
+| test.cpp:61:22:61:22 | ref arg d | test.cpp:63:24:63:24 | d |
+| test.cpp:61:22:61:22 | ref arg d | test.cpp:95:21:95:21 | d |
+| test.cpp:62:28:62:28 | d | test.cpp:42:40:42:40 | d |
+| test.cpp:63:24:63:24 | d | test.cpp:46:37:46:37 | d |
+| test.cpp:63:24:63:24 | d | test.cpp:63:24:63:24 | ref arg d |
+| test.cpp:63:24:63:24 | ref arg d | test.cpp:95:21:95:21 | d |
 | test.cpp:74:19:74:21 | dss | test.cpp:26:29:26:29 | b |
+| test.cpp:74:19:74:21 | dss | test.cpp:74:19:74:21 | ref arg dss |
+| test.cpp:74:19:74:21 | ref arg dss | test.cpp:75:25:75:27 | dss |
+| test.cpp:74:19:74:21 | ref arg dss | test.cpp:76:21:76:23 | dss |
+| test.cpp:74:19:74:21 | ref arg dss | test.cpp:96:21:96:23 | dss |
 | test.cpp:75:25:75:27 | dss | test.cpp:30:34:30:34 | b |
 | test.cpp:76:21:76:23 | dss | test.cpp:34:31:34:31 | b |
+| test.cpp:76:21:76:23 | dss | test.cpp:76:21:76:23 | ref arg dss |
+| test.cpp:76:21:76:23 | ref arg dss | test.cpp:96:21:96:23 | dss |
 | test.cpp:86:19:86:20 | d2 | test.cpp:26:29:26:29 | b |
+| test.cpp:86:19:86:20 | d2 | test.cpp:86:19:86:20 | ref arg d2 |
+| test.cpp:86:19:86:20 | ref arg d2 | test.cpp:87:25:87:26 | d2 |
+| test.cpp:86:19:86:20 | ref arg d2 | test.cpp:88:21:88:22 | d2 |
+| test.cpp:86:19:86:20 | ref arg d2 | test.cpp:90:22:90:23 | d2 |
+| test.cpp:86:19:86:20 | ref arg d2 | test.cpp:91:28:91:29 | d2 |
+| test.cpp:86:19:86:20 | ref arg d2 | test.cpp:92:24:92:25 | d2 |
 | test.cpp:87:25:87:26 | d2 | test.cpp:30:34:30:34 | b |
 | test.cpp:88:21:88:22 | d2 | test.cpp:34:31:34:31 | b |
+| test.cpp:88:21:88:22 | d2 | test.cpp:88:21:88:22 | ref arg d2 |
+| test.cpp:88:21:88:22 | ref arg d2 | test.cpp:90:22:90:23 | d2 |
+| test.cpp:88:21:88:22 | ref arg d2 | test.cpp:91:28:91:29 | d2 |
+| test.cpp:88:21:88:22 | ref arg d2 | test.cpp:92:24:92:25 | d2 |
+| test.cpp:90:22:90:23 | d2 | test.cpp:38:35:38:35 | d |
+| test.cpp:90:22:90:23 | d2 | test.cpp:90:22:90:23 | ref arg d2 |
+| test.cpp:90:22:90:23 | ref arg d2 | test.cpp:91:28:91:29 | d2 |
+| test.cpp:90:22:90:23 | ref arg d2 | test.cpp:92:24:92:25 | d2 |
+| test.cpp:91:28:91:29 | d2 | test.cpp:42:40:42:40 | d |
+| test.cpp:92:24:92:25 | d2 | test.cpp:46:37:46:37 | d |
 | test.cpp:95:21:95:21 | d | test.cpp:50:31:50:31 | b |
 | test.cpp:96:21:96:23 | dss | test.cpp:50:31:50:31 | b |
 nodes
+| test.cpp:26:29:26:29 | b | semmle.label | b |
 | test.cpp:26:29:26:29 | b | semmle.label | b |
 | test.cpp:27:2:27:2 | b | semmle.label | b |
 | test.cpp:30:34:30:34 | b | semmle.label | b |
 | test.cpp:31:2:31:2 | b | semmle.label | b |
 | test.cpp:34:31:34:31 | b | semmle.label | b |
+| test.cpp:34:31:34:31 | b | semmle.label | b |
 | test.cpp:35:2:35:2 | b | semmle.label | b |
+| test.cpp:38:35:38:35 | d | semmle.label | d |
+| test.cpp:38:35:38:35 | d | semmle.label | d |
+| test.cpp:39:2:39:2 | d | semmle.label | d |
+| test.cpp:42:40:42:40 | d | semmle.label | d |
+| test.cpp:43:2:43:2 | d | semmle.label | d |
+| test.cpp:46:37:46:37 | d | semmle.label | d |
+| test.cpp:46:37:46:37 | d | semmle.label | d |
+| test.cpp:47:2:47:2 | d | semmle.label | d |
 | test.cpp:50:31:50:31 | b | semmle.label | b |
 | test.cpp:51:11:51:11 | b | semmle.label | b |
 | test.cpp:57:19:57:19 | d | semmle.label | d |
+| test.cpp:57:19:57:19 | ref arg d | semmle.label | ref arg d |
 | test.cpp:58:25:58:25 | d | semmle.label | d |
 | test.cpp:59:21:59:21 | d | semmle.label | d |
+| test.cpp:59:21:59:21 | ref arg d | semmle.label | ref arg d |
+| test.cpp:61:22:61:22 | d | semmle.label | d |
+| test.cpp:61:22:61:22 | ref arg d | semmle.label | ref arg d |
+| test.cpp:62:28:62:28 | d | semmle.label | d |
+| test.cpp:63:24:63:24 | d | semmle.label | d |
+| test.cpp:63:24:63:24 | ref arg d | semmle.label | ref arg d |
 | test.cpp:74:19:74:21 | dss | semmle.label | dss |
+| test.cpp:74:19:74:21 | ref arg dss | semmle.label | ref arg dss |
 | test.cpp:75:25:75:27 | dss | semmle.label | dss |
 | test.cpp:76:21:76:23 | dss | semmle.label | dss |
+| test.cpp:76:21:76:23 | ref arg dss | semmle.label | ref arg dss |
 | test.cpp:86:19:86:20 | d2 | semmle.label | d2 |
+| test.cpp:86:19:86:20 | ref arg d2 | semmle.label | ref arg d2 |
 | test.cpp:87:25:87:26 | d2 | semmle.label | d2 |
 | test.cpp:88:21:88:22 | d2 | semmle.label | d2 |
+| test.cpp:88:21:88:22 | ref arg d2 | semmle.label | ref arg d2 |
+| test.cpp:90:22:90:23 | d2 | semmle.label | d2 |
+| test.cpp:90:22:90:23 | ref arg d2 | semmle.label | ref arg d2 |
+| test.cpp:91:28:91:29 | d2 | semmle.label | d2 |
+| test.cpp:92:24:92:25 | d2 | semmle.label | d2 |
 | test.cpp:95:21:95:21 | d | semmle.label | d |
 | test.cpp:96:21:96:23 | dss | semmle.label | dss |
 subpaths
+| test.cpp:57:19:57:19 | d | test.cpp:26:29:26:29 | b | test.cpp:26:29:26:29 | b | test.cpp:57:19:57:19 | ref arg d |
+| test.cpp:59:21:59:21 | d | test.cpp:34:31:34:31 | b | test.cpp:34:31:34:31 | b | test.cpp:59:21:59:21 | ref arg d |
+| test.cpp:61:22:61:22 | d | test.cpp:38:35:38:35 | d | test.cpp:38:35:38:35 | d | test.cpp:61:22:61:22 | ref arg d |
+| test.cpp:63:24:63:24 | d | test.cpp:46:37:46:37 | d | test.cpp:46:37:46:37 | d | test.cpp:63:24:63:24 | ref arg d |
+| test.cpp:74:19:74:21 | dss | test.cpp:26:29:26:29 | b | test.cpp:26:29:26:29 | b | test.cpp:74:19:74:21 | ref arg dss |
+| test.cpp:76:21:76:23 | dss | test.cpp:34:31:34:31 | b | test.cpp:34:31:34:31 | b | test.cpp:76:21:76:23 | ref arg dss |
+| test.cpp:86:19:86:20 | d2 | test.cpp:26:29:26:29 | b | test.cpp:26:29:26:29 | b | test.cpp:86:19:86:20 | ref arg d2 |
+| test.cpp:88:21:88:22 | d2 | test.cpp:34:31:34:31 | b | test.cpp:34:31:34:31 | b | test.cpp:88:21:88:22 | ref arg d2 |
+| test.cpp:90:22:90:23 | d2 | test.cpp:38:35:38:35 | d | test.cpp:38:35:38:35 | d | test.cpp:90:22:90:23 | ref arg d2 |
 #select
 | test.cpp:27:2:27:2 | b | test.cpp:57:19:57:19 | d | test.cpp:27:2:27:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:57:19:57:19 | d | here |
 | test.cpp:27:2:27:2 | b | test.cpp:74:19:74:21 | dss | test.cpp:27:2:27:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:74:19:74:21 | dss | here |
 | test.cpp:27:2:27:2 | b | test.cpp:86:19:86:20 | d2 | test.cpp:27:2:27:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:86:19:86:20 | d2 | here |
+| test.cpp:31:2:31:2 | b | test.cpp:57:19:57:19 | d | test.cpp:31:2:31:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:57:19:57:19 | d | here |
 | test.cpp:31:2:31:2 | b | test.cpp:58:25:58:25 | d | test.cpp:31:2:31:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:58:25:58:25 | d | here |
+| test.cpp:31:2:31:2 | b | test.cpp:74:19:74:21 | dss | test.cpp:31:2:31:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:74:19:74:21 | dss | here |
 | test.cpp:31:2:31:2 | b | test.cpp:75:25:75:27 | dss | test.cpp:31:2:31:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:75:25:75:27 | dss | here |
+| test.cpp:31:2:31:2 | b | test.cpp:86:19:86:20 | d2 | test.cpp:31:2:31:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:86:19:86:20 | d2 | here |
 | test.cpp:31:2:31:2 | b | test.cpp:87:25:87:26 | d2 | test.cpp:31:2:31:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:87:25:87:26 | d2 | here |
+| test.cpp:35:2:35:2 | b | test.cpp:57:19:57:19 | d | test.cpp:35:2:35:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:57:19:57:19 | d | here |
 | test.cpp:35:2:35:2 | b | test.cpp:59:21:59:21 | d | test.cpp:35:2:35:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:59:21:59:21 | d | here |
+| test.cpp:35:2:35:2 | b | test.cpp:74:19:74:21 | dss | test.cpp:35:2:35:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:74:19:74:21 | dss | here |
 | test.cpp:35:2:35:2 | b | test.cpp:76:21:76:23 | dss | test.cpp:35:2:35:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:76:21:76:23 | dss | here |
+| test.cpp:35:2:35:2 | b | test.cpp:86:19:86:20 | d2 | test.cpp:35:2:35:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:86:19:86:20 | d2 | here |
 | test.cpp:35:2:35:2 | b | test.cpp:88:21:88:22 | d2 | test.cpp:35:2:35:2 | b | Pointer arithmetic here may be done with the wrong type because of the cast $@. | test.cpp:88:21:88:22 | d2 | here |


### PR DESCRIPTION
In order to figure out which parameters can carry flow out of a function, we have a predicate `parameterIsNonConstReference`. That predicate handles pointers and iterators in one case (since pointers are also iterators [thanks to the T* specialization of iterator_traits](https://en.cppreference.com/w/cpp/iterator/iterator_traits)).

However, if that specialization isn't in the database for some reason, we won't always recognize that a parameter is of a type that can carry flow out of a function.

This PR adds a subclass of our modeling of `iterator` so that pointers are always a possible iterator.