### PR TITLE
JS: [Internal only] Rename the available ML models external predicate

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/BaseScoring.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/BaseScoring.qll
@@ -7,7 +7,7 @@
 private import javascript
 private import ATMConfig
 
-external predicate adaptiveThreatModelingModels(
+external predicate availableMlModels(
   string modelChecksum, string modelLanguage, string modelName, string modelType
 );
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
@@ -11,7 +11,7 @@ import EndpointFeatures as EndpointFeatures
 import EndpointTypes
 
 private string getACompatibleModelChecksum() {
-  adaptiveThreatModelingModels(result, "javascript", _, "atm-endpoint-scoring")
+  availableMlModels(result, "javascript", _, "atm-endpoint-scoring")
 }
 
 /**


### PR DESCRIPTION
This PR renames the `adaptiveThreatModelingModels` external predicate to `availableMlModels` per the internal ADR backlinked below.