### PR TITLE
Ruby: Revert "Update clap requirement from 2.33 to 3.0 in /ruby/generator"

### DIFF
--- a/ruby/generator/Cargo.toml
+++ b/ruby/generator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.0"
+clap = "2.33"
 node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }


### PR DESCRIPTION
Reverts github/codeql#7498

This should fix a build failure observed on ARM Macs.