### PR TITLE
JS: add query for detecting insecure temporary files

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll
@@ -1,0 +1,96 @@
+/**
+ * Provides default sources, sinks and sanitizers for reasoning about
+ * insecure temporary file creation, as well as
+ * extension points for adding your own.
+ */
+
+import javascript
+
+/**
+ * Classes and predicates for reasoning about insecure temporary file creation.
+ */
+module InsecureTemporaryFile {
+  /**
+   * A data flow source for insecure temporary file creation.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for insecure temporary file creation.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A sanitizer for random insecure temporary file creation.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /** A call that opens a file with a given path. */
+  class OpenFileCall extends DataFlow::CallNode {
+    string methodName;
+
+    OpenFileCall() {
+      methodName = ["open", "openSync", "writeFile", "writeFileSync"] and
+      this = NodeJSLib::FS::moduleMember(methodName).getACall()
+    }
+
+    DataFlow::Node getPath() { result = this.getArgument(0) }
+
+    DataFlow::Node getMode() {
+      methodName = ["open", "openSync"] and
+      result = this.getArgument(2)
+      or
+      methodName = ["writeFile", "writeFileSync"] and
+      result = this.getOptionArgument(2, "mode")
+    }
+  }
+
+  /** Holds if the `mode` ensure no access to other users. */
+  bindingset[mode]
+  private predicate isSecureMode(int mode) {
+    // the lowest 6 bits should be 0.
+    // E.g. `0o600` is secure (each digit in a octal number is 3 bits)
+    mode.bitAnd(1) = 0 and
+    mode.bitAnd(2) = 0 and
+    mode.bitAnd(4) = 0 and
+    mode.bitAnd(8) = 0 and
+    mode.bitAnd(16) = 0 and
+    mode.bitAnd(32) = 0
+  }
+
+  /** The path in a call that opens a file without specifying a secure `mode`. Seen as a sink for insecure temporary file creation. */
+  class InsecureFileOpen extends Sink {
+    InsecureFileOpen() {
+      exists(OpenFileCall call |
+        not exists(call.getMode())
+        or
+        exists(int mode | mode = call.getMode().getIntValue() | not isSecureMode(mode))
+      |
+        this = call.getPath()
+      )
+    }
+  }
+
+  /** A a string that references the global tmp dir. Seen as a source for insecure temporary file creation. */
+  class OSTempDir extends Source {
+    OSTempDir() {
+      this = DataFlow::moduleImport("os").getAMemberCall("tmpdir")
+      or
+      this.getStringValue().matches("/tmp/%")
+    }
+  }
+
+  /** A non-first leaf in a string-concatenation. Seen as a sanitizer for insecure temporary file creation. */
+  class NonFirstStringConcatLeaf extends Sanitizer {
+    NonFirstStringConcatLeaf() {
+      exists(StringOps::ConcatenationRoot root |
+        this = root.getALeaf() and
+        not this = root.getFirstLeaf()
+      )
+      or
+      exists(DataFlow::CallNode join | join = DataFlow::moduleMember("path", "join").getACall() |
+        this = join.getArgument([1 .. join.getNumArgument() - 1])
+      )
+    }
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll
@@ -30,7 +30,12 @@ module InsecureTemporaryFile {
     string methodName;
 
     OpenFileCall() {
-      methodName = ["open", "openSync", "writeFile", "writeFileSync"] and
+      methodName =
+        [
+          "open", "openSync", "writeFile", "writeFileSync", "writeJson", "writeJSON",
+          "writeJsonSync", "writeJSONSync", "outputJson", "outputJSON", "outputJsonSync",
+          "outputJSONSync", "outputFile", "outputFileSync"
+        ] and
       this = NodeJSLib::FS::moduleMember(methodName).getACall()
     }
 
@@ -40,7 +45,7 @@ module InsecureTemporaryFile {
       methodName = ["open", "openSync"] and
       result = this.getArgument(2)
       or
-      methodName = ["writeFile", "writeFileSync"] and
+      not methodName = ["open", "openSync"] and
       result = this.getOptionArgument(2, "mode")
     }
   }
@@ -88,7 +93,8 @@ module InsecureTemporaryFile {
         not this = root.getFirstLeaf()
       )
       or
-      exists(DataFlow::CallNode join | join = DataFlow::moduleMember("path", "join").getACall() |
+      exists(DataFlow::CallNode join |
+        join = DataFlow::moduleMember("path", "join").getACall() and
         this = join.getArgument([1 .. join.getNumArgument() - 1])
       )
     }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileCustomizations.qll
@@ -71,7 +71,7 @@ module InsecureTemporaryFile {
     }
   }
 
-  /** A a string that references the global tmp dir. Seen as a source for insecure temporary file creation. */
+  /** A string that references the global tmp dir. Seen as a source for insecure temporary file creation. */
   class OSTempDir extends Source {
     OSTempDir() {
       this = DataFlow::moduleImport("os").getAMemberCall("tmpdir")

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureTemporaryFileQuery.qll
@@ -1,0 +1,27 @@
+/**
+ * Provides a taint tracking configuration for reasoning about insecure temporary
+ * file creation.
+ *
+ * Note, for performance reasons: only import this file if
+ * `InsecureTemporaryFile::Configuration` is needed, otherwise
+ * `InsecureTemporaryFileCustomizations` should be imported instead.
+ */
+
+import javascript
+import InsecureTemporaryFileCustomizations::InsecureTemporaryFile
+
+/**
+ * A taint-tracking configuration for reasoning about insecure temporary file creation.
+ */
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "InsecureTemporaryFile" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    super.isSanitizer(node) or
+    node instanceof Sanitizer
+  }
+}

--- a/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.qhelp
+++ b/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.qhelp
@@ -1,0 +1,43 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Temporary files created in the operating system tmp directory are by default accessible 
+to other users. This can in some cases lead to information exposure, or in the worst 
+case to remote code execution.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Use a well tested library like <a href="https://www.npmjs.com/package/tmp">tmp</a> 
+for creating temprary files. These libraries ensure both that the file is inaccesible
+to other users and that the file does not already exist.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example creates a temporary file in the operating system tmp directory.
+</p>
+<sample src="examples/insecure-temporary-file.js" />
+
+<p>
+The file created above is accessible to other users, and there is no guarantee that
+the file does not already exist. 
+</p>
+<p>
+The below example uses the <a href="https://www.npmjs.com/package/tmp">tmp</a> library
+to securely create a temporary file.
+</p>
+<sample src="examples/secure-temporary-file.js" />
+
+</example>
+
+<references>
+<li>Mitre.org: <a href="https://cwe.mitre.org/data/definitions/377.html">CWE-377</a>.</li>
+<li>NPM: <a href="https://www.npmjs.com/package/tmp">tmp</a>.</li>
+</references>
+
+</qhelp>

--- a/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.qhelp
+++ b/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.qhelp
@@ -3,15 +3,15 @@
 
 <overview>
 <p>
-Temporary files created in the operating system tmp directory are by default accessible 
-to other users. This can in some cases lead to information exposure, or in the worst 
-case to remote code execution.
+Temporary files created in the operating system's temporary directory are by default accessible 
+to other users. In some cases, this can lead to information exposure, or in the worst 
+case, to remote code execution.
 </p>
 </overview>
 
 <recommendation>
 <p>
-Use a well tested library like <a href="https://www.npmjs.com/package/tmp">tmp</a> 
+Use a well-tested library like <a href="https://www.npmjs.com/package/tmp">tmp</a> 
 for creating temporary files. These libraries ensure both that the file is inaccessible
 to other users and that the file does not already exist.
 </p>
@@ -19,7 +19,7 @@ to other users and that the file does not already exist.
 
 <example>
 <p>
-The following example creates a temporary file in the operating system tmp directory.
+The following example creates a temporary file in the operating system's temporary directory.
 </p>
 <sample src="examples/insecure-temporary-file.js" />
 

--- a/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.qhelp
+++ b/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.qhelp
@@ -12,7 +12,7 @@ case to remote code execution.
 <recommendation>
 <p>
 Use a well tested library like <a href="https://www.npmjs.com/package/tmp">tmp</a> 
-for creating temprary files. These libraries ensure both that the file is inaccesible
+for creating temporary files. These libraries ensure both that the file is inaccessible
 to other users and that the file does not already exist.
 </p>
 </recommendation>

--- a/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
+++ b/javascript/ql/src/Security/CWE-377/InsecureTemporaryFile.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Insecure temporary file
+ * @description Creating a temporary file that is accessible by other users TODO:
+ * @kind path-problem
+ * @id js/insecure-temporary-file
+ * @problem.severity warning
+ * @security-severity 7.0
+ * @precision medium
+ * @tags external/cwe/cwe-377
+ *       external/cwe/cwe-378
+ *       security
+ */
+
+import javascript
+import DataFlow::PathGraph
+import semmle.javascript.security.dataflow.InsecureTemporaryFileQuery
+
+from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Insecure creation of file in $@.", source.getNode(),
+  "the os temp dir"

--- a/javascript/ql/src/Security/CWE-377/examples/insecure-temporary-file.js
+++ b/javascript/ql/src/Security/CWE-377/examples/insecure-temporary-file.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const file = path.join(os.tmpdir(), "test-" + (new Date()).getTime() + ".txt");
+fs.writeFileSync(file, "content");

--- a/javascript/ql/src/Security/CWE-377/examples/secure-temporary-file.js
+++ b/javascript/ql/src/Security/CWE-377/examples/secure-temporary-file.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const tmp = require('tmp');
+
+const file = tmp.fileSync().name;
+fs.writeFileSync(file, "content");

--- a/javascript/ql/src/change-notes/2022-01-18-insecure-temporary-file.md
+++ b/javascript/ql/src/change-notes/2022-01-18-insecure-temporary-file.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* A new query `js/insecure-temporary-file` has been added. The query detects the creation of temporary files that may be accessible by others users. The query is not run by default. 

--- a/javascript/ql/test/query-tests/Security/CWE-377/InsecureTemporaryFile.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-377/InsecureTemporaryFile.expected
@@ -1,0 +1,53 @@
+nodes
+| insecure-temporary-file.js:7:9:11:5 | tmpLocation |
+| insecure-temporary-file.js:7:23:11:5 | path.jo ... )\\n    ) |
+| insecure-temporary-file.js:8:9:8:45 | os.tmpd ... mpDir() |
+| insecure-temporary-file.js:8:21:8:31 | os.tmpdir() |
+| insecure-temporary-file.js:8:21:8:31 | os.tmpdir() |
+| insecure-temporary-file.js:13:22:13:32 | tmpLocation |
+| insecure-temporary-file.js:13:22:13:32 | tmpLocation |
+| insecure-temporary-file.js:15:9:15:34 | tmpPath |
+| insecure-temporary-file.js:15:19:15:34 | "/tmp/something" |
+| insecure-temporary-file.js:15:19:15:34 | "/tmp/something" |
+| insecure-temporary-file.js:17:22:17:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:17:22:17:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:17:32:17:38 | tmpPath |
+| insecure-temporary-file.js:23:22:23:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:23:22:23:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:23:32:23:38 | tmpPath |
+| insecure-temporary-file.js:25:11:25:92 | tmpPath2 |
+| insecure-temporary-file.js:25:22:25:92 | path.jo ... )}.md`) |
+| insecure-temporary-file.js:25:32:25:42 | os.tmpdir() |
+| insecure-temporary-file.js:25:32:25:42 | os.tmpdir() |
+| insecure-temporary-file.js:26:22:26:29 | tmpPath2 |
+| insecure-temporary-file.js:26:22:26:29 | tmpPath2 |
+| insecure-temporary-file.js:28:17:28:24 | tmpPath2 |
+| insecure-temporary-file.js:28:17:28:24 | tmpPath2 |
+edges
+| insecure-temporary-file.js:7:9:11:5 | tmpLocation | insecure-temporary-file.js:13:22:13:32 | tmpLocation |
+| insecure-temporary-file.js:7:9:11:5 | tmpLocation | insecure-temporary-file.js:13:22:13:32 | tmpLocation |
+| insecure-temporary-file.js:7:23:11:5 | path.jo ... )\\n    ) | insecure-temporary-file.js:7:9:11:5 | tmpLocation |
+| insecure-temporary-file.js:8:9:8:45 | os.tmpd ... mpDir() | insecure-temporary-file.js:7:23:11:5 | path.jo ... )\\n    ) |
+| insecure-temporary-file.js:8:21:8:31 | os.tmpdir() | insecure-temporary-file.js:8:9:8:45 | os.tmpd ... mpDir() |
+| insecure-temporary-file.js:8:21:8:31 | os.tmpdir() | insecure-temporary-file.js:8:9:8:45 | os.tmpd ... mpDir() |
+| insecure-temporary-file.js:15:9:15:34 | tmpPath | insecure-temporary-file.js:17:32:17:38 | tmpPath |
+| insecure-temporary-file.js:15:9:15:34 | tmpPath | insecure-temporary-file.js:23:32:23:38 | tmpPath |
+| insecure-temporary-file.js:15:19:15:34 | "/tmp/something" | insecure-temporary-file.js:15:9:15:34 | tmpPath |
+| insecure-temporary-file.js:15:19:15:34 | "/tmp/something" | insecure-temporary-file.js:15:9:15:34 | tmpPath |
+| insecure-temporary-file.js:17:32:17:38 | tmpPath | insecure-temporary-file.js:17:22:17:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:17:32:17:38 | tmpPath | insecure-temporary-file.js:17:22:17:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:23:32:23:38 | tmpPath | insecure-temporary-file.js:23:22:23:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:23:32:23:38 | tmpPath | insecure-temporary-file.js:23:22:23:49 | path.jo ... /foo/") |
+| insecure-temporary-file.js:25:11:25:92 | tmpPath2 | insecure-temporary-file.js:26:22:26:29 | tmpPath2 |
+| insecure-temporary-file.js:25:11:25:92 | tmpPath2 | insecure-temporary-file.js:26:22:26:29 | tmpPath2 |
+| insecure-temporary-file.js:25:11:25:92 | tmpPath2 | insecure-temporary-file.js:28:17:28:24 | tmpPath2 |
+| insecure-temporary-file.js:25:11:25:92 | tmpPath2 | insecure-temporary-file.js:28:17:28:24 | tmpPath2 |
+| insecure-temporary-file.js:25:22:25:92 | path.jo ... )}.md`) | insecure-temporary-file.js:25:11:25:92 | tmpPath2 |
+| insecure-temporary-file.js:25:32:25:42 | os.tmpdir() | insecure-temporary-file.js:25:22:25:92 | path.jo ... )}.md`) |
+| insecure-temporary-file.js:25:32:25:42 | os.tmpdir() | insecure-temporary-file.js:25:22:25:92 | path.jo ... )}.md`) |
+#select
+| insecure-temporary-file.js:13:22:13:32 | tmpLocation | insecure-temporary-file.js:8:21:8:31 | os.tmpdir() | insecure-temporary-file.js:13:22:13:32 | tmpLocation | Insecure creation of file in $@. | insecure-temporary-file.js:8:21:8:31 | os.tmpdir() | the os temp dir |
+| insecure-temporary-file.js:17:22:17:49 | path.jo ... /foo/") | insecure-temporary-file.js:15:19:15:34 | "/tmp/something" | insecure-temporary-file.js:17:22:17:49 | path.jo ... /foo/") | Insecure creation of file in $@. | insecure-temporary-file.js:15:19:15:34 | "/tmp/something" | the os temp dir |
+| insecure-temporary-file.js:23:22:23:49 | path.jo ... /foo/") | insecure-temporary-file.js:15:19:15:34 | "/tmp/something" | insecure-temporary-file.js:23:22:23:49 | path.jo ... /foo/") | Insecure creation of file in $@. | insecure-temporary-file.js:15:19:15:34 | "/tmp/something" | the os temp dir |
+| insecure-temporary-file.js:26:22:26:29 | tmpPath2 | insecure-temporary-file.js:25:32:25:42 | os.tmpdir() | insecure-temporary-file.js:26:22:26:29 | tmpPath2 | Insecure creation of file in $@. | insecure-temporary-file.js:25:32:25:42 | os.tmpdir() | the os temp dir |
+| insecure-temporary-file.js:28:17:28:24 | tmpPath2 | insecure-temporary-file.js:25:32:25:42 | os.tmpdir() | insecure-temporary-file.js:28:17:28:24 | tmpPath2 | Insecure creation of file in $@. | insecure-temporary-file.js:25:32:25:42 | os.tmpdir() | the os temp dir |

