### PR TITLE
Multiple scopes for neighborhood feature

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -12,11 +12,17 @@ import EndpointScoring
 class DescendantsThreshold extends int {
   DescendantsThreshold() { this = [1 .. 10000] }
 
-  predicate isLarge() { this = 1024 }
+  predicate is1024() { this = 1024 }
 
-  predicate isMedium() { this = 256 }
+  predicate is512() { this = 512 }
 
-  predicate isSmall() { this = 64 }
+  predicate is256() { this = 256 }
+
+  predicate is128() { this = 128 }
+
+  predicate is64() { this = 64 }
+
+  predicate is32() { this = 32 }
 
   int getMaxNumDescendants() { result = this }
 }
@@ -48,15 +54,23 @@ private string getTokenFeature(DataFlow::Node endpoint, string featureName) {
     Raw::AstNode rootNode, DatabaseFeatures::AstNode rootNodeWrapped, DescendantsThreshold thresh
   |
     (
-      featureName = "enclosingFunctionBodyEndpointNeighborhoodLarge" and
-      // thresh instanceof DescendantsThresholdLarge
-      thresh.isLarge()
+      featureName = "enclosingFunctionBodyEndpointNeighborhood1024" and
+      thresh.is1024()
       or
-      featureName = "enclosingFunctionBodyEndpointNeighborhoodMedium" and
-      thresh.isMedium()
+      featureName = "enclosingFunctionBodyEndpointNeighborhood512" and
+      thresh.is512()
       or
-      featureName = "enclosingFunctionBodyEndpointNeighborhoodSmall" and
-      thresh.isSmall()
+      featureName = "enclosingFunctionBodyEndpointNeighborhood256" and
+      thresh.is256()
+      or
+      featureName = "enclosingFunctionBodyEndpointNeighborhood128" and
+      thresh.is128()
+      or
+      featureName = "enclosingFunctionBodyEndpointNeighborhood64" and
+      thresh.is64()
+      or
+      featureName = "enclosingFunctionBodyEndpointNeighborhood32" and
+      thresh.is32()
     ) and
     rootNode =
       NeighborhoodBodies::getNeighborhoodAstNode(Raw::astNode(endpoint.getAstNode()), thresh) and
@@ -399,9 +413,11 @@ private string getASupportedFeatureName() {
     [
       "enclosingFunctionName", "calleeName", "receiverName", "argumentIndex", "calleeApiName",
       "calleeAccessPath", "calleeAccessPathWithStructuralInfo", "enclosingFunctionBody",
-      "enclosingFunctionBodyEndpointNeighborhoodLarge",
-      "enclosingFunctionBodyEndpointNeighborhoodMedium",
-      "enclosingFunctionBodyEndpointNeighborhoodSmall"
+      "enclosingFunctionBodyEndpointNeighborhood1024",
+      "enclosingFunctionBodyEndpointNeighborhood512",
+      "enclosingFunctionBodyEndpointNeighborhood256",
+      "enclosingFunctionBodyEndpointNeighborhood128", "enclosingFunctionBodyEndpointNeighborhood64",
+      "enclosingFunctionBodyEndpointNeighborhood32"
     ]
 }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -217,13 +217,12 @@ module NeighborhoodBodies {
   /** Count number of descendants of an AST node */
   int getNumDescendents(Raw::AstNode node) { result = count(node.getAChildNode*()) }
 
-  private ASTNode getContainer(ASTNode node) {
-    result = node.getContainer()
-  }
+  private ASTNode getContainer(ASTNode node) { result = node.getContainer() }
 
   /** Return the AST node that is outermost enclosing function (as an AST Node) */
   Raw::AstNode getOutermostEnclosingFunction(Raw::AstNode node) {
-    result = Raw::astNode(getContainer*(node.getNode())) and result.getContainer() instanceof TopLevel
+    result = Raw::astNode(getContainer*(node.getNode())) and
+    result.getContainer() instanceof TopLevel
   }
 
   /**
@@ -319,9 +318,9 @@ private module AccessPaths {
   }
 
   /**
-  * Get the access path for the node. This includes structural information like `member`, `param`,
-  * and `functionalarg` if `includeStructuralInfo` is true.
-  */
+   * Get the access path for the node. This includes structural information like `member`, `param`,
+   * and `functionalarg` if `includeStructuralInfo` is true.
+   */
   predicate accessPaths(
     API::Node node, Boolean includeStructuralInfo, string accessPath, string apiName
   ) {

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -60,7 +60,7 @@ private string getTokenFeature(DataFlow::Node endpoint, string featureName) {
     ) and
     rootNode =
       NeighborhoodBodies::getNeighborhoodAstNode(Raw::astNode(endpoint.getAstNode()), thresh) and
-    rootNodeWrapped = DatabaseFeatures::astNode(Wrapped::astNode(endpoint.getContainer(), rootNode)) and
+    rootNodeWrapped = DatabaseFeatures::astNode(Wrapped::astNode(rootNode.getContainer(), rootNode)) and
     result =
       unique(string x |
         x = NeighborhoodBodies::getBodyTokenFeatureForNeighborhoodNode(rootNodeWrapped)

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -185,8 +185,7 @@ module NeighborhoodBodies {
    */
   Raw::AstNode getNeighborhoodAstNode(Raw::AstNode node) {
     if
-      // `node` will always have a parent as we start at and endpoint
-      node.getParentNode() = getOutermostEnclosingFunction(node) or
+      node = getOutermostEnclosingFunction(node) or
       getNumDescendents(node.getParentNode()) > maxNumDescendants()
     then result = node
     else result = getNeighborhoodAstNode(node.getParentNode())

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -208,7 +208,7 @@ module NeighborhoodBodies {
    */
   Raw::AstNode getNeighborhoodAstNode(Raw::AstNode node, DescendantsThreshold maxNumDescendants) {
     if
-      node = getOutermostEnclosingFunction(node) or
+      node.getParentNode() = getOutermostEnclosingFunction(node) or
       getNumDescendents(node.getParentNode()) > maxNumDescendants.getMaxNumDescendants()
     then result = node
     else result = getNeighborhoodAstNode(node.getParentNode(), maxNumDescendants)


### PR DESCRIPTION
This PR makes several changes to the existing feature:

1. ~~It allows the neighborhood to be the entire enclosing function.~~
2. It creates multiple versions of `enclosingFunctionBodyEndpointNeighborhood`, each with a different threshold on the number of descendants.
3. It fixes a bug in the original PR, which caused the neighborhood feature to often be absent: When getting the wrapper for the root node, we must give the container of the root node, not the endpoint, because they won't necessarily be the same for functions contained within functions.

TODO: `enclosingFunctionBodyEndpointNeighborhood` doesn't match `enclosingFunctionBody` even when the function is small, which is undesired behavior. `enclosingFunctionBody` includes the arguments to the function whereas `enclosingFunctionBodyEndpointNeighborhood` does not. We should find a way to fix this.

- [Test pipeline run](https://ml.azure.com/runs/a5d366f9-1ebd-47bb-b1c6-fb9cb81533bf?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de)
- [Dev pipeline run](https://ml.azure.com/runs/a22619a3-bd2b-41d0-b1ab-3471c68af5cd?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de)
- Dataset created from the dev pipeline run: `classifier_big_temp` [version 7](https://ml.azure.com/dataset/classifier_big_temp/latest/details?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourceGroups/ATM-CodeML/providers/Microsoft.MachineLearningServices/workspaces/ATM-workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de)
- Models training runs with this data:

|Description|All six new features, plus `enclosingFunctionBody`| Only the smallest three of the new features, plus `enclosingFunctionBody`|  Only the smallest three of the new features, excluding `enclosingFunctionBody`|
|-|-|-|-| 
|AML runs|[1](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637686967_dbc6cd06?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de#details), [2](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637686989_edfad239?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de#details), [3](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637687003_4a977ae4?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de#details)|[1](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637699721_7d3c45f7?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de), [2](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637699728_33b231c6?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de)|[1](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637699616_8d8027a9?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de), [2](https://ml.azure.com/experiments/id/85e6e910-7301-4441-9079-01a1e42fd45b/runs/classification_1637699628_87599c65?wsid=/subscriptions/91095667-e119-4555-acea-1826488492f0/resourcegroups/ATM-CodeML/workspaces/ATM-Workspace&tid=398a6654-997b-47e9-b12b-9515b896b4de)|
|Evaluations| [1](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/fd95715df38aeb8635783fd3adf1531ccb1f101d), [2](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/77ca7ecd5edeb0e57886dafbab4ce3b075644486), [3](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/3f1511eb1d0aac1440c6a0cb5b93689b21fcc034)|[1](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/9d946f9585f2527a0385827a60dd04463ca6f1cf), [2](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/a258863261d6651f41e00ba526127d2bfd2af7e6)|[1](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/79a58417bb933479891b9475374416f12e7e70c8), [2](https://github.com/github/ml-ql-adaptive-threat-modeling-backend/commit/cfab6d5a31bc4e43dc66bc672eac84b185016492)|
|Results|Neutral to bad|Neutral to bad|Neutral to bad|

Adresses https://github.com/github/ml-ql-adaptive-threat-modeling/issues/1553