### PR TITLE
Python: Support SQLAlchemy `scoped_session`

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/SqlAlchemy.qll
+++ b/python/ql/lib/semmle/python/frameworks/SqlAlchemy.qll
@@ -211,6 +211,13 @@ module SqlAlchemy {
               .getReturn()
               .getMember("begin")
               .getACall()
+        or
+        this =
+          API::moduleImport("sqlalchemy")
+              .getMember("orm")
+              .getMember("scoped_session")
+              .getReturn()
+              .getACall()
       }
     }
 

--- a/python/ql/test/library-tests/frameworks/sqlalchemy/new_tests.py
+++ b/python/ql/test/library-tests/frameworks/sqlalchemy/new_tests.py
@@ -147,6 +147,13 @@ with Session.begin() as session:
     result = session.execute(raw_sql) # $ getSql=raw_sql
     assert result.fetchall() == [("FOO",)]
 
+# scoped_session
+Session = sqlalchemy.orm.scoped_session(sqlalchemy.orm.sessionmaker(engine))
+session = Session()
+
+result = session.execute(raw_sql) # $ getSql=raw_sql
+assert result.fetchall() == [("FOO",)]
+
 # Querying (1.4)
 # see https://docs.sqlalchemy.org/en/14/orm/session_basics.html#querying-1-x-style
 


### PR DESCRIPTION
I don't think this is big enough for a change-note, but let me know if you disagree.

The .py file can be run, and still doesn't raise any exceptions on those `assert`s, just FYI.