### PR TITLE
C#: Constant string interpolation (test only).

### DIFF
--- a/csharp/ql/test/library-tests/csharp10/ConstInterpolatedString.cs
+++ b/csharp/ql/test/library-tests/csharp10/ConstInterpolatedString.cs
@@ -1,0 +1,8 @@
+using System;
+
+public class MyConstStringInterpolationClass
+{
+    public const string hello = "Hello";
+    public const string helloWorld = $"{hello} World";
+    public const string reallyHelloWorld = $"Really {helloWorld}";
+}

--- a/csharp/ql/test/library-tests/csharp10/constInterpolatedString.expected
+++ b/csharp/ql/test/library-tests/csharp10/constInterpolatedString.expected
@@ -1,0 +1,6 @@
+inserts
+| ConstInterpolatedString.cs:6:38:6:53 | $"..." | ConstInterpolatedString.cs:6:41:6:45 | access to constant hello |
+| ConstInterpolatedString.cs:7:44:7:65 | $"..." | ConstInterpolatedString.cs:7:54:7:63 | access to constant helloWorld |
+texts
+| ConstInterpolatedString.cs:6:38:6:53 | $"..." | ConstInterpolatedString.cs:6:47:6:52 | " World" |
+| ConstInterpolatedString.cs:7:44:7:65 | $"..." | ConstInterpolatedString.cs:7:46:7:52 | "Really " |

--- a/csharp/ql/test/library-tests/csharp10/constInterpolatedString.ql
+++ b/csharp/ql/test/library-tests/csharp10/constInterpolatedString.ql
@@ -1,0 +1,7 @@
+import csharp
+
+query predicate inserts(InterpolatedStringExpr expr, Expr e) { expr.getAnInsert() = e }
+
+query predicate texts(InterpolatedStringExpr expr, StringLiteral literal) {
+  expr.getAText() = literal
+}


### PR DESCRIPTION
No changes are needed in the extractor to support const interpolated strings, which has been introduced in C# 10.
A small testcase has been added.