### PR TITLE
Java: Add Spring and Apache Common Langs taint flow steps

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -102,6 +102,7 @@ private module Frameworks {
   private import semmle.code.java.frameworks.ratpack.Ratpack
   private import semmle.code.java.frameworks.ratpack.RatpackExec
   private import semmle.code.java.frameworks.spring.SpringCache
+  private import semmle.code.java.frameworks.spring.SpringContext
   private import semmle.code.java.frameworks.spring.SpringHttp
   private import semmle.code.java.frameworks.spring.SpringUtil
   private import semmle.code.java.frameworks.spring.SpringUi

--- a/java/ql/lib/semmle/code/java/frameworks/apache/Lang.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/apache/Lang.qll
@@ -73,6 +73,15 @@ private class ApacheArrayUtilsModel extends SummaryModelCsv {
   }
 }
 
+private class ApacheStringEscapeUtilsModel extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "org.apache.commons.lang3;StringEscapeUtils;false;escapeJson;;;Argument[0];ReturnValue;taint"
+      ]
+  }
+}
+
 private class ApacheStringUtilsModel extends SummaryModelCsv {
   override predicate row(string row) {
     row =

--- a/java/ql/lib/semmle/code/java/frameworks/spring/Spring.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/Spring.qll
@@ -9,6 +9,7 @@ import semmle.code.java.frameworks.spring.SpringBeanFile
 import semmle.code.java.frameworks.spring.SpringBeans
 import semmle.code.java.frameworks.spring.SpringBeanRefType
 import semmle.code.java.frameworks.spring.SpringCache
+import semmle.code.java.frameworks.spring.SpringContext
 import semmle.code.java.frameworks.spring.SpringComponentScan
 import semmle.code.java.frameworks.spring.SpringConstructorArg
 import semmle.code.java.frameworks.spring.SpringController

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringContext.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringContext.qll
@@ -10,10 +10,9 @@ private class StringSummaryCsv extends SummaryModelCsv {
     row =
       [
         //`namespace; type; subtypes; name; signature; ext; input; output; kind`
-        "org.springframework.context.support;AbstractMessageSource;true;getMessage;(String,Object[],String,Locale);;ArrayElement of Argument[1];ReturnValue;taint",
-        "org.springframework.context.support;AbstractMessageSource;true;getMessage;(String,Object[],String,Locale);;Argument[2];ReturnValue;taint",
-        "org.springframework.context.support;AbstractMessageSource;true;getMessage;(String,Object[],Locale);;ArrayElement of Argument[1];ReturnValue;taint",
-        "org.springframework.context.support;AbstractMessageSource;true;getMessageFromParent;;;ArrayElement of Argument[1];ReturnValue;taint",
+        "org.springframework.context;MessageSource;true;getMessage;(String,Object[],String,Locale);;ArrayElement of Argument[1];ReturnValue;taint",
+        "org.springframework.context;MessageSource;true;getMessage;(String,Object[],String,Locale);;Argument[2];ReturnValue;taint",
+        "org.springframework.context;MessageSource;true;getMessage;(String,Object[],Locale);;ArrayElement of Argument[1];ReturnValue;taint"
       ]
   }
 }

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringContext.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringContext.qll
@@ -1,0 +1,19 @@
+/**
+ * Provides models for the `org.springframework.context` package.
+ */
+
+import java
+private import semmle.code.java.dataflow.ExternalFlow
+
+private class StringSummaryCsv extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        //`namespace; type; subtypes; name; signature; ext; input; output; kind`
+        "org.springframework.context.support;AbstractMessageSource;true;getMessage;(String,Object[],String,Locale);;ArrayElement of Argument[1];ReturnValue;taint",
+        "org.springframework.context.support;AbstractMessageSource;true;getMessage;(String,Object[],String,Locale);;Argument[2];ReturnValue;taint",
+        "org.springframework.context.support;AbstractMessageSource;true;getMessage;(String,Object[],Locale);;ArrayElement of Argument[1];ReturnValue;taint",
+        "org.springframework.context.support;AbstractMessageSource;true;getMessageFromParent;;;ArrayElement of Argument[1];ReturnValue;taint",
+      ]
+  }
+}

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringEscapeUtilsTest.java
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/StringEscapeUtilsTest.java
@@ -1,0 +1,11 @@
+import org.apache.commons.lang3.StringEscapeUtils;
+
+public class StringEscapeUtilsTest {
+  String taint() { return "tainted"; }
+
+  void sink(Object o) {}
+
+  void test() throws Exception {
+    sink(StringEscapeUtils.escapeJson(taint())); // $hasTaintFlow
+  }
+}

