### PR TITLE
Ruby: Add more potential `SystemCommandExecution` sinks

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -111,7 +111,7 @@ module IO {
    * This class includes only reads that use the `IO` class directly, not those
    * that use a subclass of `IO` such as `File`.
    */
-  class IOReader extends DataFlow::CallNode {
+  class IOReader extends DataFlow::CallNode, SystemCommandExecution::Range {
     private string receiverKind;
 
     IOReader() {
@@ -132,6 +132,14 @@ module IO {
      * Gets a string representation of the receiver kind, either "class" or "instance".
      */
     string getReceiverKind() { result = receiverKind }
+
+    override DataFlow::Node getAnArgument() { result = this.getArgument(_) }
+
+    // IO methods can cause shell commands to be executed if the argument begins
+    // with "|". As this is not necessarily possible to determine statically, we
+    // overapproximate this by assuming that any argument may be interpreted as
+    // a shell command.
+    override predicate isShellInterpreted(DataFlow::Node arg) { arg = this.getAnArgument() }
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -223,6 +223,22 @@ class KernelSpawnCall extends SystemCommandExecution::Range, KernelMethodCall {
 }
 
 /**
+ * A system command executed via the `Kernel.open` method.
+ * If the first argument passed to `Kernel.open` starts with "|" then the rest
+ * of the string will be interpreted as a shell command and executed.
+ * Ruby documentation: https://docs.ruby-lang.org/en/3.0.0/Kernel.html#method-i-open
+ */
+class KernelOpenCall extends SystemCommandExecution::Range, KernelMethodCall {
+  KernelOpenCall() { this.getMethodName() = "open" }
+
+  override DataFlow::Node getAnArgument() { result = this.getArgument(_) }
+
+  // Kernel.open invokes a subshell if the argument starts with "|".
+  // We we can't reliably determine this, so assume it always invokes a subshell.
+  override predicate isShellInterpreted(DataFlow::Node arg) { arg = this.getAnArgument() }
+}
+
+/**
  * A system command executed via one of the `Open3` methods.
  * These methods take the same argument forms as `Kernel.system`.
  * See `KernelSystemCall` for details.

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -234,7 +234,7 @@ class KernelOpenCall extends SystemCommandExecution::Range, KernelMethodCall {
   override DataFlow::Node getAnArgument() { result = this.getArgument(_) }
 
   // Kernel.open invokes a subshell if the argument starts with "|".
-  // We we can't reliably determine this, so assume it always invokes a subshell.
+  // We can't reliably determine this, so assume it always invokes a subshell.
   override predicate isShellInterpreted(DataFlow::Node arg) { arg = this.getAnArgument() }
 }
 

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
@@ -8,6 +8,8 @@ edges
 | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:33:24:33:36 | "echo #{...}" |
 | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:34:39:34:51 | "grep #{...}" |
 | CommandInjection.rb:46:15:46:20 | call to params :  | CommandInjection.rb:50:24:50:36 | "echo #{...}" |
+| KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:4:10:4:13 | file |
+| KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:5:13:5:16 | file |
 nodes
 | CommandInjection.rb:6:15:6:20 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:7:10:7:15 | #{...} | semmle.label | #{...} |
@@ -20,6 +22,9 @@ nodes
 | CommandInjection.rb:34:39:34:51 | "grep #{...}" | semmle.label | "grep #{...}" |
 | CommandInjection.rb:46:15:46:20 | call to params :  | semmle.label | call to params :  |
 | CommandInjection.rb:50:24:50:36 | "echo #{...}" | semmle.label | "echo #{...}" |
+| KernelOpen.rb:3:12:3:17 | call to params :  | semmle.label | call to params :  |
+| KernelOpen.rb:4:10:4:13 | file | semmle.label | file |
+| KernelOpen.rb:5:13:5:16 | file | semmle.label | file |
 subpaths
 #select
 | CommandInjection.rb:7:10:7:15 | #{...} | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:7:10:7:15 | #{...} | This command depends on $@. | CommandInjection.rb:6:15:6:20 | call to params | a user-provided value |
@@ -31,3 +36,5 @@ subpaths
 | CommandInjection.rb:33:24:33:36 | "echo #{...}" | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:33:24:33:36 | "echo #{...}" | This command depends on $@. | CommandInjection.rb:6:15:6:20 | call to params | a user-provided value |
 | CommandInjection.rb:34:39:34:51 | "grep #{...}" | CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:34:39:34:51 | "grep #{...}" | This command depends on $@. | CommandInjection.rb:6:15:6:20 | call to params | a user-provided value |
 | CommandInjection.rb:50:24:50:36 | "echo #{...}" | CommandInjection.rb:46:15:46:20 | call to params :  | CommandInjection.rb:50:24:50:36 | "echo #{...}" | This command depends on $@. | CommandInjection.rb:46:15:46:20 | call to params | a user-provided value |
+| KernelOpen.rb:4:10:4:13 | file | KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:4:10:4:13 | file | This command depends on $@. | KernelOpen.rb:3:12:3:17 | call to params | a user-provided value |
+| KernelOpen.rb:5:13:5:16 | file | KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:5:13:5:16 | file | This command depends on $@. | KernelOpen.rb:3:12:3:17 | call to params | a user-provided value |


### PR DESCRIPTION
`Kernel::open`, `File::open` etc. may invoke shell commands, e.g. in the cases of:
```
  file = params[:file]
  open(file)
  IO.read(file)
```
`open` and `IO.open` may invoke a shell command if `params[:file]` is a string beginning with `"|"`.

We overapproximate here by not trying to limit these sinks based on possible argument values at runtime. This is probably better placed in queries that could add guards on potential argument values as blocking flow.