### PR TITLE
Java: Unsafe Hash Query

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-328/BrokenHashAlgorithm.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-328/BrokenHashAlgorithm.qhelp
@@ -1,0 +1,36 @@
+<!DOCTYPE qhelp PUBLIC
+>
+<qhelp>
+<overview>
+<p>Using weak cryptographic algorithms can allow and adversasy to adversary to reasonably determine the original input (preimage attack).
+Find another input that can produce the same hash (2nd preimage attack).
+Or find multiple inputs that evaluate to the same hash (birthday attack).</p>
+
+<p>Many cryptographic algorithms provided by cryptography libraries are known to be weak and should be avoided.</p>
+
+</overview>
+<recommendation>
+
+<p>Ensure that you use a strong, modern cryptographic HASH algorithm.</p>
+
+</recommendation>
+<example>
+
+<p>The following code shows an example of using a java <code>Cipher</code> to encrypt some data.
+When creating a <code>Cipher</code> instance, you must specify the encryption algorithm to use. The first
+example uses DES, which is an older algorithm that is now considered weak. The second example uses AES, which
+is a strong modern algorithm.</p>
+
+<sample src="UnsafeHash.java" />
+
+</example>
+<references>
+
+<li><a href="https://cwe.mitre.org/data/definitions/328.html">
+CWE-328</a>.</li>
+
+<!--  LocalWords:  CWE
+ -->
+
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-328/SafeHash.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-328/SafeHash.java
@@ -1,0 +1,123 @@
+/**
+ * OWASP Benchmark v1.2
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project. For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Wichers
+ * @created 2015
+ */
+package org.owasp.benchmark.testcode;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/hash-00/BenchmarkTest00009")
+public class BenchmarkTest00009 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        java.util.Enumeration<String> names = request.getHeaderNames();
+        while (names.hasMoreElements()) {
+            String name = (String) names.nextElement();
+
+            if (org.owasp.benchmark.helpers.Utils.commonHeaders.contains(name)) {
+                continue;
+            }
+
+            java.util.Enumeration<String> values = request.getHeaders(name);
+            if (values != null && values.hasMoreElements()) {
+                param = name;
+                break;
+            }
+        }
+        // Note: We don't URL decode header names because people don't normally do that
+
+        java.security.Provider[] provider = java.security.Security.getProviders();
+        java.security.MessageDigest md;
+
+        try {
+            if (provider.length > 1) {
+
+                md = java.security.MessageDigest.getInstance("sha-384", provider[0]);
+            } else {
+                md = java.security.MessageDigest.getInstance("sha-384", "SUN");
+            }
+            byte[] input = {(byte) '?'};
+            Object inputParam = param;
+            if (inputParam instanceof String) input = ((String) inputParam).getBytes();
+            if (inputParam instanceof java.io.InputStream) {
+                byte[] strInput = new byte[1000];
+                int i = ((java.io.InputStream) inputParam).read(strInput);
+                if (i == -1) {
+                    response.getWriter()
+                            .println(
+                                    "This input source requires a POST, not a GET. Incompatible UI for the InputStream source.");
+                    return;
+                }
+                input = java.util.Arrays.copyOf(strInput, i);
+            }
+            md.update(input);
+
+            byte[] result = md.digest();
+            java.io.File fileTarget =
+                    new java.io.File(
+                            new java.io.File(org.owasp.benchmark.helpers.Utils.TESTFILES_DIR),
+                            "passwordFile.txt");
+            java.io.FileWriter fw =
+                    new java.io.FileWriter(fileTarget, true); // the true will append the new data
+            fw.write(
+                    "hash_value="
+                            + org.owasp.esapi.ESAPI.encoder().encodeForBase64(result, true)
+                            + "\n");
+            fw.close();
+            response.getWriter()
+                    .println(
+                            "Sensitive value '"
+                                    + org.owasp
+                                            .esapi
+                                            .ESAPI
+                                            .encoder()
+                                            .encodeForHTML(new String(input))
+                                    + "' hashed and stored<br/>");
+
+        } catch (java.security.NoSuchAlgorithmException e) {
+            System.out.println(
+                    "Problem executing hash - TestCase java.security.MessageDigest.getInstance(java.lang.String,java.security.Provider)");
+            throw new ServletException(e);
+        } catch (java.security.NoSuchProviderException e) {
+            System.out.println(
+                    "Problem executing hash - TestCase java.security.MessageDigest.getInstance(java.lang.String,java.security.Provider)");
+            throw new ServletException(e);
+        }
+
+        response.getWriter()
+                .println(
+                        "Hash Test java.security.MessageDigest.getInstance(java.lang.String,java.security.Provider) executed");
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-328/UnsafeHash.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-328/UnsafeHash.java
@@ -1,0 +1,98 @@
+/**
+ * OWASP Benchmark v1.2
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project. For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Wichers
+ * @created 2015
+ */
+package org.owasp.benchmark.testcode;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/hash-00/BenchmarkTest00046")
+public class BenchmarkTest00046 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String[] values = request.getParameterValues("BenchmarkTest00046");
+        String param;
+        if (values != null && values.length > 0) param = values[0];
+        else param = "";
+
+        try {
+            java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
+            byte[] input = {(byte) '?'};
+            Object inputParam = param;
+            if (inputParam instanceof String) input = ((String) inputParam).getBytes();
+            if (inputParam instanceof java.io.InputStream) {
+                byte[] strInput = new byte[1000];
+                int i = ((java.io.InputStream) inputParam).read(strInput);
+                if (i == -1) {
+                    response.getWriter()
+                            .println(
+                                    "This input source requires a POST, not a GET. Incompatible UI for the InputStream source.");
+                    return;
+                }
+                input = java.util.Arrays.copyOf(strInput, i);
+            }
+            md.update(input);
+
+            byte[] result = md.digest();
+            java.io.File fileTarget =
+                    new java.io.File(
+                            new java.io.File(org.owasp.benchmark.helpers.Utils.TESTFILES_DIR),
+                            "passwordFile.txt");
+            java.io.FileWriter fw =
+                    new java.io.FileWriter(fileTarget, true); // the true will append the new data
+            fw.write(
+                    "hash_value="
+                            + org.owasp.esapi.ESAPI.encoder().encodeForBase64(result, true)
+                            + "\n");
+            fw.close();
+            response.getWriter()
+                    .println(
+                            "Sensitive value '"
+                                    + org.owasp
+                                            .esapi
+                                            .ESAPI
+                                            .encoder()
+                                            .encodeForHTML(new String(input))
+                                    + "' hashed and stored<br/>");
+
+        } catch (java.security.NoSuchAlgorithmException e) {
+            System.out.println("Problem executing hash - TestCase");
+            throw new ServletException(e);
+        }
+
+        response.getWriter()
+                .println(
+                        "Hash Test java.security.MessageDigest.getInstance(java.lang.String) executed");
+    }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-328/Use of Weak Hash.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-328/Use of Weak Hash.ql
@@ -1,0 +1,65 @@
+/**
+ * @name Use of a broken or risky cryptographic hash
+ * @description Using weak hash algorithm can allow an attacker to compromise security.
+ * @kind path-problem
+ * @problem.severity warning
+ * @security-severity ??
+ * @precision ??
+ * @id java/weak-hash-algorithm
+ * @tags security
+ *       external/cwe/cwe-328
+ */
+
+import java
+import semmle.code.java.security.Encryption
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow
+import PathGraph
+
+class BrokenHashLiteral extends StringLiteral {
+  BrokenHashLiteral() {
+    getValue().length() <  10 and 
+    getValue().regexpMatch(getInsecureHashRegex())
+  }
+}
+
+class InsecureHashConfiguration extends TaintTracking::Configuration {
+  InsecureHashConfiguration() { this = "BrokenCryptoAlgortihm::InsecureHashConfiguration" }
+
+  override predicate isSource(Node n) { n.asExpr() instanceof BrokenHashLiteral }
+
+  override predicate isSink(Node n) { exists(CryptoAlgoSpec c | n.asExpr() = c.getAlgoSpec()) }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+}
+
+from
+  PathNode source, PathNode sink, CryptoAlgoSpec c, BrokenHashLiteral s,
+  InsecureHashConfiguration conf
+where
+  sink.getNode().asExpr() = c.getAlgoSpec() and
+  source.getNode().asExpr() = s and
+  conf.hasFlowPath(source, sink)
+select c, source, sink, "Hash algorithm $@ is weak and should not be used.", s,
+  s.getValue()
+
+  bindingset[hashString]
+  private string hashRegex(string hashString) {
+    // Algorithms usually appear in names surrounded by characters that are not
+    // alphabetical characters in the same case. This handles the upper and lower
+    // case cases.
+    result =
+      "((^|.*[^A-Z])(" + hashString + ")([^A-Z].*|$))" +
+        // or...
+        "|" +
+        // For lowercase, we want to be careful to avoid being confused by camelCase
+        // hence we require two preceding uppercase letters to be sure of a case switch,
+        // or a preceding non-alphabetic character
+        "((^|.*[A-Z]{2}|.*[^a-zA-Z])(" + hashString.toLowerCase() + ")([^a-z].*|$))"
+  }
+  string getInsecureHashRegex() {
+    result = hashRegex(getAnInsecureHashAlgorithmName())
+}
+


### PR DESCRIPTION
This query finds Weak Hash Vulnerabilities. 

Why a new query?

I ran codeQL againts OWASP-Benchmark and noticed the score in the Weak Hashing category was zero, I managed to make a quick query based on the one used for Weak Cryptography. This new query detects now Hash Vulnerabilities with a precision equivalent to FindSecBugs or SonarQube with a True Positive rate of 70% on the OWASP Benchmark.   

![Benchmark_v1 2_Scorecard_for_Weak_Hashing_Algorithm](https://user-images.githubusercontent.com/34873696/143866359-21ff6341-e14e-43fa-9302-3f69da037282.png)

I was wondering if there was any specific reason why this query wasn't implemented. If this query results interesting to the security lab I can put further work on it. 

I added two `.java` tests cases: a safe hash and an unsafe hash. 
