### PR TITLE
Ruby: Don't count private methods as Rails actions

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -54,13 +54,13 @@ class ActionControllerControllerClass extends ClassDeclaration {
 }
 
 /**
- * An instance method defined within an `ActionController` controller class.
+ * A public instance method defined within an `ActionController` controller class.
  * This may be the target of a route handler, if such a route is defined.
  */
 class ActionControllerActionMethod extends Method, HTTP::Server::RequestHandler::Range {
   private ActionControllerControllerClass controllerClass;
 
-  ActionControllerActionMethod() { this = controllerClass.getAMethod() }
+  ActionControllerActionMethod() { this = controllerClass.getAMethod() and not this.isPrivate() }
 
   /**
    * Establishes a mapping between a method within the file

--- a/ruby/ql/test/library-tests/frameworks/ActionController.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionController.expected
@@ -2,7 +2,7 @@ actionControllerControllerClasses
 | ActiveRecordInjection.rb:27:1:58:3 | FooController |
 | ActiveRecordInjection.rb:60:1:90:3 | BarController |
 | ActiveRecordInjection.rb:92:1:96:3 | BazController |
-| app/controllers/foo/bars_controller.rb:3:1:25:3 | BarsController |
+| app/controllers/foo/bars_controller.rb:3:1:31:3 | BarsController |
 actionControllerActionMethods
 | ActiveRecordInjection.rb:32:3:57:5 | some_request_handler |
 | ActiveRecordInjection.rb:61:3:69:5 | some_other_request_handler |
@@ -57,8 +57,8 @@ redirectToCalls
 | app/controllers/foo/bars_controller.rb:17:5:17:30 | call to redirect_to |
 actionControllerHelperMethods
 getAssociatedControllerClasses
-| app/controllers/foo/bars_controller.rb:3:1:25:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
-| app/controllers/foo/bars_controller.rb:3:1:25:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:31:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:31:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
 controllerTemplateFiles
-| app/controllers/foo/bars_controller.rb:3:1:25:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
-| app/controllers/foo/bars_controller.rb:3:1:25:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:31:3 | BarsController | app/views/foo/bars/_widget.html.erb:0:0:0:0 | app/views/foo/bars/_widget.html.erb |
+| app/controllers/foo/bars_controller.rb:3:1:31:3 | BarsController | app/views/foo/bars/show.html.erb:0:0:0:0 | app/views/foo/bars/show.html.erb |

--- a/ruby/ql/test/library-tests/frameworks/ActionView.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionView.expected
@@ -14,6 +14,7 @@ rawCalls
 renderCalls
 | app/controllers/foo/bars_controller.rb:6:5:6:37 | call to render |
 | app/controllers/foo/bars_controller.rb:23:5:23:76 | call to render |
+| app/controllers/foo/bars_controller.rb:29:5:29:17 | call to render |
 | app/views/foo/bars/show.html.erb:31:5:31:89 | call to render |
 renderToCalls
 | app/controllers/foo/bars_controller.rb:15:16:15:97 | call to render_to_string |

--- a/ruby/ql/test/library-tests/frameworks/app/controllers/foo/bars_controller.rb
+++ b/ruby/ql/test/library-tests/frameworks/app/controllers/foo/bars_controller.rb
@@ -22,4 +22,10 @@ class BarsController < ApplicationController
     dt = params[:text]
     render "foo/bars/show", locals: { display_text: dt, safe_text: "hello" }
   end
+  
+  private
+
+  def unreachable_action
+    render "show"
+  end
 end


### PR DESCRIPTION
Private instance methods on ActionController classes aren't valid
request handlers. Routing to them will raise an exception.
