### PR TITLE
Experiment with a fixed threshold

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
@@ -105,8 +105,8 @@ abstract class ATMConfig extends string {
    *
    * Specifies the default cut-off value that controls how many alerts are produced.
    * The cut-off value must be in the range [0,1].
-   * A cut-off value of 0 only produces alerts that are likely true-positives.
-   * A cut-off value of 1 produces all alerts including those that are likely false-positives.
+   * A cut-off value of >~0.5 only produces alerts that are likely true-positives.
+   * A cut-off value of 0 produces all alerts including those that are likely false-positives.
    */
-  float getScoreCutoff() { result = 0.0 }
+  float getScoreCutoff() { result = 0.65 }
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
@@ -108,5 +108,5 @@ abstract class ATMConfig extends string {
    * A cut-off value of >~0.5 only produces alerts that are likely true-positives.
    * A cut-off value of 0 produces all alerts including those that are likely false-positives.
    */
-  float getScoreCutoff() { result = 0.65 }
+  float getScoreCutoff() { result = 0. }
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
@@ -205,8 +205,8 @@ class EndpointScoringResults extends ScoringResults {
         exists(float sinkScore |
           ModelScoring::endpointScores(sink, getCfg().getASinkEndpointType().getEncoding(),
             sinkScore) and
-          // Include the endpoint if the query endpoint type scores higher than a fixed threshold of 0.65
-          sinkScore >= 0.65
+          // Include the endpoint if the query endpoint type scores higher than a fixed threshold
+          sinkScore >= getCfg().getScoreCutoff()
         )
       )
   }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
@@ -205,14 +205,8 @@ class EndpointScoringResults extends ScoringResults {
         exists(float sinkScore |
           ModelScoring::endpointScores(sink, getCfg().getASinkEndpointType().getEncoding(),
             sinkScore) and
-          // Include the endpoint if (a) the query endpoint type scores higher than all other
-          // endpoint types, or (b) the query endpoint type scores at least
-          // 0.5 - (getCfg().getScoreCutoff() / 2).
-          sinkScore >=
-            [
-              max(float s | ModelScoring::endpointScores(sink, _, s)),
-              0.5 - getCfg().getScoreCutoff() / 2
-            ]
+          // Include the endpoint if the query endpoint type scores higher than a fixed threshold of 0.65
+          sinkScore >= 0.65
         )
       )
   }


### PR DESCRIPTION
After all the changes made on the modeling side, there is now better separation in scores between TPs and FPs. 

This PR experiments with setting a hard-coded score threshold > 0.5 to determine which alerts to surface, rather than always selecting the max-likelihood class, thereby reducing FPs.

----

Replaced by https://github.com/github/codeql/pull/7519 because I need to update the worse rather than current libraries.