### PR TITLE
C++: Fix performance of 'cpp/unused-static-function'.

### DIFF
--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticFunctions.ql
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedStaticFunctions.ql
@@ -50,6 +50,16 @@ predicate reachableThing(Thing t) {
   exists(Thing mid | reachableThing(mid) and mid.callsOrAccesses() = t)
 }
 
+pragma[nomagic]
+predicate callsOrAccessesPlus(Thing thing1, FunctionToRemove thing2) {
+  thing1.callsOrAccesses() = thing2
+  or
+  exists(Thing mid |
+    thing1.callsOrAccesses() = mid and
+    callsOrAccessesPlus(mid, thing2)
+  )
+}
+
 class Thing extends Locatable {
   Thing() {
     this instanceof Function or
@@ -81,7 +91,7 @@ class FunctionToRemove extends Function {
   }
 
   Thing getOther() {
-    result.callsOrAccesses+() = this and
+    callsOrAccessesPlus(result, this) and
     this != result and
     // We will already be reporting the enclosing function of a
     // local variable, so don't also report the variable


### PR DESCRIPTION
This PR fixes some scary tuple counts on the `cpp/unused-static-function` query with some manual magic:

```ql
Tuple counts for #UnusedStaticFunctions::Thing::callsOrAccesses_dispredPlus#fb#flipped/2@i19#da588w9l after 35.7s:
    46418979  ~0%      {2} r1 = SCAN #UnusedStaticFunctions::Thing::callsOrAccesses_dispredPlus#fb#flipped#prev_delta OUTPUT In.1, In.0 'result'
    121519019 ~42%     {2} r2 = JOIN r1 WITH UnusedStaticFunctions::Thing::callsOrAccesses_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'this', Lhs.1 'result'
    48732165  ~7%      {2} r3 = r2 AND NOT #UnusedStaticFunctions::Thing::callsOrAccesses_dispredPlus#fb#flipped#prev(Lhs.1 'result', Lhs.0 'this')
    48732165  ~4%      {2} r4 = SCAN r3 OUTPUT In.1 'result', In.0 'this'
                                         return r4
```