### PR TITLE
Ruby: Move SSA consistency queries into shared SSA library

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaImplCommon.qll
@@ -634,3 +634,28 @@ class UncertainWriteDefinition extends WriteDefinition {
     )
   }
 }
+
+/** Provides a set of consistency queries. */
+module Consistency {
+  abstract class RelevantDefinition extends Definition {
+    abstract predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
+
+  query predicate nonUniqueDef(RelevantDefinition def, SourceVariable v, BasicBlock bb, int i) {
+    ssaDefReachesRead(v, def, bb, i) and
+    not exists(unique(Definition def0 | ssaDefReachesRead(_, def0, bb, i)))
+  }
+
+  query predicate readWithoutDef(SourceVariable v, BasicBlock bb, int i) {
+    variableRead(bb, i, v, _) and
+    not ssaDefReachesRead(_, _, bb, i)
+  }
+
+  query predicate deadDef(RelevantDefinition def, SourceVariable v) {
+    v = def.getSourceVariable() and
+    not ssaDefReachesRead(_, def, _, _) and
+    not phiHasInputFromBlock(_, def, _)
+  }
+}

--- a/csharp/ql/lib/semmle/code/cil/internal/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/cil/internal/SsaImplCommon.qll
@@ -634,3 +634,28 @@ class UncertainWriteDefinition extends WriteDefinition {
     )
   }
 }
+
+/** Provides a set of consistency queries. */
+module Consistency {
+  abstract class RelevantDefinition extends Definition {
+    abstract predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
+
+  query predicate nonUniqueDef(RelevantDefinition def, SourceVariable v, BasicBlock bb, int i) {
+    ssaDefReachesRead(v, def, bb, i) and
+    not exists(unique(Definition def0 | ssaDefReachesRead(_, def0, bb, i)))
+  }
+
+  query predicate readWithoutDef(SourceVariable v, BasicBlock bb, int i) {
+    variableRead(bb, i, v, _) and
+    not ssaDefReachesRead(_, _, bb, i)
+  }
+
+  query predicate deadDef(RelevantDefinition def, SourceVariable v) {
+    v = def.getSourceVariable() and
+    not ssaDefReachesRead(_, def, _, _) and
+    not phiHasInputFromBlock(_, def, _)
+  }
+}

--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/pressa/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/pressa/SsaImplCommon.qll
@@ -634,3 +634,28 @@ class UncertainWriteDefinition extends WriteDefinition {
     )
   }
 }
+
+/** Provides a set of consistency queries. */
+module Consistency {
+  abstract class RelevantDefinition extends Definition {
+    abstract predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
+
+  query predicate nonUniqueDef(RelevantDefinition def, SourceVariable v, BasicBlock bb, int i) {
+    ssaDefReachesRead(v, def, bb, i) and
+    not exists(unique(Definition def0 | ssaDefReachesRead(_, def0, bb, i)))
+  }
+
+  query predicate readWithoutDef(SourceVariable v, BasicBlock bb, int i) {
+    variableRead(bb, i, v, _) and
+    not ssaDefReachesRead(_, _, bb, i)
+  }
+
+  query predicate deadDef(RelevantDefinition def, SourceVariable v) {
+    v = def.getSourceVariable() and
+    not ssaDefReachesRead(_, def, _, _) and
+    not phiHasInputFromBlock(_, def, _)
+  }
+}

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImplCommon.qll
@@ -634,3 +634,28 @@ class UncertainWriteDefinition extends WriteDefinition {
     )
   }
 }
