### PR TITLE
Python: Extend unreachable statement test

### DIFF
--- a/python/ql/test/query-tests/Statements/unreachable/global.py
+++ b/python/ql/test/query-tests/Statements/unreachable/global.py
@@ -1,0 +1,10 @@
+# FP involving global variables modified in a different scope
+
+i = 0
+def update_i():
+    global i
+    i = i + 1
+
+update_i()
+if i > 0:
+    print("i is greater than 0") # FP: This is reachable


### PR DESCRIPTION
Adds a test demostrating the false positive observed by andersfugmann.

Note that this does not change the `.expected` file, and so the tests
will fail. This is expected.