### PR TITLE
Add inlines to reduce ATM featurisation time

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -13,6 +13,7 @@ import EndpointScoring
  *
  * This is a single string containing a space-separated list of tokens.
  */
+pragma[inline]
 private string getTokenFeature(DataFlow::Node endpoint, string featureName) {
   // Features for endpoints that are contained within a function.
   exists(DatabaseFeatures::Entity entity | entity = getRepresentativeEntityForEndpoint(endpoint) |
@@ -275,6 +276,7 @@ private string getASupportedFeatureName() {
  * This predicate holds if the generic token-based feature named `featureName` has the value
  * `featureValue` for the endpoint `endpoint`.
  */
+pragma[inline]
 predicate tokenFeatures(DataFlow::Node endpoint, string featureName, string featureValue) {
   ModelScoring::endpoints(endpoint) and
   (


### PR DESCRIPTION
Running time of `XssATM.ql` on `azure-sdk-for-node` from empty caches:
- before change: 12 minutes
- after change: 12 minutes

*However*, the running time of the entire ATM query pack on `azure-sdk-for-node` from caches populated by previously running the standard query suite:
- before change: 24 minutes 25 seconds
- after change: 15 minutes

Further testing revealed this time reduction was an artefact of inconsistent cache state. Withdrawing this PR.