--- a/javascript/ql/test/query-tests/Security/CWE-377/InsecureTemporaryFile.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-377/InsecureTemporaryFile.qlref
@@ -1,0 +1,1 @@
+Security/CWE-377/InsecureTemporaryFile.ql

--- a/javascript/ql/test/query-tests/Security/CWE-377/insecure-temporary-file.js
+++ b/javascript/ql/test/query-tests/Security/CWE-377/insecure-temporary-file.js
@@ -1,0 +1,30 @@
+const os = require('os');
+const uuid = require('node-uuid');
+const fs = require('fs');
+const path = require('path');
+
+(function main() {
+    var tmpLocation = path.join(
+        os.tmpdir ? os.tmpdir() : os.tmpDir(),
+        'something',
+        uuid.v4().slice(0, 8)
+    );
+
+    fs.writeFileSync(tmpLocation, content); // NOT OK
+
+    var tmpPath = "/tmp/something";
+    fs.writeFileSync(path.join("./foo/", tmpPath), content); // OK
+    fs.writeFileSync(path.join(tmpPath, "./foo/"), content); // NOT OK
+
+    fs.writeFileSync(path.join(tmpPath, "./foo/"), content, {mode: 0o600}); // OK
+
+    fs.writeFileSync(path.join(tmpPath, "./foo/"), content, {mode: mode}); // OK - assumed unknown mode is secure
+
+    fs.writeFileSync(path.join(tmpPath, "./foo/"), content, {mode: 0o666}); // NOT OK - explicitly insecure
+
+    const tmpPath2 = path.join(os.tmpdir(), `tmp_${Math.floor(Math.random() * 1000000)}.md`);
+    fs.writeFileSync(tmpPath2, content); // NOT OK
+
+    fs.openSync(tmpPath2, 'w'); // NOT OK
+    fs.openSync(tmpPath2, 'w', 0o600); // OK
+})


