### PR TITLE
Python: Points-to performance improvements

### DIFF
--- a/python/ql/lib/semmle/python/pointsto/MRO.qll
+++ b/python/ql/lib/semmle/python/pointsto/MRO.qll
@@ -173,7 +173,7 @@ class ClassList extends TClassList {
     this.duplicate(n) and result = this.deduplicate(n + 1)
     or
     exists(ClassObjectInternal cls, ClassList tail |
-      deduplicateCons(n, cls, tail) and
+      this.deduplicateCons(n, cls, tail) and
       result = Cons(cls, tail)
     )
   }
@@ -281,7 +281,7 @@ private class ClassListList extends TClassListList {
     removed_head = this.removedClassPartsCons1(cls, removed_tail, n).removeHead(cls)
   }
 
-  pragma[noinline]
+  pragma[nomagic]
   predicate removedClassPartsCons0(ClassObjectInternal cls, ClassListList removed_tail, int n) {
     exists(ClassList prev_head, ClassListList prev_tail |
       this.removedClassParts(cls, prev_head, prev_tail, n + 1) and
@@ -289,9 +289,9 @@ private class ClassListList extends TClassListList {
     )
   }
 
-  pragma[noinline]
+  pragma[nomagic]
   ClassList removedClassPartsCons1(ClassObjectInternal cls, ClassListList removed_tail, int n) {
-    removedClassPartsCons0(cls, removed_tail, n) and
+    this.removedClassPartsCons0(cls, removed_tail, n) and
     result = this.getItem(n)
   }
 
@@ -310,7 +310,7 @@ private class ClassListList extends TClassListList {
     cl = this.getItem(n) and
     j = cl.length()
     or
-    legalMergeCandidateNonEmpty(cls, n, cl, j + 1) and
+    this.legalMergeCandidateNonEmpty(cls, n, cl, j + 1) and
     j >= 1 and
     cls != cl.getItem(j)
   }
@@ -321,14 +321,14 @@ private class ClassListList extends TClassListList {
     this.legalMergeCandidate(cls, n + 1) and
     this.getItem(n) = Empty()
     or
-    legalMergeCandidateNonEmpty(cls, n, _, 1)
+    this.legalMergeCandidateNonEmpty(cls, n, _, 1)
   }
 
   predicate legalMergeCandidate(ClassObjectInternal cls) { this.legalMergeCandidate(cls, 0) }
 
   predicate illegalMergeCandidate(ClassObjectInternal cls) {
     exists(ClassList cl, int j |
-      legalMergeCandidateNonEmpty(cls, _, cl, j + 1) and
+      this.legalMergeCandidateNonEmpty(cls, _, cl, j + 1) and
       j >= 1 and
       cls = cl.getItem(j)
     )

--- a/python/ql/lib/semmle/python/pointsto/MRO.qll
+++ b/python/ql/lib/semmle/python/pointsto/MRO.qll
@@ -131,7 +131,7 @@ class ClassList extends TClassList {
 
   pragma[noinline]
   private ClassObjectInternal findDeclaringClassAttribute(string name) {
-    result = findDeclaringClass(name) and
+    result = this.findDeclaringClass(name) and
     (
       exists(any(Builtin b).getMember(name))
       or


### PR DESCRIPTION
Evaluation of `FromImportOfMutableAttribute.ql` on https://github.com/FiacreT/M-moire:

Before
```
Stopped during this pipeline:

[2022-01-11 20:06:33] (91497s) Tuple counts for MRO::reverse_step#fff#reorder_1_2_0/3@i132#49c0994w after 55m58s:
                      20646       ~0%     {3} r1 = JOIN MRO::needs_reversing#f#prev_delta WITH MRO::Empty#f CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0 'remainder', Lhs.0 'remainder'
                      
                      40425683500 ~2%     {4} r2 = JOIN MRO::Cons#fff#prev_delta WITH MRO::Cons#fff#prev ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1 'remainder', Rhs.2 'reversed'
                      0           ~0%     {3} r3 = JOIN r2 WITH MRO::reverse_step#fff#reorder_1_2_0#prev ON FIRST 2 OUTPUT Lhs.3 'reversed', Rhs.2 'lst', Lhs.2 'remainder'
                      
                      20646       ~0%     {3} r4 = r1 UNION r3
                      
                      40333997500 ~1%     {4} r5 = JOIN MRO::Cons#fff#prev_delta WITH MRO::Cons#fff#prev ON FIRST 1 OUTPUT Rhs.2 'reversed', Lhs.1 'remainder', Lhs.2, Rhs.1
                      21978       ~4%     {3} r6 = JOIN r5 WITH MRO::reverse_step#fff#reorder_1_2_0#prev ON FIRST 2 OUTPUT Lhs.2 'reversed', Rhs.2 'lst', Lhs.3 'remainder'
                      
                      0           ~0%     {3} r7 = SCAN MRO::reverse_step#fff#reorder_1_2_0#prev_delta OUTPUT In.0, In.2 'lst', In.1
                      0           ~0%     {4} r8 = JOIN r7 WITH MRO::Cons#fff#reorder_2_0_1#prev ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1 'lst', Rhs.2 'remainder'
                      0           ~0%     {3} r9 = JOIN r8 WITH MRO::Cons#fff#prev ON FIRST 2 OUTPUT Rhs.2 'reversed', Lhs.2 'lst', Lhs.3 'remainder'
                      
                      21978       ~4%     {3} r10 = r6 UNION r9
                      42624       ~6%     {3} r11 = r4 UNION r10
                      41958       ~6%     {3} r12 = r11 AND NOT MRO::reverse_step#fff#reorder_1_2_0#prev(Lhs.2 'remainder', Lhs.0 'reversed', Lhs.1 'lst')
                      41958       ~0%     {3} r13 = SCAN r12 OUTPUT In.2 'remainder', In.0 'reversed', In.1 'lst'
                                          return r13
```

After
```
[2022-02-02 17:11:20] (564s) Query done
[2022-02-02 17:11:20] (564s) Total timings for execution:
[2022-02-02 17:11:20] (564s) 	- Extensionals: 0ms
[2022-02-02 17:11:20] (564s) 	- Intensionals: 9min1.304s ... of which ...
[2022-02-02 17:11:20] (564s) 		- Nonrecursive intensionals: 8.492s
[2022-02-02 17:11:20] (564s) 		- Recursive intensionals: 8min52.811s
[2022-02-02 17:11:20] (564s) 	- Building results: 0ms
[2022-02-02 17:11:20] (564s) Clause timing report:
[2022-02-02 17:11:20] (564s) 
[2022-02-02 17:11:20] 
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::containsSpecial#fb .............................................. 35s (942 evaluations with max 104ms in MRO::ClassList::containsSpecial#fb/2@i841#c7b656w1)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::lookup_dispred#ffff ............................................. 33.3s (943 evaluations with max 1.7s in MRO::ClassList::lookup_dispred#ffff/4@i848#c7b65d6w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassListList::removedClassParts#fffff#reorder_2_3_4_0_1 ................... 28.3s (975 evaluations with max 66ms in MRO::ClassListList::removedClassParts#fffff#reorder_2_3_4_0_1/5@i716#c7b65xy1)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::findDeclaringClassAttribute#fff#reorder_1_2_0 ................... 27s (804 evaluations with max 1.6s in MRO::ClassList::findDeclaringClassAttribute#fff#reorder_1_2_0/3@i847#c7b65lw1)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::findDeclaringClass#fff .......................................... 23.9s (996 evaluations with max 1.4s in MRO::ClassList::findDeclaringClass#fff/3@i845#c7b65j3w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::firstIndex#2#ffff#reorder_2_1_0_3 ............................... 22.5s (1091 evaluations with max 791ms in MRO::ClassList::firstIndex#2#ffff#reorder_2_1_0_3/4@i806#c7b6515w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassListList::bestMergeCandidate#2#fff .................................... 17.4s (954 evaluations with max 43ms in MRO::ClassListList::bestMergeCandidate#2#fff/3@i548#c7b6583w)
	FromImportOfMutableAttribute.ql-9:PointsTo::InterProceduralPointsTo::scope_entry_value_transfer_from_earlier#ffff . 17.3s (531 evaluations with max 138ms in PointsTo::InterProceduralPointsTo::scope_entry_value_transfer_from_earlier#ffff/4@i2#c7b65a5w)
	FromImportOfMutableAttribute.ql-9:PointsTo::Expressions::equalityEvaluatesTo#fffff ................................ 14.8s (639 evaluations with max 40ms in PointsTo::Expressions::equalityEvaluatesTo#fffff/5@i355#c7b65t7w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::findDeclaringClass_dispred#fff .................................. 9.4s (804 evaluations with max 1.1s in MRO::ClassList::findDeclaringClass_dispred#fff/3@i810#c7b65h3w)
	FromImportOfMutableAttribute.ql-9:PointsTo::Expressions::inequalityEvaluatesTo#fffff .............................. 9.1s (532 evaluations with max 33ms in PointsTo::Expressions::inequalityEvaluatesTo#fffff/5@i355#c7b65u7w)
	FromImportOfMutableAttribute.ql-9:MRO::list_of_linearization_of_bases_plus_bases#2#fbf#reorder_1_2_0 .............. 8.1s (762 evaluations with max 173ms in MRO::list_of_linearization_of_bases_plus_bases#2#fbf#reorder_1_2_0/3@i357#c7b65m2w)
	FromImportOfMutableAttribute.ql-9:MRO::flatten_list#fff ........................................................... 8.1s (963 evaluations with max 29ms in MRO::flatten_list#fff/3@i706#c7b65a3w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::firstIndex#2#ffff#reorder_0_2_3_1 ............................... 7.7s (1083 evaluations with max 640ms in MRO::ClassList::firstIndex#2#ffff#reorder_0_2_3_1/4@i806#c7b655y1)
	FromImportOfMutableAttribute.ql-9:MRO::bases#2#bff ................................................................ 7s (817 evaluations with max 1.1s in MRO::bases#2#bff/3@i650#c7b6553w)
	FromImportOfMutableAttribute.ql-9:Instances::InstanceObject::initializer_dispred#fbf .............................. 6.1s (730 evaluations with max 20ms in Instances::InstanceObject::initializer_dispred#fbf/3@i128#c7b65f4w)
	FromImportOfMutableAttribute.ql-9:dom#MRO::Cons#ff ................................................................ 5.7s (1170 evaluations with max 45ms in dom#MRO::Cons#ff/2@i56#c7b65v1w)
	FromImportOfMutableAttribute.ql-9:PointsTo::Types::getBase#fff .................................................... 5.4s (904 evaluations with max 15ms in PointsTo::Types::getBase#fff/3@i36#c7b65yw1)
	FromImportOfMutableAttribute.ql-9:MRO::ClassListList::legalMergeCandidateNonEmpty#ffff ............................ 5.3s (1026 evaluations with max 225ms in MRO::ClassListList::legalMergeCandidateNonEmpty#ffff/4@i584#c7b65l7w)
	FromImportOfMutableAttribute.ql-9:PointsTo::AttributePointsTo::variableAttributePointsTo#fffff .................... 5.3s (902 evaluations with max 1.3s in PointsTo::AttributePointsTo::variableAttributePointsTo#fffff/5@i128#c7b6558w)
	FromImportOfMutableAttribute.ql-9:PointsTo::PointsToInternal::points_to_candidate#ffff ............................ 4.9s (952 evaluations with max 183ms in PointsTo::PointsToInternal::points_to_candidate#ffff/4@i3#c7b65v4w)
	FromImportOfMutableAttribute.ql-9:MRO::bases#2#fbf ................................................................ 4.6s (817 evaluations with max 728ms in MRO::bases#2#fbf/3@i650#c7b6563w)
	FromImportOfMutableAttribute.ql-9:PointsTo::PointsToInternal::pointsTo#ffff ....................................... 4.5s (925 evaluations with max 234ms in PointsTo::PointsToInternal::pointsTo#ffff/4@i4#c7b65ix1)
	FromImportOfMutableAttribute.ql-10:Flow::ControlFlowNode::toString_dispred#ff ..................................... 4.2s
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::deduplicateCons#ffff ............................................ 4.2s (1170 evaluations with max 127ms in MRO::ClassList::deduplicateCons#ffff/4@i833#c7b6586w)
	FromImportOfMutableAttribute.ql-9:PointsTo::PointsToInternal::multi_assignment_points_to#ffff ..................... 4s (906 evaluations with max 26ms in PointsTo::PointsToInternal::multi_assignment_points_to#ffff/4@i43#c7b65e5w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::deduplicate#2#fff ............................................... 3.6s (1175 evaluations with max 114ms in MRO::ClassList::deduplicate#2#fff/3@i825#c7b6543w)
	FromImportOfMutableAttribute.ql-9:PointsTo::PointsToInternal::iteration_points_to#ffff ............................ 3.6s (906 evaluations with max 19ms in PointsTo::PointsToInternal::iteration_points_to#ffff/4@i117#c7b65n4w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::startingAt#fff .................................................. 3.5s (941 evaluations with max 143ms in MRO::ClassList::startingAt#fff/3@i825#c7b65e4w)
	FromImportOfMutableAttribute.ql-9:Instances::SuperInstance::lookup_dispred#ffff ................................... 3.3s (985 evaluations with max 61ms in Instances::SuperInstance::lookup_dispred#ffff/4@i357#c7b65g6w)
	FromImportOfMutableAttribute.ql-9:PointsTo::InterModulePointsTo::import_points_to#ffff ............................ 3.3s (444 evaluations with max 257ms in PointsTo::InterModulePointsTo::import_points_to#ffff/4@i2#c7b65r4w)
	FromImportOfMutableAttribute.ql-9:TObject::self_parameter#fff ..................................................... 3.3s (446 evaluations with max 76ms in TObject::self_parameter#fff/3@i2#c7b65p2w)
	FromImportOfMutableAttribute.ql-10:ObjectInternal::ObjectInternal::toString_dispred#ff ............................ 2.8s (12 evaluations with max 1.6s in ObjectInternal::ObjectInternal::toString_dispred#ff/2@i1#92bf9yrd)
	FromImportOfMutableAttribute.ql-9:Instances::SpecificInstanceInternal::binds#ffff ................................. 2.7s (792 evaluations with max 20ms in Instances::SpecificInstanceInternal::binds#ffff/4@i61#c7b65y6w)
	FromImportOfMutableAttribute.ql-9:PointsTo::Types::getInheritedMetaclass#2#bff#reorder_1_0_2 ...................... 2.7s (632 evaluations with max 44ms in PointsTo::Types::getInheritedMetaclass#2#bff#reorder_1_0_2/3@i2#c7b65n2w)
	FromImportOfMutableAttribute.ql-9:PointsTo::Expressions::builtinCallPointsTo#fffff ................................ 2.7s (902 evaluations with max 44ms in PointsTo::Expressions::builtinCallPointsTo#fffff/5@i39#c7b65y7w)
	FromImportOfMutableAttribute.ql-9:PointsTo::InterProceduralPointsTo::callsite_points_to#ffff ...................... 2.5s (914 evaluations with max 19ms in PointsTo::InterProceduralPointsTo::callsite_points_to#ffff/4@i9#c7b65u5w)
	FromImportOfMutableAttribute.ql-9:PointsTo::PointsToInternal::reachableEdge#fff ................................... 2.5s (914 evaluations with max 28ms in PointsTo::PointsToInternal::reachableEdge#fff/3@i113#c7b65bw1)
	FromImportOfMutableAttribute.ql-9:PointsTo::InterProceduralPointsTo::call_points_to_from_callee#ffff .............. 2.4s (868 evaluations with max 30ms in PointsTo::InterProceduralPointsTo::call_points_to_from_callee#ffff/4@i8#c7b65u4w)
	FromImportOfMutableAttribute.ql-9:Instances::SelfInstanceInternal::binds#ffff ..................................... 2.3s (701 evaluations with max 20ms in Instances::SelfInstanceInternal::binds#ffff/4@i62#c7b65v6w)
	FromImportOfMutableAttribute.ql-9:Callables::PythonFunctionObjectInternal::descriptorGetClass#ffff ................ 2.3s (583 evaluations with max 10ms in Callables::PythonFunctionObjectInternal::descriptorGetClass#ffff/4@i450#c7b6547w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassList::getItem#fff ..................................................... 2.3s (941 evaluations with max 122ms in MRO::ClassList::getItem#fff/3@i825#c7b6513w)
	FromImportOfMutableAttribute.ql-9:Classes::PythonClassObjectInternal::lookup_dispred#ffff ......................... 2.3s (860 evaluations with max 311ms in Classes::PythonClassObjectInternal::lookup_dispred#ffff/4@i59#c7b65e6w)
	FromImportOfMutableAttribute.ql-9:dom#TObject::TProperty#fff ...................................................... 2.2s (902 evaluations with max 9ms in dom#TObject::TProperty#fff/3@i7#c7b65g2w)
	FromImportOfMutableAttribute.ql-9:Modules::PackageObjectInternal::attribute#ffff .................................. 2.2s (540 evaluations with max 18ms in Modules::PackageObjectInternal::attribute#ffff/4@i4#c7b65o6w)
	FromImportOfMutableAttribute.ql-9:MRO::list_of_linearization_of_bases_plus_bases#2#bff#reorder_1_0_2 .............. 2.2s (762 evaluations with max 280ms in MRO::list_of_linearization_of_bases_plus_bases#2#bff#reorder_1_0_2/3@i301#c7b65l2w)
	FromImportOfMutableAttribute.ql-9:TObject::super_noargs#ffff ...................................................... 2.1s (903 evaluations with max 4ms in TObject::super_noargs#ffff/4@i535#c7b6505w)
	FromImportOfMutableAttribute.ql-9:MRO::ClassListList::legalMergeCandidateNonEmpty_dispred#ffff#reorder_3_1_0_2 .... 2.1s (927 evaluations with max 231ms in MRO::ClassListList::legalMergeCandidateNonEmpty_dispred#ffff#reorder_3_1_0_2/4@i585#c7b65i7w)
	FromImportOfMutableAttribute.ql-9:PointsTo::Types::getInheritedMetaclass#ff ....................................... 2.1s (632 evaluations with max 33ms in PointsTo::Types::getInheritedMetaclass#ff/2@i2#c7b65y1w)
	FromImportOfMutableAttribute.ql-9:Constants::ConstantObjectInternal::attribute#ffff ............................... 2.1s (797 evaluations with max 8ms in Constants::ConstantObjectInternal::attribute#ffff/4@i2#c7b658y1)
[2022-02-02 17:11:20] CSV_CACHE_DIFF: #select#query#ffffffffffffffffffffffff (FromImportOfMutableAttribute.ql),6.469,25.42,0,0.584,0.448,0.072,0,0,0,0,0,0,0
```