### PR TITLE
Ruby: use Ruby object instantiation syntax in a comment

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -82,7 +82,7 @@ module API {
      * constructor is the function represented by this node.
      *
      * For example, if this node represents a use of some class `A`, then there might be a node
-     * representing instances of `A`, typically corresponding to expressions `new A()` at the
+     * representing instances of `A`, typically corresponding to expressions `A.new` at the
      * source level.
      *
      * This predicate may have multiple results when there are multiple constructor calls invoking this API component.


### PR DESCRIPTION
This was using ES6 style class instantiation syntax.