### PR TITLE
JS/Py/Ruby: Add more CWEs to bad-tag-filter queries

### DIFF
--- a/javascript/ql/src/Security/CWE-116/BadTagFilter.ql
+++ b/javascript/ql/src/Security/CWE-116/BadTagFilter.ql
@@ -10,6 +10,8 @@
  *       security
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-185
+ *       external/cwe/cwe-186
  */
 
 import semmle.javascript.security.BadTagFilterQuery

--- a/python/ql/src/Security/CWE-116/BadTagFilter.ql
+++ b/python/ql/src/Security/CWE-116/BadTagFilter.ql
@@ -10,6 +10,8 @@
  *       security
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-185
+ *       external/cwe/cwe-186
  */
 
 import semmle.python.security.BadTagFilterQuery

--- a/ruby/ql/src/queries/security/cwe-116/BadTagFilter.ql
+++ b/ruby/ql/src/queries/security/cwe-116/BadTagFilter.ql
@@ -10,6 +10,8 @@
  *       security
  *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-185
+ *       external/cwe/cwe-186
  */
 
 import codeql.ruby.security.BadTagFilterQuery


### PR DESCRIPTION
### CWE-185: Incorrect Regular Expression

> The software specifies a regular expression in a way that causes data to be improperly matched or compared.

https://cwe.mitre.org/data/definitions/185.html

### CWE-186: Overly Restrictive Regular Expression

> A regular expression is overly restrictive, which prevents dangerous values from being detected.
>
> (...) [this CWE] is about a regular expression that does not match all values that are intended. (...)

https://cwe.mitre.org/data/definitions/186.html

---

From my understanding, CWE-625: Permissive Regular Expression, is not applicable. (since this is about accepting a regex match where there should not be a match).