### PR TITLE
Ruby: Add `getBlock` and `getNumberOfArguments` predicates to `DataFlow::CallNode`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -61,6 +61,12 @@ class CallNode extends LocalSourceNode {
 
   /** Gets the name of the the method called by the method call (if any) corresponding to this data-flow node */
   string getMethodName() { result = node.getExpr().(MethodCall).getMethodName() }
+
+  /** Gets the number of arguments of this call. */
+  int getNumberOfArguments() { result = node.getNumberOfArguments() }
+
+  /** Gets the block of this call. */
+  Node getBlock() { result.asExpr() = node.getBlock() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -84,8 +84,6 @@ private class CallAgainstConfig extends DataFlow::CallNode {
   CallAgainstConfig() { this.getReceiver() instanceof ConfigNode }
 
   MethodCall getCall() { result = this.asExpr().getExpr() }
-
-  Block getBlock() { result = this.getCall().getBlock() }
 }
 
 private class ActionControllerConfigNode extends DataFlow::Node {

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -68,7 +68,7 @@ private class ConfigSourceNode extends DataFlow::LocalSourceNode {
       configCall = this.asExpr().getExpr()
     |
       configureCallNode = getAConfigureCallNode() and
-      block = configureCallNode.asExpr().getExpr().(MethodCall).getBlock() and
+      block = configureCallNode.getBlock().asExpr().getExpr() and
       configCall.getParent+() = block and
       configCall.getMethodName() = "config"
     )

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -26,8 +26,6 @@ class KernelMethodCall extends DataFlow::CallNode {
       )
     )
   }
-
-  int getNumberOfArguments() { result = methodCall.getNumberOfArguments() }
 }
 
 /**


### PR DESCRIPTION
I've run into a few more cases where these predicates would be convenient, so it seems to make sense to put them in `DataFlow::CallNode` itself.