### PR TITLE
C#: Fix `Newtonsoft.Json.JsonSerializer.{Deserialize,Serialize}` summaries

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/JsonNET.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/JsonNET.qll
@@ -153,14 +153,14 @@ module JsonNET {
       // Serialize
       c = this.getSerializeMethod() and
       preservesValue = false and
-      source = any(CallableFlowSourceArg arg | arg.getArgumentIndex() = 0) and
-      sink = any(CallableFlowSinkArg arg | arg.getArgumentIndex() = 1)
+      source = any(CallableFlowSourceArg arg | arg.getArgumentIndex() = 1) and
+      sink = any(CallableFlowSinkArg arg | arg.getArgumentIndex() = 0)
       or
       // Deserialize
       c = this.getDeserializeMethod() and
       preservesValue = false and
       source = any(CallableFlowSourceArg arg | arg.getArgumentIndex() = 0) and
-      sink = any(CallableFlowSinkArg arg | arg.getArgumentIndex() = 1)
+      sink instanceof CallableFlowSinkReturn
     }
   }
 


### PR DESCRIPTION
See
- https://www.newtonsoft.com/json/help/html/Overload_Newtonsoft_Json_JsonSerializer_Serialize.htm
- https://www.newtonsoft.com/json/help/html/Overload_Newtonsoft_Json_JsonSerializer_Deserialize.htm

Found via https://github.com/github/codeql/pull/7231.