--- a/java/ql/test/library-tests/frameworks/spring/context/Test.java
+++ b/java/ql/test/library-tests/frameworks/spring/context/Test.java
@@ -1,0 +1,20 @@
+import org.springframework.context.support.StaticMessageSource;
+import java.util.Locale;
+
+public class Test {
+
+	public static String code = "mycode";
+	public static Locale locale = Locale.US;
+
+	String taint() { return "tainted"; }
+
+	void sink(Object o) {}
+
+	public void test() {
+		StaticMessageSource sms = new StaticMessageSource();
+		sms.addMessage(code, locale, "hello {0}");
+		sink(sms.getMessage(code, new String[]{ taint() }, locale)); // $hasTaintFlow
+		sink(sms.getMessage(code, new String[]{ taint() }, "", locale)); // $hasTaintFlow
+		sink(sms.getMessage(code, null, taint(), locale)); // $hasTaintFlow
+	}
+}

--- a/java/ql/test/library-tests/frameworks/spring/context/flow.ql
+++ b/java/ql/test/library-tests/frameworks/spring/context/flow.ql
@@ -1,0 +1,2 @@
+import java
+import TestUtilities.InlineFlowTest

--- a/java/ql/test/library-tests/frameworks/spring/context/options
+++ b/java/ql/test/library-tests/frameworks/spring/context/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.3.8:${testdir}/../../../../stubs/apache-commons-logging-1.2/

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/StringEscapeUtils.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/StringEscapeUtils.java
@@ -1,0 +1,42 @@
+// Generated automatically from org.apache.commons.lang3.StringEscapeUtils for testing purposes
+
+package org.apache.commons.lang3;
+
+import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
+
+public class StringEscapeUtils
+{
+    public StringEscapeUtils(){}
+    public static CharSequenceTranslator ESCAPE_CSV = null;
+    public static CharSequenceTranslator ESCAPE_ECMASCRIPT = null;
+    public static CharSequenceTranslator ESCAPE_HTML3 = null;
+    public static CharSequenceTranslator ESCAPE_HTML4 = null;
+    public static CharSequenceTranslator ESCAPE_JAVA = null;
+    public static CharSequenceTranslator ESCAPE_JSON = null;
+    public static CharSequenceTranslator ESCAPE_XML = null;
+    public static CharSequenceTranslator ESCAPE_XML10 = null;
+    public static CharSequenceTranslator ESCAPE_XML11 = null;
+    public static CharSequenceTranslator UNESCAPE_CSV = null;
+    public static CharSequenceTranslator UNESCAPE_ECMASCRIPT = null;
+    public static CharSequenceTranslator UNESCAPE_HTML3 = null;
+    public static CharSequenceTranslator UNESCAPE_HTML4 = null;
+    public static CharSequenceTranslator UNESCAPE_JAVA = null;
+    public static CharSequenceTranslator UNESCAPE_JSON = null;
+    public static CharSequenceTranslator UNESCAPE_XML = null;
+    public static String escapeCsv(String p0){ return null; }
+    public static String escapeEcmaScript(String p0){ return null; }
+    public static String escapeHtml3(String p0){ return null; }
+    public static String escapeHtml4(String p0){ return null; }
+    public static String escapeJava(String p0){ return null; }
+    public static String escapeJson(String p0){ return null; }
+    public static String escapeXml(String p0){ return null; }
+    public static String escapeXml10(String p0){ return null; }
+    public static String escapeXml11(String p0){ return null; }
+    public static String unescapeCsv(String p0){ return null; }
+    public static String unescapeEcmaScript(String p0){ return null; }
+    public static String unescapeHtml3(String p0){ return null; }
+    public static String unescapeHtml4(String p0){ return null; }
+    public static String unescapeJava(String p0){ return null; }
+    public static String unescapeJson(String p0){ return null; }
+    public static String unescapeXml(String p0){ return null; }
+}

