### PR TITLE
Remove experimental tag from non-ATM queries

### DIFF
--- a/python/ql/src/experimental/Security/CWE-090/LDAPInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-090/LDAPInjection.ql
@@ -5,8 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @id py/ldap-injection
- * @tags experimental	
- *       security	
+ * @tags security	
  *       external/cwe/cwe-090
  */
 

--- a/python/ql/src/experimental/Security/CWE-287/ImproperLdapAuth.ql
+++ b/python/ql/src/experimental/Security/CWE-287/ImproperLdapAuth.ql
@@ -4,8 +4,7 @@
  * @kind problem
  * @problem.severity warning
  * @id py/improper-ldap-auth
- * @tags experimental
- *       security
+ * @tags security
  *       external/cwe/cwe-287
  */
 

--- a/python/ql/src/experimental/Security/CWE-522/LDAPInsecureAuth.ql
+++ b/python/ql/src/experimental/Security/CWE-522/LDAPInsecureAuth.ql
@@ -4,8 +4,7 @@
  * @kind path-problem
  * @problem.severity error
  * @id py/insecure-ldap-auth
- * @tags experimental
- *       security
+ * @tags security
  *       external/cwe/cwe-522
  *       external/cwe/cwe-523
  */

--- a/python/ql/src/experimental/Security/CWE-943/NoSQLInjection.ql
+++ b/python/ql/src/experimental/Security/CWE-943/NoSQLInjection.ql
@@ -5,8 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @id py/nosql-injection
- * @tags experimental
- *       security
+ * @tags security
  *       external/cwe/cwe-943
  */
 


### PR DESCRIPTION
When https://github.com/github/code-scanning/issues/4291 ships, we will be using the `experimental` tag on CodeQL queries as a signifier for Adaptive Threat Modeling boosted queries, and showing extra UI around them like this:

![image](https://user-images.githubusercontent.com/1507328/146223777-4fdc4ac4-734a-440b-a9f4-9b4700ff3ad2.png)

We therefore don't want to use this tag for queries that aren't to do with ATM, hence this PR.

@henrymercer @AlonaHlobina 