### PR TITLE
Python: Add `x in <var>` test for StringConstCompare 

### DIFF
--- a/python/ql/test/experimental/dataflow/tainttracking/commonSanitizer/test_string_const_compare.py
+++ b/python/ql/test/experimental/dataflow/tainttracking/commonSanitizer/test_string_const_compare.py
@@ -77,6 +77,57 @@ def test_in_set():
         ensure_tainted(ts) # $ tainted
 
 
+def test_in_local_variable():
+    ts = TAINTED_STRING
+    safe = ["safe", "also_safe"]
+    if ts in safe:
+        ensure_not_tainted(ts) # $ SPURIOUS: tainted
+    else:
+        ensure_tainted(ts) # $ tainted
+
+
+SAFE = ["safe", "also_safe"]
+
+
+def test_in_global_variable():
+    ts = TAINTED_STRING
+    if ts in SAFE:
+        ensure_not_tainted(ts) # $ SPURIOUS: tainted
+    else:
+        ensure_tainted(ts) # $ tainted
+
+
+# these global variables can be modified, so should not be considered safe
+SAFE_mod_1 = ["safe", "also_safe"]
+SAFE_mod_2 = ["safe", "also_safe"]
+SAFE_mod_3 = ["safe", "also_safe"]
+
+
+def make_modification(x):
+    global SAFE_mod_2, SAFE_mod_3
+    SAFE_mod_1.append(x)
+    SAFE_mod_2 += [x]
+    SAFE_mod_3 = SAFE_mod_3 + [x]
+
+
+def test_in_modified_global_variable():
+    ts = TAINTED_STRING
+    if ts in SAFE_mod_1:
+        ensure_tainted(ts) # $ tainted
+    else:
+        ensure_tainted(ts) # $ tainted
+
+    if ts in SAFE_mod_2:
+        ensure_tainted(ts) # $ tainted
+    else:
+        ensure_tainted(ts) # $ tainted
+
+    if ts in SAFE_mod_3:
+        ensure_tainted(ts) # $ tainted
+    else:
+        ensure_tainted(ts) # $ tainted
+
+
 def test_in_unsafe1(xs):
     ts = TAINTED_STRING
     if ts in xs:
@@ -131,6 +182,10 @@ test_non_eq2()
 test_in_list()
 test_in_tuple()
 test_in_set()
+test_in_local_variable()
+test_in_global_variable()
+make_modification("unsafe")
+test_in_modified_global_variable()
 test_in_unsafe1(["unsafe", "foo"])
 test_in_unsafe2("unsafe")
 test_not_in1()

--- a/python/ql/test/query-tests/Security/CWE-022-PathInjection/PathInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-022-PathInjection/PathInjection.expected
@@ -37,6 +37,8 @@ edges
 | path_injection.py:138:16:138:22 | ControlFlowNode for request | path_injection.py:138:16:138:27 | ControlFlowNode for Attribute |
 | path_injection.py:138:16:138:27 | ControlFlowNode for Attribute | path_injection.py:140:30:140:51 | ControlFlowNode for Attribute() |
 | path_injection.py:138:16:138:27 | ControlFlowNode for Attribute | path_injection.py:142:14:142:17 | ControlFlowNode for path |
+| path_injection.py:149:16:149:22 | ControlFlowNode for request | path_injection.py:149:16:149:27 | ControlFlowNode for Attribute |
+| path_injection.py:149:16:149:27 | ControlFlowNode for Attribute | path_injection.py:152:18:152:21 | ControlFlowNode for path |
 | test.py:9:12:9:18 | ControlFlowNode for request | test.py:9:12:9:23 | ControlFlowNode for Attribute |
 | test.py:9:12:9:18 | ControlFlowNode for request | test.py:9:12:9:23 | ControlFlowNode for Attribute |
 | test.py:9:12:9:23 | ControlFlowNode for Attribute | test.py:9:12:9:39 | ControlFlowNode for Attribute() |
