### PR TITLE
C++: Add CWE tags to some queries.

### DIFF
--- a/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id cpp/boost/tls-settings-misconfiguration
  * @tags security
+ *       external/cwe/cwe-326
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
@@ -3,6 +3,7 @@
  * @description Using the TLS or SSLv23 protocol from the boost::asio library, but not disabling deprecated protocols, or disabling minimum-recommended protocols.
  * @kind problem
  * @problem.severity error
+ * @security-severity 7.5
  * @id cpp/boost/tls-settings-misconfiguration
  * @tags security
  *       external/cwe/cwe-326

--- a/cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
@@ -5,6 +5,7 @@
  * @problem.severity error
  * @id cpp/boost/use-of-deprecated-hardcoded-security-protocol
  * @tags security
+ *       external/cwe/cwe-327
  */
 
 import cpp

--- a/cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/UseOfDeprecatedHardcodedProtocol.ql
@@ -3,6 +3,7 @@
  * @description Using a deprecated hard-coded protocol using the boost::asio library.
  * @kind problem
  * @problem.severity error
+ * @security-severity 7.5
  * @id cpp/boost/use-of-deprecated-hardcoded-security-protocol
  * @tags security
  *       external/cwe/cwe-327

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -8,6 +8,7 @@
  * @precision high
  * @id cpp/cleartext-storage-file
  * @tags security
+ *       external/cwe/cwe-260
  *       external/cwe/cwe-313
  */
 


### PR DESCRIPTION
Add [CWE-326: Inadequate Encryption Strength](https://cwe.mitre.org/data/definitions/326.html) tag to `cpp/boost/tls-settings-misconfiguration`.  This query previously had the `security` tag but no specific CWE, and this is the closest one I can find.  The query is about using `boost::asio` for TLS or SSLv23 without disabling deprecated protocols such as TLS 1.1.

Add [CWE-327: Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327.html) tag to `cpp/boost/use-of-deprecated-hardcoded-security-protocol`.  This query previously had the `security` tag but no specific CWE, and this is the closest one I can find.  The query is about explicitly specifying a deprecated protocol such as SSLv2 with the `boost::asio` library.

Add [CWE-260: Password in Configuration File](https://cwe.mitre.org/data/definitions/260.html) tag to `cpp/cleartext-storage-file`.  This query is already tagged with [CWE-313: Cleartext Storage in a File or on Disk](https://cwe.mitre.org/data/definitions/313.html), but we believe `CWE-260` has the benefit of association with [OWASP A05:2021 – Security Misconfiguration](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/).  The query is about storing data we believe to be an unencrypted password or similarly sensitive information in a file.