### PR TITLE
Add query to detect CORS misconfiguration

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-346/InsecureTomcatConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/InsecureTomcatConfig.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp SYSTEM "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+	This configuration can give the attacker the ability to control <code>Access-Control-Allow-Origin</code> , and also allow the inclusion of cookies on the cross-origin request,
+	(i.e. when the <code>Access-Control-Allow-Credentials</code> header is set to true) 
+	meaning that Peer B can send a request to Peer A that will include the cookies as if the request was executed by the user.
+</p>
+</overview>
+<recommendation>
+<p>
+	When configuring CORS that allow credentials passing,
+	it's best not to use user-provided values for the allowed origins response header,
+	especially if the cookies grant session permissions on the user's account.
+</p>
+</recommendation>
+<example>
+<p>The following example shows a Tomcat configuration with <code>cors.allowed.origins</code> is set to "*", Usually you should not set this, and <code>cors.support.credentials</code> is set to 'true'</p>
+
+<sample src="insecure-cors-web.xml" />
+<references>
+	<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin">CORS, Access-Control-Allow-Origin</a>.</li>
+	<li>Mozilla Developer Network: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials">CORS, Access-Control-Allow-Credentials</a>.</li>
+	<li>PortSwigger: <a href="http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html">Exploiting CORS Misconfigurations for Bitcoins and Bounties</a></li>
+	<li>W3C: <a href="https://w3c.github.io/webappsec-cors-for-developers/#resources">CORS for developers, Advice for Resource Owners</a></li>
+        <li>tomcat config: <a href="https://tomcat.apache.org/tomcat-8.0-doc/config/filter.html#CORS_Filter"></a></li>  
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-346/InsecureTomcatConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/InsecureTomcatConfig.ql
@@ -1,0 +1,32 @@
+/**
+ * @name CORS misconfiguration
+ * @description cors.allowed.origins is set to *, allowing a remote user to control which origins are trusted.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/tomcat-cors-origin-set
+ * @tags security
+ *       external/cwe/cwe-346
+ */
+import java
+import semmle.code.xml.WebXML
+
+private class Alloworigin extends WebContextParameter {
+  Alloworigin() { this.getParamName().getValue() = "cors.allowed.origins" }
+
+  string getParamValueElementValue() { result = getParamValue().getValue() }
+
+  predicate isallowOriginSet() { getParamValueElementValue().toLowerCase() = "*" }
+}
+private class SupportsCredentials extends WebContextParameter {
+  SupportsCredentials() { this.getParamName().getValue() = "cors.support.credentials" }
+
+  string getParamValueElementValue() { result = getParamValue().getValue() }
+
+  predicate isCredentialsSet() { getParamValueElementValue().toLowerCase() = "true" }
+}
+
+from Alloworigin origin , SupportsCredentials cred
+where origin.isallowOriginSet() and cred.isCredentialsSet()
+select origin,
+  "CORS header is being set using user controlled value"

--- a/java/ql/src/experimental/Security/CWE/CWE-346/insecure-cors-web.xml
+++ b/java/ql/src/experimental/Security/CWE/CWE-346/insecure-cors-web.xml
@@ -1,0 +1,39 @@
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+          http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+    <display-name>Sample Tomcat Web Application</display-name>
+    <context-param>
+<filter>
+  <filter-name>CorsFilter</filter-name>
+  <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>
+  <init-param>
+    <param-name>cors.allowed.origins</param-name>
+    <param-value>*</param-value>
+  </init-param>
+  <init-param>
+    <param-name>cors.allowed.methods</param-name>
+    <param-value>GET,POST,HEAD,OPTIONS,PUT</param-value>
+  </init-param>
+  <init-param>
+    <param-name>cors.allowed.headers</param-name>
+    <param-value>Content-Type,X-Requested-With,accept,Origin,Access-Control-Request-Method,Access-Control-Request-Headers</param-value>
+  </init-param>
+  <init-param>
+    <param-name>cors.exposed.headers</param-name>
+    <param-value>Access-Control-Allow-Origin,Access-Control-Allow-Credentials</param-value>
+  </init-param>
+  <init-param>
+    <param-name>cors.support.credentials</param-name>
+    <param-value>true</param-value>
+  </init-param>
+  <init-param>
+    <param-name>cors.preflight.maxage</param-name>
+    <param-value>10</param-value>
+  </init-param>
+</filter>
+<filter-mapping>
+  <filter-name>CorsFilter</filter-name>
+  <url-pattern>/*</url-pattern>
+</filter-mapping>
+    </context-param>
+</web-app> 


### PR DESCRIPTION
This PR add a new experimental query that looks for misconfigured CORS headers  in tomcat config file 
These types of issues are classified under <a href ="https://cwe.mitre.org/data/definitions/346.html"> CWE-346: Origin Validation Error</a>
The query finds the following:

* <code>Access-Control-Allow-Origin</code> being set to '*' along with <code>Access-Control-Allow-Credentials</code> set to true.


Do let me know if any feedback required to merge the PR
