### PR TITLE
C++: Fix FP in `cpp/comparison-of-identical-expressions`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonWithCancelingSubExpr.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/ComparisonWithCancelingSubExpr.ql
@@ -85,7 +85,8 @@ private predicate cancelingSubExprs(ComparisonOperation cmp, VariableAccess a1, 
   exists(Variable v |
     exists(float m | m < 0 and cmpLinearSubVariable(cmp, v, a1, m)) and
     exists(float m | m > 0 and cmpLinearSubVariable(cmp, v, a2, m))
-  )
+  ) and
+  not any(ClassTemplateInstantiation inst).getATemplateArgument() = cmp.getParent*()
 }
 
 from ComparisonOperation cmp, VariableAccess a1, VariableAccess a2

--- a/cpp/ql/src/Likely Bugs/Arithmetic/PointlessSelfComparison.qll
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/PointlessSelfComparison.qll
@@ -29,7 +29,9 @@ predicate pointlessSelfComparison(ComparisonOperation cmp) {
     not exists(lhs.getQualifier()) and // Avoid structure fields
     not exists(rhs.getQualifier()) and // Avoid structure fields
     not convertedExprMightOverflow(lhs) and
-    not convertedExprMightOverflow(rhs)
+    not convertedExprMightOverflow(rhs) and
+    // Don't warn if the comparison is part of a template argument.
+    not any(ClassTemplateInstantiation inst).getATemplateArgument() = cmp.getParent*()
   )
 }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
@@ -1,5 +1,4 @@
 | templates.cpp:17:5:17:25 | ... < ... | Self comparison. |
-| templates.cpp:31:20:31:41 | ... <= ... | Self comparison. |
 | test.cpp:13:11:13:21 | ... == ... | Self comparison. |
 | test.cpp:79:11:79:32 | ... == ... | Self comparison. |
 | test.cpp:83:10:83:15 | ... == ... | Self comparison. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/PointlessSelfComparison.expected
@@ -1,4 +1,5 @@
 | templates.cpp:17:5:17:25 | ... < ... | Self comparison. |
+| templates.cpp:31:20:31:41 | ... <= ... | Self comparison. |
 | test.cpp:13:11:13:21 | ... == ... | Self comparison. |
 | test.cpp:79:11:79:32 | ... == ... | Self comparison. |
 | test.cpp:83:10:83:15 | ... == ... | Self comparison. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
@@ -37,5 +37,5 @@ struct Value0 {
 };
 
 void instantiation_with_pointless_comparison() {
-  constant_comparison<Value0, Value0>();
+  constant_comparison<Value0, Value0>(); // GOOD
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/BadAdditionOverflowCheck/templates.cpp
@@ -20,3 +20,22 @@ bool compareValues() {
 bool callCompareValues() {
   return compareValues<C1, C2> || compareValues<C1, C1>();
 }
+
+template <bool C, typename T = void>
+struct enable_if {};
+
+template <typename T>
+struct enable_if<true, T> { typedef T type; };
+
+template<typename T1, typename T2>
+typename enable_if<T1::value <= T2::value, bool>::type constant_comparison() {
+  return true;
+}
+
+struct Value0 {
+  const static int value = 0;
+};
+
+void instantiation_with_pointless_comparison() {
+  constant_comparison<Value0, Value0>();
+}


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/7385.

Initially, I wanted to add this case to `Expr.isUnevaluated` since that would make this fix apply more broadly. But I guess, `Expr.isUnevaluated` shouldn't hold for things that are evaluated _at compile-time only_. So for now I've just special-cased this in the query containing the actual FP report.