### PR TITLE
Java: Note that XMLConstants.ACCESS_EXTERNAL_* can be used to sanitize an XMLInputFactory

### DIFF
--- a/java/change-notes/2021-11-23-safe-xmlinputfactory.md
+++ b/java/change-notes/2021-11-23-safe-xmlinputfactory.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* Query `java/xxe` now recognises `XMLInputFactory` instances that are configured safely using the `XMLConstants.ACCESS_EXTERNAL_*` properties to prevent external entity requests.

--- a/java/ql/test/query-tests/security/CWE-611/XXE.expected
+++ b/java/ql/test/query-tests/security/CWE-611/XXE.expected
@@ -235,18 +235,18 @@ nodes
 | XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | semmle.label | new InputSource(...) |
 | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | semmle.label | getInputStream(...) |
-| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:10:35:10:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:11:34:11:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:25:35:25:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:26:34:26:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:32:35:32:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:33:34:33:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:40:35:40:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:41:34:41:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:48:35:48:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:49:34:49:54 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:56:35:56:55 | getInputStream(...) | semmle.label | getInputStream(...) |
+| XmlInputFactoryTests.java:57:34:57:54 | getInputStream(...) | semmle.label | getInputStream(...) |
 subpaths
 #select
 | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | Unsafe parsing of XML file from $@. | DocumentBuilderTests.java:14:19:14:39 | getInputStream(...) | user input |
@@ -333,15 +333,15 @@ subpaths
 | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | XMLReaderTests.java:94:34:94:54 | getInputStream(...) : InputStream | XMLReaderTests.java:94:18:94:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:94:34:94:54 | getInputStream(...) | user input |
 | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | XMLReaderTests.java:100:34:100:54 | getInputStream(...) : InputStream | XMLReaderTests.java:100:18:100:55 | new InputSource(...) | Unsafe parsing of XML file from $@. | XMLReaderTests.java:100:34:100:54 | getInputStream(...) | user input |
 | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) : InputStream | XPathExpressionTests.java:27:21:27:58 | new InputSource(...) | Unsafe parsing of XML file from $@. | XPathExpressionTests.java:27:37:27:57 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:9:35:9:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:10:34:10:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:24:35:24:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:25:34:25:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:31:35:31:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:32:34:32:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:39:35:39:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:40:34:40:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:47:35:47:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:48:34:48:54 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:55:35:55:55 | getInputStream(...) | user input |
-| XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:56:34:56:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:10:35:10:55 | getInputStream(...) | XmlInputFactoryTests.java:10:35:10:55 | getInputStream(...) | XmlInputFactoryTests.java:10:35:10:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:10:35:10:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:11:34:11:54 | getInputStream(...) | XmlInputFactoryTests.java:11:34:11:54 | getInputStream(...) | XmlInputFactoryTests.java:11:34:11:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:11:34:11:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:25:35:25:55 | getInputStream(...) | XmlInputFactoryTests.java:25:35:25:55 | getInputStream(...) | XmlInputFactoryTests.java:25:35:25:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:25:35:25:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:26:34:26:54 | getInputStream(...) | XmlInputFactoryTests.java:26:34:26:54 | getInputStream(...) | XmlInputFactoryTests.java:26:34:26:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:26:34:26:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:32:35:32:55 | getInputStream(...) | XmlInputFactoryTests.java:32:35:32:55 | getInputStream(...) | XmlInputFactoryTests.java:32:35:32:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:32:35:32:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:33:34:33:54 | getInputStream(...) | XmlInputFactoryTests.java:33:34:33:54 | getInputStream(...) | XmlInputFactoryTests.java:33:34:33:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:33:34:33:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:40:35:40:55 | getInputStream(...) | XmlInputFactoryTests.java:40:35:40:55 | getInputStream(...) | XmlInputFactoryTests.java:40:35:40:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:40:35:40:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:41:34:41:54 | getInputStream(...) | XmlInputFactoryTests.java:41:34:41:54 | getInputStream(...) | XmlInputFactoryTests.java:41:34:41:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:41:34:41:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:48:35:48:55 | getInputStream(...) | XmlInputFactoryTests.java:48:35:48:55 | getInputStream(...) | XmlInputFactoryTests.java:48:35:48:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:48:35:48:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:49:34:49:54 | getInputStream(...) | XmlInputFactoryTests.java:49:34:49:54 | getInputStream(...) | XmlInputFactoryTests.java:49:34:49:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:49:34:49:54 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:56:35:56:55 | getInputStream(...) | XmlInputFactoryTests.java:56:35:56:55 | getInputStream(...) | XmlInputFactoryTests.java:56:35:56:55 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:56:35:56:55 | getInputStream(...) | user input |
+| XmlInputFactoryTests.java:57:34:57:54 | getInputStream(...) | XmlInputFactoryTests.java:57:34:57:54 | getInputStream(...) | XmlInputFactoryTests.java:57:34:57:54 | getInputStream(...) | Unsafe parsing of XML file from $@. | XmlInputFactoryTests.java:57:34:57:54 | getInputStream(...) | user input |

