### PR TITLE
Data flow: Introduce `ParameterPosition` and `ArgumentPosition`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
@@ -1,4 +1,6 @@
 private import cpp
+private import semmle.code.cpp.dataflow.internal.DataFlowPrivate
+private import semmle.code.cpp.dataflow.internal.DataFlowUtil
 
 /**
  * Gets a function that might be called by `call`.
@@ -63,3 +65,17 @@ predicate mayBenefitFromCallContext(Call call, Function f) { none() }
  * restricted to those `call`s for which a context might make a difference.
  */
 Function viableImplInCallContext(Call call, Call ctx) { none() }
+
+/** A parameter position represented by an integer. */
+class ParameterPosition extends int {
+  ParameterPosition() { any(ParameterNode p).isParameterOf(_, this) }
+}
+
+/** An argument position represented by an integer. */
+class ArgumentPosition extends int {
+  ArgumentPosition() { any(ArgumentNode a).argumentOf(_, this) }
+}
+
+/** Holds if arguments at position `apos` match parameters at position `ppos`. */
+pragma[inline]
+predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -391,14 +391,11 @@ private module Cached {
 
   /**
    * Holds if `p` is the parameter of a viable dispatch target of `call`,
-   * and `p` matches arguments at position `apos`.
+   * and `p` has position `ppos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
-    exists(ParameterPosition ppos |
-      p.isParameterOf(viableCallableExt(call), ppos) and
-      parameterMatch(ppos, apos)
-    )
+  private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    p.isParameterOf(viableCallableExt(call), ppos)
   }
 
   /**
@@ -407,9 +404,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(ArgumentPosition pos |
-      viableParam(call, pos, p) and
-      arg.argumentOf(call, pos) and
+    exists(ParameterPosition ppos |
+      viableParam(call, ppos, p) and
+      argumentPositionMatch(call, arg, ppos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -71,25 +71,31 @@ predicate accessPathCostLimits(int apLimit, int tupleLimit) {
  * calls. For this reason, we cannot reuse the code from `DataFlowImpl.qll` directly.
  */
 private module LambdaFlow {
-  private predicate viableParamNonLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallable(call), i)
+  private predicate viableParamNonLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallable(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
-  private predicate viableParamLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableLambda(call, _), i)
+  private predicate viableParamLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableLambda(call, _), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamNonLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamNonLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
   private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
@@ -322,7 +328,7 @@ private module Cached {
     or
     exists(ArgNode arg |
       result.(PostUpdateNode).getPreUpdateNode() = arg and
-      arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
+      arg.argumentOf(call, k.(ParamUpdateReturnKind).getAMatchingArgumentPosition())
     )
   }
 
@@ -330,7 +336,7 @@ private module Cached {
   predicate returnNodeExt(Node n, ReturnKindExt k) {
     k = TValueReturn(n.(ReturnNode).getKind())
     or
-    exists(ParamNode p, int pos |
+    exists(ParamNode p, ParameterPosition pos |
       parameterValueFlowsToPreUpdate(p, n) and
       p.isParameterOf(_, pos) and
       k = TParamUpdate(pos)
@@ -352,11 +358,13 @@ private module Cached {
   }
 
   cached
-  predicate parameterNode(Node p, DataFlowCallable c, int pos) { isParameterNode(p, c, pos) }
+  predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    isParameterNode(p, c, pos)
+  }
 
   cached
-  predicate argumentNode(Node n, DataFlowCall call, int pos) {
-    n.(ArgumentNode).argumentOf(call, pos)
+  predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
+    isArgumentNode(n, call, pos)
   }
 
   /**
@@ -374,12 +382,15 @@ private module Cached {
   }
 
   /**
-   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-   * The instance parameter is considered to have index `-1`.
+   * Holds if `p` is the parameter of a viable dispatch target of `call`,
+   * and `p` matches arguments at position `apos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableExt(call), i)
+  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableExt(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   /**
@@ -388,9 +399,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParam(call, i, p) and
-      arg.argumentOf(call, i) and
+    exists(ArgumentPosition pos |
+      viableParam(call, pos, p) and
+      arg.argumentOf(call, pos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }
@@ -862,7 +873,7 @@ private module Cached {
   cached
   newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
+    TParamUpdate(ParameterPosition pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
 
   cached
   newtype TBooleanOption =
@@ -1054,9 +1065,9 @@ class ParamNode extends Node {
 
   /**
    * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
+   * position.
    */
-  predicate isParameterOf(DataFlowCallable c, int i) { parameterNode(this, c, i) }
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { parameterNode(this, c, pos) }
 }
 
 /** A data-flow node that represents a call argument. */
@@ -1064,7 +1075,9 @@ class ArgNode extends Node {
   ArgNode() { argumentNode(this, _, _) }
 
   /** Holds if this argument occurs at the given position in the given call. */
-  final predicate argumentOf(DataFlowCall call, int pos) { argumentNode(this, call, pos) }
+  final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    argumentNode(this, call, pos)
+  }
 }
 
 /**
@@ -1110,11 +1123,14 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-  private int pos;
+  private ParameterPosition pos;
 
   ParamUpdateReturnKind() { this = TParamUpdate(pos) }
 
-  int getPosition() { result = pos }
+  ParameterPosition getPosition() { result = pos }
+
+  pragma[nomagic]
+  ArgumentPosition getAMatchingArgumentPosition() { parameterMatch(pos, result) }
 
   override string toString() { result = "param update " + pos }
 }

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -8,7 +8,14 @@ private import DataFlowImplConsistency
 DataFlowCallable nodeGetEnclosingCallable(Node n) { result = n.getEnclosingCallable() }
 
 /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-predicate isParameterNode(ParameterNode p, DataFlowCallable c, int pos) { p.isParameterOf(c, pos) }
+predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos) {
+  p.isParameterOf(c, pos)
+}
+
+/** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
+predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos) {
+  arg.argumentOf(c, pos)
+}
 
 /** Gets the instance argument of a non-static call. */
 private Node getInstanceArgument(Call call) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -2,6 +2,7 @@ private import cpp
 private import semmle.code.cpp.ir.IR
 private import semmle.code.cpp.ir.dataflow.DataFlow
 private import semmle.code.cpp.ir.dataflow.internal.DataFlowPrivate
+private import semmle.code.cpp.ir.dataflow.internal.DataFlowUtil
 private import DataFlowImplCommon as DataFlowImplCommon
 
 /**
@@ -266,3 +267,17 @@ Function viableImplInCallContext(CallInstruction call, CallInstruction ctx) {
     result = ctx.getArgument(i).getUnconvertedResultExpression().(FunctionAccess).getTarget()
   )
 }
+
+/** A parameter position represented by an integer. */
+class ParameterPosition extends int {
+  ParameterPosition() { any(ParameterNode p).isParameterOf(_, this) }
+}
+
+/** An argument position represented by an integer. */
+class ArgumentPosition extends int {
+  ArgumentPosition() { any(ArgumentNode a).argumentOf(_, this) }
+}
+
+/** Holds if arguments at position `apos` match parameters at position `ppos`. */
+pragma[inline]
+predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -391,14 +391,11 @@ private module Cached {
 
   /**
    * Holds if `p` is the parameter of a viable dispatch target of `call`,
-   * and `p` matches arguments at position `apos`.
+   * and `p` has position `ppos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
-    exists(ParameterPosition ppos |
-      p.isParameterOf(viableCallableExt(call), ppos) and
-      parameterMatch(ppos, apos)
-    )
+  private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    p.isParameterOf(viableCallableExt(call), ppos)
   }
 
   /**
@@ -407,9 +404,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(ArgumentPosition pos |
-      viableParam(call, pos, p) and
-      arg.argumentOf(call, pos) and
+    exists(ParameterPosition ppos |
+      viableParam(call, ppos, p) and
+      argumentPositionMatch(call, arg, ppos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -71,25 +71,31 @@ predicate accessPathCostLimits(int apLimit, int tupleLimit) {
  * calls. For this reason, we cannot reuse the code from `DataFlowImpl.qll` directly.
  */
 private module LambdaFlow {
-  private predicate viableParamNonLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallable(call), i)
+  private predicate viableParamNonLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallable(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
-  private predicate viableParamLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableLambda(call, _), i)
+  private predicate viableParamLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableLambda(call, _), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamNonLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamNonLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
   private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
@@ -322,7 +328,7 @@ private module Cached {
     or
     exists(ArgNode arg |
       result.(PostUpdateNode).getPreUpdateNode() = arg and
-      arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
+      arg.argumentOf(call, k.(ParamUpdateReturnKind).getAMatchingArgumentPosition())
     )
   }
 
@@ -330,7 +336,7 @@ private module Cached {
   predicate returnNodeExt(Node n, ReturnKindExt k) {
     k = TValueReturn(n.(ReturnNode).getKind())
     or
-    exists(ParamNode p, int pos |
+    exists(ParamNode p, ParameterPosition pos |
       parameterValueFlowsToPreUpdate(p, n) and
       p.isParameterOf(_, pos) and
       k = TParamUpdate(pos)
@@ -352,11 +358,13 @@ private module Cached {
   }
 
   cached
-  predicate parameterNode(Node p, DataFlowCallable c, int pos) { isParameterNode(p, c, pos) }
+  predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    isParameterNode(p, c, pos)
+  }
 
   cached
-  predicate argumentNode(Node n, DataFlowCall call, int pos) {
-    n.(ArgumentNode).argumentOf(call, pos)
+  predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
+    isArgumentNode(n, call, pos)
   }
 
   /**
@@ -374,12 +382,15 @@ private module Cached {
   }
 
   /**
-   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-   * The instance parameter is considered to have index `-1`.
+   * Holds if `p` is the parameter of a viable dispatch target of `call`,
+   * and `p` matches arguments at position `apos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableExt(call), i)
+  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableExt(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   /**
@@ -388,9 +399,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParam(call, i, p) and
-      arg.argumentOf(call, i) and
+    exists(ArgumentPosition pos |
+      viableParam(call, pos, p) and
+      arg.argumentOf(call, pos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }
@@ -862,7 +873,7 @@ private module Cached {
   cached
   newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
+    TParamUpdate(ParameterPosition pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
 
   cached
   newtype TBooleanOption =
@@ -1054,9 +1065,9 @@ class ParamNode extends Node {
 
   /**
    * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
+   * position.
    */
-  predicate isParameterOf(DataFlowCallable c, int i) { parameterNode(this, c, i) }
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { parameterNode(this, c, pos) }
 }
 
 /** A data-flow node that represents a call argument. */
@@ -1064,7 +1075,9 @@ class ArgNode extends Node {
   ArgNode() { argumentNode(this, _, _) }
 
   /** Holds if this argument occurs at the given position in the given call. */
-  final predicate argumentOf(DataFlowCall call, int pos) { argumentNode(this, call, pos) }
+  final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    argumentNode(this, call, pos)
+  }
 }
 
 /**
@@ -1110,11 +1123,14 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-  private int pos;
+  private ParameterPosition pos;
 
   ParamUpdateReturnKind() { this = TParamUpdate(pos) }
 
-  int getPosition() { result = pos }
+  ParameterPosition getPosition() { result = pos }
+
+  pragma[nomagic]
+  ArgumentPosition getAMatchingArgumentPosition() { parameterMatch(pos, result) }
 
   override string toString() { result = "param update " + pos }
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -8,7 +8,14 @@ private import DataFlowImplConsistency
 DataFlowCallable nodeGetEnclosingCallable(Node n) { result = n.getEnclosingCallable() }
 
 /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-predicate isParameterNode(ParameterNode p, DataFlowCallable c, int pos) { p.isParameterOf(c, pos) }
+predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos) {
+  p.isParameterOf(c, pos)
+}
+
+/** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
+predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos) {
+  arg.argumentOf(c, pos)
+}
 
 /**
  * A data flow node that occurs as the argument of a call and is passed as-is

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/FlowSummary.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/FlowSummary.qll
@@ -2,7 +2,11 @@
 
 import csharp
 private import internal.FlowSummaryImpl as Impl
-private import internal.DataFlowDispatch
+private import internal.DataFlowDispatch as DataFlowDispatch
+
+class ParameterPosition = DataFlowDispatch::ParameterPosition;
+
+class ArgumentPosition = DataFlowDispatch::ArgumentPosition;
 
 // import all instances below
 private module Summaries {
@@ -14,7 +18,27 @@ class SummaryComponent = Impl::Public::SummaryComponent;
 
 /** Provides predicates for constructing summary components. */
 module SummaryComponent {
-  import Impl::Public::SummaryComponent
+  private import Impl::Public::SummaryComponent as SummaryComponentInternal
+
+  predicate content = SummaryComponentInternal::content/1;
+
+  /** Gets a summary component for parameter `i`. */
+  SummaryComponent parameter(int i) {
+    exists(ArgumentPosition pos |
+      result = SummaryComponentInternal::parameter(pos) and
+      i = pos.getPosition()
+    )
+  }
+
+  /** Gets a summary component for argument `i`. */
+  SummaryComponent argument(int i) {
+    exists(ParameterPosition pos |
+      result = SummaryComponentInternal::argument(pos) and
+      i = pos.getPosition()
+    )
+  }
+
+  predicate return = SummaryComponentInternal::return/1;
 
   /** Gets a summary component that represents a qualifier. */
   SummaryComponent qualifier() { result = argument(-1) }
@@ -33,14 +57,14 @@ module SummaryComponent {
   }
 
   /** Gets a summary component that represents the return value of a call. */
-  SummaryComponent return() { result = return(any(NormalReturnKind rk)) }
+  SummaryComponent return() { result = return(any(DataFlowDispatch::NormalReturnKind rk)) }
 
   /** Gets a summary component that represents a jump to `c`. */
   SummaryComponent jump(Callable c) {
     result =
-      return(any(JumpReturnKind jrk |
+      return(any(DataFlowDispatch::JumpReturnKind jrk |
           jrk.getTarget() = c.getUnboundDeclaration() and
-          jrk.getTargetReturnKind() instanceof NormalReturnKind
+          jrk.getTargetReturnKind() instanceof DataFlowDispatch::NormalReturnKind
         ))
   }
 }
@@ -49,7 +73,16 @@ class SummaryComponentStack = Impl::Public::SummaryComponentStack;
 
 /** Provides predicates for constructing stacks of summary components. */
 module SummaryComponentStack {
-  import Impl::Public::SummaryComponentStack
+  private import Impl::Public::SummaryComponentStack as SummaryComponentStackInternal
+
+  predicate singleton = SummaryComponentStackInternal::singleton/1;
+
+  predicate push = SummaryComponentStackInternal::push/2;
+
+  /** Gets a singleton stack for argument `i`. */
+  SummaryComponentStack argument(int i) { result = singleton(SummaryComponent::argument(i)) }
+
+  predicate return = SummaryComponentStackInternal::return/1;
 
   /** Gets a singleton stack representing a qualifier. */
   SummaryComponentStack qualifier() { result = singleton(SummaryComponent::qualifier()) }
@@ -84,12 +117,12 @@ private class SummarizedCallableDefaultClearsContent extends Impl::Public::Summa
   }
 
   // By default, we assume that all stores into arguments are definite
-  override predicate clearsContent(int i, DataFlow::Content content) {
+  override predicate clearsContent(ParameterPosition pos, DataFlow::Content content) {
     exists(SummaryComponentStack output |
       this.propagatesFlow(_, output, _) and
       output.drop(_) =
         SummaryComponentStack::push(SummaryComponent::content(content),
-          SummaryComponentStack::argument(i)) and
+          SummaryComponentStack::argument(pos.getPosition())) and
       not content instanceof DataFlow::ElementContent
     )
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -465,10 +465,10 @@ private module FrameworkDataFlowAdaptor {
       )
     }
 
-    override predicate clearsContent(int i, Content content) {
+    override predicate clearsContent(ParameterPosition pos, Content content) {
       exists(SummaryComponentStack input |
         ltdf.clearsContent(toCallableFlowSource(input), content, this) and
-        input = SummaryComponentStack::singleton(SummaryComponent::argument(i))
+        input = SummaryComponentStack::argument(pos.getPosition())
       )
     }
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -391,14 +391,11 @@ private module Cached {
 
   /**
    * Holds if `p` is the parameter of a viable dispatch target of `call`,
-   * and `p` matches arguments at position `apos`.
+   * and `p` has position `ppos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
-    exists(ParameterPosition ppos |
-      p.isParameterOf(viableCallableExt(call), ppos) and
-      parameterMatch(ppos, apos)
-    )
+  private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    p.isParameterOf(viableCallableExt(call), ppos)
   }
 
   /**
@@ -407,9 +404,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(ArgumentPosition pos |
-      viableParam(call, pos, p) and
-      arg.argumentOf(call, pos) and
+    exists(ParameterPosition ppos |
+      viableParam(call, ppos, p) and
+      argumentPositionMatch(call, arg, ppos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -71,25 +71,31 @@ predicate accessPathCostLimits(int apLimit, int tupleLimit) {
  * calls. For this reason, we cannot reuse the code from `DataFlowImpl.qll` directly.
  */
 private module LambdaFlow {
-  private predicate viableParamNonLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallable(call), i)
+  private predicate viableParamNonLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallable(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
-  private predicate viableParamLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableLambda(call, _), i)
+  private predicate viableParamLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableLambda(call, _), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamNonLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamNonLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
   private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
@@ -322,7 +328,7 @@ private module Cached {
     or
     exists(ArgNode arg |
       result.(PostUpdateNode).getPreUpdateNode() = arg and
-      arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
+      arg.argumentOf(call, k.(ParamUpdateReturnKind).getAMatchingArgumentPosition())
     )
   }
 
@@ -330,7 +336,7 @@ private module Cached {
   predicate returnNodeExt(Node n, ReturnKindExt k) {
     k = TValueReturn(n.(ReturnNode).getKind())
     or
-    exists(ParamNode p, int pos |
+    exists(ParamNode p, ParameterPosition pos |
       parameterValueFlowsToPreUpdate(p, n) and
       p.isParameterOf(_, pos) and
       k = TParamUpdate(pos)
@@ -352,11 +358,13 @@ private module Cached {
   }
 
   cached
-  predicate parameterNode(Node p, DataFlowCallable c, int pos) { isParameterNode(p, c, pos) }
+  predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    isParameterNode(p, c, pos)
+  }
 
   cached
-  predicate argumentNode(Node n, DataFlowCall call, int pos) {
-    n.(ArgumentNode).argumentOf(call, pos)
+  predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
+    isArgumentNode(n, call, pos)
   }
 
   /**
@@ -374,12 +382,15 @@ private module Cached {
   }
 
   /**
-   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-   * The instance parameter is considered to have index `-1`.
+   * Holds if `p` is the parameter of a viable dispatch target of `call`,
+   * and `p` matches arguments at position `apos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableExt(call), i)
+  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableExt(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   /**
@@ -388,9 +399,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParam(call, i, p) and
-      arg.argumentOf(call, i) and
+    exists(ArgumentPosition pos |
+      viableParam(call, pos, p) and
+      arg.argumentOf(call, pos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }
@@ -862,7 +873,7 @@ private module Cached {
   cached
   newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
+    TParamUpdate(ParameterPosition pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
 
   cached
   newtype TBooleanOption =
@@ -1054,9 +1065,9 @@ class ParamNode extends Node {
 
   /**
    * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
+   * position.
    */
-  predicate isParameterOf(DataFlowCallable c, int i) { parameterNode(this, c, i) }
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { parameterNode(this, c, pos) }
 }
 
 /** A data-flow node that represents a call argument. */
@@ -1064,7 +1075,9 @@ class ArgNode extends Node {
   ArgNode() { argumentNode(this, _, _) }
 
   /** Holds if this argument occurs at the given position in the given call. */
-  final predicate argumentOf(DataFlowCall call, int pos) { argumentNode(this, call, pos) }
+  final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    argumentNode(this, call, pos)
+  }
 }
 
 /**
@@ -1110,11 +1123,14 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-  private int pos;
+  private ParameterPosition pos;
 
   ParamUpdateReturnKind() { this = TParamUpdate(pos) }
 
-  int getPosition() { result = pos }
+  ParameterPosition getPosition() { result = pos }
+
+  pragma[nomagic]
+  ArgumentPosition getAMatchingArgumentPosition() { parameterMatch(pos, result) }
 
   override string toString() { result = "param update " + pos }
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
@@ -12,7 +12,6 @@ private import semmle.code.csharp.dataflow.CallContext
 private import semmle.code.csharp.dataflow.internal.DataFlowDispatch
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
 private import semmle.code.csharp.dataflow.internal.DataFlowPublic
-private import semmle.code.csharp.dataflow.FlowSummary
 private import semmle.code.csharp.dispatch.Dispatch
 private import semmle.code.csharp.frameworks.system.linq.Expressions
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -144,11 +144,13 @@ module Public {
     noComponentSpecificCsv(sc) and
     (
       exists(ArgumentPosition pos |
-        sc = TParameterSummaryComponent(pos) and result = "Parameter[" + pos + "]"
+        sc = TParameterSummaryComponent(pos) and
+        result = "Parameter[" + getArgumentPositionCsv(pos) + "]"
       )
       or
       exists(ParameterPosition pos |
-        sc = TArgumentSummaryComponent(pos) and result = "Argument[" + pos + "]"
+        sc = TArgumentSummaryComponent(pos) and
+        result = "Argument[" + getParameterPositionCsv(pos) + "]"
       )
       or
       sc = TReturnSummaryComponent(getReturnValueKind()) and result = "ReturnValue"

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -26,9 +26,13 @@ module Public {
     string toString() {
       exists(Content c | this = TContentSummaryComponent(c) and result = c.toString())
       or
-      exists(int i | this = TParameterSummaryComponent(i) and result = "parameter " + i)
+      exists(ArgumentPosition pos |
+        this = TParameterSummaryComponent(pos) and result = "parameter " + pos
+      )
       or
-      exists(int i | this = TArgumentSummaryComponent(i) and result = "argument " + i)
+      exists(ParameterPosition pos |
+        this = TArgumentSummaryComponent(pos) and result = "argument " + pos
+      )
       or
       exists(ReturnKind rk | this = TReturnSummaryComponent(rk) and result = "return (" + rk + ")")
     }
@@ -39,11 +43,11 @@ module Public {
     /** Gets a summary component for content `c`. */
     SummaryComponent content(Content c) { result = TContentSummaryComponent(c) }
 
-    /** Gets a summary component for parameter `i`. */
-    SummaryComponent parameter(int i) { result = TParameterSummaryComponent(i) }
+    /** Gets a summary component for a parameter at position `pos`. */
+    SummaryComponent parameter(ArgumentPosition pos) { result = TParameterSummaryComponent(pos) }
 
-    /** Gets a summary component for argument `i`. */
-    SummaryComponent argument(int i) { result = TArgumentSummaryComponent(i) }
+    /** Gets a summary component for an argument at position `pos`. */
+    SummaryComponent argument(ParameterPosition pos) { result = TArgumentSummaryComponent(pos) }
 
     /** Gets a summary component for a return of kind `rk`. */
     SummaryComponent return(ReturnKind rk) { result = TReturnSummaryComponent(rk) }
@@ -120,8 +124,10 @@ module Public {
       result = TConsSummaryComponentStack(head, tail)
     }
 
-    /** Gets a singleton stack for argument `i`. */
-    SummaryComponentStack argument(int i) { result = singleton(SummaryComponent::argument(i)) }
+    /** Gets a singleton stack for an argument at position `pos`. */
+    SummaryComponentStack argument(ParameterPosition pos) {
+      result = singleton(SummaryComponent::argument(pos))
+    }
 
     /** Gets a singleton stack representing a return of kind `rk`. */
     SummaryComponentStack return(ReturnKind rk) { result = singleton(SummaryComponent::return(rk)) }
@@ -137,9 +143,13 @@ module Public {
     or
     noComponentSpecificCsv(sc) and
     (
-      exists(int i | sc = TParameterSummaryComponent(i) and result = "Parameter[" + i + "]")
+      exists(ArgumentPosition pos |
+        sc = TParameterSummaryComponent(pos) and result = "Parameter[" + pos + "]"
+      )
       or
-      exists(int i | sc = TArgumentSummaryComponent(i) and result = "Argument[" + i + "]")
+      exists(ParameterPosition pos |
+        sc = TArgumentSummaryComponent(pos) and result = "Argument[" + pos + "]"
+      )
       or
       sc = TReturnSummaryComponent(getReturnValueKind()) and result = "ReturnValue"
     )
@@ -201,10 +211,10 @@ module Public {
 
     /**
      * Holds if values stored inside `content` are cleared on objects passed as
-     * the `i`th argument to this callable.
+     * arguments at position `pos` to this callable.
      */
     pragma[nomagic]
-    predicate clearsContent(int i, Content content) { none() }
+    predicate clearsContent(ParameterPosition pos, Content content) { none() }
   }
 }
 
@@ -217,11 +227,11 @@ module Private {
 
   newtype TSummaryComponent =
     TContentSummaryComponent(Content c) or
-    TParameterSummaryComponent(int i) { parameterPosition(i) } or
-    TArgumentSummaryComponent(int i) { parameterPosition(i) } or
+    TParameterSummaryComponent(ArgumentPosition pos) or
+    TArgumentSummaryComponent(ParameterPosition pos) or
     TReturnSummaryComponent(ReturnKind rk)
 
-  private TSummaryComponent thisParam() {
+  private TParameterSummaryComponent thisParam() {
     result = TParameterSummaryComponent(instanceParameterPosition())
   }
 
@@ -285,9 +295,9 @@ module Private {
 
   /**
    * Holds if `c` has a flow summary from `input` to `arg`, where `arg`
-   * writes to (contents of) the `i`th argument, and `c` has a
-   * value-preserving flow summary from the `i`th argument to a return value
-   * (`return`).
+   * writes to (contents of) arguments at position `pos`, and `c` has a
+   * value-preserving flow summary from the arguments at position `pos`
+   * to a return value (`return`).
    *
    * In such a case, we derive flow from `input` to (contents of) the return
    * value.
@@ -302,10 +312,10 @@ module Private {
     SummarizedCallable c, SummaryComponentStack input, SummaryComponentStack arg,
     SummaryComponentStack return, boolean preservesValue
   ) {
-    exists(int i |
+    exists(ParameterPosition pos |
       summary(c, input, arg, preservesValue) and
-      isContentOfArgument(arg, i) and
-      summary(c, SummaryComponentStack::singleton(TArgumentSummaryComponent(i)), return, true) and
+      isContentOfArgument(arg, pos) and
+      summary(c, SummaryComponentStack::argument(pos), return, true) and
       return.bottom() = TReturnSummaryComponent(_)
     )
   }
@@ -330,10 +340,10 @@ module Private {
     s.head() = TParameterSummaryComponent(_) and exists(s.tail())
   }
 
-  private predicate isContentOfArgument(SummaryComponentStack s, int i) {
-    s.head() = TContentSummaryComponent(_) and isContentOfArgument(s.tail(), i)
+  private predicate isContentOfArgument(SummaryComponentStack s, ParameterPosition pos) {
+    s.head() = TContentSummaryComponent(_) and isContentOfArgument(s.tail(), pos)
     or
-    s = TSingletonSummaryComponentStack(TArgumentSummaryComponent(i))
+    s = SummaryComponentStack::argument(pos)
   }
 
   private predicate outputState(SummarizedCallable c, SummaryComponentStack s) {
@@ -364,8 +374,8 @@ module Private {
   private newtype TSummaryNodeState =
     TSummaryNodeInputState(SummaryComponentStack s) { inputState(_, s) } or
     TSummaryNodeOutputState(SummaryComponentStack s) { outputState(_, s) } or
-    TSummaryNodeClearsContentState(int i, boolean post) {
-      any(SummarizedCallable sc).clearsContent(i, _) and post in [false, true]
+    TSummaryNodeClearsContentState(ParameterPosition pos, boolean post) {
+      any(SummarizedCallable sc).clearsContent(pos, _) and post in [false, true]
     }
 
   /**
@@ -414,21 +424,23 @@ module Private {
         result = "to write: " + s
       )
       or
-      exists(int i, boolean post, string postStr |
-        this = TSummaryNodeClearsContentState(i, post) and
+      exists(ParameterPosition pos, boolean post, string postStr |
+        this = TSummaryNodeClearsContentState(pos, post) and
         (if post = true then postStr = " (post)" else postStr = "") and
-        result = "clear: " + i + postStr
+        result = "clear: " + pos + postStr
       )
     }
   }
 
   /**
-   * Holds if `state` represents having read the `i`th argument for `c`. In this case
-   * we are not synthesizing a data-flow node, but instead assume that a relevant
-   * parameter node already exists.
+   * Holds if `state` represents having read from a parameter at position
+   * `pos` in `c`. In this case we are not synthesizing a data-flow node,
+   * but instead assume that a relevant parameter node already exists.
    */
-  private predicate parameterReadState(SummarizedCallable c, SummaryNodeState state, int i) {
-    state.isInputState(c, SummaryComponentStack::argument(i))
+  private predicate parameterReadState(
+    SummarizedCallable c, SummaryNodeState state, ParameterPosition pos
+  ) {
+    state.isInputState(c, SummaryComponentStack::argument(pos))
   }
 
   /**
@@ -441,9 +453,9 @@ module Private {
     or
     state.isOutputState(c, _)
     or
-    exists(int i |
-      c.clearsContent(i, _) and
-      state = TSummaryNodeClearsContentState(i, _)
+    exists(ParameterPosition pos |
+      c.clearsContent(pos, _) and
+      state = TSummaryNodeClearsContentState(pos, _)
     )
   }
 
@@ -452,9 +464,9 @@ module Private {
     exists(SummaryNodeState state | state.isInputState(c, s) |
       result = summaryNode(c, state)
       or
-      exists(int i |
-        parameterReadState(c, state, i) and
-        result.(ParamNode).isParameterOf(c, i)
+      exists(ParameterPosition pos |
+        parameterReadState(c, state, pos) and
+        result.(ParamNode).isParameterOf(c, pos)
       )
     )
   }
@@ -468,20 +480,20 @@ module Private {
   }
 
   /**
-   * Holds if a write targets `post`, which is a post-update node for the `i`th
-   * parameter of `c`.
+   * Holds if a write targets `post`, which is a post-update node for a
+   * parameter at position `pos` in `c`.
    */
-  private predicate isParameterPostUpdate(Node post, SummarizedCallable c, int i) {
-    post = summaryNodeOutputState(c, SummaryComponentStack::argument(i))
+  private predicate isParameterPostUpdate(Node post, SummarizedCallable c, ParameterPosition pos) {
+    post = summaryNodeOutputState(c, SummaryComponentStack::argument(pos))
   }
 
-  /** Holds if a parameter node is required for the `i`th parameter of `c`. */
-  predicate summaryParameterNodeRange(SummarizedCallable c, int i) {
-    parameterReadState(c, _, i)
+  /** Holds if a parameter node at position `pos` is required for `c`. */
+  predicate summaryParameterNodeRange(SummarizedCallable c, ParameterPosition pos) {
+    parameterReadState(c, _, pos)
     or
-    isParameterPostUpdate(_, c, i)
+    isParameterPostUpdate(_, c, pos)
     or
-    c.clearsContent(i, _)
+    c.clearsContent(pos, _)
   }
 
   private predicate callbackOutput(
@@ -493,10 +505,10 @@ module Private {
   }
 
   private predicate callbackInput(
-    SummarizedCallable c, SummaryComponentStack s, Node receiver, int i
+    SummarizedCallable c, SummaryComponentStack s, Node receiver, ArgumentPosition pos
   ) {
     any(SummaryNodeState state).isOutputState(c, s) and
-    s.head() = TParameterSummaryComponent(i) and
+    s.head() = TParameterSummaryComponent(pos) and
     receiver = summaryNodeInputState(c, s.drop(1))
   }
 
@@ -547,17 +559,17 @@ module Private {
           result = getReturnType(c, rk)
         )
         or
-        exists(int i | head = TParameterSummaryComponent(i) |
+        exists(ArgumentPosition pos | head = TParameterSummaryComponent(pos) |
           result =
             getCallbackParameterType(getNodeType(summaryNodeInputState(pragma[only_bind_out](c),
-                  s.drop(1))), i)
+                  s.drop(1))), pos)
         )
       )
     )
     or
-    exists(SummarizedCallable c, int i, ParamNode p |
-      n = summaryNode(c, TSummaryNodeClearsContentState(i, false)) and
-      p.isParameterOf(c, i) and
+    exists(SummarizedCallable c, ParameterPosition pos, ParamNode p |
+      n = summaryNode(c, TSummaryNodeClearsContentState(pos, false)) and
+      p.isParameterOf(c, pos) and
       result = getNodeType(p)
     )
   }
@@ -571,10 +583,10 @@ module Private {
     )
   }
 
-  /** Holds if summary node `arg` is the `i`th argument of call `c`. */
-  predicate summaryArgumentNode(DataFlowCall c, Node arg, int i) {
+  /** Holds if summary node `arg` is at position `pos` in the call `c`. */
+  predicate summaryArgumentNode(DataFlowCall c, Node arg, ArgumentPosition pos) {
     exists(SummarizedCallable callable, SummaryComponentStack s, Node receiver |
-      callbackInput(callable, s, receiver, i) and
+      callbackInput(callable, s, receiver, pos) and
       arg = summaryNodeOutputState(callable, s) and
       c = summaryDataFlowCall(receiver)
     )
@@ -582,12 +594,12 @@ module Private {
 
   /** Holds if summary node `post` is a post-update node with pre-update node `pre`. */
   predicate summaryPostUpdateNode(Node post, Node pre) {
-    exists(SummarizedCallable c, int i |
-      isParameterPostUpdate(post, c, i) and
-      pre.(ParamNode).isParameterOf(c, i)
+    exists(SummarizedCallable c, ParameterPosition pos |
+      isParameterPostUpdate(post, c, pos) and
+      pre.(ParamNode).isParameterOf(c, pos)
       or
-      pre = summaryNode(c, TSummaryNodeClearsContentState(i, false)) and
-      post = summaryNode(c, TSummaryNodeClearsContentState(i, true))
+      pre = summaryNode(c, TSummaryNodeClearsContentState(pos, false)) and
+      post = summaryNode(c, TSummaryNodeClearsContentState(pos, true))
     )
     or
     exists(SummarizedCallable callable, SummaryComponentStack s |
@@ -610,13 +622,13 @@ module Private {
    * node, and back out to `p`.
    */
   predicate summaryAllowParameterReturnInSelf(ParamNode p) {
-    exists(SummarizedCallable c, int i | p.isParameterOf(c, i) |
-      c.clearsContent(i, _)
+    exists(SummarizedCallable c, ParameterPosition ppos | p.isParameterOf(c, ppos) |
+      c.clearsContent(ppos, _)
       or
       exists(SummaryComponentStack inputContents, SummaryComponentStack outputContents |
         summary(c, inputContents, outputContents, _) and
-        inputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(i)) and
-        outputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(i))
+        inputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(ppos)) and
+        outputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(ppos))
       )
     )
   }
@@ -641,9 +653,9 @@ module Private {
         preservesValue = false and not summary(c, inputContents, outputContents, true)
       )
       or
-      exists(SummarizedCallable c, int i |
-        pred.(ParamNode).isParameterOf(c, i) and
-        succ = summaryNode(c, TSummaryNodeClearsContentState(i, _)) and
+      exists(SummarizedCallable c, ParameterPosition pos |
+        pred.(ParamNode).isParameterOf(c, pos) and
+        succ = summaryNode(c, TSummaryNodeClearsContentState(pos, _)) and
         preservesValue = true
       )
     }
@@ -692,9 +704,9 @@ module Private {
      * node where field `b` is cleared).
      */
     predicate summaryClearsContent(Node n, Content c) {
-      exists(SummarizedCallable sc, int i |
-        n = summaryNode(sc, TSummaryNodeClearsContentState(i, true)) and
-        sc.clearsContent(i, c)
+      exists(SummarizedCallable sc, ParameterPosition pos |
+        n = summaryNode(sc, TSummaryNodeClearsContentState(pos, true)) and
+        sc.clearsContent(pos, c)
       )
     }
 
@@ -706,18 +718,23 @@ module Private {
      * `arg` (see comment for `summaryClearsContent`).
      */
     predicate summaryClearsContentArg(ArgNode arg, Content c) {
-      exists(DataFlowCall call, int i |
-        viableCallable(call).(SummarizedCallable).clearsContent(i, c) and
-        arg.argumentOf(call, i)
+      exists(DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos |
+        viableCallable(call).(SummarizedCallable).clearsContent(ppos, c) and
+        arg.argumentOf(call, apos) and
+        parameterMatch(ppos, apos)
       )
     }
 
     pragma[nomagic]
     private ParamNode summaryArgParam(ArgNode arg, ReturnKindExt rk, OutNodeExt out) {
-      exists(DataFlowCall call, int pos, SummarizedCallable callable |
-        arg.argumentOf(call, pos) and
+      exists(
+        DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos,
+        SummarizedCallable callable
+      |
+        arg.argumentOf(call, apos) and
         viableCallable(call) = callable and
-        result.isParameterOf(callable, pos) and
+        result.isParameterOf(callable, ppos) and
+        parameterMatch(ppos, apos) and
         out = rk.getAnOutNode(call)
       )
     }
@@ -795,39 +812,33 @@ module Private {
     }
 
     /** Holds if specification component `c` parses as parameter `n`. */
-    predicate parseParam(string c, int n) {
+    predicate parseParam(string c, ArgumentPosition pos) {
       specSplit(_, c, _) and
-      (
-        c.regexpCapture("Parameter\\[([-0-9]+)\\]", 1).toInt() = n
-        or
-        exists(int n1, int n2 |
-          c.regexpCapture("Parameter\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = n1 and
-          c.regexpCapture("Parameter\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = n2 and
-          n = [n1 .. n2]
-        )
+      exists(string body |
+        body = c.regexpCapture("Parameter\\[([^\\]]*)\\]", 1) and
+        pos = parseParamBody(body)
       )
     }
 
     /** Holds if specification component `c` parses as argument `n`. */
-    predicate parseArg(string c, int n) {
+    predicate parseArg(string c, ParameterPosition pos) {
       specSplit(_, c, _) and
-      (
-        c.regexpCapture("Argument\\[([-0-9]+)\\]", 1).toInt() = n
-        or
-        exists(int n1, int n2 |
-          c.regexpCapture("Argument\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = n1 and
-          c.regexpCapture("Argument\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = n2 and
-          n = [n1 .. n2]
-        )
+      exists(string body |
+        body = c.regexpCapture("Argument\\[([^\\]]*)\\]", 1) and
+        pos = parseArgBody(body)
       )
     }
 
     private SummaryComponent interpretComponent(string c) {
       specSplit(_, c, _) and
       (
-        exists(int pos | parseArg(c, pos) and result = SummaryComponent::argument(pos))
+        exists(ParameterPosition pos |
+          parseArg(c, pos) and result = SummaryComponent::argument(pos)
+        )
         or
-        exists(int pos | parseParam(c, pos) and result = SummaryComponent::parameter(pos))
+        exists(ArgumentPosition pos |
+          parseParam(c, pos) and result = SummaryComponent::parameter(pos)
+        )
         or
         c = "ReturnValue" and result = SummaryComponent::return(getReturnValueKind())
         or
@@ -934,14 +945,18 @@ module Private {
         interpretOutput(output, idx + 1, ref, mid) and
         specSplit(output, c, idx)
       |
-        exists(int pos |
-          node.asNode().(PostUpdateNode).getPreUpdateNode().(ArgNode).argumentOf(mid.asCall(), pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(PostUpdateNode).getPreUpdateNode().(ArgNode).argumentOf(mid.asCall(), apos) and
+          parameterMatch(ppos, apos)
         |
-          c = "Argument" or parseArg(c, pos)
+          c = "Argument" or parseArg(c, ppos)
         )
         or
-        exists(int pos | node.asNode().(ParamNode).isParameterOf(mid.asCallable(), pos) |
-          c = "Parameter" or parseParam(c, pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(ParamNode).isParameterOf(mid.asCallable(), ppos) and
+          parameterMatch(ppos, apos)
+        |
+          c = "Parameter" or parseParam(c, apos)
         )
         or
         c = "ReturnValue" and
@@ -960,8 +975,11 @@ module Private {
         interpretInput(input, idx + 1, ref, mid) and
         specSplit(input, c, idx)
       |
-        exists(int pos | node.asNode().(ArgNode).argumentOf(mid.asCall(), pos) |
-          c = "Argument" or parseArg(c, pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(ArgNode).argumentOf(mid.asCall(), apos) and
+          parameterMatch(ppos, apos)
+        |
+          c = "Argument" or parseArg(c, ppos)
         )
         or
         exists(ReturnNodeExt ret |
@@ -1110,9 +1128,9 @@ module Private {
       b.asCall() = summaryDataFlowCall(a.asNode()) and
       value = "receiver"
       or
-      exists(int i |
-        summaryArgumentNode(b.asCall(), a.asNode(), i) and
-        value = "argument (" + i + ")"
+      exists(ArgumentPosition pos |
+        summaryArgumentNode(b.asCall(), a.asNode(), pos) and
+        value = "argument (" + pos + ")"
       )
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -710,6 +710,14 @@ module Private {
       )
     }
 
+    pragma[noinline]
+    private predicate viableParam(
+      DataFlowCall call, SummarizedCallable sc, ParameterPosition ppos, ParamNode p
+    ) {
+      p.isParameterOf(sc, ppos) and
+      sc = viableCallable(call)
+    }
+
     /**
      * Holds if values stored inside content `c` are cleared inside a
      * callable to which `arg` is an argument.
@@ -718,23 +726,18 @@ module Private {
      * `arg` (see comment for `summaryClearsContent`).
      */
     predicate summaryClearsContentArg(ArgNode arg, Content c) {
-      exists(DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos |
-        viableCallable(call).(SummarizedCallable).clearsContent(ppos, c) and
-        arg.argumentOf(call, apos) and
-        parameterMatch(ppos, apos)
+      exists(DataFlowCall call, SummarizedCallable sc, ParameterPosition ppos |
+        argumentPositionMatch(call, arg, ppos) and
+        viableParam(call, sc, ppos, _) and
+        sc.clearsContent(ppos, c)
       )
     }
 
     pragma[nomagic]
     private ParamNode summaryArgParam(ArgNode arg, ReturnKindExt rk, OutNodeExt out) {
-      exists(
-        DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos,
-        SummarizedCallable callable
-      |
-        arg.argumentOf(call, apos) and
-        viableCallable(call) = callable and
-        result.isParameterOf(callable, ppos) and
-        parameterMatch(ppos, apos) and
+      exists(DataFlowCall call, ParameterPosition ppos, SummarizedCallable sc |
+        argumentPositionMatch(call, arg, ppos) and
+        viableParam(call, sc, ppos, result) and
         out = rk.getAnOutNode(call)
       )
     }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -156,6 +156,12 @@ string getComponentSpecificCsv(SummaryComponent sc) {
   )
 }
 
+/** Gets the textual representation of a parameter position in the format used for flow summaries. */
+string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() }
+
+/** Gets the textual representation of an argument position in the format used for flow summaries. */
+string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
+
 class SourceOrSinkElement = Element;
 
 /** Gets the return kind corresponding to specification `"ReturnValue"`. */
@@ -222,18 +228,21 @@ predicate interpretInputSpecific(string c, InterpretNode mid, InterpretNode n) {
   )
 }
 
-/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
 bindingset[s]
-ArgumentPosition parseParamBody(string s) {
-  result.getPosition() = s.regexpCapture("([-0-9]+)", 1).toInt()
+private int parsePosition(string s) {
+  result = s.regexpCapture("([-0-9]+)", 1).toInt()
   or
   exists(int n1, int n2 |
     s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 1).toInt() = n1 and
     s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 2).toInt() = n2 and
-    result.getPosition() in [n1 .. n2]
+    result in [n1 .. n2]
   )
 }
 
+/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
+bindingset[s]
+ArgumentPosition parseParamBody(string s) { result.getPosition() = parsePosition(s) }
+
 /** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
 bindingset[s]
-ParameterPosition parseArgBody(string s) { result.getPosition() = parseParamBody(s).getPosition() }
+ParameterPosition parseArgBody(string s) { result.getPosition() = parsePosition(s) }

--- a/csharp/ql/test/library-tests/dataflow/external-models/steps.ql
+++ b/csharp/ql/test/library-tests/dataflow/external-models/steps.ql
@@ -42,7 +42,7 @@ query predicate summarySetterStep(DataFlow::Node arg, DataFlow::Node out, Conten
   FlowSummaryImpl::Private::Steps::summarySetterStep(arg, c, out)
 }
 
-query predicate clearsContent(SummarizedCallable c, DataFlow::Content k, int i) {
-  c.clearsContent(i, k) and
+query predicate clearsContent(SummarizedCallable c, DataFlow::Content k, ParameterPosition pos) {
+  c.clearsContent(pos, k) and
   c.fromSource()
 }

--- a/docs/ql-libraries/dataflow/dataflow.md
+++ b/docs/ql-libraries/dataflow/dataflow.md
@@ -148,23 +148,31 @@ methods, constructors, lambdas, etc.). It can also be useful to represent
 `DataFlowCall` as an IPA type if implicit calls need to be modelled. The
 call-graph should be defined as a predicate:
 ```ql
+/** Gets a viable target for the call `c`. */
 DataFlowCallable viableCallable(DataFlowCall c)
 ```
 Furthermore, each `Node` must be associated with exactly one callable and this
 relation should be defined as:
 ```ql
+/** Gets the callable in which node `n` occurs. */
 DataFlowCallable nodeGetEnclosingCallable(Node n)
 ```
 
 In order to connect data-flow across calls, the 4 `Node` subclasses
 `ArgumentNode`, `ParameterNode`, `ReturnNode`, and `OutNode` are used.
-Flow into callables from arguments to parameters are matched up using an
-integer position, so these two predicates must be defined:
+Flow into callables from arguments to parameters are matched up using
+language-defined classes `ParameterPosition` and `ArgumentPosition`,
+so these three predicates must be defined:
 ```ql
-ArgumentNode::argumentOf(DataFlowCall call, int pos)
-predicate isParameterNode(ParameterNode p, DataFlowCallable c, int pos)
+/** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
+predicate isParameterNode(ParameterNodeImpl p, DataFlowCallable c, ParameterPosition pos)
+
+/** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
+predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos)
+
+/** Holds if arguments at position `apos` match parameters at position `ppos`. */
+predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos)
 ```
-It is typical to use `pos = -1` for an implicit `this`-parameter.
 
 For most languages return-flow is simpler and merely consists of matching up a
 `ReturnNode` with the data-flow node corresponding to the value of the call,
@@ -174,8 +182,13 @@ calls and `OutNode`s:
 ```ql
 private newtype TReturnKind = TNormalReturnKind()
 
+/** Gets the kind of this return node. */
 ReturnKind ReturnNode::getKind() { any() }
 
+/**
+ * Gets a node that can read the value returned from `call` with return kind
+ * `kind`.
+ */
 OutNode getAnOutNode(DataFlowCall call, ReturnKind kind) {
   result = call.getNode() and
   kind = TNormalReturnKind()

--- a/docs/ql-libraries/dataflow/dataflow.md
+++ b/docs/ql-libraries/dataflow/dataflow.md
@@ -165,7 +165,7 @@ language-defined classes `ParameterPosition` and `ArgumentPosition`,
 so these three predicates must be defined:
 ```ql
 /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-predicate isParameterNode(ParameterNodeImpl p, DataFlowCallable c, ParameterPosition pos)
+predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos)
 
 /** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
 predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
@@ -183,6 +183,22 @@ private module DispatchImpl {
       )
     )
   }
+
+  private int parameterPosition() { result in [-1, any(Parameter p).getPosition()] }
+
+  /** A parameter position represented by an integer. */
+  class ParameterPosition extends int {
+    ParameterPosition() { this = parameterPosition() }
+  }
+
+  /** An argument position represented by an integer. */
+  class ArgumentPosition extends int {
+    ArgumentPosition() { this = parameterPosition() }
+  }
+
+  /** Holds if arguments at position `apos` match parameters at position `ppos`. */
+  pragma[inline]
+  predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }
 }
 
 import DispatchImpl

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -391,14 +391,11 @@ private module Cached {
 
   /**
    * Holds if `p` is the parameter of a viable dispatch target of `call`,
-   * and `p` matches arguments at position `apos`.
+   * and `p` has position `ppos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
-    exists(ParameterPosition ppos |
-      p.isParameterOf(viableCallableExt(call), ppos) and
-      parameterMatch(ppos, apos)
-    )
+  private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    p.isParameterOf(viableCallableExt(call), ppos)
   }
 
   /**
@@ -407,9 +404,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(ArgumentPosition pos |
-      viableParam(call, pos, p) and
-      arg.argumentOf(call, pos) and
+    exists(ParameterPosition ppos |
+      viableParam(call, ppos, p) and
+      argumentPositionMatch(call, arg, ppos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -71,25 +71,31 @@ predicate accessPathCostLimits(int apLimit, int tupleLimit) {
  * calls. For this reason, we cannot reuse the code from `DataFlowImpl.qll` directly.
  */
 private module LambdaFlow {
-  private predicate viableParamNonLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallable(call), i)
+  private predicate viableParamNonLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallable(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
-  private predicate viableParamLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableLambda(call, _), i)
+  private predicate viableParamLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableLambda(call, _), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamNonLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamNonLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
   private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
@@ -322,7 +328,7 @@ private module Cached {
     or
     exists(ArgNode arg |
       result.(PostUpdateNode).getPreUpdateNode() = arg and
-      arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
+      arg.argumentOf(call, k.(ParamUpdateReturnKind).getAMatchingArgumentPosition())
     )
   }
 
@@ -330,7 +336,7 @@ private module Cached {
   predicate returnNodeExt(Node n, ReturnKindExt k) {
     k = TValueReturn(n.(ReturnNode).getKind())
     or
-    exists(ParamNode p, int pos |
+    exists(ParamNode p, ParameterPosition pos |
       parameterValueFlowsToPreUpdate(p, n) and
       p.isParameterOf(_, pos) and
       k = TParamUpdate(pos)
@@ -352,11 +358,13 @@ private module Cached {
   }
 
   cached
-  predicate parameterNode(Node p, DataFlowCallable c, int pos) { isParameterNode(p, c, pos) }
+  predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    isParameterNode(p, c, pos)
+  }
 
   cached
-  predicate argumentNode(Node n, DataFlowCall call, int pos) {
-    n.(ArgumentNode).argumentOf(call, pos)
+  predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
+    isArgumentNode(n, call, pos)
   }
 
   /**
@@ -374,12 +382,15 @@ private module Cached {
   }
 
   /**
-   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-   * The instance parameter is considered to have index `-1`.
+   * Holds if `p` is the parameter of a viable dispatch target of `call`,
+   * and `p` matches arguments at position `apos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableExt(call), i)
+  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableExt(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   /**
@@ -388,9 +399,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParam(call, i, p) and
-      arg.argumentOf(call, i) and
+    exists(ArgumentPosition pos |
+      viableParam(call, pos, p) and
+      arg.argumentOf(call, pos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }
@@ -862,7 +873,7 @@ private module Cached {
   cached
   newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
+    TParamUpdate(ParameterPosition pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
 
   cached
   newtype TBooleanOption =
@@ -1054,9 +1065,9 @@ class ParamNode extends Node {
 
   /**
    * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
+   * position.
    */
-  predicate isParameterOf(DataFlowCallable c, int i) { parameterNode(this, c, i) }
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { parameterNode(this, c, pos) }
 }
 
 /** A data-flow node that represents a call argument. */
@@ -1064,7 +1075,9 @@ class ArgNode extends Node {
   ArgNode() { argumentNode(this, _, _) }
 
   /** Holds if this argument occurs at the given position in the given call. */
-  final predicate argumentOf(DataFlowCall call, int pos) { argumentNode(this, call, pos) }
+  final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    argumentNode(this, call, pos)
+  }
 }
 
 /**
@@ -1110,11 +1123,14 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-  private int pos;
+  private ParameterPosition pos;
 
   ParamUpdateReturnKind() { this = TParamUpdate(pos) }
 
-  int getPosition() { result = pos }
+  ParameterPosition getPosition() { result = pos }
+
+  pragma[nomagic]
+  ArgumentPosition getAMatchingArgumentPosition() { parameterMatch(pos, result) }
 
   override string toString() { result = "param update " + pos }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
@@ -310,6 +310,8 @@ private class ImplicitExprPostUpdate extends ImplicitPostUpdateNode, TImplicitEx
 }
 
 module Private {
+  private import DataFlowDispatch
+
   /** Gets the callable in which this node occurs. */
   DataFlowCallable nodeGetEnclosingCallable(Node n) {
     result.asCallable() = n.asExpr().getEnclosingCallable() or
@@ -324,8 +326,13 @@ module Private {
   }
 
   /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-  predicate isParameterNode(ParameterNode p, DataFlowCallable c, int pos) {
+  predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos) {
     p.isParameterOf(c.asCallable(), pos)
+  }
+
+  /** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
+  predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos) {
+    arg.argumentOf(c, pos)
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -144,11 +144,13 @@ module Public {
     noComponentSpecificCsv(sc) and
     (
       exists(ArgumentPosition pos |
-        sc = TParameterSummaryComponent(pos) and result = "Parameter[" + pos + "]"
+        sc = TParameterSummaryComponent(pos) and
+        result = "Parameter[" + getArgumentPositionCsv(pos) + "]"
       )
       or
       exists(ParameterPosition pos |
-        sc = TArgumentSummaryComponent(pos) and result = "Argument[" + pos + "]"
+        sc = TArgumentSummaryComponent(pos) and
+        result = "Argument[" + getParameterPositionCsv(pos) + "]"
       )
       or
       sc = TReturnSummaryComponent(getReturnValueKind()) and result = "ReturnValue"

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -26,9 +26,13 @@ module Public {
     string toString() {
       exists(Content c | this = TContentSummaryComponent(c) and result = c.toString())
       or
-      exists(int i | this = TParameterSummaryComponent(i) and result = "parameter " + i)
+      exists(ArgumentPosition pos |
+        this = TParameterSummaryComponent(pos) and result = "parameter " + pos
+      )
       or
-      exists(int i | this = TArgumentSummaryComponent(i) and result = "argument " + i)
+      exists(ParameterPosition pos |
+        this = TArgumentSummaryComponent(pos) and result = "argument " + pos
+      )
       or
       exists(ReturnKind rk | this = TReturnSummaryComponent(rk) and result = "return (" + rk + ")")
     }
@@ -39,11 +43,11 @@ module Public {
     /** Gets a summary component for content `c`. */
     SummaryComponent content(Content c) { result = TContentSummaryComponent(c) }
 
-    /** Gets a summary component for parameter `i`. */
-    SummaryComponent parameter(int i) { result = TParameterSummaryComponent(i) }
+    /** Gets a summary component for a parameter at position `pos`. */
+    SummaryComponent parameter(ArgumentPosition pos) { result = TParameterSummaryComponent(pos) }
 
-    /** Gets a summary component for argument `i`. */
-    SummaryComponent argument(int i) { result = TArgumentSummaryComponent(i) }
+    /** Gets a summary component for an argument at position `pos`. */
+    SummaryComponent argument(ParameterPosition pos) { result = TArgumentSummaryComponent(pos) }
 
     /** Gets a summary component for a return of kind `rk`. */
     SummaryComponent return(ReturnKind rk) { result = TReturnSummaryComponent(rk) }
@@ -120,8 +124,10 @@ module Public {
       result = TConsSummaryComponentStack(head, tail)
     }
 
-    /** Gets a singleton stack for argument `i`. */
-    SummaryComponentStack argument(int i) { result = singleton(SummaryComponent::argument(i)) }
+    /** Gets a singleton stack for an argument at position `pos`. */
+    SummaryComponentStack argument(ParameterPosition pos) {
+      result = singleton(SummaryComponent::argument(pos))
+    }
 
     /** Gets a singleton stack representing a return of kind `rk`. */
     SummaryComponentStack return(ReturnKind rk) { result = singleton(SummaryComponent::return(rk)) }
@@ -137,9 +143,13 @@ module Public {
     or
     noComponentSpecificCsv(sc) and
     (
-      exists(int i | sc = TParameterSummaryComponent(i) and result = "Parameter[" + i + "]")
+      exists(ArgumentPosition pos |
+        sc = TParameterSummaryComponent(pos) and result = "Parameter[" + pos + "]"
+      )
       or
-      exists(int i | sc = TArgumentSummaryComponent(i) and result = "Argument[" + i + "]")
+      exists(ParameterPosition pos |
+        sc = TArgumentSummaryComponent(pos) and result = "Argument[" + pos + "]"
+      )
       or
       sc = TReturnSummaryComponent(getReturnValueKind()) and result = "ReturnValue"
     )
@@ -201,10 +211,10 @@ module Public {
 
     /**
      * Holds if values stored inside `content` are cleared on objects passed as
-     * the `i`th argument to this callable.
+     * arguments at position `pos` to this callable.
      */
     pragma[nomagic]
-    predicate clearsContent(int i, Content content) { none() }
+    predicate clearsContent(ParameterPosition pos, Content content) { none() }
   }
 }
 
@@ -217,11 +227,11 @@ module Private {
 
   newtype TSummaryComponent =
     TContentSummaryComponent(Content c) or
-    TParameterSummaryComponent(int i) { parameterPosition(i) } or
-    TArgumentSummaryComponent(int i) { parameterPosition(i) } or
+    TParameterSummaryComponent(ArgumentPosition pos) or
+    TArgumentSummaryComponent(ParameterPosition pos) or
     TReturnSummaryComponent(ReturnKind rk)
 
-  private TSummaryComponent thisParam() {
+  private TParameterSummaryComponent thisParam() {
     result = TParameterSummaryComponent(instanceParameterPosition())
   }
 
@@ -285,9 +295,9 @@ module Private {
 
   /**
    * Holds if `c` has a flow summary from `input` to `arg`, where `arg`
-   * writes to (contents of) the `i`th argument, and `c` has a
-   * value-preserving flow summary from the `i`th argument to a return value
-   * (`return`).
+   * writes to (contents of) arguments at position `pos`, and `c` has a
+   * value-preserving flow summary from the arguments at position `pos`
+   * to a return value (`return`).
    *
    * In such a case, we derive flow from `input` to (contents of) the return
    * value.
@@ -302,10 +312,10 @@ module Private {
     SummarizedCallable c, SummaryComponentStack input, SummaryComponentStack arg,
     SummaryComponentStack return, boolean preservesValue
   ) {
-    exists(int i |
+    exists(ParameterPosition pos |
       summary(c, input, arg, preservesValue) and
-      isContentOfArgument(arg, i) and
-      summary(c, SummaryComponentStack::singleton(TArgumentSummaryComponent(i)), return, true) and
+      isContentOfArgument(arg, pos) and
+      summary(c, SummaryComponentStack::argument(pos), return, true) and
       return.bottom() = TReturnSummaryComponent(_)
     )
   }
@@ -330,10 +340,10 @@ module Private {
     s.head() = TParameterSummaryComponent(_) and exists(s.tail())
   }
 
-  private predicate isContentOfArgument(SummaryComponentStack s, int i) {
-    s.head() = TContentSummaryComponent(_) and isContentOfArgument(s.tail(), i)
+  private predicate isContentOfArgument(SummaryComponentStack s, ParameterPosition pos) {
+    s.head() = TContentSummaryComponent(_) and isContentOfArgument(s.tail(), pos)
     or
-    s = TSingletonSummaryComponentStack(TArgumentSummaryComponent(i))
+    s = SummaryComponentStack::argument(pos)
   }
 
   private predicate outputState(SummarizedCallable c, SummaryComponentStack s) {
@@ -364,8 +374,8 @@ module Private {
   private newtype TSummaryNodeState =
     TSummaryNodeInputState(SummaryComponentStack s) { inputState(_, s) } or
     TSummaryNodeOutputState(SummaryComponentStack s) { outputState(_, s) } or
-    TSummaryNodeClearsContentState(int i, boolean post) {
-      any(SummarizedCallable sc).clearsContent(i, _) and post in [false, true]
+    TSummaryNodeClearsContentState(ParameterPosition pos, boolean post) {
+      any(SummarizedCallable sc).clearsContent(pos, _) and post in [false, true]
     }
 
   /**
@@ -414,21 +424,23 @@ module Private {
         result = "to write: " + s
       )
       or
-      exists(int i, boolean post, string postStr |
-        this = TSummaryNodeClearsContentState(i, post) and
+      exists(ParameterPosition pos, boolean post, string postStr |
+        this = TSummaryNodeClearsContentState(pos, post) and
         (if post = true then postStr = " (post)" else postStr = "") and
-        result = "clear: " + i + postStr
+        result = "clear: " + pos + postStr
       )
     }
   }
 
   /**
-   * Holds if `state` represents having read the `i`th argument for `c`. In this case
-   * we are not synthesizing a data-flow node, but instead assume that a relevant
-   * parameter node already exists.
+   * Holds if `state` represents having read from a parameter at position
+   * `pos` in `c`. In this case we are not synthesizing a data-flow node,
+   * but instead assume that a relevant parameter node already exists.
    */
-  private predicate parameterReadState(SummarizedCallable c, SummaryNodeState state, int i) {
-    state.isInputState(c, SummaryComponentStack::argument(i))
+  private predicate parameterReadState(
+    SummarizedCallable c, SummaryNodeState state, ParameterPosition pos
+  ) {
+    state.isInputState(c, SummaryComponentStack::argument(pos))
   }
 
   /**
@@ -441,9 +453,9 @@ module Private {
     or
     state.isOutputState(c, _)
     or
-    exists(int i |
-      c.clearsContent(i, _) and
-      state = TSummaryNodeClearsContentState(i, _)
+    exists(ParameterPosition pos |
+      c.clearsContent(pos, _) and
+      state = TSummaryNodeClearsContentState(pos, _)
     )
   }
 
@@ -452,9 +464,9 @@ module Private {
     exists(SummaryNodeState state | state.isInputState(c, s) |
       result = summaryNode(c, state)
       or
-      exists(int i |
-        parameterReadState(c, state, i) and
-        result.(ParamNode).isParameterOf(c, i)
+      exists(ParameterPosition pos |
+        parameterReadState(c, state, pos) and
+        result.(ParamNode).isParameterOf(c, pos)
       )
     )
   }
@@ -468,20 +480,20 @@ module Private {
   }
 
   /**
-   * Holds if a write targets `post`, which is a post-update node for the `i`th
-   * parameter of `c`.
+   * Holds if a write targets `post`, which is a post-update node for a
+   * parameter at position `pos` in `c`.
    */
-  private predicate isParameterPostUpdate(Node post, SummarizedCallable c, int i) {
-    post = summaryNodeOutputState(c, SummaryComponentStack::argument(i))
+  private predicate isParameterPostUpdate(Node post, SummarizedCallable c, ParameterPosition pos) {
+    post = summaryNodeOutputState(c, SummaryComponentStack::argument(pos))
   }
 
-  /** Holds if a parameter node is required for the `i`th parameter of `c`. */
-  predicate summaryParameterNodeRange(SummarizedCallable c, int i) {
-    parameterReadState(c, _, i)
+  /** Holds if a parameter node at position `pos` is required for `c`. */
+  predicate summaryParameterNodeRange(SummarizedCallable c, ParameterPosition pos) {
+    parameterReadState(c, _, pos)
     or
-    isParameterPostUpdate(_, c, i)
+    isParameterPostUpdate(_, c, pos)
     or
-    c.clearsContent(i, _)
+    c.clearsContent(pos, _)
   }
 
   private predicate callbackOutput(
@@ -493,10 +505,10 @@ module Private {
   }
 
   private predicate callbackInput(
-    SummarizedCallable c, SummaryComponentStack s, Node receiver, int i
+    SummarizedCallable c, SummaryComponentStack s, Node receiver, ArgumentPosition pos
   ) {
     any(SummaryNodeState state).isOutputState(c, s) and
-    s.head() = TParameterSummaryComponent(i) and
+    s.head() = TParameterSummaryComponent(pos) and
     receiver = summaryNodeInputState(c, s.drop(1))
   }
 
@@ -547,17 +559,17 @@ module Private {
           result = getReturnType(c, rk)
         )
         or
-        exists(int i | head = TParameterSummaryComponent(i) |
+        exists(ArgumentPosition pos | head = TParameterSummaryComponent(pos) |
           result =
             getCallbackParameterType(getNodeType(summaryNodeInputState(pragma[only_bind_out](c),
-                  s.drop(1))), i)
+                  s.drop(1))), pos)
         )
       )
     )
     or
-    exists(SummarizedCallable c, int i, ParamNode p |
-      n = summaryNode(c, TSummaryNodeClearsContentState(i, false)) and
-      p.isParameterOf(c, i) and
+    exists(SummarizedCallable c, ParameterPosition pos, ParamNode p |
+      n = summaryNode(c, TSummaryNodeClearsContentState(pos, false)) and
+      p.isParameterOf(c, pos) and
       result = getNodeType(p)
     )
   }
@@ -571,10 +583,10 @@ module Private {
     )
   }
 
-  /** Holds if summary node `arg` is the `i`th argument of call `c`. */
-  predicate summaryArgumentNode(DataFlowCall c, Node arg, int i) {
+  /** Holds if summary node `arg` is at position `pos` in the call `c`. */
+  predicate summaryArgumentNode(DataFlowCall c, Node arg, ArgumentPosition pos) {
     exists(SummarizedCallable callable, SummaryComponentStack s, Node receiver |
-      callbackInput(callable, s, receiver, i) and
+      callbackInput(callable, s, receiver, pos) and
       arg = summaryNodeOutputState(callable, s) and
       c = summaryDataFlowCall(receiver)
     )
@@ -582,12 +594,12 @@ module Private {
 
   /** Holds if summary node `post` is a post-update node with pre-update node `pre`. */
   predicate summaryPostUpdateNode(Node post, Node pre) {
-    exists(SummarizedCallable c, int i |
-      isParameterPostUpdate(post, c, i) and
-      pre.(ParamNode).isParameterOf(c, i)
+    exists(SummarizedCallable c, ParameterPosition pos |
+      isParameterPostUpdate(post, c, pos) and
+      pre.(ParamNode).isParameterOf(c, pos)
       or
-      pre = summaryNode(c, TSummaryNodeClearsContentState(i, false)) and
-      post = summaryNode(c, TSummaryNodeClearsContentState(i, true))
+      pre = summaryNode(c, TSummaryNodeClearsContentState(pos, false)) and
+      post = summaryNode(c, TSummaryNodeClearsContentState(pos, true))
     )
     or
     exists(SummarizedCallable callable, SummaryComponentStack s |
@@ -610,13 +622,13 @@ module Private {
    * node, and back out to `p`.
    */
   predicate summaryAllowParameterReturnInSelf(ParamNode p) {
-    exists(SummarizedCallable c, int i | p.isParameterOf(c, i) |
-      c.clearsContent(i, _)
+    exists(SummarizedCallable c, ParameterPosition ppos | p.isParameterOf(c, ppos) |
+      c.clearsContent(ppos, _)
       or
       exists(SummaryComponentStack inputContents, SummaryComponentStack outputContents |
         summary(c, inputContents, outputContents, _) and
-        inputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(i)) and
-        outputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(i))
+        inputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(ppos)) and
+        outputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(ppos))
       )
     )
   }
@@ -641,9 +653,9 @@ module Private {
         preservesValue = false and not summary(c, inputContents, outputContents, true)
       )
       or
-      exists(SummarizedCallable c, int i |
-        pred.(ParamNode).isParameterOf(c, i) and
-        succ = summaryNode(c, TSummaryNodeClearsContentState(i, _)) and
+      exists(SummarizedCallable c, ParameterPosition pos |
+        pred.(ParamNode).isParameterOf(c, pos) and
+        succ = summaryNode(c, TSummaryNodeClearsContentState(pos, _)) and
         preservesValue = true
       )
     }
@@ -692,9 +704,9 @@ module Private {
      * node where field `b` is cleared).
      */
     predicate summaryClearsContent(Node n, Content c) {
-      exists(SummarizedCallable sc, int i |
-        n = summaryNode(sc, TSummaryNodeClearsContentState(i, true)) and
-        sc.clearsContent(i, c)
+      exists(SummarizedCallable sc, ParameterPosition pos |
+        n = summaryNode(sc, TSummaryNodeClearsContentState(pos, true)) and
+        sc.clearsContent(pos, c)
       )
     }
 
@@ -706,18 +718,23 @@ module Private {
      * `arg` (see comment for `summaryClearsContent`).
      */
     predicate summaryClearsContentArg(ArgNode arg, Content c) {
-      exists(DataFlowCall call, int i |
-        viableCallable(call).(SummarizedCallable).clearsContent(i, c) and
-        arg.argumentOf(call, i)
+      exists(DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos |
+        viableCallable(call).(SummarizedCallable).clearsContent(ppos, c) and
+        arg.argumentOf(call, apos) and
+        parameterMatch(ppos, apos)
       )
     }
 
     pragma[nomagic]
     private ParamNode summaryArgParam(ArgNode arg, ReturnKindExt rk, OutNodeExt out) {
-      exists(DataFlowCall call, int pos, SummarizedCallable callable |
-        arg.argumentOf(call, pos) and
+      exists(
+        DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos,
+        SummarizedCallable callable
+      |
+        arg.argumentOf(call, apos) and
         viableCallable(call) = callable and
-        result.isParameterOf(callable, pos) and
+        result.isParameterOf(callable, ppos) and
+        parameterMatch(ppos, apos) and
         out = rk.getAnOutNode(call)
       )
     }
@@ -795,39 +812,33 @@ module Private {
     }
 
     /** Holds if specification component `c` parses as parameter `n`. */
-    predicate parseParam(string c, int n) {
+    predicate parseParam(string c, ArgumentPosition pos) {
       specSplit(_, c, _) and
-      (
-        c.regexpCapture("Parameter\\[([-0-9]+)\\]", 1).toInt() = n
-        or
-        exists(int n1, int n2 |
-          c.regexpCapture("Parameter\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = n1 and
-          c.regexpCapture("Parameter\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = n2 and
-          n = [n1 .. n2]
-        )
+      exists(string body |
+        body = c.regexpCapture("Parameter\\[([^\\]]*)\\]", 1) and
+        pos = parseParamBody(body)
       )
     }
 
     /** Holds if specification component `c` parses as argument `n`. */
-    predicate parseArg(string c, int n) {
+    predicate parseArg(string c, ParameterPosition pos) {
       specSplit(_, c, _) and
-      (
-        c.regexpCapture("Argument\\[([-0-9]+)\\]", 1).toInt() = n
-        or
-        exists(int n1, int n2 |
-          c.regexpCapture("Argument\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = n1 and
-          c.regexpCapture("Argument\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = n2 and
-          n = [n1 .. n2]
-        )
+      exists(string body |
+        body = c.regexpCapture("Argument\\[([^\\]]*)\\]", 1) and
+        pos = parseArgBody(body)
       )
     }
 
     private SummaryComponent interpretComponent(string c) {
       specSplit(_, c, _) and
       (
-        exists(int pos | parseArg(c, pos) and result = SummaryComponent::argument(pos))
+        exists(ParameterPosition pos |
+          parseArg(c, pos) and result = SummaryComponent::argument(pos)
+        )
         or
-        exists(int pos | parseParam(c, pos) and result = SummaryComponent::parameter(pos))
+        exists(ArgumentPosition pos |
+          parseParam(c, pos) and result = SummaryComponent::parameter(pos)
+        )
         or
         c = "ReturnValue" and result = SummaryComponent::return(getReturnValueKind())
         or
@@ -934,14 +945,18 @@ module Private {
         interpretOutput(output, idx + 1, ref, mid) and
         specSplit(output, c, idx)
       |
-        exists(int pos |
-          node.asNode().(PostUpdateNode).getPreUpdateNode().(ArgNode).argumentOf(mid.asCall(), pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(PostUpdateNode).getPreUpdateNode().(ArgNode).argumentOf(mid.asCall(), apos) and
+          parameterMatch(ppos, apos)
         |
-          c = "Argument" or parseArg(c, pos)
+          c = "Argument" or parseArg(c, ppos)
         )
         or
-        exists(int pos | node.asNode().(ParamNode).isParameterOf(mid.asCallable(), pos) |
-          c = "Parameter" or parseParam(c, pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(ParamNode).isParameterOf(mid.asCallable(), ppos) and
+          parameterMatch(ppos, apos)
+        |
+          c = "Parameter" or parseParam(c, apos)
         )
         or
         c = "ReturnValue" and
@@ -960,8 +975,11 @@ module Private {
         interpretInput(input, idx + 1, ref, mid) and
         specSplit(input, c, idx)
       |
-        exists(int pos | node.asNode().(ArgNode).argumentOf(mid.asCall(), pos) |
-          c = "Argument" or parseArg(c, pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(ArgNode).argumentOf(mid.asCall(), apos) and
+          parameterMatch(ppos, apos)
+        |
+          c = "Argument" or parseArg(c, ppos)
         )
         or
         exists(ReturnNodeExt ret |
@@ -1110,9 +1128,9 @@ module Private {
       b.asCall() = summaryDataFlowCall(a.asNode()) and
       value = "receiver"
       or
-      exists(int i |
-        summaryArgumentNode(b.asCall(), a.asNode(), i) and
-        value = "argument (" + i + ")"
+      exists(ArgumentPosition pos |
+        summaryArgumentNode(b.asCall(), a.asNode(), pos) and
+        value = "argument (" + pos + ")"
       )
     }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -710,6 +710,14 @@ module Private {
       )
     }
 
+    pragma[noinline]
+    private predicate viableParam(
+      DataFlowCall call, SummarizedCallable sc, ParameterPosition ppos, ParamNode p
+    ) {
+      p.isParameterOf(sc, ppos) and
+      sc = viableCallable(call)
+    }
+
     /**
      * Holds if values stored inside content `c` are cleared inside a
      * callable to which `arg` is an argument.
@@ -718,23 +726,18 @@ module Private {
      * `arg` (see comment for `summaryClearsContent`).
      */
     predicate summaryClearsContentArg(ArgNode arg, Content c) {
-      exists(DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos |
-        viableCallable(call).(SummarizedCallable).clearsContent(ppos, c) and
-        arg.argumentOf(call, apos) and
-        parameterMatch(ppos, apos)
+      exists(DataFlowCall call, SummarizedCallable sc, ParameterPosition ppos |
+        argumentPositionMatch(call, arg, ppos) and
+        viableParam(call, sc, ppos, _) and
+        sc.clearsContent(ppos, c)
       )
     }
 
     pragma[nomagic]
     private ParamNode summaryArgParam(ArgNode arg, ReturnKindExt rk, OutNodeExt out) {
-      exists(
-        DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos,
-        SummarizedCallable callable
-      |
-        arg.argumentOf(call, apos) and
-        viableCallable(call) = callable and
-        result.isParameterOf(callable, ppos) and
-        parameterMatch(ppos, apos) and
+      exists(DataFlowCall call, ParameterPosition ppos, SummarizedCallable sc |
+        argumentPositionMatch(call, arg, ppos) and
+        viableParam(call, sc, ppos, result) and
         out = rk.getAnOutNode(call)
       )
     }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -3,6 +3,7 @@
  */
 
 private import java
+private import DataFlowDispatch
 private import DataFlowPrivate
 private import DataFlowUtil
 private import FlowSummaryImpl::Private
@@ -12,9 +13,6 @@ private import semmle.code.java.dataflow.ExternalFlow
 private module FlowSummaries {
   private import semmle.code.java.dataflow.FlowSummary as F
 }
-
-/** Holds is `i` is a valid parameter position. */
-predicate parameterPosition(int i) { i in [-1 .. any(Parameter p).getPosition()] }
 
 /** Gets the parameter position of the instance parameter. */
 int instanceParameterPosition() { result = -1 }
@@ -189,3 +187,19 @@ predicate interpretInputSpecific(string c, InterpretNode mid, InterpretNode n) {
     n.asNode().asExpr() = fw.getRHS()
   )
 }
+
+/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
+bindingset[s]
+ArgumentPosition parseParamBody(string s) {
+  result = s.regexpCapture("([-0-9]+)", 1).toInt()
+  or
+  exists(int n1, int n2 |
+    s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 1).toInt() = n1 and
+    s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 2).toInt() = n2 and
+    result in [n1 .. n2]
+  )
+}
+
+/** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
+bindingset[s]
+ParameterPosition parseArgBody(string s) { result = parseParamBody(s) }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -96,6 +96,12 @@ string getComponentSpecificCsv(SummaryComponent sc) {
   exists(Content c | sc = TContentSummaryComponent(c) and result = getContentSpecificCsv(c))
 }
 
+/** Gets the textual representation of a parameter position in the format used for flow summaries. */
+string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() }
+
+/** Gets the textual representation of an argument position in the format used for flow summaries. */
+string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
+
 class SourceOrSinkElement = Top;
 
 /**
@@ -188,9 +194,8 @@ predicate interpretInputSpecific(string c, InterpretNode mid, InterpretNode n) {
   )
 }
 
-/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
 bindingset[s]
-ArgumentPosition parseParamBody(string s) {
+private int parsePosition(string s) {
   result = s.regexpCapture("([-0-9]+)", 1).toInt()
   or
   exists(int n1, int n2 |
@@ -200,6 +205,10 @@ ArgumentPosition parseParamBody(string s) {
   )
 }
 
+/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
+bindingset[s]
+ArgumentPosition parseParamBody(string s) { result = parsePosition(s) }
+
 /** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
 bindingset[s]
-ParameterPosition parseArgBody(string s) { result = parseParamBody(s) }
+ParameterPosition parseArgBody(string s) { result = parsePosition(s) }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -391,14 +391,11 @@ private module Cached {
 
   /**
    * Holds if `p` is the parameter of a viable dispatch target of `call`,
-   * and `p` matches arguments at position `apos`.
+   * and `p` has position `ppos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
-    exists(ParameterPosition ppos |
-      p.isParameterOf(viableCallableExt(call), ppos) and
-      parameterMatch(ppos, apos)
-    )
+  private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    p.isParameterOf(viableCallableExt(call), ppos)
   }
 
   /**
@@ -407,9 +404,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(ArgumentPosition pos |
-      viableParam(call, pos, p) and
-      arg.argumentOf(call, pos) and
+    exists(ParameterPosition ppos |
+      viableParam(call, ppos, p) and
+      argumentPositionMatch(call, arg, ppos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -71,25 +71,31 @@ predicate accessPathCostLimits(int apLimit, int tupleLimit) {
  * calls. For this reason, we cannot reuse the code from `DataFlowImpl.qll` directly.
  */
 private module LambdaFlow {
-  private predicate viableParamNonLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallable(call), i)
+  private predicate viableParamNonLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallable(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
-  private predicate viableParamLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableLambda(call, _), i)
+  private predicate viableParamLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableLambda(call, _), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamNonLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamNonLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
   private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
@@ -322,7 +328,7 @@ private module Cached {
     or
     exists(ArgNode arg |
       result.(PostUpdateNode).getPreUpdateNode() = arg and
-      arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
+      arg.argumentOf(call, k.(ParamUpdateReturnKind).getAMatchingArgumentPosition())
     )
   }
 
@@ -330,7 +336,7 @@ private module Cached {
   predicate returnNodeExt(Node n, ReturnKindExt k) {
     k = TValueReturn(n.(ReturnNode).getKind())
     or
-    exists(ParamNode p, int pos |
+    exists(ParamNode p, ParameterPosition pos |
       parameterValueFlowsToPreUpdate(p, n) and
       p.isParameterOf(_, pos) and
       k = TParamUpdate(pos)
@@ -352,11 +358,13 @@ private module Cached {
   }
 
   cached
-  predicate parameterNode(Node p, DataFlowCallable c, int pos) { isParameterNode(p, c, pos) }
+  predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    isParameterNode(p, c, pos)
+  }
 
   cached
-  predicate argumentNode(Node n, DataFlowCall call, int pos) {
-    n.(ArgumentNode).argumentOf(call, pos)
+  predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
+    isArgumentNode(n, call, pos)
   }
 
   /**
@@ -374,12 +382,15 @@ private module Cached {
   }
 
   /**
-   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-   * The instance parameter is considered to have index `-1`.
+   * Holds if `p` is the parameter of a viable dispatch target of `call`,
+   * and `p` matches arguments at position `apos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableExt(call), i)
+  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableExt(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   /**
@@ -388,9 +399,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParam(call, i, p) and
-      arg.argumentOf(call, i) and
+    exists(ArgumentPosition pos |
+      viableParam(call, pos, p) and
+      arg.argumentOf(call, pos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }
@@ -862,7 +873,7 @@ private module Cached {
   cached
   newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
+    TParamUpdate(ParameterPosition pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
 
   cached
   newtype TBooleanOption =
@@ -1054,9 +1065,9 @@ class ParamNode extends Node {
 
   /**
    * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
+   * position.
    */
-  predicate isParameterOf(DataFlowCallable c, int i) { parameterNode(this, c, i) }
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { parameterNode(this, c, pos) }
 }
 
 /** A data-flow node that represents a call argument. */
@@ -1064,7 +1075,9 @@ class ArgNode extends Node {
   ArgNode() { argumentNode(this, _, _) }
 
   /** Holds if this argument occurs at the given position in the given call. */
-  final predicate argumentOf(DataFlowCall call, int pos) { argumentNode(this, call, pos) }
+  final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    argumentNode(this, call, pos)
+  }
 }
 
 /**
@@ -1110,11 +1123,14 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-  private int pos;
+  private ParameterPosition pos;
 
   ParamUpdateReturnKind() { this = TParamUpdate(pos) }
 
-  int getPosition() { result = pos }
+  ParameterPosition getPosition() { result = pos }
+
+  pragma[nomagic]
+  ArgumentPosition getAMatchingArgumentPosition() { parameterMatch(pos, result) }
 
   override string toString() { result = "param update " + pos }
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -6,8 +6,29 @@ private import semmle.python.essa.SsaCompute
 /** Gets the callable in which this node occurs. */
 DataFlowCallable nodeGetEnclosingCallable(Node n) { result = n.getEnclosingCallable() }
 
+/** A parameter position represented by an integer. */
+class ParameterPosition extends int {
+  ParameterPosition() { exists(any(DataFlowCallable c).getParameter(this)) }
+}
+
+/** An argument position represented by an integer. */
+class ArgumentPosition extends int {
+  ArgumentPosition() { exists(any(DataFlowCall c).getArg(this)) }
+}
+
+/** Holds if arguments at position `apos` match parameters at position `ppos`. */
+pragma[inline]
+predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }
+
 /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-predicate isParameterNode(ParameterNode p, DataFlowCallable c, int pos) { p.isParameterOf(c, pos) }
+predicate isParameterNode(ParameterNode p, DataFlowCallable c, ParameterPosition pos) {
+  p.isParameterOf(c, pos)
+}
+
+/** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
+predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos) {
+  arg.argumentOf(c, pos)
+}
 
 //--------
 // Data flow graph

--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -119,7 +119,7 @@ private class SummarizedCallableAdapter extends Impl::Public::SummarizedCallable
     sc.propagatesFlow(input, output, preservesValue)
   }
 
-  final override predicate clearsContent(int i, DataFlow::Content content) {
+  final override predicate clearsContent(ParameterPosition i, DataFlow::Content content) {
     sc.clearsContent(i, content)
   }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -457,3 +457,19 @@ predicate exprNodeReturnedFrom(DataFlow::ExprNode e, Callable c) {
     )
   )
 }
+
+private int parameterPosition() { result in [-2 .. max([any(Parameter p).getPosition(), 10])] }
+
+/** A parameter position represented by an integer. */
+class ParameterPosition extends int {
+  ParameterPosition() { this = parameterPosition() }
+}
+
+/** An argument position represented by an integer. */
+class ArgumentPosition extends int {
+  ArgumentPosition() { this = parameterPosition() }
+}
+
+/** Holds if arguments at position `apos` match parameters at position `ppos`. */
+pragma[inline]
+predicate parameterMatch(ParameterPosition ppos, ArgumentPosition apos) { ppos = apos }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -256,11 +256,11 @@ private class ArgNodeEx extends NodeEx {
 private class ParamNodeEx extends NodeEx {
   ParamNodeEx() { this.asNode() instanceof ParamNode }
 
-  predicate isParameterOf(DataFlowCallable c, int i) {
-    this.asNode().(ParamNode).isParameterOf(c, i)
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+    this.asNode().(ParamNode).isParameterOf(c, pos)
   }
 
-  int getPosition() { this.isParameterOf(_, result) }
+  ParameterPosition getPosition() { this.isParameterOf(_, result) }
 
   predicate allowParameterReturnInSelf() { allowParameterReturnInSelfCached(this.asNode()) }
 }
@@ -1430,7 +1430,7 @@ private module Stage2 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2125,7 +2125,7 @@ private module Stage3 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2891,7 +2891,7 @@ private module Stage4 {
   }
 
   predicate parameterMayFlowThrough(ParamNodeEx p, DataFlowCallable c, Ap ap, Configuration config) {
-    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, int pos |
+    exists(RetNodeEx ret, Ap ap0, ReturnKindExt kind, ParameterPosition pos |
       parameterFlow(p, ap, ap0, c, config) and
       c = ret.getEnclosingCallable() and
       revFlow(pragma[only_bind_into](ret), true, apSome(_), pragma[only_bind_into](ap0),
@@ -2975,7 +2975,7 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
-  int getParameterPos() { p.isParameterOf(_, result) }
+  ParameterPosition getParameterPos() { p.isParameterOf(_, result) }
 
   ParamNodeEx getParamNode() { result = p }
 
@@ -3622,39 +3622,40 @@ private predicate pathOutOfCallable(PathNodeMid mid, NodeEx out, CallContext cc)
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap, AccessPathApprox apa,
-  Configuration config
+  PathNodeMid mid, ParameterPosition ppos, CallContext cc, DataFlowCall call, AccessPath ap,
+  AccessPathApprox apa, Configuration config
 ) {
-  exists(ArgNode arg |
+  exists(ArgNode arg, ArgumentPosition apos |
     arg = mid.getNodeEx().asNode() and
     cc = mid.getCallContext() and
-    arg.argumentOf(call, i) and
+    arg.argumentOf(call, apos) and
     ap = mid.getAp() and
     apa = ap.getApprox() and
-    config = mid.getConfiguration()
+    config = mid.getConfiguration() and
+    parameterMatch(ppos, apos)
   )
 }
 
 pragma[nomagic]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, AccessPathApprox apa, Configuration config
+  DataFlowCallable callable, ParameterPosition pos, AccessPathApprox apa, Configuration config
 ) {
   exists(ParamNodeEx p |
     Stage4::revFlow(p, _, _, apa, config) and
-    p.isParameterOf(callable, i)
+    p.isParameterOf(callable, pos)
   )
 }
 
 pragma[nomagic]
 private predicate pathIntoCallable0(
-  PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  AccessPath ap, Configuration config
+  PathNodeMid mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
+  DataFlowCall call, AccessPath ap, Configuration config
 ) {
   exists(AccessPathApprox apa |
-    pathIntoArg(mid, pragma[only_bind_into](i), outercc, call, ap, pragma[only_bind_into](apa),
+    pathIntoArg(mid, pragma[only_bind_into](pos), outercc, call, ap, pragma[only_bind_into](apa),
       pragma[only_bind_into](config)) and
     callable = resolveCall(call, outercc) and
-    parameterCand(callable, pragma[only_bind_into](i), pragma[only_bind_into](apa),
+    parameterCand(callable, pragma[only_bind_into](pos), pragma[only_bind_into](apa),
       pragma[only_bind_into](config))
   )
 }
@@ -3669,9 +3670,9 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParamNodeEx p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call, Configuration config
 ) {
-  exists(int i, DataFlowCallable callable, AccessPath ap |
-    pathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-    p.isParameterOf(callable, i) and
+  exists(ParameterPosition pos, DataFlowCallable callable, AccessPath ap |
+    pathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+    p.isParameterOf(callable, pos) and
     (
       sc = TSummaryCtxSome(p, ap)
       or
@@ -3695,7 +3696,7 @@ private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, AccessPathApprox apa,
   Configuration config
 ) {
-  exists(PathNodeMid mid, RetNodeEx ret, int pos |
+  exists(PathNodeMid mid, RetNodeEx ret, ParameterPosition pos |
     mid.getNodeEx() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
@@ -4424,24 +4425,25 @@ private module FlowExploration {
 
   pragma[noinline]
   private predicate partialPathIntoArg(
-    PartialPathNodeFwd mid, int i, CallContext cc, DataFlowCall call, PartialAccessPath ap,
-    Configuration config
+    PartialPathNodeFwd mid, ParameterPosition ppos, CallContext cc, DataFlowCall call,
+    PartialAccessPath ap, Configuration config
   ) {
-    exists(ArgNode arg |
+    exists(ArgNode arg, ArgumentPosition apos |
       arg = mid.getNodeEx().asNode() and
       cc = mid.getCallContext() and
-      arg.argumentOf(call, i) and
+      arg.argumentOf(call, apos) and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate partialPathIntoCallable0(
-    PartialPathNodeFwd mid, DataFlowCallable callable, int i, CallContext outercc,
+    PartialPathNodeFwd mid, DataFlowCallable callable, ParameterPosition pos, CallContext outercc,
     DataFlowCall call, PartialAccessPath ap, Configuration config
   ) {
-    partialPathIntoArg(mid, i, outercc, call, ap, config) and
+    partialPathIntoArg(mid, pos, outercc, call, ap, config) and
     callable = resolveCall(call, outercc)
   }
 
@@ -4450,9 +4452,9 @@ private module FlowExploration {
     TSummaryCtx1 sc1, TSummaryCtx2 sc2, DataFlowCall call, PartialAccessPath ap,
     Configuration config
   ) {
-    exists(int i, DataFlowCallable callable |
-      partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
-      p.isParameterOf(callable, i) and
+    exists(ParameterPosition pos, DataFlowCallable callable |
+      partialPathIntoCallable0(mid, callable, pos, outercc, call, ap, config) and
+      p.isParameterOf(callable, pos) and
       sc1 = TSummaryCtx1Param(p) and
       sc2 = TSummaryCtx2Some(ap)
     |
@@ -4616,22 +4618,23 @@ private module FlowExploration {
 
   pragma[nomagic]
   private predicate revPartialPathFlowsThrough(
-    int pos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2, RevPartialAccessPath ap,
-    Configuration config
+    ArgumentPosition apos, TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2,
+    RevPartialAccessPath ap, Configuration config
   ) {
-    exists(PartialPathNodeRev mid, ParamNodeEx p |
+    exists(PartialPathNodeRev mid, ParamNodeEx p, ParameterPosition ppos |
       mid.getNodeEx() = p and
-      p.getPosition() = pos and
+      p.getPosition() = ppos and
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       ap = mid.getAp() and
-      config = mid.getConfiguration()
+      config = mid.getConfiguration() and
+      parameterMatch(ppos, apos)
     )
   }
 
   pragma[nomagic]
   private predicate revPartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodeRev mid, int pos, RevPartialAccessPath ap,
+    DataFlowCall call, PartialPathNodeRev mid, ArgumentPosition pos, RevPartialAccessPath ap,
     Configuration config
   ) {
     exists(TRevSummaryCtx1Some sc1, TRevSummaryCtx2Some sc2 |
@@ -4644,7 +4647,7 @@ private module FlowExploration {
   private predicate revPartialPathThroughCallable(
     PartialPathNodeRev mid, ArgNodeEx node, RevPartialAccessPath ap, Configuration config
   ) {
-    exists(DataFlowCall call, int pos |
+    exists(DataFlowCall call, ArgumentPosition pos |
       revPartialPathThroughCallable0(call, mid, pos, ap, config) and
       node.asNode().(ArgNode).argumentOf(call, pos)
     )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
@@ -391,14 +391,11 @@ private module Cached {
 
   /**
    * Holds if `p` is the parameter of a viable dispatch target of `call`,
-   * and `p` matches arguments at position `apos`.
+   * and `p` has position `ppos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
-    exists(ParameterPosition ppos |
-      p.isParameterOf(viableCallableExt(call), ppos) and
-      parameterMatch(ppos, apos)
-    )
+  private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    p.isParameterOf(viableCallableExt(call), ppos)
   }
 
   /**
@@ -407,9 +404,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(ArgumentPosition pos |
-      viableParam(call, pos, p) and
-      arg.argumentOf(call, pos) and
+    exists(ParameterPosition ppos |
+      viableParam(call, ppos, p) and
+      argumentPositionMatch(call, arg, ppos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
@@ -71,25 +71,31 @@ predicate accessPathCostLimits(int apLimit, int tupleLimit) {
  * calls. For this reason, we cannot reuse the code from `DataFlowImpl.qll` directly.
  */
 private module LambdaFlow {
-  private predicate viableParamNonLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallable(call), i)
+  private predicate viableParamNonLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallable(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
-  private predicate viableParamLambda(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableLambda(call, _), i)
+  private predicate viableParamLambda(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableLambda(call, _), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamNonLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamNonLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
   private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParamLambda(call, i, p) and
-      arg.argumentOf(call, i)
+    exists(ArgumentPosition pos |
+      viableParamLambda(call, pos, p) and
+      arg.argumentOf(call, pos)
     )
   }
 
@@ -322,7 +328,7 @@ private module Cached {
     or
     exists(ArgNode arg |
       result.(PostUpdateNode).getPreUpdateNode() = arg and
-      arg.argumentOf(call, k.(ParamUpdateReturnKind).getPosition())
+      arg.argumentOf(call, k.(ParamUpdateReturnKind).getAMatchingArgumentPosition())
     )
   }
 
@@ -330,7 +336,7 @@ private module Cached {
   predicate returnNodeExt(Node n, ReturnKindExt k) {
     k = TValueReturn(n.(ReturnNode).getKind())
     or
-    exists(ParamNode p, int pos |
+    exists(ParamNode p, ParameterPosition pos |
       parameterValueFlowsToPreUpdate(p, n) and
       p.isParameterOf(_, pos) and
       k = TParamUpdate(pos)
@@ -352,11 +358,13 @@ private module Cached {
   }
 
   cached
-  predicate parameterNode(Node p, DataFlowCallable c, int pos) { isParameterNode(p, c, pos) }
+  predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    isParameterNode(p, c, pos)
+  }
 
   cached
-  predicate argumentNode(Node n, DataFlowCall call, int pos) {
-    n.(ArgumentNode).argumentOf(call, pos)
+  predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
+    isArgumentNode(n, call, pos)
   }
 
   /**
@@ -374,12 +382,15 @@ private module Cached {
   }
 
   /**
-   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-   * The instance parameter is considered to have index `-1`.
+   * Holds if `p` is the parameter of a viable dispatch target of `call`,
+   * and `p` matches arguments at position `apos`.
    */
   pragma[nomagic]
-  private predicate viableParam(DataFlowCall call, int i, ParamNode p) {
-    p.isParameterOf(viableCallableExt(call), i)
+  private predicate viableParam(DataFlowCall call, ArgumentPosition apos, ParamNode p) {
+    exists(ParameterPosition ppos |
+      p.isParameterOf(viableCallableExt(call), ppos) and
+      parameterMatch(ppos, apos)
+    )
   }
 
   /**
@@ -388,9 +399,9 @@ private module Cached {
    */
   cached
   predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
-    exists(int i |
-      viableParam(call, i, p) and
-      arg.argumentOf(call, i) and
+    exists(ArgumentPosition pos |
+      viableParam(call, pos, p) and
+      arg.argumentOf(call, pos) and
       compatibleTypes(getNodeDataFlowType(arg), getNodeDataFlowType(p))
     )
   }
@@ -862,7 +873,7 @@ private module Cached {
   cached
   newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
+    TParamUpdate(ParameterPosition pos) { exists(ParamNode p | p.isParameterOf(_, pos)) }
 
   cached
   newtype TBooleanOption =
@@ -1054,9 +1065,9 @@ class ParamNode extends Node {
 
   /**
    * Holds if this node is the parameter of callable `c` at the specified
-   * (zero-based) position.
+   * position.
    */
-  predicate isParameterOf(DataFlowCallable c, int i) { parameterNode(this, c, i) }
+  predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { parameterNode(this, c, pos) }
 }
 
 /** A data-flow node that represents a call argument. */
@@ -1064,7 +1075,9 @@ class ArgNode extends Node {
   ArgNode() { argumentNode(this, _, _) }
 
   /** Holds if this argument occurs at the given position in the given call. */
-  final predicate argumentOf(DataFlowCall call, int pos) { argumentNode(this, call, pos) }
+  final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    argumentNode(this, call, pos)
+  }
 }
 
 /**
@@ -1110,11 +1123,14 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-  private int pos;
+  private ParameterPosition pos;
 
   ParamUpdateReturnKind() { this = TParamUpdate(pos) }
 
-  int getPosition() { result = pos }
+  ParameterPosition getPosition() { result = pos }
+
+  pragma[nomagic]
+  ArgumentPosition getAMatchingArgumentPosition() { parameterMatch(pos, result) }
 
   override string toString() { result = "param update " + pos }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -10,8 +10,13 @@ private import FlowSummaryImpl as FlowSummaryImpl
 DataFlowCallable nodeGetEnclosingCallable(NodeImpl n) { result = n.getEnclosingCallable() }
 
 /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */
-predicate isParameterNode(ParameterNodeImpl p, DataFlowCallable c, int pos) {
+predicate isParameterNode(ParameterNodeImpl p, DataFlowCallable c, ParameterPosition pos) {
   p.isParameterOf(c, pos)
+}
+
+/** Holds if `arg` is an `ArgumentNode` of `c` with position `pos`. */
+predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos) {
+  arg.argumentOf(c, pos)
 }
 
 abstract class NodeImpl extends Node {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -144,11 +144,13 @@ module Public {
     noComponentSpecificCsv(sc) and
     (
       exists(ArgumentPosition pos |
-        sc = TParameterSummaryComponent(pos) and result = "Parameter[" + pos + "]"
+        sc = TParameterSummaryComponent(pos) and
+        result = "Parameter[" + getArgumentPositionCsv(pos) + "]"
       )
       or
       exists(ParameterPosition pos |
-        sc = TArgumentSummaryComponent(pos) and result = "Argument[" + pos + "]"
+        sc = TArgumentSummaryComponent(pos) and
+        result = "Argument[" + getParameterPositionCsv(pos) + "]"
       )
       or
       sc = TReturnSummaryComponent(getReturnValueKind()) and result = "ReturnValue"

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -26,9 +26,13 @@ module Public {
     string toString() {
       exists(Content c | this = TContentSummaryComponent(c) and result = c.toString())
       or
-      exists(int i | this = TParameterSummaryComponent(i) and result = "parameter " + i)
+      exists(ArgumentPosition pos |
+        this = TParameterSummaryComponent(pos) and result = "parameter " + pos
+      )
       or
-      exists(int i | this = TArgumentSummaryComponent(i) and result = "argument " + i)
+      exists(ParameterPosition pos |
+        this = TArgumentSummaryComponent(pos) and result = "argument " + pos
+      )
       or
       exists(ReturnKind rk | this = TReturnSummaryComponent(rk) and result = "return (" + rk + ")")
     }
@@ -39,11 +43,11 @@ module Public {
     /** Gets a summary component for content `c`. */
     SummaryComponent content(Content c) { result = TContentSummaryComponent(c) }
 
-    /** Gets a summary component for parameter `i`. */
-    SummaryComponent parameter(int i) { result = TParameterSummaryComponent(i) }
+    /** Gets a summary component for a parameter at position `pos`. */
+    SummaryComponent parameter(ArgumentPosition pos) { result = TParameterSummaryComponent(pos) }
 
-    /** Gets a summary component for argument `i`. */
-    SummaryComponent argument(int i) { result = TArgumentSummaryComponent(i) }
+    /** Gets a summary component for an argument at position `pos`. */
+    SummaryComponent argument(ParameterPosition pos) { result = TArgumentSummaryComponent(pos) }
 
     /** Gets a summary component for a return of kind `rk`. */
     SummaryComponent return(ReturnKind rk) { result = TReturnSummaryComponent(rk) }
@@ -120,8 +124,10 @@ module Public {
       result = TConsSummaryComponentStack(head, tail)
     }
 
-    /** Gets a singleton stack for argument `i`. */
-    SummaryComponentStack argument(int i) { result = singleton(SummaryComponent::argument(i)) }
+    /** Gets a singleton stack for an argument at position `pos`. */
+    SummaryComponentStack argument(ParameterPosition pos) {
+      result = singleton(SummaryComponent::argument(pos))
+    }
 
     /** Gets a singleton stack representing a return of kind `rk`. */
     SummaryComponentStack return(ReturnKind rk) { result = singleton(SummaryComponent::return(rk)) }
@@ -137,9 +143,13 @@ module Public {
     or
     noComponentSpecificCsv(sc) and
     (
-      exists(int i | sc = TParameterSummaryComponent(i) and result = "Parameter[" + i + "]")
+      exists(ArgumentPosition pos |
+        sc = TParameterSummaryComponent(pos) and result = "Parameter[" + pos + "]"
+      )
       or
-      exists(int i | sc = TArgumentSummaryComponent(i) and result = "Argument[" + i + "]")
+      exists(ParameterPosition pos |
+        sc = TArgumentSummaryComponent(pos) and result = "Argument[" + pos + "]"
+      )
       or
       sc = TReturnSummaryComponent(getReturnValueKind()) and result = "ReturnValue"
     )
@@ -201,10 +211,10 @@ module Public {
 
     /**
      * Holds if values stored inside `content` are cleared on objects passed as
-     * the `i`th argument to this callable.
+     * arguments at position `pos` to this callable.
      */
     pragma[nomagic]
-    predicate clearsContent(int i, Content content) { none() }
+    predicate clearsContent(ParameterPosition pos, Content content) { none() }
   }
 }
 
@@ -217,11 +227,11 @@ module Private {
 
   newtype TSummaryComponent =
     TContentSummaryComponent(Content c) or
-    TParameterSummaryComponent(int i) { parameterPosition(i) } or
-    TArgumentSummaryComponent(int i) { parameterPosition(i) } or
+    TParameterSummaryComponent(ArgumentPosition pos) or
+    TArgumentSummaryComponent(ParameterPosition pos) or
     TReturnSummaryComponent(ReturnKind rk)
 
-  private TSummaryComponent thisParam() {
+  private TParameterSummaryComponent thisParam() {
     result = TParameterSummaryComponent(instanceParameterPosition())
   }
 
@@ -285,9 +295,9 @@ module Private {
 
   /**
    * Holds if `c` has a flow summary from `input` to `arg`, where `arg`
-   * writes to (contents of) the `i`th argument, and `c` has a
-   * value-preserving flow summary from the `i`th argument to a return value
-   * (`return`).
+   * writes to (contents of) arguments at position `pos`, and `c` has a
+   * value-preserving flow summary from the arguments at position `pos`
+   * to a return value (`return`).
    *
    * In such a case, we derive flow from `input` to (contents of) the return
    * value.
@@ -302,10 +312,10 @@ module Private {
     SummarizedCallable c, SummaryComponentStack input, SummaryComponentStack arg,
     SummaryComponentStack return, boolean preservesValue
   ) {
-    exists(int i |
+    exists(ParameterPosition pos |
       summary(c, input, arg, preservesValue) and
-      isContentOfArgument(arg, i) and
-      summary(c, SummaryComponentStack::singleton(TArgumentSummaryComponent(i)), return, true) and
+      isContentOfArgument(arg, pos) and
+      summary(c, SummaryComponentStack::argument(pos), return, true) and
       return.bottom() = TReturnSummaryComponent(_)
     )
   }
@@ -330,10 +340,10 @@ module Private {
     s.head() = TParameterSummaryComponent(_) and exists(s.tail())
   }
 
-  private predicate isContentOfArgument(SummaryComponentStack s, int i) {
-    s.head() = TContentSummaryComponent(_) and isContentOfArgument(s.tail(), i)
+  private predicate isContentOfArgument(SummaryComponentStack s, ParameterPosition pos) {
+    s.head() = TContentSummaryComponent(_) and isContentOfArgument(s.tail(), pos)
     or
-    s = TSingletonSummaryComponentStack(TArgumentSummaryComponent(i))
+    s = SummaryComponentStack::argument(pos)
   }
 
   private predicate outputState(SummarizedCallable c, SummaryComponentStack s) {
@@ -364,8 +374,8 @@ module Private {
   private newtype TSummaryNodeState =
     TSummaryNodeInputState(SummaryComponentStack s) { inputState(_, s) } or
     TSummaryNodeOutputState(SummaryComponentStack s) { outputState(_, s) } or
-    TSummaryNodeClearsContentState(int i, boolean post) {
-      any(SummarizedCallable sc).clearsContent(i, _) and post in [false, true]
+    TSummaryNodeClearsContentState(ParameterPosition pos, boolean post) {
+      any(SummarizedCallable sc).clearsContent(pos, _) and post in [false, true]
     }
 
   /**
@@ -414,21 +424,23 @@ module Private {
         result = "to write: " + s
       )
       or
-      exists(int i, boolean post, string postStr |
-        this = TSummaryNodeClearsContentState(i, post) and
+      exists(ParameterPosition pos, boolean post, string postStr |
+        this = TSummaryNodeClearsContentState(pos, post) and
         (if post = true then postStr = " (post)" else postStr = "") and
-        result = "clear: " + i + postStr
+        result = "clear: " + pos + postStr
       )
     }
   }
 
   /**
-   * Holds if `state` represents having read the `i`th argument for `c`. In this case
-   * we are not synthesizing a data-flow node, but instead assume that a relevant
-   * parameter node already exists.
+   * Holds if `state` represents having read from a parameter at position
+   * `pos` in `c`. In this case we are not synthesizing a data-flow node,
+   * but instead assume that a relevant parameter node already exists.
    */
-  private predicate parameterReadState(SummarizedCallable c, SummaryNodeState state, int i) {
-    state.isInputState(c, SummaryComponentStack::argument(i))
+  private predicate parameterReadState(
+    SummarizedCallable c, SummaryNodeState state, ParameterPosition pos
+  ) {
+    state.isInputState(c, SummaryComponentStack::argument(pos))
   }
 
   /**
@@ -441,9 +453,9 @@ module Private {
     or
     state.isOutputState(c, _)
     or
-    exists(int i |
-      c.clearsContent(i, _) and
-      state = TSummaryNodeClearsContentState(i, _)
+    exists(ParameterPosition pos |
+      c.clearsContent(pos, _) and
+      state = TSummaryNodeClearsContentState(pos, _)
     )
   }
 
@@ -452,9 +464,9 @@ module Private {
     exists(SummaryNodeState state | state.isInputState(c, s) |
       result = summaryNode(c, state)
       or
-      exists(int i |
-        parameterReadState(c, state, i) and
-        result.(ParamNode).isParameterOf(c, i)
+      exists(ParameterPosition pos |
+        parameterReadState(c, state, pos) and
+        result.(ParamNode).isParameterOf(c, pos)
       )
     )
   }
@@ -468,20 +480,20 @@ module Private {
   }
 
   /**
-   * Holds if a write targets `post`, which is a post-update node for the `i`th
-   * parameter of `c`.
+   * Holds if a write targets `post`, which is a post-update node for a
+   * parameter at position `pos` in `c`.
    */
-  private predicate isParameterPostUpdate(Node post, SummarizedCallable c, int i) {
-    post = summaryNodeOutputState(c, SummaryComponentStack::argument(i))
+  private predicate isParameterPostUpdate(Node post, SummarizedCallable c, ParameterPosition pos) {
+    post = summaryNodeOutputState(c, SummaryComponentStack::argument(pos))
   }
 
-  /** Holds if a parameter node is required for the `i`th parameter of `c`. */
-  predicate summaryParameterNodeRange(SummarizedCallable c, int i) {
-    parameterReadState(c, _, i)
+  /** Holds if a parameter node at position `pos` is required for `c`. */
+  predicate summaryParameterNodeRange(SummarizedCallable c, ParameterPosition pos) {
+    parameterReadState(c, _, pos)
     or
-    isParameterPostUpdate(_, c, i)
+    isParameterPostUpdate(_, c, pos)
     or
-    c.clearsContent(i, _)
+    c.clearsContent(pos, _)
   }
 
   private predicate callbackOutput(
@@ -493,10 +505,10 @@ module Private {
   }
 
   private predicate callbackInput(
-    SummarizedCallable c, SummaryComponentStack s, Node receiver, int i
+    SummarizedCallable c, SummaryComponentStack s, Node receiver, ArgumentPosition pos
   ) {
     any(SummaryNodeState state).isOutputState(c, s) and
-    s.head() = TParameterSummaryComponent(i) and
+    s.head() = TParameterSummaryComponent(pos) and
     receiver = summaryNodeInputState(c, s.drop(1))
   }
 
@@ -547,17 +559,17 @@ module Private {
           result = getReturnType(c, rk)
         )
         or
-        exists(int i | head = TParameterSummaryComponent(i) |
+        exists(ArgumentPosition pos | head = TParameterSummaryComponent(pos) |
           result =
             getCallbackParameterType(getNodeType(summaryNodeInputState(pragma[only_bind_out](c),
-                  s.drop(1))), i)
+                  s.drop(1))), pos)
         )
       )
     )
     or
-    exists(SummarizedCallable c, int i, ParamNode p |
-      n = summaryNode(c, TSummaryNodeClearsContentState(i, false)) and
-      p.isParameterOf(c, i) and
+    exists(SummarizedCallable c, ParameterPosition pos, ParamNode p |
+      n = summaryNode(c, TSummaryNodeClearsContentState(pos, false)) and
+      p.isParameterOf(c, pos) and
       result = getNodeType(p)
     )
   }
@@ -571,10 +583,10 @@ module Private {
     )
   }
 
-  /** Holds if summary node `arg` is the `i`th argument of call `c`. */
-  predicate summaryArgumentNode(DataFlowCall c, Node arg, int i) {
+  /** Holds if summary node `arg` is at position `pos` in the call `c`. */
+  predicate summaryArgumentNode(DataFlowCall c, Node arg, ArgumentPosition pos) {
     exists(SummarizedCallable callable, SummaryComponentStack s, Node receiver |
-      callbackInput(callable, s, receiver, i) and
+      callbackInput(callable, s, receiver, pos) and
       arg = summaryNodeOutputState(callable, s) and
       c = summaryDataFlowCall(receiver)
     )
@@ -582,12 +594,12 @@ module Private {
 
   /** Holds if summary node `post` is a post-update node with pre-update node `pre`. */
   predicate summaryPostUpdateNode(Node post, Node pre) {
-    exists(SummarizedCallable c, int i |
-      isParameterPostUpdate(post, c, i) and
-      pre.(ParamNode).isParameterOf(c, i)
+    exists(SummarizedCallable c, ParameterPosition pos |
+      isParameterPostUpdate(post, c, pos) and
+      pre.(ParamNode).isParameterOf(c, pos)
       or
-      pre = summaryNode(c, TSummaryNodeClearsContentState(i, false)) and
-      post = summaryNode(c, TSummaryNodeClearsContentState(i, true))
+      pre = summaryNode(c, TSummaryNodeClearsContentState(pos, false)) and
+      post = summaryNode(c, TSummaryNodeClearsContentState(pos, true))
     )
     or
     exists(SummarizedCallable callable, SummaryComponentStack s |
@@ -610,13 +622,13 @@ module Private {
    * node, and back out to `p`.
    */
   predicate summaryAllowParameterReturnInSelf(ParamNode p) {
-    exists(SummarizedCallable c, int i | p.isParameterOf(c, i) |
-      c.clearsContent(i, _)
+    exists(SummarizedCallable c, ParameterPosition ppos | p.isParameterOf(c, ppos) |
+      c.clearsContent(ppos, _)
       or
       exists(SummaryComponentStack inputContents, SummaryComponentStack outputContents |
         summary(c, inputContents, outputContents, _) and
-        inputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(i)) and
-        outputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(i))
+        inputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(ppos)) and
+        outputContents.bottom() = pragma[only_bind_into](TArgumentSummaryComponent(ppos))
       )
     )
   }
@@ -641,9 +653,9 @@ module Private {
         preservesValue = false and not summary(c, inputContents, outputContents, true)
       )
       or
-      exists(SummarizedCallable c, int i |
-        pred.(ParamNode).isParameterOf(c, i) and
-        succ = summaryNode(c, TSummaryNodeClearsContentState(i, _)) and
+      exists(SummarizedCallable c, ParameterPosition pos |
+        pred.(ParamNode).isParameterOf(c, pos) and
+        succ = summaryNode(c, TSummaryNodeClearsContentState(pos, _)) and
         preservesValue = true
       )
     }
@@ -692,9 +704,9 @@ module Private {
      * node where field `b` is cleared).
      */
     predicate summaryClearsContent(Node n, Content c) {
-      exists(SummarizedCallable sc, int i |
-        n = summaryNode(sc, TSummaryNodeClearsContentState(i, true)) and
-        sc.clearsContent(i, c)
+      exists(SummarizedCallable sc, ParameterPosition pos |
+        n = summaryNode(sc, TSummaryNodeClearsContentState(pos, true)) and
+        sc.clearsContent(pos, c)
       )
     }
 
@@ -706,18 +718,23 @@ module Private {
      * `arg` (see comment for `summaryClearsContent`).
      */
     predicate summaryClearsContentArg(ArgNode arg, Content c) {
-      exists(DataFlowCall call, int i |
-        viableCallable(call).(SummarizedCallable).clearsContent(i, c) and
-        arg.argumentOf(call, i)
+      exists(DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos |
+        viableCallable(call).(SummarizedCallable).clearsContent(ppos, c) and
+        arg.argumentOf(call, apos) and
+        parameterMatch(ppos, apos)
       )
     }
 
     pragma[nomagic]
     private ParamNode summaryArgParam(ArgNode arg, ReturnKindExt rk, OutNodeExt out) {
-      exists(DataFlowCall call, int pos, SummarizedCallable callable |
-        arg.argumentOf(call, pos) and
+      exists(
+        DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos,
+        SummarizedCallable callable
+      |
+        arg.argumentOf(call, apos) and
         viableCallable(call) = callable and
-        result.isParameterOf(callable, pos) and
+        result.isParameterOf(callable, ppos) and
+        parameterMatch(ppos, apos) and
         out = rk.getAnOutNode(call)
       )
     }
@@ -795,39 +812,33 @@ module Private {
     }
 
     /** Holds if specification component `c` parses as parameter `n`. */
-    predicate parseParam(string c, int n) {
+    predicate parseParam(string c, ArgumentPosition pos) {
       specSplit(_, c, _) and
-      (
-        c.regexpCapture("Parameter\\[([-0-9]+)\\]", 1).toInt() = n
-        or
-        exists(int n1, int n2 |
-          c.regexpCapture("Parameter\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = n1 and
-          c.regexpCapture("Parameter\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = n2 and
-          n = [n1 .. n2]
-        )
+      exists(string body |
+        body = c.regexpCapture("Parameter\\[([^\\]]*)\\]", 1) and
+        pos = parseParamBody(body)
       )
     }
 
     /** Holds if specification component `c` parses as argument `n`. */
-    predicate parseArg(string c, int n) {
+    predicate parseArg(string c, ParameterPosition pos) {
       specSplit(_, c, _) and
-      (
-        c.regexpCapture("Argument\\[([-0-9]+)\\]", 1).toInt() = n
-        or
-        exists(int n1, int n2 |
-          c.regexpCapture("Argument\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = n1 and
-          c.regexpCapture("Argument\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = n2 and
-          n = [n1 .. n2]
-        )
+      exists(string body |
+        body = c.regexpCapture("Argument\\[([^\\]]*)\\]", 1) and
+        pos = parseArgBody(body)
       )
     }
 
     private SummaryComponent interpretComponent(string c) {
       specSplit(_, c, _) and
       (
-        exists(int pos | parseArg(c, pos) and result = SummaryComponent::argument(pos))
+        exists(ParameterPosition pos |
+          parseArg(c, pos) and result = SummaryComponent::argument(pos)
+        )
         or
-        exists(int pos | parseParam(c, pos) and result = SummaryComponent::parameter(pos))
+        exists(ArgumentPosition pos |
+          parseParam(c, pos) and result = SummaryComponent::parameter(pos)
+        )
         or
         c = "ReturnValue" and result = SummaryComponent::return(getReturnValueKind())
         or
@@ -934,14 +945,18 @@ module Private {
         interpretOutput(output, idx + 1, ref, mid) and
         specSplit(output, c, idx)
       |
-        exists(int pos |
-          node.asNode().(PostUpdateNode).getPreUpdateNode().(ArgNode).argumentOf(mid.asCall(), pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(PostUpdateNode).getPreUpdateNode().(ArgNode).argumentOf(mid.asCall(), apos) and
+          parameterMatch(ppos, apos)
         |
-          c = "Argument" or parseArg(c, pos)
+          c = "Argument" or parseArg(c, ppos)
         )
         or
-        exists(int pos | node.asNode().(ParamNode).isParameterOf(mid.asCallable(), pos) |
-          c = "Parameter" or parseParam(c, pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(ParamNode).isParameterOf(mid.asCallable(), ppos) and
+          parameterMatch(ppos, apos)
+        |
+          c = "Parameter" or parseParam(c, apos)
         )
         or
         c = "ReturnValue" and
@@ -960,8 +975,11 @@ module Private {
         interpretInput(input, idx + 1, ref, mid) and
         specSplit(input, c, idx)
       |
-        exists(int pos | node.asNode().(ArgNode).argumentOf(mid.asCall(), pos) |
-          c = "Argument" or parseArg(c, pos)
+        exists(ArgumentPosition apos, ParameterPosition ppos |
+          node.asNode().(ArgNode).argumentOf(mid.asCall(), apos) and
+          parameterMatch(ppos, apos)
+        |
+          c = "Argument" or parseArg(c, ppos)
         )
         or
         exists(ReturnNodeExt ret |
@@ -1110,9 +1128,9 @@ module Private {
       b.asCall() = summaryDataFlowCall(a.asNode()) and
       value = "receiver"
       or
-      exists(int i |
-        summaryArgumentNode(b.asCall(), a.asNode(), i) and
-        value = "argument (" + i + ")"
+      exists(ArgumentPosition pos |
+        summaryArgumentNode(b.asCall(), a.asNode(), pos) and
+        value = "argument (" + pos + ")"
       )
     }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -710,6 +710,14 @@ module Private {
       )
     }
 
+    pragma[noinline]
+    private predicate viableParam(
+      DataFlowCall call, SummarizedCallable sc, ParameterPosition ppos, ParamNode p
+    ) {
+      p.isParameterOf(sc, ppos) and
+      sc = viableCallable(call)
+    }
+
     /**
      * Holds if values stored inside content `c` are cleared inside a
      * callable to which `arg` is an argument.
@@ -718,23 +726,18 @@ module Private {
      * `arg` (see comment for `summaryClearsContent`).
      */
     predicate summaryClearsContentArg(ArgNode arg, Content c) {
-      exists(DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos |
-        viableCallable(call).(SummarizedCallable).clearsContent(ppos, c) and
-        arg.argumentOf(call, apos) and
-        parameterMatch(ppos, apos)
+      exists(DataFlowCall call, SummarizedCallable sc, ParameterPosition ppos |
+        argumentPositionMatch(call, arg, ppos) and
+        viableParam(call, sc, ppos, _) and
+        sc.clearsContent(ppos, c)
       )
     }
 
     pragma[nomagic]
     private ParamNode summaryArgParam(ArgNode arg, ReturnKindExt rk, OutNodeExt out) {
-      exists(
-        DataFlowCall call, ParameterPosition ppos, ArgumentPosition apos,
-        SummarizedCallable callable
-      |
-        arg.argumentOf(call, apos) and
-        viableCallable(call) = callable and
-        result.isParameterOf(callable, ppos) and
-        parameterMatch(ppos, apos) and
+      exists(DataFlowCall call, ParameterPosition ppos, SummarizedCallable sc |
+        argumentPositionMatch(call, arg, ppos) and
+        viableParam(call, sc, ppos, result) and
         out = rk.getAnOutNode(call)
       )
     }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -71,6 +71,12 @@ string getComponentSpecificCsv(SummaryComponent sc) {
   sc = TArgumentSummaryComponent(-2) and result = "BlockArgument"
 }
 
+/** Gets the textual representation of a parameter position in the format used for flow summaries. */
+string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() }
+
+/** Gets the textual representation of an argument position in the format used for flow summaries. */
+string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
+
 /** Gets the return kind corresponding to specification `"ReturnValue"`. */
 NormalReturnKind getReturnValueKind() { any() }
 
@@ -121,9 +127,8 @@ private module UnusedSourceSinkInterpretation {
 
 import UnusedSourceSinkInterpretation
 
-/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
 bindingset[s]
-ArgumentPosition parseParamBody(string s) {
+private int parsePosition(string s) {
   result = s.regexpCapture("([-0-9]+)", 1).toInt()
   or
   exists(int n1, int n2 |
@@ -133,6 +138,10 @@ ArgumentPosition parseParamBody(string s) {
   )
 }
 
+/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
+bindingset[s]
+ArgumentPosition parseParamBody(string s) { result = parsePosition(s) }
+
 /** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
 bindingset[s]
-ParameterPosition parseArgBody(string s) { result = parseParamBody(s) }
+ParameterPosition parseArgBody(string s) { result = parsePosition(s) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -11,9 +11,6 @@ private import FlowSummaryImpl::Private
 private import FlowSummaryImpl::Public
 private import codeql.ruby.dataflow.FlowSummary as FlowSummary
 
-/** Holds is `i` is a valid parameter position. */
-predicate parameterPosition(int i) { i in [-2 .. 10] }
-
 /** Gets the parameter position of the instance parameter. */
 int instanceParameterPosition() { none() } // disables implicit summary flow to `self` for callbacks
 
@@ -123,3 +120,19 @@ private module UnusedSourceSinkInterpretation {
 }
 
 import UnusedSourceSinkInterpretation
+
+/** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
+bindingset[s]
+ArgumentPosition parseParamBody(string s) {
+  result = s.regexpCapture("([-0-9]+)", 1).toInt()
+  or
+  exists(int n1, int n2 |
+    s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 1).toInt() = n1 and
+    s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 2).toInt() = n2 and
+    result in [n1 .. n2]
+  )
+}
+
+/** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
+bindingset[s]
+ParameterPosition parseArgBody(string s) { result = parseParamBody(s) }


### PR DESCRIPTION
This PR generalizes argument-to-parameter matching in the shared data-flow library from simple integer position based matching to per-language defined matching.

## Why

For static languages, integer based matching has worked just fine, since each call knows the signature of the callee(s), and adjustments of argument positions can be made accordingly at the call sites. For example, if we have a C# call
```csharp
Foo(snd: x, fst: y)
```
which targets a `Foo(int fst, int snd)` method, but swaps the order using named arguments, then we know that `x` must have position `1` and `y` must have position `0`.  Similarly, for calls to methods with variadic arguments
```csharp
Bar(1, 2, 3, 4)
```
where the signature is `Bar(params int[] args)`, we can treat the call as syntactic sugar for
```csharp
Bar(new int[] {1, 2, 3, 4})
```
that is, `1..4` are no longer `ArgumentNode`s, but instead there is a synthesized array argument node with position `0`.

However, for dynamic languages we do not know the signature of the callee(s), so we may have a Ruby call
```rb
foo(1, 2, 3, 4)
```
that targets both a `foo(a, b, c, d)` function and a `foo(first, *mid, last)` function, so whether `2` and `3` should be wrapped in an array depends on the callee, and what gets passed into `last` depends on the number of arguments at the call sites.

## How

This PR introduces two new classes `ParameterPosition` and `ArgumentPosition`, and a predicate `parameterMatch(ParameterPosition ppos, ArgumentPosition apos)` to the interface of the shared data-flow library. Each `ParameterNode` has a `ParameterPosition`, each `ArgumentNode` has an `ArgumentPosition`, and an argument is compatible with a parameter as dictated by `parameterMatch`. (Note that `parameterMatch` does *not* rely on the call graph, we already have `viableCallable` for that.)

Defining `ParameterPosition = ArgumentPosition = int` and `parameterMatch(ParameterPosition pp, ArgumentPosition ap) { pp = ap }` yields the existing behaviour, and that is how all languages are currently implemented (except for C#, where I decided to use different IPA wrappers to catch type errors).

## Follow-up work

For the named argument example, assume we have two Ruby calls
```rb
foo(fst: a, snd: b)
foo(snd: c, fst: d)
```
both targeting `foo(fst: , snd: )`. We can assign to `fst`, `a`, and `d` the positions `Named(fst)`, assign to `snd`, `b`, and `c` the positions `Named(snd)`,  and have `parameterMatch` be the identity.

For the variadic arguments example, consider the Ruby call
```rb
foo(1, 2, 3, 4)
```
that targets `foo(a, b, c, d)` and `foo(first, *mid, last)`. Assuming we have `PositionalArg(x, y)` mean positional argument `x` of `y`, `PositionalParam(x)` mean positional parameter `x`, `SplatParam(x, y)` mean splat parameter at position `x` skipping the last `y` arguments,`LastParam(x)` mean the `x`th last parameter, and `mid_synth` be a synthesized parameter node, we can assign the following positions

Element | Position
--- | ---
`1` | `PositionalArg(0, 4)`
`2` | `PositionalArg(1, 4)`
`3` | `PositionalArg(2, 4)`
`4` | `PositionalArg(3, 4)`
`a` | `PositionalParam(0)`
`b` | `PositionalParam(1)`
`c` | `PositionalParam(2)`
`d` | `PositionalParam(3)`
`first` | `PositionalParam(0)`
`mid_synth` | `SplatParam(1, 1)`
`last` | `LastParam(0)`

and define

```ql
parameterMatch(ParameterPosition ppos, ArgumentPosition apos) {
  exists(int x, int y |
    apos = PositionalArg(x, y) |
    ppos = PositionalParam(x)
    or
    exists(int from, int except |
      ppos = SplatParam(from, except) and
      x >= from and
      y - x > except
    )
    or
    exists(int last |
      ppos = LastParam(last) and
      y - x - 1 = last
    )
  )
}
```

`mid` will then no longer be a `ParameterNode`, but instead we will have an array store-step from `mid_synth` to `mid`, so we are effectively moving the implicit array creation from the caller to the callee, but in the context of the callee we know exactly which arguments to include.