### PR TITLE
JS: add js/http-dependency query

### DIFF
--- a/javascript/ql/lib/change-notes/2022-01-08-insecure-dependency-resolution.md
+++ b/javascript/ql/lib/change-notes/2022-01-08-insecure-dependency-resolution.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* The `js/http-dependency` query has been added. It detects depedencies that are downloaded using an unencrypted connection.

--- a/javascript/ql/lib/change-notes/2022-01-08-insecure-dependency-resolution.md
+++ b/javascript/ql/lib/change-notes/2022-01-08-insecure-dependency-resolution.md
@@ -1,4 +1,4 @@
 ---
 category: newQuery
 ---
-* The `js/http-dependency` query has been added. It detects depedencies that are downloaded using an unencrypted connection.
+* The `js/insecure-dependency` query has been added. It detects depedencies that are downloaded using an unencrypted connection.

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
@@ -2,34 +2,54 @@
   "-//Semmle//qhelp//EN"
   "qhelp.dtd">
 <qhelp>
+
 <overview>
-<p>Using an insecure protocol like HTTP or FTP to download your dependencies leaves your npm build vulnerable to a
-<a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man in the Middle (MITM)</a>.
-This can allow attackers to inject malicious code into the artifacts that you are resolving and infect build artifacts
-that are being produced. This can be used by attackers to perform a
-<a href="https://en.wikipedia.org/wiki/Supply_chain_attack">Supply chain attack</a>
-against your project's users.
+<p>
+Using an insecure protocol like HTTP or FTP to download build dependencies makes the build process vulnerable to a 
+Man in the Middle (MITM) attack.
+</p>
+<p>
+This can allow attackers to inject malicious code into the downloaded dependencies and thereby 
+infect the build artifacts and execute arbitrary code on the machine building the artifacts.
 </p>
 
 </overview>
 <recommendation>
 
-<p>Always use HTTPS or SFTP to download artifacts from artifact servers.</p>
+<p>Always use HTTPS or SFTP when downloading artifacts from an URL.</p>
 
 </recommendation>
 
+<example>
+<p>
+The below example shows a <code>package.json</code> file that downloads a dependency using unencrypted HTTP.
+</p>
+<sample src="examples/bad-package.json" />
+<p>
+The fix is to change the protocol to HTTPS.
+</p>
+<sample src="examples/good-package.json" />
+
+</example>
+
 <references>
 <li>
-  Research:
-  <a href="https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&amp;sk=3c99970c55a899ad9ef41f126efcde0e">
+  Jonathan Leitschuh: 
+  <a href="https://infosecwriteups.com/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb">
     Want to take over the Java ecosystem? All you need is a MITM!
   </a>
 </li>
 <li>
-  Research:
+  Max Veytsman: 
   <a href="https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/">
     How to take over the computer of any Java (or Closure or Scala) Developer.
   </a>
+</li>
+<li>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Supply_chain_attack">Supply chain attack</a>
+</li>
+<li>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man-in-the-middle attack</a>
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
@@ -1,0 +1,35 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Using an insecure protocol like HTTP or FTP to download your dependencies leaves your npm build vulnerable to a
+<a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man in the Middle (MITM)</a>.
+This can allow attackers to inject malicious code into the artifacts that you are resolving and infect build artifacts
+that are being produced. This can be used by attackers to perform a
+<a href="https://en.wikipedia.org/wiki/Supply_chain_attack">Supply chain attack</a>
+against your project's users.
+</p>
+
+</overview>
+<recommendation>
+
+<p>Always use HTTPS or SFTP to download artifacts from artifact servers.</p>
+
+</recommendation>
+
+<references>
+<li>
+  Research:
+  <a href="https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&amp;sk=3c99970c55a899ad9ef41f126efcde0e">
+    Want to take over the Java ecosystem? All you need is a MITM!
+  </a>
+</li>
+<li>
+  Research:
+  <a href="https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/">
+    How to take over the computer of any Java (or Closure or Scala) Developer.
+  </a>
+</li>
+</references>
+</qhelp>

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
@@ -6,10 +6,10 @@
 <overview>
 <p>
 Using an insecure protocol like HTTP or FTP to download build dependencies makes the build process vulnerable to a 
-Man in the Middle (MITM) attack.
+man-in-the-middle (MITM) attack.
 </p>
 <p>
-This can allow attackers to inject malicious code into the downloaded dependencies and thereby 
+This can allow attackers to inject malicious code into the downloaded dependencies, and thereby 
 infect the build artifacts and execute arbitrary code on the machine building the artifacts.
 </p>
 
@@ -46,10 +46,10 @@ The fix is to change the protocol to HTTPS.
   </a>
 </li>
 <li>
-  Wikipedia: <a href="https://en.wikipedia.org/wiki/Supply_chain_attack">Supply chain attack</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Supply_chain_attack">Supply chain attack.</a>
 </li>
 <li>
-  Wikipedia: <a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man-in-the-middle attack</a>
+  Wikipedia: <a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">Man-in-the-middle attack.</a>
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.qhelp
@@ -16,13 +16,13 @@ infect the build artifacts and execute arbitrary code on the machine building th
 </overview>
 <recommendation>
 
