### PR TITLE
Note that parameterizations of local classes are themselves local

### DIFF
--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -905,7 +905,7 @@ class Interface extends ClassOrInterface, @interface {
 /** A class or interface. */
 class ClassOrInterface extends RefType, @classorinterface {
   /** Holds if this class or interface is local. */
-  predicate isLocal() { isLocalClassOrInterface(this, _) }
+  predicate isLocal() { isLocalClassOrInterface(this.getSourceDeclaration(), _) }
 
   /** Holds if this class or interface is package protected, that is, neither public nor private nor protected. */
   predicate isPackageProtected() {

--- a/java/ql/test/library-tests/localclasses/Test.java
+++ b/java/ql/test/library-tests/localclasses/Test.java
@@ -1,0 +1,11 @@
+public class Test {
+
+  public static void method() {
+
+    class GenericLocal<T> { }
+
+    GenericLocal<Integer> instantiated = new GenericLocal<>();
+
+  }
+
+}

--- a/java/ql/test/library-tests/localclasses/test.expected
+++ b/java/ql/test/library-tests/localclasses/test.expected
@@ -1,0 +1,2 @@
+| Test$1GenericLocal.class:0:0:0:0 | GenericLocal<Integer> |
+| Test.java:5:11:5:22 | GenericLocal |

--- a/java/ql/test/library-tests/localclasses/test.ql
+++ b/java/ql/test/library-tests/localclasses/test.ql
@@ -1,0 +1,7 @@
+import java
+
+from ClassOrInterface ci
+where
+  ci.getSourceDeclaration().fromSource() and
+  ci.isLocal()
+select ci


### PR DESCRIPTION
Previously `LocalClass` itself would match `.isLocal()` whereas `LocalClass<Param>` would not. Rather than require each individual user to check for `.getSourceDeclaration().isLocal()`, let's note that the specializations themselves are local.