### PR TITLE
Ruby: Flow through arrays/enumerables

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -98,7 +98,7 @@ module API {
     /**
      * Gets a `new` call to the function represented by this API component.
      */
-    DataFlow::Node getAnInstantiation() { result = this.getInstance().getAnImmediateUse() }
+    DataFlow::ExprNode getAnInstantiation() { result = getInstance().getAnImmediateUse() }
 
     /**
      * Gets a node representing a subclass of the class represented by this node.

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -98,7 +98,7 @@ module API {
     /**
      * Gets a `new` call to the function represented by this API component.
      */
-    DataFlow::ExprNode getAnInstantiation() { result = getInstance().getAnImmediateUse() }
+    DataFlow::ExprNode getAnInstantiation() { result = this.getInstance().getAnImmediateUse() }
 
     /**
      * Gets a node representing a subclass of the class represented by this node.

--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -4,6 +4,7 @@ import ruby
 import codeql.ruby.DataFlow
 private import internal.FlowSummaryImpl as Impl
 private import internal.DataFlowDispatch
+private import internal.DataFlowPrivate
 
 // import all instances below
 private module Summaries {
@@ -22,11 +23,33 @@ module SummaryComponent {
 
   predicate content = SC::content/1;
 
-  /** Gets a summary component that represents a qualifier. */
-  SummaryComponent qualifier() { result = argument(any(ParameterPosition pos | pos.isSelf())) }
+  /** Gets a summary component that represents a `self` argument. */
+  SummaryComponent self() { result = argument(any(ParameterPosition pos | pos.isSelf())) }
 
   /** Gets a summary component that represents a block argument. */
   SummaryComponent block() { result = argument(any(ParameterPosition pos | pos.isBlock())) }
+
+  /** Gets a summary component that represents an element in an array at an unknown index. */
+  SummaryComponent arrayElementUnknown() { result = SC::content(TUnknownArrayElementContent()) }
+
+  /** Gets a summary component that represents an element in an array at a known index. */
+  bindingset[i]
+  SummaryComponent arrayElementKnown(int i) {
+    result = SC::content(TKnownArrayElementContent(i))
+    or
+    // `i` may be out of range
+    not exists(TKnownArrayElementContent(i)) and
+    result = arrayElementUnknown()
+  }
+
+  /**
+   * Gets a summary component that represents an element in an array at either an unknown
+   * index or known index. This predicate should never be used in the output specification
+   * of a flow summary; use `arrayElementUnknown()` instead.
+   */
+  SummaryComponent arrayElementAny() {
+    result in [arrayElementUnknown(), SC::content(TKnownArrayElementContent(_))]
+  }
 
   /** Gets a summary component that represents the return value of a call. */
   SummaryComponent return() { result = SC::return(any(NormalReturnKind rk)) }
@@ -44,8 +67,8 @@ module SummaryComponentStack {
 
   predicate argument = SCS::argument/1;
 
-  /** Gets a singleton stack representing a qualifier. */
-  SummaryComponentStack qualifier() { result = singleton(SummaryComponent::qualifier()) }
+  /** Gets a singleton stack representing a `self` argument. */
+  SummaryComponentStack self() { result = singleton(SummaryComponent::self()) }
 
   /** Gets a singleton stack representing a block argument. */
   SummaryComponentStack block() { result = singleton(SummaryComponent::block()) }
@@ -106,6 +129,17 @@ abstract class SummarizedCallable extends LibraryCallable {
    */
   pragma[nomagic]
   predicate clearsContent(ParameterPosition pos, DataFlow::Content content) { none() }
+}
+
+/**
+ * A callable with a flow summary, identified by a unique string, where all
+ * calls to a method with the same name are considered relevant.
+ */
+abstract class SimpleSummarizedCallable extends SummarizedCallable {
+  bindingset[this]
+  SimpleSummarizedCallable() { any() }
+
+  final override MethodCall getACall() { result.getMethodName() = this }
 }
 
 private class SummarizedCallableAdapter extends Impl::Public::SummarizedCallable {

--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -23,8 +23,8 @@ module SummaryComponent {
 
   predicate content = SC::content/1;
 
-  /** Gets a summary component that represents a `self` argument. */
-  SummaryComponent self() { result = argument(any(ParameterPosition pos | pos.isSelf())) }
+  /** Gets a summary component that represents a receiver. */
+  SummaryComponent receiver() { result = argument(any(ParameterPosition pos | pos.isSelf())) }
 
   /** Gets a summary component that represents a block argument. */
   SummaryComponent block() { result = argument(any(ParameterPosition pos | pos.isBlock())) }
@@ -67,8 +67,8 @@ module SummaryComponentStack {
 
   predicate argument = SCS::argument/1;
 
-  /** Gets a singleton stack representing a `self` argument. */
-  SummaryComponentStack self() { result = singleton(SummaryComponent::self()) }
+  /** Gets a singleton stack representing a receiver. */
+  SummaryComponentStack receiver() { result = singleton(SummaryComponent::receiver()) }
 
   /** Gets a singleton stack representing a block argument. */
   SummaryComponentStack block() { result = singleton(SummaryComponent::block()) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -250,7 +250,7 @@ private module Cached {
     TPositionalParameterPosition(int pos) {
       pos = any(Parameter p).getPosition()
       or
-      pos in [0 .. 10] // TODO: remove once `Argument[_]` summaries are replaced with `Argument[i..]`
+      pos in [0 .. 100] // TODO: remove once `Argument[_]` summaries are replaced with `Argument[i..]`
       or
       FlowSummaryImplSpecific::ParsePositions::isParsedArgumentPosition(_, pos)
     } or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -294,8 +294,12 @@ private module Cached {
   }
 
   cached
-  newtype TContent = TTodoContent() // stub
+  newtype TContent =
+    TKnownArrayElementContent(int i) { i in [0 .. 10] } or
+    TUnknownArrayElementContent()
 }
+
+class TArrayElementContent = TKnownArrayElementContent or TUnknownArrayElementContent;
 
 import Cached
 
@@ -741,8 +745,6 @@ predicate readStep(Node node1, Content c, Node node2) {
  * in `x.f = newValue`.
  */
 predicate clearsContent(Node n, Content c) {
-  storeStep(_, c, n)
-  or
   FlowSummaryImpl::Private::Steps::summaryClearsContent(n, c)
 }
 
@@ -886,4 +888,6 @@ predicate additionalLambdaFlowStep(Node nodeFrom, Node nodeTo, boolean preserves
  * One example would be to allow flow like `p.foo = p.bar;`, which is disallowed
  * by default as a heuristic.
  */
-predicate allowParameterReturnInSelf(ParameterNode p) { none() }
+predicate allowParameterReturnInSelf(ParameterNode p) {
+  FlowSummaryImpl::Private::summaryAllowParameterReturnInSelf(p)
+}

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -45,19 +45,19 @@ class Node extends TNode {
 }
 
 /** A data-flow node corresponding to a call in the control-flow graph. */
-class CallNode extends LocalSourceNode {
+class CallNode extends LocalSourceNode, ExprNode {
   private CfgNodes::ExprNodes::CallCfgNode node;
 
-  CallNode() { node = this.asExpr() }
+  CallNode() { node = this.getExprNode() }
 
   /** Gets the data-flow node corresponding to the receiver of the call corresponding to this data-flow node */
-  Node getReceiver() { result.asExpr() = node.getReceiver() }
+  ExprNode getReceiver() { result.getExprNode() = node.getReceiver() }
 
   /** Gets the data-flow node corresponding to the `n`th argument of the call corresponding to this data-flow node */
-  Node getArgument(int n) { result.asExpr() = node.getArgument(n) }
+  ExprNode getArgument(int n) { result.getExprNode() = node.getArgument(n) }
 
   /** Gets the data-flow node corresponding to the named argument of the call corresponding to this data-flow node */
-  Node getKeywordArgument(string name) { result.asExpr() = node.getKeywordArgument(name) }
+  ExprNode getKeywordArgument(string name) { result.getExprNode() = node.getKeywordArgument(name) }
 
   /** Gets the name of the the method called by the method call (if any) corresponding to this data-flow node */
   string getMethodName() { result = node.getExpr().(MethodCall).getMethodName() }
@@ -161,16 +161,38 @@ predicate localExprFlow(CfgNodes::ExprCfgNode e1, CfgNodes::ExprCfgNode e2) {
   localFlow(exprNode(e1), exprNode(e2))
 }
 
-/**
- * A reference contained in an object. This is either a field, a property,
- * or an element in a collection.
- */
+/** A reference contained in an object. */
 class Content extends TContent {
   /** Gets a textual representation of this content. */
   string toString() { none() }
 
   /** Gets the location of this content. */
   Location getLocation() { none() }
+}
+
+/** Provides different sub classes of `Content`. */
+module Content {
+  /** An element in an array. */
+  class ArrayElementContent extends Content, TArrayElementContent { }
+
+  /** An element in an array at a known index. */
+  class KnownArrayElementContent extends ArrayElementContent, TKnownArrayElementContent {
+    private int i;
+
+    KnownArrayElementContent() { this = TKnownArrayElementContent(i) }
+
+    /** Gets the index in the array. */
+    int getIndex() { result = i }
+
+    override string toString() { result = "array element " + i }
+  }
+
+  /** An element in an array at an unknown index. */
+  class UnknownArrayElementContent extends ArrayElementContent, TUnknownArrayElementContent {
+    UnknownArrayElementContent() { this = TUnknownArrayElementContent() }
+
+    override string toString() { result = "array element" }
+  }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -58,12 +58,33 @@ predicate summaryElement(DataFlowCallable c, string input, string output, string
  * This covers all the Ruby-specific components of a flow summary, and
  * is currently restricted to `"BlockArgument"`.
  */
+bindingset[c]
 SummaryComponent interpretComponentSpecific(string c) {
+  c = "Self" and
+  result = FlowSummary::SummaryComponent::self()
+  or
   c = "BlockArgument" and
   result = FlowSummary::SummaryComponent::block()
   or
   c = "Argument[_]" and
   result = FlowSummary::SummaryComponent::argument(any(ParameterPosition pos | pos.isPositional(_)))
+  or
+  c = "ArrayElement" and
+  result = FlowSummary::SummaryComponent::arrayElementAny()
+  or
+  c = "ArrayElement[?]" and
+  result = FlowSummary::SummaryComponent::arrayElementUnknown()
+  or
+  exists(int i |
+    c.regexpCapture("ArrayElement\\[([0-9]+)\\]", 1).toInt() = i and
+    result = FlowSummary::SummaryComponent::arrayElementKnown(i)
+  )
+  or
+  exists(int i1, int i2 |
+    c.regexpCapture("ArrayElement\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = i1 and
+    c.regexpCapture("ArrayElement\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = i2 and
+    result = FlowSummary::SummaryComponent::arrayElementKnown([i1 .. i2])
+  )
 }
 
 /** Gets the textual representation of a summary component in the format used for flow summaries. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -60,8 +60,8 @@ predicate summaryElement(DataFlowCallable c, string input, string output, string
  */
 bindingset[c]
 SummaryComponent interpretComponentSpecific(string c) {
-  c = "Self" and
-  result = FlowSummary::SummaryComponent::self()
+  c = "Receiver" and
+  result = FlowSummary::SummaryComponent::receiver()
   or
   c = "BlockArgument" and
   result = FlowSummary::SummaryComponent::block()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -1,4 +1,5 @@
 private import ruby
+private import DataFlowPrivate
 private import TaintTrackingPublic
 private import codeql.ruby.CFG
 private import codeql.ruby.DataFlow
@@ -34,8 +35,10 @@ predicate defaultAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nod
   nodeFrom.asExpr() =
     nodeTo.asExpr().(CfgNodes::ExprNodes::StringlikeLiteralCfgNode).getAComponent()
   or
-  // element reference from nodeFrom
-  nodeFrom.asExpr() = nodeTo.asExpr().(CfgNodes::ExprNodes::ElementReferenceCfgNode).getReceiver()
-  or
   FlowSummaryImpl::Private::Steps::summaryLocalStep(nodeFrom, nodeTo, false)
+  or
+  // Although flow through arrays is modelled precisely using stores/reads, we still
+  // allow flow out of a _tainted_ array. This is needed in order to support taint-
+  // tracking configurations where the source is an array.
+  readStep(nodeFrom, any(DataFlow::Content::ArrayElementContent c), nodeTo)
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -449,3 +449,1105 @@ private class LoggerSetPrognameCall extends LoggerLoggingCall {
     )
   }
 }
+
+private class SplatSummary extends SummarizedCallable {
+  SplatSummary() { this = "*(splat)" }
+
+  override SplatExpr getACall() { any() }
+
+  override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+    (
+      // *1 = [1]
+      input = "Self" and
+      output = "ArrayElement[0] of ReturnValue"
+      or
+      // *[1] = [1]
+      input = "Self" and
+      output = "ReturnValue"
+    ) and
+    preservesValue = true
+  }
+}
+
+private class ArrayIndex extends int {
+  ArrayIndex() { this = any(DataFlow::Content::KnownArrayElementContent c).getIndex() }
+}
+
+/**
+ * Provides flow summaries for the `Array` class.
+ *
+ * The summaries are ordered (and implemented) based on
+ * https://ruby-doc.org/core-2.7.0/Array.html, however for methods that have the
+ * more general `Enumerable` scope, they are implemented in the `Enumerable`
+ * module instead.
+ */
+module Array {
+  bindingset[arg]
+  private DataFlow::Content::KnownArrayElementContent getKnownArrayElementContent(Expr arg) {
+    result.getIndex() = arg.getValueText().toInt()
+  }
+
+  bindingset[arg]
+  private predicate isUnknownArrayElementContent(Expr arg) {
+    not exists(getKnownArrayElementContent(arg)) and
+    not arg instanceof RangeLiteral
+  }
+
+  private class ArrayLiteralSummary extends SummarizedCallable {
+    ArrayLiteralSummary() { this = "Array.[]" }
+
+    override MethodCall getACall() {
+      result = API::getTopLevelMember("Array").getAMethodCall("[]").getExprNode().getExpr()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      exists(ArrayIndex i |
+        input = "Argument[" + i + "]" and
+        output = "ArrayElement[" + i + "] of ReturnValue" and
+        preservesValue = true
+      )
+    }
+  }
+
+  private class NewSummary extends SummarizedCallable {
+    NewSummary() { this = "Array.new" }
+
+    override MethodCall getACall() {
+      result = API::getTopLevelMember("Array").getAnInstantiation().getExprNode().getExpr()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "Argument[1]" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Argument[0]" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+        or
+        input = "ArrayElement[?] of Argument[0]" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        input = "ReturnValue of BlockArgument" and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class TryConvertSummary extends SummarizedCallable {
+    TryConvertSummary() { this = "Array.try_convert" }
+
+    override MethodCall getACall() {
+      result = API::getTopLevelMember("Array").getAMethodCall("try_convert").getExprNode().getExpr()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Argument[0]" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+        or
+        input = "ArrayElement[?] of Argument[0]" and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class SetIntersectionSummary extends SummarizedCallable {
+    SetIntersectionSummary() { this = "&" }
+
+    override BitwiseAndExpr getACall() { any() }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = ["ArrayElement of Self", "ArrayElement of Argument[0]"] and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class RepetitionSummary extends SummarizedCallable {
+    RepetitionSummary() { this = "*" }
+
+    override MulExpr getACall() { any() }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class ConcatenationSummary extends SummarizedCallable {
+    ConcatenationSummary() { this = "+" }
+
+    override AddExpr getACall() { any() }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+        or
+        input = ["ArrayElement[?] of Self", "ArrayElement of Argument[0]"] and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class SetDifferenceSummary extends SummarizedCallable {
+    SetDifferenceSummary() { this = "-" }
+
+    override SubExpr getACall() { any() }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class AppendSummary extends SummarizedCallable {
+    AppendSummary() { this = "<<" }
+
+    override LShiftExpr getACall() { any() }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+        or
+        input = ["ArrayElement[?] of Self", "Argument[0]"] and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  /** A call to `[]`. */
+  abstract private class ElementReferenceReadSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    ElementReferenceReadSummary() { mc.getMethodName() = "[]" }
+
+    override MethodCall getACall() { result = mc }
+  }
+
+  /** A call to `[]` with a known index. */
+  private class ElementReferenceReadKnownSummary extends ElementReferenceReadSummary {
+    private int i;
+
+    ElementReferenceReadKnownSummary() {
+      this = "[" + i + "]" and
+      mc.getNumberOfArguments() = 1 and
+      i = getKnownArrayElementContent(mc.getArgument(0)).getIndex()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement[" + [i.toString(), "?"] + "] of Self" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  /** A call to `[]` with an unknown index. */
+  private class ElementReferenceReadUnknownSummary extends ElementReferenceReadSummary {
+    ElementReferenceReadUnknownSummary() {
+      this = "[](index)" and
+      mc.getNumberOfArguments() = 1 and
+      isUnknownArrayElementContent(mc.getArgument(0))
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  /** A call to `[]` with two arguments or a range argument. */
+  private class ElementReferenceSliceReadSummary extends ElementReferenceReadSummary {
+    ElementReferenceSliceReadSummary() {
+      this = "[](slice)" and
+      (
+        mc.getNumberOfArguments() = 2
+        or
+        mc.getNumberOfArguments() = 1 and
+        mc.getArgument(0) instanceof RangeLiteral
+      )
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  /** A call to `[]=`. */
+  abstract private class ElementReferenceStoreSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    ElementReferenceStoreSummary() { mc.getMethodName() = "[]=" }
+
+    final override MethodCall getACall() { result = mc }
+  }
+
+  /** A call to `[]=` with a known index. */
+  private class ElementReferenceStoreKnownSummary extends ElementReferenceStoreSummary {
+    private DataFlow::Content::KnownArrayElementContent c;
+
+    ElementReferenceStoreKnownSummary() {
+      mc.getNumberOfArguments() = 2 and
+      c = getKnownArrayElementContent(mc.getArgument(0)) and
+      this = "[" + c.getIndex() + "]="
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[1]" and
+      output = "ArrayElement[" + c.getIndex() + "] of Self" and
+      preservesValue = true
+    }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content = c
+    }
+  }
+
+  /** A call to `[]=` with an unknown index. */
+  private class ElementReferenceStoreUnknownSummary extends ElementReferenceStoreSummary {
+    ElementReferenceStoreUnknownSummary() {
+      mc.getNumberOfArguments() = 2 and
+      isUnknownArrayElementContent(mc.getArgument(0)) and
+      this = "[]="
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "Argument[1]" and
+      output = "ArrayElement[?] of Self" and
+      preservesValue = true
+    }
+  }
+
+  /** A call to `[]=` with two arguments or a range argument. */
+  private class ElementReferenceSliceStoreUnknownSummary extends ElementReferenceStoreSummary {
+    ElementReferenceSliceStoreUnknownSummary() {
+      this = "[]=(slice)" and
+      (
+        mc.getNumberOfArguments() > 2
+        or
+        mc.getNumberOfArguments() = 2 and
+        mc.getArgument(0) instanceof RangeLiteral
+      )
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      exists(string arg |
+        arg = "Argument[" + (mc.getNumberOfArguments() - 1) + "]" and
+        input = ["ArrayElement of " + arg, arg, "ArrayElement of Self"] and
+        output = "ArrayElement[?] of Self" and
+        preservesValue = true
+      )
+    }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content instanceof DataFlow::Content::KnownArrayElementContent
+    }
+  }
+
+  private class AssocSummary extends SimpleSummarizedCallable {
+    AssocSummary() { this = "assoc" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  abstract private class AtSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    AtSummary() { mc.getMethodName() = "at" }
+
+    override MethodCall getACall() { result = mc }
+  }
+
+  private class AtKnownSummary extends AtSummary {
+    private int i;
+
+    AtKnownSummary() {
+      this = "at(" + i + "]" and
+      mc.getNumberOfArguments() = 1 and
+      i = getKnownArrayElementContent(mc.getArgument(0)).getIndex()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement[" + [i.toString(), "?"] + "] of Self" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class AtUnknownSummary extends AtSummary {
+    AtUnknownSummary() {
+      this = "at" and
+      mc.getNumberOfArguments() = 1 and
+      isUnknownArrayElementContent(mc.getArgument(0))
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class BSearchSummary extends SimpleSummarizedCallable {
+    BSearchSummary() { this = "bsearch" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = ["Parameter[0] of BlockArgument", "ReturnValue"] and
+      preservesValue = true
+    }
+  }
+
+  private class BSearchIndexSummary extends SimpleSummarizedCallable {
+    BSearchIndexSummary() { this = "bsearch_index" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  private class ClearSummary extends SimpleSummarizedCallable {
+    ClearSummary() { this = "clear" }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content instanceof DataFlow::Content::ArrayElementContent
+    }
+  }
+
+  private class CombinationSummary extends SimpleSummarizedCallable {
+    CombinationSummary() { this = "combination" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  private class CompactSummary extends SimpleSummarizedCallable {
+    CompactSummary() { this = "compact" + ["", "!"] }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class ConcatSummary extends SimpleSummarizedCallable {
+    ConcatSummary() { this = "concat" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Argument[_]" and
+      output = "ArrayElement[?] of Self" and
+      preservesValue = true
+    }
+  }
+
+  private class DeleteSummary extends SimpleSummarizedCallable {
+    DeleteSummary() { this = "delete" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = ["ArrayElement of Self", "ReturnValue of BlockArgument"] and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class DeleteAtSummary extends SimpleSummarizedCallable {
+    DeleteAtSummary() { this = "delete_at" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class DeleteIfSummary extends SimpleSummarizedCallable {
+    DeleteIfSummary() { this = "delete_if" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = ["Parameter[0] of BlockArgument", "ArrayElement[?] of ReturnValue"] and
+      preservesValue = true
+    }
+  }
+
+  private class DifferenceSummary extends SimpleSummarizedCallable {
+    DifferenceSummary() { this = "difference" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      any(SetDifferenceSummary s).propagatesFlowExt(input, output, preservesValue)
+    }
+  }
+
+  private string getDigArg(MethodCall dig, int i) {
+    dig.getMethodName() = "dig" and
+    exists(Expr arg | arg = dig.getArgument(i) |
+      result = arg.getValueText().toInt().toString()
+      or
+      not exists(arg.getValueText()) and
+      result = "?"
+    )
+  }
+
+  private class RelevantDigMethodCall extends MethodCall {
+    RelevantDigMethodCall() {
+      forall(int i | i in [0 .. this.getNumberOfArguments() - 1] | exists(getDigArg(this, i)))
+    }
+  }
+
+  private string buildDigInputSpecComponent(RelevantDigMethodCall dig, int i) {
+    exists(string s |
+      s = getDigArg(dig, i) and
+      if s = "?" then result = "" else result = "[" + [s, "?"] + "]"
+    )
+  }
+
+  language[monotonicAggregates]
+  private string buildDigInputSpec(RelevantDigMethodCall dig) {
+    result =
+      strictconcat(int i |
+        i in [0 .. dig.getNumberOfArguments() - 1]
+      |
+        "ArrayElement" + buildDigInputSpecComponent(dig, i) + " of " order by i desc
+      )
+  }
+
+  private class DigSummary extends SummarizedCallable {
+    private RelevantDigMethodCall dig;
+
+    DigSummary() {
+      this =
+        "dig(" +
+          strictconcat(int i |
+            i in [0 .. dig.getNumberOfArguments() - 1]
+          |
+            getDigArg(dig, i), "," order by i
+          ) + ")"
+    }
+
+    override MethodCall getACall() { result = dig }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = buildDigInputSpec(dig) + "Self" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class EachSummary extends SimpleSummarizedCallable {
+    EachSummary() { this = "each" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "Parameter[0] of BlockArgument"
+        or
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class EachIndexSummary extends SimpleSummarizedCallable {
+    EachIndexSummary() { this = "each_index" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class FetchSummary extends SimpleSummarizedCallable {
+    FetchSummary() { this = "fetch" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "ReturnValue"
+        or
+        input = "Argument[0]" and
+        output = "Parameter[0] of BlockArgument"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  abstract private class FillSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    FillSummary() { mc.getMethodName() = "fill" }
+
+    override MethodCall getACall() { result = mc }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = ["Argument[0]", "ReturnValue of BlockArgument"] and
+      output = "ArrayElement[?] of Self" and
+      preservesValue = true
+    }
+  }
+
+  private class FillAllSummary extends FillSummary {
+    FillAllSummary() {
+      this = "fill(all)" and
+      if exists(mc.getBlock()) then mc.getNumberOfArguments() = 0 else mc.getNumberOfArguments() = 1
+    }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content instanceof DataFlow::Content::ArrayElementContent
+    }
+  }
+
+  private class FillSomeSummary extends FillSummary {
+    FillSomeSummary() {
+      this = "fill(some)" and
+      if exists(mc.getBlock()) then mc.getNumberOfArguments() > 0 else mc.getNumberOfArguments() > 1
+    }
+  }
+
+  private class FilterBangSummary extends SimpleSummarizedCallable {
+    FilterBangSummary() { this = "filter!" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = ["Parameter[0] of BlockArgument", "ArrayElement[?] of ReturnValue"] and
+      preservesValue = true
+    }
+  }
+
+  private class FlattenSummary extends SimpleSummarizedCallable {
+    FlattenSummary() { this = "flatten" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input =
+          [
+            "ArrayElement of Self", "ArrayElement of ArrayElement of Self",
+            "ArrayElement of ArrayElement of ArrayElement of Self"
+          ] and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class FlattenBangSummary extends SimpleSummarizedCallable {
+    FlattenBangSummary() { this = "flatten!" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input =
+          [
+            "ArrayElement of Self", "ArrayElement of ArrayElement of Self",
+            "ArrayElement of ArrayElement of ArrayElement of Self"
+          ] and
+        output = "ArrayElement[?] of Self"
+      ) and
+      preservesValue = true
+    }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content instanceof DataFlow::Content::ArrayElementContent
+    }
+  }
+
+  private class IndexSummary extends SimpleSummarizedCallable {
+    IndexSummary() { this = "index" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  private class InitializeCopySummary extends SimpleSummarizedCallable {
+    InitializeCopySummary() { this = "initialize_copy" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement[?] of Argument[0]" and
+        output = "ArrayElement[?] of Self"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Argument[0]" and
+          output = "ArrayElement[" + i + "] of Self"
+        )
+      ) and
+      preservesValue = true
+    }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content instanceof DataFlow::Content::ArrayElementContent
+    }
+  }
+
+  private class PrependSummary extends SummarizedCallable {
+    private MethodCall mc;
+
+    PrependSummary() {
+      mc.getMethodName() = "prepend" and
+      this = "prepend(" + mc.getNumberOfArguments() + ")"
+    }
+
+    override MethodCall getACall() { result = mc }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      exists(ArrayIndex i, int num | num = mc.getNumberOfArguments() and preservesValue = true |
+        input = "ArrayElement[" + i + "] of Self" and
+        output = "ArrayElement[" + (i + num) + "] of Self"
+        or
+        input = "Argument[" + i + "]" and
+        output = "ArrayElement[" + i + "] of Self"
+      )
+    }
+
+    override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
+      pos.isSelf() and
+      content instanceof DataFlow::Content::KnownArrayElementContent
+    }
+  }
+}
+
+/**
+ * Provides flow summaries for the `Enumerable` class.
+ *
+ * The summaries are ordered (and implemented) based on
+ * https://ruby-doc.org/core-2.7.0/Enumerable.html.
+ */
+module Enumerable {
+  private class AllSummary extends SimpleSummarizedCallable {
+    AllSummary() { this = "all?" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+      or
+      input = "ReturnValue of BlockArgument" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  private class AnySummary extends SimpleSummarizedCallable {
+    AnySummary() { this = "any?" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+      or
+      input = "ReturnValue of BlockArgument" and
+      output = "ReturnValue" and
+      preservesValue = false
+    }
+  }
+
+  private class CollectSummary extends SimpleSummarizedCallable {
+    CollectSummary() { this = ["collect", "collect!"] }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+      or
+      input = "ReturnValue of BlockArgument" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class CollectConcatSummary extends SimpleSummarizedCallable {
+    CollectConcatSummary() { this = "collect_concat" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+      or
+      input = "ArrayElement of ReturnValue of BlockArgument" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class CountSummary extends SimpleSummarizedCallable {
+    CountSummary() { this = "count" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  private class CycleSummary extends SimpleSummarizedCallable {
+    CycleSummary() { this = "cycle" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  private class DetectSummary extends SimpleSummarizedCallable {
+    DetectSummary() { this = "detect" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = ["Parameter[0] of BlockArgument", "ReturnValue"]
+        or
+        input = "ReturnValue of Argument[0]" and
+        output = "ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  abstract private class DropSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    DropSummary() { mc.getMethodName() = "drop" }
+
+    override MethodCall getACall() { result = mc }
+  }
+
+  private class DropKnownSummary extends DropSummary {
+    private int i;
+
+    DropKnownSummary() {
+      this = "drop(" + i + ")" and
+      i = mc.getArgument(0).getValueText().toInt()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex j |
+          input = "ArrayElement[" + j + "] of Self" and
+          output = "ArrayElement[" + (j - i) + "] of ReturnValue"
+        )
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class DropUnknownSummary extends DropSummary {
+    DropUnknownSummary() {
+      this = "drop(index)" and
+      not exists(mc.getArgument(0).getValueText().toInt())
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class DropWhileSummary extends SimpleSummarizedCallable {
+    DropWhileSummary() { this = "drop_while" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = ["ArrayElement[?] of ReturnValue", "Parameter[0] of BlockArgument"] and
+      preservesValue = true
+    }
+  }
+
+  private class EachConsSummary extends SimpleSummarizedCallable {
+    EachConsSummary() { this = "each_cons" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  private class EachEntrySummary extends SimpleSummarizedCallable {
+    EachEntrySummary() { this = "each_entry" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "Parameter[0] of BlockArgument"
+        or
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class EachSliceSummary extends SimpleSummarizedCallable {
+    EachSliceSummary() { this = "each_slice" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "ArrayElement[?] of Parameter[0] of BlockArgument"
+        or
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class EachWithIndexSummary extends SimpleSummarizedCallable {
+    EachWithIndexSummary() { this = "each_with_index" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "Parameter[0] of BlockArgument"
+        or
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+        or
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class EachWithObjectSummary extends SimpleSummarizedCallable {
+    EachWithObjectSummary() { this = "each_with_object" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "Parameter[0] of BlockArgument"
+        or
+        input = "Argument[0]" and
+        output = ["Parameter[1] of BlockArgument", "ReturnValue"]
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class FilterSummary extends SimpleSummarizedCallable {
+    FilterSummary() { this = ["filter", "filter_map"] }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = ["Parameter[0] of BlockArgument", "ArrayElement[?] of ReturnValue"] and
+      preservesValue = true
+    }
+  }
+
+  private class FindSummary extends SimpleSummarizedCallable {
+    FindSummary() { this = "find" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = ["Parameter[0] of BlockArgument", "ReturnValue"]
+        or
+        input = "ReturnValue of Argument[0]" and
+        output = "ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class FindAllSummary extends SimpleSummarizedCallable {
+    FindAllSummary() { this = "find_all" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      any(FilterSummary f).propagatesFlowExt(input, output, preservesValue)
+    }
+  }
+
+  private class FindIndexSummary extends SimpleSummarizedCallable {
+    FindIndexSummary() { this = "find_index" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "Parameter[0] of BlockArgument" and
+      preservesValue = true
+    }
+  }
+
+  abstract private class FirstSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    FirstSummary() { mc.getMethodName() = "first" }
+
+    override MethodCall getACall() { result = mc }
+  }
+
+  private class FirstNoArgSummary extends FirstSummary {
+    FirstNoArgSummary() { this = "first(no_arg)" and mc.getNumberOfArguments() = 0 }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = ["ArrayElement[0] of Self", "ArrayElement[?] of Self"] and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
+  private class FirstArgKnownSummary extends FirstSummary {
+    private int n;
+
+    FirstArgKnownSummary() {
+      this = "first(" + n + ")" and n = mc.getArgument(0).getValueText().toInt()
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        exists(ArrayIndex i |
+          i < n and
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+        or
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class FirstArgUnknownSummary extends FirstSummary {
+    FirstArgUnknownSummary() {
+      this = "first(?)" and
+      mc.getNumberOfArguments() > 0 and
+      not exists(mc.getArgument(0).getValueText().toInt())
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        exists(ArrayIndex i |
+          input = "ArrayElement[" + i + "] of Self" and
+          output = "ArrayElement[" + i + "] of ReturnValue"
+        )
+        or
+        input = "ArrayElement[?] of Self" and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class FlatMapSummary extends SimpleSummarizedCallable {
+    FlatMapSummary() { this = "flat_map" }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "Parameter[0] of BlockArgument"
+        or
+        input = "ArrayElement of ReturnValue of BlockArgument" and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  abstract private class GrepSummary extends SummarizedCallable {
+    MethodCall mc;
+
+    bindingset[this]
+    GrepSummary() { mc.getMethodName() = ["grep", "grep_v"] }
+
+    override MethodCall getACall() { result = mc }
+  }
+
+  private class GrepBlockSummary extends GrepSummary {
+    GrepBlockSummary() { this = "grep(block)" and exists(mc.getBlock()) }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      (
+        input = "ArrayElement of Self" and
+        output = "Parameter[0] of BlockArgument"
+        or
+        input = "ReturnValue of BlockArgument" and
+        output = "ArrayElement[?] of ReturnValue"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class GrepNoBlockSummary extends GrepSummary {
+    GrepNoBlockSummary() { this = "grep(no_block)" and not exists(mc.getBlock()) }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      input = "ArrayElement of Self" and
+      output = "ArrayElement[?] of ReturnValue" and
+      preservesValue = true
+    }
+  }
+  // TODO: Implement `group_by` when we have flow through hashes
+}

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -458,11 +458,11 @@ private class SplatSummary extends SummarizedCallable {
   override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
     (
       // *1 = [1]
-      input = "Self" and
+      input = "Receiver" and
       output = "ArrayElement[0] of ReturnValue"
       or
       // *[1] = [1]
-      input = "Self" and
+      input = "Receiver" and
       output = "ReturnValue"
     ) and
     preservesValue = true
@@ -563,7 +563,7 @@ module Array {
     override BitwiseAndExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["ArrayElement of Self", "ArrayElement of Argument[0]"] and
+      input = ["ArrayElement of Receiver", "ArrayElement of Argument[0]"] and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -575,7 +575,7 @@ module Array {
     override MulExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -589,11 +589,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
         or
-        input = ["ArrayElement[?] of Self", "ArrayElement of Argument[0]"] and
+        input = ["ArrayElement[?] of Receiver", "ArrayElement of Argument[0]"] and
         output = "ArrayElement[?] of ReturnValue"
       ) and
       preservesValue = true
@@ -606,7 +606,7 @@ module Array {
     override SubExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -620,11 +620,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
         or
-        input = ["ArrayElement[?] of Self", "Argument[0]"] and
+        input = ["ArrayElement[?] of Receiver", "Argument[0]"] and
         output = "ArrayElement[?] of ReturnValue"
       ) and
       preservesValue = true
@@ -652,7 +652,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement[" + [i.toString(), "?"] + "] of Self" and
+      input = "ArrayElement[" + [i.toString(), "?"] + "] of Receiver" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -667,7 +667,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -686,7 +686,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -714,7 +714,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[1]" and
-      output = "ArrayElement[" + c.getIndex() + "] of Self" and
+      output = "ArrayElement[" + c.getIndex() + "] of Receiver" and
       preservesValue = true
     }
 
@@ -734,7 +734,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[1]" and
-      output = "ArrayElement[?] of Self" and
+      output = "ArrayElement[?] of Receiver" and
       preservesValue = true
     }
   }
@@ -754,8 +754,8 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       exists(string arg |
         arg = "Argument[" + (mc.getNumberOfArguments() - 1) + "]" and
-        input = ["ArrayElement of " + arg, arg, "ArrayElement of Self"] and
-        output = "ArrayElement[?] of Self" and
+        input = ["ArrayElement of " + arg, arg, "ArrayElement of Receiver"] and
+        output = "ArrayElement[?] of Receiver" and
         preservesValue = true
       )
     }
@@ -770,7 +770,7 @@ module Array {
     AssocSummary() { this = "assoc" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of ArrayElement of Self" and
+      input = "ArrayElement of ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -795,7 +795,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement[" + [i.toString(), "?"] + "] of Self" and
+      input = "ArrayElement[" + [i.toString(), "?"] + "] of Receiver" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -809,7 +809,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -819,7 +819,7 @@ module Array {
     BSearchSummary() { this = "bsearch" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = ["Parameter[0] of BlockArgument", "ReturnValue"] and
       preservesValue = true
     }
@@ -829,7 +829,7 @@ module Array {
     BSearchIndexSummary() { this = "bsearch_index" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -848,7 +848,7 @@ module Array {
     CombinationSummary() { this = "combination" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -858,7 +858,7 @@ module Array {
     CompactSummary() { this = "compact" + ["", "!"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -869,7 +869,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "ArrayElement of Argument[_]" and
-      output = "ArrayElement[?] of Self" and
+      output = "ArrayElement[?] of Receiver" and
       preservesValue = true
     }
   }
@@ -878,7 +878,7 @@ module Array {
     DeleteSummary() { this = "delete" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["ArrayElement of Self", "ReturnValue of BlockArgument"] and
+      input = ["ArrayElement of Receiver", "ReturnValue of BlockArgument"] and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -888,7 +888,7 @@ module Array {
     DeleteAtSummary() { this = "delete_at" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -898,7 +898,7 @@ module Array {
     DeleteIfSummary() { this = "delete_if" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = ["Parameter[0] of BlockArgument", "ArrayElement[?] of ReturnValue"] and
       preservesValue = true
     }
@@ -961,7 +961,7 @@ module Array {
     override MethodCall getACall() { result = dig }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = buildDigInputSpec(dig) + "Self" and
+      input = buildDigInputSpec(dig) + "Receiver" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -972,14 +972,14 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "Parameter[0] of BlockArgument"
         or
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
         or
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
       ) and
@@ -992,11 +992,11 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
         or
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
       ) and
@@ -1009,7 +1009,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "ReturnValue"
         or
         input = "Argument[0]" and
@@ -1029,7 +1029,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = ["Argument[0]", "ReturnValue of BlockArgument"] and
-      output = "ArrayElement[?] of Self" and
+      output = "ArrayElement[?] of Receiver" and
       preservesValue = true
     }
   }
@@ -1057,7 +1057,7 @@ module Array {
     FilterBangSummary() { this = "filter!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = ["Parameter[0] of BlockArgument", "ArrayElement[?] of ReturnValue"] and
       preservesValue = true
     }
@@ -1070,8 +1070,8 @@ module Array {
       (
         input =
           [
-            "ArrayElement of Self", "ArrayElement of ArrayElement of Self",
-            "ArrayElement of ArrayElement of ArrayElement of Self"
+            "ArrayElement of Receiver", "ArrayElement of ArrayElement of Receiver",
+            "ArrayElement of ArrayElement of ArrayElement of Receiver"
           ] and
         output = "ArrayElement[?] of ReturnValue"
       ) and
@@ -1086,10 +1086,10 @@ module Array {
       (
         input =
           [
-            "ArrayElement of Self", "ArrayElement of ArrayElement of Self",
-            "ArrayElement of ArrayElement of ArrayElement of Self"
+            "ArrayElement of Receiver", "ArrayElement of ArrayElement of Receiver",
+            "ArrayElement of ArrayElement of ArrayElement of Receiver"
           ] and
-        output = "ArrayElement[?] of Self"
+        output = "ArrayElement[?] of Receiver"
       ) and
       preservesValue = true
     }
@@ -1104,7 +1104,7 @@ module Array {
     IndexSummary() { this = "index" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -1116,11 +1116,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "ArrayElement[?] of Argument[0]" and
-        output = "ArrayElement[?] of Self"
+        output = "ArrayElement[?] of Receiver"
         or
         exists(ArrayIndex i |
           input = "ArrayElement[" + i + "] of Argument[0]" and
-          output = "ArrayElement[" + i + "] of Self"
+          output = "ArrayElement[" + i + "] of Receiver"
         )
       ) and
       preservesValue = true
@@ -1144,11 +1144,11 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       exists(ArrayIndex i, int num | num = mc.getNumberOfArguments() and preservesValue = true |
-        input = "ArrayElement[" + i + "] of Self" and
-        output = "ArrayElement[" + (i + num) + "] of Self"
+        input = "ArrayElement[" + i + "] of Receiver" and
+        output = "ArrayElement[" + (i + num) + "] of Receiver"
         or
         input = "Argument[" + i + "]" and
-        output = "ArrayElement[" + i + "] of Self"
+        output = "ArrayElement[" + i + "] of Receiver"
       )
     }
 
@@ -1170,7 +1170,7 @@ module Enumerable {
     AllSummary() { this = "all?" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
       or
@@ -1184,7 +1184,7 @@ module Enumerable {
     AnySummary() { this = "any?" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
       or
@@ -1198,7 +1198,7 @@ module Enumerable {
     CollectSummary() { this = ["collect", "collect!"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
       or
@@ -1212,7 +1212,7 @@ module Enumerable {
     CollectConcatSummary() { this = "collect_concat" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
       or
@@ -1226,7 +1226,7 @@ module Enumerable {
     CountSummary() { this = "count" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -1236,7 +1236,7 @@ module Enumerable {
     CycleSummary() { this = "cycle" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -1247,7 +1247,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = ["Parameter[0] of BlockArgument", "ReturnValue"]
         or
         input = "ReturnValue of Argument[0]" and
@@ -1276,11 +1276,11 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
         or
         exists(ArrayIndex j |
-          input = "ArrayElement[" + j + "] of Self" and
+          input = "ArrayElement[" + j + "] of Receiver" and
           output = "ArrayElement[" + (j - i) + "] of ReturnValue"
         )
       ) and
@@ -1295,7 +1295,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }
@@ -1305,7 +1305,7 @@ module Enumerable {
     DropWhileSummary() { this = "drop_while" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = ["ArrayElement[?] of ReturnValue", "Parameter[0] of BlockArgument"] and
       preservesValue = true
     }
@@ -1315,7 +1315,7 @@ module Enumerable {
     EachConsSummary() { this = "each_cons" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -1326,14 +1326,14 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "Parameter[0] of BlockArgument"
         or
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
         or
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
       ) and
@@ -1346,14 +1346,14 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "ArrayElement[?] of Parameter[0] of BlockArgument"
         or
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
         or
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
       ) and
@@ -1366,14 +1366,14 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "Parameter[0] of BlockArgument"
         or
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
         or
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
       ) and
@@ -1386,7 +1386,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "Parameter[0] of BlockArgument"
         or
         input = "Argument[0]" and
@@ -1400,7 +1400,7 @@ module Enumerable {
     FilterSummary() { this = ["filter", "filter_map"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = ["Parameter[0] of BlockArgument", "ArrayElement[?] of ReturnValue"] and
       preservesValue = true
     }
@@ -1411,7 +1411,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = ["Parameter[0] of BlockArgument", "ReturnValue"]
         or
         input = "ReturnValue of Argument[0]" and
@@ -1433,7 +1433,7 @@ module Enumerable {
     FindIndexSummary() { this = "find_index" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "Parameter[0] of BlockArgument" and
       preservesValue = true
     }
@@ -1452,7 +1452,7 @@ module Enumerable {
     FirstNoArgSummary() { this = "first(no_arg)" and mc.getNumberOfArguments() = 0 }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["ArrayElement[0] of Self", "ArrayElement[?] of Self"] and
+      input = ["ArrayElement[0] of Receiver", "ArrayElement[?] of Receiver"] and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -1469,11 +1469,11 @@ module Enumerable {
       (
         exists(ArrayIndex i |
           i < n and
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
         or
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
       ) and
       preservesValue = true
@@ -1490,11 +1490,11 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "ArrayElement[" + i + "] of Self" and
+          input = "ArrayElement[" + i + "] of Receiver" and
           output = "ArrayElement[" + i + "] of ReturnValue"
         )
         or
-        input = "ArrayElement[?] of Self" and
+        input = "ArrayElement[?] of Receiver" and
         output = "ArrayElement[?] of ReturnValue"
       ) and
       preservesValue = true
@@ -1506,7 +1506,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "Parameter[0] of BlockArgument"
         or
         input = "ArrayElement of ReturnValue of BlockArgument" and
@@ -1530,7 +1530,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "ArrayElement of Self" and
+        input = "ArrayElement of Receiver" and
         output = "Parameter[0] of BlockArgument"
         or
         input = "ReturnValue of BlockArgument" and
@@ -1544,7 +1544,7 @@ module Enumerable {
     GrepNoBlockSummary() { this = "grep(no_block)" and not exists(mc.getBlock()) }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "ArrayElement of Self" and
+      input = "ArrayElement of Receiver" and
       output = "ArrayElement[?] of ReturnValue" and
       preservesValue = true
     }

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -1110,8 +1110,8 @@ module Array {
     }
   }
 
-  private class InitializeCopySummary extends SimpleSummarizedCallable {
-    InitializeCopySummary() { this = "initialize_copy" }
+  private class ReplaceSummary extends SimpleSummarizedCallable {
+    ReplaceSummary() { this = "replace" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -1,0 +1,1078 @@
+failures
+edges
+| array_flow.rb:2:9:2:18 | * ... [array element 0] :  | array_flow.rb:3:10:3:10 | a [array element 0] :  |
+| array_flow.rb:2:9:2:18 | * ... [array element 0] :  | array_flow.rb:5:10:5:10 | a [array element 0] :  |
+| array_flow.rb:2:10:2:18 | call to source :  | array_flow.rb:2:9:2:18 | * ... [array element 0] :  |
+| array_flow.rb:3:10:3:10 | a [array element 0] :  | array_flow.rb:3:10:3:13 | ...[...] |
+| array_flow.rb:5:10:5:10 | a [array element 0] :  | array_flow.rb:5:10:5:13 | ...[...] |
+| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:11:10:11:10 | a [array element 1] :  |
+| array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:13:10:13:10 | a [array element 1] :  |
+| array_flow.rb:11:10:11:10 | a [array element 1] :  | array_flow.rb:11:10:11:13 | ...[...] |
+| array_flow.rb:13:10:13:10 | a [array element 1] :  | array_flow.rb:13:10:13:13 | ...[...] |
+| array_flow.rb:17:9:17:33 | call to new [array element] :  | array_flow.rb:18:10:18:10 | a [array element] :  |
+| array_flow.rb:17:9:17:33 | call to new [array element] :  | array_flow.rb:19:10:19:10 | a [array element] :  |
+| array_flow.rb:17:9:17:33 | call to new [array element] :  | array_flow.rb:21:19:21:19 | a [array element] :  |
+| array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:17:9:17:33 | call to new [array element] :  |
+| array_flow.rb:18:10:18:10 | a [array element] :  | array_flow.rb:18:10:18:13 | ...[...] |
+| array_flow.rb:19:10:19:10 | a [array element] :  | array_flow.rb:19:10:19:13 | ...[...] |
+| array_flow.rb:21:9:21:20 | call to new [array element] :  | array_flow.rb:22:10:22:10 | b [array element] :  |
+| array_flow.rb:21:9:21:20 | call to new [array element] :  | array_flow.rb:23:10:23:10 | b [array element] :  |
+| array_flow.rb:21:19:21:19 | a [array element] :  | array_flow.rb:21:9:21:20 | call to new [array element] :  |
+| array_flow.rb:22:10:22:10 | b [array element] :  | array_flow.rb:22:10:22:13 | ...[...] |
+| array_flow.rb:23:10:23:10 | b [array element] :  | array_flow.rb:23:10:23:13 | ...[...] |
+| array_flow.rb:25:9:27:7 | call to new [array element] :  | array_flow.rb:28:10:28:10 | c [array element] :  |
+| array_flow.rb:25:9:27:7 | call to new [array element] :  | array_flow.rb:29:10:29:10 | c [array element] :  |
+| array_flow.rb:26:9:26:19 | call to source :  | array_flow.rb:25:9:27:7 | call to new [array element] :  |
+| array_flow.rb:28:10:28:10 | c [array element] :  | array_flow.rb:28:10:28:13 | ...[...] |
+| array_flow.rb:29:10:29:10 | c [array element] :  | array_flow.rb:29:10:29:13 | ...[...] |
+| array_flow.rb:33:10:33:18 | call to source :  | array_flow.rb:34:27:34:27 | a [array element 0] :  |
+| array_flow.rb:34:9:34:28 | call to try_convert [array element 0] :  | array_flow.rb:35:10:35:10 | b [array element 0] :  |
+| array_flow.rb:34:27:34:27 | a [array element 0] :  | array_flow.rb:34:9:34:28 | call to try_convert [array element 0] :  |
+| array_flow.rb:35:10:35:10 | b [array element 0] :  | array_flow.rb:35:10:35:13 | ...[...] |
+| array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:42:9:42:9 | a [array element 0] :  |
+| array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:42:13:42:13 | b [array element 2] :  |
+| array_flow.rb:42:9:42:9 | a [array element 0] :  | array_flow.rb:42:9:42:13 | ... & ... [array element] :  |
+| array_flow.rb:42:9:42:13 | ... & ... [array element] :  | array_flow.rb:43:10:43:10 | c [array element] :  |
+| array_flow.rb:42:9:42:13 | ... & ... [array element] :  | array_flow.rb:44:10:44:10 | c [array element] :  |
+| array_flow.rb:42:13:42:13 | b [array element 2] :  | array_flow.rb:42:9:42:13 | ... & ... [array element] :  |
+| array_flow.rb:43:10:43:10 | c [array element] :  | array_flow.rb:43:10:43:13 | ...[...] |
+| array_flow.rb:44:10:44:10 | c [array element] :  | array_flow.rb:44:10:44:13 | ...[...] |
+| array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:49:9:49:9 | a [array element 0] :  |
+| array_flow.rb:49:9:49:9 | a [array element 0] :  | array_flow.rb:49:9:49:13 | ... * ... [array element] :  |
+| array_flow.rb:49:9:49:13 | ... * ... [array element] :  | array_flow.rb:50:10:50:10 | b [array element] :  |
+| array_flow.rb:49:9:49:13 | ... * ... [array element] :  | array_flow.rb:51:10:51:10 | b [array element] :  |
+| array_flow.rb:50:10:50:10 | b [array element] :  | array_flow.rb:50:10:50:13 | ...[...] |
+| array_flow.rb:51:10:51:10 | b [array element] :  | array_flow.rb:51:10:51:13 | ...[...] |
+| array_flow.rb:55:10:55:20 | call to source :  | array_flow.rb:57:9:57:9 | a [array element 0] :  |
+| array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:57:13:57:13 | b [array element 1] :  |
+| array_flow.rb:57:9:57:9 | a [array element 0] :  | array_flow.rb:57:9:57:13 | ... + ... [array element 0] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [array element 0] :  | array_flow.rb:58:10:58:10 | c [array element 0] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [array element] :  | array_flow.rb:58:10:58:10 | c [array element] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [array element] :  | array_flow.rb:59:10:59:10 | c [array element] :  |
+| array_flow.rb:57:13:57:13 | b [array element 1] :  | array_flow.rb:57:9:57:13 | ... + ... [array element] :  |
+| array_flow.rb:58:10:58:10 | c [array element 0] :  | array_flow.rb:58:10:58:13 | ...[...] |
+| array_flow.rb:58:10:58:10 | c [array element] :  | array_flow.rb:58:10:58:13 | ...[...] |
+| array_flow.rb:59:10:59:10 | c [array element] :  | array_flow.rb:59:10:59:13 | ...[...] |
+| array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:65:9:65:9 | a [array element 0] :  |
+| array_flow.rb:65:9:65:9 | a [array element 0] :  | array_flow.rb:65:9:65:13 | ... - ... [array element] :  |
+| array_flow.rb:65:9:65:13 | ... - ... [array element] :  | array_flow.rb:66:10:66:10 | c [array element] :  |
+| array_flow.rb:65:9:65:13 | ... - ... [array element] :  | array_flow.rb:67:10:67:10 | c [array element] :  |
+| array_flow.rb:66:10:66:10 | c [array element] :  | array_flow.rb:66:10:66:13 | ...[...] |
+| array_flow.rb:67:10:67:10 | c [array element] :  | array_flow.rb:67:10:67:13 | ...[...] |
+| array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:72:9:72:9 | a [array element 0] :  |
+| array_flow.rb:72:9:72:9 | a [array element 0] :  | array_flow.rb:72:9:72:24 | ... << ... [array element 0] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [array element 0] :  | array_flow.rb:73:10:73:10 | b [array element 0] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [array element] :  | array_flow.rb:73:10:73:10 | b [array element] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [array element] :  | array_flow.rb:74:10:74:10 | b [array element] :  |
+| array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:72:9:72:24 | ... << ... [array element] :  |
+| array_flow.rb:73:10:73:10 | b [array element 0] :  | array_flow.rb:73:10:73:13 | ...[...] |
+| array_flow.rb:73:10:73:10 | b [array element] :  | array_flow.rb:73:10:73:13 | ...[...] |
+| array_flow.rb:74:10:74:10 | b [array element] :  | array_flow.rb:74:10:74:13 | ...[...] |
+| array_flow.rb:78:13:78:21 | call to source :  | array_flow.rb:79:15:79:15 | a [array element 1] :  |
+| array_flow.rb:79:15:79:15 | a [array element 1] :  | array_flow.rb:81:10:81:10 | c |
+| array_flow.rb:86:13:86:22 | call to source :  | array_flow.rb:87:9:87:9 | a [array element 1] :  |
+| array_flow.rb:87:9:87:9 | a [array element 1] :  | array_flow.rb:87:9:87:15 | ...[...] [array element] :  |
+| array_flow.rb:87:9:87:15 | ...[...] [array element] :  | array_flow.rb:88:10:88:10 | b [array element] :  |
+| array_flow.rb:87:9:87:15 | ...[...] [array element] :  | array_flow.rb:89:10:89:10 | b [array element] :  |
+| array_flow.rb:87:9:87:15 | ...[...] [array element] :  | array_flow.rb:90:10:90:10 | b [array element] :  |
+| array_flow.rb:88:10:88:10 | b [array element] :  | array_flow.rb:88:10:88:13 | ...[...] |
+| array_flow.rb:89:10:89:10 | b [array element] :  | array_flow.rb:89:10:89:13 | ...[...] |
+| array_flow.rb:90:10:90:10 | b [array element] :  | array_flow.rb:90:10:90:13 | ...[...] |
+| array_flow.rb:94:13:94:22 | call to source :  | array_flow.rb:95:9:95:9 | a [array element 1] :  |
+| array_flow.rb:95:9:95:9 | a [array element 1] :  | array_flow.rb:95:9:95:15 | ...[...] [array element] :  |
+| array_flow.rb:95:9:95:15 | ...[...] [array element] :  | array_flow.rb:96:10:96:10 | b [array element] :  |
+| array_flow.rb:95:9:95:15 | ...[...] [array element] :  | array_flow.rb:97:10:97:10 | b [array element] :  |
+| array_flow.rb:95:9:95:15 | ...[...] [array element] :  | array_flow.rb:98:10:98:10 | b [array element] :  |
+| array_flow.rb:96:10:96:10 | b [array element] :  | array_flow.rb:96:10:96:13 | ...[...] |
+| array_flow.rb:97:10:97:10 | b [array element] :  | array_flow.rb:97:10:97:13 | ...[...] |
+| array_flow.rb:98:10:98:10 | b [array element] :  | array_flow.rb:98:10:98:13 | ...[...] |
+| array_flow.rb:103:5:103:5 | [post] a [array element] :  | array_flow.rb:104:10:104:10 | a [array element] :  |
+| array_flow.rb:103:5:103:5 | [post] a [array element] :  | array_flow.rb:105:10:105:10 | a [array element] :  |
+| array_flow.rb:103:5:103:5 | [post] a [array element] :  | array_flow.rb:106:10:106:10 | a [array element] :  |
+| array_flow.rb:103:15:103:24 | call to source :  | array_flow.rb:103:5:103:5 | [post] a [array element] :  |
+| array_flow.rb:104:10:104:10 | a [array element] :  | array_flow.rb:104:10:104:13 | ...[...] |
+| array_flow.rb:105:10:105:10 | a [array element] :  | array_flow.rb:105:10:105:13 | ...[...] |
+| array_flow.rb:106:10:106:10 | a [array element] :  | array_flow.rb:106:10:106:13 | ...[...] |
+| array_flow.rb:111:5:111:5 | [post] a [array element] :  | array_flow.rb:112:10:112:10 | a [array element] :  |
+| array_flow.rb:111:5:111:5 | [post] a [array element] :  | array_flow.rb:113:10:113:10 | a [array element] :  |
+| array_flow.rb:111:5:111:5 | [post] a [array element] :  | array_flow.rb:114:10:114:10 | a [array element] :  |
+| array_flow.rb:111:19:111:28 | call to source :  | array_flow.rb:111:5:111:5 | [post] a [array element] :  |
+| array_flow.rb:112:10:112:10 | a [array element] :  | array_flow.rb:112:10:112:13 | ...[...] |
+| array_flow.rb:113:10:113:10 | a [array element] :  | array_flow.rb:113:10:113:13 | ...[...] |
+| array_flow.rb:114:10:114:10 | a [array element] :  | array_flow.rb:114:10:114:13 | ...[...] |
+| array_flow.rb:119:5:119:5 | [post] a [array element] :  | array_flow.rb:120:10:120:10 | a [array element] :  |
+| array_flow.rb:119:5:119:5 | [post] a [array element] :  | array_flow.rb:121:10:121:10 | a [array element] :  |
+| array_flow.rb:119:5:119:5 | [post] a [array element] :  | array_flow.rb:122:10:122:10 | a [array element] :  |
+| array_flow.rb:119:15:119:24 | call to source :  | array_flow.rb:119:5:119:5 | [post] a [array element] :  |
+| array_flow.rb:120:10:120:10 | a [array element] :  | array_flow.rb:120:10:120:13 | ...[...] |
+| array_flow.rb:121:10:121:10 | a [array element] :  | array_flow.rb:121:10:121:13 | ...[...] |
+| array_flow.rb:122:10:122:10 | a [array element] :  | array_flow.rb:122:10:122:13 | ...[...] |
+| array_flow.rb:127:5:127:5 | [post] a [array element] :  | array_flow.rb:128:10:128:10 | a [array element] :  |
+| array_flow.rb:127:5:127:5 | [post] a [array element] :  | array_flow.rb:129:10:129:10 | a [array element] :  |
+| array_flow.rb:127:5:127:5 | [post] a [array element] :  | array_flow.rb:130:10:130:10 | a [array element] :  |
+| array_flow.rb:127:19:127:28 | call to source :  | array_flow.rb:127:5:127:5 | [post] a [array element] :  |
+| array_flow.rb:128:10:128:10 | a [array element] :  | array_flow.rb:128:10:128:13 | ...[...] |
+| array_flow.rb:129:10:129:10 | a [array element] :  | array_flow.rb:129:10:129:13 | ...[...] |
+| array_flow.rb:130:10:130:10 | a [array element] :  | array_flow.rb:130:10:130:13 | ...[...] |
+| array_flow.rb:134:16:134:25 | call to source :  | array_flow.rb:135:5:135:5 | a [array element 2] :  |
+| array_flow.rb:135:5:135:5 | a [array element 2] :  | array_flow.rb:135:16:135:16 | x :  |
+| array_flow.rb:135:16:135:16 | x :  | array_flow.rb:136:14:136:14 | x |
+| array_flow.rb:141:16:141:25 | call to source :  | array_flow.rb:142:5:142:5 | a [array element 2] :  |
+| array_flow.rb:142:5:142:5 | a [array element 2] :  | array_flow.rb:142:16:142:16 | x :  |
+| array_flow.rb:142:16:142:16 | x :  | array_flow.rb:143:14:143:14 | x |
+| array_flow.rb:150:15:150:24 | call to source :  | array_flow.rb:151:16:151:16 | c [array element 1] :  |
+| array_flow.rb:151:16:151:16 | c [array element 1] :  | array_flow.rb:152:11:152:11 | d [array element 2, array element 1] :  |
+| array_flow.rb:151:16:151:16 | c [array element 1] :  | array_flow.rb:153:11:153:11 | d [array element 2, array element 1] :  |
+| array_flow.rb:152:11:152:11 | d [array element 2, array element 1] :  | array_flow.rb:152:11:152:22 | call to assoc [array element] :  |
+| array_flow.rb:152:11:152:22 | call to assoc [array element] :  | array_flow.rb:152:11:152:25 | ...[...] :  |
+| array_flow.rb:152:11:152:25 | ...[...] :  | array_flow.rb:152:10:152:26 | ( ... ) |
+| array_flow.rb:153:11:153:11 | d [array element 2, array element 1] :  | array_flow.rb:153:11:153:22 | call to assoc [array element] :  |
+| array_flow.rb:153:11:153:22 | call to assoc [array element] :  | array_flow.rb:153:11:153:25 | ...[...] :  |
+| array_flow.rb:153:11:153:25 | ...[...] :  | array_flow.rb:153:10:153:26 | ( ... ) |
+| array_flow.rb:157:13:157:22 | call to source :  | array_flow.rb:159:10:159:10 | a [array element 1] :  |
+| array_flow.rb:157:13:157:22 | call to source :  | array_flow.rb:161:10:161:10 | a [array element 1] :  |
+| array_flow.rb:159:10:159:10 | a [array element 1] :  | array_flow.rb:159:10:159:16 | call to at |
+| array_flow.rb:161:10:161:10 | a [array element 1] :  | array_flow.rb:161:10:161:16 | call to at |
+| array_flow.rb:165:16:165:25 | call to source :  | array_flow.rb:166:9:166:9 | a [array element 2] :  |
+| array_flow.rb:166:9:166:9 | a [array element 2] :  | array_flow.rb:166:9:168:7 | call to bsearch :  |
+| array_flow.rb:166:9:166:9 | a [array element 2] :  | array_flow.rb:166:23:166:23 | x :  |
+| array_flow.rb:166:9:168:7 | call to bsearch :  | array_flow.rb:169:10:169:10 | b |
+| array_flow.rb:166:23:166:23 | x :  | array_flow.rb:167:14:167:14 | x |
+| array_flow.rb:173:16:173:25 | call to source :  | array_flow.rb:174:9:174:9 | a [array element 2] :  |
+| array_flow.rb:174:9:174:9 | a [array element 2] :  | array_flow.rb:174:29:174:29 | x :  |
+| array_flow.rb:174:29:174:29 | x :  | array_flow.rb:175:14:175:14 | x |
+| array_flow.rb:187:16:187:25 | call to source :  | array_flow.rb:188:9:188:9 | a [array element 2] :  |
+| array_flow.rb:188:9:188:9 | a [array element 2] :  | array_flow.rb:188:9:191:7 | call to collect [array element] :  |
+| array_flow.rb:188:9:188:9 | a [array element 2] :  | array_flow.rb:188:23:188:23 | x :  |
+| array_flow.rb:188:9:191:7 | call to collect [array element] :  | array_flow.rb:192:10:192:10 | b [array element] :  |
+| array_flow.rb:188:23:188:23 | x :  | array_flow.rb:189:14:189:14 | x |
+| array_flow.rb:192:10:192:10 | b [array element] :  | array_flow.rb:192:10:192:13 | ...[...] |
+| array_flow.rb:196:16:196:25 | call to source :  | array_flow.rb:197:9:197:9 | a [array element 2] :  |
+| array_flow.rb:197:9:197:9 | a [array element 2] :  | array_flow.rb:197:9:200:7 | call to collect_concat [array element] :  |
+| array_flow.rb:197:9:197:9 | a [array element 2] :  | array_flow.rb:197:30:197:30 | x :  |
+| array_flow.rb:197:9:200:7 | call to collect_concat [array element] :  | array_flow.rb:201:10:201:10 | b [array element] :  |
+| array_flow.rb:197:30:197:30 | x :  | array_flow.rb:198:14:198:14 | x |
+| array_flow.rb:201:10:201:10 | b [array element] :  | array_flow.rb:201:10:201:13 | ...[...] |
+| array_flow.rb:205:16:205:25 | call to source :  | array_flow.rb:206:5:206:5 | a [array element 2] :  |
+| array_flow.rb:206:5:206:5 | a [array element 2] :  | array_flow.rb:206:26:206:26 | x [array element] :  |
+| array_flow.rb:206:26:206:26 | x [array element] :  | array_flow.rb:207:14:207:14 | x [array element] :  |
+| array_flow.rb:207:14:207:14 | x [array element] :  | array_flow.rb:207:14:207:17 | ...[...] |
+| array_flow.rb:212:16:212:25 | call to source :  | array_flow.rb:213:9:213:9 | a [array element 2] :  |
+| array_flow.rb:213:9:213:9 | a [array element 2] :  | array_flow.rb:213:9:213:17 | call to compact [array element] :  |
+| array_flow.rb:213:9:213:17 | call to compact [array element] :  | array_flow.rb:214:10:214:10 | b [array element] :  |
+| array_flow.rb:214:10:214:10 | b [array element] :  | array_flow.rb:214:10:214:13 | ...[...] |
+| array_flow.rb:218:16:218:27 | call to source :  | array_flow.rb:222:10:222:10 | a [array element 2] :  |
+| array_flow.rb:219:16:219:27 | call to source :  | array_flow.rb:220:14:220:14 | b [array element 2] :  |
+| array_flow.rb:220:5:220:5 | [post] a [array element] :  | array_flow.rb:221:10:221:10 | a [array element] :  |
+| array_flow.rb:220:5:220:5 | [post] a [array element] :  | array_flow.rb:222:10:222:10 | a [array element] :  |
+| array_flow.rb:220:14:220:14 | b [array element 2] :  | array_flow.rb:220:5:220:5 | [post] a [array element] :  |
+| array_flow.rb:221:10:221:10 | a [array element] :  | array_flow.rb:221:10:221:13 | ...[...] |
+| array_flow.rb:222:10:222:10 | a [array element 2] :  | array_flow.rb:222:10:222:13 | ...[...] |
+| array_flow.rb:222:10:222:10 | a [array element] :  | array_flow.rb:222:10:222:13 | ...[...] |
+| array_flow.rb:226:16:226:25 | call to source :  | array_flow.rb:227:5:227:5 | a [array element 2] :  |
+| array_flow.rb:227:5:227:5 | a [array element 2] :  | array_flow.rb:227:17:227:17 | x :  |
+| array_flow.rb:227:17:227:17 | x :  | array_flow.rb:228:14:228:14 | x |
+| array_flow.rb:233:16:233:25 | call to source :  | array_flow.rb:234:5:234:5 | a [array element 2] :  |
+| array_flow.rb:234:5:234:5 | a [array element 2] :  | array_flow.rb:234:20:234:20 | x :  |
+| array_flow.rb:234:20:234:20 | x :  | array_flow.rb:235:14:235:14 | x |
+| array_flow.rb:240:16:240:27 | call to source :  | array_flow.rb:241:9:241:9 | a [array element 2] :  |
+| array_flow.rb:241:9:241:9 | a [array element 2] :  | array_flow.rb:241:9:241:36 | call to delete :  |
+| array_flow.rb:241:9:241:36 | call to delete :  | array_flow.rb:242:10:242:10 | b |
+| array_flow.rb:241:23:241:34 | call to source :  | array_flow.rb:241:9:241:36 | call to delete :  |
+| array_flow.rb:246:16:246:25 | call to source :  | array_flow.rb:247:9:247:9 | a [array element 2] :  |
+| array_flow.rb:247:9:247:9 | a [array element 2] :  | array_flow.rb:247:9:247:22 | call to delete_at :  |
+| array_flow.rb:247:9:247:22 | call to delete_at :  | array_flow.rb:248:10:248:10 | b |
+| array_flow.rb:252:16:252:25 | call to source :  | array_flow.rb:253:9:253:9 | a [array element 2] :  |
+| array_flow.rb:253:9:253:9 | a [array element 2] :  | array_flow.rb:253:9:255:7 | call to delete_if [array element] :  |
+| array_flow.rb:253:9:253:9 | a [array element 2] :  | array_flow.rb:253:25:253:25 | x :  |
+| array_flow.rb:253:9:255:7 | call to delete_if [array element] :  | array_flow.rb:256:10:256:10 | b [array element] :  |
+| array_flow.rb:253:25:253:25 | x :  | array_flow.rb:254:14:254:14 | x |
+| array_flow.rb:256:10:256:10 | b [array element] :  | array_flow.rb:256:10:256:13 | ...[...] |
+| array_flow.rb:260:16:260:25 | call to source :  | array_flow.rb:261:9:261:9 | a [array element 2] :  |
+| array_flow.rb:261:9:261:9 | a [array element 2] :  | array_flow.rb:261:9:261:25 | call to difference [array element] :  |
+| array_flow.rb:261:9:261:25 | call to difference [array element] :  | array_flow.rb:262:10:262:10 | b [array element] :  |
+| array_flow.rb:262:10:262:10 | b [array element] :  | array_flow.rb:262:10:262:13 | ...[...] |
+| array_flow.rb:266:16:266:27 | call to source :  | array_flow.rb:268:10:268:10 | a [array element 2] :  |
+| array_flow.rb:266:16:266:27 | call to source :  | array_flow.rb:269:10:269:10 | a [array element 2] :  |
+| array_flow.rb:266:34:266:45 | call to source :  | array_flow.rb:271:10:271:10 | a [array element 3, array element 1] :  |
+| array_flow.rb:268:10:268:10 | a [array element 2] :  | array_flow.rb:268:10:268:17 | call to dig |
+| array_flow.rb:269:10:269:10 | a [array element 2] :  | array_flow.rb:269:10:269:17 | call to dig |
+| array_flow.rb:271:10:271:10 | a [array element 3, array element 1] :  | array_flow.rb:271:10:271:19 | call to dig |
+| array_flow.rb:275:16:275:27 | call to source :  | array_flow.rb:276:9:276:9 | a [array element 2] :  |
+| array_flow.rb:276:9:276:9 | a [array element 2] :  | array_flow.rb:276:9:278:7 | call to detect :  |
+| array_flow.rb:276:9:276:9 | a [array element 2] :  | array_flow.rb:276:43:276:43 | x :  |
+| array_flow.rb:276:9:278:7 | call to detect :  | array_flow.rb:279:10:279:10 | b |
+| array_flow.rb:276:23:276:34 | call to source :  | array_flow.rb:276:9:278:7 | call to detect :  |
+| array_flow.rb:276:43:276:43 | x :  | array_flow.rb:277:14:277:14 | x |
+| array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:284:9:284:9 | a [array element 2] :  |
+| array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:286:9:286:9 | a [array element 2] :  |
+| array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:291:9:291:9 | a [array element 2] :  |
+| array_flow.rb:283:30:283:41 | call to source :  | array_flow.rb:284:9:284:9 | a [array element 3] :  |
+| array_flow.rb:283:30:283:41 | call to source :  | array_flow.rb:286:9:286:9 | a [array element 3] :  |
+| array_flow.rb:284:9:284:9 | a [array element 2] :  | array_flow.rb:284:9:284:17 | call to drop [array element] :  |
+| array_flow.rb:284:9:284:9 | a [array element 3] :  | array_flow.rb:284:9:284:17 | call to drop [array element] :  |
+| array_flow.rb:284:9:284:17 | call to drop [array element] :  | array_flow.rb:285:10:285:10 | b [array element] :  |
+| array_flow.rb:285:10:285:10 | b [array element] :  | array_flow.rb:285:10:285:13 | ...[...] |
+| array_flow.rb:286:9:286:9 | a [array element 2] :  | array_flow.rb:286:9:286:17 | call to drop [array element 1] :  |
+| array_flow.rb:286:9:286:9 | a [array element 3] :  | array_flow.rb:286:9:286:17 | call to drop [array element 2] :  |
+| array_flow.rb:286:9:286:17 | call to drop [array element 1] :  | array_flow.rb:288:10:288:10 | b [array element 1] :  |
+| array_flow.rb:286:9:286:17 | call to drop [array element 1] :  | array_flow.rb:289:10:289:10 | b [array element 1] :  |
+| array_flow.rb:286:9:286:17 | call to drop [array element 2] :  | array_flow.rb:289:10:289:10 | b [array element 2] :  |
+| array_flow.rb:288:10:288:10 | b [array element 1] :  | array_flow.rb:288:10:288:13 | ...[...] |
+| array_flow.rb:289:10:289:10 | b [array element 1] :  | array_flow.rb:289:10:289:13 | ...[...] |
+| array_flow.rb:289:10:289:10 | b [array element 2] :  | array_flow.rb:289:10:289:13 | ...[...] |
+| array_flow.rb:290:5:290:5 | [post] a [array element] :  | array_flow.rb:291:9:291:9 | a [array element] :  |
+| array_flow.rb:290:12:290:23 | call to source :  | array_flow.rb:290:5:290:5 | [post] a [array element] :  |
+| array_flow.rb:291:9:291:9 | a [array element 2] :  | array_flow.rb:291:9:291:17 | call to drop [array element 1] :  |
+| array_flow.rb:291:9:291:9 | a [array element] :  | array_flow.rb:291:9:291:17 | call to drop [array element] :  |
+| array_flow.rb:291:9:291:17 | call to drop [array element 1] :  | array_flow.rb:292:10:292:10 | b [array element 1] :  |
+| array_flow.rb:291:9:291:17 | call to drop [array element] :  | array_flow.rb:292:10:292:10 | b [array element] :  |
+| array_flow.rb:291:9:291:17 | call to drop [array element] :  | array_flow.rb:293:9:293:9 | b [array element] :  |
+| array_flow.rb:292:10:292:10 | b [array element 1] :  | array_flow.rb:292:10:292:13 | ...[...] |
+| array_flow.rb:292:10:292:10 | b [array element] :  | array_flow.rb:292:10:292:13 | ...[...] |
+| array_flow.rb:293:9:293:9 | b [array element] :  | array_flow.rb:293:9:293:19 | call to drop [array element] :  |
+| array_flow.rb:293:9:293:19 | call to drop [array element] :  | array_flow.rb:294:10:294:10 | c [array element] :  |
+| array_flow.rb:294:10:294:10 | c [array element] :  | array_flow.rb:294:10:294:13 | ...[...] |
+| array_flow.rb:298:16:298:27 | call to source :  | array_flow.rb:299:9:299:9 | a [array element 2] :  |
+| array_flow.rb:298:30:298:41 | call to source :  | array_flow.rb:299:9:299:9 | a [array element 3] :  |
+| array_flow.rb:299:9:299:9 | a [array element 2] :  | array_flow.rb:299:9:301:7 | call to drop_while [array element] :  |
+| array_flow.rb:299:9:299:9 | a [array element 2] :  | array_flow.rb:299:26:299:26 | x :  |
+| array_flow.rb:299:9:299:9 | a [array element 3] :  | array_flow.rb:299:9:301:7 | call to drop_while [array element] :  |
+| array_flow.rb:299:9:299:9 | a [array element 3] :  | array_flow.rb:299:26:299:26 | x :  |
+| array_flow.rb:299:9:301:7 | call to drop_while [array element] :  | array_flow.rb:302:10:302:10 | b [array element] :  |
+| array_flow.rb:299:26:299:26 | x :  | array_flow.rb:300:14:300:14 | x |
+| array_flow.rb:302:10:302:10 | b [array element] :  | array_flow.rb:302:10:302:13 | ...[...] |
+| array_flow.rb:306:16:306:25 | call to source :  | array_flow.rb:307:9:307:9 | a [array element 2] :  |
+| array_flow.rb:307:9:307:9 | a [array element 2] :  | array_flow.rb:307:9:309:7 | call to each [array element 2] :  |
+| array_flow.rb:307:9:307:9 | a [array element 2] :  | array_flow.rb:307:20:307:20 | x :  |
+| array_flow.rb:307:9:309:7 | call to each [array element 2] :  | array_flow.rb:310:10:310:10 | b [array element 2] :  |
+| array_flow.rb:307:20:307:20 | x :  | array_flow.rb:308:14:308:14 | x |
+| array_flow.rb:310:10:310:10 | b [array element 2] :  | array_flow.rb:310:10:310:13 | ...[...] |
+| array_flow.rb:314:16:314:25 | call to source :  | array_flow.rb:315:18:315:18 | a [array element 2] :  |
+| array_flow.rb:315:9:317:7 | ... = ... :  | array_flow.rb:315:9:317:7 | call to each :  |
+| array_flow.rb:315:9:317:7 | __synth__0__1 :  | array_flow.rb:315:9:317:7 | ... = ... :  |
+| array_flow.rb:315:9:317:7 | __synth__0__1 :  | array_flow.rb:316:14:316:14 | x |
+| array_flow.rb:315:9:317:7 | call to each :  | array_flow.rb:318:10:318:10 | x |
+| array_flow.rb:315:18:315:18 | a [array element 2] :  | array_flow.rb:315:9:317:7 | __synth__0__1 :  |
+| array_flow.rb:315:18:315:18 | a [array element 2] :  | array_flow.rb:319:10:319:10 | b [array element 2] :  |
+| array_flow.rb:319:10:319:10 | b [array element 2] :  | array_flow.rb:319:10:319:13 | ...[...] |
+| array_flow.rb:323:16:323:25 | call to source :  | array_flow.rb:324:5:324:5 | a [array element 2] :  |
+| array_flow.rb:324:5:324:5 | a [array element 2] :  | array_flow.rb:324:24:324:24 | x [array element] :  |
+| array_flow.rb:324:24:324:24 | x [array element] :  | array_flow.rb:325:15:325:15 | x [array element] :  |
+| array_flow.rb:325:15:325:15 | x [array element] :  | array_flow.rb:325:15:325:18 | ...[...] :  |
+| array_flow.rb:325:15:325:18 | ...[...] :  | array_flow.rb:325:14:325:19 | ( ... ) |
+| array_flow.rb:330:16:330:25 | call to source :  | array_flow.rb:331:9:331:9 | a [array element 2] :  |
+| array_flow.rb:331:9:331:9 | a [array element 2] :  | array_flow.rb:331:9:333:7 | call to each_entry [array element 2] :  |
+| array_flow.rb:331:9:331:9 | a [array element 2] :  | array_flow.rb:331:26:331:26 | x :  |
+| array_flow.rb:331:9:333:7 | call to each_entry [array element 2] :  | array_flow.rb:334:10:334:10 | b [array element 2] :  |
+| array_flow.rb:331:26:331:26 | x :  | array_flow.rb:332:14:332:14 | x |
+| array_flow.rb:334:10:334:10 | b [array element 2] :  | array_flow.rb:334:10:334:13 | ...[...] |
+| array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:339:9:339:9 | a [array element 2] :  |
+| array_flow.rb:339:9:339:9 | a [array element 2] :  | array_flow.rb:339:9:341:7 | call to each_index [array element 2] :  |
+| array_flow.rb:339:9:341:7 | call to each_index [array element 2] :  | array_flow.rb:342:10:342:10 | b [array element 2] :  |
+| array_flow.rb:342:10:342:10 | b [array element 2] :  | array_flow.rb:342:10:342:13 | ...[...] |
+| array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:347:9:347:9 | a [array element 3] :  |
+| array_flow.rb:347:9:347:9 | a [array element 3] :  | array_flow.rb:347:9:349:7 | call to each_slice [array element 3] :  |
+| array_flow.rb:347:9:347:9 | a [array element 3] :  | array_flow.rb:347:26:347:26 | x [array element] :  |
+| array_flow.rb:347:9:349:7 | call to each_slice [array element 3] :  | array_flow.rb:350:10:350:10 | b [array element 3] :  |
+| array_flow.rb:347:26:347:26 | x [array element] :  | array_flow.rb:348:14:348:14 | x [array element] :  |
+| array_flow.rb:348:14:348:14 | x [array element] :  | array_flow.rb:348:14:348:17 | ...[...] |
+| array_flow.rb:350:10:350:10 | b [array element 3] :  | array_flow.rb:350:10:350:13 | ...[...] |
+| array_flow.rb:354:19:354:28 | call to source :  | array_flow.rb:355:9:355:9 | a [array element 3] :  |
+| array_flow.rb:355:9:355:9 | a [array element 3] :  | array_flow.rb:355:9:358:7 | call to each_with_index [array element 3] :  |
+| array_flow.rb:355:9:355:9 | a [array element 3] :  | array_flow.rb:355:31:355:31 | x :  |
+| array_flow.rb:355:9:358:7 | call to each_with_index [array element 3] :  | array_flow.rb:359:10:359:10 | b [array element 3] :  |
+| array_flow.rb:355:31:355:31 | x :  | array_flow.rb:356:14:356:14 | x |
+| array_flow.rb:359:10:359:10 | b [array element 3] :  | array_flow.rb:359:10:359:13 | ...[...] |
+| array_flow.rb:363:19:363:30 | call to source :  | array_flow.rb:364:9:364:9 | a [array element 3] :  |
+| array_flow.rb:364:9:364:9 | a [array element 3] :  | array_flow.rb:364:46:364:46 | x :  |
+| array_flow.rb:364:9:367:7 | call to each_with_object :  | array_flow.rb:368:10:368:10 | b |
+| array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:364:9:367:7 | call to each_with_object :  |
+| array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:364:48:364:48 | a :  |
+| array_flow.rb:364:46:364:46 | x :  | array_flow.rb:365:14:365:14 | x |
+| array_flow.rb:364:48:364:48 | a :  | array_flow.rb:366:14:366:14 | a |
+| array_flow.rb:372:19:372:30 | call to source :  | array_flow.rb:373:9:373:9 | a [array element 3] :  |
+| array_flow.rb:373:9:373:9 | a [array element 3] :  | array_flow.rb:373:9:375:7 | call to fetch :  |
+| array_flow.rb:373:9:375:7 | call to fetch :  | array_flow.rb:376:10:376:10 | b |
+| array_flow.rb:373:17:373:28 | call to source :  | array_flow.rb:373:35:373:35 | x :  |
+| array_flow.rb:373:35:373:35 | x :  | array_flow.rb:374:14:374:14 | x |
+| array_flow.rb:380:19:380:30 | call to source :  | array_flow.rb:382:10:382:10 | a [array element 3] :  |
+| array_flow.rb:381:5:381:5 | [post] a [array element] :  | array_flow.rb:382:10:382:10 | a [array element] :  |
+| array_flow.rb:381:12:381:23 | call to source :  | array_flow.rb:381:5:381:5 | [post] a [array element] :  |
+| array_flow.rb:382:10:382:10 | a [array element 3] :  | array_flow.rb:382:10:382:13 | ...[...] |
+| array_flow.rb:382:10:382:10 | a [array element] :  | array_flow.rb:382:10:382:13 | ...[...] |
+| array_flow.rb:383:5:383:5 | [post] a [array element] :  | array_flow.rb:384:10:384:10 | a [array element] :  |
+| array_flow.rb:383:12:383:23 | call to source :  | array_flow.rb:383:5:383:5 | [post] a [array element] :  |
+| array_flow.rb:384:10:384:10 | a [array element] :  | array_flow.rb:384:10:384:13 | ...[...] |
+| array_flow.rb:385:5:385:5 | [post] a [array element] :  | array_flow.rb:388:10:388:10 | a [array element] :  |
+| array_flow.rb:385:5:385:5 | [post] a [array element] :  | array_flow.rb:392:10:392:10 | a [array element] :  |
+| array_flow.rb:386:9:386:20 | call to source :  | array_flow.rb:385:5:385:5 | [post] a [array element] :  |
+| array_flow.rb:388:10:388:10 | a [array element] :  | array_flow.rb:388:10:388:13 | ...[...] |
+| array_flow.rb:389:5:389:5 | [post] a [array element] :  | array_flow.rb:392:10:392:10 | a [array element] :  |
+| array_flow.rb:390:9:390:20 | call to source :  | array_flow.rb:389:5:389:5 | [post] a [array element] :  |
+| array_flow.rb:392:10:392:10 | a [array element] :  | array_flow.rb:392:10:392:13 | ...[...] |
+| array_flow.rb:396:19:396:28 | call to source :  | array_flow.rb:397:9:397:9 | a [array element 3] :  |
+| array_flow.rb:397:9:397:9 | a [array element 3] :  | array_flow.rb:397:9:399:7 | call to filter [array element] :  |
+| array_flow.rb:397:9:397:9 | a [array element 3] :  | array_flow.rb:397:22:397:22 | x :  |
+| array_flow.rb:397:9:399:7 | call to filter [array element] :  | array_flow.rb:400:10:400:10 | b [array element] :  |
+| array_flow.rb:397:22:397:22 | x :  | array_flow.rb:398:14:398:14 | x |
+| array_flow.rb:400:10:400:10 | b [array element] :  | array_flow.rb:400:10:400:13 | ...[...] |
+| array_flow.rb:404:19:404:28 | call to source :  | array_flow.rb:405:9:405:9 | a [array element 3] :  |
+| array_flow.rb:405:9:405:9 | a [array element 3] :  | array_flow.rb:405:9:407:7 | call to filter_map [array element] :  |
+| array_flow.rb:405:9:405:9 | a [array element 3] :  | array_flow.rb:405:26:405:26 | x :  |
+| array_flow.rb:405:9:407:7 | call to filter_map [array element] :  | array_flow.rb:408:10:408:10 | b [array element] :  |
+| array_flow.rb:405:26:405:26 | x :  | array_flow.rb:406:14:406:14 | x |
+| array_flow.rb:408:10:408:10 | b [array element] :  | array_flow.rb:408:10:408:13 | ...[...] |
+| array_flow.rb:412:19:412:28 | call to source :  | array_flow.rb:413:9:413:9 | a [array element 3] :  |
+| array_flow.rb:413:9:413:9 | a [array element 3] :  | array_flow.rb:413:9:415:7 | call to filter! [array element] :  |
+| array_flow.rb:413:9:413:9 | a [array element 3] :  | array_flow.rb:413:23:413:23 | x :  |
+| array_flow.rb:413:9:415:7 | call to filter! [array element] :  | array_flow.rb:416:10:416:10 | b [array element] :  |
+| array_flow.rb:413:23:413:23 | x :  | array_flow.rb:414:14:414:14 | x |
+| array_flow.rb:416:10:416:10 | b [array element] :  | array_flow.rb:416:10:416:13 | ...[...] |
+| array_flow.rb:420:19:420:30 | call to source :  | array_flow.rb:421:9:421:9 | a [array element 3] :  |
+| array_flow.rb:421:9:421:9 | a [array element 3] :  | array_flow.rb:421:9:423:7 | call to find :  |
+| array_flow.rb:421:9:421:9 | a [array element 3] :  | array_flow.rb:421:41:421:41 | x :  |
+| array_flow.rb:421:9:423:7 | call to find :  | array_flow.rb:424:10:424:10 | b |
+| array_flow.rb:421:21:421:32 | call to source :  | array_flow.rb:421:9:423:7 | call to find :  |
+| array_flow.rb:421:41:421:41 | x :  | array_flow.rb:422:14:422:14 | x |
+| array_flow.rb:428:19:428:28 | call to source :  | array_flow.rb:429:9:429:9 | a [array element 3] :  |
+| array_flow.rb:429:9:429:9 | a [array element 3] :  | array_flow.rb:429:9:431:7 | call to find_all [array element] :  |
+| array_flow.rb:429:9:429:9 | a [array element 3] :  | array_flow.rb:429:24:429:24 | x :  |
+| array_flow.rb:429:9:431:7 | call to find_all [array element] :  | array_flow.rb:432:10:432:10 | b [array element] :  |
+| array_flow.rb:429:24:429:24 | x :  | array_flow.rb:430:14:430:14 | x |
+| array_flow.rb:432:10:432:10 | b [array element] :  | array_flow.rb:432:10:432:13 | ...[...] |
+| array_flow.rb:436:19:436:28 | call to source :  | array_flow.rb:437:5:437:5 | a [array element 3] :  |
+| array_flow.rb:437:5:437:5 | a [array element 3] :  | array_flow.rb:437:22:437:22 | x :  |
+| array_flow.rb:437:22:437:22 | x :  | array_flow.rb:438:14:438:14 | x |
+| array_flow.rb:443:10:443:21 | call to source :  | array_flow.rb:445:10:445:10 | a [array element 0] :  |
+| array_flow.rb:443:10:443:21 | call to source :  | array_flow.rb:446:9:446:9 | a [array element 0] :  |
+| array_flow.rb:443:10:443:21 | call to source :  | array_flow.rb:449:9:449:9 | a [array element 0] :  |
+| array_flow.rb:443:30:443:41 | call to source :  | array_flow.rb:449:9:449:9 | a [array element 3] :  |
+| array_flow.rb:444:5:444:5 | [post] a [array element] :  | array_flow.rb:445:10:445:10 | a [array element] :  |
+| array_flow.rb:444:5:444:5 | [post] a [array element] :  | array_flow.rb:446:9:446:9 | a [array element] :  |
+| array_flow.rb:444:5:444:5 | [post] a [array element] :  | array_flow.rb:449:9:449:9 | a [array element] :  |
+| array_flow.rb:444:12:444:23 | call to source :  | array_flow.rb:444:5:444:5 | [post] a [array element] :  |
+| array_flow.rb:445:10:445:10 | a [array element 0] :  | array_flow.rb:445:10:445:16 | call to first |
+| array_flow.rb:445:10:445:10 | a [array element] :  | array_flow.rb:445:10:445:16 | call to first |
+| array_flow.rb:446:9:446:9 | a [array element 0] :  | array_flow.rb:446:9:446:18 | call to first [array element 0] :  |
+| array_flow.rb:446:9:446:9 | a [array element] :  | array_flow.rb:446:9:446:18 | call to first [array element] :  |
+| array_flow.rb:446:9:446:18 | call to first [array element 0] :  | array_flow.rb:447:10:447:10 | b [array element 0] :  |
+| array_flow.rb:446:9:446:18 | call to first [array element] :  | array_flow.rb:447:10:447:10 | b [array element] :  |
+| array_flow.rb:446:9:446:18 | call to first [array element] :  | array_flow.rb:448:10:448:10 | b [array element] :  |
+| array_flow.rb:447:10:447:10 | b [array element 0] :  | array_flow.rb:447:10:447:13 | ...[...] |
+| array_flow.rb:447:10:447:10 | b [array element] :  | array_flow.rb:447:10:447:13 | ...[...] |
+| array_flow.rb:448:10:448:10 | b [array element] :  | array_flow.rb:448:10:448:13 | ...[...] |
+| array_flow.rb:449:9:449:9 | a [array element 0] :  | array_flow.rb:449:9:449:18 | call to first [array element 0] :  |
+| array_flow.rb:449:9:449:9 | a [array element 3] :  | array_flow.rb:449:9:449:18 | call to first [array element 3] :  |
+| array_flow.rb:449:9:449:9 | a [array element] :  | array_flow.rb:449:9:449:18 | call to first [array element] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element 0] :  | array_flow.rb:450:10:450:10 | c [array element 0] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element 3] :  | array_flow.rb:451:10:451:10 | c [array element 3] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element] :  | array_flow.rb:450:10:450:10 | c [array element] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element] :  | array_flow.rb:451:10:451:10 | c [array element] :  |
+| array_flow.rb:450:10:450:10 | c [array element 0] :  | array_flow.rb:450:10:450:13 | ...[...] |
+| array_flow.rb:450:10:450:10 | c [array element] :  | array_flow.rb:450:10:450:13 | ...[...] |
+| array_flow.rb:451:10:451:10 | c [array element 3] :  | array_flow.rb:451:10:451:13 | ...[...] |
+| array_flow.rb:451:10:451:10 | c [array element] :  | array_flow.rb:451:10:451:13 | ...[...] |
+| array_flow.rb:455:19:455:30 | call to source :  | array_flow.rb:456:9:456:9 | a [array element 3] :  |
+| array_flow.rb:456:9:456:9 | a [array element 3] :  | array_flow.rb:456:9:459:7 | call to flat_map [array element] :  |
+| array_flow.rb:456:9:456:9 | a [array element 3] :  | array_flow.rb:456:24:456:24 | x :  |
+| array_flow.rb:456:9:459:7 | call to flat_map [array element] :  | array_flow.rb:460:10:460:10 | b [array element] :  |
+| array_flow.rb:456:24:456:24 | x :  | array_flow.rb:457:14:457:14 | x |
+| array_flow.rb:458:13:458:24 | call to source :  | array_flow.rb:456:9:459:7 | call to flat_map [array element] :  |
+| array_flow.rb:460:10:460:10 | b [array element] :  | array_flow.rb:460:10:460:13 | ...[...] |
+| array_flow.rb:464:20:464:29 | call to source :  | array_flow.rb:465:9:465:9 | a [array element 2, array element 1] :  |
+| array_flow.rb:465:9:465:9 | a [array element 2, array element 1] :  | array_flow.rb:465:9:465:17 | call to flatten [array element] :  |
+| array_flow.rb:465:9:465:17 | call to flatten [array element] :  | array_flow.rb:466:10:466:10 | b [array element] :  |
+| array_flow.rb:466:10:466:10 | b [array element] :  | array_flow.rb:466:10:466:13 | ...[...] |
+| array_flow.rb:470:20:470:29 | call to source :  | array_flow.rb:471:10:471:10 | a [array element 2, array element 1] :  |
+| array_flow.rb:470:20:470:29 | call to source :  | array_flow.rb:472:5:472:5 | a [array element 2, array element 1] :  |
+| array_flow.rb:471:10:471:10 | a [array element 2, array element 1] :  | array_flow.rb:471:10:471:13 | ...[...] [array element 1] :  |
+| array_flow.rb:471:10:471:13 | ...[...] [array element 1] :  | array_flow.rb:471:10:471:16 | ...[...] |
+| array_flow.rb:472:5:472:5 | [post] a [array element, array element 1] :  | array_flow.rb:474:10:474:10 | a [array element, array element 1] :  |
+| array_flow.rb:472:5:472:5 | [post] a [array element] :  | array_flow.rb:473:10:473:10 | a [array element] :  |
+| array_flow.rb:472:5:472:5 | a [array element 2, array element 1] :  | array_flow.rb:472:5:472:5 | [post] a [array element, array element 1] :  |
+| array_flow.rb:472:5:472:5 | a [array element 2, array element 1] :  | array_flow.rb:472:5:472:5 | [post] a [array element] :  |
+| array_flow.rb:473:10:473:10 | a [array element] :  | array_flow.rb:473:10:473:13 | ...[...] |
+| array_flow.rb:474:10:474:10 | a [array element, array element 1] :  | array_flow.rb:474:10:474:13 | ...[...] [array element 1] :  |
+| array_flow.rb:474:10:474:13 | ...[...] [array element 1] :  | array_flow.rb:474:10:474:16 | ...[...] |
+| array_flow.rb:478:19:478:30 | call to source :  | array_flow.rb:479:9:479:9 | a [array element 3] :  |
+| array_flow.rb:478:19:478:30 | call to source :  | array_flow.rb:481:9:481:9 | a [array element 3] :  |
+| array_flow.rb:479:9:479:9 | a [array element 3] :  | array_flow.rb:479:9:479:20 | call to grep [array element] :  |
+| array_flow.rb:479:9:479:20 | call to grep [array element] :  | array_flow.rb:480:10:480:10 | b [array element] :  |
+| array_flow.rb:480:10:480:10 | b [array element] :  | array_flow.rb:480:10:480:13 | ...[...] |
+| array_flow.rb:481:9:481:9 | a [array element 3] :  | array_flow.rb:481:26:481:26 | x :  |
+| array_flow.rb:481:9:484:7 | call to grep [array element] :  | array_flow.rb:485:10:485:10 | b [array element] :  |
+| array_flow.rb:481:26:481:26 | x :  | array_flow.rb:482:14:482:14 | x |
+| array_flow.rb:483:9:483:20 | call to source :  | array_flow.rb:481:9:484:7 | call to grep [array element] :  |
+| array_flow.rb:485:10:485:10 | b [array element] :  | array_flow.rb:485:10:485:13 | ...[...] |
+| array_flow.rb:489:19:489:30 | call to source :  | array_flow.rb:490:9:490:9 | a [array element 3] :  |
+| array_flow.rb:489:19:489:30 | call to source :  | array_flow.rb:492:9:492:9 | a [array element 3] :  |
+| array_flow.rb:490:9:490:9 | a [array element 3] :  | array_flow.rb:490:9:490:21 | call to grep_v [array element] :  |
+| array_flow.rb:490:9:490:21 | call to grep_v [array element] :  | array_flow.rb:491:10:491:10 | b [array element] :  |
+| array_flow.rb:491:10:491:10 | b [array element] :  | array_flow.rb:491:10:491:13 | ...[...] |
+| array_flow.rb:492:9:492:9 | a [array element 3] :  | array_flow.rb:492:27:492:27 | x :  |
+| array_flow.rb:492:9:495:7 | call to grep_v [array element] :  | array_flow.rb:496:10:496:10 | b [array element] :  |
+| array_flow.rb:492:27:492:27 | x :  | array_flow.rb:493:14:493:14 | x |
+| array_flow.rb:494:9:494:20 | call to source :  | array_flow.rb:492:9:495:7 | call to grep_v [array element] :  |
+| array_flow.rb:496:10:496:10 | b [array element] :  | array_flow.rb:496:10:496:13 | ...[...] |
+| array_flow.rb:500:19:500:28 | call to source :  | array_flow.rb:501:5:501:5 | a [array element 3] :  |
+| array_flow.rb:501:5:501:5 | a [array element 3] :  | array_flow.rb:501:17:501:17 | x :  |
+| array_flow.rb:501:17:501:17 | x :  | array_flow.rb:502:14:502:14 | x |
+| array_flow.rb:508:5:508:5 | [post] a [array element 0] :  | array_flow.rb:509:10:509:10 | a [array element 0] :  |
+| array_flow.rb:508:24:508:35 | call to source :  | array_flow.rb:508:5:508:5 | [post] a [array element 0] :  |
+| array_flow.rb:509:10:509:10 | a [array element 0] :  | array_flow.rb:509:10:509:13 | ...[...] |
+| array_flow.rb:515:16:515:29 | call to source :  | array_flow.rb:516:5:516:5 | a [array element 2] :  |
+| array_flow.rb:516:5:516:5 | [post] a [array element 2] :  | array_flow.rb:519:10:519:10 | a [array element 2] :  |
+| array_flow.rb:516:5:516:5 | [post] a [array element 5] :  | array_flow.rb:522:10:522:10 | a [array element 5] :  |
+| array_flow.rb:516:5:516:5 | a [array element 2] :  | array_flow.rb:516:5:516:5 | [post] a [array element 5] :  |
+| array_flow.rb:516:21:516:34 | call to source :  | array_flow.rb:516:5:516:5 | [post] a [array element 2] :  |
+| array_flow.rb:519:10:519:10 | a [array element 2] :  | array_flow.rb:519:10:519:13 | ...[...] |
+| array_flow.rb:522:10:522:10 | a [array element 5] :  | array_flow.rb:522:10:522:13 | ...[...] |
+nodes
+| array_flow.rb:2:9:2:18 | * ... [array element 0] :  | semmle.label | * ... [array element 0] :  |
+| array_flow.rb:2:10:2:18 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:3:10:3:10 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:3:10:3:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:5:10:5:10 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:5:10:5:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:9:13:9:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:11:10:11:10 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:11:10:11:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:13:10:13:10 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:13:10:13:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:17:9:17:33 | call to new [array element] :  | semmle.label | call to new [array element] :  |
+| array_flow.rb:17:22:17:32 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:18:10:18:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:18:10:18:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:19:10:19:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:19:10:19:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:21:9:21:20 | call to new [array element] :  | semmle.label | call to new [array element] :  |
+| array_flow.rb:21:19:21:19 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:22:10:22:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:22:10:22:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:23:10:23:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:23:10:23:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:25:9:27:7 | call to new [array element] :  | semmle.label | call to new [array element] :  |
+| array_flow.rb:26:9:26:19 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:28:10:28:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:28:10:28:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:29:10:29:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:33:10:33:18 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:34:9:34:28 | call to try_convert [array element 0] :  | semmle.label | call to try_convert [array element 0] :  |
+| array_flow.rb:34:27:34:27 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:35:10:35:10 | b [array element 0] :  | semmle.label | b [array element 0] :  |
+| array_flow.rb:35:10:35:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:40:10:40:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:41:16:41:26 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:42:9:42:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:42:9:42:13 | ... & ... [array element] :  | semmle.label | ... & ... [array element] :  |
+| array_flow.rb:42:13:42:13 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:43:10:43:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:43:10:43:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:44:10:44:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:44:10:44:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:48:10:48:18 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:49:9:49:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:49:9:49:13 | ... * ... [array element] :  | semmle.label | ... * ... [array element] :  |
+| array_flow.rb:50:10:50:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:50:10:50:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:51:10:51:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:51:10:51:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:55:10:55:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:56:13:56:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:57:9:57:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [array element 0] :  | semmle.label | ... + ... [array element 0] :  |
+| array_flow.rb:57:9:57:13 | ... + ... [array element] :  | semmle.label | ... + ... [array element] :  |
+| array_flow.rb:57:13:57:13 | b [array element 1] :  | semmle.label | b [array element 1] :  |
+| array_flow.rb:58:10:58:10 | c [array element 0] :  | semmle.label | c [array element 0] :  |
+| array_flow.rb:58:10:58:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:58:10:58:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:59:10:59:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:59:10:59:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:63:10:63:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:65:9:65:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:65:9:65:13 | ... - ... [array element] :  | semmle.label | ... - ... [array element] :  |
+| array_flow.rb:66:10:66:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:66:10:66:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:67:10:67:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:67:10:67:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:71:10:71:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:72:9:72:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [array element 0] :  | semmle.label | ... << ... [array element 0] :  |
+| array_flow.rb:72:9:72:24 | ... << ... [array element] :  | semmle.label | ... << ... [array element] :  |
+| array_flow.rb:72:14:72:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:73:10:73:10 | b [array element 0] :  | semmle.label | b [array element 0] :  |
+| array_flow.rb:73:10:73:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:73:10:73:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:74:10:74:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:74:10:74:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:78:13:78:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:79:15:79:15 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:81:10:81:10 | c | semmle.label | c |
+| array_flow.rb:86:13:86:22 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:87:9:87:9 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:87:9:87:15 | ...[...] [array element] :  | semmle.label | ...[...] [array element] :  |
+| array_flow.rb:88:10:88:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:88:10:88:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:89:10:89:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:89:10:89:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:90:10:90:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:90:10:90:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:94:13:94:22 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:95:9:95:9 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:95:9:95:15 | ...[...] [array element] :  | semmle.label | ...[...] [array element] :  |
+| array_flow.rb:96:10:96:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:96:10:96:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:97:10:97:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:97:10:97:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:98:10:98:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:98:10:98:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:103:5:103:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:103:15:103:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:104:10:104:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:104:10:104:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:105:10:105:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:105:10:105:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:106:10:106:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:106:10:106:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:111:5:111:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:111:19:111:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:112:10:112:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:112:10:112:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:113:10:113:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:113:10:113:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:114:10:114:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:114:10:114:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:119:5:119:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:119:15:119:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:120:10:120:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:120:10:120:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:121:10:121:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:121:10:121:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:122:10:122:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:122:10:122:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:127:5:127:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:127:19:127:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:128:10:128:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:128:10:128:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:129:10:129:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:129:10:129:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:130:10:130:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:130:10:130:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:134:16:134:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:135:5:135:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:135:16:135:16 | x :  | semmle.label | x :  |
+| array_flow.rb:136:14:136:14 | x | semmle.label | x |
+| array_flow.rb:141:16:141:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:142:5:142:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:142:16:142:16 | x :  | semmle.label | x :  |
+| array_flow.rb:143:14:143:14 | x | semmle.label | x |
+| array_flow.rb:150:15:150:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:151:16:151:16 | c [array element 1] :  | semmle.label | c [array element 1] :  |
+| array_flow.rb:152:10:152:26 | ( ... ) | semmle.label | ( ... ) |
+| array_flow.rb:152:11:152:11 | d [array element 2, array element 1] :  | semmle.label | d [array element 2, array element 1] :  |
+| array_flow.rb:152:11:152:22 | call to assoc [array element] :  | semmle.label | call to assoc [array element] :  |
+| array_flow.rb:152:11:152:25 | ...[...] :  | semmle.label | ...[...] :  |
+| array_flow.rb:153:10:153:26 | ( ... ) | semmle.label | ( ... ) |
+| array_flow.rb:153:11:153:11 | d [array element 2, array element 1] :  | semmle.label | d [array element 2, array element 1] :  |
+| array_flow.rb:153:11:153:22 | call to assoc [array element] :  | semmle.label | call to assoc [array element] :  |
+| array_flow.rb:153:11:153:25 | ...[...] :  | semmle.label | ...[...] :  |
+| array_flow.rb:157:13:157:22 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:159:10:159:10 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:159:10:159:16 | call to at | semmle.label | call to at |
+| array_flow.rb:161:10:161:10 | a [array element 1] :  | semmle.label | a [array element 1] :  |
+| array_flow.rb:161:10:161:16 | call to at | semmle.label | call to at |
+| array_flow.rb:165:16:165:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:166:9:166:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:166:9:168:7 | call to bsearch :  | semmle.label | call to bsearch :  |
+| array_flow.rb:166:23:166:23 | x :  | semmle.label | x :  |
+| array_flow.rb:167:14:167:14 | x | semmle.label | x |
+| array_flow.rb:169:10:169:10 | b | semmle.label | b |
+| array_flow.rb:173:16:173:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:174:9:174:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:174:29:174:29 | x :  | semmle.label | x :  |
+| array_flow.rb:175:14:175:14 | x | semmle.label | x |
+| array_flow.rb:187:16:187:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:188:9:188:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:188:9:191:7 | call to collect [array element] :  | semmle.label | call to collect [array element] :  |
+| array_flow.rb:188:23:188:23 | x :  | semmle.label | x :  |
+| array_flow.rb:189:14:189:14 | x | semmle.label | x |
+| array_flow.rb:192:10:192:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:192:10:192:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:196:16:196:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:197:9:197:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:197:9:200:7 | call to collect_concat [array element] :  | semmle.label | call to collect_concat [array element] :  |
+| array_flow.rb:197:30:197:30 | x :  | semmle.label | x :  |
+| array_flow.rb:198:14:198:14 | x | semmle.label | x |
+| array_flow.rb:201:10:201:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:201:10:201:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:205:16:205:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:206:5:206:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:206:26:206:26 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:207:14:207:14 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:207:14:207:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:212:16:212:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:213:9:213:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:213:9:213:17 | call to compact [array element] :  | semmle.label | call to compact [array element] :  |
+| array_flow.rb:214:10:214:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:214:10:214:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:218:16:218:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:219:16:219:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:220:5:220:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:220:14:220:14 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:221:10:221:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:221:10:221:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:222:10:222:10 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:222:10:222:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:222:10:222:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:226:16:226:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:227:5:227:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:227:17:227:17 | x :  | semmle.label | x :  |
+| array_flow.rb:228:14:228:14 | x | semmle.label | x |
+| array_flow.rb:233:16:233:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:234:5:234:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:234:20:234:20 | x :  | semmle.label | x :  |
+| array_flow.rb:235:14:235:14 | x | semmle.label | x |
+| array_flow.rb:240:16:240:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:241:9:241:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:241:9:241:36 | call to delete :  | semmle.label | call to delete :  |
+| array_flow.rb:241:23:241:34 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:242:10:242:10 | b | semmle.label | b |
+| array_flow.rb:246:16:246:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:247:9:247:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:247:9:247:22 | call to delete_at :  | semmle.label | call to delete_at :  |
+| array_flow.rb:248:10:248:10 | b | semmle.label | b |
+| array_flow.rb:252:16:252:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:253:9:253:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:253:9:255:7 | call to delete_if [array element] :  | semmle.label | call to delete_if [array element] :  |
+| array_flow.rb:253:25:253:25 | x :  | semmle.label | x :  |
+| array_flow.rb:254:14:254:14 | x | semmle.label | x |
+| array_flow.rb:256:10:256:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:256:10:256:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:260:16:260:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:261:9:261:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:261:9:261:25 | call to difference [array element] :  | semmle.label | call to difference [array element] :  |
+| array_flow.rb:262:10:262:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:262:10:262:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:266:16:266:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:266:34:266:45 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:268:10:268:10 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:268:10:268:17 | call to dig | semmle.label | call to dig |
+| array_flow.rb:269:10:269:10 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:269:10:269:17 | call to dig | semmle.label | call to dig |
+| array_flow.rb:271:10:271:10 | a [array element 3, array element 1] :  | semmle.label | a [array element 3, array element 1] :  |
+| array_flow.rb:271:10:271:19 | call to dig | semmle.label | call to dig |
+| array_flow.rb:275:16:275:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:276:9:276:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:276:9:278:7 | call to detect :  | semmle.label | call to detect :  |
+| array_flow.rb:276:23:276:34 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:276:43:276:43 | x :  | semmle.label | x :  |
+| array_flow.rb:277:14:277:14 | x | semmle.label | x |
+| array_flow.rb:279:10:279:10 | b | semmle.label | b |
+| array_flow.rb:283:16:283:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:283:30:283:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:284:9:284:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:284:9:284:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:284:9:284:17 | call to drop [array element] :  | semmle.label | call to drop [array element] :  |
+| array_flow.rb:285:10:285:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:285:10:285:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:286:9:286:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:286:9:286:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:286:9:286:17 | call to drop [array element 1] :  | semmle.label | call to drop [array element 1] :  |
+| array_flow.rb:286:9:286:17 | call to drop [array element 2] :  | semmle.label | call to drop [array element 2] :  |
+| array_flow.rb:288:10:288:10 | b [array element 1] :  | semmle.label | b [array element 1] :  |
+| array_flow.rb:288:10:288:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:289:10:289:10 | b [array element 1] :  | semmle.label | b [array element 1] :  |
+| array_flow.rb:289:10:289:10 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:289:10:289:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:290:5:290:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:290:12:290:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:291:9:291:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:291:9:291:9 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:291:9:291:17 | call to drop [array element 1] :  | semmle.label | call to drop [array element 1] :  |
+| array_flow.rb:291:9:291:17 | call to drop [array element] :  | semmle.label | call to drop [array element] :  |
+| array_flow.rb:292:10:292:10 | b [array element 1] :  | semmle.label | b [array element 1] :  |
+| array_flow.rb:292:10:292:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:292:10:292:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:293:9:293:9 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:293:9:293:19 | call to drop [array element] :  | semmle.label | call to drop [array element] :  |
+| array_flow.rb:294:10:294:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:294:10:294:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:298:16:298:27 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:298:30:298:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:299:9:299:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:299:9:299:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:299:9:301:7 | call to drop_while [array element] :  | semmle.label | call to drop_while [array element] :  |
+| array_flow.rb:299:26:299:26 | x :  | semmle.label | x :  |
+| array_flow.rb:300:14:300:14 | x | semmle.label | x |
+| array_flow.rb:302:10:302:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:302:10:302:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:306:16:306:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:307:9:307:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:307:9:309:7 | call to each [array element 2] :  | semmle.label | call to each [array element 2] :  |
+| array_flow.rb:307:20:307:20 | x :  | semmle.label | x :  |
+| array_flow.rb:308:14:308:14 | x | semmle.label | x |
+| array_flow.rb:310:10:310:10 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:310:10:310:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:314:16:314:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:315:9:317:7 | ... = ... :  | semmle.label | ... = ... :  |
+| array_flow.rb:315:9:317:7 | __synth__0__1 :  | semmle.label | __synth__0__1 :  |
+| array_flow.rb:315:9:317:7 | call to each :  | semmle.label | call to each :  |
+| array_flow.rb:315:18:315:18 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:316:14:316:14 | x | semmle.label | x |
+| array_flow.rb:318:10:318:10 | x | semmle.label | x |
+| array_flow.rb:319:10:319:10 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:319:10:319:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:323:16:323:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:324:5:324:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:324:24:324:24 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:325:14:325:19 | ( ... ) | semmle.label | ( ... ) |
+| array_flow.rb:325:15:325:15 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:325:15:325:18 | ...[...] :  | semmle.label | ...[...] :  |
+| array_flow.rb:330:16:330:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:331:9:331:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:331:9:333:7 | call to each_entry [array element 2] :  | semmle.label | call to each_entry [array element 2] :  |
+| array_flow.rb:331:26:331:26 | x :  | semmle.label | x :  |
+| array_flow.rb:332:14:332:14 | x | semmle.label | x |
+| array_flow.rb:334:10:334:10 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:334:10:334:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:338:16:338:25 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:339:9:339:9 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:339:9:341:7 | call to each_index [array element 2] :  | semmle.label | call to each_index [array element 2] :  |
+| array_flow.rb:342:10:342:10 | b [array element 2] :  | semmle.label | b [array element 2] :  |
+| array_flow.rb:342:10:342:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:346:19:346:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:347:9:347:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:347:9:349:7 | call to each_slice [array element 3] :  | semmle.label | call to each_slice [array element 3] :  |
+| array_flow.rb:347:26:347:26 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:348:14:348:14 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:348:14:348:17 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:350:10:350:10 | b [array element 3] :  | semmle.label | b [array element 3] :  |
+| array_flow.rb:350:10:350:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:354:19:354:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:355:9:355:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:355:9:358:7 | call to each_with_index [array element 3] :  | semmle.label | call to each_with_index [array element 3] :  |
+| array_flow.rb:355:31:355:31 | x :  | semmle.label | x :  |
+| array_flow.rb:356:14:356:14 | x | semmle.label | x |
+| array_flow.rb:359:10:359:10 | b [array element 3] :  | semmle.label | b [array element 3] :  |
+| array_flow.rb:359:10:359:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:363:19:363:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:364:9:364:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:364:9:367:7 | call to each_with_object :  | semmle.label | call to each_with_object :  |
+| array_flow.rb:364:28:364:39 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:364:46:364:46 | x :  | semmle.label | x :  |
+| array_flow.rb:364:48:364:48 | a :  | semmle.label | a :  |
+| array_flow.rb:365:14:365:14 | x | semmle.label | x |
+| array_flow.rb:366:14:366:14 | a | semmle.label | a |
+| array_flow.rb:368:10:368:10 | b | semmle.label | b |
+| array_flow.rb:372:19:372:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:373:9:373:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:373:9:375:7 | call to fetch :  | semmle.label | call to fetch :  |
+| array_flow.rb:373:17:373:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:373:35:373:35 | x :  | semmle.label | x :  |
+| array_flow.rb:374:14:374:14 | x | semmle.label | x |
+| array_flow.rb:376:10:376:10 | b | semmle.label | b |
+| array_flow.rb:380:19:380:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:381:5:381:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:381:12:381:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:382:10:382:10 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:382:10:382:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:382:10:382:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:383:5:383:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:383:12:383:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:384:10:384:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:384:10:384:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:385:5:385:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:386:9:386:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:388:10:388:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:388:10:388:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:389:5:389:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:390:9:390:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:392:10:392:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:392:10:392:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:396:19:396:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:397:9:397:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:397:9:399:7 | call to filter [array element] :  | semmle.label | call to filter [array element] :  |
+| array_flow.rb:397:22:397:22 | x :  | semmle.label | x :  |
+| array_flow.rb:398:14:398:14 | x | semmle.label | x |
+| array_flow.rb:400:10:400:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:400:10:400:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:404:19:404:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:405:9:405:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:405:9:407:7 | call to filter_map [array element] :  | semmle.label | call to filter_map [array element] :  |
+| array_flow.rb:405:26:405:26 | x :  | semmle.label | x :  |
+| array_flow.rb:406:14:406:14 | x | semmle.label | x |
+| array_flow.rb:408:10:408:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:412:19:412:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:413:9:413:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:413:9:415:7 | call to filter! [array element] :  | semmle.label | call to filter! [array element] :  |
+| array_flow.rb:413:23:413:23 | x :  | semmle.label | x :  |
+| array_flow.rb:414:14:414:14 | x | semmle.label | x |
+| array_flow.rb:416:10:416:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:416:10:416:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:420:19:420:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:421:9:421:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:421:9:423:7 | call to find :  | semmle.label | call to find :  |
+| array_flow.rb:421:21:421:32 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:421:41:421:41 | x :  | semmle.label | x :  |
+| array_flow.rb:422:14:422:14 | x | semmle.label | x |
+| array_flow.rb:424:10:424:10 | b | semmle.label | b |
+| array_flow.rb:428:19:428:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:429:9:429:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:429:9:431:7 | call to find_all [array element] :  | semmle.label | call to find_all [array element] :  |
+| array_flow.rb:429:24:429:24 | x :  | semmle.label | x :  |
+| array_flow.rb:430:14:430:14 | x | semmle.label | x |
+| array_flow.rb:432:10:432:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:432:10:432:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:436:19:436:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:437:5:437:5 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:437:22:437:22 | x :  | semmle.label | x :  |
+| array_flow.rb:438:14:438:14 | x | semmle.label | x |
+| array_flow.rb:443:10:443:21 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:443:30:443:41 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:444:5:444:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:444:12:444:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:445:10:445:10 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:445:10:445:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:445:10:445:16 | call to first | semmle.label | call to first |
+| array_flow.rb:446:9:446:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:446:9:446:9 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:446:9:446:18 | call to first [array element 0] :  | semmle.label | call to first [array element 0] :  |
+| array_flow.rb:446:9:446:18 | call to first [array element] :  | semmle.label | call to first [array element] :  |
+| array_flow.rb:447:10:447:10 | b [array element 0] :  | semmle.label | b [array element 0] :  |
+| array_flow.rb:447:10:447:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:447:10:447:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:448:10:448:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:448:10:448:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:449:9:449:9 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:449:9:449:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:449:9:449:9 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element 0] :  | semmle.label | call to first [array element 0] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element 3] :  | semmle.label | call to first [array element 3] :  |
+| array_flow.rb:449:9:449:18 | call to first [array element] :  | semmle.label | call to first [array element] :  |
+| array_flow.rb:450:10:450:10 | c [array element 0] :  | semmle.label | c [array element 0] :  |
+| array_flow.rb:450:10:450:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:450:10:450:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:451:10:451:10 | c [array element 3] :  | semmle.label | c [array element 3] :  |
+| array_flow.rb:451:10:451:10 | c [array element] :  | semmle.label | c [array element] :  |
+| array_flow.rb:451:10:451:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:455:19:455:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:456:9:456:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:456:9:459:7 | call to flat_map [array element] :  | semmle.label | call to flat_map [array element] :  |
+| array_flow.rb:456:24:456:24 | x :  | semmle.label | x :  |
+| array_flow.rb:457:14:457:14 | x | semmle.label | x |
+| array_flow.rb:458:13:458:24 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:460:10:460:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:460:10:460:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:464:20:464:29 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:465:9:465:9 | a [array element 2, array element 1] :  | semmle.label | a [array element 2, array element 1] :  |
+| array_flow.rb:465:9:465:17 | call to flatten [array element] :  | semmle.label | call to flatten [array element] :  |
+| array_flow.rb:466:10:466:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:466:10:466:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:470:20:470:29 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:471:10:471:10 | a [array element 2, array element 1] :  | semmle.label | a [array element 2, array element 1] :  |
+| array_flow.rb:471:10:471:13 | ...[...] [array element 1] :  | semmle.label | ...[...] [array element 1] :  |
+| array_flow.rb:471:10:471:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:472:5:472:5 | [post] a [array element, array element 1] :  | semmle.label | [post] a [array element, array element 1] :  |
+| array_flow.rb:472:5:472:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:472:5:472:5 | a [array element 2, array element 1] :  | semmle.label | a [array element 2, array element 1] :  |
+| array_flow.rb:473:10:473:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:473:10:473:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:474:10:474:10 | a [array element, array element 1] :  | semmle.label | a [array element, array element 1] :  |
+| array_flow.rb:474:10:474:13 | ...[...] [array element 1] :  | semmle.label | ...[...] [array element 1] :  |
+| array_flow.rb:474:10:474:16 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:478:19:478:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:479:9:479:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:479:9:479:20 | call to grep [array element] :  | semmle.label | call to grep [array element] :  |
+| array_flow.rb:480:10:480:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:480:10:480:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:481:9:481:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:481:9:484:7 | call to grep [array element] :  | semmle.label | call to grep [array element] :  |
+| array_flow.rb:481:26:481:26 | x :  | semmle.label | x :  |
+| array_flow.rb:482:14:482:14 | x | semmle.label | x |
+| array_flow.rb:483:9:483:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:485:10:485:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:485:10:485:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:489:19:489:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:490:9:490:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:490:9:490:21 | call to grep_v [array element] :  | semmle.label | call to grep_v [array element] :  |
+| array_flow.rb:491:10:491:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:491:10:491:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:492:9:492:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:492:9:495:7 | call to grep_v [array element] :  | semmle.label | call to grep_v [array element] :  |
+| array_flow.rb:492:27:492:27 | x :  | semmle.label | x :  |
+| array_flow.rb:493:14:493:14 | x | semmle.label | x |
+| array_flow.rb:494:9:494:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:496:10:496:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:496:10:496:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:500:19:500:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:501:5:501:5 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:501:17:501:17 | x :  | semmle.label | x :  |
+| array_flow.rb:502:14:502:14 | x | semmle.label | x |
+| array_flow.rb:508:5:508:5 | [post] a [array element 0] :  | semmle.label | [post] a [array element 0] :  |
+| array_flow.rb:508:24:508:35 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:509:10:509:10 | a [array element 0] :  | semmle.label | a [array element 0] :  |
+| array_flow.rb:509:10:509:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:515:16:515:29 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:516:5:516:5 | [post] a [array element 2] :  | semmle.label | [post] a [array element 2] :  |
+| array_flow.rb:516:5:516:5 | [post] a [array element 5] :  | semmle.label | [post] a [array element 5] :  |
+| array_flow.rb:516:5:516:5 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:516:21:516:34 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:519:10:519:10 | a [array element 2] :  | semmle.label | a [array element 2] :  |
+| array_flow.rb:519:10:519:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:522:10:522:10 | a [array element 5] :  | semmle.label | a [array element 5] :  |
+| array_flow.rb:522:10:522:13 | ...[...] | semmle.label | ...[...] |
+subpaths
+#select
+| array_flow.rb:3:10:3:13 | ...[...] | array_flow.rb:2:10:2:18 | call to source :  | array_flow.rb:3:10:3:13 | ...[...] | $@ | array_flow.rb:2:10:2:18 | call to source :  | call to source :  |
+| array_flow.rb:5:10:5:13 | ...[...] | array_flow.rb:2:10:2:18 | call to source :  | array_flow.rb:5:10:5:13 | ...[...] | $@ | array_flow.rb:2:10:2:18 | call to source :  | call to source :  |
+| array_flow.rb:11:10:11:13 | ...[...] | array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:11:10:11:13 | ...[...] | $@ | array_flow.rb:9:13:9:21 | call to source :  | call to source :  |
+| array_flow.rb:13:10:13:13 | ...[...] | array_flow.rb:9:13:9:21 | call to source :  | array_flow.rb:13:10:13:13 | ...[...] | $@ | array_flow.rb:9:13:9:21 | call to source :  | call to source :  |
+| array_flow.rb:18:10:18:13 | ...[...] | array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:18:10:18:13 | ...[...] | $@ | array_flow.rb:17:22:17:32 | call to source :  | call to source :  |
+| array_flow.rb:19:10:19:13 | ...[...] | array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:19:10:19:13 | ...[...] | $@ | array_flow.rb:17:22:17:32 | call to source :  | call to source :  |
+| array_flow.rb:22:10:22:13 | ...[...] | array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:22:10:22:13 | ...[...] | $@ | array_flow.rb:17:22:17:32 | call to source :  | call to source :  |
+| array_flow.rb:23:10:23:13 | ...[...] | array_flow.rb:17:22:17:32 | call to source :  | array_flow.rb:23:10:23:13 | ...[...] | $@ | array_flow.rb:17:22:17:32 | call to source :  | call to source :  |
+| array_flow.rb:28:10:28:13 | ...[...] | array_flow.rb:26:9:26:19 | call to source :  | array_flow.rb:28:10:28:13 | ...[...] | $@ | array_flow.rb:26:9:26:19 | call to source :  | call to source :  |
+| array_flow.rb:29:10:29:13 | ...[...] | array_flow.rb:26:9:26:19 | call to source :  | array_flow.rb:29:10:29:13 | ...[...] | $@ | array_flow.rb:26:9:26:19 | call to source :  | call to source :  |
+| array_flow.rb:35:10:35:13 | ...[...] | array_flow.rb:33:10:33:18 | call to source :  | array_flow.rb:35:10:35:13 | ...[...] | $@ | array_flow.rb:33:10:33:18 | call to source :  | call to source :  |
+| array_flow.rb:43:10:43:13 | ...[...] | array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:43:10:43:13 | ...[...] | $@ | array_flow.rb:40:10:40:20 | call to source :  | call to source :  |
+| array_flow.rb:43:10:43:13 | ...[...] | array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:43:10:43:13 | ...[...] | $@ | array_flow.rb:41:16:41:26 | call to source :  | call to source :  |
+| array_flow.rb:44:10:44:13 | ...[...] | array_flow.rb:40:10:40:20 | call to source :  | array_flow.rb:44:10:44:13 | ...[...] | $@ | array_flow.rb:40:10:40:20 | call to source :  | call to source :  |
+| array_flow.rb:44:10:44:13 | ...[...] | array_flow.rb:41:16:41:26 | call to source :  | array_flow.rb:44:10:44:13 | ...[...] | $@ | array_flow.rb:41:16:41:26 | call to source :  | call to source :  |
+| array_flow.rb:50:10:50:13 | ...[...] | array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:50:10:50:13 | ...[...] | $@ | array_flow.rb:48:10:48:18 | call to source :  | call to source :  |
+| array_flow.rb:51:10:51:13 | ...[...] | array_flow.rb:48:10:48:18 | call to source :  | array_flow.rb:51:10:51:13 | ...[...] | $@ | array_flow.rb:48:10:48:18 | call to source :  | call to source :  |
+| array_flow.rb:58:10:58:13 | ...[...] | array_flow.rb:55:10:55:20 | call to source :  | array_flow.rb:58:10:58:13 | ...[...] | $@ | array_flow.rb:55:10:55:20 | call to source :  | call to source :  |
+| array_flow.rb:58:10:58:13 | ...[...] | array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:58:10:58:13 | ...[...] | $@ | array_flow.rb:56:13:56:23 | call to source :  | call to source :  |
+| array_flow.rb:59:10:59:13 | ...[...] | array_flow.rb:56:13:56:23 | call to source :  | array_flow.rb:59:10:59:13 | ...[...] | $@ | array_flow.rb:56:13:56:23 | call to source :  | call to source :  |
+| array_flow.rb:66:10:66:13 | ...[...] | array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:66:10:66:13 | ...[...] | $@ | array_flow.rb:63:10:63:20 | call to source :  | call to source :  |
+| array_flow.rb:67:10:67:13 | ...[...] | array_flow.rb:63:10:63:20 | call to source :  | array_flow.rb:67:10:67:13 | ...[...] | $@ | array_flow.rb:63:10:63:20 | call to source :  | call to source :  |
+| array_flow.rb:73:10:73:13 | ...[...] | array_flow.rb:71:10:71:20 | call to source :  | array_flow.rb:73:10:73:13 | ...[...] | $@ | array_flow.rb:71:10:71:20 | call to source :  | call to source :  |
+| array_flow.rb:73:10:73:13 | ...[...] | array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:73:10:73:13 | ...[...] | $@ | array_flow.rb:72:14:72:24 | call to source :  | call to source :  |
+| array_flow.rb:74:10:74:13 | ...[...] | array_flow.rb:72:14:72:24 | call to source :  | array_flow.rb:74:10:74:13 | ...[...] | $@ | array_flow.rb:72:14:72:24 | call to source :  | call to source :  |
+| array_flow.rb:81:10:81:10 | c | array_flow.rb:78:13:78:21 | call to source :  | array_flow.rb:81:10:81:10 | c | $@ | array_flow.rb:78:13:78:21 | call to source :  | call to source :  |
+| array_flow.rb:88:10:88:13 | ...[...] | array_flow.rb:86:13:86:22 | call to source :  | array_flow.rb:88:10:88:13 | ...[...] | $@ | array_flow.rb:86:13:86:22 | call to source :  | call to source :  |
+| array_flow.rb:89:10:89:13 | ...[...] | array_flow.rb:86:13:86:22 | call to source :  | array_flow.rb:89:10:89:13 | ...[...] | $@ | array_flow.rb:86:13:86:22 | call to source :  | call to source :  |
+| array_flow.rb:90:10:90:13 | ...[...] | array_flow.rb:86:13:86:22 | call to source :  | array_flow.rb:90:10:90:13 | ...[...] | $@ | array_flow.rb:86:13:86:22 | call to source :  | call to source :  |
+| array_flow.rb:96:10:96:13 | ...[...] | array_flow.rb:94:13:94:22 | call to source :  | array_flow.rb:96:10:96:13 | ...[...] | $@ | array_flow.rb:94:13:94:22 | call to source :  | call to source :  |
+| array_flow.rb:97:10:97:13 | ...[...] | array_flow.rb:94:13:94:22 | call to source :  | array_flow.rb:97:10:97:13 | ...[...] | $@ | array_flow.rb:94:13:94:22 | call to source :  | call to source :  |
+| array_flow.rb:98:10:98:13 | ...[...] | array_flow.rb:94:13:94:22 | call to source :  | array_flow.rb:98:10:98:13 | ...[...] | $@ | array_flow.rb:94:13:94:22 | call to source :  | call to source :  |
+| array_flow.rb:104:10:104:13 | ...[...] | array_flow.rb:103:15:103:24 | call to source :  | array_flow.rb:104:10:104:13 | ...[...] | $@ | array_flow.rb:103:15:103:24 | call to source :  | call to source :  |
+| array_flow.rb:105:10:105:13 | ...[...] | array_flow.rb:103:15:103:24 | call to source :  | array_flow.rb:105:10:105:13 | ...[...] | $@ | array_flow.rb:103:15:103:24 | call to source :  | call to source :  |
+| array_flow.rb:106:10:106:13 | ...[...] | array_flow.rb:103:15:103:24 | call to source :  | array_flow.rb:106:10:106:13 | ...[...] | $@ | array_flow.rb:103:15:103:24 | call to source :  | call to source :  |
+| array_flow.rb:112:10:112:13 | ...[...] | array_flow.rb:111:19:111:28 | call to source :  | array_flow.rb:112:10:112:13 | ...[...] | $@ | array_flow.rb:111:19:111:28 | call to source :  | call to source :  |
+| array_flow.rb:113:10:113:13 | ...[...] | array_flow.rb:111:19:111:28 | call to source :  | array_flow.rb:113:10:113:13 | ...[...] | $@ | array_flow.rb:111:19:111:28 | call to source :  | call to source :  |
+| array_flow.rb:114:10:114:13 | ...[...] | array_flow.rb:111:19:111:28 | call to source :  | array_flow.rb:114:10:114:13 | ...[...] | $@ | array_flow.rb:111:19:111:28 | call to source :  | call to source :  |
+| array_flow.rb:120:10:120:13 | ...[...] | array_flow.rb:119:15:119:24 | call to source :  | array_flow.rb:120:10:120:13 | ...[...] | $@ | array_flow.rb:119:15:119:24 | call to source :  | call to source :  |
+| array_flow.rb:121:10:121:13 | ...[...] | array_flow.rb:119:15:119:24 | call to source :  | array_flow.rb:121:10:121:13 | ...[...] | $@ | array_flow.rb:119:15:119:24 | call to source :  | call to source :  |
+| array_flow.rb:122:10:122:13 | ...[...] | array_flow.rb:119:15:119:24 | call to source :  | array_flow.rb:122:10:122:13 | ...[...] | $@ | array_flow.rb:119:15:119:24 | call to source :  | call to source :  |
+| array_flow.rb:128:10:128:13 | ...[...] | array_flow.rb:127:19:127:28 | call to source :  | array_flow.rb:128:10:128:13 | ...[...] | $@ | array_flow.rb:127:19:127:28 | call to source :  | call to source :  |
+| array_flow.rb:129:10:129:13 | ...[...] | array_flow.rb:127:19:127:28 | call to source :  | array_flow.rb:129:10:129:13 | ...[...] | $@ | array_flow.rb:127:19:127:28 | call to source :  | call to source :  |
+| array_flow.rb:130:10:130:13 | ...[...] | array_flow.rb:127:19:127:28 | call to source :  | array_flow.rb:130:10:130:13 | ...[...] | $@ | array_flow.rb:127:19:127:28 | call to source :  | call to source :  |
+| array_flow.rb:136:14:136:14 | x | array_flow.rb:134:16:134:25 | call to source :  | array_flow.rb:136:14:136:14 | x | $@ | array_flow.rb:134:16:134:25 | call to source :  | call to source :  |
+| array_flow.rb:143:14:143:14 | x | array_flow.rb:141:16:141:25 | call to source :  | array_flow.rb:143:14:143:14 | x | $@ | array_flow.rb:141:16:141:25 | call to source :  | call to source :  |
+| array_flow.rb:152:10:152:26 | ( ... ) | array_flow.rb:150:15:150:24 | call to source :  | array_flow.rb:152:10:152:26 | ( ... ) | $@ | array_flow.rb:150:15:150:24 | call to source :  | call to source :  |
+| array_flow.rb:153:10:153:26 | ( ... ) | array_flow.rb:150:15:150:24 | call to source :  | array_flow.rb:153:10:153:26 | ( ... ) | $@ | array_flow.rb:150:15:150:24 | call to source :  | call to source :  |
+| array_flow.rb:159:10:159:16 | call to at | array_flow.rb:157:13:157:22 | call to source :  | array_flow.rb:159:10:159:16 | call to at | $@ | array_flow.rb:157:13:157:22 | call to source :  | call to source :  |
+| array_flow.rb:161:10:161:16 | call to at | array_flow.rb:157:13:157:22 | call to source :  | array_flow.rb:161:10:161:16 | call to at | $@ | array_flow.rb:157:13:157:22 | call to source :  | call to source :  |
+| array_flow.rb:167:14:167:14 | x | array_flow.rb:165:16:165:25 | call to source :  | array_flow.rb:167:14:167:14 | x | $@ | array_flow.rb:165:16:165:25 | call to source :  | call to source :  |
+| array_flow.rb:169:10:169:10 | b | array_flow.rb:165:16:165:25 | call to source :  | array_flow.rb:169:10:169:10 | b | $@ | array_flow.rb:165:16:165:25 | call to source :  | call to source :  |
+| array_flow.rb:175:14:175:14 | x | array_flow.rb:173:16:173:25 | call to source :  | array_flow.rb:175:14:175:14 | x | $@ | array_flow.rb:173:16:173:25 | call to source :  | call to source :  |
+| array_flow.rb:189:14:189:14 | x | array_flow.rb:187:16:187:25 | call to source :  | array_flow.rb:189:14:189:14 | x | $@ | array_flow.rb:187:16:187:25 | call to source :  | call to source :  |
+| array_flow.rb:192:10:192:13 | ...[...] | array_flow.rb:187:16:187:25 | call to source :  | array_flow.rb:192:10:192:13 | ...[...] | $@ | array_flow.rb:187:16:187:25 | call to source :  | call to source :  |
+| array_flow.rb:198:14:198:14 | x | array_flow.rb:196:16:196:25 | call to source :  | array_flow.rb:198:14:198:14 | x | $@ | array_flow.rb:196:16:196:25 | call to source :  | call to source :  |
+| array_flow.rb:201:10:201:13 | ...[...] | array_flow.rb:196:16:196:25 | call to source :  | array_flow.rb:201:10:201:13 | ...[...] | $@ | array_flow.rb:196:16:196:25 | call to source :  | call to source :  |
+| array_flow.rb:207:14:207:17 | ...[...] | array_flow.rb:205:16:205:25 | call to source :  | array_flow.rb:207:14:207:17 | ...[...] | $@ | array_flow.rb:205:16:205:25 | call to source :  | call to source :  |
+| array_flow.rb:214:10:214:13 | ...[...] | array_flow.rb:212:16:212:25 | call to source :  | array_flow.rb:214:10:214:13 | ...[...] | $@ | array_flow.rb:212:16:212:25 | call to source :  | call to source :  |
+| array_flow.rb:221:10:221:13 | ...[...] | array_flow.rb:219:16:219:27 | call to source :  | array_flow.rb:221:10:221:13 | ...[...] | $@ | array_flow.rb:219:16:219:27 | call to source :  | call to source :  |
+| array_flow.rb:222:10:222:13 | ...[...] | array_flow.rb:218:16:218:27 | call to source :  | array_flow.rb:222:10:222:13 | ...[...] | $@ | array_flow.rb:218:16:218:27 | call to source :  | call to source :  |
+| array_flow.rb:222:10:222:13 | ...[...] | array_flow.rb:219:16:219:27 | call to source :  | array_flow.rb:222:10:222:13 | ...[...] | $@ | array_flow.rb:219:16:219:27 | call to source :  | call to source :  |
+| array_flow.rb:228:14:228:14 | x | array_flow.rb:226:16:226:25 | call to source :  | array_flow.rb:228:14:228:14 | x | $@ | array_flow.rb:226:16:226:25 | call to source :  | call to source :  |
+| array_flow.rb:235:14:235:14 | x | array_flow.rb:233:16:233:25 | call to source :  | array_flow.rb:235:14:235:14 | x | $@ | array_flow.rb:233:16:233:25 | call to source :  | call to source :  |
+| array_flow.rb:242:10:242:10 | b | array_flow.rb:240:16:240:27 | call to source :  | array_flow.rb:242:10:242:10 | b | $@ | array_flow.rb:240:16:240:27 | call to source :  | call to source :  |
+| array_flow.rb:242:10:242:10 | b | array_flow.rb:241:23:241:34 | call to source :  | array_flow.rb:242:10:242:10 | b | $@ | array_flow.rb:241:23:241:34 | call to source :  | call to source :  |
+| array_flow.rb:248:10:248:10 | b | array_flow.rb:246:16:246:25 | call to source :  | array_flow.rb:248:10:248:10 | b | $@ | array_flow.rb:246:16:246:25 | call to source :  | call to source :  |
+| array_flow.rb:254:14:254:14 | x | array_flow.rb:252:16:252:25 | call to source :  | array_flow.rb:254:14:254:14 | x | $@ | array_flow.rb:252:16:252:25 | call to source :  | call to source :  |
+| array_flow.rb:256:10:256:13 | ...[...] | array_flow.rb:252:16:252:25 | call to source :  | array_flow.rb:256:10:256:13 | ...[...] | $@ | array_flow.rb:252:16:252:25 | call to source :  | call to source :  |
+| array_flow.rb:262:10:262:13 | ...[...] | array_flow.rb:260:16:260:25 | call to source :  | array_flow.rb:262:10:262:13 | ...[...] | $@ | array_flow.rb:260:16:260:25 | call to source :  | call to source :  |
+| array_flow.rb:268:10:268:17 | call to dig | array_flow.rb:266:16:266:27 | call to source :  | array_flow.rb:268:10:268:17 | call to dig | $@ | array_flow.rb:266:16:266:27 | call to source :  | call to source :  |
+| array_flow.rb:269:10:269:17 | call to dig | array_flow.rb:266:16:266:27 | call to source :  | array_flow.rb:269:10:269:17 | call to dig | $@ | array_flow.rb:266:16:266:27 | call to source :  | call to source :  |
+| array_flow.rb:271:10:271:19 | call to dig | array_flow.rb:266:34:266:45 | call to source :  | array_flow.rb:271:10:271:19 | call to dig | $@ | array_flow.rb:266:34:266:45 | call to source :  | call to source :  |
+| array_flow.rb:277:14:277:14 | x | array_flow.rb:275:16:275:27 | call to source :  | array_flow.rb:277:14:277:14 | x | $@ | array_flow.rb:275:16:275:27 | call to source :  | call to source :  |
+| array_flow.rb:279:10:279:10 | b | array_flow.rb:275:16:275:27 | call to source :  | array_flow.rb:279:10:279:10 | b | $@ | array_flow.rb:275:16:275:27 | call to source :  | call to source :  |
+| array_flow.rb:279:10:279:10 | b | array_flow.rb:276:23:276:34 | call to source :  | array_flow.rb:279:10:279:10 | b | $@ | array_flow.rb:276:23:276:34 | call to source :  | call to source :  |
+| array_flow.rb:285:10:285:13 | ...[...] | array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:285:10:285:13 | ...[...] | $@ | array_flow.rb:283:16:283:27 | call to source :  | call to source :  |
+| array_flow.rb:285:10:285:13 | ...[...] | array_flow.rb:283:30:283:41 | call to source :  | array_flow.rb:285:10:285:13 | ...[...] | $@ | array_flow.rb:283:30:283:41 | call to source :  | call to source :  |
+| array_flow.rb:288:10:288:13 | ...[...] | array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:288:10:288:13 | ...[...] | $@ | array_flow.rb:283:16:283:27 | call to source :  | call to source :  |
+| array_flow.rb:289:10:289:13 | ...[...] | array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:289:10:289:13 | ...[...] | $@ | array_flow.rb:283:16:283:27 | call to source :  | call to source :  |
+| array_flow.rb:289:10:289:13 | ...[...] | array_flow.rb:283:30:283:41 | call to source :  | array_flow.rb:289:10:289:13 | ...[...] | $@ | array_flow.rb:283:30:283:41 | call to source :  | call to source :  |
+| array_flow.rb:292:10:292:13 | ...[...] | array_flow.rb:283:16:283:27 | call to source :  | array_flow.rb:292:10:292:13 | ...[...] | $@ | array_flow.rb:283:16:283:27 | call to source :  | call to source :  |
+| array_flow.rb:292:10:292:13 | ...[...] | array_flow.rb:290:12:290:23 | call to source :  | array_flow.rb:292:10:292:13 | ...[...] | $@ | array_flow.rb:290:12:290:23 | call to source :  | call to source :  |
+| array_flow.rb:294:10:294:13 | ...[...] | array_flow.rb:290:12:290:23 | call to source :  | array_flow.rb:294:10:294:13 | ...[...] | $@ | array_flow.rb:290:12:290:23 | call to source :  | call to source :  |
+| array_flow.rb:300:14:300:14 | x | array_flow.rb:298:16:298:27 | call to source :  | array_flow.rb:300:14:300:14 | x | $@ | array_flow.rb:298:16:298:27 | call to source :  | call to source :  |
+| array_flow.rb:300:14:300:14 | x | array_flow.rb:298:30:298:41 | call to source :  | array_flow.rb:300:14:300:14 | x | $@ | array_flow.rb:298:30:298:41 | call to source :  | call to source :  |
+| array_flow.rb:302:10:302:13 | ...[...] | array_flow.rb:298:16:298:27 | call to source :  | array_flow.rb:302:10:302:13 | ...[...] | $@ | array_flow.rb:298:16:298:27 | call to source :  | call to source :  |
+| array_flow.rb:302:10:302:13 | ...[...] | array_flow.rb:298:30:298:41 | call to source :  | array_flow.rb:302:10:302:13 | ...[...] | $@ | array_flow.rb:298:30:298:41 | call to source :  | call to source :  |
+| array_flow.rb:308:14:308:14 | x | array_flow.rb:306:16:306:25 | call to source :  | array_flow.rb:308:14:308:14 | x | $@ | array_flow.rb:306:16:306:25 | call to source :  | call to source :  |
+| array_flow.rb:310:10:310:13 | ...[...] | array_flow.rb:306:16:306:25 | call to source :  | array_flow.rb:310:10:310:13 | ...[...] | $@ | array_flow.rb:306:16:306:25 | call to source :  | call to source :  |
+| array_flow.rb:316:14:316:14 | x | array_flow.rb:314:16:314:25 | call to source :  | array_flow.rb:316:14:316:14 | x | $@ | array_flow.rb:314:16:314:25 | call to source :  | call to source :  |
+| array_flow.rb:318:10:318:10 | x | array_flow.rb:314:16:314:25 | call to source :  | array_flow.rb:318:10:318:10 | x | $@ | array_flow.rb:314:16:314:25 | call to source :  | call to source :  |
+| array_flow.rb:319:10:319:13 | ...[...] | array_flow.rb:314:16:314:25 | call to source :  | array_flow.rb:319:10:319:13 | ...[...] | $@ | array_flow.rb:314:16:314:25 | call to source :  | call to source :  |
+| array_flow.rb:325:14:325:19 | ( ... ) | array_flow.rb:323:16:323:25 | call to source :  | array_flow.rb:325:14:325:19 | ( ... ) | $@ | array_flow.rb:323:16:323:25 | call to source :  | call to source :  |
+| array_flow.rb:332:14:332:14 | x | array_flow.rb:330:16:330:25 | call to source :  | array_flow.rb:332:14:332:14 | x | $@ | array_flow.rb:330:16:330:25 | call to source :  | call to source :  |
+| array_flow.rb:334:10:334:13 | ...[...] | array_flow.rb:330:16:330:25 | call to source :  | array_flow.rb:334:10:334:13 | ...[...] | $@ | array_flow.rb:330:16:330:25 | call to source :  | call to source :  |
+| array_flow.rb:342:10:342:13 | ...[...] | array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:342:10:342:13 | ...[...] | $@ | array_flow.rb:338:16:338:25 | call to source :  | call to source :  |
+| array_flow.rb:348:14:348:17 | ...[...] | array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:348:14:348:17 | ...[...] | $@ | array_flow.rb:346:19:346:28 | call to source :  | call to source :  |
+| array_flow.rb:350:10:350:13 | ...[...] | array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:350:10:350:13 | ...[...] | $@ | array_flow.rb:346:19:346:28 | call to source :  | call to source :  |
+| array_flow.rb:356:14:356:14 | x | array_flow.rb:354:19:354:28 | call to source :  | array_flow.rb:356:14:356:14 | x | $@ | array_flow.rb:354:19:354:28 | call to source :  | call to source :  |
+| array_flow.rb:359:10:359:13 | ...[...] | array_flow.rb:354:19:354:28 | call to source :  | array_flow.rb:359:10:359:13 | ...[...] | $@ | array_flow.rb:354:19:354:28 | call to source :  | call to source :  |
+| array_flow.rb:365:14:365:14 | x | array_flow.rb:363:19:363:30 | call to source :  | array_flow.rb:365:14:365:14 | x | $@ | array_flow.rb:363:19:363:30 | call to source :  | call to source :  |
+| array_flow.rb:366:14:366:14 | a | array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:366:14:366:14 | a | $@ | array_flow.rb:364:28:364:39 | call to source :  | call to source :  |
+| array_flow.rb:368:10:368:10 | b | array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:368:10:368:10 | b | $@ | array_flow.rb:364:28:364:39 | call to source :  | call to source :  |
+| array_flow.rb:374:14:374:14 | x | array_flow.rb:373:17:373:28 | call to source :  | array_flow.rb:374:14:374:14 | x | $@ | array_flow.rb:373:17:373:28 | call to source :  | call to source :  |
+| array_flow.rb:376:10:376:10 | b | array_flow.rb:372:19:372:30 | call to source :  | array_flow.rb:376:10:376:10 | b | $@ | array_flow.rb:372:19:372:30 | call to source :  | call to source :  |
+| array_flow.rb:382:10:382:13 | ...[...] | array_flow.rb:380:19:380:30 | call to source :  | array_flow.rb:382:10:382:13 | ...[...] | $@ | array_flow.rb:380:19:380:30 | call to source :  | call to source :  |
+| array_flow.rb:382:10:382:13 | ...[...] | array_flow.rb:381:12:381:23 | call to source :  | array_flow.rb:382:10:382:13 | ...[...] | $@ | array_flow.rb:381:12:381:23 | call to source :  | call to source :  |
+| array_flow.rb:384:10:384:13 | ...[...] | array_flow.rb:383:12:383:23 | call to source :  | array_flow.rb:384:10:384:13 | ...[...] | $@ | array_flow.rb:383:12:383:23 | call to source :  | call to source :  |
+| array_flow.rb:388:10:388:13 | ...[...] | array_flow.rb:386:9:386:20 | call to source :  | array_flow.rb:388:10:388:13 | ...[...] | $@ | array_flow.rb:386:9:386:20 | call to source :  | call to source :  |
+| array_flow.rb:392:10:392:13 | ...[...] | array_flow.rb:386:9:386:20 | call to source :  | array_flow.rb:392:10:392:13 | ...[...] | $@ | array_flow.rb:386:9:386:20 | call to source :  | call to source :  |
+| array_flow.rb:392:10:392:13 | ...[...] | array_flow.rb:390:9:390:20 | call to source :  | array_flow.rb:392:10:392:13 | ...[...] | $@ | array_flow.rb:390:9:390:20 | call to source :  | call to source :  |
+| array_flow.rb:398:14:398:14 | x | array_flow.rb:396:19:396:28 | call to source :  | array_flow.rb:398:14:398:14 | x | $@ | array_flow.rb:396:19:396:28 | call to source :  | call to source :  |
+| array_flow.rb:400:10:400:13 | ...[...] | array_flow.rb:396:19:396:28 | call to source :  | array_flow.rb:400:10:400:13 | ...[...] | $@ | array_flow.rb:396:19:396:28 | call to source :  | call to source :  |
+| array_flow.rb:406:14:406:14 | x | array_flow.rb:404:19:404:28 | call to source :  | array_flow.rb:406:14:406:14 | x | $@ | array_flow.rb:404:19:404:28 | call to source :  | call to source :  |
+| array_flow.rb:408:10:408:13 | ...[...] | array_flow.rb:404:19:404:28 | call to source :  | array_flow.rb:408:10:408:13 | ...[...] | $@ | array_flow.rb:404:19:404:28 | call to source :  | call to source :  |
+| array_flow.rb:414:14:414:14 | x | array_flow.rb:412:19:412:28 | call to source :  | array_flow.rb:414:14:414:14 | x | $@ | array_flow.rb:412:19:412:28 | call to source :  | call to source :  |
+| array_flow.rb:416:10:416:13 | ...[...] | array_flow.rb:412:19:412:28 | call to source :  | array_flow.rb:416:10:416:13 | ...[...] | $@ | array_flow.rb:412:19:412:28 | call to source :  | call to source :  |
+| array_flow.rb:422:14:422:14 | x | array_flow.rb:420:19:420:30 | call to source :  | array_flow.rb:422:14:422:14 | x | $@ | array_flow.rb:420:19:420:30 | call to source :  | call to source :  |
+| array_flow.rb:424:10:424:10 | b | array_flow.rb:420:19:420:30 | call to source :  | array_flow.rb:424:10:424:10 | b | $@ | array_flow.rb:420:19:420:30 | call to source :  | call to source :  |
+| array_flow.rb:424:10:424:10 | b | array_flow.rb:421:21:421:32 | call to source :  | array_flow.rb:424:10:424:10 | b | $@ | array_flow.rb:421:21:421:32 | call to source :  | call to source :  |
+| array_flow.rb:430:14:430:14 | x | array_flow.rb:428:19:428:28 | call to source :  | array_flow.rb:430:14:430:14 | x | $@ | array_flow.rb:428:19:428:28 | call to source :  | call to source :  |
+| array_flow.rb:432:10:432:13 | ...[...] | array_flow.rb:428:19:428:28 | call to source :  | array_flow.rb:432:10:432:13 | ...[...] | $@ | array_flow.rb:428:19:428:28 | call to source :  | call to source :  |
+| array_flow.rb:438:14:438:14 | x | array_flow.rb:436:19:436:28 | call to source :  | array_flow.rb:438:14:438:14 | x | $@ | array_flow.rb:436:19:436:28 | call to source :  | call to source :  |
+| array_flow.rb:445:10:445:16 | call to first | array_flow.rb:443:10:443:21 | call to source :  | array_flow.rb:445:10:445:16 | call to first | $@ | array_flow.rb:443:10:443:21 | call to source :  | call to source :  |
+| array_flow.rb:445:10:445:16 | call to first | array_flow.rb:444:12:444:23 | call to source :  | array_flow.rb:445:10:445:16 | call to first | $@ | array_flow.rb:444:12:444:23 | call to source :  | call to source :  |
+| array_flow.rb:447:10:447:13 | ...[...] | array_flow.rb:443:10:443:21 | call to source :  | array_flow.rb:447:10:447:13 | ...[...] | $@ | array_flow.rb:443:10:443:21 | call to source :  | call to source :  |
+| array_flow.rb:447:10:447:13 | ...[...] | array_flow.rb:444:12:444:23 | call to source :  | array_flow.rb:447:10:447:13 | ...[...] | $@ | array_flow.rb:444:12:444:23 | call to source :  | call to source :  |
+| array_flow.rb:448:10:448:13 | ...[...] | array_flow.rb:444:12:444:23 | call to source :  | array_flow.rb:448:10:448:13 | ...[...] | $@ | array_flow.rb:444:12:444:23 | call to source :  | call to source :  |
+| array_flow.rb:450:10:450:13 | ...[...] | array_flow.rb:443:10:443:21 | call to source :  | array_flow.rb:450:10:450:13 | ...[...] | $@ | array_flow.rb:443:10:443:21 | call to source :  | call to source :  |
+| array_flow.rb:450:10:450:13 | ...[...] | array_flow.rb:444:12:444:23 | call to source :  | array_flow.rb:450:10:450:13 | ...[...] | $@ | array_flow.rb:444:12:444:23 | call to source :  | call to source :  |
+| array_flow.rb:451:10:451:13 | ...[...] | array_flow.rb:443:30:443:41 | call to source :  | array_flow.rb:451:10:451:13 | ...[...] | $@ | array_flow.rb:443:30:443:41 | call to source :  | call to source :  |
+| array_flow.rb:451:10:451:13 | ...[...] | array_flow.rb:444:12:444:23 | call to source :  | array_flow.rb:451:10:451:13 | ...[...] | $@ | array_flow.rb:444:12:444:23 | call to source :  | call to source :  |
+| array_flow.rb:457:14:457:14 | x | array_flow.rb:455:19:455:30 | call to source :  | array_flow.rb:457:14:457:14 | x | $@ | array_flow.rb:455:19:455:30 | call to source :  | call to source :  |
+| array_flow.rb:460:10:460:13 | ...[...] | array_flow.rb:455:19:455:30 | call to source :  | array_flow.rb:460:10:460:13 | ...[...] | $@ | array_flow.rb:455:19:455:30 | call to source :  | call to source :  |
+| array_flow.rb:460:10:460:13 | ...[...] | array_flow.rb:458:13:458:24 | call to source :  | array_flow.rb:460:10:460:13 | ...[...] | $@ | array_flow.rb:458:13:458:24 | call to source :  | call to source :  |
+| array_flow.rb:466:10:466:13 | ...[...] | array_flow.rb:464:20:464:29 | call to source :  | array_flow.rb:466:10:466:13 | ...[...] | $@ | array_flow.rb:464:20:464:29 | call to source :  | call to source :  |
+| array_flow.rb:471:10:471:16 | ...[...] | array_flow.rb:470:20:470:29 | call to source :  | array_flow.rb:471:10:471:16 | ...[...] | $@ | array_flow.rb:470:20:470:29 | call to source :  | call to source :  |
+| array_flow.rb:473:10:473:13 | ...[...] | array_flow.rb:470:20:470:29 | call to source :  | array_flow.rb:473:10:473:13 | ...[...] | $@ | array_flow.rb:470:20:470:29 | call to source :  | call to source :  |
+| array_flow.rb:474:10:474:16 | ...[...] | array_flow.rb:470:20:470:29 | call to source :  | array_flow.rb:474:10:474:16 | ...[...] | $@ | array_flow.rb:470:20:470:29 | call to source :  | call to source :  |
+| array_flow.rb:480:10:480:13 | ...[...] | array_flow.rb:478:19:478:30 | call to source :  | array_flow.rb:480:10:480:13 | ...[...] | $@ | array_flow.rb:478:19:478:30 | call to source :  | call to source :  |
+| array_flow.rb:482:14:482:14 | x | array_flow.rb:478:19:478:30 | call to source :  | array_flow.rb:482:14:482:14 | x | $@ | array_flow.rb:478:19:478:30 | call to source :  | call to source :  |
+| array_flow.rb:485:10:485:13 | ...[...] | array_flow.rb:483:9:483:20 | call to source :  | array_flow.rb:485:10:485:13 | ...[...] | $@ | array_flow.rb:483:9:483:20 | call to source :  | call to source :  |
+| array_flow.rb:491:10:491:13 | ...[...] | array_flow.rb:489:19:489:30 | call to source :  | array_flow.rb:491:10:491:13 | ...[...] | $@ | array_flow.rb:489:19:489:30 | call to source :  | call to source :  |
+| array_flow.rb:493:14:493:14 | x | array_flow.rb:489:19:489:30 | call to source :  | array_flow.rb:493:14:493:14 | x | $@ | array_flow.rb:489:19:489:30 | call to source :  | call to source :  |
+| array_flow.rb:496:10:496:13 | ...[...] | array_flow.rb:494:9:494:20 | call to source :  | array_flow.rb:496:10:496:13 | ...[...] | $@ | array_flow.rb:494:9:494:20 | call to source :  | call to source :  |
+| array_flow.rb:502:14:502:14 | x | array_flow.rb:500:19:500:28 | call to source :  | array_flow.rb:502:14:502:14 | x | $@ | array_flow.rb:500:19:500:28 | call to source :  | call to source :  |
+| array_flow.rb:509:10:509:13 | ...[...] | array_flow.rb:508:24:508:35 | call to source :  | array_flow.rb:509:10:509:13 | ...[...] | $@ | array_flow.rb:508:24:508:35 | call to source :  | call to source :  |
+| array_flow.rb:519:10:519:13 | ...[...] | array_flow.rb:516:21:516:34 | call to source :  | array_flow.rb:519:10:519:13 | ...[...] | $@ | array_flow.rb:516:21:516:34 | call to source :  | call to source :  |
+| array_flow.rb:522:10:522:13 | ...[...] | array_flow.rb:515:16:515:29 | call to source :  | array_flow.rb:522:10:522:13 | ...[...] | $@ | array_flow.rb:515:16:515:29 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -271,63 +271,60 @@ edges
 | array_flow.rb:339:9:339:9 | a [array element 2] :  | array_flow.rb:339:9:341:7 | call to each_index [array element 2] :  |
 | array_flow.rb:339:9:341:7 | call to each_index [array element 2] :  | array_flow.rb:342:10:342:10 | b [array element 2] :  |
 | array_flow.rb:342:10:342:10 | b [array element 2] :  | array_flow.rb:342:10:342:13 | ...[...] |
-| array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:347:9:347:9 | a [array element 3] :  |
-| array_flow.rb:347:9:347:9 | a [array element 3] :  | array_flow.rb:347:9:349:7 | call to each_slice [array element 3] :  |
-| array_flow.rb:347:9:347:9 | a [array element 3] :  | array_flow.rb:347:26:347:26 | x [array element] :  |
-| array_flow.rb:347:9:349:7 | call to each_slice [array element 3] :  | array_flow.rb:350:10:350:10 | b [array element 3] :  |
-| array_flow.rb:347:26:347:26 | x [array element] :  | array_flow.rb:348:14:348:14 | x [array element] :  |
+| array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:347:5:347:5 | a [array element 3] :  |
+| array_flow.rb:347:5:347:5 | a [array element 3] :  | array_flow.rb:347:25:347:25 | x [array element] :  |
+| array_flow.rb:347:25:347:25 | x [array element] :  | array_flow.rb:348:14:348:14 | x [array element] :  |
 | array_flow.rb:348:14:348:14 | x [array element] :  | array_flow.rb:348:14:348:17 | ...[...] |
-| array_flow.rb:350:10:350:10 | b [array element 3] :  | array_flow.rb:350:10:350:13 | ...[...] |
-| array_flow.rb:354:19:354:28 | call to source :  | array_flow.rb:355:9:355:9 | a [array element 3] :  |
-| array_flow.rb:355:9:355:9 | a [array element 3] :  | array_flow.rb:355:9:358:7 | call to each_with_index [array element 3] :  |
-| array_flow.rb:355:9:355:9 | a [array element 3] :  | array_flow.rb:355:31:355:31 | x :  |
-| array_flow.rb:355:9:358:7 | call to each_with_index [array element 3] :  | array_flow.rb:359:10:359:10 | b [array element 3] :  |
-| array_flow.rb:355:31:355:31 | x :  | array_flow.rb:356:14:356:14 | x |
-| array_flow.rb:359:10:359:10 | b [array element 3] :  | array_flow.rb:359:10:359:13 | ...[...] |
-| array_flow.rb:363:19:363:30 | call to source :  | array_flow.rb:364:9:364:9 | a [array element 3] :  |
-| array_flow.rb:364:9:364:9 | a [array element 3] :  | array_flow.rb:364:46:364:46 | x :  |
-| array_flow.rb:364:9:367:7 | call to each_with_object :  | array_flow.rb:368:10:368:10 | b |
-| array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:364:9:367:7 | call to each_with_object :  |
-| array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:364:48:364:48 | a :  |
-| array_flow.rb:364:46:364:46 | x :  | array_flow.rb:365:14:365:14 | x |
-| array_flow.rb:364:48:364:48 | a :  | array_flow.rb:366:14:366:14 | a |
-| array_flow.rb:372:19:372:30 | call to source :  | array_flow.rb:373:9:373:9 | a [array element 3] :  |
-| array_flow.rb:373:9:373:9 | a [array element 3] :  | array_flow.rb:373:9:375:7 | call to fetch :  |
-| array_flow.rb:373:9:375:7 | call to fetch :  | array_flow.rb:376:10:376:10 | b |
-| array_flow.rb:373:17:373:28 | call to source :  | array_flow.rb:373:35:373:35 | x :  |
-| array_flow.rb:373:35:373:35 | x :  | array_flow.rb:374:14:374:14 | x |
-| array_flow.rb:380:19:380:30 | call to source :  | array_flow.rb:382:10:382:10 | a [array element 3] :  |
-| array_flow.rb:381:5:381:5 | [post] a [array element] :  | array_flow.rb:382:10:382:10 | a [array element] :  |
-| array_flow.rb:381:12:381:23 | call to source :  | array_flow.rb:381:5:381:5 | [post] a [array element] :  |
-| array_flow.rb:382:10:382:10 | a [array element 3] :  | array_flow.rb:382:10:382:13 | ...[...] |
-| array_flow.rb:382:10:382:10 | a [array element] :  | array_flow.rb:382:10:382:13 | ...[...] |
-| array_flow.rb:383:5:383:5 | [post] a [array element] :  | array_flow.rb:384:10:384:10 | a [array element] :  |
-| array_flow.rb:383:12:383:23 | call to source :  | array_flow.rb:383:5:383:5 | [post] a [array element] :  |
-| array_flow.rb:384:10:384:10 | a [array element] :  | array_flow.rb:384:10:384:13 | ...[...] |
-| array_flow.rb:385:5:385:5 | [post] a [array element] :  | array_flow.rb:388:10:388:10 | a [array element] :  |
-| array_flow.rb:385:5:385:5 | [post] a [array element] :  | array_flow.rb:392:10:392:10 | a [array element] :  |
-| array_flow.rb:386:9:386:20 | call to source :  | array_flow.rb:385:5:385:5 | [post] a [array element] :  |
-| array_flow.rb:388:10:388:10 | a [array element] :  | array_flow.rb:388:10:388:13 | ...[...] |
-| array_flow.rb:389:5:389:5 | [post] a [array element] :  | array_flow.rb:392:10:392:10 | a [array element] :  |
-| array_flow.rb:390:9:390:20 | call to source :  | array_flow.rb:389:5:389:5 | [post] a [array element] :  |
-| array_flow.rb:392:10:392:10 | a [array element] :  | array_flow.rb:392:10:392:13 | ...[...] |
-| array_flow.rb:396:19:396:28 | call to source :  | array_flow.rb:397:9:397:9 | a [array element 3] :  |
-| array_flow.rb:397:9:397:9 | a [array element 3] :  | array_flow.rb:397:9:399:7 | call to filter [array element] :  |
-| array_flow.rb:397:9:397:9 | a [array element 3] :  | array_flow.rb:397:22:397:22 | x :  |
-| array_flow.rb:397:9:399:7 | call to filter [array element] :  | array_flow.rb:400:10:400:10 | b [array element] :  |
-| array_flow.rb:397:22:397:22 | x :  | array_flow.rb:398:14:398:14 | x |
-| array_flow.rb:400:10:400:10 | b [array element] :  | array_flow.rb:400:10:400:13 | ...[...] |
-| array_flow.rb:404:19:404:28 | call to source :  | array_flow.rb:405:9:405:9 | a [array element 3] :  |
-| array_flow.rb:405:9:405:9 | a [array element 3] :  | array_flow.rb:405:9:407:7 | call to filter_map [array element] :  |
-| array_flow.rb:405:9:405:9 | a [array element 3] :  | array_flow.rb:405:26:405:26 | x :  |
-| array_flow.rb:405:9:407:7 | call to filter_map [array element] :  | array_flow.rb:408:10:408:10 | b [array element] :  |
-| array_flow.rb:405:26:405:26 | x :  | array_flow.rb:406:14:406:14 | x |
-| array_flow.rb:408:10:408:10 | b [array element] :  | array_flow.rb:408:10:408:13 | ...[...] |
-| array_flow.rb:412:19:412:28 | call to source :  | array_flow.rb:413:9:413:9 | a [array element 3] :  |
-| array_flow.rb:413:9:413:9 | a [array element 3] :  | array_flow.rb:413:9:415:7 | call to filter! [array element] :  |
-| array_flow.rb:413:9:413:9 | a [array element 3] :  | array_flow.rb:413:23:413:23 | x :  |
-| array_flow.rb:413:9:415:7 | call to filter! [array element] :  | array_flow.rb:416:10:416:10 | b [array element] :  |
-| array_flow.rb:413:23:413:23 | x :  | array_flow.rb:414:14:414:14 | x |
+| array_flow.rb:353:19:353:28 | call to source :  | array_flow.rb:354:9:354:9 | a [array element 3] :  |
+| array_flow.rb:354:9:354:9 | a [array element 3] :  | array_flow.rb:354:9:357:7 | call to each_with_index [array element 3] :  |
+| array_flow.rb:354:9:354:9 | a [array element 3] :  | array_flow.rb:354:31:354:31 | x :  |
+| array_flow.rb:354:9:357:7 | call to each_with_index [array element 3] :  | array_flow.rb:358:10:358:10 | b [array element 3] :  |
+| array_flow.rb:354:31:354:31 | x :  | array_flow.rb:355:14:355:14 | x |
+| array_flow.rb:358:10:358:10 | b [array element 3] :  | array_flow.rb:358:10:358:13 | ...[...] |
+| array_flow.rb:362:19:362:30 | call to source :  | array_flow.rb:363:9:363:9 | a [array element 3] :  |
+| array_flow.rb:363:9:363:9 | a [array element 3] :  | array_flow.rb:363:46:363:46 | x :  |
+| array_flow.rb:363:9:366:7 | call to each_with_object :  | array_flow.rb:367:10:367:10 | b |
+| array_flow.rb:363:28:363:39 | call to source :  | array_flow.rb:363:9:366:7 | call to each_with_object :  |
+| array_flow.rb:363:28:363:39 | call to source :  | array_flow.rb:363:48:363:48 | a :  |
+| array_flow.rb:363:46:363:46 | x :  | array_flow.rb:364:14:364:14 | x |
+| array_flow.rb:363:48:363:48 | a :  | array_flow.rb:365:14:365:14 | a |
+| array_flow.rb:371:19:371:30 | call to source :  | array_flow.rb:372:9:372:9 | a [array element 3] :  |
+| array_flow.rb:372:9:372:9 | a [array element 3] :  | array_flow.rb:372:9:374:7 | call to fetch :  |
+| array_flow.rb:372:9:374:7 | call to fetch :  | array_flow.rb:375:10:375:10 | b |
+| array_flow.rb:372:17:372:28 | call to source :  | array_flow.rb:372:35:372:35 | x :  |
+| array_flow.rb:372:35:372:35 | x :  | array_flow.rb:373:14:373:14 | x |
+| array_flow.rb:379:19:379:30 | call to source :  | array_flow.rb:381:10:381:10 | a [array element 3] :  |
+| array_flow.rb:380:5:380:5 | [post] a [array element] :  | array_flow.rb:381:10:381:10 | a [array element] :  |
+| array_flow.rb:380:12:380:23 | call to source :  | array_flow.rb:380:5:380:5 | [post] a [array element] :  |
+| array_flow.rb:381:10:381:10 | a [array element 3] :  | array_flow.rb:381:10:381:13 | ...[...] |
+| array_flow.rb:381:10:381:10 | a [array element] :  | array_flow.rb:381:10:381:13 | ...[...] |
+| array_flow.rb:382:5:382:5 | [post] a [array element] :  | array_flow.rb:383:10:383:10 | a [array element] :  |
+| array_flow.rb:382:12:382:23 | call to source :  | array_flow.rb:382:5:382:5 | [post] a [array element] :  |
+| array_flow.rb:383:10:383:10 | a [array element] :  | array_flow.rb:383:10:383:13 | ...[...] |
+| array_flow.rb:384:5:384:5 | [post] a [array element] :  | array_flow.rb:387:10:387:10 | a [array element] :  |
+| array_flow.rb:384:5:384:5 | [post] a [array element] :  | array_flow.rb:391:10:391:10 | a [array element] :  |
+| array_flow.rb:385:9:385:20 | call to source :  | array_flow.rb:384:5:384:5 | [post] a [array element] :  |
+| array_flow.rb:387:10:387:10 | a [array element] :  | array_flow.rb:387:10:387:13 | ...[...] |
+| array_flow.rb:388:5:388:5 | [post] a [array element] :  | array_flow.rb:391:10:391:10 | a [array element] :  |
+| array_flow.rb:389:9:389:20 | call to source :  | array_flow.rb:388:5:388:5 | [post] a [array element] :  |
+| array_flow.rb:391:10:391:10 | a [array element] :  | array_flow.rb:391:10:391:13 | ...[...] |
+| array_flow.rb:395:19:395:28 | call to source :  | array_flow.rb:396:9:396:9 | a [array element 3] :  |
+| array_flow.rb:396:9:396:9 | a [array element 3] :  | array_flow.rb:396:9:398:7 | call to filter [array element] :  |
+| array_flow.rb:396:9:396:9 | a [array element 3] :  | array_flow.rb:396:22:396:22 | x :  |
+| array_flow.rb:396:9:398:7 | call to filter [array element] :  | array_flow.rb:399:10:399:10 | b [array element] :  |
+| array_flow.rb:396:22:396:22 | x :  | array_flow.rb:397:14:397:14 | x |
+| array_flow.rb:399:10:399:10 | b [array element] :  | array_flow.rb:399:10:399:13 | ...[...] |
+| array_flow.rb:403:19:403:28 | call to source :  | array_flow.rb:404:9:404:9 | a [array element 3] :  |
+| array_flow.rb:404:9:404:9 | a [array element 3] :  | array_flow.rb:404:9:406:7 | call to filter_map [array element] :  |
+| array_flow.rb:404:9:404:9 | a [array element 3] :  | array_flow.rb:404:26:404:26 | x :  |
+| array_flow.rb:404:9:406:7 | call to filter_map [array element] :  | array_flow.rb:407:10:407:10 | b [array element] :  |
+| array_flow.rb:404:26:404:26 | x :  | array_flow.rb:405:14:405:14 | x |
+| array_flow.rb:407:10:407:10 | b [array element] :  | array_flow.rb:407:10:407:13 | ...[...] |
+| array_flow.rb:411:19:411:28 | call to source :  | array_flow.rb:412:9:412:9 | a [array element 3] :  |
+| array_flow.rb:412:9:412:9 | a [array element 3] :  | array_flow.rb:412:9:415:7 | call to filter! [array element] :  |
+| array_flow.rb:412:9:412:9 | a [array element 3] :  | array_flow.rb:412:23:412:23 | x :  |
+| array_flow.rb:412:9:415:7 | call to filter! [array element] :  | array_flow.rb:416:10:416:10 | b [array element] :  |
+| array_flow.rb:412:23:412:23 | x :  | array_flow.rb:413:14:413:14 | x |
 | array_flow.rb:416:10:416:10 | b [array element] :  | array_flow.rb:416:10:416:13 | ...[...] |
 | array_flow.rb:420:19:420:30 | call to source :  | array_flow.rb:421:9:421:9 | a [array element 3] :  |
 | array_flow.rb:421:9:421:9 | a [array element 3] :  | array_flow.rb:421:9:423:7 | call to find :  |
@@ -419,7 +416,7 @@ edges
 | array_flow.rb:501:5:501:5 | a [array element 3] :  | array_flow.rb:501:17:501:17 | x :  |
 | array_flow.rb:501:17:501:17 | x :  | array_flow.rb:502:14:502:14 | x |
 | array_flow.rb:508:5:508:5 | [post] a [array element 0] :  | array_flow.rb:509:10:509:10 | a [array element 0] :  |
-| array_flow.rb:508:24:508:35 | call to source :  | array_flow.rb:508:5:508:5 | [post] a [array element 0] :  |
+| array_flow.rb:508:16:508:27 | call to source :  | array_flow.rb:508:5:508:5 | [post] a [array element 0] :  |
 | array_flow.rb:509:10:509:10 | a [array element 0] :  | array_flow.rb:509:10:509:13 | ...[...] |
 | array_flow.rb:515:16:515:29 | call to source :  | array_flow.rb:516:5:516:5 | a [array element 2] :  |
 | array_flow.rb:516:5:516:5 | [post] a [array element 2] :  | array_flow.rb:519:10:519:10 | a [array element 2] :  |
@@ -743,73 +740,70 @@ nodes
 | array_flow.rb:342:10:342:10 | b [array element 2] :  | semmle.label | b [array element 2] :  |
 | array_flow.rb:342:10:342:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:346:19:346:28 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:347:9:347:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:347:9:349:7 | call to each_slice [array element 3] :  | semmle.label | call to each_slice [array element 3] :  |
-| array_flow.rb:347:26:347:26 | x [array element] :  | semmle.label | x [array element] :  |
+| array_flow.rb:347:5:347:5 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:347:25:347:25 | x [array element] :  | semmle.label | x [array element] :  |
 | array_flow.rb:348:14:348:14 | x [array element] :  | semmle.label | x [array element] :  |
 | array_flow.rb:348:14:348:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:350:10:350:10 | b [array element 3] :  | semmle.label | b [array element 3] :  |
-| array_flow.rb:350:10:350:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:354:19:354:28 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:355:9:355:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:355:9:358:7 | call to each_with_index [array element 3] :  | semmle.label | call to each_with_index [array element 3] :  |
-| array_flow.rb:355:31:355:31 | x :  | semmle.label | x :  |
-| array_flow.rb:356:14:356:14 | x | semmle.label | x |
-| array_flow.rb:359:10:359:10 | b [array element 3] :  | semmle.label | b [array element 3] :  |
-| array_flow.rb:359:10:359:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:363:19:363:30 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:364:9:364:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:364:9:367:7 | call to each_with_object :  | semmle.label | call to each_with_object :  |
-| array_flow.rb:364:28:364:39 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:364:46:364:46 | x :  | semmle.label | x :  |
-| array_flow.rb:364:48:364:48 | a :  | semmle.label | a :  |
-| array_flow.rb:365:14:365:14 | x | semmle.label | x |
-| array_flow.rb:366:14:366:14 | a | semmle.label | a |
-| array_flow.rb:368:10:368:10 | b | semmle.label | b |
-| array_flow.rb:372:19:372:30 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:373:9:373:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:373:9:375:7 | call to fetch :  | semmle.label | call to fetch :  |
-| array_flow.rb:373:17:373:28 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:373:35:373:35 | x :  | semmle.label | x :  |
-| array_flow.rb:374:14:374:14 | x | semmle.label | x |
-| array_flow.rb:376:10:376:10 | b | semmle.label | b |
-| array_flow.rb:380:19:380:30 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:381:5:381:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
-| array_flow.rb:381:12:381:23 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:382:10:382:10 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:382:10:382:10 | a [array element] :  | semmle.label | a [array element] :  |
-| array_flow.rb:382:10:382:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:383:5:383:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
-| array_flow.rb:383:12:383:23 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:384:10:384:10 | a [array element] :  | semmle.label | a [array element] :  |
-| array_flow.rb:384:10:384:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:385:5:385:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
-| array_flow.rb:386:9:386:20 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:388:10:388:10 | a [array element] :  | semmle.label | a [array element] :  |
-| array_flow.rb:388:10:388:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:389:5:389:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
-| array_flow.rb:390:9:390:20 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:392:10:392:10 | a [array element] :  | semmle.label | a [array element] :  |
-| array_flow.rb:392:10:392:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:396:19:396:28 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:397:9:397:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:397:9:399:7 | call to filter [array element] :  | semmle.label | call to filter [array element] :  |
-| array_flow.rb:397:22:397:22 | x :  | semmle.label | x :  |
-| array_flow.rb:398:14:398:14 | x | semmle.label | x |
-| array_flow.rb:400:10:400:10 | b [array element] :  | semmle.label | b [array element] :  |
-| array_flow.rb:400:10:400:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:404:19:404:28 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:405:9:405:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:405:9:407:7 | call to filter_map [array element] :  | semmle.label | call to filter_map [array element] :  |
-| array_flow.rb:405:26:405:26 | x :  | semmle.label | x :  |
-| array_flow.rb:406:14:406:14 | x | semmle.label | x |
-| array_flow.rb:408:10:408:10 | b [array element] :  | semmle.label | b [array element] :  |
-| array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:412:19:412:28 | call to source :  | semmle.label | call to source :  |
-| array_flow.rb:413:9:413:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:413:9:415:7 | call to filter! [array element] :  | semmle.label | call to filter! [array element] :  |
-| array_flow.rb:413:23:413:23 | x :  | semmle.label | x :  |
-| array_flow.rb:414:14:414:14 | x | semmle.label | x |
+| array_flow.rb:353:19:353:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:354:9:354:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:354:9:357:7 | call to each_with_index [array element 3] :  | semmle.label | call to each_with_index [array element 3] :  |
+| array_flow.rb:354:31:354:31 | x :  | semmle.label | x :  |
+| array_flow.rb:355:14:355:14 | x | semmle.label | x |
+| array_flow.rb:358:10:358:10 | b [array element 3] :  | semmle.label | b [array element 3] :  |
+| array_flow.rb:358:10:358:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:362:19:362:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:363:9:363:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:363:9:366:7 | call to each_with_object :  | semmle.label | call to each_with_object :  |
+| array_flow.rb:363:28:363:39 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:363:46:363:46 | x :  | semmle.label | x :  |
+| array_flow.rb:363:48:363:48 | a :  | semmle.label | a :  |
+| array_flow.rb:364:14:364:14 | x | semmle.label | x |
+| array_flow.rb:365:14:365:14 | a | semmle.label | a |
+| array_flow.rb:367:10:367:10 | b | semmle.label | b |
+| array_flow.rb:371:19:371:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:372:9:372:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:372:9:374:7 | call to fetch :  | semmle.label | call to fetch :  |
+| array_flow.rb:372:17:372:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:372:35:372:35 | x :  | semmle.label | x :  |
+| array_flow.rb:373:14:373:14 | x | semmle.label | x |
+| array_flow.rb:375:10:375:10 | b | semmle.label | b |
+| array_flow.rb:379:19:379:30 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:380:5:380:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:380:12:380:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:381:10:381:10 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:381:10:381:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:381:10:381:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:382:5:382:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:382:12:382:23 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:383:10:383:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:384:5:384:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:385:9:385:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:387:10:387:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:387:10:387:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:388:5:388:5 | [post] a [array element] :  | semmle.label | [post] a [array element] :  |
+| array_flow.rb:389:9:389:20 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:391:10:391:10 | a [array element] :  | semmle.label | a [array element] :  |
+| array_flow.rb:391:10:391:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:395:19:395:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:396:9:396:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:396:9:398:7 | call to filter [array element] :  | semmle.label | call to filter [array element] :  |
+| array_flow.rb:396:22:396:22 | x :  | semmle.label | x :  |
+| array_flow.rb:397:14:397:14 | x | semmle.label | x |
+| array_flow.rb:399:10:399:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:399:10:399:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:403:19:403:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:404:9:404:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:404:9:406:7 | call to filter_map [array element] :  | semmle.label | call to filter_map [array element] :  |
+| array_flow.rb:404:26:404:26 | x :  | semmle.label | x :  |
+| array_flow.rb:405:14:405:14 | x | semmle.label | x |
+| array_flow.rb:407:10:407:10 | b [array element] :  | semmle.label | b [array element] :  |
+| array_flow.rb:407:10:407:13 | ...[...] | semmle.label | ...[...] |
+| array_flow.rb:411:19:411:28 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:412:9:412:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
+| array_flow.rb:412:9:415:7 | call to filter! [array element] :  | semmle.label | call to filter! [array element] :  |
+| array_flow.rb:412:23:412:23 | x :  | semmle.label | x :  |
+| array_flow.rb:413:14:413:14 | x | semmle.label | x |
 | array_flow.rb:416:10:416:10 | b [array element] :  | semmle.label | b [array element] :  |
 | array_flow.rb:416:10:416:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:420:19:420:30 | call to source :  | semmle.label | call to source :  |
@@ -912,7 +906,7 @@ nodes
 | array_flow.rb:501:17:501:17 | x :  | semmle.label | x :  |
 | array_flow.rb:502:14:502:14 | x | semmle.label | x |
 | array_flow.rb:508:5:508:5 | [post] a [array element 0] :  | semmle.label | [post] a [array element 0] :  |
-| array_flow.rb:508:24:508:35 | call to source :  | semmle.label | call to source :  |
+| array_flow.rb:508:16:508:27 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:509:10:509:10 | a [array element 0] :  | semmle.label | a [array element 0] :  |
 | array_flow.rb:509:10:509:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:515:16:515:29 | call to source :  | semmle.label | call to source :  |
@@ -1024,26 +1018,25 @@ subpaths
 | array_flow.rb:334:10:334:13 | ...[...] | array_flow.rb:330:16:330:25 | call to source :  | array_flow.rb:334:10:334:13 | ...[...] | $@ | array_flow.rb:330:16:330:25 | call to source :  | call to source :  |
 | array_flow.rb:342:10:342:13 | ...[...] | array_flow.rb:338:16:338:25 | call to source :  | array_flow.rb:342:10:342:13 | ...[...] | $@ | array_flow.rb:338:16:338:25 | call to source :  | call to source :  |
 | array_flow.rb:348:14:348:17 | ...[...] | array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:348:14:348:17 | ...[...] | $@ | array_flow.rb:346:19:346:28 | call to source :  | call to source :  |
-| array_flow.rb:350:10:350:13 | ...[...] | array_flow.rb:346:19:346:28 | call to source :  | array_flow.rb:350:10:350:13 | ...[...] | $@ | array_flow.rb:346:19:346:28 | call to source :  | call to source :  |
-| array_flow.rb:356:14:356:14 | x | array_flow.rb:354:19:354:28 | call to source :  | array_flow.rb:356:14:356:14 | x | $@ | array_flow.rb:354:19:354:28 | call to source :  | call to source :  |
-| array_flow.rb:359:10:359:13 | ...[...] | array_flow.rb:354:19:354:28 | call to source :  | array_flow.rb:359:10:359:13 | ...[...] | $@ | array_flow.rb:354:19:354:28 | call to source :  | call to source :  |
-| array_flow.rb:365:14:365:14 | x | array_flow.rb:363:19:363:30 | call to source :  | array_flow.rb:365:14:365:14 | x | $@ | array_flow.rb:363:19:363:30 | call to source :  | call to source :  |
-| array_flow.rb:366:14:366:14 | a | array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:366:14:366:14 | a | $@ | array_flow.rb:364:28:364:39 | call to source :  | call to source :  |
-| array_flow.rb:368:10:368:10 | b | array_flow.rb:364:28:364:39 | call to source :  | array_flow.rb:368:10:368:10 | b | $@ | array_flow.rb:364:28:364:39 | call to source :  | call to source :  |
-| array_flow.rb:374:14:374:14 | x | array_flow.rb:373:17:373:28 | call to source :  | array_flow.rb:374:14:374:14 | x | $@ | array_flow.rb:373:17:373:28 | call to source :  | call to source :  |
-| array_flow.rb:376:10:376:10 | b | array_flow.rb:372:19:372:30 | call to source :  | array_flow.rb:376:10:376:10 | b | $@ | array_flow.rb:372:19:372:30 | call to source :  | call to source :  |
-| array_flow.rb:382:10:382:13 | ...[...] | array_flow.rb:380:19:380:30 | call to source :  | array_flow.rb:382:10:382:13 | ...[...] | $@ | array_flow.rb:380:19:380:30 | call to source :  | call to source :  |
-| array_flow.rb:382:10:382:13 | ...[...] | array_flow.rb:381:12:381:23 | call to source :  | array_flow.rb:382:10:382:13 | ...[...] | $@ | array_flow.rb:381:12:381:23 | call to source :  | call to source :  |
-| array_flow.rb:384:10:384:13 | ...[...] | array_flow.rb:383:12:383:23 | call to source :  | array_flow.rb:384:10:384:13 | ...[...] | $@ | array_flow.rb:383:12:383:23 | call to source :  | call to source :  |
-| array_flow.rb:388:10:388:13 | ...[...] | array_flow.rb:386:9:386:20 | call to source :  | array_flow.rb:388:10:388:13 | ...[...] | $@ | array_flow.rb:386:9:386:20 | call to source :  | call to source :  |
-| array_flow.rb:392:10:392:13 | ...[...] | array_flow.rb:386:9:386:20 | call to source :  | array_flow.rb:392:10:392:13 | ...[...] | $@ | array_flow.rb:386:9:386:20 | call to source :  | call to source :  |
-| array_flow.rb:392:10:392:13 | ...[...] | array_flow.rb:390:9:390:20 | call to source :  | array_flow.rb:392:10:392:13 | ...[...] | $@ | array_flow.rb:390:9:390:20 | call to source :  | call to source :  |
-| array_flow.rb:398:14:398:14 | x | array_flow.rb:396:19:396:28 | call to source :  | array_flow.rb:398:14:398:14 | x | $@ | array_flow.rb:396:19:396:28 | call to source :  | call to source :  |
-| array_flow.rb:400:10:400:13 | ...[...] | array_flow.rb:396:19:396:28 | call to source :  | array_flow.rb:400:10:400:13 | ...[...] | $@ | array_flow.rb:396:19:396:28 | call to source :  | call to source :  |
-| array_flow.rb:406:14:406:14 | x | array_flow.rb:404:19:404:28 | call to source :  | array_flow.rb:406:14:406:14 | x | $@ | array_flow.rb:404:19:404:28 | call to source :  | call to source :  |
-| array_flow.rb:408:10:408:13 | ...[...] | array_flow.rb:404:19:404:28 | call to source :  | array_flow.rb:408:10:408:13 | ...[...] | $@ | array_flow.rb:404:19:404:28 | call to source :  | call to source :  |
-| array_flow.rb:414:14:414:14 | x | array_flow.rb:412:19:412:28 | call to source :  | array_flow.rb:414:14:414:14 | x | $@ | array_flow.rb:412:19:412:28 | call to source :  | call to source :  |
-| array_flow.rb:416:10:416:13 | ...[...] | array_flow.rb:412:19:412:28 | call to source :  | array_flow.rb:416:10:416:13 | ...[...] | $@ | array_flow.rb:412:19:412:28 | call to source :  | call to source :  |
+| array_flow.rb:355:14:355:14 | x | array_flow.rb:353:19:353:28 | call to source :  | array_flow.rb:355:14:355:14 | x | $@ | array_flow.rb:353:19:353:28 | call to source :  | call to source :  |
+| array_flow.rb:358:10:358:13 | ...[...] | array_flow.rb:353:19:353:28 | call to source :  | array_flow.rb:358:10:358:13 | ...[...] | $@ | array_flow.rb:353:19:353:28 | call to source :  | call to source :  |
+| array_flow.rb:364:14:364:14 | x | array_flow.rb:362:19:362:30 | call to source :  | array_flow.rb:364:14:364:14 | x | $@ | array_flow.rb:362:19:362:30 | call to source :  | call to source :  |
+| array_flow.rb:365:14:365:14 | a | array_flow.rb:363:28:363:39 | call to source :  | array_flow.rb:365:14:365:14 | a | $@ | array_flow.rb:363:28:363:39 | call to source :  | call to source :  |
+| array_flow.rb:367:10:367:10 | b | array_flow.rb:363:28:363:39 | call to source :  | array_flow.rb:367:10:367:10 | b | $@ | array_flow.rb:363:28:363:39 | call to source :  | call to source :  |
+| array_flow.rb:373:14:373:14 | x | array_flow.rb:372:17:372:28 | call to source :  | array_flow.rb:373:14:373:14 | x | $@ | array_flow.rb:372:17:372:28 | call to source :  | call to source :  |
+| array_flow.rb:375:10:375:10 | b | array_flow.rb:371:19:371:30 | call to source :  | array_flow.rb:375:10:375:10 | b | $@ | array_flow.rb:371:19:371:30 | call to source :  | call to source :  |
+| array_flow.rb:381:10:381:13 | ...[...] | array_flow.rb:379:19:379:30 | call to source :  | array_flow.rb:381:10:381:13 | ...[...] | $@ | array_flow.rb:379:19:379:30 | call to source :  | call to source :  |
+| array_flow.rb:381:10:381:13 | ...[...] | array_flow.rb:380:12:380:23 | call to source :  | array_flow.rb:381:10:381:13 | ...[...] | $@ | array_flow.rb:380:12:380:23 | call to source :  | call to source :  |
+| array_flow.rb:383:10:383:13 | ...[...] | array_flow.rb:382:12:382:23 | call to source :  | array_flow.rb:383:10:383:13 | ...[...] | $@ | array_flow.rb:382:12:382:23 | call to source :  | call to source :  |
+| array_flow.rb:387:10:387:13 | ...[...] | array_flow.rb:385:9:385:20 | call to source :  | array_flow.rb:387:10:387:13 | ...[...] | $@ | array_flow.rb:385:9:385:20 | call to source :  | call to source :  |
+| array_flow.rb:391:10:391:13 | ...[...] | array_flow.rb:385:9:385:20 | call to source :  | array_flow.rb:391:10:391:13 | ...[...] | $@ | array_flow.rb:385:9:385:20 | call to source :  | call to source :  |
+| array_flow.rb:391:10:391:13 | ...[...] | array_flow.rb:389:9:389:20 | call to source :  | array_flow.rb:391:10:391:13 | ...[...] | $@ | array_flow.rb:389:9:389:20 | call to source :  | call to source :  |
+| array_flow.rb:397:14:397:14 | x | array_flow.rb:395:19:395:28 | call to source :  | array_flow.rb:397:14:397:14 | x | $@ | array_flow.rb:395:19:395:28 | call to source :  | call to source :  |
+| array_flow.rb:399:10:399:13 | ...[...] | array_flow.rb:395:19:395:28 | call to source :  | array_flow.rb:399:10:399:13 | ...[...] | $@ | array_flow.rb:395:19:395:28 | call to source :  | call to source :  |
+| array_flow.rb:405:14:405:14 | x | array_flow.rb:403:19:403:28 | call to source :  | array_flow.rb:405:14:405:14 | x | $@ | array_flow.rb:403:19:403:28 | call to source :  | call to source :  |
+| array_flow.rb:407:10:407:13 | ...[...] | array_flow.rb:403:19:403:28 | call to source :  | array_flow.rb:407:10:407:13 | ...[...] | $@ | array_flow.rb:403:19:403:28 | call to source :  | call to source :  |
+| array_flow.rb:413:14:413:14 | x | array_flow.rb:411:19:411:28 | call to source :  | array_flow.rb:413:14:413:14 | x | $@ | array_flow.rb:411:19:411:28 | call to source :  | call to source :  |
+| array_flow.rb:416:10:416:13 | ...[...] | array_flow.rb:411:19:411:28 | call to source :  | array_flow.rb:416:10:416:13 | ...[...] | $@ | array_flow.rb:411:19:411:28 | call to source :  | call to source :  |
 | array_flow.rb:422:14:422:14 | x | array_flow.rb:420:19:420:30 | call to source :  | array_flow.rb:422:14:422:14 | x | $@ | array_flow.rb:420:19:420:30 | call to source :  | call to source :  |
 | array_flow.rb:424:10:424:10 | b | array_flow.rb:420:19:420:30 | call to source :  | array_flow.rb:424:10:424:10 | b | $@ | array_flow.rb:420:19:420:30 | call to source :  | call to source :  |
 | array_flow.rb:424:10:424:10 | b | array_flow.rb:421:21:421:32 | call to source :  | array_flow.rb:424:10:424:10 | b | $@ | array_flow.rb:421:21:421:32 | call to source :  | call to source :  |
@@ -1073,6 +1066,6 @@ subpaths
 | array_flow.rb:493:14:493:14 | x | array_flow.rb:489:19:489:30 | call to source :  | array_flow.rb:493:14:493:14 | x | $@ | array_flow.rb:489:19:489:30 | call to source :  | call to source :  |
 | array_flow.rb:496:10:496:13 | ...[...] | array_flow.rb:494:9:494:20 | call to source :  | array_flow.rb:496:10:496:13 | ...[...] | $@ | array_flow.rb:494:9:494:20 | call to source :  | call to source :  |
 | array_flow.rb:502:14:502:14 | x | array_flow.rb:500:19:500:28 | call to source :  | array_flow.rb:502:14:502:14 | x | $@ | array_flow.rb:500:19:500:28 | call to source :  | call to source :  |
-| array_flow.rb:509:10:509:13 | ...[...] | array_flow.rb:508:24:508:35 | call to source :  | array_flow.rb:509:10:509:13 | ...[...] | $@ | array_flow.rb:508:24:508:35 | call to source :  | call to source :  |
+| array_flow.rb:509:10:509:13 | ...[...] | array_flow.rb:508:16:508:27 | call to source :  | array_flow.rb:509:10:509:13 | ...[...] | $@ | array_flow.rb:508:16:508:27 | call to source :  | call to source :  |
 | array_flow.rb:519:10:519:13 | ...[...] | array_flow.rb:516:21:516:34 | call to source :  | array_flow.rb:519:10:519:13 | ...[...] | $@ | array_flow.rb:516:21:516:34 | call to source :  | call to source :  |
 | array_flow.rb:522:10:522:13 | ...[...] | array_flow.rb:515:16:515:29 | call to source :  | array_flow.rb:522:10:522:13 | ...[...] | $@ | array_flow.rb:515:16:515:29 | call to source :  | call to source :  |

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.ql
@@ -1,0 +1,15 @@
+/**
+ * @kind path-problem
+ */
+
+import ruby
+import TestUtilities.InlineFlowTest
+import PathGraph
+
+class HasFlowTest extends InlineFlowTest {
+  override DataFlow::Configuration getTaintFlowConfig() { none() }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, DefaultValueFlowConf conf
+where conf.hasFlowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -14,7 +14,7 @@ def m1(i)
 end
 
 def m2(i)
-    a = Array.new(0, source(2.1))
+    a = Array.new(1, source(2.1))
     sink(a[0]) # $ hasValueFlow=2.1
     sink(a[i]) # $ hasValueFlow=2.1
 
@@ -344,10 +344,9 @@ end
 
 def m43
     a = [0, 1, 2, source(43)]
-    b = a.each_slice do |x|
+    a.each_slice(1) do |x|
         sink(x[0]) # $ hasValueFlow=43
     end
-    sink(b[3]) # $ hasValueFlow=43
 end
 
 def m44
@@ -412,6 +411,7 @@ def m50
     a = [0, 1, 2, source(50)]
     b = a.filter! do |x|
         sink(x) # $ hasValueFlow=50
+        x > 2
     end
     sink(b[0]) # $ hasValueFlow=50
 end
@@ -505,7 +505,7 @@ end
 
 def m61
     a = [0, 1, 2, source(61.1)]
-    a.initialize_copy([source(61.2)])
+    a.replace([source(61.2)])
     sink(a[0]) # $ hasValueFlow=61.2
 end
 

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array_flow.rb
@@ -1,0 +1,523 @@
+def m0(i)
+    a = *source(0)
+    sink(a[0]) # $ hasValueFlow=0
+    sink(a[1])
+    sink(a[i]) # $ hasValueFlow=0
+end
+
+def m1(i)
+    a = [0, source(1), 2]
+    sink(a[0])
+    sink(a[1]) # $ hasValueFlow=1
+    sink(a[2])
+    sink(a[i]) # $ hasValueFlow=1
+end
+
+def m2(i)
+    a = Array.new(0, source(2.1))
+    sink(a[0]) # $ hasValueFlow=2.1
+    sink(a[i]) # $ hasValueFlow=2.1
+
+    b = Array.new(a)
+    sink(b[0]) # $ hasValueFlow=2.1
+    sink(b[i]) # $ hasValueFlow=2.1
+
+    c = Array.new(1) do |x|
+        source(2.2)
+    end
+    sink(c[0]) # $ hasValueFlow=2.2
+    sink(c[i]) # $ hasValueFlow=2.2
+end
+
+def m3
+    a = [source(3), 1]
+    b = Array.try_convert(a)
+    sink(b[0]) # $ hasValueFlow=3
+    sink(b[1])
+end
+
+def m4
+    a = [source(4.1), 1]
+    b = [2, 3, source(4.2)]
+    c = a & b
+    sink(c[0]) # $ hasValueFlow=4.1 $ hasValueFlow=4.2
+    sink(c[1]) # $ hasValueFlow=4.1 $ hasValueFlow=4.2
+end
+
+def m5
+    a = [source(5), 1]
+    b = a * 3
+    sink(b[0]) # $ hasValueFlow=5
+    sink(b[1]) # $ hasValueFlow=5
+end
+
+def m6
+    a = [source(6.1), 1]
+    b = [2, source(6.2)]
+    c = a + b
+    sink(c[0]) # $ hasValueFlow=6.1 $ hasValueFlow=6.2
+    sink(c[1]) # $ hasValueFlow=6.2
+end
+
+def m7
+    a = [source(7.1), 1]
+    b = [2, source(7.2)]
+    c = a - b
+    sink(c[0]) # $ hasValueFlow=7.1
+    sink(c[1]) # $ hasValueFlow=7.1
+end
+
+def m8
+    a = [source(8.1), 1]
+    b = a << source(8.2)
+    sink(b[0]) # $ hasValueFlow=8.1 $ hasValueFlow=8.2
+    sink(b[1]) # $ hasValueFlow=8.2
+end
+
+def m9(i)
+    a = [0, source(9), 2]
+    b, c, d = a
+    sink(b)
+    sink(c) # $ hasValueFlow=9
+    sink(d)
+end
+
+def m10(i)
+    a = [0, source(10), 2]
+    b = a[0, 2]
+    sink(b[0]) # $ hasValueFlow=10
+    sink(b[1]) # $ hasValueFlow=10
+    sink(b[i]) # $ hasValueFlow=10
+end
+
+def m11(i)
+    a = [0, source(11), 2]
+    b = a[0..2]
+    sink(b[0]) # $ hasValueFlow=11
+    sink(b[1]) # $ hasValueFlow=11
+    sink(b[i]) # $ hasValueFlow=11
+end
+
+def m12(i)
+    a = [0, 1]
+    a[0, 1] = source(12)
+    sink(a[0]) # $ hasValueFlow=12
+    sink(a[1]) # $ hasValueFlow=12
+    sink(a[i]) # $ hasValueFlow=12
+end
+
+def m13(i)
+    a = [0, 1]
+    a[0, 1] = [0, source(13), 2]
+    sink(a[0]) # $ hasValueFlow=13
+    sink(a[1]) # $ hasValueFlow=13
+    sink(a[i]) # $ hasValueFlow=13
+end
+
+def m14(i)
+    a = [0, 1]
+    a[0..1] = source(14)
+    sink(a[0]) # $ hasValueFlow=14
+    sink(a[1]) # $ hasValueFlow=14
+    sink(a[i]) # $ hasValueFlow=14
+end
+
+def m15(i)
+    a = [0, 1]
+    a[0..1] = [0, source(15), 2]
+    sink(a[0]) # $ hasValueFlow=15
+    sink(a[1]) # $ hasValueFlow=15
+    sink(a[i]) # $ hasValueFlow=15
+end
+
+def m16
+    a = [0, 1, source(16)]
+    a.all? do |x|
+        sink x # $ hasValueFlow=16
+    end
+end
+
+def m17
+    a = [0, 1, source(17)]
+    a.any? do |x|
+        sink x # $ hasValueFlow=17
+    end
+end
+
+def m18
+    a = ["a", 0]
+    b = ["b", 1]
+    c = ["c", source(18)]
+    d = [a, b, c]
+    sink (d.assoc("a")[0]) # $ hasValueFlow=18
+    sink (d.assoc("c")[0]) # $ hasValueFlow=18
+end
+
+def m19(i)
+    a = [0, source(19), 2]
+    sink(a.at(0))
+    sink(a.at(1)) # $ hasValueFlow=19
+    sink(a.at(2))
+    sink(a.at(i)) # $ hasValueFlow=19
+end
+
+def m20
+    a = [0, 1, source(20)]
+    b = a.bsearch do |x|
+        sink x # $ hasValueFlow=20
+    end
+    sink b # $ hasValueFlow=20
+end
+
+def m21
+    a = [0, 1, source(21)]
+    b = a.bsearch_index do |x|
+        sink x # $ hasValueFlow=21
+    end
+    sink b
+end
+
+def m22
+    a = [0, 1, source(22)]
+    a.clear()
+    sink(a[2])
+end
+
+def m23
+    a = [0, 1, source(23)]
+    b = a.collect do |x|
+        sink x # $ hasValueFlow=23
+        x
+    end
+    sink(b[0]) # $ hasValueFlow=23
+end
+
+def m24
+    a = [0, 1, source(24)]
+    b = a.collect_concat do |x|
+        sink x # $ hasValueFlow=24
+        [x, x]
+    end
+    sink(b[0]) # $ hasValueFlow=24
+end
+
+def m25
+    a = [0, 1, source(25)]
+    a.combination(1) do |x|
+        sink(x[0]) # $ hasValueFlow=25
+    end
+end
+
+def m26
+    a = [0, 1, source(26)]
+    b = a.compact
+    sink(b[0]) # $ hasValueFlow=26
+end
+
+def m27
+    a = [0, 1, source(27.1)]
+    b = [0, 1, source(27.2)]
+    a.concat(b)
+    sink(a[0]) # $ hasValueFlow=27.2
+    sink(a[2]) # $ hasValueFlow=27.1 $ hasValueFlow=27.2
+end
+
+def m28
+    a = [0, 1, source(28)]
+    a.count do |x|
+        sink x # $ hasValueFlow=28
+    end
+end
+
+def m29
+    a = [0, 1, source(29)]
+    a.cycle(2) do |x|
+        sink x # $ hasValueFlow=29
+    end
+end
+
+def m30
+    a = [0, 1, source(30.1)]
+    b = a.delete(2) { source(30.2) }
+    sink b # $ hasValueFlow=30.1 $ hasValueFlow=30.2
+end
+
+def m31
+    a = [0, 1, source(31)]
+    b = a.delete_at(2)
+    sink b # $ hasValueFlow=31
+end
+
+def m32
+    a = [0, 1, source(32)]
+    b = a.delete_if do |x|
+        sink x # $ hasValueFlow=32
+    end
+    sink(b[0]) # $ hasValueFlow=32
+end
+
+def m33
+    a = [0, 1, source(33)]
+    b = a.difference([1])
+    sink(b[0]) # $ hasValueFlow=33
+end
+
+def m34(i)
+    a = [0, 1, source(34.1), [0, source(34.2)]]
+    sink(a.dig(0))
+    sink(a.dig(2)) # $ hasValueFlow=34.1
+    sink(a.dig(i)) # $ hasValueFlow=34.1
+    sink(a.dig(3,0))
+    sink(a.dig(3,1)) # $ hasValueFlow=34.2
+end
+
+def m35
+    a = [0, 1, source(35.1)]
+    b = a.detect(-> { source(35.2) }) do |x|
+        sink x # $ hasValueFlow=35.1
+    end
+    sink b # $ hasValueFlow=35.1 $ hasValueFlow=35.2
+end
+
+def m36(i)
+    a = [0, 1, source(36.1), source(36.2)]
+    b = a.drop(i)
+    sink(b[0]) # $ hasValueFlow=36.1 # $ hasValueFlow=36.2
+    b = a.drop(1)
+    sink(b[0])
+    sink(b[1]) # $ hasValueFlow=36.1
+    sink(b[i]) # $ hasValueFlow=36.1 # $ hasValueFlow=36.2
+    a[i] = source(36.3)
+    b = a.drop(1)
+    sink(b[1]) # $ hasValueFlow=36.1 # $ hasValueFlow=36.3
+    c = b.drop(100)
+    sink(c[1]) # $ hasValueFlow=36.3
+end
+
+def m37
+    a = [0, 1, source(37.1), source(37.2)]
+    b = a.drop_while do |x|
+        sink x # $ hasValueFlow=37.1 # $ hasValueFlow=37.2
+    end
+    sink(b[0]) # $ hasValueFlow=37.1 # $ hasValueFlow=37.2
+end
+
+def m38
+    a = [0, 1, source(38)]
+    b = a.each do |x|
+        sink x # $ hasValueFlow=38
+    end
+    sink(b[2]) # $ hasValueFlow=38
+end
+
+def m39
+    a = [0, 1, source(39)]
+    b = for x in a # desugars to an `each` call
+        sink x # $ hasValueFlow=39
+    end
+    sink x # $ hasValueFlow=39
+    sink(b[2]) # $ hasValueFlow=39
+end
+
+def m40
+    a = [0, 1, source(40)]
+    a.each_cons(2) do |x|
+        sink (x[0]) # $ hasValueFlow=40
+    end
+end
+
+def m41
+    a = [0, 1, source(41)]
+    b = a.each_entry do |x|
+        sink x # $ hasValueFlow=41
+    end
+    sink(b[2]) # $ hasValueFlow=41
+end
+
+def m42
+    a = [0, 1, source(42)]
+    b = a.each_index do |x|
+        sink x
+    end
+    sink(b[2]) # $ hasValueFlow=42
+end
+
+def m43
+    a = [0, 1, 2, source(43)]
+    b = a.each_slice do |x|
+        sink(x[0]) # $ hasValueFlow=43
+    end
+    sink(b[3]) # $ hasValueFlow=43
+end
+
+def m44
+    a = [0, 1, 2, source(44)]
+    b = a.each_with_index do |x,i|
+        sink(x) # $ hasValueFlow=44
+        sink(i)
+    end
+    sink(b[3]) # $ hasValueFlow=44
+end
+
+def m45
+    a = [0, 1, 2, source(45.1)]
+    b = a.each_with_object(source(45.2)) do |x,a|
+        sink(x) # $ hasValueFlow=45.1
+        sink(a) # $ hasValueFlow=45.2
+    end
+    sink(b) # $ hasValueFlow=45.2
+end
+
+def m46(i)
+    a = [0, 1, 2, source(46.1)]
+    b = a.fetch(source(46.2)) do |x|
+        sink(x) # $ hasValueFlow=46.2
+    end
+    sink(b) # $ hasValueFlow=46.1
+end
+
+def m47
+    a = [0, 1, 2, source(47.1)]
+    a.fill(source(47.2), 1, 1)
+    sink(a[3]) # $ hasValueFlow=47.1 $ hasValueFlow=47.2
+    a.fill(source(47.3))
+    sink(a[0]) # $ hasValueFlow=47.3
+    a.fill do |i|
+        source(47.4)
+    end
+    sink(a[0]) # $ hasValueFlow=47.4
+    a.fill(2) do |i|
+        source(47.5)
+    end
+    sink(a[0]) # $ hasValueFlow=47.4 $ hasValueFlow=47.5
+end
+
+def m48
+    a = [0, 1, 2, source(48)]
+    b = a.filter do |x|
+        sink(x) # $ hasValueFlow=48
+    end
+    sink(b[0]) # $ hasValueFlow=48
+end
+
+def m49
+    a = [0, 1, 2, source(49)]
+    b = a.filter_map do |x|
+        sink(x) # $ hasValueFlow=49
+    end
+    sink(b[0]) # $ hasValueFlow=49
+end
+
+def m50
+    a = [0, 1, 2, source(50)]
+    b = a.filter! do |x|
+        sink(x) # $ hasValueFlow=50
+    end
+    sink(b[0]) # $ hasValueFlow=50
+end
+
+def m51
+    a = [0, 1, 2, source(51.1)]
+    b = a.find(-> { source(51.2) }) do |x|
+        sink(x) # $ hasValueFlow=51.1
+    end
+    sink(b) # $ hasValueFlow=51.1 $ hasValueFlow=51.2
+end
+
+def m52
+    a = [0, 1, 2, source(52)]
+    b = a.find_all do |x|
+        sink(x) # $ hasValueFlow=52
+    end
+    sink(b[0]) # $ hasValueFlow=52
+end
+
+def m53
+    a = [0, 1, 2, source(53)]
+    a.find_index do |x|
+        sink(x) # $ hasValueFlow=53
+    end
+end
+
+def m54(i)
+    a = [source(54.1), 1, 2, source(54.2)]
+    a[i] = source(54.3)
+    sink(a.first) # $ hasValueFlow=54.1 $ hasValueFlow=54.3
+    b = a.first(2)
+    sink(b[0]) # $ hasValueFlow=54.1 $ hasValueFlow=54.3
+    sink(b[4]) # $ hasValueFlow=54.3
+    c = a.first(i)
+    sink(c[0]) # $ hasValueFlow=54.1 $ hasValueFlow=54.3
+    sink(c[3]) # $ hasValueFlow=54.2 $ hasValueFlow=54.3
+end
+
+def m55
+    a = [0, 1, 2, source(55.1)]
+    b = a.flat_map do |x|
+        sink(x) # $ hasValueFlow=55.1
+        [x, source(55.2)]
+    end
+    sink(b[0]) # $ hasValueFlow=55.1 $ hasValueFlow=55.2
+end
+
+def m56
+    a = [0, 1, [2, source(56)]]
+    b = a.flatten
+    sink(b[0]) # $ hasValueFlow=56
+end
+
+def m57
+    a = [0, 1, [2, source(57)]]
+    sink(a[2][1]) # $ hasValueFlow=57
+    a.flatten!
+    sink(a[0]) # $ hasValueFlow=57
+    sink(a[2][1]) # $ SPURIOUS: hasValueFlow=57
+end
+
+def m58
+    a = [0, 1, 2, source(58.1)]
+    b = a.grep(/.*/)
+    sink(b[0]) # $ hasValueFlow=58.1
+    b = a.grep(/.*/) do |x|
+        sink x # $ hasValueFlow=58.1
+        source(58.2)
+    end
+    sink(b[0]) # $ hasValueFlow=58.2
+end
+
+def m59
+    a = [0, 1, 2, source(59.1)]
+    b = a.grep_v(/A/)
+    sink(b[0]) # $ hasValueFlow=59.1
+    b = a.grep_v(/A/) do |x|
+        sink x # $ hasValueFlow=59.1
+        source(59.2)
+    end
+    sink(b[0]) # $ hasValueFlow=59.2
+end
+
+def m60
+    a = [0, 1, 2, source(60)]
+    a.index do |x|
+        sink x # $ hasValueFlow=60
+    end
+end
+
+def m61
+    a = [0, 1, 2, source(61.1)]
+    a.initialize_copy([source(61.2)])
+    sink(a[0]) # $ hasValueFlow=61.2
+end
+
+
+# TODO: assign appropriate number when reached in the alphabetical ordering
+def m2600
+    a = [0, 1, source(2600.1)]
+    a.prepend(2, 3, source(2600.2))
+    sink(a[0])
+    sink(a[1])
+    sink(a[2]) # $ hasValueFlow=2600.2
+    sink(a[3])
+    sink(a[4])
+    sink(a[5]) # $ hasValueFlow=2600.1
+end

--- a/ruby/ql/test/library-tests/dataflow/local/Nodes.ql
+++ b/ruby/ql/test/library-tests/dataflow/local/Nodes.ql
@@ -5,5 +5,6 @@ import codeql.ruby.dataflow.internal.DataFlowDispatch
 query predicate ret(ReturningNode node) { any() }
 
 query predicate arg(ArgumentNode n, DataFlowCall call, ArgumentPosition pos) {
-  n.argumentOf(call, pos)
+  n.argumentOf(call, pos) and
+  not n instanceof SummaryNode
 }

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -27,6 +27,7 @@ nodes
 | summaries.rb:18:6:18:13 | tainted3 | semmle.label | tainted3 |
 subpaths
 invalidSpecComponent
+invalidOutputSpecComponent
 #select
 | summaries.rb:2:6:2:12 | tainted | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:2:6:2:12 | tainted | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
 | summaries.rb:5:8:5:8 | x | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:5:8:5:8 | x | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -13,6 +13,12 @@ query predicate invalidSpecComponent(SummarizedCallable sc, string s, string c) 
   Private::External::invalidSpecComponent(s, c)
 }
 
+query predicate invalidOutputSpecComponent(SummarizedCallable sc, string s, string c) {
+  sc.propagatesFlowExt(_, s, _) and
+  Private::External::specSplit(s, c, _) and
+  c = "ArrayElement" // not allowed in output specs; use `ArrayElement[?] instead
+}
+
 private class SummarizedCallableIdentity extends SummarizedCallable {
   SummarizedCallableIdentity() { this = "identity" }
 

--- a/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
@@ -1,5 +1,6 @@
 edges
-| tainted_path.rb:4:12:4:17 | call to params :  | tainted_path.rb:5:26:5:29 | path |
+| tainted_path.rb:4:12:4:17 | call to params :  | tainted_path.rb:4:12:4:24 | ...[...] :  |
+| tainted_path.rb:4:12:4:24 | ...[...] :  | tainted_path.rb:5:26:5:29 | path |
 | tainted_path.rb:10:12:10:43 | call to absolute_path :  | tainted_path.rb:11:26:11:29 | path |
 | tainted_path.rb:10:31:10:36 | call to params :  | tainted_path.rb:10:31:10:43 | ...[...] :  |
 | tainted_path.rb:10:31:10:43 | ...[...] :  | tainted_path.rb:10:12:10:43 | call to absolute_path :  |
@@ -23,6 +24,7 @@ edges
 | tainted_path.rb:47:43:47:55 | ...[...] :  | tainted_path.rb:47:12:47:63 | call to join :  |
 nodes
 | tainted_path.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
+| tainted_path.rb:4:12:4:24 | ...[...] :  | semmle.label | ...[...] :  |
 | tainted_path.rb:5:26:5:29 | path | semmle.label | path |
 | tainted_path.rb:10:12:10:43 | call to absolute_path :  | semmle.label | call to absolute_path :  |
 | tainted_path.rb:10:31:10:36 | call to params :  | semmle.label | call to params :  |

--- a/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/CommandInjection.expected
@@ -1,15 +1,18 @@
 edges
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:7:10:7:15 | #{...} |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:8:16:8:18 | cmd |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:10:14:10:16 | cmd |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:11:17:11:22 | #{...} |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:13:9:13:14 | #{...} |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:29:19:29:24 | #{...} |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:33:24:33:36 | "echo #{...}" |
-| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:34:39:34:51 | "grep #{...}" |
-| CommandInjection.rb:46:15:46:20 | call to params :  | CommandInjection.rb:50:24:50:36 | "echo #{...}" |
+| CommandInjection.rb:6:15:6:20 | call to params :  | CommandInjection.rb:6:15:6:26 | ...[...] :  |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:7:10:7:15 | #{...} |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:8:16:8:18 | cmd |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:10:14:10:16 | cmd |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:11:17:11:22 | #{...} |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:13:9:13:14 | #{...} |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:29:19:29:24 | #{...} |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:33:24:33:36 | "echo #{...}" |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | CommandInjection.rb:34:39:34:51 | "grep #{...}" |
+| CommandInjection.rb:46:15:46:20 | call to params :  | CommandInjection.rb:46:15:46:26 | ...[...] :  |
+| CommandInjection.rb:46:15:46:26 | ...[...] :  | CommandInjection.rb:50:24:50:36 | "echo #{...}" |
 nodes
 | CommandInjection.rb:6:15:6:20 | call to params :  | semmle.label | call to params :  |
+| CommandInjection.rb:6:15:6:26 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:7:10:7:15 | #{...} | semmle.label | #{...} |
 | CommandInjection.rb:8:16:8:18 | cmd | semmle.label | cmd |
 | CommandInjection.rb:10:14:10:16 | cmd | semmle.label | cmd |
@@ -19,6 +22,7 @@ nodes
 | CommandInjection.rb:33:24:33:36 | "echo #{...}" | semmle.label | "echo #{...}" |
 | CommandInjection.rb:34:39:34:51 | "grep #{...}" | semmle.label | "grep #{...}" |
 | CommandInjection.rb:46:15:46:20 | call to params :  | semmle.label | call to params :  |
+| CommandInjection.rb:46:15:46:26 | ...[...] :  | semmle.label | ...[...] :  |
 | CommandInjection.rb:50:24:50:36 | "echo #{...}" | semmle.label | "echo #{...}" |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-078/KernelOpen.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/KernelOpen.expected
@@ -1,8 +1,10 @@
 edges
-| KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:4:10:4:13 | file |
-| KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:5:13:5:16 | file |
+| KernelOpen.rb:3:12:3:17 | call to params :  | KernelOpen.rb:3:12:3:24 | ...[...] :  |
+| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:4:10:4:13 | file |
+| KernelOpen.rb:3:12:3:24 | ...[...] :  | KernelOpen.rb:5:13:5:16 | file |
 nodes
 | KernelOpen.rb:3:12:3:17 | call to params :  | semmle.label | call to params :  |
+| KernelOpen.rb:3:12:3:24 | ...[...] :  | semmle.label | ...[...] :  |
 | KernelOpen.rb:4:10:4:13 | file | semmle.label | file |
 | KernelOpen.rb:5:13:5:16 | file | semmle.label | file |
 subpaths

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -1,11 +1,13 @@
 edges
 | app/controllers/foo/bars_controller.rb:9:12:9:17 | call to params :  | app/controllers/foo/bars_controller.rb:9:12:9:29 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:9:12:9:29 | ...[...] :  | app/views/foo/bars/show.html.erb:47:5:47:13 | call to user_name |
-| app/controllers/foo/bars_controller.rb:13:20:13:25 | call to params :  | app/views/foo/bars/show.html.erb:51:5:51:18 | call to user_name_memo |
+| app/controllers/foo/bars_controller.rb:13:20:13:25 | call to params :  | app/controllers/foo/bars_controller.rb:13:20:13:37 | ...[...] :  |
+| app/controllers/foo/bars_controller.rb:13:20:13:37 | ...[...] :  | app/views/foo/bars/show.html.erb:51:5:51:18 | call to user_name_memo |
 | app/controllers/foo/bars_controller.rb:17:21:17:26 | call to params :  | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website |
-| app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  |
-| app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/controllers/foo/bars_controller.rb:23:53:23:54 | dt :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | app/controllers/foo/bars_controller.rb:23:53:23:54 | dt :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | app/views/foo/bars/show.html.erb:41:3:41:16 | @instance_text |
 | app/controllers/foo/bars_controller.rb:23:53:23:54 | dt :  | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text |
 | app/controllers/foo/bars_controller.rb:23:53:23:54 | dt :  | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] |
@@ -21,9 +23,11 @@ nodes
 | app/controllers/foo/bars_controller.rb:9:12:9:17 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:9:12:9:29 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:13:20:13:25 | call to params :  | semmle.label | call to params :  |
+| app/controllers/foo/bars_controller.rb:13:20:13:37 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:17:21:17:26 | call to params :  | semmle.label | call to params :  |
 | app/controllers/foo/bars_controller.rb:17:21:17:36 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:18:10:18:15 | call to params :  | semmle.label | call to params :  |
+| app/controllers/foo/bars_controller.rb:18:10:18:22 | ...[...] :  | semmle.label | ...[...] :  |
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt :  | semmle.label | dt :  |
 | app/controllers/foo/bars_controller.rb:23:53:23:54 | dt :  | semmle.label | dt :  |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -4,22 +4,31 @@ edges
 | ActiveRecordInjection.rb:20:22:20:30 | condition :  | ActiveRecordInjection.rb:23:16:23:24 | condition |
 | ActiveRecordInjection.rb:35:30:35:35 | call to params :  | ActiveRecordInjection.rb:35:30:35:44 | ...[...] |
 | ActiveRecordInjection.rb:39:18:39:23 | call to params :  | ActiveRecordInjection.rb:39:18:39:32 | ...[...] |
-| ActiveRecordInjection.rb:43:29:43:34 | call to params :  | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" |
-| ActiveRecordInjection.rb:48:30:48:35 | call to params :  | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" |
-| ActiveRecordInjection.rb:52:31:52:36 | call to params :  | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" |
-| ActiveRecordInjection.rb:57:32:57:37 | call to params :  | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" |
-| ActiveRecordInjection.rb:62:21:62:26 | call to params :  | ActiveRecordInjection.rb:61:16:61:21 | <<-SQL |
-| ActiveRecordInjection.rb:68:34:68:39 | call to params :  | ActiveRecordInjection.rb:68:20:68:47 | "user.id = '#{...}'" |
+| ActiveRecordInjection.rb:43:29:43:34 | call to params :  | ActiveRecordInjection.rb:43:29:43:39 | ...[...] :  |
+| ActiveRecordInjection.rb:43:29:43:39 | ...[...] :  | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:48:30:48:35 | call to params :  | ActiveRecordInjection.rb:48:30:48:40 | ...[...] :  |
+| ActiveRecordInjection.rb:48:30:48:40 | ...[...] :  | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:52:31:52:36 | call to params :  | ActiveRecordInjection.rb:52:31:52:41 | ...[...] :  |
+| ActiveRecordInjection.rb:52:31:52:41 | ...[...] :  | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:57:32:57:37 | call to params :  | ActiveRecordInjection.rb:57:32:57:42 | ...[...] :  |
+| ActiveRecordInjection.rb:57:32:57:42 | ...[...] :  | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:62:21:62:26 | call to params :  | ActiveRecordInjection.rb:62:21:62:35 | ...[...] :  |
+| ActiveRecordInjection.rb:62:21:62:35 | ...[...] :  | ActiveRecordInjection.rb:61:16:61:21 | <<-SQL |
+| ActiveRecordInjection.rb:68:34:68:39 | call to params :  | ActiveRecordInjection.rb:68:34:68:44 | ...[...] :  |
+| ActiveRecordInjection.rb:68:34:68:44 | ...[...] :  | ActiveRecordInjection.rb:68:20:68:47 | "user.id = '#{...}'" |
 | ActiveRecordInjection.rb:70:23:70:28 | call to params :  | ActiveRecordInjection.rb:70:23:70:35 | ...[...] :  |
 | ActiveRecordInjection.rb:70:23:70:35 | ...[...] :  | ActiveRecordInjection.rb:8:25:8:28 | name :  |
 | ActiveRecordInjection.rb:70:38:70:43 | call to params :  | ActiveRecordInjection.rb:70:38:70:50 | ...[...] :  |
 | ActiveRecordInjection.rb:70:38:70:50 | ...[...] :  | ActiveRecordInjection.rb:8:31:8:34 | pass :  |
-| ActiveRecordInjection.rb:74:41:74:46 | call to params :  | ActiveRecordInjection.rb:74:32:74:54 | "id = '#{...}'" |
+| ActiveRecordInjection.rb:74:41:74:46 | call to params :  | ActiveRecordInjection.rb:74:41:74:51 | ...[...] :  |
+| ActiveRecordInjection.rb:74:41:74:51 | ...[...] :  | ActiveRecordInjection.rb:74:32:74:54 | "id = '#{...}'" |
 | ActiveRecordInjection.rb:83:17:83:22 | call to params :  | ActiveRecordInjection.rb:83:17:83:31 | ...[...] |
 | ActiveRecordInjection.rb:84:19:84:24 | call to params :  | ActiveRecordInjection.rb:84:19:84:33 | ...[...] |
 | ActiveRecordInjection.rb:88:18:88:23 | call to params :  | ActiveRecordInjection.rb:88:18:88:35 | ...[...] |
 | ActiveRecordInjection.rb:92:21:92:26 | call to params :  | ActiveRecordInjection.rb:92:21:92:35 | ...[...] |
-| ActiveRecordInjection.rb:98:10:98:15 | call to params :  | ActiveRecordInjection.rb:104:20:104:32 | ... + ... |
+| ActiveRecordInjection.rb:98:10:98:15 | call to params :  | ActiveRecordInjection.rb:99:11:99:12 | ps :  |
+| ActiveRecordInjection.rb:99:11:99:12 | ps :  | ActiveRecordInjection.rb:99:11:99:17 | ...[...] :  |
+| ActiveRecordInjection.rb:99:11:99:17 | ...[...] :  | ActiveRecordInjection.rb:104:20:104:32 | ... + ... |
 | ActiveRecordInjection.rb:137:21:137:26 | call to params :  | ActiveRecordInjection.rb:137:21:137:44 | ...[...] :  |
 | ActiveRecordInjection.rb:137:21:137:44 | ...[...] :  | ActiveRecordInjection.rb:20:22:20:30 | condition :  |
 nodes
@@ -34,22 +43,29 @@ nodes
 | ActiveRecordInjection.rb:39:18:39:32 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:43:20:43:42 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:43:29:43:34 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:43:29:43:39 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:48:21:48:43 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:48:30:48:35 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:48:30:48:40 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:52:22:52:44 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:52:31:52:36 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:52:31:52:41 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:57:23:57:45 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:57:32:57:37 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:57:32:57:42 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:61:16:61:21 | <<-SQL | semmle.label | <<-SQL |
 | ActiveRecordInjection.rb:62:21:62:26 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:62:21:62:35 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:68:20:68:47 | "user.id = '#{...}'" | semmle.label | "user.id = '#{...}'" |
 | ActiveRecordInjection.rb:68:34:68:39 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:68:34:68:44 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:70:23:70:28 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:70:23:70:35 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:70:38:70:43 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:70:38:70:50 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:74:32:74:54 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:74:41:74:46 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:74:41:74:51 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:83:17:83:22 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:83:17:83:31 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:84:19:84:24 | call to params :  | semmle.label | call to params :  |
@@ -59,6 +75,8 @@ nodes
 | ActiveRecordInjection.rb:92:21:92:26 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:92:21:92:35 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:98:10:98:15 | call to params :  | semmle.label | call to params :  |
+| ActiveRecordInjection.rb:99:11:99:12 | ps :  | semmle.label | ps :  |
+| ActiveRecordInjection.rb:99:11:99:17 | ...[...] :  | semmle.label | ...[...] :  |
 | ActiveRecordInjection.rb:104:20:104:32 | ... + ... | semmle.label | ... + ... |
 | ActiveRecordInjection.rb:137:21:137:26 | call to params :  | semmle.label | call to params :  |
 | ActiveRecordInjection.rb:137:21:137:44 | ...[...] :  | semmle.label | ...[...] :  |

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection.expected
@@ -1,9 +1,11 @@
 edges
-| CodeInjection.rb:3:12:3:17 | call to params :  | CodeInjection.rb:6:10:6:13 | code |
-| CodeInjection.rb:3:12:3:17 | call to params :  | CodeInjection.rb:18:20:18:23 | code |
-| CodeInjection.rb:3:12:3:17 | call to params :  | CodeInjection.rb:21:21:21:24 | code |
+| CodeInjection.rb:3:12:3:17 | call to params :  | CodeInjection.rb:3:12:3:24 | ...[...] :  |
+| CodeInjection.rb:3:12:3:24 | ...[...] :  | CodeInjection.rb:6:10:6:13 | code |
+| CodeInjection.rb:3:12:3:24 | ...[...] :  | CodeInjection.rb:18:20:18:23 | code |
+| CodeInjection.rb:3:12:3:24 | ...[...] :  | CodeInjection.rb:21:21:21:24 | code |
 nodes
 | CodeInjection.rb:3:12:3:17 | call to params :  | semmle.label | call to params :  |
+| CodeInjection.rb:3:12:3:24 | ...[...] :  | semmle.label | ...[...] :  |
 | CodeInjection.rb:6:10:6:13 | code | semmle.label | code |
 | CodeInjection.rb:9:10:9:15 | call to params | semmle.label | call to params |
 | CodeInjection.rb:18:20:18:23 | code | semmle.label | code |

--- a/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-polynomial-redos/PolynomialReDoS.expected
@@ -1,24 +1,29 @@
 edges
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:10:5:10:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:11:5:11:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:12:5:12:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:13:5:13:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:14:5:14:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:15:5:15:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:16:5:16:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:17:5:17:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:18:5:18:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:19:5:19:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:20:5:20:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:21:5:21:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:22:5:22:8 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:23:17:23:20 | name |
-| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:24:18:24:21 | name |
-| PolynomialReDoS.rb:27:9:27:14 | call to params :  | PolynomialReDoS.rb:28:5:28:5 | a |
-| PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:30:5:30:5 | b |
-| PolynomialReDoS.rb:31:9:31:14 | call to params :  | PolynomialReDoS.rb:32:5:32:5 | c |
+| PolynomialReDoS.rb:4:12:4:17 | call to params :  | PolynomialReDoS.rb:4:12:4:24 | ...[...] :  |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:10:5:10:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:11:5:11:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:12:5:12:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:13:5:13:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:14:5:14:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:15:5:15:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:16:5:16:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:17:5:17:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:18:5:18:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:19:5:19:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:20:5:20:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:21:5:21:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:22:5:22:8 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:23:17:23:20 | name |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | PolynomialReDoS.rb:24:18:24:21 | name |
+| PolynomialReDoS.rb:27:9:27:14 | call to params :  | PolynomialReDoS.rb:27:9:27:18 | ...[...] :  |
+| PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | PolynomialReDoS.rb:28:5:28:5 | a |
+| PolynomialReDoS.rb:29:9:29:14 | call to params :  | PolynomialReDoS.rb:29:9:29:18 | ...[...] :  |
+| PolynomialReDoS.rb:29:9:29:18 | ...[...] :  | PolynomialReDoS.rb:30:5:30:5 | b |
+| PolynomialReDoS.rb:31:9:31:14 | call to params :  | PolynomialReDoS.rb:31:9:31:18 | ...[...] :  |
+| PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | PolynomialReDoS.rb:32:5:32:5 | c |
 nodes
 | PolynomialReDoS.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
+| PolynomialReDoS.rb:4:12:4:24 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:10:5:10:8 | name | semmle.label | name |
 | PolynomialReDoS.rb:11:5:11:8 | name | semmle.label | name |
 | PolynomialReDoS.rb:12:5:12:8 | name | semmle.label | name |
@@ -35,10 +40,13 @@ nodes
 | PolynomialReDoS.rb:23:17:23:20 | name | semmle.label | name |
 | PolynomialReDoS.rb:24:18:24:21 | name | semmle.label | name |
 | PolynomialReDoS.rb:27:9:27:14 | call to params :  | semmle.label | call to params :  |
+| PolynomialReDoS.rb:27:9:27:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:28:5:28:5 | a | semmle.label | a |
 | PolynomialReDoS.rb:29:9:29:14 | call to params :  | semmle.label | call to params :  |
+| PolynomialReDoS.rb:29:9:29:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:30:5:30:5 | b | semmle.label | b |
 | PolynomialReDoS.rb:31:9:31:14 | call to params :  | semmle.label | call to params :  |
+| PolynomialReDoS.rb:31:9:31:18 | ...[...] :  | semmle.label | ...[...] :  |
 | PolynomialReDoS.rb:32:5:32:5 | c | semmle.label | c |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
@@ -1,19 +1,29 @@
 edges
-| RegExpInjection.rb:4:12:4:17 | call to params :  | RegExpInjection.rb:5:13:5:21 | /#{...}/ |
-| RegExpInjection.rb:10:12:10:17 | call to params :  | RegExpInjection.rb:11:13:11:27 | /foo#{...}bar/ |
-| RegExpInjection.rb:16:12:16:17 | call to params :  | RegExpInjection.rb:17:24:17:27 | name |
-| RegExpInjection.rb:22:12:22:17 | call to params :  | RegExpInjection.rb:23:24:23:33 | ... + ... |
-| RegExpInjection.rb:54:12:54:17 | call to params :  | RegExpInjection.rb:55:28:55:37 | ... + ... |
+| RegExpInjection.rb:4:12:4:17 | call to params :  | RegExpInjection.rb:4:12:4:24 | ...[...] :  |
+| RegExpInjection.rb:4:12:4:24 | ...[...] :  | RegExpInjection.rb:5:13:5:21 | /#{...}/ |
+| RegExpInjection.rb:10:12:10:17 | call to params :  | RegExpInjection.rb:10:12:10:24 | ...[...] :  |
+| RegExpInjection.rb:10:12:10:24 | ...[...] :  | RegExpInjection.rb:11:13:11:27 | /foo#{...}bar/ |
+| RegExpInjection.rb:16:12:16:17 | call to params :  | RegExpInjection.rb:16:12:16:24 | ...[...] :  |
+| RegExpInjection.rb:16:12:16:24 | ...[...] :  | RegExpInjection.rb:17:24:17:27 | name |
+| RegExpInjection.rb:22:12:22:17 | call to params :  | RegExpInjection.rb:22:12:22:24 | ...[...] :  |
+| RegExpInjection.rb:22:12:22:24 | ...[...] :  | RegExpInjection.rb:23:24:23:33 | ... + ... |
+| RegExpInjection.rb:54:12:54:17 | call to params :  | RegExpInjection.rb:54:12:54:24 | ...[...] :  |
+| RegExpInjection.rb:54:12:54:24 | ...[...] :  | RegExpInjection.rb:55:28:55:37 | ... + ... |
 nodes
 | RegExpInjection.rb:4:12:4:17 | call to params :  | semmle.label | call to params :  |
+| RegExpInjection.rb:4:12:4:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:5:13:5:21 | /#{...}/ | semmle.label | /#{...}/ |
 | RegExpInjection.rb:10:12:10:17 | call to params :  | semmle.label | call to params :  |
+| RegExpInjection.rb:10:12:10:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:11:13:11:27 | /foo#{...}bar/ | semmle.label | /foo#{...}bar/ |
 | RegExpInjection.rb:16:12:16:17 | call to params :  | semmle.label | call to params :  |
+| RegExpInjection.rb:16:12:16:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:17:24:17:27 | name | semmle.label | name |
 | RegExpInjection.rb:22:12:22:17 | call to params :  | semmle.label | call to params :  |
+| RegExpInjection.rb:22:12:22:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:23:24:23:33 | ... + ... | semmle.label | ... + ... |
 | RegExpInjection.rb:54:12:54:17 | call to params :  | semmle.label | call to params :  |
+| RegExpInjection.rb:54:12:54:24 | ...[...] :  | semmle.label | ...[...] :  |
 | RegExpInjection.rb:55:28:55:37 | ... + ... | semmle.label | ... + ... |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-502/oj-global-options/UnsafeDeserialization.expected
+++ b/ruby/ql/test/query-tests/security/cwe-502/oj-global-options/UnsafeDeserialization.expected
@@ -1,7 +1,9 @@
 edges
-| OjGlobalOptions.rb:13:17:13:22 | call to params :  | OjGlobalOptions.rb:14:22:14:30 | json_data |
+| OjGlobalOptions.rb:13:17:13:22 | call to params :  | OjGlobalOptions.rb:13:17:13:28 | ...[...] :  |
+| OjGlobalOptions.rb:13:17:13:28 | ...[...] :  | OjGlobalOptions.rb:14:22:14:30 | json_data |
 nodes
 | OjGlobalOptions.rb:13:17:13:22 | call to params :  | semmle.label | call to params :  |
+| OjGlobalOptions.rb:13:17:13:28 | ...[...] :  | semmle.label | ...[...] :  |
 | OjGlobalOptions.rb:14:22:14:30 | json_data | semmle.label | json_data |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-502/unsafe-deserialization/UnsafeDeserialization.expected
+++ b/ruby/ql/test/query-tests/security/cwe-502/unsafe-deserialization/UnsafeDeserialization.expected
@@ -1,27 +1,41 @@
 edges
-| UnsafeDeserialization.rb:9:39:9:44 | call to params :  | UnsafeDeserialization.rb:10:27:10:41 | serialized_data |
-| UnsafeDeserialization.rb:15:39:15:44 | call to params :  | UnsafeDeserialization.rb:16:30:16:44 | serialized_data |
-| UnsafeDeserialization.rb:21:17:21:22 | call to params :  | UnsafeDeserialization.rb:22:24:22:32 | json_data |
-| UnsafeDeserialization.rb:27:17:27:22 | call to params :  | UnsafeDeserialization.rb:28:27:28:35 | json_data |
-| UnsafeDeserialization.rb:39:17:39:22 | call to params :  | UnsafeDeserialization.rb:40:24:40:32 | yaml_data |
-| UnsafeDeserialization.rb:51:17:51:22 | call to params :  | UnsafeDeserialization.rb:52:22:52:30 | json_data |
-| UnsafeDeserialization.rb:51:17:51:22 | call to params :  | UnsafeDeserialization.rb:53:22:53:30 | json_data |
-| UnsafeDeserialization.rb:58:17:58:22 | call to params :  | UnsafeDeserialization.rb:68:23:68:31 | json_data |
+| UnsafeDeserialization.rb:9:39:9:44 | call to params :  | UnsafeDeserialization.rb:9:39:9:50 | ...[...] :  |
+| UnsafeDeserialization.rb:9:39:9:50 | ...[...] :  | UnsafeDeserialization.rb:10:27:10:41 | serialized_data |
+| UnsafeDeserialization.rb:15:39:15:44 | call to params :  | UnsafeDeserialization.rb:15:39:15:50 | ...[...] :  |
+| UnsafeDeserialization.rb:15:39:15:50 | ...[...] :  | UnsafeDeserialization.rb:16:30:16:44 | serialized_data |
+| UnsafeDeserialization.rb:21:17:21:22 | call to params :  | UnsafeDeserialization.rb:21:17:21:28 | ...[...] :  |
+| UnsafeDeserialization.rb:21:17:21:28 | ...[...] :  | UnsafeDeserialization.rb:22:24:22:32 | json_data |
+| UnsafeDeserialization.rb:27:17:27:22 | call to params :  | UnsafeDeserialization.rb:27:17:27:28 | ...[...] :  |
+| UnsafeDeserialization.rb:27:17:27:28 | ...[...] :  | UnsafeDeserialization.rb:28:27:28:35 | json_data |
+| UnsafeDeserialization.rb:39:17:39:22 | call to params :  | UnsafeDeserialization.rb:39:17:39:28 | ...[...] :  |
+| UnsafeDeserialization.rb:39:17:39:28 | ...[...] :  | UnsafeDeserialization.rb:40:24:40:32 | yaml_data |
+| UnsafeDeserialization.rb:51:17:51:22 | call to params :  | UnsafeDeserialization.rb:51:17:51:28 | ...[...] :  |
+| UnsafeDeserialization.rb:51:17:51:28 | ...[...] :  | UnsafeDeserialization.rb:52:22:52:30 | json_data |
+| UnsafeDeserialization.rb:51:17:51:28 | ...[...] :  | UnsafeDeserialization.rb:53:22:53:30 | json_data |
+| UnsafeDeserialization.rb:58:17:58:22 | call to params :  | UnsafeDeserialization.rb:58:17:58:28 | ...[...] :  |
+| UnsafeDeserialization.rb:58:17:58:28 | ...[...] :  | UnsafeDeserialization.rb:68:23:68:31 | json_data |
 nodes
 | UnsafeDeserialization.rb:9:39:9:44 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:9:39:9:50 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:10:27:10:41 | serialized_data | semmle.label | serialized_data |
 | UnsafeDeserialization.rb:15:39:15:44 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:15:39:15:50 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:16:30:16:44 | serialized_data | semmle.label | serialized_data |
 | UnsafeDeserialization.rb:21:17:21:22 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:21:17:21:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:22:24:22:32 | json_data | semmle.label | json_data |
 | UnsafeDeserialization.rb:27:17:27:22 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:27:17:27:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:28:27:28:35 | json_data | semmle.label | json_data |
 | UnsafeDeserialization.rb:39:17:39:22 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:39:17:39:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:40:24:40:32 | yaml_data | semmle.label | yaml_data |
 | UnsafeDeserialization.rb:51:17:51:22 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:51:17:51:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:52:22:52:30 | json_data | semmle.label | json_data |
 | UnsafeDeserialization.rb:53:22:53:30 | json_data | semmle.label | json_data |
 | UnsafeDeserialization.rb:58:17:58:22 | call to params :  | semmle.label | call to params :  |
+| UnsafeDeserialization.rb:58:17:58:28 | ...[...] :  | semmle.label | ...[...] :  |
 | UnsafeDeserialization.rb:68:23:68:31 | json_data | semmle.label | json_data |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-601/UrlRedirect.expected
+++ b/ruby/ql/test/query-tests/security/cwe-601/UrlRedirect.expected
@@ -4,7 +4,8 @@ edges
 | UrlRedirect.rb:19:17:19:22 | call to params :  | UrlRedirect.rb:19:17:19:37 | call to to_unsafe_hash |
 | UrlRedirect.rb:24:31:24:36 | call to params :  | UrlRedirect.rb:24:17:24:37 | call to filter_params |
 | UrlRedirect.rb:24:31:24:36 | call to params :  | UrlRedirect.rb:56:21:56:32 | input_params :  |
-| UrlRedirect.rb:34:20:34:25 | call to params :  | UrlRedirect.rb:34:17:34:37 | "#{...}/foo" |
+| UrlRedirect.rb:34:20:34:25 | call to params :  | UrlRedirect.rb:34:20:34:31 | ...[...] :  |
+| UrlRedirect.rb:34:20:34:31 | ...[...] :  | UrlRedirect.rb:34:17:34:37 | "#{...}/foo" |
 | UrlRedirect.rb:56:21:56:32 | input_params :  | UrlRedirect.rb:57:5:57:29 | call to permit :  |
 nodes
 | UrlRedirect.rb:4:17:4:22 | call to params | semmle.label | call to params |
@@ -18,6 +19,7 @@ nodes
 | UrlRedirect.rb:24:31:24:36 | call to params :  | semmle.label | call to params :  |
 | UrlRedirect.rb:34:17:34:37 | "#{...}/foo" | semmle.label | "#{...}/foo" |
 | UrlRedirect.rb:34:20:34:25 | call to params :  | semmle.label | call to params :  |
+| UrlRedirect.rb:34:20:34:31 | ...[...] :  | semmle.label | ...[...] :  |
 | UrlRedirect.rb:56:21:56:32 | input_params :  | semmle.label | input_params :  |
 | UrlRedirect.rb:57:5:57:29 | call to permit :  | semmle.label | call to permit :  |
 subpaths

--- a/ruby/ql/test/query-tests/security/cwe-611/Xxe.expected
+++ b/ruby/ql/test/query-tests/security/cwe-611/Xxe.expected
@@ -1,29 +1,32 @@
 edges
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:4:34:4:40 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:5:32:5:38 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:6:30:6:36 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:7:32:7:38 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:8:30:8:36 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:9:28:9:34 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:11:26:11:32 | content |
-| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:12:24:12:30 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:5:26:5:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:6:26:6:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:7:26:7:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:8:26:8:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:9:26:9:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:11:26:11:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:12:26:12:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:15:26:15:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:16:26:16:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:18:26:18:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:19:26:19:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:22:26:22:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:25:26:25:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:27:26:27:32 | content |
-| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:28:26:28:32 | content |
+| LibXmlRuby.rb:3:15:3:20 | call to params :  | LibXmlRuby.rb:3:15:3:26 | ...[...] :  |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:4:34:4:40 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:5:32:5:38 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:6:30:6:36 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:7:32:7:38 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:8:30:8:36 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:9:28:9:34 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:11:26:11:32 | content |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | LibXmlRuby.rb:12:24:12:30 | content |
+| Nokogiri.rb:3:15:3:20 | call to params :  | Nokogiri.rb:3:15:3:26 | ...[...] :  |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:5:26:5:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:6:26:6:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:7:26:7:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:8:26:8:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:9:26:9:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:11:26:11:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:12:26:12:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:15:26:15:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:16:26:16:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:18:26:18:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:19:26:19:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:22:26:22:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:25:26:25:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:27:26:27:32 | content |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | Nokogiri.rb:28:26:28:32 | content |
 nodes
 | LibXmlRuby.rb:3:15:3:20 | call to params :  | semmle.label | call to params :  |
+| LibXmlRuby.rb:3:15:3:26 | ...[...] :  | semmle.label | ...[...] :  |
 | LibXmlRuby.rb:4:34:4:40 | content | semmle.label | content |
 | LibXmlRuby.rb:5:32:5:38 | content | semmle.label | content |
 | LibXmlRuby.rb:6:30:6:36 | content | semmle.label | content |
@@ -33,6 +36,7 @@ nodes
 | LibXmlRuby.rb:11:26:11:32 | content | semmle.label | content |
 | LibXmlRuby.rb:12:24:12:30 | content | semmle.label | content |
 | Nokogiri.rb:3:15:3:20 | call to params :  | semmle.label | call to params :  |
+| Nokogiri.rb:3:15:3:26 | ...[...] :  | semmle.label | ...[...] :  |
 | Nokogiri.rb:5:26:5:32 | content | semmle.label | content |
 | Nokogiri.rb:6:26:6:32 | content | semmle.label | content |
 | Nokogiri.rb:7:26:7:32 | content | semmle.label | content |

--- a/ruby/ql/test/query-tests/security/cwe-807-user-controlled-bypass/ConditionalBypass.expected
+++ b/ruby/ql/test/query-tests/security/cwe-807-user-controlled-bypass/ConditionalBypass.expected
@@ -1,12 +1,13 @@
 edges
-| ConditionalBypass.rb:3:13:3:18 | call to params :  | ConditionalBypass.rb:6:8:6:12 | check |
+| ConditionalBypass.rb:3:13:3:18 | call to params :  | ConditionalBypass.rb:3:13:3:26 | ...[...] :  |
+| ConditionalBypass.rb:3:13:3:26 | ...[...] :  | ConditionalBypass.rb:6:8:6:12 | check |
 | ConditionalBypass.rb:14:14:14:19 | call to params :  | ConditionalBypass.rb:14:14:14:27 | ...[...] |
 | ConditionalBypass.rb:25:10:25:15 | call to params :  | ConditionalBypass.rb:25:10:25:22 | ...[...] |
 | ConditionalBypass.rb:25:10:25:15 | call to params :  | ConditionalBypass.rb:25:10:25:22 | ...[...] :  |
-| ConditionalBypass.rb:25:10:25:15 | call to params :  | ConditionalBypass.rb:27:8:27:8 | p |
 | ConditionalBypass.rb:25:10:25:22 | ...[...] :  | ConditionalBypass.rb:27:8:27:8 | p |
 nodes
 | ConditionalBypass.rb:3:13:3:18 | call to params :  | semmle.label | call to params :  |
+| ConditionalBypass.rb:3:13:3:26 | ...[...] :  | semmle.label | ...[...] :  |
 | ConditionalBypass.rb:6:8:6:12 | check | semmle.label | check |
 | ConditionalBypass.rb:14:14:14:19 | call to params :  | semmle.label | call to params :  |
 | ConditionalBypass.rb:14:14:14:27 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-918/ServerSideRequestForgery.expected
+++ b/ruby/ql/test/query-tests/security/cwe-918/ServerSideRequestForgery.expected
@@ -1,7 +1,9 @@
 edges
-| ServerSideRequestForgery.rb:9:32:9:37 | call to params :  | ServerSideRequestForgery.rb:10:31:10:62 | "#{...}/logins" |
+| ServerSideRequestForgery.rb:9:32:9:37 | call to params :  | ServerSideRequestForgery.rb:9:32:9:60 | ...[...] :  |
+| ServerSideRequestForgery.rb:9:32:9:60 | ...[...] :  | ServerSideRequestForgery.rb:10:31:10:62 | "#{...}/logins" |
 nodes
 | ServerSideRequestForgery.rb:9:32:9:37 | call to params :  | semmle.label | call to params :  |
+| ServerSideRequestForgery.rb:9:32:9:60 | ...[...] :  | semmle.label | ...[...] :  |
 | ServerSideRequestForgery.rb:10:31:10:62 | "#{...}/logins" | semmle.label | "#{...}/logins" |
 subpaths
 #select


### PR DESCRIPTION
This PR adds support for (precise) data-flow through arrays (and `Enumerable`s). For the sake of data-flow, arrays and `Enumerable`s are treated the same, and we track array content using either `TKnownArrayElementContent(i)` when the exact array index is known or `TUnknownArrayElementContent()` when the index is unknown.

For example, if we have
```rb
a = [no_taint, taint, no_taint]
```
then `taint` will flow into `TKnownArrayElementContent(1)` on `a`.

Similarly, if we have
```rb
a[i] = taint
```
where `i` is not a known integer constant, then we have flow from `taint` to `TUnknownArrayElementContent` on `a`.

The first commit adds the machinery for defining flow summaries, that is, introduces `T{Known,Unknown}ArrayElementContent` and all the necessary plumbing. Like C# and Java, we also also consider all array reads as taint steps, in order to handle the case where a taint source is an array.

The second commit adds a whole bunch of [`Array`](https://ruby-doc.org/core-2.7.0/Array.html) and [`Enumerable`](https://ruby-doc.org/core-2.7.0/Enumerable.html) summaries, and I have started from the top of the list and made it to `Array::initialize_copy` and `Enumerable::grep`, respectively (remaining methods should be modelled in a follow-up PR). Whenever a method exists in both `Array` and `Enumerable`, I have added it to the `Enumerable` module.

### Example 1

```rb
a = [no_taint, taint]
b, c = a
sink b # safe
sink c # unsafe
```

The example above works, because array literals are just calls to `Array::[]` (with flow summary `Argument[i] -> ArrayElement[i] of ReturnValue`), and `b, c = a` desugars (simplified) to `b = a[0]; c = a[1]` (and `Array#[i]` has flow summary `ArrayElement[i] of Self -> ReturnValue`; note, we will synthesize different targets for `a[0]` and `a[1]`, one in which `ArrayElement[0]` is read, and one in which `ArrayElement[1]` is read).

### Example 2

```rb
a = [no_taint, taint]
a[1] = no_taint
sink (a[1]) # safe
```

The example above works, because `Array#[i]=`, in addition to having summary `Argument[0] -> ArrayElement[i] of Self`, also implements `clearsContent(int j, Content c) { j = -1 and c = TKnownArrayElementContent(i) }`. That is, the array update both stores a new value, but also removes the old value (provided that the old value is at the known index).

### Example 3

```rb
a = [no_taint, taint]
a.prepend(no_taint)
sink(a[1]) # safe
sink(a[2]) # unsafe
```

The example above works, because `Array#prepend(x_1,...x_n)`, in addition to having summary `ArrayElement[i] of self -> ArrayElement[i + n] of Self`, also implements `clearsContent(int j, Content c) { j = -1 and c = TKnownArrayElementContent(_) }`. That is, all known indexes are shifted by `n`, and all previously known indexes are cleared.