-<p>Always use HTTPS or SFTP when downloading artifacts from an URL.</p>
+<p>Always use a secure protocol, such as HTTPS or SFTP, when downloading artifacts from an URL.</p>
 
 </recommendation>
 
 <example>
 <p>
-The below example shows a <code>package.json</code> file that downloads a dependency using unencrypted HTTP.
+The below example shows a <code>package.json</code> file that downloads a dependency using the insecure HTTP protocol.
 </p>
 <sample src="examples/bad-package.json" />
 <p>

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.ql
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.ql
@@ -1,7 +1,7 @@
 /**
  * @name Dependency download using unencrypted communication channel
  * @description Using unencrypted protocols to fetch dependencies can leave an application
- *              open to man in the middle attacks.
+ *              open to man-in-the-middle attacks.
  * @kind problem
  * @problem.severity warning
  * @security-severity 8.1

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.ql
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.ql
@@ -1,12 +1,12 @@
 /**
  * @name Dependency download using unencrypted communication channel
- * @description Using unencrypted HTTP URLs to fetch dependencies can leave an application
+ * @description Using unencrypted protocols to fetch dependencies can leave an application
  *              open to man in the middle attacks.
  * @kind problem
  * @problem.severity warning
  * @security-severity 8.1
  * @precision high
- * @id js/http-dependency
+ * @id js/insecure-dependency
  * @tags security
  *       external/cwe/cwe-300
  *       external/cwe/cwe-319

--- a/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.ql
+++ b/javascript/ql/src/Security/CWE-300/InsecureDependencyResolution.ql
@@ -1,0 +1,23 @@
+/**
+ * @name Dependency download using unencrypted communication channel
+ * @description Using unencrypted HTTP URLs to fetch dependencies can leave an application
+ *              open to man in the middle attacks.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 8.1
+ * @precision high
+ * @id js/http-dependency
+ * @tags security
+ *       external/cwe/cwe-300
+ *       external/cwe/cwe-319
+ *       external/cwe/cwe-494
+ *       external/cwe/cwe-829
+ */
+
+import javascript
+
+from PackageJSON pack, JSONString val
+where
+  [pack.getDependencies(), pack.getDevDependencies()].getPropValue(_) = val and
+  val.getValue().regexpMatch("(http|ftp)://.*")
+select val, "Dependency downloaded using unencrypted communication channel."

--- a/javascript/ql/src/Security/CWE-300/examples/bad-package.json
+++ b/javascript/ql/src/Security/CWE-300/examples/bad-package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example-project",
+  "dependencies": {
+    "unencrypted": "http://example.org/foo/tarball/release/0.0.1",
+    "lodash": "^4.0.0"
+  }
+}

--- a/javascript/ql/src/Security/CWE-300/examples/good-package.json
+++ b/javascript/ql/src/Security/CWE-300/examples/good-package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example-project",
+  "dependencies": {
+    "unencrypted": "https://example.org/foo/tarball/release/0.0.1",
+    "lodash": "^4.0.0"
+  }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-300/InsecureDependencyResolution.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-300/InsecureDependencyResolution.expected
@@ -1,0 +1,4 @@
+| package.json:6:17:6:40 | "http:/ ... rg/foo" | Dependency downloaded using unencrypted communication channel. |
+| package.json:7:17:7:39 | "ftp:// ... rg/foo" | Dependency downloaded using unencrypted communication channel. |
+| package.json:12:17:12:40 | "http:/ ... rg/foo" | Dependency downloaded using unencrypted communication channel. |
+| package.json:13:17:13:39 | "ftp:// ... rg/foo" | Dependency downloaded using unencrypted communication channel. |

--- a/javascript/ql/test/query-tests/Security/CWE-300/InsecureDependencyResolution.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-300/InsecureDependencyResolution.qlref
@@ -1,0 +1,1 @@
+Security/CWE-300/InsecureDependencyResolution.ql

--- a/javascript/ql/test/query-tests/Security/CWE-300/foo.js
+++ b/javascript/ql/test/query-tests/Security/CWE-300/foo.js
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/javascript/ql/test/query-tests/Security/CWE-300/package.json
+++ b/javascript/ql/test/query-tests/Security/CWE-300/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "insecure-dep-downloader",
+    "dependencies": {
+        "foo": "*",
+        "good1": "https://example.org/foo",
+        "bad1": "http://example.org/foo",
+        "bad2": "ftp://example.org/foo"
+    },
+    "devDependencies": {
+        "bar": "*",
+        "good2": "https://example.org/foo",
+        "bad3": "http://example.org/foo",
+        "bad4": "ftp://example.org/foo"
+    }
+}


### PR DESCRIPTION
Inspired by [this java query](https://github.com/github/codeql/blob/main/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql). 

[An evaluation looks fine](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/CWE-300-nightly-custom/reports). 

This query has extremely few results, but you [can find a few using code search](https://cs.github.com/?scopeName=All+repos&scope=&q=%2F%5E++++%22%5B%5Euwphtb%5D%5Cw%2B%22%3A+%22%28http%7Cftp%29%3A%5C%2F%5C%2Fgithub.com%5C%2F%2F+path%3A%2Fpackage.json).   
[Here is a LGTM run with some of those projects](https://lgtm.com/query/6137303895174543215/). 