### PR TITLE
JS: extend syntax of handlebars tags

### DIFF
--- a/javascript/change-notes/2021-12-07-handlebars-more-raw-interpolation.md
+++ b/javascript/change-notes/2021-12-07-handlebars-more-raw-interpolation.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* Support for handlebars templates has improved. Raw interpolation tags of the form `{{& ... }}` are now recognized,
+  as well as whitespace-trimming tags like `{{~ ... }}`.

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -43,7 +43,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2021-11-23";
+  public static final String EXTRACTOR_VERSION = "2021-12-17";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/extractor/src/com/semmle/js/extractor/TemplateEngines.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/TemplateEngines.java
@@ -22,7 +22,7 @@ public class TemplateEngines {
   public static final Pattern TEMPLATE_TAGS =
       Pattern.compile(
           StringUtil.glue(
-              "|", TemplateEngines.MUSTACHE_TAG_DOUBLE, MUSTACHE_TAG_TRIPLE, MUSTACHE_TAG_PERCENT, EJS_TAG),
+              "|", MUSTACHE_TAG_DOUBLE, MUSTACHE_TAG_TRIPLE, MUSTACHE_TAG_PERCENT, EJS_TAG),
           Pattern.DOTALL);
 
   /**

--- a/javascript/extractor/src/com/semmle/js/extractor/TemplateEngines.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/TemplateEngines.java
@@ -7,8 +7,8 @@ import com.semmle.util.locations.Position;
 import com.semmle.util.trap.TrapWriter.Label;
 
 public class TemplateEngines {
-  private static final String MUSTACHE_TAG_TRIPLE = "\\{\\{\\{(.*?)\\}\\}\\}"; // {{{ x }}}
-  private static final String MUSTACHE_TAG_DOUBLE = "\\{\\{(?!\\{)(.*?)\\}\\}"; // {{ x }}}
+  private static final String MUSTACHE_TAG_TRIPLE = "\\{\\{\\{[~]?(.*?)[~]?\\}\\}\\}"; // {{{ x }}}
+  private static final String MUSTACHE_TAG_DOUBLE = "\\{\\{(?!\\{)[~&]?(.*?)[~]?\\}\\}"; // {{ x }}}
   private static final String MUSTACHE_TAG_PERCENT = "\\{%(?!>)(.*?)%\\}"; // {% x %}
   private static final String EJS_TAG = "<%(?![%<>}])[-=]?(.*?)[_-]?%>"; // <% x %>
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
@@ -522,9 +522,9 @@ module Templating {
   private class MustacheStyleSyntax extends TemplateSyntax {
     MustacheStyleSyntax() { this = "mustache" }
 
-    override string getRawInterpolationRegexp() { result = "(?s)\\{\\{\\{(.*?)\\}\\}\\}" }
+    override string getRawInterpolationRegexp() { result = "(?s)\\{\\{\\{(.*?)\\}\\}\\}|\\{\\{&(.*?)\\}\\}" }
 
-    override string getEscapingInterpolationRegexp() { result = "(?s)\\{\\{[^{](.*?)\\}\\}" }
+    override string getEscapingInterpolationRegexp() { result = "(?s)\\{\\{[^{&](.*?)\\}\\}" }
 
     override string getAFileExtension() { result = ["hbs", "njk"] }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Templating.qll
@@ -522,7 +522,9 @@ module Templating {
   private class MustacheStyleSyntax extends TemplateSyntax {
     MustacheStyleSyntax() { this = "mustache" }
 
-    override string getRawInterpolationRegexp() { result = "(?s)\\{\\{\\{(.*?)\\}\\}\\}|\\{\\{&(.*?)\\}\\}" }
+    override string getRawInterpolationRegexp() {
+      result = "(?s)\\{\\{\\{(.*?)\\}\\}\\}|\\{\\{&(.*?)\\}\\}"
+    }
 
     override string getEscapingInterpolationRegexp() { result = "(?s)\\{\\{[^{&](.*?)\\}\\}" }
 

--- a/javascript/ql/test/library-tests/frameworks/Templating/CodeInjection.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/CodeInjection.expected
@@ -48,15 +48,15 @@ nodes
 | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> |
 | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> |
 | views/ejs_sinks.ejs:21:43:21:66 | dataInE ... rString |
-| views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} |
-| views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} |
-| views/hbs_sinks.hbs:13:42:13:60 | dataInGeneratedCode |
-| views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} |
-| views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} |
-| views/hbs_sinks.hbs:16:22:16:35 | backslashSink1 |
-| views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} |
-| views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} |
-| views/hbs_sinks.hbs:21:42:21:65 | dataInE ... rString |
+| views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} |
+| views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} |
+| views/hbs_sinks.hbs:25:42:25:60 | dataInGeneratedCode |
+| views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} |
+| views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} |
+| views/hbs_sinks.hbs:28:22:28:35 | backslashSink1 |
+| views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} |
+| views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} |
+| views/hbs_sinks.hbs:33:42:33:65 | dataInE ... rString |
 | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} |
 | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} |
 | views/njk_sinks.njk:13:42:13:60 | dataInGeneratedCode |
@@ -86,12 +86,12 @@ edges
 | app.js:17:25:17:48 | req.que ... shSink1 | views/ejs_sinks.ejs:16:23:16:36 | backslashSink1 |
 | app.js:19:35:19:68 | req.que ... rString | views/ejs_sinks.ejs:21:43:21:66 | dataInE ... rString |
 | app.js:19:35:19:68 | req.que ... rString | views/ejs_sinks.ejs:21:43:21:66 | dataInE ... rString |
-| app.js:34:30:34:58 | req.que ... tedCode | views/hbs_sinks.hbs:13:42:13:60 | dataInGeneratedCode |
-| app.js:34:30:34:58 | req.que ... tedCode | views/hbs_sinks.hbs:13:42:13:60 | dataInGeneratedCode |
-| app.js:36:25:36:48 | req.que ... shSink1 | views/hbs_sinks.hbs:16:22:16:35 | backslashSink1 |
-| app.js:36:25:36:48 | req.que ... shSink1 | views/hbs_sinks.hbs:16:22:16:35 | backslashSink1 |
-| app.js:38:35:38:68 | req.que ... rString | views/hbs_sinks.hbs:21:42:21:65 | dataInE ... rString |
-| app.js:38:35:38:68 | req.que ... rString | views/hbs_sinks.hbs:21:42:21:65 | dataInE ... rString |
+| app.js:34:30:34:58 | req.que ... tedCode | views/hbs_sinks.hbs:25:42:25:60 | dataInGeneratedCode |
+| app.js:34:30:34:58 | req.que ... tedCode | views/hbs_sinks.hbs:25:42:25:60 | dataInGeneratedCode |
+| app.js:36:25:36:48 | req.que ... shSink1 | views/hbs_sinks.hbs:28:22:28:35 | backslashSink1 |
+| app.js:36:25:36:48 | req.que ... shSink1 | views/hbs_sinks.hbs:28:22:28:35 | backslashSink1 |
+| app.js:38:35:38:68 | req.que ... rString | views/hbs_sinks.hbs:33:42:33:65 | dataInE ... rString |
+| app.js:38:35:38:68 | req.que ... rString | views/hbs_sinks.hbs:33:42:33:65 | dataInE ... rString |
 | app.js:53:30:53:58 | req.que ... tedCode | views/njk_sinks.njk:13:42:13:60 | dataInGeneratedCode |
 | app.js:53:30:53:58 | req.que ... tedCode | views/njk_sinks.njk:13:42:13:60 | dataInGeneratedCode |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
@@ -126,12 +126,12 @@ edges
 | views/ejs_sinks.ejs:16:23:16:36 | backslashSink1 | views/ejs_sinks.ejs:16:19:16:39 | <%= backslashSink1 %> |
 | views/ejs_sinks.ejs:21:43:21:66 | dataInE ... rString | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> |
 | views/ejs_sinks.ejs:21:43:21:66 | dataInE ... rString | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> |
-| views/hbs_sinks.hbs:13:42:13:60 | dataInGeneratedCode | views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} |
-| views/hbs_sinks.hbs:13:42:13:60 | dataInGeneratedCode | views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} |
-| views/hbs_sinks.hbs:16:22:16:35 | backslashSink1 | views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} |
-| views/hbs_sinks.hbs:16:22:16:35 | backslashSink1 | views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} |
-| views/hbs_sinks.hbs:21:42:21:65 | dataInE ... rString | views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} |
-| views/hbs_sinks.hbs:21:42:21:65 | dataInE ... rString | views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} |
+| views/hbs_sinks.hbs:25:42:25:60 | dataInGeneratedCode | views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} |
+| views/hbs_sinks.hbs:25:42:25:60 | dataInGeneratedCode | views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} |
+| views/hbs_sinks.hbs:28:22:28:35 | backslashSink1 | views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} |
+| views/hbs_sinks.hbs:28:22:28:35 | backslashSink1 | views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} |
+| views/hbs_sinks.hbs:33:42:33:65 | dataInE ... rString | views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} |
+| views/hbs_sinks.hbs:33:42:33:65 | dataInE ... rString | views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} |
 | views/njk_sinks.njk:13:42:13:60 | dataInGeneratedCode | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} |
 | views/njk_sinks.njk:13:42:13:60 | dataInGeneratedCode | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} |
 | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw | views/njk_sinks.njk:14:45:14:73 | dataInG ...  \| safe |
@@ -156,9 +156,9 @@ edges
 | views/ejs_sinks.ejs:13:39:13:64 | <%= dataInGeneratedCode %> | app.js:15:30:15:58 | req.que ... tedCode | views/ejs_sinks.ejs:13:39:13:64 | <%= dataInGeneratedCode %> | $@ flows to here and is interpreted as code. | app.js:15:30:15:58 | req.que ... tedCode | User-provided value |
 | views/ejs_sinks.ejs:16:19:16:39 | <%= backslashSink1 %> | app.js:17:25:17:48 | req.que ... shSink1 | views/ejs_sinks.ejs:16:19:16:39 | <%= backslashSink1 %> | $@ flows to here and is interpreted as code. | app.js:17:25:17:48 | req.que ... shSink1 | User-provided value |
 | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> | app.js:19:35:19:68 | req.que ... rString | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> | $@ flows to here and is interpreted as code. | app.js:19:35:19:68 | req.que ... rString | User-provided value |
-| views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} | app.js:34:30:34:58 | req.que ... tedCode | views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} | $@ flows to here and is interpreted as code. | app.js:34:30:34:58 | req.que ... tedCode | User-provided value |
-| views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} | app.js:36:25:36:48 | req.que ... shSink1 | views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} | $@ flows to here and is interpreted as code. | app.js:36:25:36:48 | req.que ... shSink1 | User-provided value |
-| views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} | app.js:38:35:38:68 | req.que ... rString | views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} | $@ flows to here and is interpreted as code. | app.js:38:35:38:68 | req.que ... rString | User-provided value |
+| views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} | app.js:34:30:34:58 | req.que ... tedCode | views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} | $@ flows to here and is interpreted as code. | app.js:34:30:34:58 | req.que ... tedCode | User-provided value |
+| views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} | app.js:36:25:36:48 | req.que ... shSink1 | views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} | $@ flows to here and is interpreted as code. | app.js:36:25:36:48 | req.que ... shSink1 | User-provided value |
+| views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} | app.js:38:35:38:68 | req.que ... rString | views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} | $@ flows to here and is interpreted as code. | app.js:38:35:38:68 | req.que ... rString | User-provided value |
 | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} | app.js:53:30:53:58 | req.que ... tedCode | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} | $@ flows to here and is interpreted as code. | app.js:53:30:53:58 | req.que ... tedCode | User-provided value |
 | views/njk_sinks.njk:14:42:14:76 | {{ dataInGeneratedCodeRaw \| safe }} | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:42:14:76 | {{ dataInGeneratedCodeRaw \| safe }} | $@ flows to here and is interpreted as code. | app.js:54:33:54:64 | req.que ... CodeRaw | User-provided value |
 | views/njk_sinks.njk:15:46:15:91 | {{ dataInGeneratedCodeJsonRaw \| json \| safe }} | app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:46:15:91 | {{ dataInGeneratedCodeJsonRaw \| json \| safe }} | $@ flows to here and is interpreted as code. | app.js:55:37:55:72 | req.que ... JsonRaw | User-provided value |

--- a/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
@@ -104,21 +104,33 @@ nodes
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
 | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
-| views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
-| views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
-| views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
-| views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
-| views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
-| views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
-| views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
-| views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
-| views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
-| views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
-| views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
-| views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
-| views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
-| views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
-| views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
+| views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
+| views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
+| views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
+| views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
+| views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
+| views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
+| views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
+| views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
+| views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
@@ -147,16 +159,24 @@ edges
 | app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
-| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
-| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:13:4:19 | rawHtml |
-| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
-| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp |
-| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
-| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw |
-| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
-| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw |
-| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
-| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
+| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
+| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
+| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
+| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
@@ -238,16 +258,24 @@ edges
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:24:44:24:50 | rawHtml | views/ejs_include1.ejs:1:5:1:7 | foo |
-| views/hbs_sinks.hbs:4:13:4:19 | rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
-| views/hbs_sinks.hbs:4:13:4:19 | rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
-| views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
-| views/hbs_sinks.hbs:7:13:7:30 | object.rawHtmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
-| views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
-| views/hbs_sinks.hbs:11:47:11:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
-| views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
-| views/hbs_sinks.hbs:14:46:14:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
-| views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
-| views/hbs_sinks.hbs:22:43:22:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:9:13:9:19 | rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:9:13:9:19 | rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:10:13:10:19 | rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:13:10:19 | rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:11:13:11:19 | rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:11:13:11:19 | rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 #select
@@ -271,11 +299,15 @@ edges
 | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> | app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> | Cross-site scripting vulnerability due to $@. | app.js:14:33:14:64 | req.que ... eralRaw | user-provided value |
 | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> | app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> | Cross-site scripting vulnerability due to $@. | app.js:16:33:16:64 | req.que ... CodeRaw | user-provided value |
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> | Cross-site scripting vulnerability due to $@. | app.js:20:38:20:74 | req.que ... ringRaw | user-provided value |
-| views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
-| views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} | Cross-site scripting vulnerability due to $@. | app.js:30:26:30:46 | req.que ... tmlProp | user-provided value |
-| views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:33:33:33:64 | req.que ... eralRaw | user-provided value |
-| views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:35:33:35:64 | req.que ... CodeRaw | user-provided value |
-| views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} | app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:39:38:39:74 | req.que ... ringRaw | user-provided value |
+| views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
+| views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
+| views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
+| views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
+| views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
+| views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} | Cross-site scripting vulnerability due to $@. | app.js:30:26:30:46 | req.que ... tmlProp | user-provided value |
+| views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:33:33:33:64 | req.que ... eralRaw | user-provided value |
+| views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:35:33:35:64 | req.que ... CodeRaw | user-provided value |
+| views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} | app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:39:38:39:74 | req.que ... ringRaw | user-provided value |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml | Cross-site scripting vulnerability due to $@. | app.js:46:18:46:34 | req.query.rawHtml | user-provided value |
 | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp | Cross-site scripting vulnerability due to $@. | app.js:49:26:49:46 | req.que ... tmlProp | user-provided value |
 | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw | Cross-site scripting vulnerability due to $@. | app.js:52:33:52:64 | req.que ... eralRaw | user-provided value |

--- a/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
@@ -119,6 +119,9 @@ nodes
 | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
+| views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
 | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
@@ -169,6 +172,8 @@ edges
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
 | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
@@ -268,6 +273,8 @@ edges
 | views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
 | views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:15:13:15:19 | rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:13:15:19 | rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
 | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
@@ -304,6 +311,7 @@ edges
 | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
 | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
 | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
+| views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} | Cross-site scripting vulnerability due to $@. | app.js:27:18:27:34 | req.query.rawHtml | user-provided value |
 | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} | Cross-site scripting vulnerability due to $@. | app.js:30:26:30:46 | req.que ... tmlProp | user-provided value |
 | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:33:33:33:64 | req.que ... eralRaw | user-provided value |
 | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} | Cross-site scripting vulnerability due to $@. | app.js:35:33:35:64 | req.que ... CodeRaw | user-provided value |

--- a/javascript/ql/test/library-tests/frameworks/Templating/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/test.expected
@@ -62,6 +62,7 @@ xssSink
 | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
 | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
 | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
 | views/hbs_sinks.hbs:17:9:17:32 | {{{ rawHtmlSafeValue }}} |
 | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |

--- a/javascript/ql/test/library-tests/frameworks/Templating/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/test.expected
@@ -57,12 +57,16 @@ xssSink
 | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:24:9:24:57 | <%- include('ejs_include1', { foo: rawHtml }) _%> |
-| views/hbs_sinks.hbs:4:9:4:23 | {{{ rawHtml }}} |
-| views/hbs_sinks.hbs:5:9:5:32 | {{{ rawHtmlSafeValue }}} |
-| views/hbs_sinks.hbs:7:9:7:34 | {{{ object.rawHtmlProp }}} |
-| views/hbs_sinks.hbs:11:43:11:72 | {{{ dataInStringLiteralRaw }}} |
-| views/hbs_sinks.hbs:14:42:14:71 | {{{ dataInGeneratedCodeRaw }}} |
-| views/hbs_sinks.hbs:22:39:22:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:17:9:17:32 | {{{ rawHtmlSafeValue }}} |
+| views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
 | views/instantiated_as_ejs.html:4:9:4:23 | <%- xss_sink %> |
 | views/instantiated_as_hbs.html:7:9:7:24 | {{{ xss_sink }}} |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
@@ -81,9 +85,9 @@ codeInjectionSink
 | views/ejs_sinks.ejs:13:39:13:64 | <%= dataInGeneratedCode %> |
 | views/ejs_sinks.ejs:16:19:16:39 | <%= backslashSink1 %> |
 | views/ejs_sinks.ejs:21:39:21:69 | <%= dataInEventHandlerString %> |
-| views/hbs_sinks.hbs:13:39:13:63 | {{ dataInGeneratedCode }} |
-| views/hbs_sinks.hbs:16:19:16:38 | {{ backslashSink1 }} |
-| views/hbs_sinks.hbs:21:39:21:68 | {{ dataInEventHandlerString }} |
+| views/hbs_sinks.hbs:25:39:25:63 | {{ dataInGeneratedCode }} |
+| views/hbs_sinks.hbs:28:19:28:38 | {{ backslashSink1 }} |
+| views/hbs_sinks.hbs:33:39:33:68 | {{ dataInEventHandlerString }} |
 | views/njk_sinks.njk:13:39:13:63 | {{ dataInGeneratedCode }} |
 | views/njk_sinks.njk:14:42:14:76 | {{ dataInGeneratedCodeRaw \| safe }} |
 | views/njk_sinks.njk:15:46:15:91 | {{ dataInGeneratedCodeJsonRaw \| json \| safe }} |

--- a/javascript/ql/test/library-tests/frameworks/Templating/views/hbs_sinks.hbs
+++ b/javascript/ql/test/library-tests/frameworks/Templating/views/hbs_sinks.hbs
@@ -1,7 +1,19 @@
 <html>
     <body>
         {{ escapedHtml }}
+        {{~ escapedHtml }}
+        {{ escapedHtml ~}}
+        {{~ escapedHtml ~}}
+        {{~escapedHtml~}}
+
         {{{ rawHtml }}}
+        {{{~rawHtml }}}
+        {{{ rawHtml~}}}
+        {{{~rawHtml~}}}
+        {{{~ rawHtml ~}}}
+
+        {{& rawHtml }}
+
         {{{ rawHtmlSafeValue }}}
 
         {{{ object.rawHtmlProp }}}


### PR DESCRIPTION
Recognizes the raw interpolation tag `{{& foo }}`, and whitespace-trimming tags like `{{~ foo }}`.