### PR TITLE
Remove security-severity tag to java/random-used-once

### DIFF
--- a/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
@@ -4,12 +4,10 @@
  *              guarantee an evenly distributed sequence of random numbers.
  * @kind problem
  * @problem.severity warning
- * @security-severity 9.8
  * @precision medium
  * @id java/random-used-once
  * @tags reliability
  *       maintainability
- *       security
  *       external/cwe/cwe-335
  */
 

--- a/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/RandomUsedOnce.ql
@@ -9,6 +9,7 @@
  * @id java/random-used-once
  * @tags reliability
  *       maintainability
+ *       security
  *       external/cwe/cwe-335
  */
 

--- a/java/ql/src/change-notes/2022-01-19-random-used-once.md
+++ b/java/ql/src/change-notes/2022-01-19-random-used-once.md
@@ -1,0 +1,4 @@
+---
+category: queryMetadata
+---
+* The "Random used only once" (`java/random-used-once`) query no longer has a `security-severity` score. This has been causing some tools to categorise it as a security query, when it is more useful as a code-quality query.


### PR DESCRIPTION
Raised in https://github.com/github/codeql/issues/7601, this is one of the only .ql files that has a security-severity score but not the tag "security", including many other queries that live outside the `Security/` subdirectory.

Besides this the only other files with this security-severity-but-no-security-tag combination are:

```
java/ql/src/Frameworks/JavaEE/EJB/EjbContainerInterference.ql
java/ql/src/Frameworks/JavaEE/EJB/EjbFileIO.ql
java/ql/src/Frameworks/JavaEE/EJB/EjbNative.ql
java/ql/src/Frameworks/JavaEE/EJB/EjbReflection.ql
java/ql/src/Frameworks/JavaEE/EJB/EjbSecurityConfiguration.ql
java/ql/src/Frameworks/JavaEE/EJB/EjbSerialization.ql
java/ql/src/Frameworks/JavaEE/EJB/EjbSetSocketOrUrlFactory.ql
```

Given their location I'm assuming these queries are disabled by default and likely shouldn't changed?