### PR TITLE
use matches instead of regexpMatch/prefix/suffix

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
+++ b/cpp/ql/src/Security/CWE/CWE-313/CleartextSqliteDatabase.ql
@@ -29,7 +29,7 @@ class SqliteFunctionCall extends FunctionCall {
 }
 
 predicate sqlite_encryption_used() {
-  any(StringLiteral l).getValue().toLowerCase().regexpMatch("pragma key.*") or
+  any(StringLiteral l).getValue().toLowerCase().matches("pragma key%") or
   any(StringLiteral l).getValue().toLowerCase().matches("%attach%database%key%") or
   any(FunctionCall fc).getTarget().getName().matches("sqlite%\\_key\\_%")
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-598/SensitiveGetQuery.ql
@@ -20,7 +20,7 @@ class SensitiveInfoExpr extends Expr {
   SensitiveInfoExpr() {
     exists(Variable v | this = v.getAnAccess() |
       v.getName().regexpMatch(getCommonSensitiveInfoRegex()) and
-      not v.getName().regexpMatch("token.*") // exclude ^token.* since sensitive tokens are usually in the form of accessToken, authToken, ...
+      not v.getName().matches("token%") // exclude ^token.* since sensitive tokens are usually in the form of accessToken, authToken, ...
     )
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSExpressions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSExpressions.qll
@@ -833,7 +833,7 @@ class NgDataFlowNode extends TNode {
 private predicate fileIsImplicitlyAngularJS(HTML::HtmlFile file) {
   // The file contains ng-* attributes.
   exists(HTML::Attribute attrib |
-    attrib.getName().regexpMatch("ng-.*") and
+    attrib.getName().matches("ng-%") and
     attrib.getFile() = file
   ) and
   // But does not contain the ng-app root element, implying that file is

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -787,7 +787,7 @@ module ClientRequest {
         cmd.getACommandArgument()
             .(StringOps::ConcatenationRoot)
             .getConstantStringParts()
-            .regexpMatch("curl .*")
+            .matches("curl %")
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -554,7 +554,7 @@ module NodeJSLib {
     }
 
     override DataFlow::Node getADataNode() {
-      if methodName.regexpMatch(".*Sync")
+      if methodName.matches("%Sync")
       then result = this
       else
         exists(int i, string paramName | fsDataParam(methodName, i, paramName) |
@@ -720,9 +720,9 @@ module NodeJSLib {
       not result = getParameter(0).getARhs() and
       // fork/spawn and all sync methos always has options as the last argument
       if
-        methodName.regexpMatch("fork.*") or
-        methodName.regexpMatch("spawn.*") or
-        methodName.regexpMatch(".*Sync")
+        methodName.matches("fork%") or
+        methodName.matches("spawn%") or
+        methodName.matches("%Sync")
       then result = getLastArgument()
       else
         // the rest (exec/execFile) has the options argument as their second last.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -22,8 +22,8 @@ module XssThroughDom {
    */
   bindingset[result]
   string unsafeAttributeName() {
-    result.regexpMatch("data-.*") or
-    result.regexpMatch("aria-.*") or
+    result.matches("data-%") or
+    result.matches("aria-%") or
     result = ["name", "value", "title", "alt"]
   }
 

--- a/javascript/ql/src/Expressions/UnknownDirective.ql
+++ b/javascript/ql/src/Expressions/UnknownDirective.ql
@@ -18,5 +18,5 @@ where
   // but exclude attribute top-levels: `<a href="javascript:'some-attribute-string'">`
   not d.getParent() instanceof CodeInAttribute and
   // exclude babel generated directives like "@babel/helpers - typeof".
-  not d.getDirectiveText().prefix(14) = "@babel/helpers"
+  not d.getDirectiveText().matches("@babel/helpers%")
 select d, "Unknown directive: '" + truncate(d.getDirectiveText(), 20, " ... (truncated)") + "'."

--- a/javascript/ql/test/library-tests/RangeAnalysis/DeadBranch.ql
+++ b/javascript/ql/test/library-tests/RangeAnalysis/DeadBranch.ql
@@ -4,9 +4,9 @@ class AssertionComment extends LineComment {
   boolean isOK;
 
   AssertionComment() {
-    isOK = true and getText().trim().regexpMatch("OK.*")
+    isOK = true and getText().trim().matches("OK%")
     or
-    isOK = false and getText().trim().regexpMatch("NOT OK.*")
+    isOK = false and getText().trim().matches("NOT OK%")
   }
 
   ConditionGuardNode getAGuardNode() {

--- a/javascript/ql/test/library-tests/StringConcatenation/ClassContainsTwo.ql
+++ b/javascript/ql/test/library-tests/StringConcatenation/ClassContainsTwo.ql
@@ -2,7 +2,7 @@ import javascript
 
 // Select all expressions whose string value contains the word "two"
 predicate containsTwo(DataFlow::Node node) {
-  node.getStringValue().regexpMatch(".*two.*")
+  node.getStringValue().matches("%two%")
   or
   containsTwo(node.getAPredecessor())
   or

--- a/javascript/ql/test/library-tests/StringConcatenation/ContainsTwo.ql
+++ b/javascript/ql/test/library-tests/StringConcatenation/ContainsTwo.ql
@@ -2,7 +2,7 @@ import javascript
 
 // Select all expressions whose string value contains the word "two"
 predicate containsTwo(DataFlow::Node node) {
-  node.getStringValue().regexpMatch(".*two.*")
+  node.getStringValue().matches("%two%")
   or
   containsTwo(node.getAPredecessor())
   or

--- a/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
+++ b/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
@@ -85,7 +85,7 @@ private string getACredentialRegExp() {
 bindingset[name]
 private predicate maybeCredentialName(string name) {
   name.regexpMatch(getACredentialRegExp()) and
-  not name.suffix(name.length() - 4) = "file"
+  not name.matches("%file")
 }
 
 // Positional parameter


### PR DESCRIPTION
The `matches` predicate has better performance, so it should be used when possible. 

The patch was written automatically by a tool. 

Evalutions (see backrefs) look OK. 