### PR TITLE
JS: Improve inter-procedural type inference for FunctionExpr

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -203,19 +203,14 @@ class LocalFunction extends Function {
   DataFlow::Impl::ExplicitInvokeNode invk;
 
   LocalFunction() {
-    (
-      exists(LocalVariable v |
-        getOnlyAccess(this, v) = invk.getCalleeNode().asExpr() and
-        not exists(v.getAnAssignedExpr()) and
-        not exists(ExportDeclaration export | export.exportsAs(v, _))
-      )
-    or
-      exists(LocalVariable v |
-        getOnlyAccessToFunctionExpr(this, v) = invk.getCalleeNode().asExpr() and
-        not exists(ExportDeclaration export | export.exportsAs(v, _))
-      )
-    )
-    and
+    exists(LocalVariable v |
+      getOnlyAccess(this, v) = invk.getCalleeNode().asExpr() and
+      not exists(v.getAnAssignedExpr()) and
+      not exists(ExportDeclaration export | export.exportsAs(v, _))
+      or
+      getOnlyAccessToFunctionExpr(this, v) = invk.getCalleeNode().asExpr() and
+      not exists(ExportDeclaration export | export.exportsAs(v, _))
+    ) and
     // if the function is non-strict and its `arguments` object is accessed, we
     // also assume that there may be other calls (through `arguments.callee`)
     (isStrict() or not usesArgumentsObject())

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -191,9 +191,9 @@ private VarAccess getOnlyAccess(FunctionDeclStmt fn, LocalVariable v) {
 }
 
 private VarAccess getOnlyAccessToFunctionExpr(FunctionExpr fn, LocalVariable v) {
-  exists( DeclStmt st |
-    fn = st.(DeclStmt).getADecl().getInit() and 
-    v = st.(DeclStmt).getADecl().getBindingPattern().getVariable() and
+  exists(VariableDeclarator decl |
+    fn = decl.getInit() and
+    v = decl.getBindingPattern().getVariable() and
     result = unique(VarAccess acc | acc = v.getAnAccess())
   )
 }

--- a/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/CalleeNodeValue.expected
+++ b/javascript/ql/test/library-tests/TypeInference/CallWithAnalyzedReturnFlow/CalleeNodeValue.expected
@@ -58,7 +58,6 @@
 | tst.js:80:5:80:7 | f20 | file://:0:0:0:0 | undefined |
 | tst.js:80:5:80:7 | f20 | tst.js:79:24:79:25 | object literal |
 | tst.js:84:17:84:20 | getF | tst.js:83:20:83:31 | function getF |
-| tst.js:86:13:86:13 | f | file://:0:0:0:0 | indefinite value (call) |
 | tst.js:86:13:86:13 | f | file://:0:0:0:0 | undefined |
 | tst.js:89:17:89:20 | getG | tst.js:88:9:88:25 | function getG |
 | tst.js:91:13:91:13 | g | file://:0:0:0:0 | undefined |

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.expected
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.expected
@@ -1,8 +1,10 @@
 | LocalFunction.js:4:5:4:19 | function f1(){} | LocalFunction.js:5:5:5:8 | f1() |
 | LocalFunction.js:11:5:11:19 | function f3(){} | LocalFunction.js:13:5:13:8 | f3() |
 | LocalFunction.js:12:5:12:19 | function f3(){} | LocalFunction.js:13:5:13:8 | f3() |
-| LocalFunction.js:27:5:29:5 | functio ... ;\\n    } | LocalFunction.js:33:17:33:24 | f_zero() |
-| LocalFunction.js:30:5:32:5 | functio ... ;\\n    } | LocalFunction.js:33:5:33:12 | f_null() |
-| LocalFunction.js:35:5:37:5 | functio ... ;\\n    } | LocalFunction.js:41:5:41:12 | f_id1(0) |
-| LocalFunction.js:38:5:40:5 | functio ... ;\\n    } | LocalFunction.js:41:17:41:27 | f_id2(null) |
+| LocalFunction.js:15:14:15:25 | function(){} | LocalFunction.js:16:5:16:8 | f4() |
+| LocalFunction.js:31:5:33:5 | functio ... ;\\n    } | LocalFunction.js:37:17:37:24 | f_zero() |
+| LocalFunction.js:34:5:36:5 | functio ... ;\\n    } | LocalFunction.js:37:5:37:12 | f_null() |
+| LocalFunction.js:39:5:41:5 | functio ... ;\\n    } | LocalFunction.js:45:5:45:12 | f_id1(0) |
+| LocalFunction.js:42:5:44:5 | functio ... ;\\n    } | LocalFunction.js:45:17:45:27 | f_id2(null) |
 | LocalFunction_arguments.js:17:5:20:5 | functio ... e\\n    } | LocalFunction_arguments.js:21:5:21:7 | i() |
