### PR TITLE
C++: Improvements to cpp/cleartext-transmission

### DIFF
--- a/cpp/change-notes/2021-10-07-cleartext-transmission.md
+++ b/cpp/change-notes/2021-10-07-cleartext-transmission.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The "Cleartext transmission of sensitive information" (`cpp/cleartext-transmission`) query has been improved, reducing the number of false positive results when encryption is present.

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -14,11 +14,14 @@
 import cpp
 import semmle.code.cpp.security.SensitiveExprs
 import semmle.code.cpp.dataflow.TaintTracking
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.models.interfaces.FlowSource
 import DataFlow::PathGraph
 
 /**
  * A function call that sends or receives data over a network.
+ *
+ * note: functions such as `write` may be writing to a network source or a file. We could attempt to determine which, and sort results into `cpp/cleartext-transmission` and perhaps `cpp/cleartext-storage-file`. In practice it usually isn't very important which query reports a result as long as its reported exactly once. See `checkSocket` to narrow this down somewhat.
  */
 abstract class NetworkSendRecv extends FunctionCall {
   /**
@@ -31,12 +34,21 @@ abstract class NetworkSendRecv extends FunctionCall {
    * Gets the expression for the buffer to be sent from / received into.
    */
   abstract Expr getDataExpr();
+
+  /**
+   * Holds if any socket used by this call could be a true network socket.
+   * A zero socket descriptor is standard input, which is not a network
+   * operation.
+   */
+  predicate checkSocket() {
+    not exists(Zero zero |
+      DataFlow::localFlow(DataFlow::exprNode(zero), DataFlow::exprNode(getSocketExpr()))
+    )
+  }
 }
 
 /**
  * A function call that sends data over a network.
- *
- * note: functions such as `write` may be writing to a network source or a file. We could attempt to determine which, and sort results into `cpp/cleartext-transmission` and perhaps `cpp/cleartext-storage-file`. In practice it usually isn't very important which query reports a result as long as its reported exactly once.
  */
 class NetworkSend extends NetworkSendRecv {
   RemoteFlowSinkFunction target;
@@ -86,33 +98,65 @@ class NetworkRecv extends NetworkSendRecv {
 }
 
 /**
- * Taint flow from a sensitive expression to a network operation with data
- * tainted by that expression.
+ * An expression that is an argument or return value from an encryption or
+ * decryption call.
  */
-class SensitiveSendRecvConfiguration extends TaintTracking::Configuration {
-  SensitiveSendRecvConfiguration() { this = "SensitiveSendRecvConfiguration" }
-
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof SensitiveExpr }
-
-  override predicate isSink(DataFlow::Node sink) {
-    exists(NetworkSendRecv transmission |
-      sink.asExpr() = transmission.getDataExpr() and
-      // a zero socket descriptor is standard input, which is not interesting for this query.
-      not exists(Zero zero |
-        DataFlow::localFlow(DataFlow::exprNode(zero),
-          DataFlow::exprNode(transmission.getSocketExpr()))
+class Encrypted extends Expr {
+  Encrypted() {
+    exists(FunctionCall fc |
+      fc.getTarget().getName().toLowerCase().regexpMatch(".*(crypt|encode|decode).*") and
+      (
+        this = fc or
+        this = fc.getAnArgument()
       )
     )
   }
 }
 
+/**
+ * Taint flow from a sensitive expression.
+ */
+class FromSensitiveConfiguration extends TaintTracking::Configuration {
+  FromSensitiveConfiguration() { this = "FromSensitiveConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof SensitiveExpr }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink.asExpr() = any(NetworkSendRecv nsr | nsr.checkSocket()).getDataExpr()
+    or
+    sink.asExpr() instanceof Encrypted
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    // flow from pre-update to post-update of the source
+    isSource(node1) and
+    node2.(DataFlow::PostUpdateNode).getPreUpdateNode() = node1
+    or
+    // flow from pre-update to post-update of the sink (in case we can reach other sinks)
+    isSink(node1) and
+    node2.(DataFlow::PostUpdateNode).getPreUpdateNode() = node1
+    or
+    // flow through encryption functions to the return value (in case we can reach other sinks)
+    node2.asExpr().(Encrypted).(FunctionCall).getAnArgument() = node1.asExpr()
+  }
+}
+
 from
-  SensitiveSendRecvConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink,
-  NetworkSendRecv transmission, string msg
+  FromSensitiveConfiguration config, DataFlow::PathNode source, DataFlow::PathNode sink,
+  NetworkSendRecv networkSendRecv, string msg
 where
+  // flow from sensitive -> network data
   config.hasFlowPath(source, sink) and
-  sink.getNode().asExpr() = transmission.getDataExpr() and
-  if transmission instanceof NetworkSend
+  sink.getNode().asExpr() = networkSendRecv.getDataExpr() and
+  networkSendRecv.checkSocket() and
+  // no flow from sensitive -> evidence of encryption
+  not exists(DataFlow::Node anySource, DataFlow::Node encrypted |
+    config.hasFlow(anySource, sink.getNode()) and
+    config.hasFlow(anySource, encrypted) and
+    encrypted.asExpr() instanceof Encrypted
+  ) and
+  // construct result
+  if networkSendRecv instanceof NetworkSend
   then
     msg =
       "This operation transmits '" + sink.toString() +
@@ -121,4 +165,4 @@ where
     msg =
       "This operation receives into '" + sink.toString() +
         "', which may put unencrypted sensitive data into $@"
-select transmission, source, sink, msg, source, source.getNode().asExpr().toString()
+select networkSendRecv, source, sink, msg, source, source.getNode().asExpr().toString()

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -177,10 +177,6 @@ class FromSensitiveConfiguration extends TaintTracking::Configuration {
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    // flow from pre-update to post-update of the source
-    isSource(node1) and
-    node2.(DataFlow::PostUpdateNode).getPreUpdateNode() = node1
-    or
     // flow through encryption functions to the return value (in case we can reach other sinks)
     node2.asExpr().(Encrypted).(FunctionCall).getAnArgument() = node1.asExpr()
   }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -89,7 +89,12 @@ class Recv extends SendRecv instanceof RemoteFlowSourceFunction {
 /**
  * A function call that sends or receives data over a network.
  *
- * note: functions such as `write` may be writing to a network source or a file. We could attempt to determine which, and sort results into `cpp/cleartext-transmission` and perhaps `cpp/cleartext-storage-file`. In practice it usually isn't very important which query reports a result as long as its reported exactly once. See `checkSocket` to narrow this down somewhat.
+ * note: functions such as `write` may be writing to a network source or a
+ * file. We could attempt to determine which, and sort results into
+ * `cpp/cleartext-transmission` and perhaps `cpp/cleartext-storage-file`. In
+ * practice it usually isn't very important which query reports a result as
+ * long as its reported exactly once. See `checkSocket` to narrow this down
+ * somewhat.
  */
 abstract class NetworkSendRecv extends FunctionCall {
   SendRecv target;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -147,6 +147,10 @@ edges
 | test3.cpp:324:11:324:14 | data | test3.cpp:324:11:324:14 | ref arg data |
 | test3.cpp:324:11:324:14 | ref arg data | test3.cpp:325:11:325:14 | data |
 | test3.cpp:325:11:325:14 | data | test3.cpp:298:20:298:23 | data |
+| test3.cpp:352:16:352:23 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
+| test3.cpp:352:16:352:23 | password | test3.cpp:353:20:353:27 | password |
+| test3.cpp:352:16:352:23 | password | test3.cpp:353:20:353:27 | password |
+| test3.cpp:353:20:353:27 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
 | test.cpp:48:29:48:39 | thePassword | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:58:11:58:16 | passwd | test.cpp:61:11:61:16 | passwd |
 | test.cpp:76:29:76:39 | thePassword | test.cpp:76:21:76:27 | call to encrypt |
@@ -311,6 +315,12 @@ nodes
 | test3.cpp:324:11:324:14 | data | semmle.label | data |
 | test3.cpp:324:11:324:14 | ref arg data | semmle.label | ref arg data |
 | test3.cpp:325:11:325:14 | data | semmle.label | data |
+| test3.cpp:341:16:341:23 | password | semmle.label | password |
+| test3.cpp:352:16:352:23 | password | semmle.label | password |
+| test3.cpp:352:16:352:23 | password | semmle.label | password |
+| test3.cpp:353:4:353:18 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
+| test3.cpp:353:20:353:27 | password | semmle.label | password |
+| test3.cpp:353:20:353:27 | password | semmle.label | password |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -352,3 +362,4 @@ subpaths
 | test3.cpp:290:2:290:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
 | test3.cpp:295:2:295:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
+| test3.cpp:341:4:341:7 | call to recv | test3.cpp:341:16:341:23 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:341:16:341:23 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -56,37 +56,26 @@ edges
 | test3.cpp:278:20:278:23 | data | test3.cpp:280:14:280:17 | data |
 | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data |
 | test3.cpp:283:20:283:23 | data | test3.cpp:285:14:285:17 | data |
-| test3.cpp:288:20:288:23 | data | test3.cpp:288:20:288:23 | data |
 | test3.cpp:288:20:288:23 | data | test3.cpp:290:14:290:17 | data |
 | test3.cpp:293:20:293:23 | data | test3.cpp:293:20:293:23 | data |
 | test3.cpp:293:20:293:23 | data | test3.cpp:295:14:295:17 | data |
 | test3.cpp:298:20:298:23 | data | test3.cpp:300:14:300:17 | data |
-| test3.cpp:308:41:308:48 | password | test3.cpp:312:3:312:17 | call to encrypt_inplace |
-| test3.cpp:308:41:308:48 | password | test3.cpp:312:19:312:26 | password |
-| test3.cpp:308:41:308:48 | password | test3.cpp:313:11:313:18 | password |
-| test3.cpp:308:41:308:48 | password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:308:41:308:48 | password | test3.cpp:316:11:316:18 | password |
-| test3.cpp:308:41:308:48 | password | test3.cpp:317:11:317:18 | password |
-| test3.cpp:308:41:308:48 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:308:41:308:48 | password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:313:11:313:18 | password | test3.cpp:278:20:278:23 | data |
-| test3.cpp:313:11:313:18 | password | test3.cpp:313:11:313:18 | ref arg password |
-| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:314:11:314:18 | password | test3.cpp:283:20:283:23 | data |
-| test3.cpp:314:11:314:18 | password | test3.cpp:314:11:314:18 | ref arg password |
-| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:316:11:316:18 | password | test3.cpp:283:20:283:23 | data |
-| test3.cpp:316:11:316:18 | password | test3.cpp:316:11:316:18 | ref arg password |
-| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:317:11:317:18 | password |
-| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:317:11:317:18 | password | test3.cpp:288:20:288:23 | data |
-| test3.cpp:317:11:317:18 | password | test3.cpp:317:11:317:18 | ref arg password |
-| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:308:41:308:49 | password1 | test3.cpp:312:3:312:17 | call to encrypt_inplace |
+| test3.cpp:308:41:308:49 | password1 | test3.cpp:312:19:312:27 | password1 |
+| test3.cpp:308:41:308:49 | password1 | test3.cpp:313:11:313:19 | password1 |
+| test3.cpp:308:41:308:49 | password1 | test3.cpp:314:11:314:19 | password1 |
+| test3.cpp:308:41:308:49 | password1 | test3.cpp:316:11:316:19 | password1 |
+| test3.cpp:308:41:308:49 | password1 | test3.cpp:317:11:317:19 | password1 |
+| test3.cpp:308:58:308:66 | password2 | test3.cpp:324:11:324:14 | data |
+| test3.cpp:308:58:308:66 | password2 | test3.cpp:325:11:325:14 | data |
+| test3.cpp:313:11:313:19 | password1 | test3.cpp:278:20:278:23 | data |
+| test3.cpp:313:11:313:19 | password1 | test3.cpp:313:11:313:19 | ref arg password1 |
+| test3.cpp:313:11:313:19 | ref arg password1 | test3.cpp:314:11:314:19 | password1 |
+| test3.cpp:314:11:314:19 | password1 | test3.cpp:283:20:283:23 | data |
+| test3.cpp:316:11:316:19 | password1 | test3.cpp:283:20:283:23 | data |
+| test3.cpp:316:11:316:19 | password1 | test3.cpp:316:11:316:19 | ref arg password1 |
+| test3.cpp:316:11:316:19 | ref arg password1 | test3.cpp:317:11:317:19 | password1 |
+| test3.cpp:317:11:317:19 | password1 | test3.cpp:288:20:288:23 | data |
 | test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data |
 | test3.cpp:324:11:324:14 | data | test3.cpp:324:11:324:14 | ref arg data |
 | test3.cpp:324:11:324:14 | ref arg data | test3.cpp:325:11:325:14 | data |
@@ -181,24 +170,22 @@ nodes
 | test3.cpp:283:20:283:23 | data | semmle.label | data |
 | test3.cpp:285:14:285:17 | data | semmle.label | data |
 | test3.cpp:288:20:288:23 | data | semmle.label | data |
-| test3.cpp:288:20:288:23 | data | semmle.label | data |
 | test3.cpp:290:14:290:17 | data | semmle.label | data |
 | test3.cpp:293:20:293:23 | data | semmle.label | data |
 | test3.cpp:293:20:293:23 | data | semmle.label | data |
 | test3.cpp:295:14:295:17 | data | semmle.label | data |
 | test3.cpp:298:20:298:23 | data | semmle.label | data |
 | test3.cpp:300:14:300:17 | data | semmle.label | data |
-| test3.cpp:308:41:308:48 | password | semmle.label | password |
+| test3.cpp:308:41:308:49 | password1 | semmle.label | password1 |
+| test3.cpp:308:58:308:66 | password2 | semmle.label | password2 |
 | test3.cpp:312:3:312:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
-| test3.cpp:312:19:312:26 | password | semmle.label | password |
-| test3.cpp:313:11:313:18 | password | semmle.label | password |
-| test3.cpp:313:11:313:18 | ref arg password | semmle.label | ref arg password |
-| test3.cpp:314:11:314:18 | password | semmle.label | password |
-| test3.cpp:314:11:314:18 | ref arg password | semmle.label | ref arg password |
-| test3.cpp:316:11:316:18 | password | semmle.label | password |
-| test3.cpp:316:11:316:18 | ref arg password | semmle.label | ref arg password |
-| test3.cpp:317:11:317:18 | password | semmle.label | password |
-| test3.cpp:317:11:317:18 | ref arg password | semmle.label | ref arg password |
+| test3.cpp:312:19:312:27 | password1 | semmle.label | password1 |
+| test3.cpp:313:11:313:19 | password1 | semmle.label | password1 |
+| test3.cpp:313:11:313:19 | ref arg password1 | semmle.label | ref arg password1 |
+| test3.cpp:314:11:314:19 | password1 | semmle.label | password1 |
+| test3.cpp:316:11:316:19 | password1 | semmle.label | password1 |
+| test3.cpp:316:11:316:19 | ref arg password1 | semmle.label | ref arg password1 |
+| test3.cpp:317:11:317:19 | password1 | semmle.label | password1 |
 | test3.cpp:324:11:324:14 | data | semmle.label | data |
 | test3.cpp:324:11:324:14 | ref arg data | semmle.label | ref arg data |
 | test3.cpp:325:11:325:14 | data | semmle.label | data |
@@ -216,10 +203,8 @@ nodes
 | test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer | test3.cpp:138:21:138:22 | call to id |
-| test3.cpp:313:11:313:18 | password | test3.cpp:278:20:278:23 | data | test3.cpp:278:20:278:23 | data | test3.cpp:313:11:313:18 | ref arg password |
-| test3.cpp:314:11:314:18 | password | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data | test3.cpp:314:11:314:18 | ref arg password |
-| test3.cpp:316:11:316:18 | password | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data | test3.cpp:316:11:316:18 | ref arg password |
-| test3.cpp:317:11:317:18 | password | test3.cpp:288:20:288:23 | data | test3.cpp:288:20:288:23 | data | test3.cpp:317:11:317:18 | ref arg password |
+| test3.cpp:313:11:313:19 | password1 | test3.cpp:278:20:278:23 | data | test3.cpp:278:20:278:23 | data | test3.cpp:313:11:313:19 | ref arg password1 |
+| test3.cpp:316:11:316:19 | password1 | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data | test3.cpp:316:11:316:19 | ref arg password1 |
 | test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data | test3.cpp:293:20:293:23 | data | test3.cpp:324:11:324:14 | ref arg data |
 #select
 | test3.cpp:22:3:22:6 | call to send | test3.cpp:17:28:17:36 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:17:28:17:36 | password1 | password1 |
@@ -238,4 +223,6 @@ subpaths
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
 | test3.cpp:242:2:242:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
 | test3.cpp:272:3:272:6 | call to send | test3.cpp:268:19:268:26 | password | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:268:19:268:26 | password | password |
+| test3.cpp:295:2:295:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
+| test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -13,6 +13,7 @@ edges
 nodes
 | test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
 | test3.cpp:26:15:26:23 | password2 | semmle.label | password2 |
+| test3.cpp:38:23:38:31 | password2 | semmle.label | password2 |
 | test3.cpp:47:15:47:22 | password | semmle.label | password |
 | test3.cpp:55:15:55:22 | password | semmle.label | password |
 | test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
@@ -33,11 +34,22 @@ nodes
 | test3.cpp:146:15:146:18 | data | semmle.label | data |
 | test3.cpp:157:19:157:26 | password | semmle.label | password |
 | test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
+| test3.cpp:173:15:173:22 | password | semmle.label | password |
+| test3.cpp:181:15:181:22 | password | semmle.label | password |
+| test3.cpp:191:15:191:22 | password | semmle.label | password |
+| test3.cpp:201:15:201:22 | password | semmle.label | password |
+| test3.cpp:210:15:210:22 | password | semmle.label | password |
+| test3.cpp:219:15:219:26 | password_ptr | semmle.label | password_ptr |
+| test3.cpp:227:22:227:29 | password | semmle.label | password |
+| test3.cpp:228:26:228:33 | password | semmle.label | password |
+| test3.cpp:241:8:241:15 | password | semmle.label | password |
+| test3.cpp:242:8:242:15 | password | semmle.label | password |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer | test3.cpp:138:21:138:22 | call to id |
 #select
 | test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:22:15:22:23 | password1 | password1 |
 | test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:26:15:26:23 | password2 | password2 |
+| test3.cpp:38:3:38:6 | call to send | test3.cpp:38:23:38:31 | password2 | test3.cpp:38:23:38:31 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:38:23:38:31 | password2 | password2 |
 | test3.cpp:47:3:47:6 | call to recv | test3.cpp:47:15:47:22 | password | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:47:15:47:22 | password | password |
 | test3.cpp:55:3:55:6 | call to recv | test3.cpp:55:15:55:22 | password | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:55:15:55:22 | password | password |
 | test3.cpp:76:3:76:6 | call to send | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:74:21:74:29 | password1 | password1 |
@@ -47,3 +59,13 @@ subpaths
 | test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:138:24:138:32 | password1 | password1 |
 | test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:126:9:126:23 | global_password | global_password |
 | test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:157:19:157:26 | password | password |
+| test3.cpp:173:3:173:6 | call to recv | test3.cpp:173:15:173:22 | password | test3.cpp:173:15:173:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:173:15:173:22 | password | password |
+| test3.cpp:181:3:181:6 | call to recv | test3.cpp:181:15:181:22 | password | test3.cpp:181:15:181:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:181:15:181:22 | password | password |
+| test3.cpp:191:3:191:6 | call to recv | test3.cpp:191:15:191:22 | password | test3.cpp:191:15:191:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:191:15:191:22 | password | password |
+| test3.cpp:201:3:201:6 | call to send | test3.cpp:201:15:201:22 | password | test3.cpp:201:15:201:22 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:201:15:201:22 | password | password |
+| test3.cpp:210:3:210:6 | call to send | test3.cpp:210:15:210:22 | password | test3.cpp:210:15:210:22 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:210:15:210:22 | password | password |
+| test3.cpp:219:3:219:6 | call to send | test3.cpp:219:15:219:26 | password_ptr | test3.cpp:219:15:219:26 | password_ptr | This operation transmits 'password_ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:219:15:219:26 | password_ptr | password_ptr |
+| test3.cpp:227:2:227:5 | call to send | test3.cpp:227:22:227:29 | password | test3.cpp:227:22:227:29 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:227:22:227:29 | password | password |
+| test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:228:26:228:33 | password | password |
+| test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
+| test3.cpp:242:2:242:6 | call to fgets | test3.cpp:242:8:242:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:242:8:242:15 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -65,6 +65,88 @@ edges
 | test3.cpp:217:30:217:37 | password | test3.cpp:219:15:219:26 | password_ptr |
 | test3.cpp:217:30:217:37 | password | test3.cpp:219:36:219:47 | password_ptr |
 | test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password |
+| test3.cpp:254:15:254:23 | password1 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
+| test3.cpp:254:15:254:23 | password1 | test3.cpp:256:21:256:29 | password1 |
+| test3.cpp:254:15:254:23 | password1 | test3.cpp:256:21:256:29 | password1 |
+| test3.cpp:256:21:256:29 | password1 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
+| test3.cpp:256:32:256:40 | password2 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
+| test3.cpp:262:21:262:29 | password1 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer |
+| test3.cpp:262:32:262:40 | password2 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer |
+| test3.cpp:262:32:262:40 | password2 | test3.cpp:264:15:264:23 | password2 |
+| test3.cpp:262:32:262:40 | password2 | test3.cpp:264:33:264:41 | password2 |
+| test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data |
+| test3.cpp:278:20:278:23 | data | test3.cpp:278:20:278:23 | data |
+| test3.cpp:278:20:278:23 | data | test3.cpp:280:14:280:17 | data |
+| test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data |
+| test3.cpp:283:20:283:23 | data | test3.cpp:285:14:285:17 | data |
+| test3.cpp:288:20:288:23 | data | test3.cpp:288:20:288:23 | data |
+| test3.cpp:288:20:288:23 | data | test3.cpp:290:14:290:17 | data |
+| test3.cpp:293:20:293:23 | data | test3.cpp:293:20:293:23 | data |
+| test3.cpp:293:20:293:23 | data | test3.cpp:295:14:295:17 | data |
+| test3.cpp:298:20:298:23 | data | test3.cpp:300:14:300:17 | data |
+| test3.cpp:312:19:312:26 | password | test3.cpp:312:3:312:17 | call to encrypt_inplace |
+| test3.cpp:312:19:312:26 | password | test3.cpp:313:11:313:18 | password |
+| test3.cpp:312:19:312:26 | password | test3.cpp:313:11:313:18 | password |
+| test3.cpp:312:19:312:26 | password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:312:19:312:26 | password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:312:19:312:26 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:312:19:312:26 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:312:19:312:26 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:312:19:312:26 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:313:11:313:18 | password | test3.cpp:278:20:278:23 | data |
+| test3.cpp:313:11:313:18 | password | test3.cpp:313:11:313:18 | ref arg password |
+| test3.cpp:313:11:313:18 | password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:313:11:313:18 | password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:313:11:313:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:313:11:313:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:313:11:313:18 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:313:11:313:18 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:314:11:314:18 | password | test3.cpp:283:20:283:23 | data |
+| test3.cpp:314:11:314:18 | password | test3.cpp:314:11:314:18 | ref arg password |
+| test3.cpp:314:11:314:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:314:11:314:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:314:11:314:18 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:314:11:314:18 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:316:11:316:18 | password | test3.cpp:283:20:283:23 | data |
+| test3.cpp:316:11:316:18 | password | test3.cpp:316:11:316:18 | ref arg password |
+| test3.cpp:316:11:316:18 | password | test3.cpp:317:11:317:18 | password |
+| test3.cpp:316:11:316:18 | password | test3.cpp:317:11:317:18 | password |
+| test3.cpp:316:11:316:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:316:11:316:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:316:11:316:18 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:316:11:316:18 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:317:11:317:18 | password |
+| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:317:11:317:18 | password |
+| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:317:11:317:18 | password | test3.cpp:288:20:288:23 | data |
+| test3.cpp:317:11:317:18 | password | test3.cpp:317:11:317:18 | ref arg password |
+| test3.cpp:317:11:317:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:317:11:317:18 | password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:317:11:317:18 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:317:11:317:18 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:322:16:322:23 | password |
+| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:322:16:322:23 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:322:16:322:23 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data |
+| test3.cpp:324:11:324:14 | data | test3.cpp:324:11:324:14 | ref arg data |
+| test3.cpp:324:11:324:14 | ref arg data | test3.cpp:325:11:325:14 | data |
+| test3.cpp:325:11:325:14 | data | test3.cpp:298:20:298:23 | data |
 | test.cpp:48:29:48:39 | thePassword | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:58:11:58:16 | passwd | test.cpp:61:11:61:16 | passwd |
 | test.cpp:76:29:76:39 | thePassword | test.cpp:76:21:76:27 | call to encrypt |
@@ -178,6 +260,57 @@ nodes
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
 | test3.cpp:242:8:242:15 | password | semmle.label | password |
+| test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
+| test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
+| test3.cpp:256:3:256:19 | call to decrypt_to_buffer | semmle.label | call to decrypt_to_buffer |
+| test3.cpp:256:21:256:29 | password1 | semmle.label | password1 |
+| test3.cpp:256:21:256:29 | password1 | semmle.label | password1 |
+| test3.cpp:256:32:256:40 | password2 | semmle.label | password2 |
+| test3.cpp:256:32:256:40 | password2 | semmle.label | password2 |
+| test3.cpp:262:3:262:19 | call to encrypt_to_buffer | semmle.label | call to encrypt_to_buffer |
+| test3.cpp:262:21:262:29 | password1 | semmle.label | password1 |
+| test3.cpp:262:21:262:29 | password1 | semmle.label | password1 |
+| test3.cpp:262:32:262:40 | password2 | semmle.label | password2 |
+| test3.cpp:262:32:262:40 | password2 | semmle.label | password2 |
+| test3.cpp:264:15:264:23 | password2 | semmle.label | password2 |
+| test3.cpp:264:33:264:41 | password2 | semmle.label | password2 |
+| test3.cpp:270:16:270:23 | password | semmle.label | password |
+| test3.cpp:270:16:270:23 | password | semmle.label | password |
+| test3.cpp:272:15:272:18 | data | semmle.label | data |
+| test3.cpp:278:20:278:23 | data | semmle.label | data |
+| test3.cpp:278:20:278:23 | data | semmle.label | data |
+| test3.cpp:280:14:280:17 | data | semmle.label | data |
+| test3.cpp:283:20:283:23 | data | semmle.label | data |
+| test3.cpp:283:20:283:23 | data | semmle.label | data |
+| test3.cpp:285:14:285:17 | data | semmle.label | data |
+| test3.cpp:288:20:288:23 | data | semmle.label | data |
+| test3.cpp:288:20:288:23 | data | semmle.label | data |
+| test3.cpp:290:14:290:17 | data | semmle.label | data |
+| test3.cpp:293:20:293:23 | data | semmle.label | data |
+| test3.cpp:293:20:293:23 | data | semmle.label | data |
+| test3.cpp:295:14:295:17 | data | semmle.label | data |
+| test3.cpp:298:20:298:23 | data | semmle.label | data |
+| test3.cpp:300:14:300:17 | data | semmle.label | data |
+| test3.cpp:312:3:312:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
+| test3.cpp:312:19:312:26 | password | semmle.label | password |
+| test3.cpp:312:19:312:26 | password | semmle.label | password |
+| test3.cpp:313:11:313:18 | password | semmle.label | password |
+| test3.cpp:313:11:313:18 | password | semmle.label | password |
+| test3.cpp:313:11:313:18 | ref arg password | semmle.label | ref arg password |
+| test3.cpp:314:11:314:18 | password | semmle.label | password |
+| test3.cpp:314:11:314:18 | password | semmle.label | password |
+| test3.cpp:314:11:314:18 | ref arg password | semmle.label | ref arg password |
+| test3.cpp:316:11:316:18 | password | semmle.label | password |
+| test3.cpp:316:11:316:18 | password | semmle.label | password |
+| test3.cpp:316:11:316:18 | ref arg password | semmle.label | ref arg password |
+| test3.cpp:317:11:317:18 | password | semmle.label | password |
+| test3.cpp:317:11:317:18 | password | semmle.label | password |
+| test3.cpp:317:11:317:18 | ref arg password | semmle.label | ref arg password |
+| test3.cpp:322:16:322:23 | password | semmle.label | password |
+| test3.cpp:322:16:322:23 | password | semmle.label | password |
+| test3.cpp:324:11:324:14 | data | semmle.label | data |
+| test3.cpp:324:11:324:14 | ref arg data | semmle.label | ref arg data |
+| test3.cpp:325:11:325:14 | data | semmle.label | data |
 | test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -193,6 +326,11 @@ nodes
 | test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer | test3.cpp:138:21:138:22 | call to id |
+| test3.cpp:313:11:313:18 | password | test3.cpp:278:20:278:23 | data | test3.cpp:278:20:278:23 | data | test3.cpp:313:11:313:18 | ref arg password |
+| test3.cpp:314:11:314:18 | password | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data | test3.cpp:314:11:314:18 | ref arg password |
+| test3.cpp:316:11:316:18 | password | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data | test3.cpp:316:11:316:18 | ref arg password |
+| test3.cpp:317:11:317:18 | password | test3.cpp:288:20:288:23 | data | test3.cpp:288:20:288:23 | data | test3.cpp:317:11:317:18 | ref arg password |
+| test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data | test3.cpp:293:20:293:23 | data | test3.cpp:324:11:324:14 | ref arg data |
 #select
 | test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:22:15:22:23 | password1 | password1 |
 | test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:26:15:26:23 | password2 | password2 |
@@ -209,3 +347,8 @@ subpaths
 | test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:228:26:228:33 | password | password |
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
 | test3.cpp:242:2:242:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
+| test3.cpp:272:3:272:6 | call to send | test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:270:16:270:23 | password | password |
+| test3.cpp:285:2:285:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:285:14:285:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
+| test3.cpp:290:2:290:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
+| test3.cpp:295:2:295:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
+| test3.cpp:300:2:300:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -1,49 +1,49 @@
 edges
-| test3.cpp:68:21:68:29 | password1 | test3.cpp:70:15:70:17 | ptr |
-| test3.cpp:75:15:75:22 | password | test3.cpp:77:15:77:17 | ptr |
-| test3.cpp:106:20:106:25 | buffer | test3.cpp:108:14:108:19 | buffer |
-| test3.cpp:111:28:111:33 | buffer | test3.cpp:113:9:113:14 | buffer |
-| test3.cpp:120:9:120:23 | global_password | test3.cpp:138:16:138:29 | call to get_global_str |
-| test3.cpp:128:11:128:18 | password | test3.cpp:106:20:106:25 | buffer |
-| test3.cpp:132:21:132:22 | call to id | test3.cpp:134:15:134:17 | ptr |
-| test3.cpp:132:24:132:32 | password1 | test3.cpp:111:28:111:33 | buffer |
-| test3.cpp:132:24:132:32 | password1 | test3.cpp:132:21:132:22 | call to id |
-| test3.cpp:138:16:138:29 | call to get_global_str | test3.cpp:140:15:140:18 | data |
-| test3.cpp:151:19:151:26 | password | test3.cpp:153:15:153:20 | buffer |
+| test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
+| test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
+| test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
+| test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer |
+| test3.cpp:126:9:126:23 | global_password | test3.cpp:144:16:144:29 | call to get_global_str |
+| test3.cpp:134:11:134:18 | password | test3.cpp:112:20:112:25 | buffer |
+| test3.cpp:138:21:138:22 | call to id | test3.cpp:140:15:140:17 | ptr |
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer |
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:138:21:138:22 | call to id |
+| test3.cpp:144:16:144:29 | call to get_global_str | test3.cpp:146:15:146:18 | data |
+| test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer |
 nodes
-| test3.cpp:20:15:20:23 | password1 | semmle.label | password1 |
-| test3.cpp:24:15:24:23 | password2 | semmle.label | password2 |
-| test3.cpp:41:15:41:22 | password | semmle.label | password |
-| test3.cpp:49:15:49:22 | password | semmle.label | password |
-| test3.cpp:68:21:68:29 | password1 | semmle.label | password1 |
-| test3.cpp:70:15:70:17 | ptr | semmle.label | ptr |
-| test3.cpp:75:15:75:22 | password | semmle.label | password |
-| test3.cpp:77:15:77:17 | ptr | semmle.label | ptr |
-| test3.cpp:95:12:95:19 | password | semmle.label | password |
-| test3.cpp:106:20:106:25 | buffer | semmle.label | buffer |
-| test3.cpp:108:14:108:19 | buffer | semmle.label | buffer |
-| test3.cpp:111:28:111:33 | buffer | semmle.label | buffer |
-| test3.cpp:113:9:113:14 | buffer | semmle.label | buffer |
-| test3.cpp:120:9:120:23 | global_password | semmle.label | global_password |
-| test3.cpp:128:11:128:18 | password | semmle.label | password |
-| test3.cpp:132:21:132:22 | call to id | semmle.label | call to id |
-| test3.cpp:132:24:132:32 | password1 | semmle.label | password1 |
-| test3.cpp:134:15:134:17 | ptr | semmle.label | ptr |
-| test3.cpp:138:16:138:29 | call to get_global_str | semmle.label | call to get_global_str |
-| test3.cpp:140:15:140:18 | data | semmle.label | data |
-| test3.cpp:151:19:151:26 | password | semmle.label | password |
-| test3.cpp:153:15:153:20 | buffer | semmle.label | buffer |
+| test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
+| test3.cpp:26:15:26:23 | password2 | semmle.label | password2 |
+| test3.cpp:47:15:47:22 | password | semmle.label | password |
+| test3.cpp:55:15:55:22 | password | semmle.label | password |
+| test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
+| test3.cpp:76:15:76:17 | ptr | semmle.label | ptr |
+| test3.cpp:81:15:81:22 | password | semmle.label | password |
+| test3.cpp:83:15:83:17 | ptr | semmle.label | ptr |
+| test3.cpp:101:12:101:19 | password | semmle.label | password |
+| test3.cpp:112:20:112:25 | buffer | semmle.label | buffer |
+| test3.cpp:114:14:114:19 | buffer | semmle.label | buffer |
+| test3.cpp:117:28:117:33 | buffer | semmle.label | buffer |
+| test3.cpp:119:9:119:14 | buffer | semmle.label | buffer |
+| test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
+| test3.cpp:134:11:134:18 | password | semmle.label | password |
+| test3.cpp:138:21:138:22 | call to id | semmle.label | call to id |
+| test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
+| test3.cpp:140:15:140:17 | ptr | semmle.label | ptr |
+| test3.cpp:144:16:144:29 | call to get_global_str | semmle.label | call to get_global_str |
+| test3.cpp:146:15:146:18 | data | semmle.label | data |
+| test3.cpp:157:19:157:26 | password | semmle.label | password |
+| test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
 subpaths
-| test3.cpp:132:24:132:32 | password1 | test3.cpp:111:28:111:33 | buffer | test3.cpp:113:9:113:14 | buffer | test3.cpp:132:21:132:22 | call to id |
+| test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer | test3.cpp:138:21:138:22 | call to id |
 #select
-| test3.cpp:20:3:20:6 | call to send | test3.cpp:20:15:20:23 | password1 | test3.cpp:20:15:20:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:20:15:20:23 | password1 | password1 |
-| test3.cpp:24:3:24:6 | call to send | test3.cpp:24:15:24:23 | password2 | test3.cpp:24:15:24:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:24:15:24:23 | password2 | password2 |
-| test3.cpp:41:3:41:6 | call to recv | test3.cpp:41:15:41:22 | password | test3.cpp:41:15:41:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:41:15:41:22 | password | password |
-| test3.cpp:49:3:49:6 | call to recv | test3.cpp:49:15:49:22 | password | test3.cpp:49:15:49:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:49:15:49:22 | password | password |
-| test3.cpp:70:3:70:6 | call to send | test3.cpp:68:21:68:29 | password1 | test3.cpp:70:15:70:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:68:21:68:29 | password1 | password1 |
-| test3.cpp:77:3:77:6 | call to recv | test3.cpp:75:15:75:22 | password | test3.cpp:77:15:77:17 | ptr | This operation receives into 'ptr', which may put unencrypted sensitive data into $@ | test3.cpp:75:15:75:22 | password | password |
-| test3.cpp:95:3:95:6 | call to read | test3.cpp:95:12:95:19 | password | test3.cpp:95:12:95:19 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:95:12:95:19 | password | password |
-| test3.cpp:108:2:108:5 | call to recv | test3.cpp:128:11:128:18 | password | test3.cpp:108:14:108:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@ | test3.cpp:128:11:128:18 | password | password |
-| test3.cpp:134:3:134:6 | call to send | test3.cpp:132:24:132:32 | password1 | test3.cpp:134:15:134:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:132:24:132:32 | password1 | password1 |
-| test3.cpp:140:3:140:6 | call to send | test3.cpp:120:9:120:23 | global_password | test3.cpp:140:15:140:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:120:9:120:23 | global_password | global_password |
-| test3.cpp:153:3:153:6 | call to send | test3.cpp:151:19:151:26 | password | test3.cpp:153:15:153:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:151:19:151:26 | password | password |
+| test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:22:15:22:23 | password1 | password1 |
+| test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:26:15:26:23 | password2 | password2 |
+| test3.cpp:47:3:47:6 | call to recv | test3.cpp:47:15:47:22 | password | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:47:15:47:22 | password | password |
+| test3.cpp:55:3:55:6 | call to recv | test3.cpp:55:15:55:22 | password | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:55:15:55:22 | password | password |
+| test3.cpp:76:3:76:6 | call to send | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:74:21:74:29 | password1 | password1 |
+| test3.cpp:83:3:83:6 | call to recv | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr | This operation receives into 'ptr', which may put unencrypted sensitive data into $@ | test3.cpp:81:15:81:22 | password | password |
+| test3.cpp:101:3:101:6 | call to read | test3.cpp:101:12:101:19 | password | test3.cpp:101:12:101:19 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:101:12:101:19 | password | password |
+| test3.cpp:114:2:114:5 | call to recv | test3.cpp:134:11:134:18 | password | test3.cpp:114:14:114:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@ | test3.cpp:134:11:134:18 | password | password |
+| test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:138:24:138:32 | password1 | password1 |
+| test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:126:9:126:23 | global_password | global_password |
+| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:157:19:157:26 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -1,4 +1,10 @@
 edges
+| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:63:22:63:22 | s [password] |
+| test2.cpp:43:36:43:43 | password | test2.cpp:43:36:43:43 | ref arg password |
+| test2.cpp:43:36:43:43 | ref arg password | test2.cpp:43:34:43:34 | s [post update] [password] |
+| test2.cpp:63:22:63:22 | s [password] | test2.cpp:63:24:63:31 | password |
+| test2.cpp:63:22:63:22 | s [password] | test2.cpp:63:24:63:31 | password |
+| test2.cpp:63:24:63:31 | password | test2.cpp:63:16:63:20 | call to crypt |
 | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
 | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
 | test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
@@ -10,7 +16,37 @@ edges
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:138:21:138:22 | call to id |
 | test3.cpp:144:16:144:29 | call to get_global_str | test3.cpp:146:15:146:18 | data |
 | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer |
+| test3.cpp:173:15:173:22 | password | test3.cpp:175:3:175:17 | call to decrypt_inplace |
+| test3.cpp:173:15:173:22 | password | test3.cpp:175:19:175:26 | password |
+| test3.cpp:173:15:173:22 | password | test3.cpp:175:19:175:26 | password |
+| test3.cpp:175:19:175:26 | password | test3.cpp:175:3:175:17 | call to decrypt_inplace |
+| test3.cpp:181:15:181:22 | password | test3.cpp:184:3:184:17 | call to decrypt_inplace |
+| test3.cpp:181:15:181:22 | password | test3.cpp:184:19:184:26 | password |
+| test3.cpp:181:15:181:22 | password | test3.cpp:184:19:184:26 | password |
+| test3.cpp:184:19:184:26 | password | test3.cpp:184:3:184:17 | call to decrypt_inplace |
+| test3.cpp:191:15:191:22 | password | test3.cpp:193:18:193:28 | call to rtn_decrypt |
+| test3.cpp:191:15:191:22 | password | test3.cpp:193:30:193:37 | password |
+| test3.cpp:191:15:191:22 | password | test3.cpp:193:30:193:37 | password |
+| test3.cpp:193:30:193:37 | password | test3.cpp:193:18:193:28 | call to rtn_decrypt |
+| test3.cpp:199:19:199:26 | password | test3.cpp:199:3:199:17 | call to encrypt_inplace |
+| test3.cpp:199:19:199:26 | password | test3.cpp:201:15:201:22 | password |
+| test3.cpp:207:19:207:26 | password | test3.cpp:207:3:207:17 | call to encrypt_inplace |
+| test3.cpp:207:19:207:26 | password | test3.cpp:210:15:210:22 | password |
+| test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:15:219:26 | password_ptr |
+| test3.cpp:217:30:217:37 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
+| test3.cpp:217:30:217:37 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
+| test3.cpp:217:30:217:37 | password | test3.cpp:219:15:219:26 | password_ptr |
+| test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password |
+| test.cpp:48:29:48:39 | thePassword | test.cpp:48:21:48:27 | call to encrypt |
+| test.cpp:76:29:76:39 | thePassword | test.cpp:76:21:76:27 | call to encrypt |
 nodes
+| test2.cpp:43:34:43:34 | s [post update] [password] | semmle.label | s [post update] [password] |
+| test2.cpp:43:36:43:43 | password | semmle.label | password |
+| test2.cpp:43:36:43:43 | ref arg password | semmle.label | ref arg password |
+| test2.cpp:63:16:63:20 | call to crypt | semmle.label | call to crypt |
+| test2.cpp:63:22:63:22 | s [password] | semmle.label | s [password] |
+| test2.cpp:63:24:63:31 | password | semmle.label | password |
+| test2.cpp:63:24:63:31 | password | semmle.label | password |
 | test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
 | test3.cpp:26:15:26:23 | password2 | semmle.label | password2 |
 | test3.cpp:38:23:38:31 | password2 | semmle.label | password2 |
@@ -35,15 +71,44 @@ nodes
 | test3.cpp:157:19:157:26 | password | semmle.label | password |
 | test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
 | test3.cpp:173:15:173:22 | password | semmle.label | password |
+| test3.cpp:173:15:173:22 | password | semmle.label | password |
+| test3.cpp:175:3:175:17 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
+| test3.cpp:175:19:175:26 | password | semmle.label | password |
+| test3.cpp:175:19:175:26 | password | semmle.label | password |
 | test3.cpp:181:15:181:22 | password | semmle.label | password |
+| test3.cpp:181:15:181:22 | password | semmle.label | password |
+| test3.cpp:184:3:184:17 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
+| test3.cpp:184:19:184:26 | password | semmle.label | password |
+| test3.cpp:184:19:184:26 | password | semmle.label | password |
 | test3.cpp:191:15:191:22 | password | semmle.label | password |
+| test3.cpp:191:15:191:22 | password | semmle.label | password |
+| test3.cpp:193:18:193:28 | call to rtn_decrypt | semmle.label | call to rtn_decrypt |
+| test3.cpp:193:30:193:37 | password | semmle.label | password |
+| test3.cpp:193:30:193:37 | password | semmle.label | password |
+| test3.cpp:199:3:199:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
+| test3.cpp:199:19:199:26 | password | semmle.label | password |
+| test3.cpp:199:19:199:26 | password | semmle.label | password |
 | test3.cpp:201:15:201:22 | password | semmle.label | password |
+| test3.cpp:207:3:207:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
+| test3.cpp:207:19:207:26 | password | semmle.label | password |
+| test3.cpp:207:19:207:26 | password | semmle.label | password |
 | test3.cpp:210:15:210:22 | password | semmle.label | password |
+| test3.cpp:217:18:217:28 | call to rtn_encrypt | semmle.label | call to rtn_encrypt |
+| test3.cpp:217:18:217:28 | call to rtn_encrypt | semmle.label | call to rtn_encrypt |
+| test3.cpp:217:30:217:37 | password | semmle.label | password |
+| test3.cpp:217:30:217:37 | password | semmle.label | password |
 | test3.cpp:219:15:219:26 | password_ptr | semmle.label | password_ptr |
 | test3.cpp:227:22:227:29 | password | semmle.label | password |
 | test3.cpp:228:26:228:33 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
+| test3.cpp:241:8:241:15 | password | semmle.label | password |
 | test3.cpp:242:8:242:15 | password | semmle.label | password |
+| test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
+| test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
+| test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
+| test.cpp:76:21:76:27 | call to encrypt | semmle.label | call to encrypt |
+| test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
+| test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer | test3.cpp:138:21:138:22 | call to id |
 #select
@@ -59,13 +124,8 @@ subpaths
 | test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:138:24:138:32 | password1 | password1 |
 | test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:126:9:126:23 | global_password | global_password |
 | test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:157:19:157:26 | password | password |
-| test3.cpp:173:3:173:6 | call to recv | test3.cpp:173:15:173:22 | password | test3.cpp:173:15:173:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:173:15:173:22 | password | password |
-| test3.cpp:181:3:181:6 | call to recv | test3.cpp:181:15:181:22 | password | test3.cpp:181:15:181:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:181:15:181:22 | password | password |
-| test3.cpp:191:3:191:6 | call to recv | test3.cpp:191:15:191:22 | password | test3.cpp:191:15:191:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:191:15:191:22 | password | password |
-| test3.cpp:201:3:201:6 | call to send | test3.cpp:201:15:201:22 | password | test3.cpp:201:15:201:22 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:201:15:201:22 | password | password |
-| test3.cpp:210:3:210:6 | call to send | test3.cpp:210:15:210:22 | password | test3.cpp:210:15:210:22 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:210:15:210:22 | password | password |
-| test3.cpp:219:3:219:6 | call to send | test3.cpp:219:15:219:26 | password_ptr | test3.cpp:219:15:219:26 | password_ptr | This operation transmits 'password_ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:219:15:219:26 | password_ptr | password_ptr |
 | test3.cpp:227:2:227:5 | call to send | test3.cpp:227:22:227:29 | password | test3.cpp:227:22:227:29 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:227:22:227:29 | password | password |
 | test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:228:26:228:33 | password | password |
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
+| test3.cpp:242:2:242:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
 | test3.cpp:242:2:242:6 | call to fgets | test3.cpp:242:8:242:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:242:8:242:15 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -1,80 +1,57 @@
 edges
-| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:62:16:62:16 | s [password] |
-| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:63:22:63:22 | s [password] |
-| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:72:15:72:15 | s [password] |
-| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:79:34:79:34 | s [password] |
-| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:91:43:91:43 | s [password] |
-| test2.cpp:43:36:43:43 | password | test2.cpp:43:36:43:43 | ref arg password |
-| test2.cpp:43:36:43:43 | ref arg password | test2.cpp:43:34:43:34 | s [post update] [password] |
-| test2.cpp:54:39:54:39 | s [post update] [widepassword] | test2.cpp:55:38:55:38 | s [widepassword] |
-| test2.cpp:54:41:54:52 | ref arg widepassword | test2.cpp:54:39:54:39 | s [post update] [widepassword] |
-| test2.cpp:54:41:54:52 | widepassword | test2.cpp:54:41:54:52 | ref arg widepassword |
-| test2.cpp:55:38:55:38 | s [widepassword] | test2.cpp:55:40:55:51 | widepassword |
-| test2.cpp:62:16:62:16 | s [password] | test2.cpp:62:18:62:25 | password |
-| test2.cpp:63:22:63:22 | s [password] | test2.cpp:63:24:63:31 | password |
-| test2.cpp:63:22:63:22 | s [password] | test2.cpp:63:24:63:31 | password |
-| test2.cpp:63:22:63:22 | s [post update] [password] | test2.cpp:72:15:72:15 | s [password] |
-| test2.cpp:63:22:63:22 | s [post update] [password] | test2.cpp:79:34:79:34 | s [password] |
-| test2.cpp:63:22:63:22 | s [post update] [password] | test2.cpp:91:43:91:43 | s [password] |
-| test2.cpp:63:24:63:31 | password | test2.cpp:63:16:63:20 | call to crypt |
-| test2.cpp:63:24:63:31 | password | test2.cpp:63:24:63:31 | ref arg password |
-| test2.cpp:63:24:63:31 | ref arg password | test2.cpp:63:22:63:22 | s [post update] [password] |
-| test2.cpp:72:15:72:15 | s [password] | test2.cpp:72:17:72:24 | password |
-| test2.cpp:79:34:79:34 | s [password] | test2.cpp:79:36:79:43 | password |
-| test2.cpp:79:34:79:34 | s [password] | test2.cpp:79:36:79:43 | password |
-| test2.cpp:79:34:79:34 | s [post update] [password] | test2.cpp:91:43:91:43 | s [password] |
-| test2.cpp:79:36:79:43 | password | test2.cpp:79:36:79:43 | ref arg password |
-| test2.cpp:79:36:79:43 | ref arg password | test2.cpp:79:34:79:34 | s [post update] [password] |
-| test2.cpp:91:43:91:43 | s [password] | test2.cpp:91:45:91:52 | password |
-| test3.cpp:47:15:47:22 | password | test3.cpp:49:28:49:35 | password |
-| test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
-| test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
+| test3.cpp:17:28:17:36 | password1 | test3.cpp:22:15:22:23 | password1 |
+| test3.cpp:17:51:17:59 | password2 | test3.cpp:26:15:26:23 | password2 |
+| test3.cpp:45:8:45:15 | password | test3.cpp:47:15:47:22 | password |
+| test3.cpp:53:8:53:15 | password | test3.cpp:55:15:55:22 | password |
+| test3.cpp:71:32:71:40 | password1 | test3.cpp:76:15:76:17 | ptr |
+| test3.cpp:80:8:80:15 | password | test3.cpp:83:15:83:17 | ptr |
+| test3.cpp:98:8:98:15 | password | test3.cpp:101:12:101:19 | password |
 | test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer |
 | test3.cpp:126:9:126:23 | global_password | test3.cpp:144:16:144:29 | call to get_global_str |
+| test3.cpp:129:39:129:47 | password1 | test3.cpp:138:24:138:32 | password1 |
+| test3.cpp:132:8:132:15 | password | test3.cpp:134:11:134:18 | password |
 | test3.cpp:134:11:134:18 | password | test3.cpp:112:20:112:25 | buffer |
 | test3.cpp:138:21:138:22 | call to id | test3.cpp:140:15:140:17 | ptr |
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer |
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:138:21:138:22 | call to id |
 | test3.cpp:144:16:144:29 | call to get_global_str | test3.cpp:146:15:146:18 | data |
-| test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer |
-| test3.cpp:173:15:173:22 | password | test3.cpp:175:3:175:17 | call to decrypt_inplace |
-| test3.cpp:173:15:173:22 | password | test3.cpp:175:19:175:26 | password |
-| test3.cpp:173:15:173:22 | password | test3.cpp:175:19:175:26 | password |
-| test3.cpp:175:19:175:26 | password | test3.cpp:175:3:175:17 | call to decrypt_inplace |
-| test3.cpp:181:15:181:22 | password | test3.cpp:182:3:182:10 | password |
-| test3.cpp:181:15:181:22 | password | test3.cpp:184:3:184:17 | call to decrypt_inplace |
-| test3.cpp:181:15:181:22 | password | test3.cpp:184:19:184:26 | password |
-| test3.cpp:181:15:181:22 | password | test3.cpp:184:19:184:26 | password |
-| test3.cpp:184:19:184:26 | password | test3.cpp:184:3:184:17 | call to decrypt_inplace |
-| test3.cpp:191:15:191:22 | password | test3.cpp:193:18:193:28 | call to rtn_decrypt |
-| test3.cpp:191:15:191:22 | password | test3.cpp:193:30:193:37 | password |
-| test3.cpp:191:15:191:22 | password | test3.cpp:193:30:193:37 | password |
-| test3.cpp:193:30:193:37 | password | test3.cpp:193:18:193:28 | call to rtn_decrypt |
-| test3.cpp:199:19:199:26 | password | test3.cpp:199:3:199:17 | call to encrypt_inplace |
-| test3.cpp:199:19:199:26 | password | test3.cpp:201:15:201:22 | password |
-| test3.cpp:199:19:199:26 | password | test3.cpp:201:32:201:39 | password |
-| test3.cpp:207:19:207:26 | password | test3.cpp:207:3:207:17 | call to encrypt_inplace |
-| test3.cpp:207:19:207:26 | password | test3.cpp:208:3:208:10 | password |
-| test3.cpp:207:19:207:26 | password | test3.cpp:210:15:210:22 | password |
-| test3.cpp:207:19:207:26 | password | test3.cpp:210:32:210:39 | password |
+| test3.cpp:152:29:152:36 | password | test3.cpp:159:15:159:20 | buffer |
+| test3.cpp:171:8:171:15 | password | test3.cpp:173:15:173:22 | password |
+| test3.cpp:171:8:171:15 | password | test3.cpp:175:3:175:17 | call to decrypt_inplace |
+| test3.cpp:171:8:171:15 | password | test3.cpp:175:19:175:26 | password |
+| test3.cpp:179:8:179:15 | password | test3.cpp:181:15:181:22 | password |
+| test3.cpp:179:8:179:15 | password | test3.cpp:184:3:184:17 | call to decrypt_inplace |
+| test3.cpp:179:8:179:15 | password | test3.cpp:184:19:184:26 | password |
+| test3.cpp:188:8:188:15 | password | test3.cpp:191:15:191:22 | password |
+| test3.cpp:188:8:188:15 | password | test3.cpp:193:18:193:28 | call to rtn_decrypt |
+| test3.cpp:188:8:188:15 | password | test3.cpp:193:30:193:37 | password |
+| test3.cpp:197:8:197:15 | password | test3.cpp:199:3:199:17 | call to encrypt_inplace |
+| test3.cpp:197:8:197:15 | password | test3.cpp:199:19:199:26 | password |
+| test3.cpp:197:8:197:15 | password | test3.cpp:201:15:201:22 | password |
+| test3.cpp:205:8:205:15 | password | test3.cpp:207:3:207:17 | call to encrypt_inplace |
+| test3.cpp:205:8:205:15 | password | test3.cpp:207:19:207:26 | password |
+| test3.cpp:205:8:205:15 | password | test3.cpp:210:15:210:22 | password |
+| test3.cpp:214:8:214:15 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
+| test3.cpp:214:8:214:15 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
+| test3.cpp:214:8:214:15 | password | test3.cpp:217:30:217:37 | password |
+| test3.cpp:214:8:214:15 | password | test3.cpp:219:15:219:26 | password_ptr |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:15:219:26 | password_ptr |
-| test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:36:219:47 | password_ptr |
-| test3.cpp:217:30:217:37 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
-| test3.cpp:217:30:217:37 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
-| test3.cpp:217:30:217:37 | password | test3.cpp:219:15:219:26 | password_ptr |
-| test3.cpp:217:30:217:37 | password | test3.cpp:219:36:219:47 | password_ptr |
-| test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password |
-| test3.cpp:254:15:254:23 | password1 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
-| test3.cpp:254:15:254:23 | password1 | test3.cpp:256:21:256:29 | password1 |
-| test3.cpp:254:15:254:23 | password1 | test3.cpp:256:21:256:29 | password1 |
-| test3.cpp:256:21:256:29 | password1 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
-| test3.cpp:256:32:256:40 | password2 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
-| test3.cpp:262:21:262:29 | password1 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer |
-| test3.cpp:262:32:262:40 | password2 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer |
-| test3.cpp:262:32:262:40 | password2 | test3.cpp:264:15:264:23 | password2 |
-| test3.cpp:262:32:262:40 | password2 | test3.cpp:264:33:264:41 | password2 |
-| test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data |
+| test3.cpp:225:34:225:41 | password | test3.cpp:227:22:227:29 | password |
+| test3.cpp:225:34:225:41 | password | test3.cpp:228:26:228:33 | password |
+| test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password |
+| test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password |
+| test3.cpp:252:8:252:16 | password1 | test3.cpp:254:15:254:23 | password1 |
+| test3.cpp:252:8:252:16 | password1 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
+| test3.cpp:252:8:252:16 | password1 | test3.cpp:256:21:256:29 | password1 |
+| test3.cpp:252:24:252:32 | password2 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
+| test3.cpp:252:24:252:32 | password2 | test3.cpp:256:32:256:40 | password2 |
+| test3.cpp:260:8:260:16 | password1 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer |
+| test3.cpp:260:8:260:16 | password1 | test3.cpp:262:21:262:29 | password1 |
+| test3.cpp:260:24:260:32 | password2 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer |
+| test3.cpp:260:24:260:32 | password2 | test3.cpp:262:32:262:40 | password2 |
+| test3.cpp:260:24:260:32 | password2 | test3.cpp:264:15:264:23 | password2 |
+| test3.cpp:268:19:268:26 | password | test3.cpp:272:15:272:18 | data |
 | test3.cpp:278:20:278:23 | data | test3.cpp:278:20:278:23 | data |
 | test3.cpp:278:20:278:23 | data | test3.cpp:280:14:280:17 | data |
 | test3.cpp:283:20:283:23 | data | test3.cpp:283:20:283:23 | data |
@@ -84,202 +61,118 @@ edges
 | test3.cpp:293:20:293:23 | data | test3.cpp:293:20:293:23 | data |
 | test3.cpp:293:20:293:23 | data | test3.cpp:295:14:295:17 | data |
 | test3.cpp:298:20:298:23 | data | test3.cpp:300:14:300:17 | data |
-| test3.cpp:312:19:312:26 | password | test3.cpp:312:3:312:17 | call to encrypt_inplace |
-| test3.cpp:312:19:312:26 | password | test3.cpp:313:11:313:18 | password |
-| test3.cpp:312:19:312:26 | password | test3.cpp:313:11:313:18 | password |
-| test3.cpp:312:19:312:26 | password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:312:19:312:26 | password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:312:19:312:26 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:312:19:312:26 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:312:19:312:26 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:312:19:312:26 | password | test3.cpp:325:11:325:14 | data |
+| test3.cpp:308:41:308:48 | password | test3.cpp:312:3:312:17 | call to encrypt_inplace |
+| test3.cpp:308:41:308:48 | password | test3.cpp:312:19:312:26 | password |
+| test3.cpp:308:41:308:48 | password | test3.cpp:313:11:313:18 | password |
+| test3.cpp:308:41:308:48 | password | test3.cpp:314:11:314:18 | password |
+| test3.cpp:308:41:308:48 | password | test3.cpp:316:11:316:18 | password |
+| test3.cpp:308:41:308:48 | password | test3.cpp:317:11:317:18 | password |
+| test3.cpp:308:41:308:48 | password | test3.cpp:324:11:324:14 | data |
+| test3.cpp:308:41:308:48 | password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:313:11:313:18 | password | test3.cpp:278:20:278:23 | data |
 | test3.cpp:313:11:313:18 | password | test3.cpp:313:11:313:18 | ref arg password |
-| test3.cpp:313:11:313:18 | password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:313:11:313:18 | password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:313:11:313:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:313:11:313:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:313:11:313:18 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:313:11:313:18 | password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:313:11:313:18 | ref arg password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:314:11:314:18 | password |
-| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:313:11:313:18 | ref arg password | test3.cpp:322:16:322:23 | password |
 | test3.cpp:313:11:313:18 | ref arg password | test3.cpp:324:11:324:14 | data |
 | test3.cpp:313:11:313:18 | ref arg password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:314:11:314:18 | password | test3.cpp:283:20:283:23 | data |
 | test3.cpp:314:11:314:18 | password | test3.cpp:314:11:314:18 | ref arg password |
-| test3.cpp:314:11:314:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:314:11:314:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:314:11:314:18 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:314:11:314:18 | password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:314:11:314:18 | ref arg password | test3.cpp:322:16:322:23 | password |
 | test3.cpp:314:11:314:18 | ref arg password | test3.cpp:324:11:324:14 | data |
 | test3.cpp:314:11:314:18 | ref arg password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:316:11:316:18 | password | test3.cpp:283:20:283:23 | data |
 | test3.cpp:316:11:316:18 | password | test3.cpp:316:11:316:18 | ref arg password |
-| test3.cpp:316:11:316:18 | password | test3.cpp:317:11:317:18 | password |
-| test3.cpp:316:11:316:18 | password | test3.cpp:317:11:317:18 | password |
-| test3.cpp:316:11:316:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:316:11:316:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:316:11:316:18 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:316:11:316:18 | password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:316:11:316:18 | ref arg password | test3.cpp:317:11:317:18 | password |
-| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:317:11:317:18 | password |
-| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:316:11:316:18 | ref arg password | test3.cpp:322:16:322:23 | password |
 | test3.cpp:316:11:316:18 | ref arg password | test3.cpp:324:11:324:14 | data |
 | test3.cpp:316:11:316:18 | ref arg password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:317:11:317:18 | password | test3.cpp:288:20:288:23 | data |
 | test3.cpp:317:11:317:18 | password | test3.cpp:317:11:317:18 | ref arg password |
-| test3.cpp:317:11:317:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:317:11:317:18 | password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:317:11:317:18 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:317:11:317:18 | password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:322:16:322:23 | password |
-| test3.cpp:317:11:317:18 | ref arg password | test3.cpp:322:16:322:23 | password |
 | test3.cpp:317:11:317:18 | ref arg password | test3.cpp:324:11:324:14 | data |
 | test3.cpp:317:11:317:18 | ref arg password | test3.cpp:325:11:325:14 | data |
-| test3.cpp:322:16:322:23 | password | test3.cpp:324:11:324:14 | data |
-| test3.cpp:322:16:322:23 | password | test3.cpp:325:11:325:14 | data |
 | test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data |
 | test3.cpp:324:11:324:14 | data | test3.cpp:324:11:324:14 | ref arg data |
 | test3.cpp:324:11:324:14 | ref arg data | test3.cpp:325:11:325:14 | data |
 | test3.cpp:325:11:325:14 | data | test3.cpp:298:20:298:23 | data |
-| test3.cpp:352:16:352:23 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
-| test3.cpp:352:16:352:23 | password | test3.cpp:353:20:353:27 | password |
-| test3.cpp:352:16:352:23 | password | test3.cpp:353:20:353:27 | password |
-| test3.cpp:353:20:353:27 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
-| test.cpp:48:29:48:39 | thePassword | test.cpp:48:21:48:27 | call to encrypt |
-| test.cpp:58:11:58:16 | passwd | test.cpp:61:11:61:16 | passwd |
-| test.cpp:76:29:76:39 | thePassword | test.cpp:76:21:76:27 | call to encrypt |
+| test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password |
+| test3.cpp:350:9:350:16 | password | test3.cpp:352:16:352:23 | password |
+| test3.cpp:350:9:350:16 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
+| test3.cpp:350:9:350:16 | password | test3.cpp:353:20:353:27 | password |
+| test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
+| test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
+| test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
+| test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:29:76:39 | thePassword |
 nodes
-| test2.cpp:43:34:43:34 | s [post update] [password] | semmle.label | s [post update] [password] |
-| test2.cpp:43:36:43:43 | password | semmle.label | password |
-| test2.cpp:43:36:43:43 | password | semmle.label | password |
-| test2.cpp:43:36:43:43 | ref arg password | semmle.label | ref arg password |
-| test2.cpp:44:37:44:45 | thepasswd | semmle.label | thepasswd |
-| test2.cpp:50:41:50:53 | passwd_config | semmle.label | passwd_config |
-| test2.cpp:52:44:52:57 | password_tries | semmle.label | password_tries |
-| test2.cpp:54:39:54:39 | s [post update] [widepassword] | semmle.label | s [post update] [widepassword] |
-| test2.cpp:54:41:54:52 | ref arg widepassword | semmle.label | ref arg widepassword |
-| test2.cpp:54:41:54:52 | widepassword | semmle.label | widepassword |
-| test2.cpp:54:41:54:52 | widepassword | semmle.label | widepassword |
-| test2.cpp:55:38:55:38 | s [widepassword] | semmle.label | s [widepassword] |
-| test2.cpp:55:40:55:51 | widepassword | semmle.label | widepassword |
-| test2.cpp:57:39:57:49 | call to getPassword | semmle.label | call to getPassword |
-| test2.cpp:62:16:62:16 | s [password] | semmle.label | s [password] |
-| test2.cpp:62:18:62:25 | password | semmle.label | password |
-| test2.cpp:63:16:63:20 | call to crypt | semmle.label | call to crypt |
-| test2.cpp:63:22:63:22 | s [password] | semmle.label | s [password] |
-| test2.cpp:63:22:63:22 | s [post update] [password] | semmle.label | s [post update] [password] |
-| test2.cpp:63:24:63:31 | password | semmle.label | password |
-| test2.cpp:63:24:63:31 | password | semmle.label | password |
-| test2.cpp:63:24:63:31 | ref arg password | semmle.label | ref arg password |
-| test2.cpp:72:15:72:15 | s [password] | semmle.label | s [password] |
-| test2.cpp:72:17:72:24 | password | semmle.label | password |
-| test2.cpp:79:34:79:34 | s [password] | semmle.label | s [password] |
-| test2.cpp:79:34:79:34 | s [post update] [password] | semmle.label | s [post update] [password] |
-| test2.cpp:79:36:79:43 | password | semmle.label | password |
-| test2.cpp:79:36:79:43 | password | semmle.label | password |
-| test2.cpp:79:36:79:43 | ref arg password | semmle.label | ref arg password |
-| test2.cpp:82:15:82:28 | passwd_config2 | semmle.label | passwd_config2 |
-| test2.cpp:84:50:84:63 | passwd_config2 | semmle.label | passwd_config2 |
-| test2.cpp:91:43:91:43 | s [password] | semmle.label | s [password] |
-| test2.cpp:91:45:91:52 | password | semmle.label | password |
-| test3.cpp:20:28:20:36 | password1 | semmle.label | password1 |
+| test3.cpp:17:28:17:36 | password1 | semmle.label | password1 |
+| test3.cpp:17:51:17:59 | password2 | semmle.label | password2 |
 | test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
-| test3.cpp:22:33:22:41 | password1 | semmle.label | password1 |
 | test3.cpp:26:15:26:23 | password2 | semmle.label | password2 |
-| test3.cpp:26:33:26:41 | password2 | semmle.label | password2 |
-| test3.cpp:38:23:38:31 | password2 | semmle.label | password2 |
-| test3.cpp:38:41:38:49 | password2 | semmle.label | password2 |
+| test3.cpp:45:8:45:15 | password | semmle.label | password |
 | test3.cpp:47:15:47:22 | password | semmle.label | password |
-| test3.cpp:47:15:47:22 | password | semmle.label | password |
-| test3.cpp:49:28:49:35 | password | semmle.label | password |
+| test3.cpp:53:8:53:15 | password | semmle.label | password |
 | test3.cpp:55:15:55:22 | password | semmle.label | password |
-| test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
-| test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
+| test3.cpp:71:32:71:40 | password1 | semmle.label | password1 |
 | test3.cpp:76:15:76:17 | ptr | semmle.label | ptr |
-| test3.cpp:81:15:81:22 | password | semmle.label | password |
-| test3.cpp:81:15:81:22 | password | semmle.label | password |
+| test3.cpp:80:8:80:15 | password | semmle.label | password |
 | test3.cpp:83:15:83:17 | ptr | semmle.label | ptr |
+| test3.cpp:98:8:98:15 | password | semmle.label | password |
 | test3.cpp:101:12:101:19 | password | semmle.label | password |
-| test3.cpp:108:12:108:19 | password | semmle.label | password |
 | test3.cpp:112:20:112:25 | buffer | semmle.label | buffer |
 | test3.cpp:114:14:114:19 | buffer | semmle.label | buffer |
 | test3.cpp:117:28:117:33 | buffer | semmle.label | buffer |
 | test3.cpp:119:9:119:14 | buffer | semmle.label | buffer |
 | test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
-| test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
-| test3.cpp:134:11:134:18 | password | semmle.label | password |
+| test3.cpp:129:39:129:47 | password1 | semmle.label | password1 |
+| test3.cpp:132:8:132:15 | password | semmle.label | password |
 | test3.cpp:134:11:134:18 | password | semmle.label | password |
 | test3.cpp:138:21:138:22 | call to id | semmle.label | call to id |
-| test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
 | test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
 | test3.cpp:140:15:140:17 | ptr | semmle.label | ptr |
 | test3.cpp:144:16:144:29 | call to get_global_str | semmle.label | call to get_global_str |
 | test3.cpp:146:15:146:18 | data | semmle.label | data |
-| test3.cpp:157:19:157:26 | password | semmle.label | password |
-| test3.cpp:157:19:157:26 | password | semmle.label | password |
+| test3.cpp:152:29:152:36 | password | semmle.label | password |
 | test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
-| test3.cpp:173:15:173:22 | password | semmle.label | password |
+| test3.cpp:171:8:171:15 | password | semmle.label | password |
 | test3.cpp:173:15:173:22 | password | semmle.label | password |
 | test3.cpp:175:3:175:17 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
 | test3.cpp:175:19:175:26 | password | semmle.label | password |
-| test3.cpp:175:19:175:26 | password | semmle.label | password |
+| test3.cpp:179:8:179:15 | password | semmle.label | password |
 | test3.cpp:181:15:181:22 | password | semmle.label | password |
-| test3.cpp:181:15:181:22 | password | semmle.label | password |
-| test3.cpp:182:3:182:10 | password | semmle.label | password |
 | test3.cpp:184:3:184:17 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
 | test3.cpp:184:19:184:26 | password | semmle.label | password |
-| test3.cpp:184:19:184:26 | password | semmle.label | password |
+| test3.cpp:188:8:188:15 | password | semmle.label | password |
 | test3.cpp:191:15:191:22 | password | semmle.label | password |
-| test3.cpp:191:15:191:22 | password | semmle.label | password |
-| test3.cpp:193:3:193:14 | password_ptr | semmle.label | password_ptr |
 | test3.cpp:193:18:193:28 | call to rtn_decrypt | semmle.label | call to rtn_decrypt |
 | test3.cpp:193:30:193:37 | password | semmle.label | password |
-| test3.cpp:193:30:193:37 | password | semmle.label | password |
+| test3.cpp:197:8:197:15 | password | semmle.label | password |
 | test3.cpp:199:3:199:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
 | test3.cpp:199:19:199:26 | password | semmle.label | password |
-| test3.cpp:199:19:199:26 | password | semmle.label | password |
 | test3.cpp:201:15:201:22 | password | semmle.label | password |
-| test3.cpp:201:32:201:39 | password | semmle.label | password |
+| test3.cpp:205:8:205:15 | password | semmle.label | password |
 | test3.cpp:207:3:207:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
 | test3.cpp:207:19:207:26 | password | semmle.label | password |
-| test3.cpp:207:19:207:26 | password | semmle.label | password |
-| test3.cpp:208:3:208:10 | password | semmle.label | password |
 | test3.cpp:210:15:210:22 | password | semmle.label | password |
-| test3.cpp:210:32:210:39 | password | semmle.label | password |
-| test3.cpp:217:3:217:14 | password_ptr | semmle.label | password_ptr |
+| test3.cpp:214:8:214:15 | password | semmle.label | password |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | semmle.label | call to rtn_encrypt |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | semmle.label | call to rtn_encrypt |
-| test3.cpp:217:30:217:37 | password | semmle.label | password |
 | test3.cpp:217:30:217:37 | password | semmle.label | password |
 | test3.cpp:219:15:219:26 | password_ptr | semmle.label | password_ptr |
-| test3.cpp:219:36:219:47 | password_ptr | semmle.label | password_ptr |
+| test3.cpp:225:34:225:41 | password | semmle.label | password |
 | test3.cpp:227:22:227:29 | password | semmle.label | password |
 | test3.cpp:228:26:228:33 | password | semmle.label | password |
-| test3.cpp:241:8:241:15 | password | semmle.label | password |
+| test3.cpp:239:7:239:14 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
 | test3.cpp:242:8:242:15 | password | semmle.label | password |
-| test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
+| test3.cpp:252:8:252:16 | password1 | semmle.label | password1 |
+| test3.cpp:252:24:252:32 | password2 | semmle.label | password2 |
 | test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer | semmle.label | call to decrypt_to_buffer |
 | test3.cpp:256:21:256:29 | password1 | semmle.label | password1 |
-| test3.cpp:256:21:256:29 | password1 | semmle.label | password1 |
 | test3.cpp:256:32:256:40 | password2 | semmle.label | password2 |
-| test3.cpp:256:32:256:40 | password2 | semmle.label | password2 |
+| test3.cpp:260:8:260:16 | password1 | semmle.label | password1 |
+| test3.cpp:260:24:260:32 | password2 | semmle.label | password2 |
 | test3.cpp:262:3:262:19 | call to encrypt_to_buffer | semmle.label | call to encrypt_to_buffer |
 | test3.cpp:262:21:262:29 | password1 | semmle.label | password1 |
-| test3.cpp:262:21:262:29 | password1 | semmle.label | password1 |
-| test3.cpp:262:32:262:40 | password2 | semmle.label | password2 |
 | test3.cpp:262:32:262:40 | password2 | semmle.label | password2 |
 | test3.cpp:264:15:264:23 | password2 | semmle.label | password2 |
-| test3.cpp:264:33:264:41 | password2 | semmle.label | password2 |
-| test3.cpp:270:16:270:23 | password | semmle.label | password |
-| test3.cpp:270:16:270:23 | password | semmle.label | password |
+| test3.cpp:268:19:268:26 | password | semmle.label | password |
 | test3.cpp:272:15:272:18 | data | semmle.label | data |
 | test3.cpp:278:20:278:23 | data | semmle.label | data |
 | test3.cpp:278:20:278:23 | data | semmle.label | data |
@@ -295,44 +188,31 @@ nodes
 | test3.cpp:295:14:295:17 | data | semmle.label | data |
 | test3.cpp:298:20:298:23 | data | semmle.label | data |
 | test3.cpp:300:14:300:17 | data | semmle.label | data |
+| test3.cpp:308:41:308:48 | password | semmle.label | password |
 | test3.cpp:312:3:312:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
 | test3.cpp:312:19:312:26 | password | semmle.label | password |
-| test3.cpp:312:19:312:26 | password | semmle.label | password |
-| test3.cpp:313:11:313:18 | password | semmle.label | password |
 | test3.cpp:313:11:313:18 | password | semmle.label | password |
 | test3.cpp:313:11:313:18 | ref arg password | semmle.label | ref arg password |
 | test3.cpp:314:11:314:18 | password | semmle.label | password |
-| test3.cpp:314:11:314:18 | password | semmle.label | password |
 | test3.cpp:314:11:314:18 | ref arg password | semmle.label | ref arg password |
-| test3.cpp:316:11:316:18 | password | semmle.label | password |
 | test3.cpp:316:11:316:18 | password | semmle.label | password |
 | test3.cpp:316:11:316:18 | ref arg password | semmle.label | ref arg password |
 | test3.cpp:317:11:317:18 | password | semmle.label | password |
-| test3.cpp:317:11:317:18 | password | semmle.label | password |
 | test3.cpp:317:11:317:18 | ref arg password | semmle.label | ref arg password |
-| test3.cpp:322:16:322:23 | password | semmle.label | password |
-| test3.cpp:322:16:322:23 | password | semmle.label | password |
 | test3.cpp:324:11:324:14 | data | semmle.label | data |
 | test3.cpp:324:11:324:14 | ref arg data | semmle.label | ref arg data |
 | test3.cpp:325:11:325:14 | data | semmle.label | data |
+| test3.cpp:339:9:339:16 | password | semmle.label | password |
 | test3.cpp:341:16:341:23 | password | semmle.label | password |
-| test3.cpp:352:16:352:23 | password | semmle.label | password |
+| test3.cpp:350:9:350:16 | password | semmle.label | password |
 | test3.cpp:352:16:352:23 | password | semmle.label | password |
 | test3.cpp:353:4:353:18 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
 | test3.cpp:353:20:353:27 | password | semmle.label | password |
-| test3.cpp:353:20:353:27 | password | semmle.label | password |
-| test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
+| test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
-| test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
-| test.cpp:58:11:58:16 | passwd | semmle.label | passwd |
-| test.cpp:58:11:58:16 | passwd | semmle.label | passwd |
-| test.cpp:61:11:61:16 | passwd | semmle.label | passwd |
-| test.cpp:70:38:70:48 | thePassword | semmle.label | thePassword |
-| test.cpp:73:43:73:53 | thePassword | semmle.label | thePassword |
-| test.cpp:73:63:73:73 | thePassword | semmle.label | thePassword |
+| test.cpp:66:23:66:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:76:21:76:27 | call to encrypt | semmle.label | call to encrypt |
-| test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
 | test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
 subpaths
 | test3.cpp:138:24:138:32 | password1 | test3.cpp:117:28:117:33 | buffer | test3.cpp:119:9:119:14 | buffer | test3.cpp:138:21:138:22 | call to id |
@@ -342,24 +222,20 @@ subpaths
 | test3.cpp:317:11:317:18 | password | test3.cpp:288:20:288:23 | data | test3.cpp:288:20:288:23 | data | test3.cpp:317:11:317:18 | ref arg password |
 | test3.cpp:324:11:324:14 | data | test3.cpp:293:20:293:23 | data | test3.cpp:293:20:293:23 | data | test3.cpp:324:11:324:14 | ref arg data |
 #select
-| test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:22:15:22:23 | password1 | password1 |
-| test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:26:15:26:23 | password2 | password2 |
-| test3.cpp:47:3:47:6 | call to recv | test3.cpp:47:15:47:22 | password | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:47:15:47:22 | password | password |
-| test3.cpp:55:3:55:6 | call to recv | test3.cpp:55:15:55:22 | password | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:55:15:55:22 | password | password |
-| test3.cpp:76:3:76:6 | call to send | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:74:21:74:29 | password1 | password1 |
-| test3.cpp:83:3:83:6 | call to recv | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr | This operation receives into 'ptr', which may put unencrypted sensitive data into $@ | test3.cpp:81:15:81:22 | password | password |
-| test3.cpp:101:3:101:6 | call to read | test3.cpp:101:12:101:19 | password | test3.cpp:101:12:101:19 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:101:12:101:19 | password | password |
-| test3.cpp:114:2:114:5 | call to recv | test3.cpp:134:11:134:18 | password | test3.cpp:114:14:114:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@ | test3.cpp:134:11:134:18 | password | password |
-| test3.cpp:140:3:140:6 | call to send | test3.cpp:138:24:138:32 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:138:24:138:32 | password1 | password1 |
+| test3.cpp:22:3:22:6 | call to send | test3.cpp:17:28:17:36 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:17:28:17:36 | password1 | password1 |
+| test3.cpp:26:3:26:6 | call to send | test3.cpp:17:51:17:59 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:17:51:17:59 | password2 | password2 |
+| test3.cpp:47:3:47:6 | call to recv | test3.cpp:45:8:45:15 | password | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:45:8:45:15 | password | password |
+| test3.cpp:55:3:55:6 | call to recv | test3.cpp:53:8:53:15 | password | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:53:8:53:15 | password | password |
+| test3.cpp:76:3:76:6 | call to send | test3.cpp:71:32:71:40 | password1 | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:71:32:71:40 | password1 | password1 |
+| test3.cpp:83:3:83:6 | call to recv | test3.cpp:80:8:80:15 | password | test3.cpp:83:15:83:17 | ptr | This operation receives into 'ptr', which may put unencrypted sensitive data into $@ | test3.cpp:80:8:80:15 | password | password |
+| test3.cpp:101:3:101:6 | call to read | test3.cpp:98:8:98:15 | password | test3.cpp:101:12:101:19 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:98:8:98:15 | password | password |
+| test3.cpp:114:2:114:5 | call to recv | test3.cpp:132:8:132:15 | password | test3.cpp:114:14:114:19 | buffer | This operation receives into 'buffer', which may put unencrypted sensitive data into $@ | test3.cpp:132:8:132:15 | password | password |
+| test3.cpp:140:3:140:6 | call to send | test3.cpp:129:39:129:47 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:129:39:129:47 | password1 | password1 |
 | test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:126:9:126:23 | global_password | global_password |
-| test3.cpp:159:3:159:6 | call to send | test3.cpp:157:19:157:26 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:157:19:157:26 | password | password |
-| test3.cpp:227:2:227:5 | call to send | test3.cpp:227:22:227:29 | password | test3.cpp:227:22:227:29 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:227:22:227:29 | password | password |
-| test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:228:26:228:33 | password | password |
-| test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
-| test3.cpp:242:2:242:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
-| test3.cpp:272:3:272:6 | call to send | test3.cpp:270:16:270:23 | password | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:270:16:270:23 | password | password |
-| test3.cpp:285:2:285:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:285:14:285:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
-| test3.cpp:290:2:290:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:290:14:290:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
-| test3.cpp:295:2:295:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
-| test3.cpp:300:2:300:5 | call to send | test3.cpp:316:11:316:18 | password | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:316:11:316:18 | password | password |
-| test3.cpp:341:4:341:7 | call to recv | test3.cpp:341:16:341:23 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:341:16:341:23 | password | password |
+| test3.cpp:159:3:159:6 | call to send | test3.cpp:152:29:152:36 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:152:29:152:36 | password | password |
+| test3.cpp:227:2:227:5 | call to send | test3.cpp:225:34:225:41 | password | test3.cpp:227:22:227:29 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:225:34:225:41 | password | password |
+| test3.cpp:228:2:228:5 | call to send | test3.cpp:225:34:225:41 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:225:34:225:41 | password | password |
+| test3.cpp:241:2:241:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
+| test3.cpp:242:2:242:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
+| test3.cpp:272:3:272:6 | call to send | test3.cpp:268:19:268:26 | password | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:268:19:268:26 | password | password |
+| test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -1,10 +1,32 @@
 edges
+| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:62:16:62:16 | s [password] |
 | test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:63:22:63:22 | s [password] |
+| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:72:15:72:15 | s [password] |
+| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:79:34:79:34 | s [password] |
+| test2.cpp:43:34:43:34 | s [post update] [password] | test2.cpp:91:43:91:43 | s [password] |
 | test2.cpp:43:36:43:43 | password | test2.cpp:43:36:43:43 | ref arg password |
 | test2.cpp:43:36:43:43 | ref arg password | test2.cpp:43:34:43:34 | s [post update] [password] |
+| test2.cpp:54:39:54:39 | s [post update] [widepassword] | test2.cpp:55:38:55:38 | s [widepassword] |
+| test2.cpp:54:41:54:52 | ref arg widepassword | test2.cpp:54:39:54:39 | s [post update] [widepassword] |
+| test2.cpp:54:41:54:52 | widepassword | test2.cpp:54:41:54:52 | ref arg widepassword |
+| test2.cpp:55:38:55:38 | s [widepassword] | test2.cpp:55:40:55:51 | widepassword |
+| test2.cpp:62:16:62:16 | s [password] | test2.cpp:62:18:62:25 | password |
 | test2.cpp:63:22:63:22 | s [password] | test2.cpp:63:24:63:31 | password |
 | test2.cpp:63:22:63:22 | s [password] | test2.cpp:63:24:63:31 | password |
+| test2.cpp:63:22:63:22 | s [post update] [password] | test2.cpp:72:15:72:15 | s [password] |
+| test2.cpp:63:22:63:22 | s [post update] [password] | test2.cpp:79:34:79:34 | s [password] |
+| test2.cpp:63:22:63:22 | s [post update] [password] | test2.cpp:91:43:91:43 | s [password] |
 | test2.cpp:63:24:63:31 | password | test2.cpp:63:16:63:20 | call to crypt |
+| test2.cpp:63:24:63:31 | password | test2.cpp:63:24:63:31 | ref arg password |
+| test2.cpp:63:24:63:31 | ref arg password | test2.cpp:63:22:63:22 | s [post update] [password] |
+| test2.cpp:72:15:72:15 | s [password] | test2.cpp:72:17:72:24 | password |
+| test2.cpp:79:34:79:34 | s [password] | test2.cpp:79:36:79:43 | password |
+| test2.cpp:79:34:79:34 | s [password] | test2.cpp:79:36:79:43 | password |
+| test2.cpp:79:34:79:34 | s [post update] [password] | test2.cpp:91:43:91:43 | s [password] |
+| test2.cpp:79:36:79:43 | password | test2.cpp:79:36:79:43 | ref arg password |
+| test2.cpp:79:36:79:43 | ref arg password | test2.cpp:79:34:79:34 | s [post update] [password] |
+| test2.cpp:91:43:91:43 | s [password] | test2.cpp:91:45:91:52 | password |
+| test3.cpp:47:15:47:22 | password | test3.cpp:49:28:49:35 | password |
 | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr |
 | test3.cpp:81:15:81:22 | password | test3.cpp:83:15:83:17 | ptr |
 | test3.cpp:112:20:112:25 | buffer | test3.cpp:114:14:114:19 | buffer |
@@ -20,6 +42,7 @@ edges
 | test3.cpp:173:15:173:22 | password | test3.cpp:175:19:175:26 | password |
 | test3.cpp:173:15:173:22 | password | test3.cpp:175:19:175:26 | password |
 | test3.cpp:175:19:175:26 | password | test3.cpp:175:3:175:17 | call to decrypt_inplace |
+| test3.cpp:181:15:181:22 | password | test3.cpp:182:3:182:10 | password |
 | test3.cpp:181:15:181:22 | password | test3.cpp:184:3:184:17 | call to decrypt_inplace |
 | test3.cpp:181:15:181:22 | password | test3.cpp:184:19:184:26 | password |
 | test3.cpp:181:15:181:22 | password | test3.cpp:184:19:184:26 | password |
@@ -30,44 +53,89 @@ edges
 | test3.cpp:193:30:193:37 | password | test3.cpp:193:18:193:28 | call to rtn_decrypt |
 | test3.cpp:199:19:199:26 | password | test3.cpp:199:3:199:17 | call to encrypt_inplace |
 | test3.cpp:199:19:199:26 | password | test3.cpp:201:15:201:22 | password |
+| test3.cpp:199:19:199:26 | password | test3.cpp:201:32:201:39 | password |
 | test3.cpp:207:19:207:26 | password | test3.cpp:207:3:207:17 | call to encrypt_inplace |
+| test3.cpp:207:19:207:26 | password | test3.cpp:208:3:208:10 | password |
 | test3.cpp:207:19:207:26 | password | test3.cpp:210:15:210:22 | password |
+| test3.cpp:207:19:207:26 | password | test3.cpp:210:32:210:39 | password |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:15:219:26 | password_ptr |
+| test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:36:219:47 | password_ptr |
 | test3.cpp:217:30:217:37 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
 | test3.cpp:217:30:217:37 | password | test3.cpp:217:18:217:28 | call to rtn_encrypt |
 | test3.cpp:217:30:217:37 | password | test3.cpp:219:15:219:26 | password_ptr |
+| test3.cpp:217:30:217:37 | password | test3.cpp:219:36:219:47 | password_ptr |
 | test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password |
 | test.cpp:48:29:48:39 | thePassword | test.cpp:48:21:48:27 | call to encrypt |
+| test.cpp:58:11:58:16 | passwd | test.cpp:61:11:61:16 | passwd |
 | test.cpp:76:29:76:39 | thePassword | test.cpp:76:21:76:27 | call to encrypt |
 nodes
 | test2.cpp:43:34:43:34 | s [post update] [password] | semmle.label | s [post update] [password] |
 | test2.cpp:43:36:43:43 | password | semmle.label | password |
+| test2.cpp:43:36:43:43 | password | semmle.label | password |
 | test2.cpp:43:36:43:43 | ref arg password | semmle.label | ref arg password |
+| test2.cpp:44:37:44:45 | thepasswd | semmle.label | thepasswd |
+| test2.cpp:50:41:50:53 | passwd_config | semmle.label | passwd_config |
+| test2.cpp:52:44:52:57 | password_tries | semmle.label | password_tries |
+| test2.cpp:54:39:54:39 | s [post update] [widepassword] | semmle.label | s [post update] [widepassword] |
+| test2.cpp:54:41:54:52 | ref arg widepassword | semmle.label | ref arg widepassword |
+| test2.cpp:54:41:54:52 | widepassword | semmle.label | widepassword |
+| test2.cpp:54:41:54:52 | widepassword | semmle.label | widepassword |
+| test2.cpp:55:38:55:38 | s [widepassword] | semmle.label | s [widepassword] |
+| test2.cpp:55:40:55:51 | widepassword | semmle.label | widepassword |
+| test2.cpp:57:39:57:49 | call to getPassword | semmle.label | call to getPassword |
+| test2.cpp:62:16:62:16 | s [password] | semmle.label | s [password] |
+| test2.cpp:62:18:62:25 | password | semmle.label | password |
 | test2.cpp:63:16:63:20 | call to crypt | semmle.label | call to crypt |
 | test2.cpp:63:22:63:22 | s [password] | semmle.label | s [password] |
+| test2.cpp:63:22:63:22 | s [post update] [password] | semmle.label | s [post update] [password] |
 | test2.cpp:63:24:63:31 | password | semmle.label | password |
 | test2.cpp:63:24:63:31 | password | semmle.label | password |
+| test2.cpp:63:24:63:31 | ref arg password | semmle.label | ref arg password |
+| test2.cpp:72:15:72:15 | s [password] | semmle.label | s [password] |
+| test2.cpp:72:17:72:24 | password | semmle.label | password |
+| test2.cpp:79:34:79:34 | s [password] | semmle.label | s [password] |
+| test2.cpp:79:34:79:34 | s [post update] [password] | semmle.label | s [post update] [password] |
+| test2.cpp:79:36:79:43 | password | semmle.label | password |
+| test2.cpp:79:36:79:43 | password | semmle.label | password |
+| test2.cpp:79:36:79:43 | ref arg password | semmle.label | ref arg password |
+| test2.cpp:82:15:82:28 | passwd_config2 | semmle.label | passwd_config2 |
+| test2.cpp:84:50:84:63 | passwd_config2 | semmle.label | passwd_config2 |
+| test2.cpp:91:43:91:43 | s [password] | semmle.label | s [password] |
+| test2.cpp:91:45:91:52 | password | semmle.label | password |
+| test3.cpp:20:28:20:36 | password1 | semmle.label | password1 |
 | test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
+| test3.cpp:22:33:22:41 | password1 | semmle.label | password1 |
 | test3.cpp:26:15:26:23 | password2 | semmle.label | password2 |
+| test3.cpp:26:33:26:41 | password2 | semmle.label | password2 |
 | test3.cpp:38:23:38:31 | password2 | semmle.label | password2 |
+| test3.cpp:38:41:38:49 | password2 | semmle.label | password2 |
 | test3.cpp:47:15:47:22 | password | semmle.label | password |
+| test3.cpp:47:15:47:22 | password | semmle.label | password |
+| test3.cpp:49:28:49:35 | password | semmle.label | password |
 | test3.cpp:55:15:55:22 | password | semmle.label | password |
+| test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
 | test3.cpp:74:21:74:29 | password1 | semmle.label | password1 |
 | test3.cpp:76:15:76:17 | ptr | semmle.label | ptr |
 | test3.cpp:81:15:81:22 | password | semmle.label | password |
+| test3.cpp:81:15:81:22 | password | semmle.label | password |
 | test3.cpp:83:15:83:17 | ptr | semmle.label | ptr |
 | test3.cpp:101:12:101:19 | password | semmle.label | password |
+| test3.cpp:108:12:108:19 | password | semmle.label | password |
 | test3.cpp:112:20:112:25 | buffer | semmle.label | buffer |
 | test3.cpp:114:14:114:19 | buffer | semmle.label | buffer |
 | test3.cpp:117:28:117:33 | buffer | semmle.label | buffer |
 | test3.cpp:119:9:119:14 | buffer | semmle.label | buffer |
 | test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
+| test3.cpp:126:9:126:23 | global_password | semmle.label | global_password |
+| test3.cpp:134:11:134:18 | password | semmle.label | password |
 | test3.cpp:134:11:134:18 | password | semmle.label | password |
 | test3.cpp:138:21:138:22 | call to id | semmle.label | call to id |
+| test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
 | test3.cpp:138:24:138:32 | password1 | semmle.label | password1 |
 | test3.cpp:140:15:140:17 | ptr | semmle.label | ptr |
 | test3.cpp:144:16:144:29 | call to get_global_str | semmle.label | call to get_global_str |
 | test3.cpp:146:15:146:18 | data | semmle.label | data |
+| test3.cpp:157:19:157:26 | password | semmle.label | password |
 | test3.cpp:157:19:157:26 | password | semmle.label | password |
 | test3.cpp:159:15:159:20 | buffer | semmle.label | buffer |
 | test3.cpp:173:15:173:22 | password | semmle.label | password |
@@ -77,11 +145,13 @@ nodes
 | test3.cpp:175:19:175:26 | password | semmle.label | password |
 | test3.cpp:181:15:181:22 | password | semmle.label | password |
 | test3.cpp:181:15:181:22 | password | semmle.label | password |
+| test3.cpp:182:3:182:10 | password | semmle.label | password |
 | test3.cpp:184:3:184:17 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
 | test3.cpp:184:19:184:26 | password | semmle.label | password |
 | test3.cpp:184:19:184:26 | password | semmle.label | password |
 | test3.cpp:191:15:191:22 | password | semmle.label | password |
 | test3.cpp:191:15:191:22 | password | semmle.label | password |
+| test3.cpp:193:3:193:14 | password_ptr | semmle.label | password_ptr |
 | test3.cpp:193:18:193:28 | call to rtn_decrypt | semmle.label | call to rtn_decrypt |
 | test3.cpp:193:30:193:37 | password | semmle.label | password |
 | test3.cpp:193:30:193:37 | password | semmle.label | password |
@@ -89,23 +159,35 @@ nodes
 | test3.cpp:199:19:199:26 | password | semmle.label | password |
 | test3.cpp:199:19:199:26 | password | semmle.label | password |
 | test3.cpp:201:15:201:22 | password | semmle.label | password |
+| test3.cpp:201:32:201:39 | password | semmle.label | password |
 | test3.cpp:207:3:207:17 | call to encrypt_inplace | semmle.label | call to encrypt_inplace |
 | test3.cpp:207:19:207:26 | password | semmle.label | password |
 | test3.cpp:207:19:207:26 | password | semmle.label | password |
+| test3.cpp:208:3:208:10 | password | semmle.label | password |
 | test3.cpp:210:15:210:22 | password | semmle.label | password |
+| test3.cpp:210:32:210:39 | password | semmle.label | password |
+| test3.cpp:217:3:217:14 | password_ptr | semmle.label | password_ptr |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | semmle.label | call to rtn_encrypt |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | semmle.label | call to rtn_encrypt |
 | test3.cpp:217:30:217:37 | password | semmle.label | password |
 | test3.cpp:217:30:217:37 | password | semmle.label | password |
 | test3.cpp:219:15:219:26 | password_ptr | semmle.label | password_ptr |
+| test3.cpp:219:36:219:47 | password_ptr | semmle.label | password_ptr |
 | test3.cpp:227:22:227:29 | password | semmle.label | password |
 | test3.cpp:228:26:228:33 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
 | test3.cpp:242:8:242:15 | password | semmle.label | password |
+| test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
+| test.cpp:58:11:58:16 | passwd | semmle.label | passwd |
+| test.cpp:58:11:58:16 | passwd | semmle.label | passwd |
+| test.cpp:61:11:61:16 | passwd | semmle.label | passwd |
+| test.cpp:70:38:70:48 | thePassword | semmle.label | thePassword |
+| test.cpp:73:43:73:53 | thePassword | semmle.label | thePassword |
+| test.cpp:73:63:73:73 | thePassword | semmle.label | thePassword |
 | test.cpp:76:21:76:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
 | test.cpp:76:29:76:39 | thePassword | semmle.label | thePassword |
@@ -128,4 +210,3 @@ subpaths
 | test3.cpp:228:2:228:5 | call to send | test3.cpp:228:26:228:33 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:228:26:228:33 | password | password |
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
 | test3.cpp:242:2:242:6 | call to fgets | test3.cpp:241:8:241:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:241:8:241:15 | password | password |
-| test3.cpp:242:2:242:6 | call to fgets | test3.cpp:242:8:242:15 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:242:8:242:15 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -196,7 +196,6 @@ subpaths
 #select
 | test3.cpp:22:3:22:6 | call to send | test3.cpp:22:15:22:23 | password1 | test3.cpp:22:15:22:23 | password1 | This operation transmits 'password1', which may contain unencrypted sensitive data from $@ | test3.cpp:22:15:22:23 | password1 | password1 |
 | test3.cpp:26:3:26:6 | call to send | test3.cpp:26:15:26:23 | password2 | test3.cpp:26:15:26:23 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:26:15:26:23 | password2 | password2 |
-| test3.cpp:38:3:38:6 | call to send | test3.cpp:38:23:38:31 | password2 | test3.cpp:38:23:38:31 | password2 | This operation transmits 'password2', which may contain unencrypted sensitive data from $@ | test3.cpp:38:23:38:31 | password2 | password2 |
 | test3.cpp:47:3:47:6 | call to recv | test3.cpp:47:15:47:22 | password | test3.cpp:47:15:47:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:47:15:47:22 | password | password |
 | test3.cpp:55:3:55:6 | call to recv | test3.cpp:55:15:55:22 | password | test3.cpp:55:15:55:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:55:15:55:22 | password | password |
 | test3.cpp:76:3:76:6 | call to send | test3.cpp:74:21:74:29 | password1 | test3.cpp:76:15:76:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:74:21:74:29 | password1 | password1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -35,7 +35,7 @@ void test_send(const char *password1, const char *password2, const char *passwor
 	}
 
 	{
-		send(stdout_fileno, password2, strlen(password2), val()); // GOOD: `password2` is sent to stdout, not a network socket (this may be an issue but is not within the scope of the `cpp/cleartext-transmission` query) [FALSE POSITIVE]
+		send(stdout_fileno, password2, strlen(password2), val()); // GOOD: `password2` is sent to stdout, not a network socket (this may be an issue but is not within the scope of the `cpp/cleartext-transmission` query)
 	}
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -2,6 +2,8 @@
 typedef unsigned long size_t;
 #define STDIN_FILENO (0)
 
+
+
 size_t strlen(const char *s);
 
 void send(int fd, const void *buf, size_t bufLen, int d);
@@ -31,6 +33,10 @@ void test_send(const char *password1, const char *password2, const char *passwor
 	{
 		send(val(), message, strlen(message), val()); // GOOD: `message` is not a password
 	}
+
+
+
+
 }
 
 void test_receive()
@@ -125,7 +131,7 @@ void test_interprocedural(const char *password1)
 	{
 		char password[256];
 
-		my_recv(password, 256); // BAD: `password` is received plaintext [detected on line 108]
+		my_recv(password, 256); // BAD: `password` is received plaintext [detected in `my_recv`]
 	}
 
 	{

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -170,7 +170,7 @@ void test_decrypt()
 	{
 		char password[256];
 
-		recv(val(), password, 256, val()); // GOOD: password is encrypted [FALSE POSITIVE]
+		recv(val(), password, 256, val()); // GOOD: password is encrypted
 
 		decrypt_inplace(password); // proof that `password` was in fact encrypted
 	}
@@ -178,7 +178,7 @@ void test_decrypt()
 	{
 		char password[256];
 
-		recv(val(), password, 256, val()); // GOOD: password is encrypted [FALSE POSITIVE]
+		recv(val(), password, 256, val()); // GOOD: password is encrypted
 		password[255] = 0;
 
 		decrypt_inplace(password); // proof that `password` was in fact encrypted
@@ -188,7 +188,7 @@ void test_decrypt()
 		char password[256];
 		char *password_ptr;
 
-		recv(val(), password, 256, val()); // GOOD: password is encrypted [FALSE POSITIVE]
+		recv(val(), password, 256, val()); // GOOD: password is encrypted
 
 		password_ptr = rtn_decrypt(password); // proof that `password` was in fact encrypted
 	}
@@ -198,7 +198,7 @@ void test_decrypt()
 
 		encrypt_inplace(password); // proof that `password` is in fact encrypted
 
-		send(val(), password, strlen(password), val()); // GOOD: password is encrypted [FALSE POSITIVE]
+		send(val(), password, strlen(password), val()); // GOOD: password is encrypted
 	}
 
 	{
@@ -207,7 +207,7 @@ void test_decrypt()
 		encrypt_inplace(password); // proof that `password` is in fact encrypted
 		password[255] = 0;
 
-		send(val(), password, strlen(password), val()); // GOOD: password is encrypted [FALSE POSITIVE]
+		send(val(), password, strlen(password), val()); // GOOD: password is encrypted
 	}
 
 	{
@@ -216,7 +216,7 @@ void test_decrypt()
 
 		password_ptr = rtn_encrypt(password); // proof that `password` is in fact encrypted
 
-		send(val(), password_ptr, strlen(password_ptr), val()); // GOOD: password is encrypted [FALSE POSITIVE]
+		send(val(), password_ptr, strlen(password_ptr), val()); // GOOD: password is encrypted
 	}
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -330,3 +330,29 @@ void test_multiple_sources_source(char *password)
 		target6(data);
 	}
 }
+
+void test_loops()
+{
+	{
+		while (cond())
+		{
+			char password[256];
+
+			recv(val(), password, 256, val()); // BAD: not encrypted
+			
+			// ...
+		}
+	}
+
+	{
+		while (cond())
+		{
+			char password[256];
+
+			recv(val(), password, 256, val()); // GOOD: password is encrypted
+			decrypt_inplace(password); // proof that `password` was in fact encrypted
+			
+			// ...
+		}
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -292,12 +292,12 @@ void target3(char *data)
 
 void target4(char *data)
 {
-	send(val(), data, strlen(data), val()); // BAD: data is a plaintext password [NOT DETECTED]
+	send(val(), data, strlen(data), val()); // BAD: data is a plaintext password
 }
 
 void target5(char *data)
 {
-	send(val(), data, strlen(data), val()); // BAD: from one source this is a plaintext password [NOT DETECTED]
+	send(val(), data, strlen(data), val()); // BAD: from one source this is a plaintext password
 }
 
 void target6(char *data)
@@ -305,21 +305,21 @@ void target6(char *data)
 	send(val(), data, strlen(data), val()); // GOOD: not a password
 }
 
-void test_multiple_sources_source(char *password)
+void test_multiple_sources_source(char *password1, char *password2)
 {
 	if (cond())
 	{
-		encrypt_inplace(password);
-		target1(password);
-		target2(password);
+		encrypt_inplace(password1);
+		target1(password1);
+		target2(password1);
 	} else {
-		target2(password);
-		target3(password);
+		target2(password1);
+		target3(password1);
 	}
 
 	if (cond())
 	{
-		char *data = password;
+		char *data = password2;
 
 		target4(data);
 		target5(data);

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -282,22 +282,22 @@ void target1(char *data)
 
 void target2(char *data)
 {
-	send(val(), data, strlen(data), val()); // BAD: from one source this is a plaintext password
+	send(val(), data, strlen(data), val()); // BAD: from one source this is a plaintext password [NOT DETECTED]
 }
 
 void target3(char *data)
 {
-	send(val(), data, strlen(data), val()); // BAD: data is a plaintext password
+	send(val(), data, strlen(data), val()); // BAD: data is a plaintext password [NOT DETECTED]
 }
 
 void target4(char *data)
 {
-	send(val(), data, strlen(data), val()); // BAD: data is a plaintext password
+	send(val(), data, strlen(data), val()); // BAD: data is a plaintext password [NOT DETECTED]
 }
 
 void target5(char *data)
 {
-	send(val(), data, strlen(data), val()); // BAD: from one source this is a plaintext password
+	send(val(), data, strlen(data), val()); // BAD: from one source this is a plaintext password [NOT DETECTED]
 }
 
 void target6(char *data)


### PR DESCRIPTION
Improvements to `cpp/cleartext-transmission`, aiming to reduce FPs on the SAMATE Juliet test suite and on real world LGTM projects.  I have more improvements to come (mostly developed a while ago), but I've limited this PR to a couple of changes to keep things manageable.

The implementation of `checkSocket()` does not cover everything, but it is very much tuned to catch typically definitions of standard input etc.  We can generalize it a bit more at some point if we need to.

SAMATE Juliet tests:
- before:
  - https://jenkins.internal.semmle.com/job/Security/job/SAMATE/job/SAMATE-cpp-detailed/189/
  - CWE-319 `cpp/cleartext-transmission`: TP 192 (100%); FP 192 (100%)
- after:
  - https://jenkins.internal.semmle.com/job/Security/job/SAMATE/job/SAMATE-cpp-detailed/191/
  - CWE-319 `cpp/cleartext-transmission`: TP 188 (98%), FP 36 (19%) 🎉

LGTM:
- before: https://lgtm.com/query/2475452651980372556/
- after: https://lgtm.com/query/2831900053668992399/
- query attempting to show where encryption was found: ~https://lgtm.com/query/6939588351660049749/
- final: https://lgtm.com/query/4602397715990060632/
```
LGTM RESULTS				orig		new		final		explained by
bitcoin/bitcoin				1		1		0		sensitive field access no longer a source?*
openldap/openldap			1		1		1		-
curl/curl				2		3		3		result added due to more accurate stdin/stdout check
git/git					1		0		0		original result no longer exists on latest build?
google/boringssl			1		0		0		encryption found
Kitware/CMake				2		2		2		-
alibaba/AliSQL				1		0		0		encryption found
openwall/john				1		1		1		-
BOINC/boinc				4		3		3		result lost, I think failing to track flow after a global is accessed in a particular way?*
apple/cups				2		2		0		sensitive field access no longer a source?*
squid-cache/squid			2		1		0		encryption found; and sensitive field access no longer a source?*
haiku/haiku				5		4		3		encryption found; and more encryption found.
GNOME/libxml2				5		5		4		sensitive field access no longer a source?*
bloomberg/comdb2			5		5		5		-
FreeRADIUS/freeradius-server		1		0		0		encryption found
steveathon/cups				2		2		0		-
awslabs/awc-lc				1		0		0		encryption found
```
* - I've added items to the main ticket to fix the field access one, and possibly the other issue, as follow-up work.

Performance:
- local, `torvalds/linux`, clean cache, 542s -> 1234s.  The slowdown appears to be almost entirely explained by the addition of GVN, as such it is not concerning.
- ~TODO: probably worth running DCA.~ done.
