### PR TITLE
C++: Fix join order in `isArgumentForParameter`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -266,6 +266,20 @@ private predicate operandReturned(Operand operand, IntValue bitOffset) {
   bitOffset = Ints::unknown()
 }
 
+pragma[nomagic]
+private predicate initializeParameterInstructionHasVariable(
+  IRVariable var, InitializeParameterInstruction init
+) {
+  init.getIRVariable() = var
+}
+
+private predicate instructionInitializesThisInFunction(
+  Language::Function f, InitializeParameterInstruction init
+) {
+  initializeParameterInstructionHasVariable(any(IRThisVariable var), pragma[only_bind_into](init)) and
+  init.getEnclosingFunction() = f
+}
+
 private predicate isArgumentForParameter(
   CallInstruction ci, Operand operand, InitializeParameterInstruction init
 ) {
@@ -275,8 +289,7 @@ private predicate isArgumentForParameter(
     (
       init.getParameter() = f.getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
-      init.getIRVariable() instanceof IRThisVariable and
-      unique( | | init.getEnclosingFunction()) = f and
+      instructionInitializesThisInFunction(f, init) and
       operand instanceof ThisArgumentOperand
     ) and
     not Language::isFunctionVirtual(f) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -266,6 +266,20 @@ private predicate operandReturned(Operand operand, IntValue bitOffset) {
   bitOffset = Ints::unknown()
 }
 
+pragma[nomagic]
+private predicate initializeParameterInstructionHasVariable(
+  IRVariable var, InitializeParameterInstruction init
+) {
+  init.getIRVariable() = var
+}
+
+private predicate instructionInitializesThisInFunction(
+  Language::Function f, InitializeParameterInstruction init
+) {
+  initializeParameterInstructionHasVariable(any(IRThisVariable var), pragma[only_bind_into](init)) and
+  init.getEnclosingFunction() = f
+}
+
 private predicate isArgumentForParameter(
   CallInstruction ci, Operand operand, InitializeParameterInstruction init
 ) {
@@ -275,8 +289,7 @@ private predicate isArgumentForParameter(
     (
       init.getParameter() = f.getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
-      init.getIRVariable() instanceof IRThisVariable and
-      unique( | | init.getEnclosingFunction()) = f and
+      instructionInitializesThisInFunction(f, init) and
       operand instanceof ThisArgumentOperand
     ) and
     not Language::isFunctionVirtual(f) and

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -266,6 +266,20 @@ private predicate operandReturned(Operand operand, IntValue bitOffset) {
   bitOffset = Ints::unknown()
 }
 
+pragma[nomagic]
+private predicate initializeParameterInstructionHasVariable(
+  IRVariable var, InitializeParameterInstruction init
+) {
+  init.getIRVariable() = var
+}
+
+private predicate instructionInitializesThisInFunction(
+  Language::Function f, InitializeParameterInstruction init
+) {
+  initializeParameterInstructionHasVariable(any(IRThisVariable var), pragma[only_bind_into](init)) and
+  init.getEnclosingFunction() = f
+}
+
 private predicate isArgumentForParameter(
   CallInstruction ci, Operand operand, InitializeParameterInstruction init
 ) {
@@ -275,8 +289,7 @@ private predicate isArgumentForParameter(
     (
       init.getParameter() = f.getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
-      init.getIRVariable() instanceof IRThisVariable and
-      unique( | | init.getEnclosingFunction()) = f and
+      instructionInitializesThisInFunction(f, init) and
       operand instanceof ThisArgumentOperand
     ) and
     not Language::isFunctionVirtual(f) and


### PR DESCRIPTION
This join was previously fixed in https://github.com/github/codeql/pull/3813, but it seems like it's broken again. This is another attempt that will hopefully be more robust.

`main` (on ChakraCore):
```ql
Tuple counts for AliasAnalysis::isArgumentForParameter#fff/3@5f8d3acp after 1.7s:
  1040290  ~0%      {3} r1 = JOIN Operand::NonPhiOperand#fff_10#join_rhs WITH Instruction::CallInstruction::getStaticCallTarget_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'operand', Lhs.0 'ci', Rhs.1
  942858   ~0%      {3} r2 = r1 AND NOT IRCppLanguage::isFunctionVirtual#f(Lhs.2)
  937251   ~0%      {3} r3 = r2 AND NOT Alias::AliasFunction#class#f(Lhs.2)
  
  937251   ~0%      {3} r4 = r3 AND NOT IRCppLanguage::isFunctionVirtual#f(Lhs.2)
  937251   ~0%      {3} r5 = r4 AND NOT Alias::AliasFunction#class#f(Lhs.2)
  391018   ~2%      {4} r6 = JOIN r5 WITH Operand::PositionalArgumentOperand::getIndex_dispred#ff ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.0 'operand', Lhs.1 'ci'
  387998   ~0%      {3} r7 = JOIN r6 WITH Function::Function::getParameter_dispred#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.2 'operand', Lhs.3 'ci'
  316602   ~13%     {3} r8 = JOIN r7 WITH Instruction::InitializeParameterInstruction::getParameter_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'init', Lhs.1 'operand', Lhs.2 'ci'
  316602   ~4%      {3} r9 = JOIN r8 WITH project#Instruction::InitializeParameterInstruction#class#ff ON FIRST 1 OUTPUT Lhs.2 'ci', Lhs.1 'operand', Lhs.0 'init'
  
  219363   ~0%      {3} r10 = JOIN r3 WITH Operand::ThisArgumentOperand#class#ffff ON FIRST 1 OUTPUT Lhs.0 'operand', Lhs.1 'ci', Lhs.2
  219363   ~0%      {3} r11 = r10 AND NOT IRCppLanguage::isFunctionVirtual#f(Lhs.2)
  219363   ~0%      {3} r12 = r11 AND NOT Alias::AliasFunction#class#f(Lhs.2)
  219363   ~0%      {3} r13 = SCAN r12 OUTPUT In.2, In.0 'operand', In.1 'ci'
  10784166 ~0%      {3} r14 = JOIN r13 WITH AliasAnalysis::isArgumentForParameter#fff#join_rhs ON FIRST 1 OUTPUT Rhs.1 'init', Lhs.1 'operand', Lhs.2 'ci'
  366572   ~1%      {3} r15 = JOIN r14 WITH project#Instruction::InitializeParameterInstruction#class#ff ON FIRST 1 OUTPUT Lhs.0 'init', Lhs.1 'operand', Lhs.2 'ci'
  367997   ~0%      {4} r16 = JOIN r15 WITH IRConstruction::Raw::getInstructionVariable#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'operand', Lhs.2 'ci', Lhs.0 'init'
  190284   ~3%      {3} r17 = JOIN r16 WITH IRVariable::IRThisVariable#class#fffff ON FIRST 1 OUTPUT Lhs.2 'ci', Lhs.1 'operand', Lhs.3 'init'
  
  506886   ~4%      {3} r18 = r9 UNION r17
                    return r18
```
This PR:
```ql
[2021-12-14 13:29:29] (167s) Tuple counts for AliasAnalysis::initializeParameterInstructionHasVariable#ff/2@b2762c2g after 13ms:
  193946 ~0%     {2} r1 = JOIN project#Instruction::InitializeParameterInstruction#class#ff WITH IRConstruction::Raw::getInstructionVariable#ff ON FIRST 1 OUTPUT Rhs.1 'var', Lhs.0 'init'
                  return r1
...
[2021-12-14 13:29:29] (167s) Tuple counts for AliasAnalysis::instructionInitializesThisInFunction#ff/2@aa4c75mm after 11ms:
  60518 ~0%     {1} r1 = SCAN IRVariable::IRThisVariable#class#fffff OUTPUT In.0
  60518 ~1%     {1} r2 = JOIN r1 WITH AliasAnalysis::initializeParameterInstructionHasVariable#ff ON FIRST 1 OUTPUT Rhs.1 'init'
  60518 ~1%     {1} r3 = JOIN r2 WITH project#Instruction::InitializeParameterInstruction#class#ff ON FIRST 1 OUTPUT Lhs.0 'init'
  60518 ~0%     {2} r4 = JOIN r3 WITH Instruction::Instruction::getEnclosingIRFunction_dispred#2#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'init'
  60518 ~4%     {2} r5 = JOIN r4 WITH IRFunctionBase::IRFunctionBase#ff ON FIRST 1 OUTPUT Rhs.1 'f', Lhs.1 'init'
                return r5
...
Tuple counts for AliasAnalysis::isArgumentForParameter#fff/3@b135b8cc after 1.1s:
  1040290 ~0%     {3} r1 = JOIN Operand::NonPhiOperand#fff_10#join_rhs WITH Instruction::CallInstruction::getStaticCallTarget_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'operand', Lhs.0 'ci', Rhs.1
  942858  ~0%     {3} r2 = r1 AND NOT IRCppLanguage::isFunctionVirtual#f(Lhs.2)
  937251  ~0%     {3} r3 = r2 AND NOT Alias::AliasFunction#class#f(Lhs.2)
  
  219363  ~0%     {3} r4 = JOIN r3 WITH Operand::ThisArgumentOperand#class#ffff ON FIRST 1 OUTPUT Lhs.0 'operand', Lhs.1 'ci', Lhs.2
  219363  ~0%     {3} r5 = r4 AND NOT IRCppLanguage::isFunctionVirtual#f(Lhs.2)
  219363  ~0%     {3} r6 = r5 AND NOT Alias::AliasFunction#class#f(Lhs.2)
  219363  ~9%     {3} r7 = SCAN r6 OUTPUT In.2, In.0 'operand', In.1 'ci'
  190284  ~0%     {3} r8 = JOIN r7 WITH AliasAnalysis::instructionInitializesThisInFunction#ff ON FIRST 1 OUTPUT Lhs.2 'ci', Lhs.1 'operand', Rhs.1 'init'
  
  937251  ~0%     {3} r9 = r3 AND NOT IRCppLanguage::isFunctionVirtual#f(Lhs.2)
  937251  ~0%     {3} r10 = r9 AND NOT Alias::AliasFunction#class#f(Lhs.2)
  391018  ~2%     {4} r11 = JOIN r10 WITH Operand::PositionalArgumentOperand::getIndex_dispred#ff ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.0 'operand', Lhs.1 'ci'
  387998  ~0%     {3} r12 = JOIN r11 WITH Function::Function::getParameter_dispred#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.2 'operand', Lhs.3 'ci'
  316602  ~4%     {3} r13 = JOIN r12 WITH Instruction::InitializeParameterInstruction::getParameter_dispred#ff_10#join_rhs ON FIRST 1 OUTPUT Lhs.2 'ci', Lhs.1 'operand', Rhs.1 'init'
  
  506886  ~0%     {3} r14 = r8 UNION r13
                  return r14
```