@@ -130,6 +132,9 @@ nodes
 | path_injection.py:138:16:138:27 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
 | path_injection.py:140:30:140:51 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | path_injection.py:142:14:142:17 | ControlFlowNode for path | semmle.label | ControlFlowNode for path |
+| path_injection.py:149:16:149:22 | ControlFlowNode for request | semmle.label | ControlFlowNode for request |
+| path_injection.py:149:16:149:27 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
+| path_injection.py:152:18:152:21 | ControlFlowNode for path | semmle.label | ControlFlowNode for path |
 | test.py:9:12:9:18 | ControlFlowNode for request | semmle.label | ControlFlowNode for request |
 | test.py:9:12:9:18 | ControlFlowNode for request | semmle.label | ControlFlowNode for request |
 | test.py:9:12:9:23 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
@@ -181,6 +186,7 @@ nodes
 | path_injection.py:124:14:124:17 | ControlFlowNode for path | path_injection.py:118:16:118:22 | ControlFlowNode for request | path_injection.py:124:14:124:17 | ControlFlowNode for path | This path depends on $@. | path_injection.py:118:16:118:22 | ControlFlowNode for request | a user-provided value |
 | path_injection.py:132:14:132:22 | ControlFlowNode for sanitized | path_injection.py:129:16:129:22 | ControlFlowNode for request | path_injection.py:132:14:132:22 | ControlFlowNode for sanitized | This path depends on $@. | path_injection.py:129:16:129:22 | ControlFlowNode for request | a user-provided value |
 | path_injection.py:142:14:142:17 | ControlFlowNode for path | path_injection.py:138:16:138:22 | ControlFlowNode for request | path_injection.py:142:14:142:17 | ControlFlowNode for path | This path depends on $@. | path_injection.py:138:16:138:22 | ControlFlowNode for request | a user-provided value |
+| path_injection.py:152:18:152:21 | ControlFlowNode for path | path_injection.py:149:16:149:22 | ControlFlowNode for request | path_injection.py:152:18:152:21 | ControlFlowNode for path | This path depends on $@. | path_injection.py:149:16:149:22 | ControlFlowNode for request | a user-provided value |
 | test.py:19:10:19:10 | ControlFlowNode for x | test.py:9:12:9:18 | ControlFlowNode for request | test.py:19:10:19:10 | ControlFlowNode for x | This path depends on $@. | test.py:9:12:9:18 | ControlFlowNode for request | a user-provided value |
 | test.py:26:10:26:10 | ControlFlowNode for y | test.py:9:12:9:18 | ControlFlowNode for request | test.py:26:10:26:10 | ControlFlowNode for y | This path depends on $@. | test.py:9:12:9:18 | ControlFlowNode for request | a user-provided value |
 | test.py:33:14:33:14 | ControlFlowNode for x | test.py:9:12:9:18 | ControlFlowNode for request | test.py:33:14:33:14 | ControlFlowNode for x | This path depends on $@. | test.py:9:12:9:18 | ControlFlowNode for request | a user-provided value |

--- a/python/ql/test/query-tests/Security/CWE-022-PathInjection/path_injection.py
+++ b/python/ql/test/query-tests/Security/CWE-022-PathInjection/path_injection.py
@@ -140,3 +140,13 @@ def stackoverflow_solution():
     if os.path.commonprefix((os.path.realpath(path), STATIC_DIR)) != STATIC_DIR:
         return "not this time"
     f = open(path) # OK TODO: FP
+
+
+SAFE_FILES = ['foo', 'bar', 'baz']
+
+@app.route("/safe-set-of-files")
+def safe_set_of_files():
+    filename = request.args.get('filename', '')
+    if filename in SAFE_FILES:
+        path = os.path.join(STATIC_DIR, filename)
+        f = open(path) # OK TODO: FP


### PR DESCRIPTION
Fixing this problem is not 100% trivial. We want to track iterables that only contain string constants throughout the program (easy with type-tracking), but we probably don't want to include those that could have been modified... I don't want to go down the rabbit whole of doing that implementation right now, so this PR only adds tests cases.