### PR TITLE
JS: DB reads as taint sources

### DIFF
--- a/javascript/ql/lib/semmle/javascript/Concepts.qll
+++ b/javascript/ql/lib/semmle/javascript/Concepts.qll
@@ -89,16 +89,6 @@ abstract class DatabaseAccess extends DataFlow::Node {
   DataFlow::Node getAResult() {
     none() // Overridden in subclass
   }
-
-  /**
-   * Holds if the data returned can be a user-controlled object,
-   * such as a JSON object parsed from user-controlled data.
-   */
-  predicate returnsUserControlledObject() {
-    // NB: Most data bases support JSON data (some via plugins),
-    // which is why this has a default implementation.
-    any()
-  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/Concepts.qll
+++ b/javascript/ql/lib/semmle/javascript/Concepts.qll
@@ -84,6 +84,21 @@ abstract class FileNameSource extends DataFlow::Node { }
 abstract class DatabaseAccess extends DataFlow::Node {
   /** Gets an argument to this database access that is interpreted as a query. */
   abstract DataFlow::Node getAQueryArgument();
+
+  /** Gets a node to which a result of the access may flow. */
+  DataFlow::Node getAResult() {
+    none() // Overridden in subclass
+  }
+
+  /**
+   * Holds if the data returned can be a user-controlled object,
+   * such as a JSON object parsed from user-controlled data.
+   */
+  predicate returnsUserControlledObject() {
+    // NB: Most data bases support JSON data (some via plugins),
+    // which is why this has a default implementation.
+    any()
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/Shared.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/Shared.qll
@@ -31,7 +31,7 @@
  *     - Instance: the value returned by a constructor call
  *     - Awaited: the value from a resolved promise/future-like object
  *     - WithArity[n]: match a call with the given arity. May be a range of form `x..y` (inclusive) and/or a comma-separated list.
- *     - Other langauge-specific tokens mentioned in `ModelsAsData.qll`.
+ *     - Other language-specific tokens mentioned in `ModelsAsData.qll`.
  * 4. The `input` and `output` columns specify how data enters and leaves the element selected by the
  *    first `(package, type, path)` tuple. Both strings are `.`-separated access paths
  *    of the same syntax as the `path` column.

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
@@ -61,7 +61,21 @@ class DatabaseAccessResultRemoteFlowSource extends HeuristicSource, RemoteFlowSo
 
   override string getSourceType() { result = "Database query result" }
 
+  override predicate isUserControlledObject() { any() }
+}
+
+/**
+ * A remote flow source originating from a database access.
+ */
+private class RemoteFlowSourceFromDBAccess extends RemoteFlowSource, HeuristicSource {
+  RemoteFlowSourceFromDBAccess() {
+    this = ModelOutput::getASourceNode("database-access-result").getAUse()
+  }
+
+  override string getSourceType() { result = "Database access" }
+
   override predicate isUserControlledObject() {
-    this.(DatabaseAccess).returnsUserControlledObject()
+    // NB. supported databases all might return JSON.
+    any()
   }
 }

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
@@ -54,22 +54,12 @@ class RemoteServerResponse extends HeuristicSource, RemoteFlowSource {
 }
 
 /**
- * The data read from a database.
- */
-class DatabaseAccessResultRemoteFlowSource extends HeuristicSource, RemoteFlowSource {
-  DatabaseAccessResultRemoteFlowSource() { exists(DatabaseAccess dba | this = dba.getAResult()) }
-
-  override string getSourceType() { result = "Database query result" }
-
-  override predicate isUserControlledObject() { any() }
-}
-
-/**
  * A remote flow source originating from a database access.
  */
 private class RemoteFlowSourceFromDBAccess extends RemoteFlowSource, HeuristicSource {
   RemoteFlowSourceFromDBAccess() {
-    this = ModelOutput::getASourceNode("database-access-result").getAUse()
+    this = ModelOutput::getASourceNode("database-access-result").getAUse() or
+    exists(DatabaseAccess dba | this = dba.getAResult())
   }
 
   override string getSourceType() { result = "Database access" }

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalSources.qll
@@ -14,7 +14,7 @@ private import semmle.javascript.security.dataflow.CommandInjectionCustomization
 abstract class HeuristicSource extends DataFlow::Node { }
 
 /**
- * An access to a password, viewed a source of remote flow.
+ * An access to a password, viewed as a source of remote flow.
  */
 private class RemoteFlowPassword extends HeuristicSource, RemoteFlowSource {
   RemoteFlowPassword() { isReadFrom(this, "(?is).*(password|passwd).*") }
@@ -51,4 +51,17 @@ class RemoteServerResponse extends HeuristicSource, RemoteFlowSource {
   }
 
   override string getSourceType() { result = "a response from a remote server" }
+}
+
+/**
+ * The data read from a database.
+ */
+class DatabaseAccessResultRemoteFlowSource extends HeuristicSource, RemoteFlowSource {
+  DatabaseAccessResultRemoteFlowSource() { exists(DatabaseAccess dba | this = dba.getAResult()) }
+
+  override string getSourceType() { result = "Database query result" }
+
+  override predicate isUserControlledObject() {
+    this.(DatabaseAccess).returnsUserControlledObject()
+  }
 }

--- a/javascript/ql/test/library-tests/Security/heuristics/HeuristicSink.ql
+++ b/javascript/ql/test/library-tests/Security/heuristics/HeuristicSink.ql
@@ -1,4 +1,4 @@
 import javascript
 private import semmle.javascript.heuristics.AdditionalSinks
 
-select any(HeuristicSink s)
+select any(HeuristicSink s | s.getFile().getBaseName() = "sinks.js")

--- a/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.expected
+++ b/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.expected
@@ -1,2 +1,0 @@
-| sources.js:2:5:2:12 | password |
-| sources.js:3:5:3:20 | JSON.stringify() |

--- a/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.ql
+++ b/javascript/ql/test/library-tests/Security/heuristics/HeuristicSource.ql
@@ -1,4 +1,13 @@
 import javascript
 private import semmle.javascript.heuristics.AdditionalSources
+import testUtilities.ConsistencyChecking
 
-select any(HeuristicSource s)
+class Taint extends TaintTracking::Configuration {
+  Taint() { this = "Taint" }
+
+  override predicate isSource(DataFlow::Node node) { node instanceof HeuristicSource }
+
+  override predicate isSink(DataFlow::Node node) {
+    node = any(DataFlow::CallNode call | call.getCalleeName() = "sink").getAnArgument()
+  }
+}

--- a/javascript/ql/test/library-tests/Security/heuristics/sources.js
+++ b/javascript/ql/test/library-tests/Security/heuristics/sources.js
@@ -1,9 +1,3 @@
-const pg = require('pg');
-const { Stream } = require('stream');
-const pool = new pg.Pool({});
-
-function sink(data) {}
-
 (function() {
     const password = '1234';
     sink(password); // NOT OK
@@ -130,6 +124,13 @@ function sink(data) {}
     const db = new Spanner({projectId: 'test'})
         .instance('instanceid')
         .database('databaseid');
+
+    db.executeSql('SELECT * FROM users', {}, function (err, users) {
+        sink(users); // NOT OK
+    });
+
+    const [users] = (await db.executeSql('SELECT * FROM users', {}));
+    sink(users); // NOT OK
     
     const spannerpromise = db.run({
         sql: 'SELECT * FROM users'
@@ -152,6 +153,7 @@ function sink(data) {}
         txn.run('SELECT * FROM users', function (err, users) {
             sink(users); // NOT OK
         });
+        txn.commit(function () {});
     });
 
     db.getSnapshot(function (err, txn) {

--- a/javascript/ql/test/library-tests/Security/heuristics/sources.js
+++ b/javascript/ql/test/library-tests/Security/heuristics/sources.js
@@ -1,4 +1,234 @@
+const pg = require('pg');
+const { Stream } = require('stream');
+const pool = new pg.Pool({});
+
+function sink(data) {}
+
 (function() {
-    password;
-    JSON.stringify();
+    const password = '1234';
+    sink(password); // NOT OK
+    
+    const s = JSON.stringify();
+    sink(s); // NOT OK
+})();
+
+(async function() {
+    const knex = require('knex');
+    
+    const users = knex().select('*').from('users');
+    users.then(function (users) {
+        sink(users); // NOT OK
+    });
+
+    users.asCallback(function (err, users) {
+        sink(users); // NOT OK
+    });
+
+    sink(await users); // NOT OK
+})();
+
+(function() {
+    const pg = require('pg');
+    
+    const pool = new pg.Pool({});
+    pool.connect(async function (err, client, done) {
+        client.query('SELECT * FROM users', function (err, users) {
+            sink(users);
+        });
+        
+        const thenable = client.query('SELECT * FROM users')
+        thenable.then(function(users) {
+            sink(users); // NOT OK
+        });
+
+        const pgpromise = client.query('SELECT * FROM users');
+        sink(await pgpromise); // NOT OK
+    });
+})();
+
+(async function () {
+    const pgpromise = require('pg-promise')();
+    const db = pgpromise('postgres://username:password@localhost:1234/database');
+    const pgppromise = db.any('SELECT * FROM users');
+
+    pgppromise.then(function (users) {
+        sink(users);
+    });
+
+    sink(await pgppromise);
+})();
+
+(function () {
+    const mysql = require('mysql2');
+    const conn = mysql.createConnection({});
+
+    conn.query(
+        'SELECT * FROM `users`',
+        function(err, users, fields) {
+          sink(users); // NOT OK
+        }
+    );
+
+    conn.execute(
+        'SELECT * FROM `users` WHERE name = ?',
+        ['Alice'],
+        function(err, users) {
+            sink(users);
+        }
+    );
+})();
+
+(async function () {
+    const sqlite = require('sqlite3');
+    const db = new sqlite.Database(':memory:');
+
+    db.all('SELECT * FROM users', function (err, users) {
+        sink(users); // NOT OK
+    });
+    
+    const sqlitepromise = db.all('SELECT * FROM users');
+
+    sink(await sqlitepromise); // NOT OK
+})();
+
+(async function () {
+    const { Sequelize } = require('sequelize');
+    const sequelize = new Sequelize('sqlite::memory:');
+
+    class User extends sequelize.Model {}
+    User.init({ name: sequelize.DataTypes.String }, { sequelize, modelName: 'user' });
+
+    sequelize.query('SELECT * FROM users').then(function (users) {
+        sink(users); // NOT OK
+    });
+})();
+
+(async function () {
+    const sql = require('mssql');
+    await sql.connect('...');
+    
+    sql.query('SELECT * FROM users', function (err, users) {
+        sink(users); // NOT OK
+    });
+
+    const mssqlthenable = sql.query('SELECT * FROM users');
+    
+    mssqlthenable.then(function (users) {
+        sink(users); // NOT OK
+    });
+
+    const mssqlpromise = sql.query('SELECT * FROM users');
+    sink(await mssqlpromise); // NOT OK
+
+    const uname = 'Alice';
+    const mssqltaggedquery = sql.query`SELECT * FROM users where name=${uname}`
+    sink(await mssqltaggedquery); // NOT OK
+})();
+
+(async function () {
+    const {Spanner} = require('@google-cloud/spanner');
+    const db = new Spanner({projectId: 'test'})
+        .instance('instanceid')
+        .database('databaseid');
+    
+    const spannerpromise = db.run({
+        sql: 'SELECT * FROM users'
+    });
+
+    sink(await spannerpromise); // NOT OK
+
+    db.run({
+        sql: 'SELECT * FROM users'
+    }, function (err, rows, stats, meta) {
+        sink(rows); // NOT OK
+    });
+
+    const client = new Spanner.v1.SpannerClient({});
+    client.executeSql('SELECT * FROM users', {}, function (err, users) {
+        sink(users); // NOT OK
+    });
+
+    db.runTransaction(function(err, txn) {
+        txn.run('SELECT * FROM users', function (err, users) {
+            sink(users); // NOT OK
+        });
+    });
+
+    db.getSnapshot(function (err, txn) {
+        txn.run('SELECT * FROM users', function (err, users) {
+            sink(users); // NOT OK
+        });
+        txn.end();
+    });
+})();
+
+(function () {
+    const { MongoClient } = require('mongodb');
+    
+    MongoClient.connect('mongodb://localhost:1234', async function (err, db) {
+        const collection = db.collection('users');
+        const users = await collection.find({});
+        sink(users); // NOT OK
+    });
+})();
+
+(async function () {
+    const mongoose = require('mongoose');
+    await mongoose.connect('mongodb://localhost:1234');
+
+    const User = mongoose.model('User', {
+        name: {
+            type: String,
+            unique: true
+        }
+    });
+
+    User.find({ name: 'Alice' }, function (err, alice) {
+        sink(alice); // NOT OK
+    });
+
+    User.find({ name: 'Bob' }).exec(function (err, bob) {
+        sink(bob); // NOT OK
+    });
+
+    const promise = User.find({ name: 'Claire' });
+    promise.then(c => sink(c)); // NOT OK
+})();
+
+(async function () {
+    const minimongo = require('minimongo');
+    const LocalDb = minimongo.MemoryDb;
+    const db = new LocalDb();
+    const doc = db.users;
+
+    const users = await doc.find({});
+    sink(users); // NOT OK
+})();
+
+(async function () {
+    const { Collection } = require('marsdb');
+    
+    const doc = new Collection('users');
+
+    const users = await doc.find({});
+    
+    sink(users); // NOT OK
+})();
+
+(async function () {
+    const redis = require("redis");
+    const client = redis.createClient();
+
+    const alice = await client.get('alice');
+
+    sink(alice); // NOT OK
+})();
+
+(async function () {
+    const Redis = require('ioredis');
+    const redis = new Redis();
+
+    const bob = await redis.get('bob');
+
+    sink(bob); // NOT OK
 })();


### PR DESCRIPTION
This adds DB reads as taint sources in `AdditionalSources.qll`.

~~**This is not yet complete**, as it's not handling streaming database queries where the result is consumed by a pipe call (eg, knex, spanner, have such features).~~