### PR DESCRIPTION
To safely create a temporary file in the OS temp dir in a multi-user environment you must: 
- Ensure that the file is created with `0o600` permissions or similar. 
- Ensure that you're not reusing an existing file (Use [the `O_EXCL` and `O_CREAT` flags](https://nodejs.org/api/fs.html#fs_fs_constants))   
  (An exploit requires extremely precise timing by inserting a file between an `fs.exists(..)` and a `fs.open(..)` call.) 

This query checks for the first of these requirements.   

The only way to ensure the second requirement is to use `fs.open(.., O_EXCL | O_CREAT)`, which is what e.g. [`tmp`](https://www.npmjs.com/package/tmp) does.  
Checking for the second requirement gets complicated. One of the complications is that NodeJS programs very rarely use file handles, and instead just calls the `fs` module multiple times with the same string `path`.   
So I went the easy route and just look for bad permissions, which is the most important part.  
(But the recommendation in the `.qhelp` basically says: use [`tmp`](https://www.npmjs.com/package/tmp). Because that package does everything right). 

I haven't found any FPs.  
But I suspect that FPs might happen when a program safely creates a temp file in a utility method, but the query still sees that utility method as a source. 

[An evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/CWE-377__default__CustomSuite__1/reports) shows no new results, and a constant 30s slowdown (that's the extra time it takes to compile the query, something went wrong in a preparation step).   
So the evaluation show no noticeable slowdown. 

[A test run](https://lgtm.com/query/2488387209030888032/) finds some results.  
All the results are either in test code or benign, which is why I've set the precision to `medium`. 