### PR TITLE
Ruby: SimpleParameter should not be an Expr

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/Erb.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Erb.qll
@@ -118,7 +118,7 @@ private class ErbDirectiveFile extends File {
 
   /** Gets a statement in this file. */
   pragma[nomagic]
-  Stmt getAStmt(int startLine, int startColumn) {
+  AstNode getAnAstNode(int startLine, int startColumn) {
     exists(Location loc |
       result.getLocation() = loc and
       loc.getFile() = this and
@@ -142,13 +142,13 @@ class ErbDirective extends TDirectiveNode, ErbAstNode {
     )
   }
 
-  private predicate containsStmtStart(Stmt s) {
+  private predicate containsAstNodeStart(AstNode s) {
     // `Toplevel` statements are not contained within individual directives,
     // though their start location may appear within a directive location
     not s instanceof Toplevel and
     exists(ErbDirectiveFile file, int startLine, int startColumn |
       this.spans(file, startLine) and
-      s = file.getAStmt(startLine, startColumn) and
+      s = file.getAnAstNode(startLine, startColumn) and
       locationIncludesPosition(this.getLocation(), startLine, startColumn)
     )
   }
@@ -158,8 +158,8 @@ class ErbDirective extends TDirectiveNode, ErbAstNode {
    * statement starting in this directive.
    */
   Stmt getAChildStmt() {
-    this.containsStmtStart(result) and
-    not this.containsStmtStart(parent*(result).getParent())
+    this.containsAstNodeStart(result) and
+    not this.containsAstNodeStart(result.getParent())
   }
 
   /**
@@ -181,11 +181,6 @@ class ErbDirective extends TDirectiveNode, ErbAstNode {
   override string toString() { result = "erb directive" }
 
   override string getAPrimaryQlClass() { result = "ErbDirective" }
-}
-
-private AstNode parent(AstNode n) {
-  result = n.getParent() and
-  not result instanceof Stmt
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/ast/Erb.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Erb.qll
@@ -159,7 +159,7 @@ class ErbDirective extends TDirectiveNode, ErbAstNode {
    */
   Stmt getAChildStmt() {
     this.containsStmtStart(result) and
-    not this.containsStmtStart(result.getParent())
+    not this.containsStmtStart(parent*(result).getParent())
   }
 
   /**
@@ -181,6 +181,11 @@ class ErbDirective extends TDirectiveNode, ErbAstNode {
   override string toString() { result = "erb directive" }
 
   override string getAPrimaryQlClass() { result = "ErbDirective" }
+}
+
+private AstNode parent(AstNode n) {
+  result = n.getParent() and
+  not result instanceof Stmt
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/ast/Pattern.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Pattern.qll
@@ -28,14 +28,12 @@ deprecated class Pattern extends AstNode {
   Variable getAVariable() { none() }
 }
 
-deprecated private class TVariablePattern = TVariableAccess or TSimpleParameter;
-
 /**
  * DEPRECATED
  *
  * A simple variable pattern.
  */
-deprecated class VariablePattern extends Pattern, LhsExpr, TVariablePattern {
+deprecated class VariablePattern extends Pattern, LhsExpr, TVariableAccess {
   override Variable getAVariable() { result = this.(VariableAccess).getVariable() }
 }
 

--- a/ruby/ql/lib/codeql/ruby/ast/internal/AST.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/AST.qll
@@ -660,7 +660,7 @@ class TExpr =
   TSelf or TArgumentList or TInClause or TRescueClause or TRescueModifierExpr or TPair or
       TStringConcatenation or TCall or TBlockArgument or TConstantAccess or TControlExpr or
       TWhenExpr or TLiteral or TCallable or TVariableAccess or TStmtSequence or TOperation or
-      TSimpleParameter or TForwardArgument or TDestructuredLhsExpr;
+      TForwardArgument or TDestructuredLhsExpr;
 
 class TSplatExpr = TSplatExprReal or TSplatExprSynth;
 

--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -227,7 +227,7 @@ private module Shared {
       isHelperMethod(helperMethod, name, template) and
       isMethodCall(helperMethodCall.getExpr(), name, template) and
       helperMethodCall.getArgument(pragma[only_bind_into](argIdx)) = node1.asExpr() and
-      helperMethod.getParameter(pragma[only_bind_into](argIdx)) = node2.asExpr().getExpr()
+      helperMethod.getParameter(pragma[only_bind_into](argIdx)) = node2.asParameter()
     )
   }
 


### PR DESCRIPTION
PR #7394 makes all expressions "post-order" nodes in the control flow graph except for [`SimpleParameter`](https://github.com/github/codeql/pull/7394/files#diff-32ce71534428bfb48247fdc1f6ca40704b369d31bb38b73e2972cadd97367b1aR1) . I think parameters should not be instance of `Expr` , therefore, this pull requests removes the `Expr` class from the super class list of `SimpleParameter`. 