### PR TITLE
C#: Fix bad magic `Element::fromSource` in context of `SelfAssignment.ql`

### DIFF
--- a/csharp/ql/lib/semmle/code/dotnet/Element.qll
+++ b/csharp/ql/lib/semmle/code/dotnet/Element.qll
@@ -14,6 +14,7 @@ class Element extends @dotnet_element {
   string toString() { none() }
 
   /** Gets the location of this element. */
+  pragma[nomagic]
   Location getLocation() { none() }
 
   /**


### PR DESCRIPTION
The optimizer decides to push in this magic context into `Element::getLocation`:

```
m#Element::Element::getLocation_dispred#bf(/* Element::Element */ cached unique entity this)
:-
  exists(/* Assignment::AssignExpr */ cached dontcare entity _,
         cached dontcare string _1 |
    rec #select#cpe#134#fff(_, this, _1)
  );
  ...
```

which makes `StructuralComparisonConfig::candidate` recursive, and perform extremely bad:

```
SelfAssignment.ql-14:StructuralComparison::StructuralComparisonConfiguration::candidate_dispred#fff ...................................................................................................................................................... 35m14s (4 evaluations with max 35m14s in StructuralComparison::StructuralComparisonConfiguration::candidate_dispred#fff/3@i6#ad086iwe)
```