### PR TITLE
Update version numbers in CodeQL support notes for LGTM 1.29

### DIFF
--- a/docs/codeql/support/conf.py
+++ b/docs/codeql/support/conf.py
@@ -41,9 +41,12 @@ project = u'Supported languages and frameworks for LGTM Enterprise'
 
 # The version info for this project, if different from version and release in main conf.py file.
 # The short X.Y version.
-version = u'1.27'
-# The full version, including alpha/beta/rc tags.
-release = u'1.27'
+
+# LGTM Enterprise release
+release = u'1.29'
+
+# CodeQL CLI version used by LGTM Enterprise release
+version = u'2.6.4'
 
 # -- Project-specifc options for HTML output ----------------------------------------------
 

--- a/docs/codeql/support/framework-support.rst
+++ b/docs/codeql/support/framework-support.rst
@@ -1,7 +1,7 @@
 Frameworks and libraries
 ########################
 
-The libraries and queries in version |version| have been explicitly checked against the libraries and frameworks listed below.
+LGTM Enterprise |release| includes CodeQL CLI |version|. The CodeQL libraries and queries used by this version of LGTM Enterprise have been explicitly checked against the libraries and frameworks listed below.
 
 .. pull-quote::
 

--- a/docs/codeql/support/framework-support.rst
+++ b/docs/codeql/support/framework-support.rst
@@ -5,6 +5,12 @@ LGTM Enterprise |release| includes CodeQL CLI |version|. The CodeQL libraries an
 
 .. pull-quote::
 
+    Note
+
+    For details of language and compiler support in the most recent release of the CodeQL CLI, see `Supported languages and frameworks <https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/>`__ in the CodeQL CLI documentation.
+
+.. pull-quote::
+
     Tip
     
     If you're interested in other libraries or frameworks, you can extend the analysis to cover them. 

--- a/docs/codeql/support/framework-support.rst
+++ b/docs/codeql/support/framework-support.rst
@@ -7,7 +7,7 @@ LGTM Enterprise |release| includes CodeQL CLI |version|. The CodeQL libraries an
 
     Note
 
-    For details of language and compiler support in the most recent release of the CodeQL CLI, see `Supported languages and frameworks <https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/>`__ in the CodeQL CLI documentation.
+    For details of framework and library support in the most recent release of the CodeQL CLI, see `Supported languages and frameworks <https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/>`__ in the CodeQL CLI documentation.
 
 .. pull-quote::
 

--- a/docs/codeql/support/language-support.rst
+++ b/docs/codeql/support/language-support.rst
@@ -3,6 +3,12 @@ Languages and compilers
 
 LGTM Enterprise |release| includes CodeQL CLI |version|. LGTM Enterprise supports analysis of the following languages compiled by the following compilers.
 
+.. pull-quote::
+
+    Note
+
+    For details of language and compiler support in the most recent release of the CodeQL CLI, see `Supported languages and frameworks <https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/>`__ in the CodeQL CLI documentation.
+
 Note that where there are several versions or dialects of a language, the supported variants are listed.
 If your code requires a particular version of a compiler, check that this version is included below. 
 If you have any questions about language and compiler support, you can find help on the `GitHub Security Lab discussions board <https://github.com/github/securitylab/discussions>`__.

--- a/docs/codeql/support/language-support.rst
+++ b/docs/codeql/support/language-support.rst
@@ -1,8 +1,7 @@
 Languages and compilers
 #######################
 
-CodeQL and LGTM version |version| support analysis of the following languages compiled by the following compilers.
-(CodeQL was previously known as QL.)
+LGTM Enterprise |release| includes CodeQL CLI |version|. LGTM Enterprise supports analysis of the following languages compiled by the following compilers.
 
 Note that where there are several versions or dialects of a language, the supported variants are listed.
 If your code requires a particular version of a compiler, check that this version is included below. 


### PR DESCRIPTION
This PR moves a change that was made in `main` for the LGTM Enterprise 1.28 release into the `rc/3.3` branch and updates the version numbers for the upcoming release of LGTM Enterprise 1.29.

In addition, it adds a note linking out to the main CodeQL CLI docs for anyone who wants information on the latest release and ended up on these pages by mistake (closes https://github.com/github/docs-content/issues/4158).

![image](https://user-images.githubusercontent.com/1877141/149813376-6f2cf6c7-724d-4e06-b4f9-1a8f5c9cef8f.png)
