### PR TITLE
Python: Fix bad `scope_entry_points_to` join

### DIFF
--- a/python/ql/lib/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/lib/semmle/python/pointsto/PointsTo.qll
@@ -656,6 +656,7 @@ module PointsToInternal {
     builtin_not_in_outer_scope(def, context, value, origin)
   }
 
+  pragma[nomagic]
   private predicate undefined_variable(
     ScopeEntryDefinition def, PointsToContext context, ObjectInternal value, ControlFlowNode origin
   ) {
@@ -674,6 +675,7 @@ module PointsToInternal {
     origin = def.getDefiningNode()
   }
 
+  pragma[nomagic]
   private predicate builtin_not_in_outer_scope(
     ScopeEntryDefinition def, PointsToContext context, ObjectInternal value, ControlFlowNode origin
   ) {


### PR DESCRIPTION
From `pritomrajkhowa/LoopBound`:

```
Definitions.ql-7:PointsTo::PointsToInternal::scope_entry_points_to#ffff#antijoin_rhs#2 ........... 55.1s
```

specifically

```
(443s) Tuple counts for PointsTo::PointsToInternal::scope_entry_points_to#ffff#antijoin_rhs#2/3@74a7cart after 55.1s:
184070    ~0%        {3} r1 = JOIN PointsTo::PointsToInternal::scope_entry_points_to#ffff#shared#1 WITH Variables::GlobalVariable#class#f ON FIRST 1 OUTPUT Lhs.0 'arg2', Lhs.1 'arg0', Lhs.2 'arg1'
184070    ~0%        {3} r2 = STREAM DEDUP r1
919966523 ~2%        {4} r3 = JOIN r2 WITH Essa::EssaDefinition::getSourceVariable_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'arg0', Lhs.2 'arg1', Lhs.0 'arg2'
4281779   ~2293%     {3} r4 = JOIN r3 WITH Essa::EssaVariable::getScope_dispred#ff ON FIRST 2 OUTPUT Lhs.1 'arg0', Lhs.2 'arg1', Lhs.3 'arg2'
                    return r4
```

First, this is an `antijoin`, so there's likely some negation involved. Also, there's mention of `GlobalVariable`, `getScope`, and `getSourceVariable`, none of which appear in `scope_entry_points_to`, so it's likely that something got inlined.

Taking a closer look at the predicates mentioned in the body, we spot `undefined_variable` as a likely culprit.

Evaluating this predicate in isolation reveals that it's not terribly big, so we could try just marking it with `pragma[noinline]` (I opted for the slightly more solid `nomagic`) and see how that fares. I also checked that `builtin_not_in_outer_scope` was similarly small, and made that one un-inlineable as well.

The result? Well, I can't even show you. Both `scope_entry_points_to` and `undefined_variable` are so fast that they don't appear in the clause timing report (so they can at most take 3.5s each to evaluate, as that is the smallest timing in the list).