### PR TITLE
C#: Record types are allowed to seal ToString (test only).

### DIFF
--- a/csharp/ql/test/library-tests/csharp10/RecordTypeSealedToString.cs
+++ b/csharp/ql/test/library-tests/csharp10/RecordTypeSealedToString.cs
@@ -1,0 +1,6 @@
+using System;
+
+public record MyEntry(string Name, string Address)
+{
+    sealed public override string ToString() => $"{Name} lives at {Address}";
+};

--- a/csharp/ql/test/library-tests/csharp10/recordTypeSealedToString.expected
+++ b/csharp/ql/test/library-tests/csharp10/recordTypeSealedToString.expected
@@ -1,0 +1,1 @@
+| RecordTypeSealedToString.cs:5:35:5:42 | ToString |

--- a/csharp/ql/test/library-tests/csharp10/recordTypeSealedToString.ql
+++ b/csharp/ql/test/library-tests/csharp10/recordTypeSealedToString.ql
@@ -1,0 +1,3 @@
+import csharp
+
+query predicate sealed(Modifiable m) { m.getDeclaringType().fromSource() and m.isSealed() }


### PR DESCRIPTION
In C# 10 it is allowed to declare a ToString override as sealed on record types.
This is does not require any changes to the extractor.