### PR TITLE
C++: New query for SSL result conflation

### DIFF
--- a/cpp/change-notes/2021-11-25-certificate-result-conflation.md
+++ b/cpp/change-notes/2021-11-25-certificate-result-conflation.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* A new query `cpp/certificate-result-conflation` has been added for C/C++. The query flags unsafe use of OpenSSL and similar libraries.

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>When checking the result of SSL certificate verification, accepting any error code may allow an attacker to impersonate someone who is trusted.</p>
+
+</overview>
+<recommendation>
+
+<p>When checking an SSL certificate with <code>SSL_get_verify_result</code>, only <code>X509_V_OK</code> is a success code. If there is any other result the certificate should not be accepted.</p>
+
+</recommendation>
+<example>
+
+<p>In this example the error code <code>X509_V_ERR_CERT_HAS_EXPIRED</code> is treated the same as an OK result. An expired certificate should not be accepted as it is more likely to be compromised than a valid certificate.</p>
+
+<sample src="SSLResultConflationBad.cpp" />
+
+<p>In the corrected example, only a result of <code>X509_V_OK</code> is accepted.</p>
+
+<sample src="SSLResultConflationGood.cpp" />
+
+</example>
+<references>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -10,15 +10,12 @@
  *       external/cwe/cwe-295
  */
 
-
 import cpp
 import semmle.code.cpp.controlflow.Guards
 import semmle.code.cpp.dataflow.DataFlow
 
 class SSLGetVerifyResultCall extends FunctionCall {
-  SSLGetVerifyResultCall() {
-    getTarget().getName() = "SSL_get_verify_result"
-  }
+  SSLGetVerifyResultCall() { getTarget().getName() = "SSL_get_verify_result" }
 }
 
 class VerifyResultConfig extends DataFlow::Configuration {
@@ -29,21 +26,18 @@ class VerifyResultConfig extends DataFlow::Configuration {
   }
 
   override predicate isSink(DataFlow::Node sink) {
-    exists(GuardCondition guard |
-      guard.getAChild*() = sink.asExpr()
-    )
+    exists(GuardCondition guard | guard.getAChild*() = sink.asExpr())
   }
 }
 
 from
-	VerifyResultConfig config, DataFlow::Node source, DataFlow::Node sink1, DataFlow::Node sink2,
-	GuardCondition guard, Expr c1, Expr c2, boolean testIsTrue
+  VerifyResultConfig config, DataFlow::Node source, DataFlow::Node sink1, DataFlow::Node sink2,
+  GuardCondition guard, Expr c1, Expr c2, boolean testIsTrue
 where
-	config.hasFlow(source, sink1) and
-	config.hasFlow(source, sink2) and
-	guard.comparesEq(sink1.asExpr(), c1, 0, false, testIsTrue) and // (value != c1) => testIsTrue
-	guard.comparesEq(sink2.asExpr(), c2, 0, false, testIsTrue) and // (value != c2) => testIsTrue
-	c1.getValue().toInt() = 0 and
-	c2.getValue().toInt() != 0
-select
-	guard, "This expression conflates OK and non-OK results from $@.", source, source.toString()
+  config.hasFlow(source, sink1) and
+  config.hasFlow(source, sink2) and
+  guard.comparesEq(sink1.asExpr(), c1, 0, false, testIsTrue) and // (value != c1) => testIsTrue
+  guard.comparesEq(sink2.asExpr(), c2, 0, false, testIsTrue) and // (value != c2) => testIsTrue
+  c1.getValue().toInt() = 0 and
+  c2.getValue().toInt() != 0
+select guard, "This expression conflates OK and non-OK results from $@.", source, source.toString()

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -13,7 +13,6 @@
 
 import cpp
 import semmle.code.cpp.controlflow.Guards
-import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.dataflow.DataFlow
 
 class SSLGetVerifyResultCall extends FunctionCall {
@@ -36,14 +35,12 @@ class VerifyResultConfig extends DataFlow::Configuration {
   }
 }
 
-// TODO: use GVN on *both* sinks to get more results!?
-
 from
 	VerifyResultConfig config, DataFlow::Node source, DataFlow::Node sink1, DataFlow::Node sink2,
 	GuardCondition guard, Expr c1, Expr c2, boolean testIsTrue
 where
 	config.hasFlow(source, sink1) and
