### PR TITLE
JS: Recognize "sql" option as a query string in MySQL

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
@@ -84,7 +84,9 @@ private module MySql {
 
     override DataFlow::Node getAResult() { result = this.getCallback(_).getParameter(1) }
 
-    override DataFlow::Node getAQueryArgument() { result = this.getArgument(0) }
+    override DataFlow::Node getAQueryArgument() {
+      result = this.getArgument(0) or result = this.getOptionArgument(0, "sql")
+    }
   }
 
   /** An expression that is passed to the `query` method and hence interpreted as SQL. */

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -8,6 +8,7 @@
 | mssql-types.ts:7:31:7:42 | 'SELECT 123' |
 | mysql1.js:13:18:13:43 | 'SELECT ... lution' |
 | mysql1.js:18:18:22:1 | {\\n    s ... vid']\\n} |
+| mysql1.js:19:10:19:51 | 'SELECT ... r` = ?' |
 | mysql1a.js:17:18:17:43 | 'SELECT ... lution' |
 | mysql2-promise.js:14:3:14:62 | 'SELECT ... ` > 45' |
 | mysql2-promise.js:23:3:23:56 | 'SELECT ... e` > ?' |
@@ -23,6 +24,7 @@
 | mysql3.js:26:14:26:31 | 'SELECT something' |
 | mysql4.js:14:18:14:20 | sql |
 | mysqlImport.js:3:18:5:1 | {\\n    s ... = ?',\\n} |
+| mysqlImport.js:4:10:4:51 | 'SELECT ... r` = ?' |
 | postgres1.js:37:21:37:24 | text |
 | postgres2.js:30:16:30:41 | 'SELECT ... number' |
 | postgres2.js:43:15:43:26 | 'SELECT 123' |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -41,6 +41,9 @@
 | mongoose.js:97:2:97:52 | Documen ... query)) |
 | mongoose.js:99:2:99:50 | Documen ... query)) |
 | mongoose.js:113:2:113:53 | Documen ... () { }) |
+| mysql.js:8:9:11:47 | connect ... ds) {}) |
+| mysql.js:14:9:16:47 | connect ... ds) {}) |
+| mysql.js:19:9:20:48 | connect ... ds) {}) |
 | pg-promise-types.ts:8:5:8:22 | this.db.one(taint) |
 | pg-promise.js:9:3:9:15 | db.any(query) |
 | pg-promise.js:10:3:10:16 | db.many(query) |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -296,6 +296,15 @@ nodes
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:32 | req.body.id |
+| mysql.js:6:9:6:31 | temp |
+| mysql.js:6:16:6:31 | req.params.value |
+| mysql.js:6:16:6:31 | req.params.value |
+| mysql.js:15:18:15:65 | 'SELECT ...  + temp |
+| mysql.js:15:18:15:65 | 'SELECT ...  + temp |
+| mysql.js:15:62:15:65 | temp |
+| mysql.js:19:26:19:73 | 'SELECT ...  + temp |
+| mysql.js:19:26:19:73 | 'SELECT ...  + temp |
+| mysql.js:19:70:19:73 | temp |
 | pg-promise-types.ts:7:9:7:28 | taint |
 | pg-promise-types.ts:7:17:7:28 | req.params.x |
 | pg-promise-types.ts:7:17:7:28 | req.params.x |
@@ -792,6 +801,14 @@ edges
 | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:22:12:32 | req.body.id |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
+| mysql.js:6:9:6:31 | temp | mysql.js:15:62:15:65 | temp |
+| mysql.js:6:9:6:31 | temp | mysql.js:19:70:19:73 | temp |
+| mysql.js:6:16:6:31 | req.params.value | mysql.js:6:9:6:31 | temp |
+| mysql.js:6:16:6:31 | req.params.value | mysql.js:6:9:6:31 | temp |
+| mysql.js:15:62:15:65 | temp | mysql.js:15:18:15:65 | 'SELECT ...  + temp |
+| mysql.js:15:62:15:65 | temp | mysql.js:15:18:15:65 | 'SELECT ...  + temp |
+| mysql.js:19:70:19:73 | temp | mysql.js:19:26:19:73 | 'SELECT ...  + temp |
+| mysql.js:19:70:19:73 | temp | mysql.js:19:26:19:73 | 'SELECT ...  + temp |
 | pg-promise-types.ts:7:9:7:28 | taint | pg-promise-types.ts:8:17:8:21 | taint |
 | pg-promise-types.ts:7:9:7:28 | taint | pg-promise-types.ts:8:17:8:21 | taint |
 | pg-promise-types.ts:7:17:7:28 | req.params.x | pg-promise-types.ts:7:9:7:28 | taint |
@@ -978,6 +995,8 @@ edges
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query depends on $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | a user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query depends on $@. | mongooseModelClient.js:10:22:10:29 | req.body | a user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query depends on $@. | mongooseModelClient.js:12:22:12:29 | req.body | a user-provided value |
+| mysql.js:15:18:15:65 | 'SELECT ...  + temp | mysql.js:6:16:6:31 | req.params.value | mysql.js:15:18:15:65 | 'SELECT ...  + temp | This query depends on $@. | mysql.js:6:16:6:31 | req.params.value | a user-provided value |
+| mysql.js:19:26:19:73 | 'SELECT ...  + temp | mysql.js:6:16:6:31 | req.params.value | mysql.js:19:26:19:73 | 'SELECT ...  + temp | This query depends on $@. | mysql.js:6:16:6:31 | req.params.value | a user-provided value |
 | pg-promise-types.ts:8:17:8:21 | taint | pg-promise-types.ts:7:17:7:28 | req.params.x | pg-promise-types.ts:8:17:8:21 | taint | This query depends on $@. | pg-promise-types.ts:7:17:7:28 | req.params.x | a user-provided value |
 | pg-promise.js:9:10:9:14 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:9:10:9:14 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |
 | pg-promise.js:10:11:10:15 | query | pg-promise.js:7:16:7:34 | req.params.category | pg-promise.js:10:11:10:15 | query | This query depends on $@. | pg-promise.js:7:16:7:34 | req.params.category | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/mysql.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/mysql.js
@@ -1,0 +1,22 @@
+const app = require("express")();
+const mysql = require('mysql');
+const pool = mysql.createPool(getConfig());
+
+app.get("search", function handler(req, res) {
+    let temp = req.params.value;
+    pool.getConnection(function(err, connection) {
+        connection.query({
+            sql: 'SELECT * FROM `books` WHERE `author` = ?', // OK
+            values: [temp]
+        }, function(error, results, fields) {});
+    });
+    pool.getConnection(function(err, connection) {
+        connection.query({
+            sql: 'SELECT * FROM `books` WHERE `author` = ' + temp, // NOT OK
+        }, function(error, results, fields) {});
+    });
+    pool.getConnection(function(err, connection) {
+        connection.query('SELECT * FROM `books` WHERE `author` = ' + temp, // NOT OK
+            function(error, results, fields) {});
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/7586

Recognizes the MySQL sink `connection.query({ sql: <sink> })`, instead of just `connection.query(<sink>)`.

Thanks to @Naman-ntc for finding this missing part of the model ✨ 