### PR TITLE
Propagate taint through AbstractStringBuilder.reverse()

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/Strings.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Strings.qll
@@ -50,6 +50,8 @@ private class StringSummaryCsv extends SummaryModelCsv {
         "java.lang;AbstractStringBuilder;true;insert;;;Argument[-1];ReturnValue;value",
         "java.lang;AbstractStringBuilder;true;replace;;;Argument[-1];ReturnValue;value",
         "java.lang;AbstractStringBuilder;true;replace;;;Argument[2];Argument[-1];taint",
+        "java.lang;AbstractStringBuilder;true;reverse;;;Argument[-1];ReturnValue;value",
+        "java.lang;AbstractStringBuilder;true;reverse;;;Argument[-1];ReturnValue;taint",
         "java.lang;AbstractStringBuilder;true;toString;;;Argument[-1];ReturnValue;taint",
         "java.lang;StringBuffer;true;StringBuffer;(CharSequence);;Argument[0];Argument[-1];taint",
         "java.lang;StringBuffer;true;StringBuffer;(String);;Argument[0];Argument[-1];taint",

--- a/java/ql/lib/semmle/code/java/frameworks/Strings.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Strings.qll
@@ -51,7 +51,6 @@ private class StringSummaryCsv extends SummaryModelCsv {
         "java.lang;AbstractStringBuilder;true;replace;;;Argument[-1];ReturnValue;value",
         "java.lang;AbstractStringBuilder;true;replace;;;Argument[2];Argument[-1];taint",
         "java.lang;AbstractStringBuilder;true;reverse;;;Argument[-1];ReturnValue;value",
-        "java.lang;AbstractStringBuilder;true;reverse;;;Argument[-1];ReturnValue;taint",
         "java.lang;AbstractStringBuilder;true;toString;;;Argument[-1];ReturnValue;taint",
         "java.lang;StringBuffer;true;StringBuffer;(CharSequence);;Argument[0];Argument[-1];taint",
         "java.lang;StringBuffer;true;StringBuffer;(String);;Argument[0];Argument[-1];taint",


### PR DESCRIPTION
... and its overrides. Currently, we do not propagate taint through `AbstractStringBuilder.reverse()` calls, which leads us to miss out on results e.g. within [this webgoat example](https://github.com/zbazztian/webgoat-delombok/blob/main/webgoat-lessons/http-basics/src/main/java/org/owasp/webgoat/http_basics/HttpBasicsLesson.java#L43).

Is there a motivation for this or was this just an oversight?