### PR TITLE
JS: Bump ATM pack versions to 0.0.4

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/javascript-experimental-atm-lib
-version: 0.0.2
+version: 0.0.4
 extractor: javascript
 library: true
 groups:

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -1,6 +1,6 @@
 name: codeql/javascript-experimental-atm-queries
 language: javascript
-version: 0.0.2
+version: 0.0.4
 suites: codeql-suites
 defaultSuiteFile: codeql-suites/javascript-atm-code-scanning.qls
 groups:


### PR DESCRIPTION
In the future we'll do this automatically after a release using `codeql pack release`.