### PR TITLE
C++: Fix join-order in `phi_node` predicate.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
@@ -153,9 +153,11 @@ library class SSAHelper extends int {
    * Modern Compiler Implementation by Andrew Appel.
    */
   private predicate frontier_phi_node(StackVariable v, BasicBlock b) {
-    exists(BasicBlock x | dominanceFrontier(pragma[only_bind_into](x), b) and ssa_defn_rec(v, x)) and
+    exists(BasicBlock x |
+      dominanceFrontier(x, pragma[only_bind_into](b)) and ssa_defn_rec(pragma[only_bind_into](v), x)
+    ) and
     /* We can also eliminate those nodes where the variable is not live on any incoming edge */
-    live_at_start_of_bb(v, b)
+    live_at_start_of_bb(pragma[only_bind_into](v), b)
   }
 
   private predicate ssa_defn_rec(StackVariable v, BasicBlock b) {

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
@@ -153,7 +153,7 @@ library class SSAHelper extends int {
    * Modern Compiler Implementation by Andrew Appel.
    */
   private predicate frontier_phi_node(StackVariable v, BasicBlock b) {
-    exists(BasicBlock x | dominanceFrontier(x, b) and ssa_defn_rec(v, x)) and
+    exists(BasicBlock x | dominanceFrontier(pragma[only_bind_into](x), b) and ssa_defn_rec(v, x)) and
     /* We can also eliminate those nodes where the variable is not live on any incoming edge */
     live_at_start_of_bb(v, b)
   }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/SSAUtils.qll
@@ -154,7 +154,7 @@ library class SSAHelper extends int {
    */
   private predicate frontier_phi_node(StackVariable v, BasicBlock b) {
     exists(BasicBlock x |
-      dominanceFrontier(x, pragma[only_bind_into](b)) and ssa_defn_rec(pragma[only_bind_into](v), x)
+      dominanceFrontier(x, b) and ssa_defn_rec(pragma[only_bind_into](v), pragma[only_bind_into](x))
     ) and
     /* We can also eliminate those nodes where the variable is not live on any incoming edge */
     live_at_start_of_bb(pragma[only_bind_into](v), b)


### PR DESCRIPTION
On main (on `php`):
```ql
Tuple counts for SSAUtils::SSAHelper::phi_node#fff/3@i2#c6b1fxk6 after 7.7s:
  256024    ~0%      {3} r1 = SCAN SSAUtils::SSAHelper::ssa_defn_rec_dispred#fff#prev_delta OUTPUT In.1 'v', In.0 'this', In.2
  104208654 ~0%      {4} r2 = JOIN r1 WITH SSAUtils::live_at_start_of_bb#ff ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0 'v', Lhs.2, Rhs.1 'b'
  90588757  ~0%      {4} r3 = r2 AND NOT SSAUtils::SSAHelper::phi_node#fff#prev(Lhs.0 'this', Lhs.1 'v', Lhs.3 'b')
  90588757  ~2%      {4} r4 = SCAN r3 OUTPUT In.2, In.3 'b', In.0 'this', In.1 'v'
  82651     ~79%     {3} r5 = JOIN r4 WITH SSAUtils::dominanceFrontier#ff ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.3 'v', Lhs.1 'b'
                      return r5
...
>>> Created relation SSAUtils::SSAHelper::phi_node_dispred#fff/3@80af8ckn with 155170 rows.
```

On this PR:
```ql

Tuple counts for SSAUtils::SSAHelper::phi_node_dispred#fff/3@i2#c9f58w5t after 103ms:
  256024 ~2%      {3} r1 = SCAN SSAUtils::SSAHelper::ssa_defn_rec_dispred#fff#prev_delta OUTPUT In.2, In.0 'this', In.1 'v'
  196746 ~64%     {3} r2 = JOIN r1 WITH SSAUtils::dominanceFrontier#ff ON FIRST 1 OUTPUT Rhs.1 'b', Lhs.1 'this', Lhs.2 'v'
  124032 ~6%      {3} r3 = r2 AND NOT SSAUtils::SSAHelper::phi_node_dispred#fff#prev(Lhs.1 'this', Lhs.2 'v', Lhs.0 'b')
  124032 ~2%      {3} r4 = SCAN r3 OUTPUT In.2 'v', In.0 'b', In.1 'this'
  44842  ~0%      {3} r5 = JOIN r4 WITH SSAUtils::live_at_start_of_bb#ff ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.0 'v', Lhs.1 'b'
                  return r5
...
>>> Created relation SSAUtils::SSAHelper::phi_node_dispred#fff/3@c9f58w5t with 155170 rows.
```

It's slightly difficult to compare the tuple counts on a per-iteration basis, so I've included the final tuple counts in the resulting predicate to show that the number of tuples doesn't change.