### PR TITLE
Java: Start running telemetry queries on Code Scanning

### DIFF
--- a/java/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/java/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -2,7 +2,7 @@
  * @name External libraries
  * @description A list of external libraries used in the code
  * @kind metric
- * @metricType callable
+ * @tags summary
  * @id java/telemetry/external-libs
  */
 

--- a/java/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -1,9 +1,9 @@
 /**
  * @name Supported sinks in external libraries
  * @description A list of 3rd party APIs detected as sinks. Excludes test and generated code.
- * @id java/telemetry/supported-external-api-sinks
  * @kind metric
- * @metricType callable
+ * @tags summary
+ * @id java/telemetry/supported-external-api-sinks
  */
 
 import java

--- a/java/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSources.ql
@@ -1,9 +1,9 @@
 /**
  * @name Supported sources in external libraries
  * @description A list of 3rd party APIs detected as sources. Excludes test and generated code.
- * @id java/telemetry/supported-external-api-sources
  * @kind metric
- * @metricType callable
+ * @tags summary
+ * @id java/telemetry/supported-external-api-sources
  */
 
 import java

--- a/java/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/java/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -1,9 +1,9 @@
 /**
  * @name Supported sinks in external libraries
  * @description A list of 3rd party APIs detected as sinks. Excludes test and generated code.
- * @id java/telemetry/supported-external-api-taint
  * @kind metric
- * @metricType callable
+ * @tags summary
+ * @id java/telemetry/supported-external-api-taint
  */
 
 import java

--- a/java/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/java/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -1,6 +1,6 @@
 /**
- * @name Supported sinks in external libraries
- * @description A list of 3rd party APIs detected as sinks. Excludes test and generated code.
+ * @name Supported flow steps in external libraries
+ * @description A list of 3rd party APIs detected as flow steps. Excludes test and generated code.
  * @kind metric
  * @tags summary
  * @id java/telemetry/supported-external-api-taint

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -1,9 +1,9 @@
 /**
  * @name Usage of unsupported APIs coming from external libraries
  * @description A list of 3rd party APIs used in the codebase. Excludes test and generated code.
- * @id java/telemetry/unsupported-external-api
  * @kind metric
- * @metricType callable
+ * @tags summary
+ * @id java/telemetry/unsupported-external-api
  */
 
 import java


### PR DESCRIPTION
This PR incorporates the telemetry queries for Java into the summary metrics framework.  Specifically we use the support for summary metrics with messages that was introduced in CodeQL CLI v2.8.0.

This has a few effects:

1. We'll start running these queries on Code Scanning.
2. We will start displaying a summary output of these queries in the metrics summary table produced on Code Scanning and in the CLI (see example below).
3. We can ingest the results of these queries as part of generic internal pipelines that operate on summary metrics.

<details>
<summary>Example metrics summary table additions</summary>

```
Analysis produced the following metric data:

|                          Metric                          |      Value     |
+----------------------------------------------------------+----------------+
| Supported sinks in external libraries                    |  (574 results) |
| Usage of unsupported APIs coming from external libraries | (3949 results) |
| Supported sources in external libraries                  |   (15 results) |
| External libraries                                       |   (75 results) |
| Supported sinks in external libraries                    |   (22 results) |
```

</details>

/cc @bmuskalla @turbo @yo-h