### PR TITLE
C++: Store destinations should not be uses for dataflow SSA

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -178,7 +178,7 @@ private predicate isExplicitUse(Operand op) {
       load.getAUse().getUse() instanceof InitializeIndirectionInstruction
     ) and
     // Don't include this operand as a use if the only use of the address is for a write
-    // that definately overrides a variable.
+    // that definitely overrides a variable.
     not (explicitWrite(true, _, vai) and exists(unique( | | vai.getAUse())))
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -170,10 +170,16 @@ private class ReturnParameterIndirection extends Use, TReturnParamIndirection {
 }
 
 private predicate isExplicitUse(Operand op) {
-  op.getDef() instanceof VariableAddressInstruction and
-  not exists(LoadInstruction load |
-    load.getSourceAddressOperand() = op and
-    load.getAUse().getUse() instanceof InitializeIndirectionInstruction
+  exists(VariableAddressInstruction vai | vai = op.getDef() |
+    // Don't include this operand as a use if it only exists to initialize the
+    // indirection of a parameter.
+    not exists(LoadInstruction load |
+      load.getSourceAddressOperand() = op and
+      load.getAUse().getUse() instanceof InitializeIndirectionInstruction
+    ) and
+    // Don't include this operand as a use if the only use of the address is for a write
+    // that definately overrides a variable.
+    not (explicitWrite(true, _, vai) and exists(unique( | | vai.getAUse())))
   )
 }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -570,6 +570,9 @@ postWithInFlow
 | test.cpp:481:24:481:30 | FieldAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:481:24:481:30 | content [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:482:8:482:16 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:489:7:489:7 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:491:5:491:5 | x [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:494:5:494:5 | x [post update] | PostUpdateNode should not be the target of local flow. |
 | true_upon_entry.cpp:9:7:9:7 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | true_upon_entry.cpp:10:12:10:12 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |
 | true_upon_entry.cpp:10:27:10:27 | VariableAddress [post update] | PostUpdateNode should not be the target of local flow. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -490,7 +490,7 @@ void regression_with_phi_flow(int clean1) {
   while (unknown()) {
     x = clean1;
     if (unknown()) { }
-    sink(x); // $ SPURIOUS: ir
+    sink(x); // clean
     x = source();
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -482,3 +482,15 @@ void local_field_flow_def_by_ref_steps_with_local_flow(MyStruct * s) {
   int* p_content = s->content;
   sink(*p_content);
 }
+
+bool unknown();
+
+void regression_with_phi_flow(int clean1) {
+  int x = 0;
+  while (unknown()) {
+    x = clean1;
+    if (unknown()) { }
+    sink(x); // $ SPURIOUS: ir
+    x = source();
+  }
+}


### PR DESCRIPTION
This PR is basically a glorified cherry-pick of https://github.com/github/codeql/commit/092beb8b73cc23c20f568246fb8e6568d51ed608. The code was written as a response to one of the reviews on https://github.com/github/codeql/pull/6825, but the commit had to be reverted because it caused a loss of dataflow on some projects.

I've now looked at those results, and it turns out they were all FPs caused by weird interaction with phi nodes. e8afec413aabf7407e5502bf1245d50aacb22af9 demonstrates the kind of false-positive that underlies all of the lost results, and 25253c7b8df9a5bf800841881575fc9803f8d7c0 fixes the false-positive by doing exactly what 092beb8b73cc23c20f568246fb8e6568d51ed608 did.

Performance on DCA looks fine.