### PR TITLE
JS: [Internal only] Add ML models specification to ATM query pack definition

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/src/.gitignore
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/.gitignore
@@ -1,0 +1,3 @@
+# Avoid checking in ML models
+# This matches the mlModels property of qlpack.yml.
+resources/*.codeqlmodel

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -5,3 +5,5 @@ suites: codeql-suites
 defaultSuiteFile: codeql-suites/javascript-atm-code-scanning.qls
 dependencies:
     codeql/javascript-experimental-atm-lib: "*"
+mlModels:
+- "resources/*.codeqlmodel"


### PR DESCRIPTION
This will allow us to resolve the ATM machine learning models that will be distributed within this pack.