### PR TITLE
JS: Update alert messages for ML-powered queries

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/src/NosqlInjectionATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/NosqlInjectionATM.ql
@@ -16,15 +16,11 @@ import ATM::ResultsInfo
 import DataFlow::PathGraph
 import experimental.adaptivethreatmodeling.NosqlInjectionATM
 
-from
-  DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score,
-  string scoreString
+from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score
 where
   cfg.hasFlowPath(source, sink) and
   not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
-  score = getScoreForFlow(source.getNode(), sink.getNode()) and
-  scoreString = getScoreStringForFlow(source.getNode(), sink.getNode())
+  score = getScoreForFlow(source.getNode(), sink.getNode())
 select sink.getNode(), source, sink,
-  "[Score = " + scoreString + "] This may be a NoSQL query depending on $@ " +
-    getAdditionalAlertInfo(source.getNode(), sink.getNode()), source.getNode(),
-  "a user-provided value", score
+  "(Experimental) This may be a database query that depends on $@. Identified using machine learning.",
+  source.getNode(), "a user-provided value", score

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/SqlInjectionATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/SqlInjectionATM.ql
@@ -16,15 +16,11 @@ import experimental.adaptivethreatmodeling.SqlInjectionATM
 import ATM::ResultsInfo
 import DataFlow::PathGraph
 
-from
-  DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score,
-  string scoreString
+from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score
 where
   cfg.hasFlowPath(source, sink) and
   not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
-  score = getScoreForFlow(source.getNode(), sink.getNode()) and
-  scoreString = getScoreStringForFlow(source.getNode(), sink.getNode())
+  score = getScoreForFlow(source.getNode(), sink.getNode())
 select sink.getNode(), source, sink,
-  "[Score = " + scoreString + "] This may be a js/sql result depending on $@ " +
-    getAdditionalAlertInfo(source.getNode(), sink.getNode()), source.getNode(),
-  "a user-provided value", score
+  "(Experimental) This may be a database query that depends on $@. Identified using machine learning.",
+  source.getNode(), "a user-provided value", score

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/TaintedPathATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/TaintedPathATM.ql
@@ -16,15 +16,11 @@ import ATM::ResultsInfo
 import DataFlow::PathGraph
 import experimental.adaptivethreatmodeling.TaintedPathATM
 
-from
-  DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score,
-  string scoreString
+from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score
 where
   cfg.hasFlowPath(source, sink) and
   not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
-  score = getScoreForFlow(source.getNode(), sink.getNode()) and
-  scoreString = getScoreStringForFlow(source.getNode(), sink.getNode())
+  score = getScoreForFlow(source.getNode(), sink.getNode())
 select sink.getNode(), source, sink,
-  "[Score = " + scoreString + "] This may be a js/path-injection result depending on $@ " +
-    getAdditionalAlertInfo(source.getNode(), sink.getNode()), source.getNode(),
-  "a user-provided value", score
+  "(Experimental) This may be a path that depends on $@. Identified using machine learning.",
+  source.getNode(), "a user-provided value", score

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.ql
@@ -17,15 +17,11 @@ import ATM::ResultsInfo
 import DataFlow::PathGraph
 import experimental.adaptivethreatmodeling.XssATM
 
-from
-  DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score,
-  string scoreString
+from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score
 where
   cfg.hasFlowPath(source, sink) and
   not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
-  score = getScoreForFlow(source.getNode(), sink.getNode()) and
-  scoreString = getScoreStringForFlow(source.getNode(), sink.getNode())
+  score = getScoreForFlow(source.getNode(), sink.getNode())
 select sink.getNode(), source, sink,
-  "[Score = " + scoreString + "] This may be a js/xss result depending on $@ " +
-    getAdditionalAlertInfo(source.getNode(), sink.getNode()), source.getNode(),
-  "a user-provided value", score
+  "(Experimental) This may be a cross-site scripting vulnerability due to $@. Identified using machine learning."
+    + "a user-provided value", score


### PR DESCRIPTION
We follow a template of `(Experimental) <alert message for original query> Identified using machine learning.`, but also modify the original message to indicate uncertainty, for example "This is a path that depends on a user-provided value." -> "This may be a path that depends on a user-provided value."