### PR TITLE
C#: Fix false positive alert for shadowing on record types.

### DIFF
--- a/csharp/ql/lib/change-notes/2022-01-18-local-shadows-member.md
+++ b/csharp/ql/lib/change-notes/2022-01-18-local-shadows-member.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The query `cs/local-shadows-member` no longer highlights parameters of `record` types.

--- a/csharp/ql/src/Bad Practices/Declarations/LocalScopeVariableShadowsMember.ql
+++ b/csharp/ql/src/Bad Practices/Declarations/LocalScopeVariableShadowsMember.ql
@@ -39,6 +39,10 @@ private predicate acceptableShadowing(LocalScopeVariable v, Member m) {
     )
     or
     t.getAConstructor().getAParameter() = v
+    or
+    // Record types have auto-generated Deconstruct methods, which declare an out parameter
+    // with the same name as the property field(s).
+    t.(RecordType).getAMethod("Deconstruct").getAParameter() = v
   )
 }
 

--- a/csharp/ql/test/query-tests/Bad Practices/Declarations/LocalScopeVariableShadowsMember/LocalScopeVariableShadowsMember.cs
+++ b/csharp/ql/test/query-tests/Bad Practices/Declarations/LocalScopeVariableShadowsMember/LocalScopeVariableShadowsMember.cs
@@ -61,4 +61,8 @@ class LocalScopeVariableShadowsMember
     {
         public C4(int f) { } // GOOD
     }
+
+    record class GoodRecordClass(object Prop1, object Prop2) { } // GOOD
+
+    record struct GoodRecordStruct(object Prop1, object Prop2) { } // GOOD
 }


### PR DESCRIPTION
When defining a record type, the compiler generates a Deconstruct method on the class or struct representing the record type.
This method has out parameters with the same name as property accessors.
In this PR we add this exception to the rule that identifies bad practices related to shadowing.