### PR TITLE
Python: remove duplicated spaces in qldoc

### DIFF
--- a/python/ql/lib/semmle/python/Comparisons.qll
+++ b/python/ql/lib/semmle/python/Comparisons.qll
@@ -514,7 +514,7 @@ class ComparisonControlBlock extends ConditionBlock {
 
   Comparison getTest() { this.getLastNode() = result }
 
-  /** Whether this conditional guard implies that, in block `b`,  the result of `that` is `thatIsTrue` */
+  /** Whether this conditional guard implies that, in block `b`, the result of `that` is `thatIsTrue` */
   predicate impliesThat(BasicBlock b, Comparison that, boolean thatIsTrue) {
     exists(boolean controlSense |
       this.controls(b, controlSense) and

--- a/python/ql/lib/semmle/python/Operations.qll
+++ b/python/ql/lib/semmle/python/Operations.qll
@@ -98,7 +98,7 @@ class LShift extends LShift_ {
   override string getSpecialMethodName() { result = "__lshift__" }
 }
 
-/** A modulo (`%`) binary operator, which includes  string formatting */
+/** A modulo (`%`) binary operator, which includes string formatting */
 class Mod extends Mod_ {
   override string getSpecialMethodName() { result = "__mod__" }
 }

--- a/python/ql/lib/semmle/python/essa/Essa.qll
+++ b/python/ql/lib/semmle/python/essa/Essa.qll
@@ -8,7 +8,7 @@ import semmle.python.essa.Definitions
 
 /** An (enhanced) SSA variable derived from `SsaSourceVariable`. */
 class EssaVariable extends TEssaDefinition {
-  /** Gets the (unique) definition of this  variable. */
+  /** Gets the (unique) definition of this variable. */
   EssaDefinition getDefinition() { this = result }
 
   /**

--- a/python/ql/lib/semmle/python/essa/SsaDefinitions.qll
+++ b/python/ql/lib/semmle/python/essa/SsaDefinitions.qll
@@ -127,7 +127,7 @@ module SsaSource {
     not test_contains(_, call)
   }
 
-  /** Holds if an attribute is deleted  at `def` and `use` is the use of `v` for that deletion */
+  /** Holds if an attribute is deleted at `def` and `use` is the use of `v` for that deletion */
   cached
   predicate attribute_deletion_refinement(Variable v, NameNode use, DeletionNode def) {
     use.uses(v) and

--- a/python/ql/src/Security/CWE-327/TlsLibraryModel.qll
+++ b/python/ql/src/Security/CWE-327/TlsLibraryModel.qll
@@ -88,7 +88,7 @@ abstract class TlsLibrary extends string {
   /** The name of a specific protocol version. */
   abstract string specific_version_name(ProtocolVersion version);
 
-  /** Gets a name, which is a member of `version_constants`,  that can be used to specify the protocol family `family`. */
+  /** Gets a name, which is a member of `version_constants`, that can be used to specify the protocol family `family`. */
   abstract string unspecific_version_name(ProtocolFamily family);
 
   /** Gets an API node representing the module or class holding the version constants. */


### PR DESCRIPTION
I was inspired by a duplicated space in some QLDoc in the [MaD implementation](https://github.com/github/codeql/pull/7171/). 

So I tried to see if that would be viable as a QL-for-QL query.  
But it only found a few results in Python, so I think I'll just skip the QL-for-QL query. 

(PR was   written automatically by a tool). 