### PR TITLE
Java: A few perf fixes for getASupertype*().

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/SSA.qll
@@ -366,7 +366,7 @@ private module SsaImpl {
 
   pragma[nomagic]
   private predicate innerclassSupertypeStar(InnerClass t1, RefType t2) {
-    t1.getASupertype*().getSourceDeclaration() = t2
+    t1.getASourceSupertype*().getSourceDeclaration() = t2
   }
 
   /**

--- a/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
+++ b/java/ql/src/Likely Bugs/Collections/ContainsTypeMismatch.ql
@@ -102,7 +102,7 @@ class MismatchedContainerAccess extends MethodAccess {
     |
       this.getCallee()
           .getDeclaringType()
-          .getASupertype*()
+          .getASourceSupertype*()
           .getSourceDeclaration()
           .hasQualifiedName(package, type) and
       this.getCallee().getParameter(i).getType() instanceof TypeObject

--- a/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
+++ b/java/ql/src/Likely Bugs/Collections/RemoveTypeMismatch.ql
@@ -72,7 +72,7 @@ class MismatchedContainerModification extends MethodAccess {
     |
       this.getCallee()
           .getDeclaringType()
-          .getASupertype*()
+          .getASourceSupertype*()
           .getSourceDeclaration()
           .hasQualifiedName(package, type) and
       this.getCallee().getParameter(i).getType() instanceof TypeObject


### PR DESCRIPTION
`t.getASupertype*().getSourceDeclaration()` and `.getASourceSupertype*().getSourceDeclaration()` are completely equivalent, but the latter is generally much faster to compute.