### PR TITLE
C#: Make it possible to define flow for property backing methods.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/ExternalFlow.qll
@@ -78,6 +78,7 @@ private import internal.DataFlowPublic
 private import internal.FlowSummaryImpl::Public
 private import internal.FlowSummaryImpl::Private::External
 private import internal.FlowSummaryImplSpecific
+private import semmle.code.csharp.dispatch.OverridableCallable
 
 /**
  * A module importing the frameworks that provide external flow data,
@@ -347,12 +348,15 @@ private class UnboundValueOrRefType extends ValueOrRefType {
   }
 }
 
-private class UnboundCallable extends Callable, Virtualizable {
+private class UnboundCallable extends Callable {
   UnboundCallable() { this.isUnboundDeclaration() }
 
   predicate overridesOrImplementsUnbound(UnboundCallable that) {
     exists(Callable c |
-      this.overridesOrImplementsOrEquals(c) and
+      this.(Virtualizable).overridesOrImplementsOrEquals(c) or
+      this = c.(OverridableCallable).getAnUltimateImplementor() or
+      this = c.(OverridableCallable).getAnOverrider+()
+    |
       this != c and
       that = c.getUnboundDeclaration()
     )
@@ -409,7 +413,7 @@ private Element interpretElement0(
   string namespace, string type, boolean subtypes, string name, string signature
 ) {
   exists(UnboundValueOrRefType t | elementSpec(namespace, type, subtypes, name, signature, _, t) |
-    exists(Member m |
+    exists(Declaration m |
       (
         result = m
         or

--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.cs
@@ -105,6 +105,13 @@ namespace My.Qltest
             Sink(d2.Field2);
         }
 
+        void M16()
+        {
+            var f = new F();
+            f.MyProp = new object();
+            Sink(f.MyProp);
+        }
+
         object StepArgRes(object x) { return null; }
 
         void StepArgArg(object @in, object @out) { }
@@ -141,5 +148,25 @@ namespace My.Qltest
         static void Parse(string s, out int i) => throw null;
 
         static void Sink(object o) { }
+    }
+
+    public class E
+    {
+        object MyField;
+
+        public virtual object MyProp
+        {
+            get { throw null; }
+            set { throw null; }
+        }
+    }
+
+    public class F : E
+    {
+        public override object MyProp
+        {
+            get { throw null; }
+            set { throw null; }
+        }
     }
 }

--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.expected
@@ -53,6 +53,9 @@ edges
 | ExternalFlow.cs:100:20:100:20 | d : Object | ExternalFlow.cs:102:22:102:22 | access to parameter d |
 | ExternalFlow.cs:103:16:103:17 | access to local variable d1 [field Field] : Object | ExternalFlow.cs:100:20:100:20 | d : Object |
 | ExternalFlow.cs:104:18:104:19 | access to local variable d1 [field Field] : Object | ExternalFlow.cs:104:18:104:25 | access to field Field |
+| ExternalFlow.cs:111:13:111:13 | [post] access to local variable f [field MyField] : Object | ExternalFlow.cs:112:18:112:18 | access to local variable f [field MyField] : Object |
+| ExternalFlow.cs:111:24:111:35 | object creation of type Object : Object | ExternalFlow.cs:111:13:111:13 | [post] access to local variable f [field MyField] : Object |
+| ExternalFlow.cs:112:18:112:18 | access to local variable f [field MyField] : Object | ExternalFlow.cs:112:18:112:25 | access to property MyProp |
 nodes
 | ExternalFlow.cs:9:27:9:38 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | ExternalFlow.cs:10:18:10:33 | call to method StepArgRes | semmle.label | call to method StepArgRes |
@@ -123,6 +126,10 @@ nodes
 | ExternalFlow.cs:103:16:103:17 | access to local variable d1 [field Field] : Object | semmle.label | access to local variable d1 [field Field] : Object |
 | ExternalFlow.cs:104:18:104:19 | access to local variable d1 [field Field] : Object | semmle.label | access to local variable d1 [field Field] : Object |
 | ExternalFlow.cs:104:18:104:25 | access to field Field | semmle.label | access to field Field |
+| ExternalFlow.cs:111:13:111:13 | [post] access to local variable f [field MyField] : Object | semmle.label | [post] access to local variable f [field MyField] : Object |
+| ExternalFlow.cs:111:24:111:35 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| ExternalFlow.cs:112:18:112:18 | access to local variable f [field MyField] : Object | semmle.label | access to local variable f [field MyField] : Object |
+| ExternalFlow.cs:112:18:112:25 | access to property MyProp | semmle.label | access to property MyProp |
 subpaths
 invalidModelRow
 #select
@@ -144,3 +151,4 @@ invalidModelRow
 | ExternalFlow.cs:92:18:92:18 | (...) ... | ExternalFlow.cs:90:21:90:34 | object creation of type String : String | ExternalFlow.cs:92:18:92:18 | (...) ... | $@ | ExternalFlow.cs:90:21:90:34 | object creation of type String : String | object creation of type String : String |
 | ExternalFlow.cs:102:22:102:22 | access to parameter d | ExternalFlow.cs:98:24:98:35 | object creation of type Object : Object | ExternalFlow.cs:102:22:102:22 | access to parameter d | $@ | ExternalFlow.cs:98:24:98:35 | object creation of type Object : Object | object creation of type Object : Object |
 | ExternalFlow.cs:104:18:104:25 | access to field Field | ExternalFlow.cs:98:24:98:35 | object creation of type Object : Object | ExternalFlow.cs:104:18:104:25 | access to field Field | $@ | ExternalFlow.cs:98:24:98:35 | object creation of type Object : Object | object creation of type Object : Object |
+| ExternalFlow.cs:112:18:112:25 | access to property MyProp | ExternalFlow.cs:111:24:111:35 | object creation of type Object : Object | ExternalFlow.cs:112:18:112:25 | access to property MyProp | $@ | ExternalFlow.cs:111:24:111:35 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/external-models/ExternalFlow.ql
@@ -28,7 +28,9 @@ class SummaryModelTest extends SummaryModelCsv {
         "My.Qltest;D;false;Apply2<>;(System.Action<S>,S,S);;Field[My.Qltest.D.Field2] of Argument[2];Parameter[0] of Argument[0];value",
         "My.Qltest;D;false;Map<,>;(S[],System.Func<S,T>);;Element of Argument[0];Parameter[0] of Argument[1];value",
         "My.Qltest;D;false;Map<,>;(S[],System.Func<S,T>);;ReturnValue of Argument[1];Element of ReturnValue;value",
-        "My.Qltest;D;false;Parse;(System.String,System.Int32);;Argument[0];Argument[1];taint"
+        "My.Qltest;D;false;Parse;(System.String,System.Int32);;Argument[0];Argument[1];taint",
+        "My.Qltest;E;true;get_MyProp;();;Field[My.Qltest.E.MyField] of Argument[-1];ReturnValue;value",
+        "My.Qltest;E;true;set_MyProp;(System.Object);;Argument[0];Field[My.Qltest.E.MyField] of Argument[-1];value"
       ]
   }
 }


### PR DESCRIPTION
In this PR we make it possible to define flow for the backing methods for property methods for getting and setting values.
These were discarded prior to this to change as they were not "Members".