### PR TITLE
JS: track functions with methods

### DIFF
--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -81,6 +81,8 @@ typeInferenceMismatch
 | exceptions.js:144:9:144:16 | source() | exceptions.js:132:8:132:27 | returnThrownSource() |
 | exceptions.js:150:13:150:20 | source() | exceptions.js:153:10:153:10 | e |
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
+| factory-function.js:21:13:21:20 | source() | factory-function.js:7:10:7:12 | obj |
+| factory-function.js:22:13:22:20 | source() | factory-function.js:7:10:7:12 | obj |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:9:10:9:18 | new C().x |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:13:18:13:20 | c.x |
 | getters-and-setters.js:27:15:27:22 | source() | getters-and-setters.js:23:18:23:18 | v |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -83,6 +83,8 @@ typeInferenceMismatch
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
 | factory-function.js:21:13:21:20 | source() | factory-function.js:7:10:7:12 | obj |
 | factory-function.js:22:13:22:20 | source() | factory-function.js:7:10:7:12 | obj |
+| factory-function.js:26:7:26:14 | source() | factory-function.js:16:14:16:16 | obj |
+| factory-function.js:27:7:27:14 | source() | factory-function.js:16:14:16:16 | obj |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:9:10:9:18 | new C().x |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:13:18:13:20 | c.x |
 | getters-and-setters.js:27:15:27:22 | source() | getters-and-setters.js:23:18:23:18 | v |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -43,6 +43,8 @@
 | exceptions.js:144:9:144:16 | source() | exceptions.js:132:8:132:27 | returnThrownSource() |
 | exceptions.js:150:13:150:20 | source() | exceptions.js:153:10:153:10 | e |
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
+| factory-function.js:21:13:21:20 | source() | factory-function.js:7:10:7:12 | obj |
+| factory-function.js:22:13:22:20 | source() | factory-function.js:7:10:7:12 | obj |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:9:10:9:18 | new C().x |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:13:18:13:20 | c.x |
 | getters-and-setters.js:27:15:27:22 | source() | getters-and-setters.js:23:18:23:18 | v |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -45,6 +45,8 @@
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
 | factory-function.js:21:13:21:20 | source() | factory-function.js:7:10:7:12 | obj |
 | factory-function.js:22:13:22:20 | source() | factory-function.js:7:10:7:12 | obj |
+| factory-function.js:26:7:26:14 | source() | factory-function.js:16:14:16:16 | obj |
+| factory-function.js:27:7:27:14 | source() | factory-function.js:16:14:16:16 | obj |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:9:10:9:18 | new C().x |
 | getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:13:18:13:20 | c.x |
 | getters-and-setters.js:27:15:27:22 | source() | getters-and-setters.js:23:18:23:18 | v |

--- a/javascript/ql/test/library-tests/TaintTracking/factory-function.js
+++ b/javascript/ql/test/library-tests/TaintTracking/factory-function.js
@@ -1,0 +1,27 @@
+import * as dummy from 'dummy';
+
+var objectA = function(){
+    return {};
+}
+objectA.set = function (obj){
+    sink(obj);
+};
+
+function factory() {
+    var objectB = function(){
+        return {};
+    }
+
+    objectB.set = function (obj){
+        sink(obj); // NOT OK
+    };
+    return objectB;
+}
+
+objectA.set(source());
+objectA.set(source());
+
+factory();
+b = factory();
+b.set(source())
+b.set(source())


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/7106 by tracking functions with methods.

Evaluations:
- [Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/track-functions__default__dist-compare__3/reports) on default slugs looks ok (unfortunately the meta-queries don't currently works on default slugs)
- [Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/track-functions__smoke-test__smoke-test/reports) on smoke test shows 1 new call edge