-	globalValueNumber(sink1.asExpr()) = globalValueNumber(sink2.asExpr()) and
+	config.hasFlow(source, sink2) and
 	guard.comparesEq(sink1.asExpr(), c1, 0, false, testIsTrue) and // (value != c1) => testIsTrue
 	guard.comparesEq(sink2.asExpr(), c2, 0, false, testIsTrue) and // (value != c2) => testIsTrue
 	c1.getValue().toInt() = 0 and

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -1,12 +1,13 @@
 /**
- * @name TODO
- * @description TODO
+ * @name Certificate result conflation
+ * @description Only accept SSL certificates that pass certificate verification.
  * @kind problem
- * @problem.severity TODO
+ * @problem.severity error
  * @security-severity TODO
  * @precision TODO
- * @id TODO
- * @tags TODO
+ * @id cpp/certificate-result-conflation
+ * @tags security
+ *       external/cwe/cwe-295
  */
 
 

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -1,0 +1,51 @@
+/**
+ * @name TODO
+ * @description TODO
+ * @kind problem
+ * @problem.severity TODO
+ * @security-severity TODO
+ * @precision TODO
+ * @id TODO
+ * @tags TODO
+ */
+
+
+import cpp
+import semmle.code.cpp.controlflow.Guards
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+import semmle.code.cpp.dataflow.DataFlow
+
+class SSLGetVerifyResultCall extends FunctionCall {
+  SSLGetVerifyResultCall() {
+    getTarget().getName() = "SSL_get_verify_result"
+  }
+}
+
+class VerifyResultConfig extends DataFlow::Configuration {
+  VerifyResultConfig() { this = "VerifyResultConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.asExpr() instanceof SSLGetVerifyResultCall
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(GuardCondition guard |
+      guard.getAChild*() = sink.asExpr()
+    )
+  }
+}
+
+// TODO: use GVN on *both* sinks to get more results!?
+
+from
+	VerifyResultConfig config, DataFlow::Node source, DataFlow::Node sink1, DataFlow::Node sink2,
+	GuardCondition guard, Expr c1, Expr c2, boolean testIsTrue
+where
+	config.hasFlow(source, sink1) and
+	globalValueNumber(sink1.asExpr()) = globalValueNumber(sink2.asExpr()) and
+	guard.comparesEq(sink1.asExpr(), c1, 0, false, testIsTrue) and // (value != c1) => testIsTrue
+	guard.comparesEq(sink2.asExpr(), c2, 0, false, testIsTrue) and // (value != c2) => testIsTrue
+	c1.getValue().toInt() = 0 and
+	c2.getValue().toInt() != 0
+select
+	guard, "This expression conflates OK and non-OK results from $@.", source, source.toString()

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -14,10 +14,17 @@ import cpp
 import semmle.code.cpp.controlflow.Guards
 import semmle.code.cpp.dataflow.DataFlow
 
+/**
+ * A call to `SSL_get_verify_result`.
+ */
 class SSLGetVerifyResultCall extends FunctionCall {
   SSLGetVerifyResultCall() { getTarget().getName() = "SSL_get_verify_result" }
 }
 
