### PR TITLE
Data flow: Performance tuning

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1019,12 +1019,14 @@ private module Stage2 {
 
   pragma[nomagic]
   private predicate flowThroughOutOfCall(
-    DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+    Configuration config
   ) {
     flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
     PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
     PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config))
+      pragma[only_bind_into](config)) and
+    ccc.matchesCall(call)
   }
 
   /**
@@ -1171,8 +1173,7 @@ private module Stage2 {
   ) {
     exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
       fwdFlow(ret, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      ccc.matchesCall(call)
+      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -1712,12 +1713,14 @@ private module Stage3 {
 
   pragma[nomagic]
   private predicate flowThroughOutOfCall(
-    DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+    Configuration config
   ) {
     flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
     PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
     PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config))
+      pragma[only_bind_into](config)) and
+    ccc.matchesCall(call)
   }
 
   /**
@@ -1871,8 +1874,7 @@ private module Stage3 {
   ) {
     exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
       fwdFlow(ret, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      ccc.matchesCall(call)
+      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )
@@ -2483,12 +2485,14 @@ private module Stage4 {
 
   pragma[nomagic]
   private predicate flowThroughOutOfCall(
-    DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow, Configuration config
+    DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow,
+    Configuration config
   ) {
     flowOutOfCall(call, ret, out, allowsFieldFlow, pragma[only_bind_into](config)) and
     PrevStage::callMayFlowThroughRev(call, pragma[only_bind_into](config)) and
     PrevStage::parameterMayFlowThrough(_, ret.getEnclosingCallable(), _,
-      pragma[only_bind_into](config))
+      pragma[only_bind_into](config)) and
+    ccc.matchesCall(call)
   }
 
   /**
@@ -2642,8 +2646,7 @@ private module Stage4 {
   ) {
     exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
       fwdFlow(ret, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ret, out, allowsFieldFlow, config) and
-      ccc.matchesCall(call)
+      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config)
     |
       ap instanceof ApNil or allowsFieldFlow = true
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1144,9 +1144,8 @@ private module Stage2 {
     exists(ArgNodeEx arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1161,9 +1160,8 @@ private module Stage2 {
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
       inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      ccOut = getCallContextReturn(inner, call, innercc) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1173,9 +1171,8 @@ private module Stage2 {
   ) {
     exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
       fwdFlow(ret, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1845,9 +1842,8 @@ private module Stage3 {
     exists(ArgNodeEx arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1862,9 +1858,8 @@ private module Stage3 {
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
       inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      ccOut = getCallContextReturn(inner, call, innercc) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1874,9 +1869,8 @@ private module Stage3 {
   ) {
     exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
       fwdFlow(ret, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2617,9 +2611,8 @@ private module Stage4 {
     exists(ArgNodeEx arg, boolean allowsFieldFlow |
       fwdFlow(arg, outercc, argAp, ap, config) and
       flowIntoCall(call, arg, p, allowsFieldFlow, config) and
-      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      innercc = getCallContextCall(call, p.getEnclosingCallable(), outercc) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2634,9 +2627,8 @@ private module Stage4 {
       fwdFlow(ret, innercc, argAp, ap, config) and
       flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
       inner = ret.getEnclosingCallable() and
-      ccOut = getCallContextReturn(inner, call, innercc)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      ccOut = getCallContextReturn(inner, call, innercc) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2646,9 +2638,8 @@ private module Stage4 {
   ) {
     exists(RetNodeEx ret, boolean allowsFieldFlow, CcCall ccc |
       fwdFlow(ret, ccc, apSome(argAp), ap, config) and
-      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowThroughOutOfCall(call, ccc, ret, out, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1230,6 +1230,11 @@ private module Stage2 {
     callMayFlowThroughFwd(call, pragma[only_bind_into](config))
   }
 
+  pragma[nomagic]
+  private predicate returnNodeMayFlowThrough(RetNodeEx ret, Ap ap, Configuration config) {
+    fwdFlow(ret, any(CcCall ccc), apSome(_), ap, config)
+  }
+
   /**
    * Holds if `node` with access path `ap` is part of a path from a source to a
    * sink in the configuration `config`.
@@ -1306,7 +1311,7 @@ private module Stage2 {
     // flow out of a callable
     revFlowOut(_, node, _, _, ap, config) and
     toReturn = true and
-    if fwdFlow(node, any(CcCall ccc), apSome(_), ap, config)
+    if returnNodeMayFlowThrough(node, ap, config)
     then returnAp = apSome(ap)
     else returnAp = apNone()
   }
@@ -1925,6 +1930,11 @@ private module Stage3 {
     callMayFlowThroughFwd(call, pragma[only_bind_into](config))
   }
 
+  pragma[nomagic]
+  private predicate returnNodeMayFlowThrough(RetNodeEx ret, Ap ap, Configuration config) {
+    fwdFlow(ret, any(CcCall ccc), apSome(_), ap, config)
+  }
+
   /**
    * Holds if `node` with access path `ap` is part of a path from a source to a
    * sink in the configuration `config`.
@@ -2001,7 +2011,7 @@ private module Stage3 {
     // flow out of a callable
     revFlowOut(_, node, _, _, ap, config) and
     toReturn = true and
-    if fwdFlow(node, any(CcCall ccc), apSome(_), ap, config)
+    if returnNodeMayFlowThrough(node, ap, config)
     then returnAp = apSome(ap)
     else returnAp = apNone()
   }
@@ -2691,6 +2701,11 @@ private module Stage4 {
     callMayFlowThroughFwd(call, pragma[only_bind_into](config))
   }
 
+  pragma[nomagic]
+  private predicate returnNodeMayFlowThrough(RetNodeEx ret, Ap ap, Configuration config) {
+    fwdFlow(ret, any(CcCall ccc), apSome(_), ap, config)
+  }
+
   /**
    * Holds if `node` with access path `ap` is part of a path from a source to a
    * sink in the configuration `config`.
@@ -2767,7 +2782,7 @@ private module Stage4 {
     // flow out of a callable
     revFlowOut(_, node, _, _, ap, config) and
     toReturn = true and
-    if fwdFlow(node, any(CcCall ccc), apSome(_), ap, config)
+    if returnNodeMayFlowThrough(node, ap, config)
     then returnAp = apSome(ap)
     else returnAp = apNone()
   }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1347,9 +1347,8 @@ private module Stage2 {
   ) {
     exists(NodeEx out, boolean allowsFieldFlow |
       revFlow(out, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1359,9 +1358,8 @@ private module Stage2 {
   ) {
     exists(ParamNodeEx p, boolean allowsFieldFlow |
       revFlow(p, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -1371,9 +1369,8 @@ private module Stage2 {
   ) {
     exists(ParamNodeEx p, boolean allowsFieldFlow |
       revFlow(p, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2045,9 +2042,8 @@ private module Stage3 {
   ) {
     exists(NodeEx out, boolean allowsFieldFlow |
       revFlow(out, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2057,9 +2053,8 @@ private module Stage3 {
   ) {
     exists(ParamNodeEx p, boolean allowsFieldFlow |
       revFlow(p, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2069,9 +2064,8 @@ private module Stage3 {
   ) {
     exists(ParamNodeEx p, boolean allowsFieldFlow |
       revFlow(p, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2814,9 +2808,8 @@ private module Stage4 {
   ) {
     exists(NodeEx out, boolean allowsFieldFlow |
       revFlow(out, toReturn, returnAp, ap, config) and
-      flowOutOfCall(call, ret, out, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowOutOfCall(call, ret, out, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2826,9 +2819,8 @@ private module Stage4 {
   ) {
     exists(ParamNodeEx p, boolean allowsFieldFlow |
       revFlow(p, false, returnAp, ap, config) and
-      flowIntoCall(_, arg, p, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowIntoCall(_, arg, p, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 
@@ -2838,9 +2830,8 @@ private module Stage4 {
   ) {
     exists(ParamNodeEx p, boolean allowsFieldFlow |
       revFlow(p, true, apSome(returnAp), ap, config) and
-      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config)
-    |
-      ap instanceof ApNil or allowsFieldFlow = true
+      flowThroughIntoCall(call, arg, p, allowsFieldFlow, config) and
+      if allowsFieldFlow = false then ap instanceof ApNil else any()
     )
   }
 


### PR DESCRIPTION
This is a sequence of smaller performance tweaks (commit-by-commit review is encouraged). All of them relate to reducing work by avoiding splits of the tuple stream in the main recursive pipelines. Either by making sure negations are simple anti-joins (thereby also avoiding materialisation) or by avoiding tuple duplication arising from disjunctive filters.