### PR TITLE
QL: recognize dependecies of the form: libraryPathDependencies: library-name

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2460,6 +2460,9 @@ module YAML {
         name = entry.getListItem().getValue().getValue().trim() and
         version = "\"*\""
       )
+      or
+      name = getProperty("libraryPathDependencies") and
+      version = "\"*\""
     }
 
     /** Gets the database scheme of this qlpack */

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -2461,7 +2461,7 @@ module YAML {
         version = "\"*\""
       )
       or
-      name = getProperty("libraryPathDependencies") and
+      name = this.getProperty("libraryPathDependencies") and
       version = "\"*\""
     }
 

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -18,9 +18,12 @@ getTarget
 | Overrides.qll:24:39:24:48 | MemberCall | Overrides.qll:22:12:22:44 | ClassPredicate bar |
 | Overrides.qll:28:3:28:9 | MemberCall | Overrides.qll:6:3:6:29 | ClassPredicate bar |
 | Overrides.qll:29:3:29:10 | MemberCall | Overrides.qll:8:3:8:41 | ClassPredicate baz |
+| packs/other/OtherThing.qll:5:3:5:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |
+| packs/other/OtherThing.qll:6:3:6:8 | PredicateCall | packs/src/SrcThing.qll:8:1:8:30 | ClasslessPredicate bar |
 | packs/src/SrcThing.qll:4:3:4:8 | PredicateCall | packs/lib/LibThing/Foo.qll:1:1:1:30 | ClasslessPredicate foo |
 | packs/src/SrcThing.qll:5:3:5:8 | PredicateCall | packs/src/SrcThing.qll:8:1:8:30 | ClasslessPredicate bar |
 dependsOn
+| packs/other/qlpack.yml:1:1:1:4 | ql-other-pack-thing | packs/src/qlpack.yml:1:1:1:4 | ql-testing-src-pack |
 | packs/src/qlpack.yml:1:1:1:4 | ql-testing-src-pack | packs/lib/qlpack.yml:1:1:1:4 | ql-testing-lib-pack |
 exprPredicate
 | Foo.qll:24:22:24:31 | predicate | Foo.qll:22:3:22:32 | ClasslessPredicate myThing0 |

--- a/ql/ql/test/callgraph/packs/other/OtherThing.qll
+++ b/ql/ql/test/callgraph/packs/other/OtherThing.qll
@@ -1,0 +1,7 @@
+import LibThing.Foo
+import SrcThing
+
+predicate otherThing(int i) {
+  foo(i) and
+  bar(i)
+}

--- a/ql/ql/test/callgraph/packs/other/qlpack.yml
+++ b/ql/ql/test/callgraph/packs/other/qlpack.yml
@@ -1,0 +1,3 @@
+name: ql-other-pack-thing
+version: 0.1.0
+libraryPathDependencies: ql-testing-src-pack


### PR DESCRIPTION
I added QL-for-QL to an internal project of mine, and QL-for-QL didn't recognize the dependency in a `qlpack.yml` file of the following form: 

```
name: my-ql-thing
version: 0.0.0
libraryPathDependencies: codeql-ql  # <- this one wasn't recognized. 
```