--- a/java/ql/test/query-tests/security/CWE-611/XmlInputFactoryTests.java
+++ b/java/ql/test/query-tests/security/CWE-611/XmlInputFactoryTests.java
@@ -1,6 +1,7 @@
 import java.net.Socket;
 
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.XMLConstants;
 
 public class XmlInputFactoryTests {
 
@@ -9,7 +10,7 @@ public class XmlInputFactoryTests {
     factory.createXMLStreamReader(sock.getInputStream()); //unsafe
     factory.createXMLEventReader(sock.getInputStream()); //unsafe
   }
-  
+
   public void safeFactory(Socket sock) throws Exception {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
@@ -17,21 +18,21 @@ public class XmlInputFactoryTests {
     factory.createXMLStreamReader(sock.getInputStream()); //safe
     factory.createXMLEventReader(sock.getInputStream()); //safe
   }
-  
+
   public void misConfiguredFactory(Socket sock) throws Exception {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
     factory.createXMLStreamReader(sock.getInputStream()); //unsafe
     factory.createXMLEventReader(sock.getInputStream()); //unsafe
   }
-  
+
   public void misConfiguredFactory2(Socket sock) throws Exception {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
     factory.createXMLStreamReader(sock.getInputStream()); //unsafe
     factory.createXMLEventReader(sock.getInputStream()); //unsafe
   }
-  
+
   public void misConfiguredFactory3(Socket sock) throws Exception {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty("javax.xml.stream.isSupportingExternalEntities", true);
@@ -39,7 +40,7 @@ public class XmlInputFactoryTests {
     factory.createXMLStreamReader(sock.getInputStream()); //unsafe
     factory.createXMLEventReader(sock.getInputStream()); //unsafe
   }
-  
+
   public void misConfiguredFactory4(Socket sock) throws Exception {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
@@ -47,12 +48,21 @@ public class XmlInputFactoryTests {
     factory.createXMLStreamReader(sock.getInputStream()); //unsafe
     factory.createXMLEventReader(sock.getInputStream()); //unsafe
   }
-  
+
   public void misConfiguredFactory5(Socket sock) throws Exception {
     XMLInputFactory factory = XMLInputFactory.newFactory();
     factory.setProperty("javax.xml.stream.isSupportingExternalEntities", true);
     factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
     factory.createXMLStreamReader(sock.getInputStream()); //unsafe
     factory.createXMLEventReader(sock.getInputStream()); //unsafe
-  }  
+  }
+
+  public void alternateSafeFactory(Socket sock) throws Exception {
+    XMLInputFactory factory = XMLInputFactory.newFactory();
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setProperty("http://javax.xml.XMLConstants/property/accessExternalSchema", "");
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    factory.createXMLStreamReader(sock.getInputStream()); //safe
+    factory.createXMLEventReader(sock.getInputStream()); //safe
+  }
 }


### PR DESCRIPTION
To check here:

We already regarded `XMLInputFactory` as safe when `IS_SUPPORTING_EXTERNAL_ENTITIES` and `SUPPORT_DTD` were both disabled, and regarded `TransformerFactory` and `SchemaFactory` as safe when 2 out of 3 of the `ACCESS_EXTERNAL_{DTD,SCHEMA,STYLESHEET}` variables were set to `""` (i.e., no external access allowed).

The `TransformerFactory` was allowed to access external schemas, and the `SchemaFactory` was allowed to access external stylesheets (I don’t know why). Forbidding all three on `XMLInputFactory` seems like probably the right thing to ask for?