### PR TITLE
C#: Filtered flow summaries

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -1004,6 +1004,13 @@ module Private {
     abstract class RelevantSummarizedCallable extends SummarizedCallable {
       /** Gets the string representation of this callable used by `summary/1`. */
       abstract string getCallableCsv();
+
+      /** Holds if flow is progated between `input` and `output` */
+      predicate relevantSummary(
+        SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+      ) {
+        this.propagatesFlow(input, output, preservesValue)
+      }
     }
 
     /** Render the kind in the format used in flow summaries. */
@@ -1023,7 +1030,7 @@ module Private {
         RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
         boolean preservesValue
       |
-        c.propagatesFlow(input, output, preservesValue) and
+        c.relevantSummary(input, output, preservesValue) and
         csv =
           c.getCallableCsv() + ";;" + getComponentStackCsv(input) + ";" +
             getComponentStackCsv(output) + ";" + renderKind(preservesValue)

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -1,0 +1,2810 @@
+| Microsoft.VisualBasic;Collection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| Microsoft.VisualBasic;Collection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| Microsoft.VisualBasic;Collection;false;get_Item;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| Microsoft.VisualBasic;Collection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| Microsoft.VisualBasic;Collection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JArray;false;Add;(Newtonsoft.Json.Linq.JToken);;Argument[0];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JArray;false;CopyTo;(Newtonsoft.Json.Linq.JToken[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| Newtonsoft.Json.Linq;JArray;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| Newtonsoft.Json.Linq;JArray;false;Insert;(System.Int32, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JArray;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JArray;false;get_Item;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JArray;false;set_Item;(System.Int32, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JArray;false;set_Item;(System.Object, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JConstructor;false;get_Item;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JConstructor;false;set_Item;(System.Object, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JContainer;false;Add;(Newtonsoft.Json.Linq.JToken);;Argument[0];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JContainer;false;Add;(System.Object);;Argument[0];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JContainer;false;CopyTo;(Newtonsoft.Json.Linq.JToken[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| Newtonsoft.Json.Linq;JContainer;false;Insert;(System.Int32, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JContainer;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JContainer;false;set_Item;(System.Int32, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JContainer;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;Add;(System.Collections.Generic.KeyValuePair<System.String,Newtonsoft.Json.Linq.JToken>);;Argument[0];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;Add;(System.Collections.Generic.KeyValuePair<System.String,Newtonsoft.Json.Linq.JToken>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;Add;(System.Collections.Generic.KeyValuePair<System.String,Newtonsoft.Json.Linq.JToken>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;Add;(System.String, Newtonsoft.Json.Linq.JToken);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;Add;(System.String, Newtonsoft.Json.Linq.JToken);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;CopyTo;(System.Collections.Generic.KeyValuePair<System.String,Newtonsoft.Json.Linq.JToken>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| Newtonsoft.Json.Linq;JObject;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;JObject;(Newtonsoft.Json.Linq.JObject);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;JObject;(Newtonsoft.Json.Linq.JObject);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;JObject;(System.Object[]);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;JObject;(System.Object[]);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;Parse;(System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json.Linq;JObject;false;Parse;(System.String, Newtonsoft.Json.Linq.JsonLoadSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json.Linq;JObject;false;get_Item;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;get_Item;(System.String);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| Newtonsoft.Json.Linq;JObject;false;set_Item;(System.Object, Newtonsoft.Json.Linq.JToken);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;set_Item;(System.Object, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;set_Item;(System.Object, Newtonsoft.Json.Linq.JToken);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;set_Item;(System.String, Newtonsoft.Json.Linq.JToken);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;set_Item;(System.String, Newtonsoft.Json.Linq.JToken);;Argument[1];Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JObject;false;set_Item;(System.String, Newtonsoft.Json.Linq.JToken);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| Newtonsoft.Json.Linq;JToken;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| Newtonsoft.Json.Linq;JToken;false;SelectToken;(System.String);;Argument[-1];ReturnValue;taint |
+| Newtonsoft.Json.Linq;JToken;false;SelectToken;(System.String, Newtonsoft.Json.Linq.JsonSelectSettings);;Argument[-1];ReturnValue;taint |
+| Newtonsoft.Json.Linq;JToken;false;SelectToken;(System.String, System.Boolean);;Argument[-1];ReturnValue;taint |
+| Newtonsoft.Json.Linq;JToken;false;explicit conversion;(Newtonsoft.Json.Linq.JToken);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeAnonymousType<>;(System.String, T);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeAnonymousType<>;(System.String, T, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject;(System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject;(System.String, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject;(System.String, System.Type);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject;(System.String, System.Type, Newtonsoft.Json.JsonConverter[]);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject;(System.String, System.Type, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject<>;(System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject<>;(System.String, Newtonsoft.Json.JsonConverter[]);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeObject<>;(System.String, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXNode;(System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXNode;(System.String, System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXNode;(System.String, System.String, System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXNode;(System.String, System.String, System.Boolean, System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXmlNode;(System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXmlNode;(System.String, System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXmlNode;(System.String, System.String, System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;DeserializeXmlNode;(System.String, System.String, System.Boolean, System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;PopulateObject;(System.String, System.Object);;Argument[0];Argument[1];taint |
+| Newtonsoft.Json;JsonConvert;false;PopulateObject;(System.String, System.Object, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];Argument[1];taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, Newtonsoft.Json.Formatting);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, Newtonsoft.Json.Formatting, Newtonsoft.Json.JsonConverter[]);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, Newtonsoft.Json.Formatting, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, Newtonsoft.Json.JsonConverter[]);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, System.Type, Newtonsoft.Json.Formatting, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeObject;(System.Object, System.Type, Newtonsoft.Json.JsonSerializerSettings);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeXNode;(System.Xml.Linq.XObject);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeXNode;(System.Xml.Linq.XObject, Newtonsoft.Json.Formatting);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeXNode;(System.Xml.Linq.XObject, Newtonsoft.Json.Formatting, System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeXmlNode;(System.Xml.XmlNode);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeXmlNode;(System.Xml.XmlNode, Newtonsoft.Json.Formatting);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;SerializeXmlNode;(System.Xml.XmlNode, Newtonsoft.Json.Formatting, System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Boolean);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Byte);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Char);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.DateTime);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.DateTime, Newtonsoft.Json.DateFormatHandling, Newtonsoft.Json.DateTimeZoneHandling);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.DateTimeOffset);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.DateTimeOffset, Newtonsoft.Json.DateFormatHandling);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Decimal);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Double);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Enum);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Guid);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Int16);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Int32);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Int64);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Object);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.SByte);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Single);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.String);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.String, System.Char);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.String, System.Char, Newtonsoft.Json.StringEscapeHandling);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.TimeSpan);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.UInt16);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.UInt32);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.UInt64);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonConvert;false;ToString;(System.Uri);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonSerializer;false;Deserialize;(Newtonsoft.Json.JsonReader);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonSerializer;false;Deserialize;(Newtonsoft.Json.JsonReader, System.Type);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonSerializer;false;Deserialize;(System.IO.TextReader, System.Type);;Argument[0];ReturnValue;taint |
+| Newtonsoft.Json;JsonSerializer;false;Serialize;(Newtonsoft.Json.JsonWriter, System.Object);;Argument[1];Argument[0];taint |
+| Newtonsoft.Json;JsonSerializer;false;Serialize;(Newtonsoft.Json.JsonWriter, System.Object, System.Type);;Argument[1];Argument[0];taint |
+| Newtonsoft.Json;JsonSerializer;false;Serialize;(System.IO.TextWriter, System.Object);;Argument[1];Argument[0];taint |
+| Newtonsoft.Json;JsonSerializer;false;Serialize;(System.IO.TextWriter, System.Object, System.Type);;Argument[1];Argument[0];taint |
+| System.Collections.Concurrent;BlockingCollection<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Concurrent;BlockingCollection<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Concurrent;BlockingCollection<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentBag<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentBag<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Concurrent;ConcurrentBag<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;ConcurrentDictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;ConcurrentDictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;ConcurrentDictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;ConcurrentDictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;ConcurrentDictionary;(System.Int32, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;ConcurrentDictionary;(System.Int32, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentDictionary<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Concurrent;ConcurrentQueue<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Concurrent;ConcurrentQueue<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Concurrent;ConcurrentStack<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Concurrent;ConcurrentStack<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>+KeyCollection;false;Add;(TKey);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>+KeyCollection;false;CopyTo;(TKey[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;Dictionary<,>+KeyCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.Dictionary<,>+KeyCollection+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>+KeyCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>+ValueCollection;false;Add;(TValue);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>+ValueCollection;false;CopyTo;(TValue[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;Dictionary<,>+ValueCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.Dictionary<,>+ValueCollection+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>+ValueCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IDictionary<TKey,TValue>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IDictionary<TKey,TValue>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;Dictionary;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>, System.Collections.Generic.IEqualityComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.Dictionary<,>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;Dictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;Dictionary<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;HashSet<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;HashSet<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;HashSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.HashSet<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;HashSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;IDictionary<,>;true;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;IDictionary<,>;true;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;IDictionary<,>;true;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;IDictionary<,>;true;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;IDictionary<,>;true;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;IList<>;true;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;IList<>;true;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Generic;KeyValuePair<,>;false;KeyValuePair;();;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of ReturnValue;value |
+| System.Collections.Generic;KeyValuePair<,>;false;KeyValuePair;();;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of ReturnValue;value |
+| System.Collections.Generic;KeyValuePair<,>;false;KeyValuePair;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of ReturnValue;value |
+| System.Collections.Generic;KeyValuePair<,>;false;KeyValuePair;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of ReturnValue;value |
+| System.Collections.Generic;LinkedList<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;LinkedList<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;LinkedList<>;false;Find;(T);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;LinkedList<>;false;FindLast;(T);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;LinkedList<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;LinkedList<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.LinkedList<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;List<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;List<>;false;AddRange;(System.Collections.Generic.IEnumerable<T>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;List<>;false;AsReadOnly;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Generic;List<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;List<>;false;Find;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Generic;List<>;false;Find;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;List<>;false;FindAll;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Generic;List<>;false;FindAll;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;List<>;false;FindLast;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Generic;List<>;false;FindLast;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;List<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;List<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.List<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;List<>;false;GetRange;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Generic;List<>;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Generic;List<>;false;InsertRange;(System.Int32, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];Element of Argument[-1];value |
+| System.Collections.Generic;List<>;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Generic;List<>;false;Reverse;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Generic;List<>;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;List<>;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Generic;List<>;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Generic;Queue<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;Queue<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;Queue<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.Queue<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;Queue<>;false;Peek;();;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>+KeyCollection;false;Add;(TKey);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>+KeyCollection;false;CopyTo;(TKey[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;SortedDictionary<,>+KeyCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>+KeyCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.SortedDictionary<,>+KeyCollection+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>+ValueCollection;false;Add;(TValue);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>+ValueCollection;false;CopyTo;(TValue[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;SortedDictionary<,>+ValueCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>+ValueCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.SortedDictionary<,>+ValueCollection+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;SortedDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.SortedDictionary<,>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;SortedDictionary;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;SortedDictionary;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;SortedDictionary;(System.Collections.Generic.IDictionary<TKey,TValue>, System.Collections.Generic.IComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;SortedDictionary;(System.Collections.Generic.IDictionary<TKey,TValue>, System.Collections.Generic.IComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;SortedDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedDictionary<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;SortedList<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;SortedList;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;SortedList;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;SortedList;(System.Collections.Generic.IDictionary<TKey,TValue>, System.Collections.Generic.IComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;SortedList;(System.Collections.Generic.IDictionary<TKey,TValue>, System.Collections.Generic.IComparer<TKey>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Generic;SortedList<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedList<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Generic;SortedSet<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Generic;SortedSet<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;SortedSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.SortedSet<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;SortedSet<>;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Generic;Stack<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Generic;Stack<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Generic;Stack<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.Stack<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Generic;Stack<>;false;Peek;();;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Generic;Stack<>;false;Pop;();;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange;(System.Collections.Generic.IEnumerable<T>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange;(System.Collections.Immutable.ImmutableArray<>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange;(System.Collections.Immutable.ImmutableArray<>+Builder);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange;(T[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange<>;(System.Collections.Immutable.ImmutableArray<TDerived>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange<>;(System.Collections.Immutable.ImmutableArray<TDerived>+Builder);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;AddRange<>;(TDerived[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableArray<>+Builder;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;AddRange;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableDictionary<,>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>+Builder;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;AddRange;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableDictionary<,>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableDictionary<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableHashSet<>+Builder;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableHashSet<>+Builder;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableHashSet<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableHashSet<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableHashSet<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableHashSet<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableHashSet<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableHashSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableHashSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableHashSet<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;AddRange;(System.Collections.Generic.IEnumerable<T>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;Find;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;Find;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;FindAll;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;FindAll;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;FindLast;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;FindLast;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableList<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;GetRange;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;InsertRange;(System.Int32, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;Reverse;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>+Builder;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>;false;AddRange;(System.Collections.Generic.IEnumerable<T>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>;false;Find;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>;false;Find;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;FindAll;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>;false;FindAll;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;FindLast;(System.Predicate<T>);;Element of Argument[-1];Parameter[0] of Argument[0];value |
+| System.Collections.Immutable;ImmutableList<>;false;FindLast;(System.Predicate<T>);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableList<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;GetRange;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>;false;InsertRange;(System.Int32, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;Reverse;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableList<>;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableList<>;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableQueue<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableQueue<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableQueue<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;AddRange;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableSortedDictionary<,>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>+Builder;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;AddRange;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey,TValue>>);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableSortedDictionary<,>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedDictionary<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedSet<>+Builder;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedSet<>+Builder;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableSortedSet<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>+Builder;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableSortedSet<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>+Builder;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableSortedSet<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableSortedSet<>;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Immutable;ImmutableStack<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.Immutable;ImmutableStack<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Immutable.ImmutableStack<>+Enumerator.Current] of ReturnValue;value |
+| System.Collections.ObjectModel;Collection<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.ObjectModel;Collection<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.ObjectModel;Collection<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.ObjectModel;Collection<>;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.ObjectModel;Collection<>;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.ObjectModel;Collection<>;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.ObjectModel;Collection<>;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.ObjectModel;KeyedCollection<,>;false;get_Item;(TKey);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyCollection<>;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>+KeyCollection;false;Add;(TKey);;Argument[0];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>+KeyCollection;false;CopyTo;(TKey[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>+KeyCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>+ValueCollection;false;Add;(TValue);;Argument[0];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>+ValueCollection;false;CopyTo;(TValue[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>+ValueCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Argument[0];Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;Add;(System.Collections.Generic.KeyValuePair<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;Add;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;Add;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;CopyTo;(System.Collections.Generic.KeyValuePair<TKey,TValue>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;ReadOnlyDictionary;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;ReadOnlyDictionary;(System.Collections.Generic.IDictionary<TKey,TValue>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;get_Item;(TKey);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;set_Item;(TKey, TValue);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.ObjectModel;ReadOnlyDictionary<,>;false;set_Item;(TKey, TValue);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Specialized;HybridDictionary;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Specialized;HybridDictionary;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Specialized;HybridDictionary;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Specialized;HybridDictionary;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Specialized;HybridDictionary;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Specialized;IOrderedDictionary;true;get_Item;(System.Int32);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Specialized;IOrderedDictionary;true;set_Item;(System.Int32, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Specialized;IOrderedDictionary;true;set_Item;(System.Int32, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Specialized;ListDictionary;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Specialized;ListDictionary;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Specialized;ListDictionary;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Specialized;ListDictionary;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Specialized;ListDictionary;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Specialized;NameValueCollection;false;Add;(System.Collections.Specialized.NameValueCollection);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Specialized;NameValueCollection;false;CopyTo;(System.Array, System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Specialized;OrderedDictionary;false;AsReadOnly;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections.Specialized;OrderedDictionary;false;get_Item;(System.Int32);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Specialized;OrderedDictionary;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections.Specialized;OrderedDictionary;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Specialized;OrderedDictionary;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections.Specialized;OrderedDictionary;false;set_Item;(System.Int32, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Specialized;OrderedDictionary;false;set_Item;(System.Int32, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Specialized;OrderedDictionary;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections.Specialized;OrderedDictionary;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections.Specialized;StringCollection;false;Add;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Collections.Specialized;StringCollection;false;AddRange;(System.String[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections.Specialized;StringCollection;false;CopyTo;(System.String[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Collections.Specialized;StringCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Specialized.StringEnumerator.Current] of ReturnValue;value |
+| System.Collections.Specialized;StringCollection;false;Insert;(System.Int32, System.String);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Specialized;StringCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections.Specialized;StringCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections.Specialized;StringCollection;false;set_Item;(System.Int32, System.String);;Argument[1];Element of Argument[-1];value |
+| System.Collections;ArrayList;false;AddRange;(System.Collections.ICollection);;Element of Argument[0];Element of Argument[-1];value |
+| System.Collections;ArrayList;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;FixedSize;(System.Collections.ArrayList);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;FixedSize;(System.Collections.IList);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;GetEnumerator;(System.Int32, System.Int32);;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| System.Collections;ArrayList;false;GetRange;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;InsertRange;(System.Int32, System.Collections.ICollection);;Element of Argument[1];Element of Argument[-1];value |
+| System.Collections;ArrayList;false;Repeat;(System.Object, System.Int32);;Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;Reverse;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;ArrayList;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections;ArrayList;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections;BitArray;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;CollectionBase;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections;CollectionBase;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections;DictionaryBase;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections;DictionaryBase;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;DictionaryBase;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;DictionaryBase;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections;DictionaryBase;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections;Hashtable;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Collections.IEqualityComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Collections.IEqualityComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Collections.IHashCodeProvider, System.Collections.IComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Collections.IHashCodeProvider, System.Collections.IComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Single);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Single);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Single, System.Collections.IEqualityComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Single, System.Collections.IEqualityComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Single, System.Collections.IHashCodeProvider, System.Collections.IComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;Hashtable;(System.Collections.IDictionary, System.Single, System.Collections.IHashCodeProvider, System.Collections.IComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;Hashtable;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections;Hashtable;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;Hashtable;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;Hashtable;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections;Hashtable;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections;IDictionary;true;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections;IDictionary;true;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;IDictionary;true;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;IDictionary;true;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections;IDictionary;true;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections;IList;true;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Collections;IList;true;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Collections;Queue;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;Queue;false;Peek;();;Element of Argument[-1];ReturnValue;value |
+| System.Collections;SortedList;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;SortedList;false;GetByIndex;(System.Int32);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections;SortedList;false;GetValueList;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;SortedList;false;SortedList;(System.Collections.IDictionary);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;SortedList;false;SortedList;(System.Collections.IDictionary);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;SortedList;false;SortedList;(System.Collections.IDictionary, System.Collections.IComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Collections;SortedList;false;SortedList;(System.Collections.IDictionary, System.Collections.IComparer);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Collections;SortedList;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Collections;SortedList;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;SortedList;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Collections;SortedList;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Collections;SortedList;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Collections;Stack;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Collections;Stack;false;Peek;();;Element of Argument[-1];ReturnValue;value |
+| System.Collections;Stack;false;Pop;();;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel.Design;DesignerCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| System.ComponentModel.Design;DesignerOptionService+DesignerOptionCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel.Design;DesignerOptionService+DesignerOptionCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel.Design;DesignerOptionService+DesignerOptionCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;Add;(System.ComponentModel.Design.DesignerVerb);;Argument[0];Element of Argument[-1];value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;AddRange;(System.ComponentModel.Design.DesignerVerbCollection);;Element of Argument[0];Element of Argument[-1];value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;AddRange;(System.ComponentModel.Design.DesignerVerb[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;CopyTo;(System.ComponentModel.Design.DesignerVerb[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;Insert;(System.Int32, System.ComponentModel.Design.DesignerVerb);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel.Design;DesignerVerbCollection;false;set_Item;(System.Int32, System.ComponentModel.Design.DesignerVerb);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;AttributeCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| System.ComponentModel;ComponentCollection;false;CopyTo;(System.ComponentModel.IComponent[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.ComponentModel;EventDescriptorCollection;false;Add;(System.ComponentModel.EventDescriptor);;Argument[0];Element of Argument[-1];value |
+| System.ComponentModel;EventDescriptorCollection;false;Find;(System.String, System.Boolean);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;EventDescriptorCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| System.ComponentModel;EventDescriptorCollection;false;Insert;(System.Int32, System.ComponentModel.EventDescriptor);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;EventDescriptorCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;EventDescriptorCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;EventDescriptorCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;ListSortDescriptionCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;ListSortDescriptionCollection;false;set_Item;(System.Int32, System.ComponentModel.ListSortDescription);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;ListSortDescriptionCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Add;(System.ComponentModel.PropertyDescriptor);;Argument[0];Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Add;(System.ComponentModel.PropertyDescriptor);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Add;(System.ComponentModel.PropertyDescriptor);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Add;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Add;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Find;(System.String, System.Boolean);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;Insert;(System.Int32, System.ComponentModel.PropertyDescriptor);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;PropertyDescriptorCollection;(System.ComponentModel.PropertyDescriptor[]);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;PropertyDescriptorCollection;(System.ComponentModel.PropertyDescriptor[]);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;PropertyDescriptorCollection;(System.ComponentModel.PropertyDescriptor[], System.Boolean);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;PropertyDescriptorCollection;(System.ComponentModel.PropertyDescriptor[], System.Boolean);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Item;(System.Int32);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Item;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Item;(System.String);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.ComponentModel;PropertyDescriptorCollection;false;set_Item;(System.Int32, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;set_Item;(System.Object, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.ComponentModel;PropertyDescriptorCollection;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;AddRange;(System.Array);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;AddRange;(System.Data.Common.DataColumnMapping[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;CopyTo;(System.Data.Common.DataColumnMapping[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data.Common;DataColumnMappingCollection;false;Insert;(System.Int32, System.Data.Common.DataColumnMapping);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DataColumnMappingCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DataColumnMappingCollection;false;set_Item;(System.Int32, System.Data.Common.DataColumnMapping);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;set_Item;(System.String, System.Data.Common.DataColumnMapping);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataColumnMappingCollection;false;set_Item;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;AddRange;(System.Array);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;AddRange;(System.Data.Common.DataTableMapping[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;CopyTo;(System.Data.Common.DataTableMapping[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data.Common;DataTableMappingCollection;false;Insert;(System.Int32, System.Data.Common.DataTableMapping);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DataTableMappingCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DataTableMappingCollection;false;set_Item;(System.Int32, System.Data.Common.DataTableMapping);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;set_Item;(System.String, System.Data.Common.DataTableMapping);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DataTableMappingCollection;false;set_Item;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DbConnectionStringBuilder;false;Add;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Data.Common;DbConnectionStringBuilder;false;Add;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Data.Common;DbConnectionStringBuilder;false;get_Item;(System.Object);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DbConnectionStringBuilder;false;get_Item;(System.String);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DbConnectionStringBuilder;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Data.Common;DbConnectionStringBuilder;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Data.Common;DbConnectionStringBuilder;false;set_Item;(System.Object, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Data.Common;DbConnectionStringBuilder;false;set_Item;(System.Object, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Data.Common;DbConnectionStringBuilder;false;set_Item;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Data.Common;DbConnectionStringBuilder;false;set_Item;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Data.Common;DbParameterCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DbParameterCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Data.Common;DbParameterCollection;false;set_Item;(System.Int32, System.Data.Common.DbParameter);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DbParameterCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DbParameterCollection;false;set_Item;(System.String, System.Data.Common.DbParameter);;Argument[1];Element of Argument[-1];value |
+| System.Data.Common;DbParameterCollection;false;set_Item;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data;ConstraintCollection;false;Add;(System.Data.Constraint);;Argument[0];Element of Argument[-1];value |
+| System.Data;ConstraintCollection;false;AddRange;(System.Data.Constraint[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data;ConstraintCollection;false;CopyTo;(System.Data.Constraint[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data;DataColumnCollection;false;Add;(System.Data.DataColumn);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataColumnCollection;false;Add;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataColumnCollection;false;AddRange;(System.Data.DataColumn[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data;DataColumnCollection;false;CopyTo;(System.Data.DataColumn[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data;DataRelationCollection;false;Add;(System.Data.DataRelation);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataRelationCollection;false;AddRange;(System.Data.DataRelation[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data;DataRelationCollection;false;CopyTo;(System.Data.DataRelation[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data;DataRowCollection;false;Add;(System.Data.DataRow);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataRowCollection;false;Add;(System.Object[]);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataRowCollection;false;CopyTo;(System.Data.DataRow[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data;DataRowCollection;false;Find;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| System.Data;DataRowCollection;false;Find;(System.Object[]);;Element of Argument[-1];ReturnValue;value |
+| System.Data;DataTableCollection;false;Add;(System.Data.DataTable);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataTableCollection;false;Add;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Data;DataTableCollection;false;AddRange;(System.Data.DataTable[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Data;DataTableCollection;false;CopyTo;(System.Data.DataTable[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data;DataView;false;Find;(System.Object);;Element of Argument[-1];ReturnValue;value |
+| System.Data;DataView;false;Find;(System.Object[]);;Element of Argument[-1];ReturnValue;value |
+| System.Data;DataView;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Data;DataView;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data;DataViewManager;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Data;DataViewManager;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data;DataViewSettingCollection;false;CopyTo;(System.Data.DataViewSetting[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Data;EnumerableRowCollection<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;Cast<>;(System.Data.EnumerableRowCollection);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderBy<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderBy<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderBy<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderBy<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderByDescending<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderByDescending<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderByDescending<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;OrderByDescending<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;Select<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,S>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;Select<,>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,S>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenBy<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenBy<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenBy<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenBy<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenByDescending<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenByDescending<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenByDescending<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;ThenByDescending<,>;(System.Data.OrderedEnumerableRowCollection<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;EnumerableRowCollectionExtensions;false;Where<>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;EnumerableRowCollectionExtensions;false;Where<>;(System.Data.EnumerableRowCollection<TRow>, System.Func<TRow,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;IColumnMappingCollection;true;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Data;IColumnMappingCollection;true;set_Item;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data;IDataParameterCollection;true;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Data;IDataParameterCollection;true;set_Item;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data;ITableMappingCollection;true;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Data;ITableMappingCollection;true;set_Item;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Data;PropertyCollection;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBase<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;AsEnumerable<>;(System.Data.TypedTableBase<TRow>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;ElementAtOrDefault<>;(System.Data.TypedTableBase<TRow>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;OrderBy<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;OrderBy<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;TypedTableBaseExtensions;false;OrderBy<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;OrderBy<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;TypedTableBaseExtensions;false;OrderByDescending<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;OrderByDescending<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;TypedTableBaseExtensions;false;OrderByDescending<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;OrderByDescending<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;TypedTableBaseExtensions;false;Select<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,S>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Data;TypedTableBaseExtensions;false;Select<,>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,S>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;Where<>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Data;TypedTableBaseExtensions;false;Where<>;(System.Data.TypedTableBase<TRow>, System.Func<TRow,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Diagnostics;ActivityTagsCollection;false;ActivityTagsCollection;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String,System.Object>>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;ActivityTagsCollection;(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String,System.Object>>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Argument[0];Element of Argument[-1];value |
+| System.Diagnostics;ActivityTagsCollection;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Diagnostics;ActivityTagsCollection;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Diagnostics;ActivityTagsCollection;false;Add;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Diagnostics;ActivityTagsCollection;false;Add;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Diagnostics;ActivityTagsCollection;false;CopyTo;(System.Collections.Generic.KeyValuePair<System.String,System.Object>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Diagnostics;ActivityTagsCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Diagnostics.ActivityTagsCollection+Enumerator.Current] of ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;get_Item;(System.String);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Diagnostics;ActivityTagsCollection;false;set_Item;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Diagnostics;ActivityTagsCollection;false;set_Item;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Diagnostics;ProcessModuleCollection;false;CopyTo;(System.Diagnostics.ProcessModule[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Diagnostics;ProcessThreadCollection;false;Add;(System.Diagnostics.ProcessThread);;Argument[0];Element of Argument[-1];value |
+| System.Diagnostics;ProcessThreadCollection;false;CopyTo;(System.Diagnostics.ProcessThread[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Diagnostics;TraceListenerCollection;false;Add;(System.Diagnostics.TraceListener);;Argument[0];Element of Argument[-1];value |
+| System.Diagnostics;TraceListenerCollection;false;AddRange;(System.Diagnostics.TraceListenerCollection);;Element of Argument[0];Element of Argument[-1];value |
+| System.Diagnostics;TraceListenerCollection;false;AddRange;(System.Diagnostics.TraceListener[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Diagnostics;TraceListenerCollection;false;CopyTo;(System.Diagnostics.TraceListener[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Diagnostics;TraceListenerCollection;false;Insert;(System.Int32, System.Diagnostics.TraceListener);;Argument[1];Element of Argument[-1];value |
+| System.Diagnostics;TraceListenerCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Diagnostics;TraceListenerCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Diagnostics;TraceListenerCollection;false;set_Item;(System.Int32, System.Diagnostics.TraceListener);;Argument[1];Element of Argument[-1];value |
+| System.Diagnostics;TraceListenerCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Argument[0];Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;Add;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;Add;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;CopyTo;(System.Collections.Generic.KeyValuePair<System.String,System.Object>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Dynamic;ExpandoObject;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Dynamic;ExpandoObject;false;get_Item;(System.String);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Dynamic;ExpandoObject;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Dynamic;ExpandoObject;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Dynamic;ExpandoObject;false;set_Item;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Dynamic;ExpandoObject;false;set_Item;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.IO.Compression;BrotliStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;BrotliStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO.Compression;BrotliStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;BrotliStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO.Compression;DeflateStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;DeflateStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO.Compression;DeflateStream;false;CopyTo;(System.IO.Stream, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;DeflateStream;false;CopyToAsync;(System.IO.Stream, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;DeflateStream;false;DeflateStream;(System.IO.Stream, System.IO.Compression.CompressionLevel);;Argument[0];ReturnValue;taint |
+| System.IO.Compression;DeflateStream;false;DeflateStream;(System.IO.Stream, System.IO.Compression.CompressionLevel, System.Boolean);;Argument[0];ReturnValue;taint |
+| System.IO.Compression;DeflateStream;false;DeflateStream;(System.IO.Stream, System.IO.Compression.CompressionMode);;Argument[0];ReturnValue;taint |
+| System.IO.Compression;DeflateStream;false;DeflateStream;(System.IO.Stream, System.IO.Compression.CompressionMode, System.Boolean);;Argument[0];ReturnValue;taint |
+| System.IO.Compression;DeflateStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;DeflateStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO.Compression;GZipStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;GZipStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO.Compression;GZipStream;false;CopyTo;(System.IO.Stream, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;GZipStream;false;CopyToAsync;(System.IO.Stream, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;GZipStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.Compression;GZipStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO.Enumeration;FileSystemEnumerable<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.IO.IsolatedStorage;IsolatedStorageFileStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO.IsolatedStorage;IsolatedStorageFileStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO.IsolatedStorage;IsolatedStorageFileStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.IsolatedStorage;IsolatedStorageFileStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO.Pipes;PipeStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO.Pipes;PipeStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO.Pipes;PipeStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO.Pipes;PipeStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO;BufferedStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO;BufferedStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO;BufferedStream;false;CopyTo;(System.IO.Stream, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO;BufferedStream;false;CopyToAsync;(System.IO.Stream, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;BufferedStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;BufferedStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO;FileStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO;FileStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO;FileStream;false;CopyToAsync;(System.IO.Stream, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;FileStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;FileStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO;MemoryStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO;MemoryStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO;MemoryStream;false;CopyTo;(System.IO.Stream, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO;MemoryStream;false;CopyToAsync;(System.IO.Stream, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;MemoryStream;false;MemoryStream;(System.Byte[]);;Argument[0];ReturnValue;taint |
+| System.IO;MemoryStream;false;MemoryStream;(System.Byte[], System.Boolean);;Argument[0];ReturnValue;taint |
+| System.IO;MemoryStream;false;MemoryStream;(System.Byte[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System.IO;MemoryStream;false;MemoryStream;(System.Byte[], System.Int32, System.Int32, System.Boolean);;Argument[0];ReturnValue;taint |
+| System.IO;MemoryStream;false;MemoryStream;(System.Byte[], System.Int32, System.Int32, System.Boolean, System.Boolean);;Argument[0];ReturnValue;taint |
+| System.IO;MemoryStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;MemoryStream;false;ToArray;();;Argument[-1];ReturnValue;taint |
+| System.IO;MemoryStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO;Path;false;Combine;(System.String, System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String);;Argument[1];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String);;Argument[1];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String);;Argument[2];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String, System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String, System.String);;Argument[1];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String, System.String);;Argument[2];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String, System.String, System.String, System.String);;Argument[3];ReturnValue;taint |
+| System.IO;Path;false;Combine;(System.String[]);;Element of Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetDirectoryName;(System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetDirectoryName;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetExtension;(System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetExtension;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetFileName;(System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetFileName;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetFileNameWithoutExtension;(System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetFileNameWithoutExtension;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetFullPath;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetFullPath;(System.String, System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetPathRoot;(System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetPathRoot;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;Path;false;GetRelativePath;(System.String, System.String);;Argument[1];ReturnValue;taint |
+| System.IO;Stream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.IO;Stream;false;CopyTo;(System.IO.Stream);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;CopyTo;(System.IO.Stream, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;CopyToAsync;(System.IO.Stream);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;CopyToAsync;(System.IO.Stream, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;CopyToAsync;(System.IO.Stream, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;CopyToAsync;(System.IO.Stream, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;Stream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32);;Argument[0];Argument[-1];taint |
+| System.IO;Stream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.IO;StringReader;false;Read;();;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;Read;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;Read;(System.Span<System.Char>);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadAsync;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadAsync;(System.Memory<System.Char>, System.Threading.CancellationToken);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadBlock;(System.Span<System.Char>);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadBlockAsync;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadBlockAsync;(System.Memory<System.Char>, System.Threading.CancellationToken);;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadLine;();;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadLineAsync;();;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadToEnd;();;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;ReadToEndAsync;();;Argument[-1];ReturnValue;taint |
+| System.IO;StringReader;false;StringReader;(System.String);;Argument[0];ReturnValue;taint |
+| System.IO;TextReader;false;Read;();;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;Read;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;Read;(System.Span<System.Char>);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadAsync;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadAsync;(System.Memory<System.Char>, System.Threading.CancellationToken);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadBlock;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadBlock;(System.Span<System.Char>);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadBlockAsync;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadBlockAsync;(System.Memory<System.Char>, System.Threading.CancellationToken);;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadLine;();;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadLineAsync;();;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadToEnd;();;Argument[-1];ReturnValue;taint |
+| System.IO;TextReader;false;ReadToEndAsync;();;Argument[-1];ReturnValue;taint |
+| System.IO;UnmanagedMemoryStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.IO;UnmanagedMemoryStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.Linq;Enumerable;false;Aggregate<,,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;Aggregate<,,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;Element of Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;Enumerable;false;Aggregate<,,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;ReturnValue of Argument[2];Parameter[0] of Argument[3];value |
+| System.Linq;Enumerable;false;Aggregate<,,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;ReturnValue of Argument[3];ReturnValue;value |
+| System.Linq;Enumerable;false;Aggregate<,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>);;Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;Aggregate<,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>);;Element of Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;Enumerable;false;Aggregate<,>;(System.Collections.Generic.IEnumerable<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>);;ReturnValue of Argument[2];ReturnValue;value |
+| System.Linq;Enumerable;false;Aggregate<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TSource,TSource>);;Element of Argument[0];Parameter[1] of Argument[1];value |
+| System.Linq;Enumerable;false;Aggregate<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TSource,TSource>);;ReturnValue of Argument[1];ReturnValue;value |
+| System.Linq;Enumerable;false;All<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Any<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;AsEnumerable<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Average<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Cast<>;(System.Collections.IEnumerable);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Concat<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Concat<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Count<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;DefaultIfEmpty<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;DefaultIfEmpty<>;(System.Collections.Generic.IEnumerable<TSource>, TSource);;Argument[1];ReturnValue;value |
+| System.Linq;Enumerable;false;DefaultIfEmpty<>;(System.Collections.Generic.IEnumerable<TSource>, TSource);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;Distinct<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Distinct<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ElementAt<>;(System.Collections.Generic.IEnumerable<TSource>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;ElementAtOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;Except<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;Except<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;First<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;First<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;First<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;FirstOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;FirstOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;FirstOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;ReturnValue of Argument[2];Element of Parameter[1] of Argument[3];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;ReturnValue of Argument[3];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of Parameter[1] of Argument[3];value |
+| System.Linq;Enumerable;false;GroupBy<,,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[3];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupBy<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupBy<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Enumerable;false;GroupJoin<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Intersect<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Intersect<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Intersect<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Intersect<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Enumerable;false;Join<,,,>;(System.Collections.Generic.IEnumerable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Last<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;Last<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Last<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;LastOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;LastOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;LastOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;LongCount<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Max<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Min<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;OfType<>;(System.Collections.IEnumerable);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;OrderBy<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;OrderBy<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;OrderBy<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;OrderBy<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;OrderByDescending<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;OrderByDescending<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;OrderByDescending<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;OrderByDescending<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Reverse<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Select<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Select<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,TResult>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Select<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Select<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TResult>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of ReturnValue of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of ReturnValue of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;Enumerable;false;SelectMany<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SelectMany<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;SelectMany<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TResult>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SelectMany<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;SelectMany<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TResult>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Single<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;Single<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Single<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;SingleOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;SingleOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;SingleOrDefault<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Enumerable;false;Skip<>;(System.Collections.Generic.IEnumerable<TSource>, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SkipWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SkipWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;SkipWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;SkipWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Sum<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Take<>;(System.Collections.Generic.IEnumerable<TSource>, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;TakeWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;TakeWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;TakeWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;TakeWhile<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ThenBy<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ThenBy<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ThenBy<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ThenBy<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ThenByDescending<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ThenByDescending<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ThenByDescending<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ThenByDescending<,>;(System.Linq.IOrderedEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToArray<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToDictionary<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToDictionary<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;ToDictionary<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToDictionary<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToDictionary<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;ToDictionary<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToDictionary<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToDictionary<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToDictionary<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToDictionary<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToList<>;(System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToLookup<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToLookup<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;ToLookup<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToLookup<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToLookup<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;ToLookup<,,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToLookup<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToLookup<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;ToLookup<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;ToLookup<,>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Union<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Union<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Union<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Union<>;(System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Where<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Where<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Where<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Enumerable;false;Where<>;(System.Collections.Generic.IEnumerable<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Enumerable;false;Zip<,,>;(System.Collections.Generic.IEnumerable<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Func<TFirst,TSecond,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Enumerable;false;Zip<,,>;(System.Collections.Generic.IEnumerable<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Func<TFirst,TSecond,TResult>);;Element of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;Enumerable;false;Zip<,,>;(System.Collections.Generic.IEnumerable<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Func<TFirst,TSecond,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;EnumerableQuery<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Linq;ImmutableArrayExtensions;false;First<>;(System.Collections.Immutable.ImmutableArray<T>+Builder);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ImmutableArrayExtensions;false;FirstOrDefault<>;(System.Collections.Immutable.ImmutableArray<T>+Builder);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ImmutableArrayExtensions;false;Last<>;(System.Collections.Immutable.ImmutableArray<T>+Builder);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ImmutableArrayExtensions;false;LastOrDefault<>;(System.Collections.Immutable.ImmutableArray<T>+Builder);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Lookup<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Linq;OrderedParallelQuery<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;Element of Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;ReturnValue of Argument[2];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>, System.Func<TAccumulate,TResult>);;ReturnValue of Argument[3];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>);;Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>);;Element of Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Aggregate<,>;(System.Linq.ParallelQuery<TSource>, TAccumulate, System.Func<TAccumulate,TSource,TAccumulate>);;ReturnValue of Argument[2];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Aggregate<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TSource,TSource>);;Element of Argument[0];Parameter[1] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Aggregate<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TSource,TSource>);;ReturnValue of Argument[1];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;All<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Any<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;AsEnumerable<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Average<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Cast<>;(System.Linq.ParallelQuery);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Concat<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Concat<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Concat<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Concat<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Count<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;DefaultIfEmpty<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;DefaultIfEmpty<>;(System.Linq.ParallelQuery<TSource>, TSource);;Argument[1];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;DefaultIfEmpty<>;(System.Linq.ParallelQuery<TSource>, TSource);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Distinct<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Distinct<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ElementAt<>;(System.Linq.ParallelQuery<TSource>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ElementAtOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Except<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Except<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Except<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Except<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;First<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;First<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;First<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;FirstOrDefault<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;FirstOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;FirstOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;ReturnValue of Argument[2];Element of Parameter[1] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>);;ReturnValue of Argument[3];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of Parameter[1] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[3];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupBy<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;GroupJoin<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Intersect<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;ParallelEnumerable;false;Join<,,,>;(System.Linq.ParallelQuery<TOuter>, System.Linq.ParallelQuery<TInner>, System.Func<TOuter,TKey>, System.Func<TInner,TKey>, System.Func<TOuter,TInner,TResult>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Last<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Last<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Last<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;LastOrDefault<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;LastOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;LastOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;LongCount<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Max<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Min<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;OfType<>;(System.Linq.ParallelQuery);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;OrderBy<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;OrderBy<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;OrderBy<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;OrderBy<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;OrderByDescending<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;OrderByDescending<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;OrderByDescending<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;OrderByDescending<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Reverse<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Select<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Select<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,TResult>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Select<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Select<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TResult>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of ReturnValue of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;Element of ReturnValue of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>, System.Func<TSource,TCollection,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Collections.Generic.IEnumerable<TResult>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;SelectMany<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TResult>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Single<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Single<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Single<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SingleOrDefault<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SingleOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;SingleOrDefault<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Skip<>;(System.Linq.ParallelQuery<TSource>, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SkipWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SkipWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;SkipWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;SkipWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Decimal>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Double>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int64>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Nullable<System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Sum<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Single>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Take<>;(System.Linq.ParallelQuery<TSource>, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;TakeWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;TakeWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;TakeWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;TakeWhile<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ThenBy<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ThenBy<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ThenBy<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ThenBy<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ThenByDescending<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ThenByDescending<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ThenByDescending<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ThenByDescending<,>;(System.Linq.OrderedParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToArray<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToDictionary<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToList<>;(System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Func<TSource,TElement>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;ToLookup<,>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,TKey>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Union<>;(System.Linq.ParallelQuery<TSource>, System.Linq.ParallelQuery<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Where<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Where<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Where<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Where<>;(System.Linq.ParallelQuery<TSource>, System.Func<TSource,System.Int32,System.Boolean>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;ParallelEnumerable;false;Zip<,,>;(System.Linq.ParallelQuery<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Func<TFirst,TSecond,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Zip<,,>;(System.Linq.ParallelQuery<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Func<TFirst,TSecond,TResult>);;Element of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Zip<,,>;(System.Linq.ParallelQuery<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Func<TFirst,TSecond,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelEnumerable;false;Zip<,,>;(System.Linq.ParallelQuery<TFirst>, System.Linq.ParallelQuery<TSecond>, System.Func<TFirst,TSecond,TResult>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Zip<,,>;(System.Linq.ParallelQuery<TFirst>, System.Linq.ParallelQuery<TSecond>, System.Func<TFirst,TSecond,TResult>);;Element of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;ParallelEnumerable;false;Zip<,,>;(System.Linq.ParallelQuery<TFirst>, System.Linq.ParallelQuery<TSecond>, System.Func<TFirst,TSecond,TResult>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;ParallelQuery<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Linq;Queryable;false;Aggregate<,,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>, System.Linq.Expressions.Expression<System.Func<TAccumulate,TResult>>);;Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;Aggregate<,,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>, System.Linq.Expressions.Expression<System.Func<TAccumulate,TResult>>);;Element of Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;Queryable;false;Aggregate<,,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>, System.Linq.Expressions.Expression<System.Func<TAccumulate,TResult>>);;ReturnValue of Argument[2];Parameter[0] of Argument[3];value |
+| System.Linq;Queryable;false;Aggregate<,,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>, System.Linq.Expressions.Expression<System.Func<TAccumulate,TResult>>);;ReturnValue of Argument[3];ReturnValue;value |
+| System.Linq;Queryable;false;Aggregate<,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>);;Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;Aggregate<,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>);;Element of Argument[0];Parameter[1] of Argument[2];value |
+| System.Linq;Queryable;false;Aggregate<,>;(System.Linq.IQueryable<TSource>, TAccumulate, System.Linq.Expressions.Expression<System.Func<TAccumulate,TSource,TAccumulate>>);;ReturnValue of Argument[2];ReturnValue;value |
+| System.Linq;Queryable;false;Aggregate<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TSource,TSource>>);;Element of Argument[0];Parameter[1] of Argument[1];value |
+| System.Linq;Queryable;false;Aggregate<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TSource,TSource>>);;ReturnValue of Argument[1];ReturnValue;value |
+| System.Linq;Queryable;false;All<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Any<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;AsQueryable;(System.Collections.IEnumerable);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;AsQueryable<>;(System.Collections.Generic.IEnumerable<TElement>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Decimal>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Double>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Int32>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Int64>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Single>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Average<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Cast<>;(System.Linq.IQueryable);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Concat<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Concat<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Count<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;DefaultIfEmpty<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;DefaultIfEmpty<>;(System.Linq.IQueryable<TSource>, TSource);;Argument[1];ReturnValue;value |
+| System.Linq;Queryable;false;DefaultIfEmpty<>;(System.Linq.IQueryable<TSource>, TSource);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;Distinct<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Distinct<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;ElementAt<>;(System.Linq.IQueryable<TSource>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;ElementAtOrDefault<>;(System.Linq.IQueryable<TSource>, System.Int32);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;Except<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;Except<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;First<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;First<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;First<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;FirstOrDefault<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;FirstOrDefault<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;FirstOrDefault<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>);;ReturnValue of Argument[2];Element of Parameter[1] of Argument[3];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>);;ReturnValue of Argument[3];Element of ReturnValue;value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[2];Element of Parameter[1] of Argument[3];value |
+| System.Linq;Queryable;false;GroupBy<,,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TElement>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[3];Element of ReturnValue;value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TKey,System.Collections.Generic.IEnumerable<TSource>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Linq.Expressions.Expression<System.Func<TSource,TElement>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[1];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupBy<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupBy<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Queryable;false;GroupJoin<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,System.Collections.Generic.IEnumerable<TInner>,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Intersect<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Intersect<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Intersect<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Intersect<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[4];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[0] of Argument[3];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;Element of Argument[1];Parameter[1] of Argument[4];value |
+| System.Linq;Queryable;false;Join<,,,>;(System.Linq.IQueryable<TOuter>, System.Collections.Generic.IEnumerable<TInner>, System.Linq.Expressions.Expression<System.Func<TOuter,TKey>>, System.Linq.Expressions.Expression<System.Func<TInner,TKey>>, System.Linq.Expressions.Expression<System.Func<TOuter,TInner,TResult>>, System.Collections.Generic.IEqualityComparer<TKey>);;ReturnValue of Argument[4];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Last<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;Last<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Last<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;LastOrDefault<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;LastOrDefault<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;LastOrDefault<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;LongCount<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Max<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Min<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;OfType<>;(System.Linq.IQueryable);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;OrderBy<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;OrderBy<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;OrderBy<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;OrderBy<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;OrderByDescending<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;OrderByDescending<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;OrderByDescending<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;OrderByDescending<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Reverse<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Select<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Select<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,TResult>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Select<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Select<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TResult>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;Element of ReturnValue of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;Element of ReturnValue of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;Queryable;false;SelectMany<,,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TCollection>>>, System.Linq.Expressions.Expression<System.Func<TSource,TCollection,TResult>>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SelectMany<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Collections.Generic.IEnumerable<TResult>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;SelectMany<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Collections.Generic.IEnumerable<TResult>>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SelectMany<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TResult>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;SelectMany<,>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Collections.Generic.IEnumerable<TResult>>>);;ReturnValue of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Single<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;Single<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Single<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;SingleOrDefault<>;(System.Linq.IQueryable<TSource>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;SingleOrDefault<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;SingleOrDefault<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];ReturnValue;value |
+| System.Linq;Queryable;false;Skip<>;(System.Linq.IQueryable<TSource>, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SkipWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SkipWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;SkipWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Boolean>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;SkipWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Decimal>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Double>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int64>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Decimal>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Double>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Int32>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Int64>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Nullable<System.Single>>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Sum<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Single>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Take<>;(System.Linq.IQueryable<TSource>, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;TakeWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;TakeWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;TakeWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Boolean>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;TakeWhile<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;ThenBy<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;ThenBy<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;ThenBy<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;ThenBy<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;ThenByDescending<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;ThenByDescending<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;ThenByDescending<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;ThenByDescending<,>;(System.Linq.IOrderedQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,TKey>>, System.Collections.Generic.IComparer<TKey>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Union<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Union<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Union<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Union<>;(System.Linq.IQueryable<TSource>, System.Collections.Generic.IEnumerable<TSource>, System.Collections.Generic.IEqualityComparer<TSource>);;Element of Argument[1];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Where<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Where<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Where<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Boolean>>);;Element of Argument[0];Element of ReturnValue;value |
+| System.Linq;Queryable;false;Where<>;(System.Linq.IQueryable<TSource>, System.Linq.Expressions.Expression<System.Func<TSource,System.Int32,System.Boolean>>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System.Linq;Queryable;false;Zip<,,>;(System.Linq.IQueryable<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Linq.Expressions.Expression<System.Func<TFirst,TSecond,TResult>>);;Element of Argument[0];Parameter[0] of Argument[2];value |
+| System.Linq;Queryable;false;Zip<,,>;(System.Linq.IQueryable<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Linq.Expressions.Expression<System.Func<TFirst,TSecond,TResult>>);;Element of Argument[1];Parameter[1] of Argument[2];value |
+| System.Linq;Queryable;false;Zip<,,>;(System.Linq.IQueryable<TFirst>, System.Collections.Generic.IEnumerable<TSecond>, System.Linq.Expressions.Expression<System.Func<TFirst,TSecond,TResult>>);;ReturnValue of Argument[2];Element of ReturnValue;value |
+| System.Net.Http.Headers;HttpHeaderValueCollection<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Net.Http.Headers;HttpHeaderValueCollection<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.Http.Headers;HttpHeaderValueCollection<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.Http.Headers;HttpHeaders;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.Http;HttpRequestOptions;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Argument[0];Element of Argument[-1];value |
+| System.Net.Http;HttpRequestOptions;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Net.Http;HttpRequestOptions;false;Add;(System.Collections.Generic.KeyValuePair<System.String,System.Object>);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Net.Http;HttpRequestOptions;false;Add;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Net.Http;HttpRequestOptions;false;Add;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Net.Http;HttpRequestOptions;false;CopyTo;(System.Collections.Generic.KeyValuePair<System.String,System.Object>[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.Http;HttpRequestOptions;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.Http;HttpRequestOptions;false;get_Item;(System.String);;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];ReturnValue;value |
+| System.Net.Http;HttpRequestOptions;false;get_Keys;();;Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Net.Http;HttpRequestOptions;false;get_Values;();;Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];Element of ReturnValue;value |
+| System.Net.Http;HttpRequestOptions;false;set_Item;(System.String, System.Object);;Argument[0];Property[System.Collections.Generic.KeyValuePair<,>.Key] of Element of Argument[-1];value |
+| System.Net.Http;HttpRequestOptions;false;set_Item;(System.String, System.Object);;Argument[1];Property[System.Collections.Generic.KeyValuePair<,>.Value] of Element of Argument[-1];value |
+| System.Net.Http;MultipartContent;false;Add;(System.Net.Http.HttpContent);;Argument[0];Element of Argument[-1];value |
+| System.Net.Http;MultipartContent;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.Http;MultipartFormDataContent;false;Add;(System.Net.Http.HttpContent);;Argument[0];Element of Argument[-1];value |
+| System.Net.Mail;MailAddressCollection;false;Add;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Net.NetworkInformation;GatewayIPAddressInformationCollection;false;Add;(System.Net.NetworkInformation.GatewayIPAddressInformation);;Argument[0];Element of Argument[-1];value |
+| System.Net.NetworkInformation;GatewayIPAddressInformationCollection;false;CopyTo;(System.Net.NetworkInformation.GatewayIPAddressInformation[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.NetworkInformation;GatewayIPAddressInformationCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.NetworkInformation;IPAddressCollection;false;Add;(System.Net.IPAddress);;Argument[0];Element of Argument[-1];value |
+| System.Net.NetworkInformation;IPAddressCollection;false;CopyTo;(System.Net.IPAddress[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.NetworkInformation;IPAddressCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.NetworkInformation;IPAddressInformationCollection;false;Add;(System.Net.NetworkInformation.IPAddressInformation);;Argument[0];Element of Argument[-1];value |
+| System.Net.NetworkInformation;IPAddressInformationCollection;false;CopyTo;(System.Net.NetworkInformation.IPAddressInformation[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.NetworkInformation;IPAddressInformationCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.NetworkInformation;MulticastIPAddressInformationCollection;false;Add;(System.Net.NetworkInformation.MulticastIPAddressInformation);;Argument[0];Element of Argument[-1];value |
+| System.Net.NetworkInformation;MulticastIPAddressInformationCollection;false;CopyTo;(System.Net.NetworkInformation.MulticastIPAddressInformation[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.NetworkInformation;MulticastIPAddressInformationCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.NetworkInformation;UnicastIPAddressInformationCollection;false;Add;(System.Net.NetworkInformation.UnicastIPAddressInformation);;Argument[0];Element of Argument[-1];value |
+| System.Net.NetworkInformation;UnicastIPAddressInformationCollection;false;CopyTo;(System.Net.NetworkInformation.UnicastIPAddressInformation[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net.NetworkInformation;UnicastIPAddressInformationCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net.Security;NegotiateStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.Net.Security;NegotiateStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.Net.Security;NegotiateStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.Net.Security;NegotiateStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.Net.Security;SslStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.Net.Security;SslStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.Net.Security;SslStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.Net.Security;SslStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.Net.Sockets;NetworkStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.Net.Sockets;NetworkStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.Net.Sockets;NetworkStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.Net.Sockets;NetworkStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.Net;Cookie;false;get_Value;();;Argument[-1];ReturnValue;taint |
+| System.Net;CookieCollection;false;Add;(System.Net.Cookie);;Argument[0];Element of Argument[-1];value |
+| System.Net;CookieCollection;false;Add;(System.Net.CookieCollection);;Argument[0];Element of Argument[-1];value |
+| System.Net;CookieCollection;false;CopyTo;(System.Net.Cookie[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net;CookieCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net;HttpListenerPrefixCollection;false;Add;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Net;HttpListenerPrefixCollection;false;CopyTo;(System.Array, System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net;HttpListenerPrefixCollection;false;CopyTo;(System.String[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Net;HttpListenerPrefixCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Net;IPHostEntry;false;get_Aliases;();;Argument[-1];ReturnValue;taint |
+| System.Net;IPHostEntry;false;get_HostName;();;Argument[-1];ReturnValue;taint |
+| System.Net;WebHeaderCollection;false;Add;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Net;WebUtility;false;HtmlEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Net;WebUtility;false;HtmlEncode;(System.String, System.IO.TextWriter);;Argument[0];ReturnValue;taint |
+| System.Net;WebUtility;false;UrlEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Runtime.CompilerServices;ConditionalWeakTable<,>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;Add;(T);;Argument[0];Element of Argument[-1];value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;CopyTo;(T[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;Insert;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;Reverse;();;Element of Argument[0];Element of ReturnValue;value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;Reverse;(System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Runtime.CompilerServices;ReadOnlyCollectionBuilder<>;false;set_Item;(System.Int32, T);;Argument[1];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;Add;(System.Security.Cryptography.X509Certificates.X509Certificate2);;Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;AddRange;(System.Security.Cryptography.X509Certificates.X509Certificate2Collection);;Element of Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;AddRange;(System.Security.Cryptography.X509Certificates.X509Certificate2[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;Find;(System.Security.Cryptography.X509Certificates.X509FindType, System.Object, System.Boolean);;Element of Argument[-1];ReturnValue;value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Security.Cryptography.X509Certificates.X509Certificate2Enumerator.Current] of ReturnValue;value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;Insert;(System.Int32, System.Security.Cryptography.X509Certificates.X509Certificate2);;Argument[1];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Security.Cryptography.X509Certificates;X509Certificate2Collection;false;set_Item;(System.Int32, System.Security.Cryptography.X509Certificates.X509Certificate2);;Argument[1];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;Add;(System.Security.Cryptography.X509Certificates.X509Certificate);;Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;AddRange;(System.Security.Cryptography.X509Certificates.X509CertificateCollection);;Element of Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;AddRange;(System.Security.Cryptography.X509Certificates.X509Certificate[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;CopyTo;(System.Security.Cryptography.X509Certificates.X509Certificate[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Security.Cryptography.X509Certificates.X509CertificateCollection+X509CertificateEnumerator.Current] of ReturnValue;value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;Insert;(System.Int32, System.Security.Cryptography.X509Certificates.X509Certificate);;Argument[1];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Security.Cryptography.X509Certificates;X509CertificateCollection;false;set_Item;(System.Int32, System.Security.Cryptography.X509Certificates.X509Certificate);;Argument[1];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509ChainElementCollection;false;CopyTo;(System.Security.Cryptography.X509Certificates.X509ChainElement[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Security.Cryptography.X509Certificates;X509ChainElementCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Security.Cryptography.X509Certificates.X509ChainElementEnumerator.Current] of ReturnValue;value |
+| System.Security.Cryptography.X509Certificates;X509ExtensionCollection;false;Add;(System.Security.Cryptography.X509Certificates.X509Extension);;Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography.X509Certificates;X509ExtensionCollection;false;CopyTo;(System.Security.Cryptography.X509Certificates.X509Extension[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Security.Cryptography.X509Certificates;X509ExtensionCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Security.Cryptography.X509Certificates.X509ExtensionEnumerator.Current] of ReturnValue;value |
+| System.Security.Cryptography;AsnEncodedDataCollection;false;Add;(System.Security.Cryptography.AsnEncodedData);;Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography;AsnEncodedDataCollection;false;CopyTo;(System.Security.Cryptography.AsnEncodedData[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Security.Cryptography;AsnEncodedDataCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Security.Cryptography.AsnEncodedDataEnumerator.Current] of ReturnValue;value |
+| System.Security.Cryptography;CryptoStream;false;BeginRead;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[-1];Argument[0];taint |
+| System.Security.Cryptography;CryptoStream;false;BeginWrite;(System.Byte[], System.Int32, System.Int32, System.AsyncCallback, System.Object);;Argument[0];Argument[-1];taint |
+| System.Security.Cryptography;CryptoStream;false;ReadAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[-1];Argument[0];taint |
+| System.Security.Cryptography;CryptoStream;false;WriteAsync;(System.Byte[], System.Int32, System.Int32, System.Threading.CancellationToken);;Argument[0];Argument[-1];taint |
+| System.Security.Cryptography;OidCollection;false;Add;(System.Security.Cryptography.Oid);;Argument[0];Element of Argument[-1];value |
+| System.Security.Cryptography;OidCollection;false;CopyTo;(System.Security.Cryptography.Oid[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Security.Cryptography;OidCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Security.Cryptography.OidEnumerator.Current] of ReturnValue;value |
+| System.Text.RegularExpressions;CaptureCollection;false;Add;(System.Text.RegularExpressions.Capture);;Argument[0];Element of Argument[-1];value |
+| System.Text.RegularExpressions;CaptureCollection;false;CopyTo;(System.Text.RegularExpressions.Capture[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Text.RegularExpressions;CaptureCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Text.RegularExpressions;CaptureCollection;false;Insert;(System.Int32, System.Text.RegularExpressions.Capture);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;CaptureCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Text.RegularExpressions;CaptureCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;CaptureCollection;false;set_Item;(System.Int32, System.Text.RegularExpressions.Capture);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;GroupCollection;false;Add;(System.Text.RegularExpressions.Group);;Argument[0];Element of Argument[-1];value |
+| System.Text.RegularExpressions;GroupCollection;false;CopyTo;(System.Text.RegularExpressions.Group[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Text.RegularExpressions;GroupCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Text.RegularExpressions;GroupCollection;false;Insert;(System.Int32, System.Text.RegularExpressions.Group);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;GroupCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Text.RegularExpressions;GroupCollection;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Text.RegularExpressions;GroupCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;GroupCollection;false;set_Item;(System.Int32, System.Text.RegularExpressions.Group);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;MatchCollection;false;Add;(System.Text.RegularExpressions.Match);;Argument[0];Element of Argument[-1];value |
+| System.Text.RegularExpressions;MatchCollection;false;CopyTo;(System.Text.RegularExpressions.Match[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Text.RegularExpressions;MatchCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Text.RegularExpressions;MatchCollection;false;Insert;(System.Int32, System.Text.RegularExpressions.Match);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;MatchCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Text.RegularExpressions;MatchCollection;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text.RegularExpressions;MatchCollection;false;set_Item;(System.Int32, System.Text.RegularExpressions.Match);;Argument[1];Element of Argument[-1];value |
+| System.Text;Encoding;false;GetBytes;(System.Char*, System.Int32, System.Byte*, System.Int32);;Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetBytes;(System.Char[]);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetBytes;(System.Char[], System.Int32, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetBytes;(System.ReadOnlySpan<System.Char>, System.Span<System.Byte>);;Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetBytes;(System.String);;Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetBytes;(System.String, System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetBytes;(System.String, System.Int32, System.Int32, System.Byte[], System.Int32);;Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetChars;(System.Byte*, System.Int32, System.Char*, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetChars;(System.Byte[]);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetChars;(System.Byte[], System.Int32, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetChars;(System.ReadOnlySpan<System.Byte>, System.Span<System.Char>);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetString;(System.Byte*, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetString;(System.Byte[]);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetString;(System.Byte[], System.Int32, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System.Text;Encoding;false;GetString;(System.ReadOnlySpan<System.Byte>);;Element of Argument[0];ReturnValue;taint |
+| System.Text;StringBuilder;false;Append;(System.Boolean);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Byte);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Char);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Char*, System.Int32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Char, System.Int32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Char[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Char[]);;Element of Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;Append;(System.Char[], System.Int32, System.Int32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Char[], System.Int32, System.Int32);;Element of Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;Append;(System.Decimal);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Double);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Int16);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Int32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Int64);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Object);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;Append;(System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.ReadOnlyMemory<System.Char>);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.ReadOnlySpan<System.Char>);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.SByte);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Single);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;Append;(System.String);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.String, System.Int32, System.Int32);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;Append;(System.String, System.Int32, System.Int32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Text.StringBuilder);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.Text.StringBuilder, System.Int32, System.Int32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.UInt16);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.UInt32);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;Append;(System.UInt64);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object);;Argument[2];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[2];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[3];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[2];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[3];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[4];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object[]);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.IFormatProvider, System.String, System.Object[]);;Element of Argument[2];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object);;Argument[2];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object, System.Object);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object, System.Object);;Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object, System.Object);;Argument[2];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object, System.Object);;Argument[3];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object, System.Object, System.Object);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object[]);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendFormat;(System.String, System.Object[]);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin;(System.Char, System.Object[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendJoin;(System.Char, System.Object[]);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin;(System.Char, System.String[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendJoin;(System.Char, System.String[]);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin;(System.String, System.Object[]);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin;(System.String, System.Object[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendJoin;(System.String, System.Object[]);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin;(System.String, System.String[]);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin;(System.String, System.String[]);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendJoin;(System.String, System.String[]);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin<>;(System.Char, System.Collections.Generic.IEnumerable<T>);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendJoin<>;(System.Char, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin<>;(System.String, System.Collections.Generic.IEnumerable<T>);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendJoin<>;(System.String, System.Collections.Generic.IEnumerable<T>);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendJoin<>;(System.String, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendLine;();;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;AppendLine;(System.String);;Argument[0];Element of Argument[-1];value |
+| System.Text;StringBuilder;false;AppendLine;(System.String);;Argument[-1];ReturnValue;value |
+| System.Text;StringBuilder;false;StringBuilder;(System.String);;Argument[0];Element of ReturnValue;value |
+| System.Text;StringBuilder;false;StringBuilder;(System.String, System.Int32);;Argument[0];Element of ReturnValue;value |
+| System.Text;StringBuilder;false;StringBuilder;(System.String, System.Int32, System.Int32, System.Int32);;Argument[0];Element of ReturnValue;value |
+| System.Text;StringBuilder;false;ToString;();;Element of Argument[-1];ReturnValue;taint |
+| System.Text;StringBuilder;false;ToString;(System.Int32, System.Int32);;Element of Argument[-1];ReturnValue;taint |
+| System.Threading.Tasks;Task;false;ContinueWith;(System.Action<System.Threading.Tasks.Task,System.Object>, System.Object);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith;(System.Action<System.Threading.Tasks.Task,System.Object>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith;(System.Action<System.Threading.Tasks.Task,System.Object>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith;(System.Action<System.Threading.Tasks.Task,System.Object>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith;(System.Action<System.Threading.Tasks.Task,System.Object>, System.Object, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,System.Object,TResult>, System.Object, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,TResult>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;FromResult<>;(TResult);;Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;Run<>;(System.Func<System.Threading.Tasks.Task<TResult>>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;Run<>;(System.Func<System.Threading.Tasks.Task<TResult>>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;Run<>;(System.Func<TResult>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;Run<>;(System.Func<TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;Task;(System.Action<System.Object>, System.Object);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task;false;Task;(System.Action<System.Object>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task;false;Task;(System.Action<System.Object>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task;false;Task;(System.Action<System.Object>, System.Object, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task;false;WhenAll<>;(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<TResult>>);;Property[System.Threading.Tasks.Task<>.Result] of Element of Argument[0];Element of Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;WhenAll<>;(System.Threading.Tasks.Task<TResult>[]);;Property[System.Threading.Tasks.Task<>.Result] of Element of Argument[0];Element of Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;WhenAny<>;(System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task<TResult>>);;Property[System.Threading.Tasks.Task<>.Result] of Element of Argument[0];Element of Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;WhenAny<>;(System.Threading.Tasks.Task<TResult>, System.Threading.Tasks.Task<TResult>);;Property[System.Threading.Tasks.Task<>.Result] of Element of Argument[0];Element of Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;WhenAny<>;(System.Threading.Tasks.Task<TResult>, System.Threading.Tasks.Task<TResult>);;Property[System.Threading.Tasks.Task<>.Result] of Element of Argument[1];Element of Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task;false;WhenAny<>;(System.Threading.Tasks.Task<TResult>[]);;Property[System.Threading.Tasks.Task<>.Result] of Element of Argument[0];Element of Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.CancellationToken);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>,System.Object>, System.Object, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>>);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>>, System.Threading.CancellationToken);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>>, System.Threading.Tasks.TaskContinuationOptions);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith;(System.Action<System.Threading.Tasks.Task<>>, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.CancellationToken);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[1] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,System.Object,TNewResult>, System.Object, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.CancellationToken);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.Tasks.TaskContinuationOptions);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.Tasks.TaskScheduler);;Argument[-1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;ContinueWith<>;(System.Func<System.Threading.Tasks.Task<>,TNewResult>, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<System.Object,TResult>, System.Object, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<TResult>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;Task;(System.Func<TResult>, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;Task<>;false;get_Result;();;Argument[-1];ReturnValue;taint |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.Tasks.TaskContinuationOptions);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>[]>);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>[]>, System.Threading.CancellationToken);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>[]>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>[]>, System.Threading.Tasks.TaskContinuationOptions);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAll<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.Tasks.TaskContinuationOptions);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<,>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>>);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>>, System.Threading.CancellationToken);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Action<System.Threading.Tasks.Task<TAntecedentResult>>, System.Threading.Tasks.TaskContinuationOptions);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;ContinueWhenAny<>;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew;(System.Action<System.Object>, System.Object);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew;(System.Action<System.Object>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew;(System.Action<System.Object>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew;(System.Action<System.Object>, System.Object, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<System.Object,TResult>, System.Object, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<TResult>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory;false;StartNew<>;(System.Func<TResult>, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task[],TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.Tasks.TaskContinuationOptions);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAll<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>[],TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny;(System.Threading.Tasks.Task[], System.Func<System.Threading.Tasks.Task,TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskContinuationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.Tasks.TaskContinuationOptions);;Argument[0];Parameter[0] of Argument[1];value |
+| System.Threading.Tasks;TaskFactory<>;false;ContinueWhenAny<>;(System.Threading.Tasks.Task<TAntecedentResult>[], System.Func<System.Threading.Tasks.Task<TAntecedentResult>,TResult>, System.Threading.Tasks.TaskContinuationOptions);;ReturnValue of Argument[1];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object, System.Threading.Tasks.TaskCreationOptions);;Argument[1];Parameter[0] of Argument[0];value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<System.Object,TResult>, System.Object, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<TResult>);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<TResult>, System.Threading.CancellationToken);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<TResult>, System.Threading.CancellationToken, System.Threading.Tasks.TaskCreationOptions, System.Threading.Tasks.TaskScheduler);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Threading.Tasks;TaskFactory<>;false;StartNew;(System.Func<TResult>, System.Threading.Tasks.TaskCreationOptions);;ReturnValue of Argument[0];Property[System.Threading.Tasks.Task<>.Result] of ReturnValue;value |
+| System.Web.UI.WebControls;TextBox;false;get_Text;();;Argument[-1];ReturnValue;taint |
+| System.Web;HttpCookie;false;get_Value;();;Argument[-1];ReturnValue;taint |
+| System.Web;HttpCookie;false;get_Values;();;Argument[-1];ReturnValue;taint |
+| System.Web;HttpServerUtility;false;UrlEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;HtmlAttributeEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;HtmlAttributeEncode;(System.String, System.IO.TextWriter);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;HtmlEncode;(System.Object);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;HtmlEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;HtmlEncode;(System.String, System.IO.TextWriter);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;JavaScriptStringEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;JavaScriptStringEncode;(System.String, System.Boolean);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;UrlEncode;(System.Byte[]);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;UrlEncode;(System.Byte[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;UrlEncode;(System.String);;Argument[0];ReturnValue;taint |
+| System.Web;HttpUtility;false;UrlEncode;(System.String, System.Text.Encoding);;Argument[0];ReturnValue;taint |
+| System.Xml.Schema;XmlSchemaCollection;false;Add;(System.Xml.Schema.XmlSchema);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Schema;XmlSchemaCollection;false;Add;(System.Xml.Schema.XmlSchemaCollection);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Schema;XmlSchemaCollection;false;CopyTo;(System.Xml.Schema.XmlSchema[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml.Schema;XmlSchemaCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Xml.Schema.XmlSchemaCollectionEnumerator.Current] of ReturnValue;value |
+| System.Xml.Schema;XmlSchemaObjectCollection;false;Add;(System.Xml.Schema.XmlSchemaObject);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Schema;XmlSchemaObjectCollection;false;CopyTo;(System.Xml.Schema.XmlSchemaObject[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml.Schema;XmlSchemaObjectCollection;false;GetEnumerator;();;Element of Argument[-1];Property[System.Xml.Schema.XmlSchemaObjectEnumerator.Current] of ReturnValue;value |
+| System.Xml.Schema;XmlSchemaObjectCollection;false;Insert;(System.Int32, System.Xml.Schema.XmlSchemaObject);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Schema;XmlSchemaObjectCollection;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Schema;XmlSchemaObjectCollection;false;set_Item;(System.Int32, System.Xml.Schema.XmlSchemaObject);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlAnyElementAttributes;false;Add;(System.Xml.Serialization.XmlAnyElementAttribute);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlAnyElementAttributes;false;CopyTo;(System.Xml.Serialization.XmlAnyElementAttribute[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml.Serialization;XmlAnyElementAttributes;false;Insert;(System.Int32, System.Xml.Serialization.XmlAnyElementAttribute);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlAnyElementAttributes;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Serialization;XmlAnyElementAttributes;false;set_Item;(System.Int32, System.Xml.Serialization.XmlAnyElementAttribute);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlArrayItemAttributes;false;Add;(System.Xml.Serialization.XmlArrayItemAttribute);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlArrayItemAttributes;false;CopyTo;(System.Xml.Serialization.XmlArrayItemAttribute[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml.Serialization;XmlArrayItemAttributes;false;Insert;(System.Int32, System.Xml.Serialization.XmlArrayItemAttribute);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlArrayItemAttributes;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Serialization;XmlArrayItemAttributes;false;set_Item;(System.Int32, System.Xml.Serialization.XmlArrayItemAttribute);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlElementAttributes;false;Add;(System.Xml.Serialization.XmlElementAttribute);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlElementAttributes;false;CopyTo;(System.Xml.Serialization.XmlElementAttribute[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml.Serialization;XmlElementAttributes;false;Insert;(System.Int32, System.Xml.Serialization.XmlElementAttribute);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlElementAttributes;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Serialization;XmlElementAttributes;false;set_Item;(System.Int32, System.Xml.Serialization.XmlElementAttribute);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlSchemas;false;Add;(System.Xml.Schema.XmlSchema);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlSchemas;false;Add;(System.Xml.Serialization.XmlSchemas);;Argument[0];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlSchemas;false;CopyTo;(System.Xml.Schema.XmlSchema[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml.Serialization;XmlSchemas;false;Find;(System.Xml.XmlQualifiedName, System.Type);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Serialization;XmlSchemas;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System.Xml.Serialization;XmlSchemas;false;Insert;(System.Int32, System.Xml.Schema.XmlSchema);;Argument[1];Element of Argument[-1];value |
+| System.Xml.Serialization;XmlSchemas;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Serialization;XmlSchemas;false;get_Item;(System.String);;Element of Argument[-1];ReturnValue;value |
+| System.Xml.Serialization;XmlSchemas;false;set_Item;(System.Int32, System.Xml.Schema.XmlSchema);;Argument[1];Element of Argument[-1];value |
+| System.Xml;XmlAttributeCollection;false;CopyTo;(System.Xml.XmlAttribute[], System.Int32);;Element of Argument[-1];Element of Argument[0];value |
+| System.Xml;XmlNamedNodeMap;false;GetNamedItem;(System.String);;Argument[-1];ReturnValue;value |
+| System.Xml;XmlNamedNodeMap;false;GetNamedItem;(System.String, System.String);;Argument[-1];ReturnValue;value |
+| System.Xml;XmlNode;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.IEnumerator.Current] of ReturnValue;value |
+| System.Xml;XmlNode;false;SelectNodes;(System.String);;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;SelectNodes;(System.String, System.Xml.XmlNamespaceManager);;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;SelectSingleNode;(System.String);;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;SelectSingleNode;(System.String, System.Xml.XmlNamespaceManager);;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_Attributes;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_BaseURI;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_ChildNodes;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_FirstChild;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_HasChildNodes;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_InnerText;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_InnerXml;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_IsReadOnly;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_LastChild;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_NamespaceURI;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_NextSibling;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_OuterXml;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_OwnerDocument;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_ParentNode;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_Prefix;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_PreviousSibling;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_PreviousText;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_SchemaInfo;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;false;get_Value;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;true;get_LocalName;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;true;get_Name;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlNode;true;get_NodeType;();;Argument[-1];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.Stream);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.Stream, System.Xml.XmlReaderSettings);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.Stream, System.Xml.XmlReaderSettings, System.String);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.Stream, System.Xml.XmlReaderSettings, System.Xml.XmlParserContext);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.TextReader);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.TextReader, System.Xml.XmlReaderSettings);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.TextReader, System.Xml.XmlReaderSettings, System.String);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.IO.TextReader, System.Xml.XmlReaderSettings, System.Xml.XmlParserContext);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.String);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.String, System.Xml.XmlReaderSettings);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.String, System.Xml.XmlReaderSettings, System.Xml.XmlParserContext);;Argument[0];ReturnValue;taint |
+| System.Xml;XmlReader;false;Create;(System.Xml.XmlReader, System.Xml.XmlReaderSettings);;Argument[0];ReturnValue;taint |
+| System;Array;false;AsReadOnly<>;(T[]);;Element of Argument[0];Element of ReturnValue;value |
+| System;Array;false;Clone;();;Element of Argument[0];Element of ReturnValue;value |
+| System;Array;false;CopyTo;(System.Array, System.Int64);;Element of Argument[-1];Element of Argument[0];value |
+| System;Array;false;Find<>;(T[], System.Predicate<T>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System;Array;false;Find<>;(T[], System.Predicate<T>);;Element of Argument[0];ReturnValue;value |
+| System;Array;false;FindAll<>;(T[], System.Predicate<T>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System;Array;false;FindAll<>;(T[], System.Predicate<T>);;Element of Argument[0];ReturnValue;value |
+| System;Array;false;FindLast<>;(T[], System.Predicate<T>);;Element of Argument[0];Parameter[0] of Argument[1];value |
+| System;Array;false;FindLast<>;(T[], System.Predicate<T>);;Element of Argument[0];ReturnValue;value |
+| System;Array;false;Reverse;(System.Array);;Element of Argument[0];Element of ReturnValue;value |
+| System;Array;false;Reverse;(System.Array, System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System;Array;false;Reverse<>;(T[]);;Element of Argument[0];Element of ReturnValue;value |
+| System;Array;false;Reverse<>;(T[], System.Int32, System.Int32);;Element of Argument[0];Element of ReturnValue;value |
+| System;Array;false;get_Item;(System.Int32);;Element of Argument[-1];ReturnValue;value |
+| System;Array;false;set_Item;(System.Int32, System.Object);;Argument[1];Element of Argument[-1];value |
+| System;Boolean;false;Parse;(System.String);;Argument[0];ReturnValue;taint |
+| System;Boolean;false;TryParse;(System.String, System.Boolean);;Argument[0];Argument[1];taint |
+| System;Boolean;false;TryParse;(System.String, System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ChangeType;(System.Object, System.Type);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ChangeType;(System.Object, System.Type, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ChangeType;(System.Object, System.TypeCode);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ChangeType;(System.Object, System.TypeCode, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;FromBase64CharArray;(System.Char[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;FromBase64String;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;FromHexString;(System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System;Convert;false;FromHexString;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;GetTypeCode;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;IsDBNull;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64CharArray;(System.Byte[], System.Int32, System.Int32, System.Char[], System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64CharArray;(System.Byte[], System.Int32, System.Int32, System.Char[], System.Int32, System.Base64FormattingOptions);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64String;(System.Byte[]);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64String;(System.Byte[], System.Base64FormattingOptions);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64String;(System.Byte[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64String;(System.Byte[], System.Int32, System.Int32, System.Base64FormattingOptions);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBase64String;(System.ReadOnlySpan<System.Byte>, System.Base64FormattingOptions);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToBoolean;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToByte;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToChar;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDateTime;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDecimal;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToDouble;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToHexString;(System.Byte[]);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToHexString;(System.Byte[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToHexString;(System.ReadOnlySpan<System.Byte>);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt16;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt32;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToInt64;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSByte;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToSingle;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Boolean, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Byte, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Byte, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Char, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.DateTime, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Decimal, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Double, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int16, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int16, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int32, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int64, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Int64, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.SByte, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.Single, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.UInt16, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.UInt32, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToString;(System.UInt64, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt16;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt32;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Byte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Char);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.DateTime);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Decimal);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Double);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Int16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Int64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Object);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Object, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.SByte);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.Single);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.String);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.UInt16);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.UInt32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;ToUInt64;(System.UInt64);;Argument[0];ReturnValue;taint |
+| System;Convert;false;TryFromBase64Chars;(System.ReadOnlySpan<System.Char>, System.Span<System.Byte>, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;TryFromBase64String;(System.String, System.Span<System.Byte>, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Convert;false;TryToBase64Chars;(System.ReadOnlySpan<System.Byte>, System.Span<System.Char>, System.Int32, System.Base64FormattingOptions);;Argument[0];ReturnValue;taint |
+| System;Int32;false;Parse;(System.ReadOnlySpan<System.Char>, System.Globalization.NumberStyles, System.IFormatProvider);;Element of Argument[0];ReturnValue;taint |
+| System;Int32;false;Parse;(System.String);;Argument[0];ReturnValue;taint |
+| System;Int32;false;Parse;(System.String, System.Globalization.NumberStyles);;Argument[0];ReturnValue;taint |
+| System;Int32;false;Parse;(System.String, System.Globalization.NumberStyles, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Int32;false;Parse;(System.String, System.IFormatProvider);;Argument[0];ReturnValue;taint |
+| System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>, System.Globalization.NumberStyles, System.IFormatProvider, System.Int32);;Element of Argument[0];Argument[3];taint |
+| System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>, System.Globalization.NumberStyles, System.IFormatProvider, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>, System.Int32);;Element of Argument[0];Argument[1];taint |
+| System;Int32;false;TryParse;(System.ReadOnlySpan<System.Char>, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System;Int32;false;TryParse;(System.String, System.Globalization.NumberStyles, System.IFormatProvider, System.Int32);;Argument[0];Argument[3];taint |
+| System;Int32;false;TryParse;(System.String, System.Globalization.NumberStyles, System.IFormatProvider, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Int32;false;TryParse;(System.String, System.Int32);;Argument[0];Argument[1];taint |
+| System;Int32;false;TryParse;(System.String, System.Int32);;Argument[0];ReturnValue;taint |
+| System;Lazy<>;false;Lazy;(System.Func<T>);;ReturnValue of Argument[0];Property[System.Lazy<>.Value] of ReturnValue;value |
+| System;Lazy<>;false;Lazy;(System.Func<T>, System.Boolean);;ReturnValue of Argument[0];Property[System.Lazy<>.Value] of ReturnValue;value |
+| System;Lazy<>;false;Lazy;(System.Func<T>, System.Threading.LazyThreadSafetyMode);;ReturnValue of Argument[0];Property[System.Lazy<>.Value] of ReturnValue;value |
+| System;Lazy<>;false;get_Value;();;Argument[-1];ReturnValue;taint |
+| System;Nullable<>;false;GetValueOrDefault;();;Property[System.Nullable<>.Value] of Argument[-1];ReturnValue;value |
+| System;Nullable<>;false;GetValueOrDefault;(T);;Argument[0];ReturnValue;value |
+| System;Nullable<>;false;GetValueOrDefault;(T);;Property[System.Nullable<>.Value] of Argument[-1];ReturnValue;value |
+| System;Nullable<>;false;Nullable;(T);;Argument[0];Property[System.Nullable<>.Value] of ReturnValue;value |
+| System;Nullable<>;false;get_HasValue;();;Property[System.Nullable<>.Value] of Argument[-1];ReturnValue;taint |
+| System;Nullable<>;false;get_Value;();;Argument[-1];ReturnValue;taint |
+| System;String;false;Clone;();;Argument[-1];ReturnValue;value |
+| System;String;false;Concat;(System.Collections.Generic.IEnumerable<System.String>);;Element of Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.Object);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.Object, System.Object);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.Object, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.Object, System.Object, System.Object);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.Object, System.Object, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.Object, System.Object, System.Object);;Argument[2];ReturnValue;taint |
+| System;String;false;Concat;(System.Object[]);;Element of Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[2];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[2];ReturnValue;taint |
+| System;String;false;Concat;(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>);;Argument[3];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String);;Argument[2];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String, System.String);;Argument[0];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String, System.String);;Argument[1];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String, System.String);;Argument[2];ReturnValue;taint |
+| System;String;false;Concat;(System.String, System.String, System.String, System.String);;Argument[3];ReturnValue;taint |
+| System;String;false;Concat;(System.String[]);;Element of Argument[0];ReturnValue;taint |
+| System;String;false;Concat<>;(System.Collections.Generic.IEnumerable<T>);;Element of Argument[0];ReturnValue;taint |
+| System;String;false;Copy;(System.String);;Argument[0];ReturnValue;value |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object);;Argument[2];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[2];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object);;Argument[3];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[2];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[3];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object, System.Object, System.Object);;Argument[4];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object[]);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.IFormatProvider, System.String, System.Object[]);;Element of Argument[2];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object);;Argument[0];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object);;Argument[0];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object);;Argument[2];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object, System.Object);;Argument[0];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object, System.Object);;Argument[1];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object, System.Object);;Argument[2];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object, System.Object, System.Object);;Argument[3];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object[]);;Argument[0];ReturnValue;taint |
+| System;String;false;Format;(System.String, System.Object[]);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;GetEnumerator;();;Element of Argument[-1];Property[System.CharEnumerator.Current] of ReturnValue;value |
+| System;String;false;GetEnumerator;();;Element of Argument[-1];Property[System.Collections.Generic.IEnumerator<>.Current] of ReturnValue;value |
+| System;String;false;Insert;(System.Int32, System.String);;Argument[1];ReturnValue;taint |
+| System;String;false;Insert;(System.Int32, System.String);;Argument[-1];ReturnValue;taint |
+| System;String;false;Join;(System.Char, System.Object[]);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.Char, System.Object[]);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join;(System.Char, System.String[]);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.Char, System.String[]);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join;(System.Char, System.String[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.Char, System.String[], System.Int32, System.Int32);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.Collections.Generic.IEnumerable<System.String>);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.Collections.Generic.IEnumerable<System.String>);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.Object[]);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.Object[]);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.String[]);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.String[]);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.String[], System.Int32, System.Int32);;Argument[0];ReturnValue;taint |
+| System;String;false;Join;(System.String, System.String[], System.Int32, System.Int32);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join<>;(System.Char, System.Collections.Generic.IEnumerable<T>);;Argument[0];ReturnValue;taint |
+| System;String;false;Join<>;(System.Char, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Join<>;(System.String, System.Collections.Generic.IEnumerable<T>);;Argument[0];ReturnValue;taint |
+| System;String;false;Join<>;(System.String, System.Collections.Generic.IEnumerable<T>);;Element of Argument[1];ReturnValue;taint |
+| System;String;false;Normalize;();;Argument[-1];ReturnValue;taint |
+| System;String;false;Normalize;(System.Text.NormalizationForm);;Argument[-1];ReturnValue;taint |
+| System;String;false;PadLeft;(System.Int32);;Argument[-1];ReturnValue;taint |
+| System;String;false;PadLeft;(System.Int32, System.Char);;Argument[-1];ReturnValue;taint |
+| System;String;false;PadRight;(System.Int32);;Argument[-1];ReturnValue;taint |
+| System;String;false;PadRight;(System.Int32, System.Char);;Argument[-1];ReturnValue;taint |
+| System;String;false;Remove;(System.Int32);;Argument[-1];ReturnValue;taint |
+| System;String;false;Remove;(System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System;String;false;Replace;(System.Char, System.Char);;Argument[1];ReturnValue;taint |
+| System;String;false;Replace;(System.Char, System.Char);;Argument[-1];ReturnValue;taint |
+| System;String;false;Replace;(System.String, System.String);;Argument[1];ReturnValue;taint |
+| System;String;false;Replace;(System.String, System.String);;Argument[-1];ReturnValue;taint |
+| System;String;false;Split;(System.Char, System.Int32, System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.Char, System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.Char[]);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.Char[], System.Int32);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.Char[], System.Int32, System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.Char[], System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.String, System.Int32, System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.String, System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.String[], System.Int32, System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;Split;(System.String[], System.StringSplitOptions);;Argument[-1];Element of ReturnValue;taint |
+| System;String;false;String;(System.Char[]);;Element of Argument[0];ReturnValue;taint |
+| System;String;false;String;(System.Char[], System.Int32, System.Int32);;Element of Argument[0];ReturnValue;taint |
+| System;String;false;Substring;(System.Int32);;Argument[-1];ReturnValue;taint |
+| System;String;false;Substring;(System.Int32, System.Int32);;Argument[-1];ReturnValue;taint |
+| System;String;false;ToLower;();;Argument[-1];ReturnValue;taint |
+| System;String;false;ToLower;(System.Globalization.CultureInfo);;Argument[-1];ReturnValue;taint |
+| System;String;false;ToLowerInvariant;();;Argument[-1];ReturnValue;taint |
+| System;String;false;ToString;();;Argument[-1];ReturnValue;value |
+| System;String;false;ToString;(System.IFormatProvider);;Argument[-1];ReturnValue;value |
+| System;String;false;ToUpper;();;Argument[-1];ReturnValue;taint |
+| System;String;false;ToUpper;(System.Globalization.CultureInfo);;Argument[-1];ReturnValue;taint |
+| System;String;false;ToUpperInvariant;();;Argument[-1];ReturnValue;taint |
+| System;String;false;Trim;();;Argument[-1];ReturnValue;taint |
+| System;String;false;Trim;(System.Char);;Argument[-1];ReturnValue;taint |
+| System;String;false;Trim;(System.Char[]);;Argument[-1];ReturnValue;taint |
+| System;String;false;TrimEnd;();;Argument[-1];ReturnValue;taint |
+| System;String;false;TrimEnd;(System.Char);;Argument[-1];ReturnValue;taint |
+| System;String;false;TrimEnd;(System.Char[]);;Argument[-1];ReturnValue;taint |
+| System;String;false;TrimStart;();;Argument[-1];ReturnValue;taint |
+| System;String;false;TrimStart;(System.Char);;Argument[-1];ReturnValue;taint |
+| System;String;false;TrimStart;(System.Char[]);;Argument[-1];ReturnValue;taint |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[0];Property[System.Tuple<,,,,,,,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[1];Property[System.Tuple<,,,,,,,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[2];Property[System.Tuple<,,,,,,,>.Item3] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[3];Property[System.Tuple<,,,,,,,>.Item4] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[4];Property[System.Tuple<,,,,,,,>.Item5] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[5];Property[System.Tuple<,,,,,,,>.Item6] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[6];Property[System.Tuple<,,,,,,,>.Item7] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[0];Property[System.Tuple<,,,,,,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[1];Property[System.Tuple<,,,,,,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[2];Property[System.Tuple<,,,,,,>.Item3] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[3];Property[System.Tuple<,,,,,,>.Item4] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[4];Property[System.Tuple<,,,,,,>.Item5] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[5];Property[System.Tuple<,,,,,,>.Item6] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[6];Property[System.Tuple<,,,,,,>.Item7] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[0];Property[System.Tuple<,,,,,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[1];Property[System.Tuple<,,,,,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[2];Property[System.Tuple<,,,,,>.Item3] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[3];Property[System.Tuple<,,,,,>.Item4] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[4];Property[System.Tuple<,,,,,>.Item5] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[5];Property[System.Tuple<,,,,,>.Item6] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[0];Property[System.Tuple<,,,,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[1];Property[System.Tuple<,,,,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[2];Property[System.Tuple<,,,,>.Item3] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[3];Property[System.Tuple<,,,,>.Item4] of ReturnValue;value |
+| System;Tuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[4];Property[System.Tuple<,,,,>.Item5] of ReturnValue;value |
+| System;Tuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[0];Property[System.Tuple<,,,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[1];Property[System.Tuple<,,,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[2];Property[System.Tuple<,,,>.Item3] of ReturnValue;value |
+| System;Tuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[3];Property[System.Tuple<,,,>.Item4] of ReturnValue;value |
+| System;Tuple;false;Create<,,>;(T1, T2, T3);;Argument[0];Property[System.Tuple<,,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,,>;(T1, T2, T3);;Argument[1];Property[System.Tuple<,,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<,,>;(T1, T2, T3);;Argument[2];Property[System.Tuple<,,>.Item3] of ReturnValue;value |
+| System;Tuple;false;Create<,>;(T1, T2);;Argument[0];Property[System.Tuple<,>.Item1] of ReturnValue;value |
+| System;Tuple;false;Create<,>;(T1, T2);;Argument[1];Property[System.Tuple<,>.Item2] of ReturnValue;value |
+| System;Tuple;false;Create<>;(T1);;Argument[0];Property[System.Tuple<>.Item1] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[0];Property[System.Tuple<,,,,,,,>.Item1] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[1];Property[System.Tuple<,,,,,,,>.Item2] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[2];Property[System.Tuple<,,,,,,,>.Item3] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[3];Property[System.Tuple<,,,,,,,>.Item4] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[4];Property[System.Tuple<,,,,,,,>.Item5] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[5];Property[System.Tuple<,,,,,,,>.Item6] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[6];Property[System.Tuple<,,,,,,,>.Item7] of ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[0];Property[System.Tuple<,,,,,,>.Item1] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[1];Property[System.Tuple<,,,,,,>.Item2] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[2];Property[System.Tuple<,,,,,,>.Item3] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[3];Property[System.Tuple<,,,,,,>.Item4] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[4];Property[System.Tuple<,,,,,,>.Item5] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[5];Property[System.Tuple<,,,,,,>.Item6] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[6];Property[System.Tuple<,,,,,,>.Item7] of ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item6] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,,>.Item7] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6);;Argument[0];Property[System.Tuple<,,,,,>.Item1] of ReturnValue;value |
+| System;Tuple<,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6);;Argument[1];Property[System.Tuple<,,,,,>.Item2] of ReturnValue;value |
+| System;Tuple<,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6);;Argument[2];Property[System.Tuple<,,,,,>.Item3] of ReturnValue;value |
+| System;Tuple<,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6);;Argument[3];Property[System.Tuple<,,,,,>.Item4] of ReturnValue;value |
+| System;Tuple<,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6);;Argument[4];Property[System.Tuple<,,,,,>.Item5] of ReturnValue;value |
+| System;Tuple<,,,,,>;false;Tuple;(T1, T2, T3, T4, T5, T6);;Argument[5];Property[System.Tuple<,,,,,>.Item6] of ReturnValue;value |
+| System;Tuple<,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,,>.Item6] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,>;false;Tuple;(T1, T2, T3, T4, T5);;Argument[0];Property[System.Tuple<,,,,>.Item1] of ReturnValue;value |
+| System;Tuple<,,,,>;false;Tuple;(T1, T2, T3, T4, T5);;Argument[1];Property[System.Tuple<,,,,>.Item2] of ReturnValue;value |
+| System;Tuple<,,,,>;false;Tuple;(T1, T2, T3, T4, T5);;Argument[2];Property[System.Tuple<,,,,>.Item3] of ReturnValue;value |
+| System;Tuple<,,,,>;false;Tuple;(T1, T2, T3, T4, T5);;Argument[3];Property[System.Tuple<,,,,>.Item4] of ReturnValue;value |
+| System;Tuple<,,,,>;false;Tuple;(T1, T2, T3, T4, T5);;Argument[4];Property[System.Tuple<,,,,>.Item5] of ReturnValue;value |
+| System;Tuple<,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,>;false;Tuple;(T1, T2, T3, T4);;Argument[0];Property[System.Tuple<,,,>.Item1] of ReturnValue;value |
+| System;Tuple<,,,>;false;Tuple;(T1, T2, T3, T4);;Argument[1];Property[System.Tuple<,,,>.Item2] of ReturnValue;value |
+| System;Tuple<,,,>;false;Tuple;(T1, T2, T3, T4);;Argument[2];Property[System.Tuple<,,,>.Item3] of ReturnValue;value |
+| System;Tuple<,,,>;false;Tuple;(T1, T2, T3, T4);;Argument[3];Property[System.Tuple<,,,>.Item4] of ReturnValue;value |
+| System;Tuple<,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,>;false;Tuple;(T1, T2, T3);;Argument[0];Property[System.Tuple<,,>.Item1] of ReturnValue;value |
+| System;Tuple<,,>;false;Tuple;(T1, T2, T3);;Argument[1];Property[System.Tuple<,,>.Item2] of ReturnValue;value |
+| System;Tuple<,,>;false;Tuple;(T1, T2, T3);;Argument[2];Property[System.Tuple<,,>.Item3] of ReturnValue;value |
+| System;Tuple<,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<,,>;false;get_Item;(System.Int32);;Property[System.Tuple<,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;Tuple<,>;false;Tuple;(T1, T2);;Argument[0];Property[System.Tuple<,>.Item1] of ReturnValue;value |
+| System;Tuple<,>;false;Tuple;(T1, T2);;Argument[1];Property[System.Tuple<,>.Item2] of ReturnValue;value |
+| System;Tuple<,>;false;get_Item;(System.Int32);;Property[System.Tuple<,>.Item1] of Argument[-1];ReturnValue;value |
+| System;Tuple<,>;false;get_Item;(System.Int32);;Property[System.Tuple<,>.Item2] of Argument[-1];ReturnValue;value |
+| System;Tuple<>;false;Tuple;(T1);;Argument[0];Property[System.Tuple<>.Item1] of ReturnValue;value |
+| System;Tuple<>;false;get_Item;(System.Int32);;Property[System.Tuple<>.Item1] of Argument[-1];ReturnValue;value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20,T21>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19,T20>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18,T19>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17,T18>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16,T17>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15,T16>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14,System.Tuple<T15>>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13,T14>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12,T13>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11,T12>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10,T11>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9,T10>>, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8,T9>>, T1, T2, T3, T4, T5, T6, T7, T8, T9);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7,System.Tuple<T8>>, T1, T2, T3, T4, T5, T6, T7, T8);;Property[System.Tuple<,,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6,T7>, T1, T2, T3, T4, T5, T6, T7);;Property[System.Tuple<,,,,,,>.Item7] of Argument[0];Argument[7];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6>, T1, T2, T3, T4, T5, T6);;Property[System.Tuple<,,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6>, T1, T2, T3, T4, T5, T6);;Property[System.Tuple<,,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6>, T1, T2, T3, T4, T5, T6);;Property[System.Tuple<,,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6>, T1, T2, T3, T4, T5, T6);;Property[System.Tuple<,,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6>, T1, T2, T3, T4, T5, T6);;Property[System.Tuple<,,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,,,>;(System.Tuple<T1,T2,T3,T4,T5,T6>, T1, T2, T3, T4, T5, T6);;Property[System.Tuple<,,,,,>.Item6] of Argument[0];Argument[6];value |
+| System;TupleExtensions;false;Deconstruct<,,,,>;(System.Tuple<T1,T2,T3,T4,T5>, T1, T2, T3, T4, T5);;Property[System.Tuple<,,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,,>;(System.Tuple<T1,T2,T3,T4,T5>, T1, T2, T3, T4, T5);;Property[System.Tuple<,,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,,>;(System.Tuple<T1,T2,T3,T4,T5>, T1, T2, T3, T4, T5);;Property[System.Tuple<,,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,,>;(System.Tuple<T1,T2,T3,T4,T5>, T1, T2, T3, T4, T5);;Property[System.Tuple<,,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,,,>;(System.Tuple<T1,T2,T3,T4,T5>, T1, T2, T3, T4, T5);;Property[System.Tuple<,,,,>.Item5] of Argument[0];Argument[5];value |
+| System;TupleExtensions;false;Deconstruct<,,,>;(System.Tuple<T1,T2,T3,T4>, T1, T2, T3, T4);;Property[System.Tuple<,,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,,>;(System.Tuple<T1,T2,T3,T4>, T1, T2, T3, T4);;Property[System.Tuple<,,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,,>;(System.Tuple<T1,T2,T3,T4>, T1, T2, T3, T4);;Property[System.Tuple<,,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,,,>;(System.Tuple<T1,T2,T3,T4>, T1, T2, T3, T4);;Property[System.Tuple<,,,>.Item4] of Argument[0];Argument[4];value |
+| System;TupleExtensions;false;Deconstruct<,,>;(System.Tuple<T1,T2,T3>, T1, T2, T3);;Property[System.Tuple<,,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,,>;(System.Tuple<T1,T2,T3>, T1, T2, T3);;Property[System.Tuple<,,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<,,>;(System.Tuple<T1,T2,T3>, T1, T2, T3);;Property[System.Tuple<,,>.Item3] of Argument[0];Argument[3];value |
+| System;TupleExtensions;false;Deconstruct<,>;(System.Tuple<T1,T2>, T1, T2);;Property[System.Tuple<,>.Item1] of Argument[0];Argument[1];value |
+| System;TupleExtensions;false;Deconstruct<,>;(System.Tuple<T1,T2>, T1, T2);;Property[System.Tuple<,>.Item2] of Argument[0];Argument[2];value |
+| System;TupleExtensions;false;Deconstruct<>;(System.Tuple<T1>, T1);;Property[System.Tuple<>.Item1] of Argument[0];Argument[1];value |
+| System;Uri;false;ToString;();;Argument[-1];ReturnValue;taint |
+| System;Uri;false;Uri;(System.String);;Argument[0];ReturnValue;taint |
+| System;Uri;false;Uri;(System.String, System.Boolean);;Argument[0];ReturnValue;taint |
+| System;Uri;false;Uri;(System.String, System.UriKind);;Argument[0];ReturnValue;taint |
+| System;Uri;false;get_OriginalString;();;Argument[-1];ReturnValue;taint |
+| System;Uri;false;get_PathAndQuery;();;Argument[-1];ReturnValue;taint |
+| System;Uri;false;get_Query;();;Argument[-1];ReturnValue;taint |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[0];Field[System.ValueTuple<,,,,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[1];Field[System.ValueTuple<,,,,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[2];Field[System.ValueTuple<,,,,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[3];Field[System.ValueTuple<,,,,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[4];Field[System.ValueTuple<,,,,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[5];Field[System.ValueTuple<,,,,,,,>.Item6] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,,>;(T1, T2, T3, T4, T5, T6, T7, T8);;Argument[6];Field[System.ValueTuple<,,,,,,,>.Item7] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[0];Field[System.ValueTuple<,,,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[1];Field[System.ValueTuple<,,,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[2];Field[System.ValueTuple<,,,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[3];Field[System.ValueTuple<,,,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[4];Field[System.ValueTuple<,,,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[5];Field[System.ValueTuple<,,,,,,>.Item6] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,,>;(T1, T2, T3, T4, T5, T6, T7);;Argument[6];Field[System.ValueTuple<,,,,,,>.Item7] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[0];Field[System.ValueTuple<,,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[1];Field[System.ValueTuple<,,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[2];Field[System.ValueTuple<,,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[3];Field[System.ValueTuple<,,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[4];Field[System.ValueTuple<,,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,,>;(T1, T2, T3, T4, T5, T6);;Argument[5];Field[System.ValueTuple<,,,,,>.Item6] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[0];Field[System.ValueTuple<,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[1];Field[System.ValueTuple<,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[2];Field[System.ValueTuple<,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[3];Field[System.ValueTuple<,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,,>;(T1, T2, T3, T4, T5);;Argument[4];Field[System.ValueTuple<,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[0];Field[System.ValueTuple<,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[1];Field[System.ValueTuple<,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[2];Field[System.ValueTuple<,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,,>;(T1, T2, T3, T4);;Argument[3];Field[System.ValueTuple<,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,>;(T1, T2, T3);;Argument[0];Field[System.ValueTuple<,,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,>;(T1, T2, T3);;Argument[1];Field[System.ValueTuple<,,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<,,>;(T1, T2, T3);;Argument[2];Field[System.ValueTuple<,,>.Item3] of ReturnValue;value |
+| System;ValueTuple;false;Create<,>;(T1, T2);;Argument[0];Field[System.ValueTuple<,>.Item1] of ReturnValue;value |
+| System;ValueTuple;false;Create<,>;(T1, T2);;Argument[1];Field[System.ValueTuple<,>.Item2] of ReturnValue;value |
+| System;ValueTuple;false;Create<>;(T1);;Argument[0];Field[System.ValueTuple<>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[0];Field[System.ValueTuple<,,,,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[1];Field[System.ValueTuple<,,,,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[2];Field[System.ValueTuple<,,,,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[3];Field[System.ValueTuple<,,,,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[4];Field[System.ValueTuple<,,,,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[5];Field[System.ValueTuple<,,,,,,,>.Item6] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7, TRest);;Argument[6];Field[System.ValueTuple<,,,,,,,>.Item7] of ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item6] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,,>.Item7] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[0];Field[System.ValueTuple<,,,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[1];Field[System.ValueTuple<,,,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[2];Field[System.ValueTuple<,,,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[3];Field[System.ValueTuple<,,,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[4];Field[System.ValueTuple<,,,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[5];Field[System.ValueTuple<,,,,,,>.Item6] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6, T7);;Argument[6];Field[System.ValueTuple<,,,,,,>.Item7] of ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item6] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,,>.Item7] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6);;Argument[0];Field[System.ValueTuple<,,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6);;Argument[1];Field[System.ValueTuple<,,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6);;Argument[2];Field[System.ValueTuple<,,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6);;Argument[3];Field[System.ValueTuple<,,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6);;Argument[4];Field[System.ValueTuple<,,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5, T6);;Argument[5];Field[System.ValueTuple<,,,,,>.Item6] of ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,,>.Item6] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5);;Argument[0];Field[System.ValueTuple<,,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5);;Argument[1];Field[System.ValueTuple<,,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5);;Argument[2];Field[System.ValueTuple<,,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple<,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5);;Argument[3];Field[System.ValueTuple<,,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple<,,,,>;false;ValueTuple;(T1, T2, T3, T4, T5);;Argument[4];Field[System.ValueTuple<,,,,>.Item5] of ReturnValue;value |
+| System;ValueTuple<,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,,>.Item5] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,>;false;ValueTuple;(T1, T2, T3, T4);;Argument[0];Field[System.ValueTuple<,,,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,,>;false;ValueTuple;(T1, T2, T3, T4);;Argument[1];Field[System.ValueTuple<,,,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,,,>;false;ValueTuple;(T1, T2, T3, T4);;Argument[2];Field[System.ValueTuple<,,,>.Item3] of ReturnValue;value |
+| System;ValueTuple<,,,>;false;ValueTuple;(T1, T2, T3, T4);;Argument[3];Field[System.ValueTuple<,,,>.Item4] of ReturnValue;value |
+| System;ValueTuple<,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,,>.Item4] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,>;false;ValueTuple;(T1, T2, T3);;Argument[0];Field[System.ValueTuple<,,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,,>;false;ValueTuple;(T1, T2, T3);;Argument[1];Field[System.ValueTuple<,,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,,>;false;ValueTuple;(T1, T2, T3);;Argument[2];Field[System.ValueTuple<,,>.Item3] of ReturnValue;value |
+| System;ValueTuple<,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,,>.Item3] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,>;false;ValueTuple;(T1, T2);;Argument[0];Field[System.ValueTuple<,>.Item1] of ReturnValue;value |
+| System;ValueTuple<,>;false;ValueTuple;(T1, T2);;Argument[1];Field[System.ValueTuple<,>.Item2] of ReturnValue;value |
+| System;ValueTuple<,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,>.Item1] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<,>;false;get_Item;(System.Int32);;Field[System.ValueTuple<,>.Item2] of Argument[-1];ReturnValue;value |
+| System;ValueTuple<>;false;ValueTuple;(T1);;Argument[0];Field[System.ValueTuple<>.Item1] of ReturnValue;value |
+| System;ValueTuple<>;false;get_Item;(System.Int32);;Field[System.ValueTuple<>.Item1] of Argument[-1];ReturnValue;value |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
@@ -1,0 +1,21 @@
+import shared.FlowSummaries
+
+class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable {
+  IncludeFilteredSummarizedCallable() { this instanceof SummarizedCallable }
+
+  /**
+   * Holds if flow is propagated between `input` and `output` and
+   * if there is no summary for a callable in a `base` class or interface
+   * that propagates the same flow between `input` and `output`.
+   */
+  override predicate relevantSummary(
+    SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+  ) {
+    this.propagatesFlow(input, output, preservesValue) and
+    not exists(IncludeSummarizedCallable rsc |
+      rsc.isAbstractOrInterface() and
+      this.(Virtualizable).overridesOrImplementsOrEquals(rsc) and
+      rsc.propagatesFlow(input, output, preservesValue)
+    )
+  }
+}

--- a/csharp/ql/test/shared/FlowSummaries.qll
+++ b/csharp/ql/test/shared/FlowSummaries.qll
@@ -16,13 +16,14 @@ abstract class IncludeSummarizedCallable extends RelevantSummarizedCallable {
       )
   }
 
-  /* Gets a string representing, whether the declaring type is an interface. */
+  predicate isAbstractOrInterface() {
+    this.getDeclaringType() instanceof Interface or
+    this.(Modifiable).isAbstract()
+  }
+
+  /** Gets a string representing, whether the declaring type is an interface. */
   private string getCallableOverride() {
-    if
-      this.getDeclaringType() instanceof Interface or
-      this.(Modifiable).isAbstract()
-    then result = "true"
-    else result = "false"
+    if this.isAbstractOrInterface() then result = "true" else result = "false"
   }
 
   /** Gets a string representing the callable in semi-colon separated format for use in flow summaries. */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -1004,6 +1004,13 @@ module Private {
     abstract class RelevantSummarizedCallable extends SummarizedCallable {
       /** Gets the string representation of this callable used by `summary/1`. */
       abstract string getCallableCsv();
+
+      /** Holds if flow is progated between `input` and `output` */
+      predicate relevantSummary(
+        SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+      ) {
+        this.propagatesFlow(input, output, preservesValue)
+      }
     }
 
     /** Render the kind in the format used in flow summaries. */
@@ -1023,7 +1030,7 @@ module Private {
         RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
         boolean preservesValue
       |
-        c.propagatesFlow(input, output, preservesValue) and
+        c.relevantSummary(input, output, preservesValue) and
         csv =
           c.getCallableCsv() + ";;" + getComponentStackCsv(input) + ";" +
             getComponentStackCsv(output) + ";" + renderKind(preservesValue)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -1004,6 +1004,13 @@ module Private {
     abstract class RelevantSummarizedCallable extends SummarizedCallable {
       /** Gets the string representation of this callable used by `summary/1`. */
       abstract string getCallableCsv();
+
+      /** Holds if flow is progated between `input` and `output` */
+      predicate relevantSummary(
+        SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+      ) {
+        this.propagatesFlow(input, output, preservesValue)
+      }
     }
 
     /** Render the kind in the format used in flow summaries. */
@@ -1023,7 +1030,7 @@ module Private {
         RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
         boolean preservesValue
       |
-        c.propagatesFlow(input, output, preservesValue) and
+        c.relevantSummary(input, output, preservesValue) and
         csv =
           c.getCallableCsv() + ";;" + getComponentStackCsv(input) + ";" +
             getComponentStackCsv(output) + ";" + renderKind(preservesValue)


### PR DESCRIPTION
In this PR we introduce a new test case for flow summaries.
The idea is, that we filter out all summaries for interface implementations and overrides.
This will become relevant, when we want to use the flow summaries produced by the test to replace the existing models.