### PR TITLE
Add `kind` metadata to example query.

### DIFF
--- a/javascript/ql/examples/snippets/todocomment.ql
+++ b/javascript/ql/examples/snippets/todocomment.ql
@@ -3,6 +3,7 @@
  * @name TODO comments
  * @description Finds comments containing the word TODO
  * @kind problem
+ * @problem.severity recommendation
  * @tags comment
  *       TODO
  */
@@ -11,4 +12,4 @@ import javascript
 
 from Comment c
 where c.getText().regexpMatch("(?si).*\\bTODO\\b.*")
-select c
+select c, "TODO comments indicate that the code may not be complete."

--- a/javascript/ql/examples/snippets/todocomment.ql
+++ b/javascript/ql/examples/snippets/todocomment.ql
@@ -2,6 +2,7 @@
  * @id js/examples/todocomment
  * @name TODO comments
  * @description Finds comments containing the word TODO
+ * @kind problem
  * @tags comment
  *       TODO
  */


### PR DESCRIPTION
This is just an example query, but it would be nice for people trying to run it if it had the `kind` metadata so its results can be interpreted.