### PR TITLE
Dataflow: Add language-specific NeedsReference predicates

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -921,13 +921,15 @@ module Private {
 
     private predicate inputNeedsReference(string c) {
       c = "Argument" or
-      parseArg(c, _)
+      parseArg(c, _) or
+      inputNeedsReferenceSpecific(c)
     }
 
     private predicate outputNeedsReference(string c) {
       c = "Argument" or
       parseArg(c, _) or
-      c = "ReturnValue"
+      c = "ReturnValue" or
+      outputNeedsReferenceSpecific(c)
     }
 
     private predicate sourceElementRef(InterpretNode ref, string output, string kind) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -171,6 +171,12 @@ string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() 
 /** Gets the textual representation of an argument position in the format used for flow summaries. */
 string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
 
+/** Holds if input specification component `c` needs a reference. */
+predicate inputNeedsReferenceSpecific(string c) { none() }
+
+/** Holds if output specification component `c` needs a reference. */
+predicate outputNeedsReferenceSpecific(string c) { none() }
+
 class SourceOrSinkElement = Element;
 
 /** Gets the return kind corresponding to specification `"ReturnValue"`. */

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -921,13 +921,15 @@ module Private {
 
     private predicate inputNeedsReference(string c) {
       c = "Argument" or
-      parseArg(c, _)
+      parseArg(c, _) or
+      inputNeedsReferenceSpecific(c)
     }
 
     private predicate outputNeedsReference(string c) {
       c = "Argument" or
       parseArg(c, _) or
-      c = "ReturnValue"
+      c = "ReturnValue" or
+      outputNeedsReferenceSpecific(c)
     }
 
     private predicate sourceElementRef(InterpretNode ref, string output, string kind) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -102,6 +102,12 @@ string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() 
 /** Gets the textual representation of an argument position in the format used for flow summaries. */
 string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
 
+/** Holds if input specification component `c` needs a reference. */
+predicate inputNeedsReferenceSpecific(string c) { none() }
+
+/** Holds if output specification component `c` needs a reference. */
+predicate outputNeedsReferenceSpecific(string c) { none() }
+
 class SourceOrSinkElement = Top;
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -921,13 +921,15 @@ module Private {
 
     private predicate inputNeedsReference(string c) {
       c = "Argument" or
-      parseArg(c, _)
+      parseArg(c, _) or
+      inputNeedsReferenceSpecific(c)
     }
 
     private predicate outputNeedsReference(string c) {
       c = "Argument" or
       parseArg(c, _) or
-      c = "ReturnValue"
+      c = "ReturnValue" or
+      outputNeedsReferenceSpecific(c)
     }
 
     private predicate sourceElementRef(InterpretNode ref, string output, string kind) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -99,6 +99,12 @@ string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() 
 /** Gets the textual representation of an argument position in the format used for flow summaries. */
 string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
 
+/** Holds if input specification component `c` needs a reference. */
+predicate inputNeedsReferenceSpecific(string c) { none() }
+
+/** Holds if output specification component `c` needs a reference. */
+predicate outputNeedsReferenceSpecific(string c) { none() }
+
 /** Gets the return kind corresponding to specification `"ReturnValue"`. */
 NormalReturnKind getReturnValueKind() { any() }
 


### PR DESCRIPTION
This is needed for codeql-go, which wants to specify that "ReturnValue[n]" needs a reference