+
+/** Provides a set of consistency queries. */
+module Consistency {
+  abstract class RelevantDefinition extends Definition {
+    abstract predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
+
+  query predicate nonUniqueDef(RelevantDefinition def, SourceVariable v, BasicBlock bb, int i) {
+    ssaDefReachesRead(v, def, bb, i) and
+    not exists(unique(Definition def0 | ssaDefReachesRead(_, def0, bb, i)))
+  }
+
+  query predicate readWithoutDef(SourceVariable v, BasicBlock bb, int i) {
+    variableRead(bb, i, v, _) and
+    not ssaDefReachesRead(_, _, bb, i)
+  }
+
+  query predicate deadDef(RelevantDefinition def, SourceVariable v) {
+    v = def.getSourceVariable() and
+    not ssaDefReachesRead(_, def, _, _) and
+    not phiHasInputFromBlock(_, def, _)
+  }
+}

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImplSpecific.qll
@@ -3,6 +3,7 @@
 private import csharp
 private import AssignableDefinitions
 private import SsaImpl as SsaImpl
+private import semmle.code.csharp.dataflow.SSA
 
 class BasicBlock = ControlFlow::BasicBlock;
 
@@ -12,7 +13,7 @@ BasicBlock getABasicBlockSuccessor(BasicBlock bb) { result = bb.getASuccessor() 
 
 class ExitBasicBlock = ControlFlow::BasicBlocks::ExitBlock;
 
-class SourceVariable = SsaImpl::TSourceVariable;
+class SourceVariable = Ssa::SourceVariable;
 
 predicate variableWrite = SsaImpl::variableWrite/4;
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/basessa/SsaImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/basessa/SsaImplCommon.qll
@@ -634,3 +634,28 @@ class UncertainWriteDefinition extends WriteDefinition {
     )
   }
 }
+
+/** Provides a set of consistency queries. */
+module Consistency {
+  abstract class RelevantDefinition extends Definition {
+    abstract predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
+
+  query predicate nonUniqueDef(RelevantDefinition def, SourceVariable v, BasicBlock bb, int i) {
+    ssaDefReachesRead(v, def, bb, i) and
+    not exists(unique(Definition def0 | ssaDefReachesRead(_, def0, bb, i)))
+  }
+
+  query predicate readWithoutDef(SourceVariable v, BasicBlock bb, int i) {
+    variableRead(bb, i, v, _) and
+    not ssaDefReachesRead(_, _, bb, i)
+  }
+
+  query predicate deadDef(RelevantDefinition def, SourceVariable v) {
+    v = def.getSourceVariable() and
+    not ssaDefReachesRead(_, def, _, _) and
+    not phiHasInputFromBlock(_, def, _)
+  }
+}

--- a/ruby/ql/consistency-queries/SsaConsistency.ql
+++ b/ruby/ql/consistency-queries/SsaConsistency.ql
@@ -1,22 +1,10 @@
-import ruby
 import codeql.ruby.dataflow.SSA
-import codeql.ruby.controlflow.ControlFlowGraph
+import codeql.ruby.dataflow.internal.SsaImplCommon::Consistency
 
-query predicate nonUniqueDef(CfgNode read, Ssa::Definition def) {
-  read = def.getARead() and
-  exists(Ssa::Definition other | read = other.getARead() and other != def)
-}
-
-query predicate readWithoutDef(LocalVariableReadAccess read) {
-  exists(CfgNode node |
-    node = read.getAControlFlowNode() and
-    not node = any(Ssa::Definition def).getARead()
-  )
-}
-
-query predicate deadDef(Ssa::Definition def, LocalVariable v) {
-  v = def.getSourceVariable() and
-  not v.isCaptured() and
-  not exists(def.getARead()) and
-  not def = any(Ssa::PhiNode phi).getAnInput()
+class MyRelevantDefinition extends RelevantDefinition, Ssa::Definition {
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImplCommon.qll
@@ -634,3 +634,28 @@ class UncertainWriteDefinition extends WriteDefinition {
     )
   }
 }
+
+/** Provides a set of consistency queries. */
+module Consistency {
+  abstract class RelevantDefinition extends Definition {
+    abstract predicate hasLocationInfo(
+      string filepath, int startline, int startcolumn, int endline, int endcolumn
+    );
+  }
+
+  query predicate nonUniqueDef(RelevantDefinition def, SourceVariable v, BasicBlock bb, int i) {
+    ssaDefReachesRead(v, def, bb, i) and
+    not exists(unique(Definition def0 | ssaDefReachesRead(_, def0, bb, i)))
+  }
+
+  query predicate readWithoutDef(SourceVariable v, BasicBlock bb, int i) {
+    variableRead(bb, i, v, _) and
+    not ssaDefReachesRead(_, _, bb, i)
+  }
+
+  query predicate deadDef(RelevantDefinition def, SourceVariable v) {
+    v = def.getSourceVariable() and
+    not ssaDefReachesRead(_, def, _, _) and
+    not phiHasInputFromBlock(_, def, _)
+  }
+}


### PR DESCRIPTION
This makes the consistency queries available for other languages too (cc @MathiasVP).