### PR TITLE
Shared CFG: Add another consistency test

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -957,10 +957,31 @@ module Consistency {
     not split.hasEntry(pred, succ, c)
   }
 
+  private class SimpleSuccessorType extends SuccessorType {
+    SimpleSuccessorType() {
+      this = getAMatchingSuccessorType(any(Completion c | completionIsSimple(c)))
+    }
+  }
+
+  private class NormalSuccessorType extends SuccessorType {
+    NormalSuccessorType() {
+      this = getAMatchingSuccessorType(any(Completion c | completionIsNormal(c)))
+    }
+  }
+
   query predicate multipleSuccessors(Node node, SuccessorType t, Node successor) {
-    not node instanceof TEntryNode and
     strictcount(getASuccessor(node, t)) > 1 and
-    successor = getASuccessor(node, t)
+    successor = getASuccessor(node, t) and
+    // allow for functions with multiple bodies
+    not (t instanceof SimpleSuccessorType and node instanceof TEntryNode)
+  }
+
+  query predicate simpleAndNormalSuccessors(
+    Node node, NormalSuccessorType t1, SimpleSuccessorType t2, Node succ1, Node succ2
+  ) {
+    t1 != t2 and
+    succ1 = getASuccessor(node, t1) and
+    succ2 = getASuccessor(node, t2)
   }
 
   query predicate deadEnd(Node node) {

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplShared.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplShared.qll
@@ -957,10 +957,31 @@ module Consistency {
     not split.hasEntry(pred, succ, c)
   }
 
+  private class SimpleSuccessorType extends SuccessorType {
+    SimpleSuccessorType() {
+      this = getAMatchingSuccessorType(any(Completion c | completionIsSimple(c)))
+    }
+  }
+
+  private class NormalSuccessorType extends SuccessorType {
+    NormalSuccessorType() {
+      this = getAMatchingSuccessorType(any(Completion c | completionIsNormal(c)))
+    }
+  }
+
   query predicate multipleSuccessors(Node node, SuccessorType t, Node successor) {
-    not node instanceof TEntryNode and
     strictcount(getASuccessor(node, t)) > 1 and
-    successor = getASuccessor(node, t)
+    successor = getASuccessor(node, t) and
+    // allow for functions with multiple bodies
+    not (t instanceof SimpleSuccessorType and node instanceof TEntryNode)
+  }
+
+  query predicate simpleAndNormalSuccessors(
+    Node node, NormalSuccessorType t1, SimpleSuccessorType t2, Node succ1, Node succ2
+  ) {
+    t1 != t2 and
+    succ1 = getASuccessor(node, t1) and
+    succ2 = getASuccessor(node, t2)
   }
 
   query predicate deadEnd(Node node) {


### PR DESCRIPTION
Finds nodes with multiple normal successors, where one is the special simple successor. For example, this would flag a node that has both a "simple" and a "true" successor.