### PR TITLE
Ruby: Add CFG test for `||`

### DIFF
--- a/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -3661,7 +3661,7 @@ ifs.rb:
 #-----|  -> b
 
 #   46| empty_else
-#-----|  -> exit ifs.rb (normal)
+#-----|  -> disjunct
 
 #   46| exit empty_else
 
@@ -3696,6 +3696,58 @@ ifs.rb:
 #-----|  -> "done"
 
 #   51| "done"
+#-----|  -> call to puts
+
+#   54| enter disjunct
+#-----|  -> b1
+
+#   54| disjunct
+#-----|  -> exit ifs.rb (normal)
+
+#   54| exit disjunct
+
+#   54| exit disjunct (normal)
+#-----|  -> exit disjunct
+
+#   54| b1
+#-----|  -> b2
+
+#   54| b2
+#-----|  -> b1
+
+#   55| if ...
+#-----|  -> exit disjunct (normal)
+
+#   55| [false] ( ... )
+#-----| false -> if ...
+
+#   55| [true] ( ... )
+#-----| true -> self
+
+#   55| [false] ... || ...
+#-----| false -> [false] ( ... )
+
+#   55| [true] ... || ...
+#-----| true -> [true] ( ... )
+
+#   55| b1
+#-----| true -> [true] ... || ...
+#-----| false -> b2
+
+#   55| b2
+#-----| false -> [false] ... || ...
+#-----| true -> [true] ... || ...
+
+#   55| then ...
+#-----|  -> if ...
+
+#   56| call to puts
+#-----|  -> then ...
+
+#   56| self
+#-----|  -> "b1 or b2"
+
+#   56| "b1 or b2"
 #-----|  -> call to puts
 
 loops.rb:

--- a/ruby/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/ruby/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -241,6 +241,9 @@ positionalArguments
 | ifs.rb:38:12:38:17 | ... == ... | ifs.rb:38:17:38:17 | 2 |
 | ifs.rb:48:5:48:15 | call to puts | ifs.rb:48:10:48:15 | "true" |
 | ifs.rb:51:3:51:13 | call to puts | ifs.rb:51:8:51:13 | "done" |
+| ifs.rb:55:7:55:14 | [false] ... \|\| ... | ifs.rb:55:13:55:14 | b2 |
+| ifs.rb:55:7:55:14 | [true] ... \|\| ... | ifs.rb:55:13:55:14 | b2 |
+| ifs.rb:56:5:56:19 | call to puts | ifs.rb:56:10:56:19 | "b1 or b2" |
 | loops.rb:2:9:2:14 | ... >= ... | loops.rb:2:14:2:14 | 0 |
 | loops.rb:3:5:3:10 | call to puts | loops.rb:3:10:3:10 | x |
 | loops.rb:4:7:4:8 | ... - ... | loops.rb:4:10:4:10 | 1 |

--- a/ruby/ql/test/library-tests/controlflow/graph/ifs.rb
+++ b/ruby/ql/test/library-tests/controlflow/graph/ifs.rb
@@ -50,3 +50,9 @@ def empty_else b
   end
   puts "done"
 end
+
+def disjunct (b1, b2)
+  if (b1 || b2) then
+    puts "b1 or b2"
+  end
+end


### PR DESCRIPTION
Turns out we didn't have this already.