### PR TITLE
Java: Tag queries with CWE-328

### DIFF
--- a/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/BrokenCryptoAlgorithm.ql
@@ -8,6 +8,7 @@
  * @id java/weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       external/cwe/cwe-328
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
@@ -8,6 +8,7 @@
  * @id java/potentially-weak-cryptographic-algorithm
  * @tags security
  *       external/cwe/cwe-327
+ *       external/cwe/cwe-328
  */
 
 import java


### PR DESCRIPTION
CWE-328: Use of Weak Hash, see https://cwe.mitre.org/data/definitions/328.html

Since weak hash functions (md5/sha1) are considered for the
`java/weak-cryptographic-algorithm` query. See
https://github.com/github/codeql/blob/caeeebf572f84f428476ec36745c832f21c8e5c0/java/ql/lib/semmle/code/java/security/Encryption.qll#L148

To keep things consistent between `java/weak-cryptographic-algorithm`
and `java/potentially-weak-cryptographic-algorithm`, I also added the
tag to the latter.