### PR TITLE
Update license text for CodeQL CLI to reflect GHAS

### DIFF
--- a/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
+++ b/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
@@ -34,7 +34,7 @@ in the GitHub documentation.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The CodeQL CLI download package is a zip archive containing tools, scripts, and
-various CodeQL-specific files. If you don't have an Enterprise license then, by
+various CodeQL-specific files. If you don't have a GitHub Advanced Security license then, by
 downloading this archive, you are agreeing to the `GitHub CodeQL Terms and
 Conditions <https://securitylab.github.com/tools/codeql/license>`__.
 


### PR DESCRIPTION
Change `Enterprise` to `GitHub Advanced Security` for the license to keep consistent with https://github.com/github/codeql-cli-binaries/blob/main/LICENSE.md#license-restrictions