--- a/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
+++ b/java/ql/test/stubs/apache-commons-lang3-3.7/org/apache/commons/lang3/text/translate/CharSequenceTranslator.java
@@ -1,0 +1,15 @@
+// Generated automatically from org.apache.commons.lang3.text.translate.CharSequenceTranslator for testing purposes
+
+package org.apache.commons.lang3.text.translate;
+
+import java.io.Writer;
+
+abstract public class CharSequenceTranslator
+{
+    public CharSequenceTranslator(){}
+    public abstract int translate(CharSequence p0, int p1, Writer p2);
+    public final CharSequenceTranslator with(CharSequenceTranslator... p0){ return null; }
+    public final String translate(CharSequence p0){ return null; }
+    public final void translate(CharSequence p0, Writer p1){}
+    public static String hex(int p0){ return null; }
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/HierarchicalMessageSource.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/HierarchicalMessageSource.java
@@ -1,0 +1,11 @@
+// Generated automatically from org.springframework.context.HierarchicalMessageSource for testing purposes
+
+package org.springframework.context;
+
+import org.springframework.context.MessageSource;
+
+public interface HierarchicalMessageSource extends MessageSource
+{
+    MessageSource getParentMessageSource();
+    void setParentMessageSource(MessageSource p0);
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/MessageSource.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/MessageSource.java
@@ -1,3 +1,13 @@
+// Generated automatically from org.springframework.context.MessageSource for testing purposes
+
 package org.springframework.context;
 
-public interface MessageSource {}
+import java.util.Locale;
+import org.springframework.context.MessageSourceResolvable;
+
+public interface MessageSource
+{
+    String getMessage(MessageSourceResolvable p0, Locale p1);
+    String getMessage(String p0, Object[] p1, Locale p2);
+    String getMessage(String p0, Object[] p1, String p2, Locale p3);
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/MessageSourceResolvable.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/MessageSourceResolvable.java
@@ -1,29 +1,11 @@
-/*
- * Copyright 2002-2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Generated automatically from org.springframework.context.MessageSourceResolvable for testing purposes
 
 package org.springframework.context;
 
-public interface MessageSourceResolvable {
-  String[] getCodes();
 
-  default Object[] getArguments() {
-    return null;
-  }
-
-  default String getDefaultMessage() {
-    return null;
-  }
+public interface MessageSourceResolvable
+{
+    String[] getCodes();
+    default Object[] getArguments(){ return null; }
+    default String getDefaultMessage(){ return null; }
 }

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/support/AbstractMessageSource.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/support/AbstractMessageSource.java
@@ -1,0 +1,32 @@
+// Generated automatically from org.springframework.context.support.AbstractMessageSource for testing purposes
+
+package org.springframework.context.support;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.Properties;
+import org.springframework.context.HierarchicalMessageSource;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.MessageSourceSupport;
+
+abstract public class AbstractMessageSource extends MessageSourceSupport implements HierarchicalMessageSource
+{
+    protected Object[] resolveArguments(Object[] p0, Locale p1){ return null; }
+    protected Properties getCommonMessages(){ return null; }
+    protected String getDefaultMessage(MessageSourceResolvable p0, Locale p1){ return null; }
+    protected String getDefaultMessage(String p0){ return null; }
+    protected String getMessageFromParent(String p0, Object[] p1, Locale p2){ return null; }
+    protected String getMessageInternal(String p0, Object[] p1, Locale p2){ return null; }
+    protected String resolveCodeWithoutArguments(String p0, Locale p1){ return null; }
+    protected abstract MessageFormat resolveCode(String p0, Locale p1);
+    protected boolean isUseCodeAsDefaultMessage(){ return false; }
+    public AbstractMessageSource(){}
+    public MessageSource getParentMessageSource(){ return null; }
+    public final String getMessage(MessageSourceResolvable p0, Locale p1){ return null; }
+    public final String getMessage(String p0, Object[] p1, Locale p2){ return null; }
+    public final String getMessage(String p0, Object[] p1, String p2, Locale p3){ return null; }
+    public void setCommonMessages(Properties p0){}
+    public void setParentMessageSource(MessageSource p0){}
+    public void setUseCodeAsDefaultMessage(boolean p0){}
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/support/MessageSourceSupport.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/support/MessageSourceSupport.java
@@ -1,0 +1,19 @@
+// Generated automatically from org.springframework.context.support.MessageSourceSupport for testing purposes
+
+package org.springframework.context.support;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import org.apache.commons.logging.Log;
+
+abstract public class MessageSourceSupport
+{
+    protected MessageFormat createMessageFormat(String p0, Locale p1){ return null; }
+    protected Object[] resolveArguments(Object[] p0, Locale p1){ return null; }
+    protected String formatMessage(String p0, Object[] p1, Locale p2){ return null; }
+    protected String renderDefaultMessage(String p0, Object[] p1, Locale p2){ return null; }
+    protected boolean isAlwaysUseMessageFormat(){ return false; }
+    protected final Log logger = null;
+    public MessageSourceSupport(){}
+    public void setAlwaysUseMessageFormat(boolean p0){}
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/support/StaticMessageSource.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/context/support/StaticMessageSource.java
@@ -1,0 +1,18 @@
+// Generated automatically from org.springframework.context.support.StaticMessageSource for testing purposes
+
+package org.springframework.context.support;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.context.support.AbstractMessageSource;
+
+public class StaticMessageSource extends AbstractMessageSource
+{
+    protected MessageFormat resolveCode(String p0, Locale p1){ return null; }
+    protected String resolveCodeWithoutArguments(String p0, Locale p1){ return null; }
+    public StaticMessageSource(){}
+    public String toString(){ return null; }
+    public void addMessage(String p0, Locale p1, String p2){}
+    public void addMessages(Map<String, String> p0, Locale p1){}
+}


### PR DESCRIPTION
Additional details can be found [here](https://github.com/github/advanced-security-field/issues/1455).

I created a [proof-of-concept XSS query](https://github.com/zbazztian/webgoat-xss-proof-of-concept/blob/main/.github/custom-xss/custom-xss.ql) showcasing [the results](https://github.com/zbazztian/webgoat-xss-proof-of-concept/security/code-scanning) on WebGoat. The default query did not detect any XSS results in said repository. The results of the modified version look promising and many of them are exploitable (I tested with the WebGoat Docker image).