+| LocalFunction_arguments.js:40:14:43:5 | functio ... e\\n    } | LocalFunction_arguments.js:44:5:44:8 | i1() |

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.js
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction.js
@@ -22,6 +22,10 @@
     function f6(){}
     g(f6);
     f6();
+
+    var f7 = function(){}
+    f7();
+    f7();
 })();
 (function types(){
     function f_zero() {
@@ -48,3 +52,9 @@ export default function bar() {
 
 }
 bar();
+
+var foo1 = function foo1(){
+
+}
+foo1();
+export {foo1};

--- a/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction_arguments.js
+++ b/javascript/ql/test/library-tests/TypeInference/LocalFunction/LocalFunction_arguments.js
@@ -20,3 +20,26 @@
     }
     i();
 })();
+
+(function(){
+    var f1 = function f1() {
+        arguments.callee()
+    }
+    f1();
+    var g1 = function g1() {
+        var args = arguments;
+        var callee = args.callee;
+        callee();
+    }
+    g1();
+    var h1 = function h1() {
+        var args = arguments;
+        args.callee;
+    }
+    h1();
+    var i1 = function i1() {
+        "use strict";
+        arguments.callee(); // does not work in strict mode
+    }
+    i1();
+})();

--- a/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/SuspiciousInvocation.expected
+++ b/javascript/ql/test/query-tests/Expressions/SuspiciousInvocation/SuspiciousInvocation.expected
@@ -3,3 +3,4 @@
 | optional-chaining.js:3:5:3:7 | a() | Callee is not a function: it has type null. |
 | optional-chaining.js:7:5:7:7 | b() | Callee is not a function: it has type undefined. |
 | super.js:11:5:11:11 | super() | Callee is not a function: it has type number. |
+| unreachable-code.js:5:9:5:11 | f() | Callee is not a function: it has type undefined. |


### PR DESCRIPTION
To improve inter-procedural type inference for FunctionExpr.


codeql conduct an [Inter-procedural type inference](https://github.com/github/codeql/blob/753d886b0dd8217cfa3fafcc36afd9de9a2aed26/javascript/ql/lib/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll#L194) for `LocalFunction` .  But `LocalFunction` represents `FunctionDeclStmt` which is only called once locally, so we can easily handle the case below. 

```javascript
function f(source){return source;}
function c(source){return source;}
var sink = c(f)(easySource);
```

But codeql can not handle the case below. Function c is declare by a `FunctionExpr`. 
```javascript
function f(source){return source;}
var c = function c(source){return source;}
var sink = c(f)(easySource);
```

This usage is common so I improve it by extending the LocalFunction definition. BTW, this issue is mentioned in the previous [pull request](https://github.com/github/codeql/pull/68/files#r211149568) but still not improved.

I test all unit tests [before](https://blog.szfszf.top/static/codeqltest/before.json) and [after](https://blog.szfszf.top/static/codeqltest/after.json) modification, I found there are no noticeable performance changes.