### PR TITLE
Ruby: Extend `FileSystemReadAccess` to include more potential sources of input from the filesystem

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -135,7 +135,7 @@ module IO {
 
   /**
    * A `DataFlow::CallNode` that reads data from the filesystem using the `IO`
-   * or `File` classes. For example, the `IO.read call in:
+   * or `File` classes. For example, the `IO.read` call in:
    *
    * ```rb
    * IO.read("foo.txt")

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -98,17 +98,18 @@ module IO {
 
   /**
    * A `DataFlow::CallNode` that reads data using the `IO` class. For example,
-   * the `IO.read call in:
+   * the `read` and `readline` calls in:
    *
    * ```rb
+   * # invokes the `date` shell command as a subprocess, returning its output as a string
    * IO.read("|date")
+   *
+   * # reads from the file `foo.txt`, returning its first line as a string
+   * IO.new(IO.sysopen("foo.txt")).readline
    * ```
    *
-   * returns the output of the `date` shell command, invoked as a subprocess.
-   *
-   * This class includes reads both from shell commands and reads from the
-   * filesystem. For working with filesystem accesses specifically, see
-   * `FileReader` or the `FileSystemReadAccess` concept.
+   * This class includes only reads that use the `IO` class directly, not those
+   * that use a subclass of `IO` such as `File`.
    */
   class IOReader extends DataFlow::CallNode {
     private string receiverKind;
@@ -135,13 +136,15 @@ module IO {
 
   /**
    * A `DataFlow::CallNode` that reads data from the filesystem using the `IO`
-   * or `File` classes. For example, the `IO.read` call in:
+   * or `File` classes. For example, the `IO.read` and `File#readline` calls in:
    *
    * ```rb
+   * # reads the file `foo.txt` and returns its contents as a string.
    * IO.read("foo.txt")
-   * ```
    *
-   * reads the file `foo.txt` and returns its contents as a string.
+   * # reads from the file `foo.txt`, returning its first line as a string
+   * File.new("foo.txt").readline
+   * ```
    */
   class FileReader extends DataFlow::CallNode, FileSystemReadAccess::Range {
     private string receiverKind;

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -34,7 +34,7 @@ private predicate pathArgSpawnsSubprocess(Expr arg) {
 private DataFlow::Node fileInstanceInstantiation() {
   result = API::getTopLevelMember("File").getAnInstantiation()
   or
-  result = API::getTopLevelMember("File").getAMethodCall("open")
+  result = API::getTopLevelMember("File").getAMethodCall(["open", "try_convert"])
   or
   // Calls to `Kernel.open` can yield `File` instances
   result.(KernelMethodCall).getMethodName() = "open" and

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -52,9 +52,7 @@ private DataFlow::Node fileInstance() {
   )
 }
 
-private string ioReaderClassMethodName() {
-  result = ["binread", "foreach", "read", "readlines", "try_convert"]
-}
+private string ioReaderClassMethodName() { result = ["binread", "foreach", "read", "readlines"] }
 
 private string ioReaderInstanceMethodName() {
   result =

--- a/ruby/ql/test/library-tests/frameworks/files/Files.expected
+++ b/ruby/ql/test/library-tests/frameworks/files/Files.expected
@@ -36,16 +36,16 @@ ioInstances
 | Files.rb:24:19:24:40 | call to open |
 | Files.rb:35:1:35:56 | ... = ... |
 | Files.rb:35:13:35:56 | call to open |
-fileReaders
+fileModuleReaders
 | Files.rb:7:13:7:32 | call to readlines |
 ioReaders
-| Files.rb:7:13:7:32 | call to readlines | File |
-| Files.rb:20:13:20:25 | call to read | IO |
-| Files.rb:29:12:29:29 | call to read | IO |
-| Files.rb:32:8:32:23 | call to read | IO |
-ioFileReaders
-| Files.rb:7:13:7:32 | call to readlines | File |
-| Files.rb:29:12:29:29 | call to read | IO |
+| Files.rb:20:13:20:25 | call to read |
+| Files.rb:29:12:29:29 | call to read |
+| Files.rb:32:8:32:23 | call to read |
+fileReaders
+| Files.rb:7:13:7:32 | call to readlines |
+| Files.rb:20:13:20:25 | call to read |
+| Files.rb:29:12:29:29 | call to read |
 fileModuleFilenameSources
 | Files.rb:10:6:10:18 | call to path |
 | Files.rb:11:6:11:21 | call to to_path |
@@ -53,6 +53,7 @@ fileUtilsFilenameSources
 | Files.rb:14:8:14:43 | call to makedirs |
 fileSystemReadAccesses
 | Files.rb:7:13:7:32 | call to readlines |
+| Files.rb:20:13:20:25 | call to read |
 | Files.rb:29:12:29:29 | call to read |
 fileNameSources
 | Files.rb:10:6:10:18 | call to path |

--- a/ruby/ql/test/library-tests/frameworks/files/Files.ql
+++ b/ruby/ql/test/library-tests/frameworks/files/Files.ql
@@ -6,11 +6,11 @@ query predicate fileInstances(File::FileInstance i) { any() }
 
 query predicate ioInstances(IO::IOInstance i) { any() }
 
-query predicate fileReaders(File::FileModuleReader r) { any() }
+query predicate fileModuleReaders(File::FileModuleReader r) { any() }
 
-query predicate ioReaders(IO::IOReader r, string api) { api = r.getAPI() }
+query predicate ioReaders(IO::IOReader r) { any() }
 
-query predicate ioFileReaders(IO::IOFileReader r, string api) { api = r.getAPI() }
+query predicate fileReaders(IO::FileReader r) { any() }
 
 query predicate fileModuleFilenameSources(File::FileModuleFilenameSource s) { any() }
 


### PR DESCRIPTION
The main aim here is to consider expressions like `IO.new(IO.sysopen("foo.txt", "r"), "r").read` as potential reads from a file. We previously would not have considered this as a file read because `IO.new(IO.sysopen("foo.txt", "r"), "r")` was assumed to be some non-file input source. In other words, this changes from under-approximating possible file reads for these cases to over-approximating them.

There is some minor restructuring here to support this. In particular, `IOReader` only deals with the `IO` module directly, and `FileReader` is the new name for `IOFileReader` (extended, as mentioned above).

Separately, calls to `{IO,File}::try_convert` are no longer considered as a potential `IO`/`File` read nodes. Rather, they potentially return an `IO`/`File` instance.