### PR TITLE
fix dependency cycle by removing superfluous classes

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -266,13 +266,13 @@ module ReflectedXSS {
   abstract class Source extends Shared::Source { }
 
   /** A data flow sink for stored XSS vulnerabilities. */
-  abstract class Sink extends Shared::Sink { }
+  class Sink = Shared::Sink;
 
   /** A sanitizer for stored XSS vulnerabilities. */
-  abstract class Sanitizer extends Shared::Sanitizer { }
+  class Sanitizer = Shared::Sanitizer;
 
   /** A sanitizer guard for stored XSS vulnerabilities. */
-  abstract class SanitizerGuard extends Shared::SanitizerGuard { }
+  class SanitizerGuard = Shared::SanitizerGuard;
 
   /**
    * An additional step that is preserves dataflow in the context of reflected XSS.
@@ -314,13 +314,13 @@ module StoredXSS {
   abstract class Source extends Shared::Source { }
 
   /** A data flow sink for stored XSS vulnerabilities. */
-  abstract class Sink extends Shared::Sink { }
+  class Sink = Shared::Sink;
 
   /** A sanitizer for stored XSS vulnerabilities. */
-  abstract class Sanitizer extends Shared::Sanitizer { }
+  class Sanitizer = Shared::Sanitizer;
 
   /** A sanitizer guard for stored XSS vulnerabilities. */
-  abstract class SanitizerGuard extends Shared::SanitizerGuard { }
+  class SanitizerGuard = Shared::SanitizerGuard;
 
   /**
    * An additional step that preserves dataflow in the context of stored XSS.

--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -274,19 +274,6 @@ module ReflectedXSS {
   /** A sanitizer guard for stored XSS vulnerabilities. */
   abstract class SanitizerGuard extends Shared::SanitizerGuard { }
 
-  // Consider all arbitrary XSS sinks to be reflected XSS sinks
-  private class AnySink extends Sink instanceof Shared::Sink { }
-
-  // Consider all arbitrary XSS sanitizers to be reflected XSS sanitizers
-  private class AnySanitizer extends Sanitizer instanceof Shared::Sanitizer { }
-
-  // Consider all arbitrary XSS sanitizer guards to be reflected XSS sanitizer guards
-  private class AnySanitizerGuard extends SanitizerGuard instanceof Shared::SanitizerGuard {
-    override predicate checks(CfgNode expr, boolean branch) {
-      Shared::SanitizerGuard.super.checks(expr, branch)
-    }
-  }
-
   /**
    * An additional step that is preserves dataflow in the context of reflected XSS.
    */
@@ -334,19 +321,6 @@ module StoredXSS {
 
   /** A sanitizer guard for stored XSS vulnerabilities. */
   abstract class SanitizerGuard extends Shared::SanitizerGuard { }
-
-  // Consider all arbitrary XSS sinks to be stored XSS sinks
-  private class AnySink extends Sink instanceof Shared::Sink { }
-
-  // Consider all arbitrary XSS sanitizers to be stored XSS sanitizers
-  private class AnySanitizer extends Sanitizer instanceof Shared::Sanitizer { }
-
-  // Consider all arbitrary XSS sanitizer guards to be stored XSS sanitizer guards
-  private class AnySanitizerGuard extends SanitizerGuard instanceof Shared::SanitizerGuard {
-    override predicate checks(CfgNode expr, boolean branch) {
-      Shared::SanitizerGuard.super.checks(expr, branch)
-    }
-  }
 
   /**
    * An additional step that preserves dataflow in the context of stored XSS.


### PR DESCRIPTION
These classes were introducing dependency cycles during type compilation. This only even compiled due to a bug in the compiler: https://github.com/github/semmle-code/pull/41019

The problem (by example) is this: `ReflectedXSS::Sink` is an abstract class with only one extension (`ReflectedXSS::AnySink`). Therefore, computing this type requires calculating the type `ReflectedXSS::AnySink` first. At the same time, `ReflectedXSS::AnySink` is `instanceof Shared::Sink`, so that type needs to be calculated first. But then `Shared::Sink` is also abstract and requires `ReflectedXSS::Sink`, introducing a cycle.

These classes aren'y currently used, so I just removed them. Feel free to suggest a better approach.

This seems to be the only case of that pattern occurring in existing QL code, so it is blocking a PR that will raise an appropriate error message for these cases in the future (https://github.com/github/semmle-code/pull/41091).