### PR TITLE
Java: Don't clear content in store steps in summaries.

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -150,8 +150,7 @@ predicate readStep(Node node1, Content f, Node node2) {
  * in `x.f = newValue`.
  */
 predicate clearsContent(Node n, Content c) {
-  c instanceof FieldContent and
-  n = any(PostUpdateNode pun | storeStep(_, c, pun)).getPreUpdateNode()
+  exists(FieldAccess fa | instanceFieldAssign(_, fa) and n = getFieldQualifier(fa))
   or
   FlowSummaryImpl::Private::Steps::summaryClearsContent(n, c)
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -150,7 +150,11 @@ predicate readStep(Node node1, Content f, Node node2) {
  * in `x.f = newValue`.
  */
 predicate clearsContent(Node n, Content c) {
-  exists(FieldAccess fa | instanceFieldAssign(_, fa) and n = getFieldQualifier(fa))
+  exists(FieldAccess fa |
+    instanceFieldAssign(_, fa) and
+    n = getFieldQualifier(fa) and
+    c.(FieldContent).getField() = fa.getField()
+  )
   or
   FlowSummaryImpl::Private::Steps::summaryClearsContent(n, c)
 }

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/A.java
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/A.java
@@ -174,7 +174,7 @@ public class A {
     a1.field1 = source(20);
     A a2 = new A();
     applyConsumer1Field1Field2(a1, a2, p -> {
-      sink(p); // MISSING FLOW
+      sink(p); // $ flow=20
     });
     wrapSinkToAvoidFieldSsa(a1);
     sink(a2.field2);


### PR DESCRIPTION
Store steps in summaries aren't likely to be intended to clear the targeted content (also, this currently doesn't even work consistently). This caused false negative flow for any field-of-argument-to-callback summary as these summaries simply didn't work.

This fix could alternatively have been achieved by changing the synthesised read-/store-steps such that more store steps would be inferred as side-effects through reverse reads, but that seemed unnecessarily complicated.