### PR TITLE
C++: relax ambiguously-signed-bit-field by allowing GLib's gboolean

### DIFF
--- a/cpp/ql/src/Likely Bugs/AmbiguouslySignedBitField.ql
+++ b/cpp/ql/src/Likely Bugs/AmbiguouslySignedBitField.ql
@@ -26,6 +26,8 @@ where
   // At least for C programs on Windows, BOOL is a common typedef for a type
   // representing BoolType.
   not bf.getType().hasName("BOOL") and
+  // GLib's gboolean is a typedef for a type representing BoolType.
+  not bf.getType().hasName("gboolean") and
   // If this is true, then there cannot be unsigned sign extension or overflow.
   not bf.getDeclaredNumBits() = bf.getType().getSize() * 8 and
   not bf.isAnonymous() and

--- a/cpp/ql/src/change-notes/2021-12-30-ambiguously-signed-bit-field.md
+++ b/cpp/ql/src/change-notes/2021-12-30-ambiguously-signed-bit-field.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added exception for GLib's gboolean to cpp/ambiguously-signed-bit-field.
+  This change reduces the number of false positives in the query.


### PR DESCRIPTION
The gboolean type of GLib (a widely used C library) is a typedef to int.

It is meant to represent a simple true/false value.

Resolves #7491