### PR TITLE
QL: support this.method() calls in the charpred that references non-extending supertypes

### DIFF
--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -77,8 +77,12 @@ private module Cached {
       p = t.getClassPredicate(mc.getMemberName(), mc.getNumberOfArguments())
     )
     or
-    // super calls
-    exists(Super sup, ClassType type, Type supertype |
+    // super calls - and `this.method()` calls in charpreds (for confusing reasons)
+    exists(AstNode sup, ClassType type, Type supertype |
+      sup instanceof Super
+      or
+      sup.(ThisAccess).getEnclosingPredicate() instanceof CharPred
+    |
       mc.getBase() = sup and
       sup.getEnclosingPredicate().getParent().(Class).getType() = type and
       supertype in [type.getASuperType(), type.getAnInstanceofType()] and

--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -77,7 +77,7 @@ private module Cached {
       p = t.getClassPredicate(mc.getMemberName(), mc.getNumberOfArguments())
     )
     or
-    // super calls - and `this.method()` calls in charpreds (for confusing reasons)
+    // super calls - and `this.method()` calls in charpreds. (Basically: in charpreds there is no difference between super and this.)
     exists(AstNode sup, ClassType type, Type supertype |
       sup instanceof Super
       or

--- a/ql/ql/test/callgraph/Bar.qll
+++ b/ql/ql/test/callgraph/Bar.qll
@@ -7,3 +7,28 @@ module Firebase {
 
   int snapshot() { result = 2 }
 }
+
+class Foo extends int {
+  Foo() { this = 1 or this = 2 }
+}
+
+class Function extends int {
+  Function() { this = 1 }
+
+  bindingset[i]
+  int getParameter(int i) { result = i * this }
+}
+
+class Bar extends Foo instanceof Function {
+  Bar() {
+    exists(super.getParameter(0))
+    or
+    exists(this.getParameter(0)) // <- we support this, until it's clear whether it's a compile error or not
+  }
+
+  predicate bar() {
+    exists(super.getParameter(0))
+    // or
+    // exists(this.getParameter(0)) // <- this is definitely a compile error
+  }
+}

--- a/ql/ql/test/callgraph/callgraph.expected
+++ b/ql/ql/test/callgraph/callgraph.expected
@@ -1,5 +1,8 @@
 getTarget
 | Bar.qll:5:38:5:47 | PredicateCall | Bar.qll:8:3:8:31 | ClasslessPredicate snapshot |
+| Bar.qll:24:12:24:32 | MemberCall | Bar.qll:19:3:19:47 | ClassPredicate getParameter |
+| Bar.qll:26:12:26:31 | MemberCall | Bar.qll:19:3:19:47 | ClassPredicate getParameter |
+| Bar.qll:30:12:30:32 | MemberCall | Bar.qll:19:3:19:47 | ClassPredicate getParameter |
 | Baz.qll:8:18:8:44 | MemberCall | Baz.qll:4:3:4:37 | ClassPredicate getImportedPath |
 | Foo.qll:5:26:5:30 | PredicateCall | Foo.qll:3:1:3:26 | ClasslessPredicate foo |
 | Foo.qll:10:21:10:25 | PredicateCall | Foo.qll:8:3:8:28 | ClassPredicate bar |


### PR DESCRIPTION
See the below example.  
I've added support for the `this might be a compile error?` line. 

If it turns out that it's actually supposed to be a compile-error, then we'll revert this PR. 

```CodeQL
class Expr extends int {
  Expr() { this = 1 or this = 2 }
}

class Function extends int {
  Function() { this = 1 }

  int getParameter(int i) { result = i * this }
}

class Foo extends Expr instanceof Function {
  Foo() {
    exists(super.getParameter(0))
    or
    exists(this.getParameter(0)) // <- this might be a compile error? But currently the compiler doesn't think so. 
  }

  predicate bar() {
    exists(super.getParameter(0))
    or
    exists(this.getParameter(0)) // <- this is a compile error, everyone agrees on that. 
  }
}
```