+/**
+ * Data flow from a call to `SSL_get_verify_result` to a guard condition
+ * that references the result.
+ */
 class VerifyResultConfig extends DataFlow::Configuration {
   VerifyResultConfig() { this = "VerifyResultConfig" }
 

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflation.ql
@@ -3,8 +3,8 @@
  * @description Only accept SSL certificates that pass certificate verification.
  * @kind problem
  * @problem.severity error
- * @security-severity TODO
- * @precision TODO
+ * @security-severity 7.5
+ * @precision medium
  * @id cpp/certificate-result-conflation
  * @tags security
  *       external/cwe/cwe-295

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflationBad.cpp
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflationBad.cpp
@@ -1,0 +1,13 @@
+// ...
+
+if (cert = SSL_get_peer_certificate(ssl))
+{
+	result = SSL_get_verify_result(ssl);
+
+	if ((result == X509_V_OK) || (result == X509_V_ERR_CERT_HAS_EXPIRED)) // BAD (conflates OK and a non-OK codes)
+	{
+		do_ok();
+	} else {
+		do_error();
+	}
+}

--- a/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflationGood.cpp
+++ b/cpp/ql/src/Security/CWE/CWE-295/SSLResultConflationGood.cpp
@@ -1,0 +1,13 @@
+// ...
+
+if (cert = SSL_get_peer_certificate(ssl))
+{
+	result = SSL_get_verify_result(ssl);
+
+	if (result == X509_V_OK) // GOOD
+	{
+		do_ok();
+	} else {
+		do_error();
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-295/SSLResultConflation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-295/SSLResultConflation.expected
@@ -1,0 +1,8 @@
+| test.cpp:18:9:18:38 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:100:18:100:38 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:38:7:38:36 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:36:16:36:36 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:54:7:54:47 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:52:16:52:36 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:62:7:62:36 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:60:16:60:36 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:70:7:70:36 | ... && ... | This expression conflates OK and non-OK results from $@. | test.cpp:68:16:68:36 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:83:7:83:40 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:78:16:78:36 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:87:7:87:38 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:7:57:7:77 | call to SSL_get_verify_result | call to SSL_get_verify_result |
+| test.cpp:107:13:107:42 | ... \|\| ... | This expression conflates OK and non-OK results from $@. | test.cpp:105:16:105:36 | call to SSL_get_verify_result | call to SSL_get_verify_result |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-295/SSLResultConflation.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-295/SSLResultConflation.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-295/SSLResultConflation.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-295/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-295/test.cpp
@@ -1,0 +1,149 @@
+
+struct SSL {
+	// ...
+};
+
+int SSL_get_verify_result(const SSL *ssl);
+int get_verify_result_indirect(const SSL *ssl) { return SSL_get_verify_result(ssl); }
+
+int something_else(const SSL *ssl);
+
+bool is_ok(int result)
+{
+	return (result == 0); // GOOD
+}
+
+bool is_maybe_ok(int result)
+{
+	return (result == 0) || (result == 1); // BAD (conflates OK and a non-OK codes)
+}
+
+void test1_1(SSL *ssl)
+{
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if (result == 0) // GOOD
+		{
+		}
+
+		if (result == 1) // GOOD
+		{
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if ((result == 0) || (result == 1)) // BAD (conflates OK and a non-OK codes)
+		{
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if ((result == 1) || (result == 2)) // GOOD (both results are non-OK)
+		{
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if ((result == 0) || (false) || (result == 2)) // BAD (conflates OK and a non-OK codes)
+		{
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if ((0 == result) || (1 == result)) // BAD (conflates OK and a non-OK codes)
+		{
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if ((result != 0) && (result != 1)) // BAD (conflates OK and a non-OK codes)
+		{
+		} else {
+			// conflation occurs here
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+		int result_cpy = result;
+		int result2 = get_verify_result_indirect(ssl);
+		int result3 = something_else(ssl);
+
+		if ((result == 0) || (result_cpy == 1)) // BAD (conflates OK and a non-OK codes)
+		{
+		}
+	
+		if ((result2 == 0) || (result2 == 1)) // BAD (conflates OK and a non-OK codes)
+		{
+		}
+	
+		if ((result3 == 0) || (result3 == 1)) // GOOD (not an SSL result)
+		{
+		}
+	}
+
+	if (is_ok(SSL_get_verify_result(ssl)))
+	{
+	}
+
+	if (is_maybe_ok(SSL_get_verify_result(ssl)))
+	{
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		bool ok = (result == 0) || (result == 1); // BAD (conflates OK and a non-OK codes)
+	
+		if (ok) {
+		}
+	}
+
+	{
+		int result = SSL_get_verify_result(ssl);
+
+		if (result == 1) // BAD (conflates OK and a non-OK codes in `else`) [NOT DETECTED]
+		{
+		} else {
+		}
+	}
+}
+
+void do_good();
+
+void test1_2(SSL *ssl)
+{
+	int result = SSL_get_verify_result(ssl);
+
+	if (result == 0) { // GOOD
+		do_good();
+	} else if (result == 1) {
+		throw 1;
+	} else {
+		throw 1;
+	}
+}
+
+void test1_3(SSL *ssl)
+{
+	int result = SSL_get_verify_result(ssl);
+
+	if (result == 0) { // BAD (error code 1 is treated as OK, not as non-OK) [NOT DETECTED]
+		do_good();
+	} else if (result == 1) {
+		do_good();
+	} else {
+		throw 1;
+	}
+}


### PR DESCRIPTION
This is the first of two new queries for [CWE-295: Improper Certificate Validation](https://cwe.mitre.org/data/definitions/295.html).

Results:
 - [on all LGTM C/C++ projects](https://lgtm.com/query/1243915003686309152/); very thin (only 1 result).
 - this is disappointing, but the query does cover 2 of the 5 examples given in the CWE definition.

Precision:
 - provisionally set to `@medium`, it's difficult to judge without seeing more real world results.

Performance:
 - tested locally on `kamailio_kamailio` and `chakra-core` (performance is great with a warmed up cache)
 - no timeouts on the above LGTM run.