### PR TITLE
JS: Update names, IDs, and tags for ML-powered queries

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/src/NosqlInjectionATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/NosqlInjectionATM.ql
@@ -1,15 +1,15 @@
 /**
  * For internal use only.
  *
- * @name NoSQL database query built from user-controlled sources (boosted)
+ * @name NoSQL database query built from user-controlled sources (experimental)
  * @description Building a database query from user-controlled sources is vulnerable to insertion of
  *              malicious code by the user.
  * @kind path-problem
  * @scored
  * @problem.severity error
  * @security-severity 8.8
- * @id adaptive-threat-modeling/js/nosql-injection
- * @tags experimental experimental/atm security
+ * @id js/ml-powered/nosql-injection
+ * @tags experimental security
  */
 
 import ATM::ResultsInfo

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/SqlInjectionATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/SqlInjectionATM.ql
@@ -1,15 +1,15 @@
 /**
  * For internal use only.
  *
- * @name SQL database query built from user-controlled sources (boosted)
+ * @name SQL database query built from user-controlled sources (experimental)
  * @description Building a database query from user-controlled sources is vulnerable to insertion of
  *              malicious code by the user.
  * @kind path-problem
  * @scored
  * @problem.severity error
  * @security-severity 8.8
- * @id adaptive-threat-modeling/js/sql-injection
- * @tags experimental experimental/atm security
+ * @id js/ml-powered/sql-injection
+ * @tags experimental security
  */
 
 import experimental.adaptivethreatmodeling.SqlInjectionATM

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/TaintedPathATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/TaintedPathATM.ql
@@ -1,15 +1,15 @@
 /**
  * For internal use only.
  *
- * @name Uncontrolled data used in path expression (boosted)
+ * @name Uncontrolled data used in path expression (experimental)
  * @description Accessing paths influenced by users can allow an attacker to access
  *              unexpected resources.
  * @kind path-problem
  * @scored
  * @problem.severity error
  * @security-severity 7.5
- * @id adaptive-threat-modeling/js/path-injection
- * @tags experimental experimental/atm security
+ * @id js/ml-powered/path-injection
+ * @tags experimental security
  */
 
 import ATM::ResultsInfo

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.ql
@@ -1,15 +1,15 @@
 /**
  * For internal use only.
  *
- * @name Client-side cross-site scripting (boosted)
+ * @name Client-side cross-site scripting (experimental)
  * @description Writing user input directly to the DOM allows for
  *              a cross-site scripting vulnerability.
  * @kind path-problem
  * @scored
  * @problem.severity error
  * @security-severity 6.1
- * @id adaptive-threat-modeling/js/xss
- * @tags experimental experimental/atm security
+ * @id js/ml-powered/xss
+ * @tags experimental security
  */
 
 import javascript


### PR DESCRIPTION
- Change the `(boosted)` suffix in the query name to `(experimental)` (we can rename this later without causing alerts to be closed/opened)
- Remove the `experimental/atm` tag — this was requested to improve how the alerts look in the UI
- Update the query IDs to `js/ml-powered/*`