### PR TITLE
Ruby: use A/An/The to start qlDoc for classes

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
@@ -4,7 +4,7 @@ private import codeql.ruby.Concepts
 private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.FlowSummary
 
-/** Defines calls to  `ActiveStorage::Filename#sanitized` as path sanitizers. */
+/** A call to  `ActiveStorage::Filename#sanitized` as path sanitizers. */
 class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range, DataFlow::CallNode {
   ActiveStorageFilenameSanitizedCall() {
     this.getReceiver() =
@@ -13,7 +13,7 @@ class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range, 
   }
 }
 
-/** Taint summary for `ActiveStorage::Filename.new`. */
+/** The taint summary for `ActiveStorage::Filename.new`. */
 class ActiveStorageFilenameNewSummary extends SummarizedCallable {
   ActiveStorageFilenameNewSummary() { this = "ActiveStorage::Filename.new" }
 
@@ -33,7 +33,7 @@ class ActiveStorageFilenameNewSummary extends SummarizedCallable {
   }
 }
 
-/** Taint summary for `ActiveStorage::Filename#sanitized`. */
+/** The taint summary for `ActiveStorage::Filename#sanitized`. */
 class ActiveStorageFilenameSanitizedSummary extends SummarizedCallable {
   ActiveStorageFilenameSanitizedSummary() { this = "ActiveStorage::Filename#sanitized" }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
@@ -4,7 +4,7 @@ private import codeql.ruby.Concepts
 private import codeql.ruby.DataFlow
 private import codeql.ruby.dataflow.FlowSummary
 
-/** A call to  `ActiveStorage::Filename#sanitized` as path sanitizers. */
+/** A call to `ActiveStorage::Filename#sanitized`, considered as a path sanitizer. */
 class ActiveStorageFilenameSanitizedCall extends Path::PathSanitization::Range, DataFlow::CallNode {
   ActiveStorageFilenameSanitizedCall() {
     this.getReceiver() =

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -254,7 +254,7 @@ module File {
   }
 
   /**
-   * Flow summary for several methods on the `File` class that propagate taint
+   * A flow summary for several methods on the `File` class that propagate taint
    * from their first argument to the return value.
    */
   class FilePathConversionSummary extends SummarizedCallable {
@@ -277,7 +277,7 @@ module File {
   }
 
   /**
-   * Flow summary for `File.join`, which propagates taint from every argument to
+   * A flow summary for `File.join`, which propagates taint from every argument to
    * its return value.
    */
   class FileJoinSummary extends SummarizedCallable {

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -71,7 +71,7 @@ string basicObjectInstanceMethodName() {
 }
 
 /**
- * Instance methods on `BasicObject`, which are available to all classes.
+ * An instance method on `BasicObject`, which is available to all classes.
  */
 class BasicObjectInstanceMethodCall extends UnknownMethodCall {
   BasicObjectInstanceMethodCall() { this.getMethodName() = basicObjectInstanceMethodName() }
@@ -92,14 +92,14 @@ string objectInstanceMethodName() {
 }
 
 /**
- * Instance methods on `Object`, which are available to all classes except `BasicObject`.
+ * An instance method on `Object`, which is available to all classes except `BasicObject`.
  */
 class ObjectInstanceMethodCall extends UnknownMethodCall {
   ObjectInstanceMethodCall() { this.getMethodName() = objectInstanceMethodName() }
 }
 
 /**
- * Method calls which have no known target.
+ * A Method call which has no known target.
  * These will typically be calls to methods inherited from a superclass.
  */
 class UnknownMethodCall extends MethodCall {

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -99,7 +99,7 @@ class ObjectInstanceMethodCall extends UnknownMethodCall {
 }
 
 /**
- * A Method call which has no known target.
+ * A `Method` call that has no known target.
  * These will typically be calls to methods inherited from a superclass.
  */
 class UnknownMethodCall extends MethodCall {

--- a/ruby/ql/lib/codeql/ruby/security/UrlRedirectCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UrlRedirectCustomizations.qll
@@ -85,6 +85,8 @@ module UrlRedirect {
   }
 
   /**
+   * A string interpolation, seen as a sanitizer for "URL redirection" vulnerabilities.
+   *
    * String interpolation is considered safe, provided the string is prefixed by a non-tainted value.
    * In most cases this will prevent the tainted value from controlling e.g. the host of the URL.
    *

--- a/ruby/ql/src/ide-contextual-queries/printAst.ql
+++ b/ruby/ql/src/ide-contextual-queries/printAst.ql
@@ -17,7 +17,7 @@ private import codeql.ruby.printAst
 external string selectedSourceFile();
 
 /**
- * Overrides the configuration to print only nodes in the selected source file.
+ * A configuration that only prints nodes in the selected source file.
  */
 class Cfg extends PrintAstConfiguration {
   override predicate shouldPrintNode(AstNode n) {

--- a/ruby/ql/src/queries/security/cwe-078/KernelOpen.ql
+++ b/ruby/ql/src/queries/security/cwe-078/KernelOpen.ql
@@ -23,7 +23,7 @@ import codeql.ruby.dataflow.RemoteFlowSources
 import DataFlow::PathGraph
 
 /**
- * Method calls that have a suggested replacement.
+ * A method call that have a suggested replacement.
  */
 abstract class Replacement extends DataFlow::CallNode {
   abstract string getFrom();

--- a/ruby/ql/src/queries/security/cwe-078/KernelOpen.ql
+++ b/ruby/ql/src/queries/security/cwe-078/KernelOpen.ql
@@ -23,7 +23,7 @@ import codeql.ruby.dataflow.RemoteFlowSources
 import DataFlow::PathGraph
 
 /**
- * A method call that have a suggested replacement.
+ * A method call that has a suggested replacement.
  */
 abstract class Replacement extends DataFlow::CallNode {
   abstract string getFrom();


### PR DESCRIPTION
QLDoc for classes should generally start with A/An/The.  

I found a few violations of that during a dist-upgrade of `codeql-ql`.  
Ruby was the worst offender, so I tried to fix them for you. 