### PR TITLE
Ruby: fix CI jobs after removal of `.codeql-manifest.json`

### DIFF
--- a/.github/workflows/ruby-dataset-measure.yml
+++ b/.github/workflows/ruby-dataset-measure.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create database
         run: |
           codeql database create \
-            --search-path "${{ github.workspace }}/ruby" \
+            --search-path "${{ github.workspace }}/ruby/extractor-pack" \
             --threads 4 \
             --language ruby --source-root "${{ github.workspace }}/repo" \
             "${{ runner.temp }}/database"

--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -32,14 +32,14 @@ jobs:
       - uses: ./ruby/actions/create-extractor-pack
       - name: Run QL tests
         run: |
-          codeql test run --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --consistency-queries ql/consistency-queries ql/test
+          codeql test run --search-path "${{ github.workspace }}/ruby/extractor-pack" --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --consistency-queries ql/consistency-queries ql/test
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Check QL formatting
         run: find ql "(" -name "*.ql" -or -name "*.qll" ")" -print0 | xargs -0 codeql query format --check-only
       - name: Check QL compilation
         run: |
-          codeql query compile --check-only --threads=4 --warnings=error --search-path "${{ github.workspace }}/ruby" --additional-packs "${{ github.workspace }}" "ql/src" "ql/examples"
+          codeql query compile --check-only --threads=4 --warnings=error "ql/src" "ql/examples"
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Check DB upgrade scripts

--- a/ruby/Makefile
+++ b/ruby/Makefile
@@ -67,5 +67,4 @@ extractor:	$(FILES) $(BIN_FILES)
 	cp target/release/ruby-autobuilder$(EXE) extractor-pack/tools/$(CODEQL_PLATFORM)/autobuilder$(EXE)
 
 test: extractor dbscheme
-	codeql pack install ql/test
-	codeql test run --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --search-path . --consistency-queries ql/consistency-queries ql/test
+	codeql test run --check-databases --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --search-path extractor-pack --consistency-queries ql/consistency-queries ql/test

--- a/ruby/doc/HOWTO.md
+++ b/ruby/doc/HOWTO.md
@@ -39,7 +39,7 @@ codeql database create <database-path> -l ruby -s <project-source-path> --search
 Run
 
 ```bash
-codeql test run <test-path> --search-path <repository-root-path>
+codeql test run <test-path> --search-path <extractor-pack-path>
 ```
 
 ## Writing database upgrade scripts


### PR DESCRIPTION
The CI jobs should use a freshly built extractor and not rely on the Ruby extractor bundled with the CodeQL CLI.

@dbartol 