### PR TITLE
C#: Struct (and to a minor extent anonymous types) improvements 

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1481,6 +1481,8 @@ class FieldOrProperty extends Assignable, Modifiable {
           p.isAutoImplemented()
           or
           p.matchesHandle(any(CIL::TrivialProperty tp))
+          or
+          p.getDeclaringType() instanceof AnonymousClass
         )
       )
   }

--- a/csharp/ql/test/library-tests/csharp10/RecordTypes.cs
+++ b/csharp/ql/test/library-tests/csharp10/RecordTypes.cs
@@ -9,4 +9,4 @@ public record class MyClassRecord(DateTime stuff) { }
 
 public readonly record struct MyReadonlyRecordStruct(string Stuff) { }
 
-public record struct MyRecordStruct(int Stuff) { }
+public record struct MyRecordStruct1(int Stuff) { }

--- a/csharp/ql/test/library-tests/csharp10/StructTypes.cs
+++ b/csharp/ql/test/library-tests/csharp10/StructTypes.cs
@@ -1,0 +1,19 @@
+using System;
+
+// Struct with user declared parameterless constructor.
+public struct MyStructParameterlessConstructor
+{
+    public int X;
+    public readonly int Y;
+    public int Z { get; }
+
+    public MyStructParameterlessConstructor()
+    {
+        X = 1;
+        Y = 2;
+        Z = 3;
+    }
+}
+
+// Struct with compiler generated parameterless constructor.
+public struct MyDefaultStruct { }

--- a/csharp/ql/test/library-tests/csharp10/WithExpression.cs
+++ b/csharp/ql/test/library-tests/csharp10/WithExpression.cs
@@ -1,0 +1,30 @@
+using System;
+
+public struct MyStruct
+{
+    public int X;
+    public MyStruct(int x) => X = x;
+}
+
+public record struct MyRecordStruct2(int Y) { }
+
+public class MyWithExamples
+{
+    public void M1()
+    {
+        var s1 = new MyStruct(1);
+        var s2 = s1 with { X = 2 };
+    }
+
+    public void M2()
+    {
+        var r1 = new MyRecordStruct2(4);
+        var r2 = r1 with { Y = 6 };
+    }
+
+    public void M3()
+    {
+        var anon1 = new { A = 3, B = 4 };
+        var anon2 = anon1 with { A = 5 };
+    }
+}

--- a/csharp/ql/test/library-tests/csharp10/recordTypes.expected
+++ b/csharp/ql/test/library-tests/csharp10/recordTypes.expected
@@ -2,10 +2,12 @@ recordTypes
 | RecordTypes.cs:3:1:6:2 | MyEntry |
 | RecordTypes.cs:8:1:8:53 | MyClassRecord |
 | RecordTypes.cs:10:1:10:70 | MyReadonlyRecordStruct |
-| RecordTypes.cs:12:1:12:50 | MyRecordStruct |
+| RecordTypes.cs:12:1:12:51 | MyRecordStruct1 |
+| WithExpression.cs:9:1:9:47 | MyRecordStruct2 |
 recordStructs
 | RecordTypes.cs:10:1:10:70 | MyReadonlyRecordStruct |
-| RecordTypes.cs:12:1:12:50 | MyRecordStruct |
+| RecordTypes.cs:12:1:12:51 | MyRecordStruct1 |
+| WithExpression.cs:9:1:9:47 | MyRecordStruct2 |
 recordClass
 | RecordTypes.cs:3:1:6:2 | MyEntry |
 | RecordTypes.cs:8:1:8:53 | MyClassRecord |

--- a/csharp/ql/test/library-tests/csharp10/structTypes.expected
+++ b/csharp/ql/test/library-tests/csharp10/structTypes.expected
@@ -1,0 +1,5 @@
+structAllDefaultConstructors
+| StructTypes.cs:4:15:4:46 | MyStructParameterlessConstructor | StructTypes.cs:10:12:10:43 | MyStructParameterlessConstructor |
+| StructTypes.cs:19:15:19:29 | MyDefaultStruct | StructTypes.cs:19:15:19:29 | MyDefaultStruct |
+structFromSourceDefaultConstructors
+| StructTypes.cs:4:15:4:46 | MyStructParameterlessConstructor | StructTypes.cs:10:12:10:43 | MyStructParameterlessConstructor |

--- a/csharp/ql/test/library-tests/csharp10/structTypes.ql
+++ b/csharp/ql/test/library-tests/csharp10/structTypes.ql
@@ -1,0 +1,15 @@
+import csharp
+
+predicate structDefaultConstructors(Struct struct, Constructor c) {
+  struct.getAConstructor() = c and
+  struct.getFile().getBaseName() = "StructTypes.cs" and
+  c.hasNoParameters()
+}
+
+query predicate structAllDefaultConstructors(Struct struct, Constructor c) {
+  structDefaultConstructors(struct, c)
+}
+
+query predicate structFromSourceDefaultConstructors(Struct struct, Constructor c) {
+  structDefaultConstructors(struct, c) and c.fromSource()
+}

--- a/csharp/ql/test/library-tests/csharp10/withExpression.expected
+++ b/csharp/ql/test/library-tests/csharp10/withExpression.expected
@@ -1,0 +1,3 @@
+| WithExpression.cs:16:18:16:34 | ... with { ... } | MyStruct | WithExpression.cs:16:18:16:19 | access to local variable s1 | WithExpression.cs:16:26:16:34 | { ..., ... } |
+| WithExpression.cs:22:18:22:34 | ... with { ... } | MyRecordStruct2 | WithExpression.cs:22:18:22:19 | access to local variable r1 | WithExpression.cs:22:26:22:34 | { ..., ... } |
+| WithExpression.cs:28:21:28:40 | ... with { ... } | <>__AnonType0<Int32,Int32> | WithExpression.cs:28:21:28:25 | access to local variable anon1 | WithExpression.cs:28:32:28:40 | { ..., ... } |

--- a/csharp/ql/test/library-tests/csharp10/withExpression.ql
+++ b/csharp/ql/test/library-tests/csharp10/withExpression.ql
@@ -1,0 +1,7 @@
+import csharp
+
+query predicate withExpressions(WithExpr with, string type, Expr expr, ObjectInitializer init) {
+  type = with.getType().toStringWithTypes() and
+  expr = with.getExpr() and
+  init = with.getInitializer()
+}

--- a/csharp/ql/test/library-tests/dataflow/fields/F.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/F.cs
@@ -5,7 +5,7 @@ public class F
 
     static F Create(object o1, object o2) => new F() { Field1 = o1, Field2 = o2 };
 
-    private void M()
+    private void M1()
     {
         var o = Source<object>(1);
         var f = Create(o, null);
@@ -23,6 +23,15 @@ public class F
         f = new F() { Field2 = Source<object>(4) };
         Sink(f.Field1); // no flow
         Sink(f.Field2); // $ hasValueFlow=4
+    }
+
+    private void M2()
+    {
+        var o = Source<object>(2);
+        object @null = null;
+        var a = new { X = o, Y = @null };
+        Sink(a.X); // $ hasValueFlow=2
+        Sink(a.Y); // no flow
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -802,10 +802,24 @@ edges
 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:35:35:35:35 | access to local variable o : Object |
 | J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object |
 | J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object |
+| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object |
+| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object |
+| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object |
+| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object |
 | J.cs:35:35:35:35 | access to local variable o : Object | J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object |
 | J.cs:35:35:35:35 | access to local variable o : Object | J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object |
 | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | J.cs:36:14:36:21 | access to property Prop1 |
 | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | J.cs:36:14:36:21 | access to property Prop1 |
+| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | J.cs:40:14:40:21 | access to property Prop1 |
+| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | J.cs:40:14:40:21 | access to property Prop1 |
+| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object |
+| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object |
+| J.cs:43:36:43:52 | call to method Source<Object> : Object | J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object |
+| J.cs:43:36:43:52 | call to method Source<Object> : Object | J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object |
+| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | J.cs:44:14:44:21 | access to property Prop1 |
+| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | J.cs:44:14:44:21 | access to property Prop1 |
+| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | J.cs:45:14:45:21 | access to property Prop2 |
+| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | J.cs:45:14:45:21 | access to property Prop2 |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
@@ -1681,6 +1695,22 @@ nodes
 | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
 | J.cs:36:14:36:21 | access to property Prop1 | semmle.label | access to property Prop1 |
 | J.cs:36:14:36:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
+| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
+| J.cs:40:14:40:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:40:14:40:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
+| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
+| J.cs:43:36:43:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:43:36:43:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
+| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
+| J.cs:44:14:44:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:44:14:44:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
+| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
+| J.cs:45:14:45:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:45:14:45:21 | access to property Prop2 | semmle.label | access to property Prop2 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
@@ -1838,3 +1868,6 @@ subpaths
 | J.cs:24:14:24:21 | access to property Prop1 | J.cs:14:17:14:33 | call to method Source<Object> : Object | J.cs:24:14:24:21 | access to property Prop1 | $@ | J.cs:14:17:14:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:25:14:25:21 | access to property Prop2 | J.cs:23:36:23:52 | call to method Source<Object> : Object | J.cs:25:14:25:21 | access to property Prop2 | $@ | J.cs:23:36:23:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:36:14:36:21 | access to property Prop1 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:36:14:36:21 | access to property Prop1 | $@ | J.cs:34:17:34:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:40:14:40:21 | access to property Prop1 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:40:14:40:21 | access to property Prop1 | $@ | J.cs:34:17:34:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:44:14:44:21 | access to property Prop1 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:44:14:44:21 | access to property Prop1 | $@ | J.cs:34:17:34:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:45:14:45:21 | access to property Prop2 | J.cs:43:36:43:52 | call to method Source<Object> : Object | J.cs:45:14:45:21 | access to property Prop2 | $@ | J.cs:43:36:43:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -456,6 +456,14 @@ edges
 | F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:23:21:23:50 | { ..., ... } [field Field2] : Object |
 | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | F.cs:25:14:25:21 | access to field Field2 |
 | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | F.cs:25:14:25:21 | access to field Field2 |
+| F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:32:27:32:27 | access to local variable o : Object |
+| F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:32:27:32:27 | access to local variable o : Object |
+| F.cs:32:17:32:40 | { ..., ... } [property X] : Object | F.cs:33:14:33:14 | access to local variable a [property X] : Object |
+| F.cs:32:17:32:40 | { ..., ... } [property X] : Object | F.cs:33:14:33:14 | access to local variable a [property X] : Object |
+| F.cs:32:27:32:27 | access to local variable o : Object | F.cs:32:17:32:40 | { ..., ... } [property X] : Object |
+| F.cs:32:27:32:27 | access to local variable o : Object | F.cs:32:17:32:40 | { ..., ... } [property X] : Object |
+| F.cs:33:14:33:14 | access to local variable a [property X] : Object | F.cs:33:14:33:16 | access to property X |
+| F.cs:33:14:33:14 | access to local variable a [property X] : Object | F.cs:33:14:33:16 | access to property X |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:9:23:9:23 | access to local variable e : Elem |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:9:23:9:23 | access to local variable e : Elem |
 | G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem | G.cs:10:18:10:18 | access to local variable b [field Box1, field Elem] : Elem |
@@ -1367,6 +1375,16 @@ nodes
 | F.cs:25:14:25:14 | access to local variable f [field Field2] : Object | semmle.label | access to local variable f [field Field2] : Object |
 | F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
 | F.cs:25:14:25:21 | access to field Field2 | semmle.label | access to field Field2 |
+| F.cs:30:17:30:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:30:17:30:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| F.cs:32:17:32:40 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
+| F.cs:32:17:32:40 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
+| F.cs:32:27:32:27 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| F.cs:32:27:32:27 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| F.cs:33:14:33:14 | access to local variable a [property X] : Object | semmle.label | access to local variable a [property X] : Object |
+| F.cs:33:14:33:14 | access to local variable a [property X] : Object | semmle.label | access to local variable a [property X] : Object |
+| F.cs:33:14:33:16 | access to property X | semmle.label | access to property X |
+| F.cs:33:14:33:16 | access to property X | semmle.label | access to property X |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | semmle.label | call to method Source<Elem> : Elem |
 | G.cs:9:9:9:9 | [post] access to local variable b [field Box1, field Elem] : Elem | semmle.label | [post] access to local variable b [field Box1, field Elem] : Elem |
@@ -1952,6 +1970,7 @@ subpaths
 | F.cs:17:14:17:21 | access to field Field2 | F.cs:15:26:15:42 | call to method Source<Object> : Object | F.cs:17:14:17:21 | access to field Field2 | $@ | F.cs:15:26:15:42 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:20:14:20:21 | access to field Field1 | F.cs:19:32:19:48 | call to method Source<Object> : Object | F.cs:20:14:20:21 | access to field Field1 | $@ | F.cs:19:32:19:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | F.cs:25:14:25:21 | access to field Field2 | F.cs:23:32:23:48 | call to method Source<Object> : Object | F.cs:25:14:25:21 | access to field Field2 | $@ | F.cs:23:32:23:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| F.cs:33:14:33:16 | access to property X | F.cs:30:17:30:33 | call to method Source<Object> : Object | F.cs:33:14:33:16 | access to property X | $@ | F.cs:30:17:30:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:7:18:7:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:15:18:15:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:23:18:23:32 | call to method Source<Elem> : Elem | call to method Source<Elem> : Elem |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -876,6 +876,24 @@ edges
 | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
 | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
 | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
+| J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:99:28:99:28 | access to local variable o : Object |
+| J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:99:28:99:28 | access to local variable o : Object |
+| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:102:14:102:15 | access to local variable a2 [property X] : Object |
+| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:102:14:102:15 | access to local variable a2 [property X] : Object |
+| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object |
+| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | J.cs:106:14:106:15 | access to local variable a3 [property X] : Object |
+| J.cs:99:28:99:28 | access to local variable o : Object | J.cs:99:18:99:41 | { ..., ... } [property X] : Object |
+| J.cs:99:28:99:28 | access to local variable o : Object | J.cs:99:18:99:41 | { ..., ... } [property X] : Object |
+| J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | J.cs:102:14:102:17 | access to property X |
+| J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | J.cs:102:14:102:17 | access to property X |
+| J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object |
+| J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object |
+| J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:105:18:105:50 | ... with { ... } [property Y] : Object |
+| J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:105:18:105:50 | ... with { ... } [property Y] : Object |
+| J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | J.cs:106:14:106:17 | access to property X |
+| J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | J.cs:106:14:106:17 | access to property X |
+| J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
+| J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | J.cs:107:14:107:17 | access to property Y |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
@@ -1833,6 +1851,28 @@ nodes
 | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
 | J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
 | J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:97:17:97:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:97:17:97:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
+| J.cs:99:18:99:41 | { ..., ... } [property X] : Object | semmle.label | { ..., ... } [property X] : Object |
+| J.cs:99:28:99:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:99:28:99:28 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | semmle.label | access to local variable a2 [property X] : Object |
+| J.cs:102:14:102:15 | access to local variable a2 [property X] : Object | semmle.label | access to local variable a2 [property X] : Object |
+| J.cs:102:14:102:17 | access to property X | semmle.label | access to property X |
+| J.cs:102:14:102:17 | access to property X | semmle.label | access to property X |
+| J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | semmle.label | ... with { ... } [property Y] : Object |
+| J.cs:105:18:105:50 | ... with { ... } [property Y] : Object | semmle.label | ... with { ... } [property Y] : Object |
+| J.cs:105:32:105:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:105:32:105:48 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | semmle.label | access to local variable a3 [property X] : Object |
+| J.cs:106:14:106:15 | access to local variable a3 [property X] : Object | semmle.label | access to local variable a3 [property X] : Object |
+| J.cs:106:14:106:17 | access to property X | semmle.label | access to property X |
+| J.cs:106:14:106:17 | access to property X | semmle.label | access to property X |
+| J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | semmle.label | access to local variable a3 [property Y] : Object |
+| J.cs:107:14:107:15 | access to local variable a3 [property Y] : Object | semmle.label | access to local variable a3 [property Y] : Object |
+| J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
+| J.cs:107:14:107:17 | access to property Y | semmle.label | access to property Y |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
@@ -2004,3 +2044,6 @@ subpaths
 | J.cs:84:14:84:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:84:14:84:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:87:14:87:21 | access to field Field | J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:87:14:87:21 | access to field Field | $@ | J.cs:86:36:86:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | J.cs:88:14:88:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:88:14:88:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:102:14:102:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:102:14:102:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:106:14:106:17 | access to property X | J.cs:97:17:97:33 | call to method Source<Object> : Object | J.cs:106:14:106:17 | access to property X | $@ | J.cs:97:17:97:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:107:14:107:17 | access to property Y | J.cs:105:32:105:48 | call to method Source<Object> : Object | J.cs:107:14:107:17 | access to property Y | $@ | J.cs:105:32:105:48 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -776,50 +776,98 @@ edges
 | I.cs:39:9:39:9 | access to parameter i [field Field1] : Object | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
 | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
-| J.cs:14:17:14:33 | call to method Source<Object> : Object | J.cs:15:34:15:34 | access to local variable o : Object |
-| J.cs:14:17:14:33 | call to method Source<Object> : Object | J.cs:15:34:15:34 | access to local variable o : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:16:14:16:15 | access to local variable r1 [property Prop1] : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:16:14:16:15 | access to local variable r1 [property Prop1] : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:20:14:20:15 | access to local variable r2 [property Prop1] : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:20:14:20:15 | access to local variable r2 [property Prop1] : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:24:14:24:15 | access to local variable r3 [property Prop1] : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:24:14:24:15 | access to local variable r3 [property Prop1] : Object |
-| J.cs:15:34:15:34 | access to local variable o : Object | J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object |
-| J.cs:15:34:15:34 | access to local variable o : Object | J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object |
-| J.cs:16:14:16:15 | access to local variable r1 [property Prop1] : Object | J.cs:16:14:16:21 | access to property Prop1 |
-| J.cs:16:14:16:15 | access to local variable r1 [property Prop1] : Object | J.cs:16:14:16:21 | access to property Prop1 |
-| J.cs:20:14:20:15 | access to local variable r2 [property Prop1] : Object | J.cs:20:14:20:21 | access to property Prop1 |
-| J.cs:20:14:20:15 | access to local variable r2 [property Prop1] : Object | J.cs:20:14:20:21 | access to property Prop1 |
-| J.cs:23:18:23:54 | ... with { ... } [property Prop2] : Object | J.cs:25:14:25:15 | access to local variable r3 [property Prop2] : Object |
-| J.cs:23:18:23:54 | ... with { ... } [property Prop2] : Object | J.cs:25:14:25:15 | access to local variable r3 [property Prop2] : Object |
-| J.cs:23:36:23:52 | call to method Source<Object> : Object | J.cs:23:18:23:54 | ... with { ... } [property Prop2] : Object |
-| J.cs:23:36:23:52 | call to method Source<Object> : Object | J.cs:23:18:23:54 | ... with { ... } [property Prop2] : Object |
-| J.cs:24:14:24:15 | access to local variable r3 [property Prop1] : Object | J.cs:24:14:24:21 | access to property Prop1 |
-| J.cs:24:14:24:15 | access to local variable r3 [property Prop1] : Object | J.cs:24:14:24:21 | access to property Prop1 |
-| J.cs:25:14:25:15 | access to local variable r3 [property Prop2] : Object | J.cs:25:14:25:21 | access to property Prop2 |
-| J.cs:25:14:25:15 | access to local variable r3 [property Prop2] : Object | J.cs:25:14:25:21 | access to property Prop2 |
-| J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:35:35:35:35 | access to local variable o : Object |
-| J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:35:35:35:35 | access to local variable o : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object |
-| J.cs:35:35:35:35 | access to local variable o : Object | J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:35:35:35:35 | access to local variable o : Object | J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | J.cs:36:14:36:21 | access to property Prop1 |
-| J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | J.cs:36:14:36:21 | access to property Prop1 |
-| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | J.cs:40:14:40:21 | access to property Prop1 |
-| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | J.cs:40:14:40:21 | access to property Prop1 |
-| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object |
-| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object |
-| J.cs:43:36:43:52 | call to method Source<Object> : Object | J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object |
-| J.cs:43:36:43:52 | call to method Source<Object> : Object | J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object |
-| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | J.cs:44:14:44:21 | access to property Prop1 |
-| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | J.cs:44:14:44:21 | access to property Prop1 |
-| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | J.cs:45:14:45:21 | access to property Prop2 |
-| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | J.cs:45:14:45:21 | access to property Prop2 |
+| J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object |
+| J.cs:14:26:14:30 | field : Object | J.cs:14:66:14:70 | access to parameter field : Object |
+| J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object |
+| J.cs:14:40:14:43 | prop : Object | J.cs:14:73:14:76 | access to parameter prop : Object |
+| J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object |
+| J.cs:14:66:14:70 | access to parameter field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object |
+| J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object |
+| J.cs:14:73:14:76 | access to parameter prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object |
+| J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:22:34:22:34 | access to local variable o : Object |
+| J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:22:34:22:34 | access to local variable o : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object |
+| J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 |
+| J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | J.cs:23:14:23:21 | access to property Prop1 |
+| J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | J.cs:27:14:27:21 | access to property Prop1 |
+| J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | J.cs:27:14:27:21 | access to property Prop1 |
+| J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object |
+| J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object |
+| J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object |
+| J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object |
+| J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | J.cs:31:14:31:21 | access to property Prop1 |
+| J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | J.cs:31:14:31:21 | access to property Prop1 |
+| J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | J.cs:32:14:32:21 | access to property Prop2 |
+| J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | J.cs:32:14:32:21 | access to property Prop2 |
+| J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:42:35:42:35 | access to local variable o : Object |
+| J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:42:35:42:35 | access to local variable o : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object |
+| J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 |
+| J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | J.cs:43:14:43:21 | access to property Prop1 |
+| J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | J.cs:47:14:47:21 | access to property Prop1 |
+| J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | J.cs:47:14:47:21 | access to property Prop1 |
+| J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object |
+| J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object |
+| J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object |
+| J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object |
+| J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | J.cs:51:14:51:21 | access to property Prop1 |
+| J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | J.cs:51:14:51:21 | access to property Prop1 |
+| J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | J.cs:52:14:52:21 | access to property Prop2 |
+| J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | J.cs:52:14:52:21 | access to property Prop2 |
+| J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:62:29:62:29 | access to local variable o : Object |
+| J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:62:29:62:29 | access to local variable o : Object |
+| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object |
+| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object |
+| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object |
+| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
+| J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | J.cs:65:14:65:21 | access to field Field |
+| J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | J.cs:65:14:65:21 | access to field Field |
+| J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object |
+| J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object |
+| J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object |
+| J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object |
+| J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | J.cs:69:14:69:21 | access to field Field |
+| J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | J.cs:69:14:69:21 | access to field Field |
+| J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | J.cs:70:14:70:20 | access to property Prop |
+| J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | J.cs:70:14:70:20 | access to property Prop |
+| J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:80:35:80:35 | access to local variable o : Object |
+| J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:80:35:80:35 | access to local variable o : Object |
+| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
+| J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | J.cs:84:14:84:20 | access to property Prop |
+| J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | J.cs:84:14:84:20 | access to property Prop |
+| J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object |
+| J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object |
+| J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:86:18:86:54 | ... with { ... } [field Field] : Object |
+| J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:86:18:86:54 | ... with { ... } [field Field] : Object |
+| J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
+| J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | J.cs:87:14:87:21 | access to field Field |
+| J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
+| J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | J.cs:88:14:88:20 | access to property Prop |
 nodes
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
 | A.cs:5:17:5:28 | call to method Source<C> : C | semmle.label | call to method Source<C> : C |
@@ -1659,58 +1707,114 @@ nodes
 | I.cs:40:14:40:14 | access to parameter i [field Field1] : Object | semmle.label | access to parameter i [field Field1] : Object |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
-| J.cs:14:17:14:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:14:17:14:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass [property Prop1] : Object |
-| J.cs:15:18:15:41 | object creation of type RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass [property Prop1] : Object |
-| J.cs:15:34:15:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:15:34:15:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:16:14:16:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
-| J.cs:16:14:16:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
-| J.cs:16:14:16:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:16:14:16:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:20:14:20:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
-| J.cs:20:14:20:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
-| J.cs:20:14:20:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:20:14:20:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:23:18:23:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
-| J.cs:23:18:23:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
-| J.cs:23:36:23:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:23:36:23:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:24:14:24:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
-| J.cs:24:14:24:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
-| J.cs:24:14:24:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:24:14:24:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:25:14:25:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
-| J.cs:25:14:25:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
-| J.cs:25:14:25:21 | access to property Prop2 | semmle.label | access to property Prop2 |
-| J.cs:25:14:25:21 | access to property Prop2 | semmle.label | access to property Prop2 |
-| J.cs:34:17:34:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:34:17:34:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:35:18:35:42 | object creation of type RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct [property Prop1] : Object |
-| J.cs:35:35:35:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:35:35:35:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
-| J.cs:36:14:36:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
-| J.cs:36:14:36:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:36:14:36:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
-| J.cs:40:14:40:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
-| J.cs:40:14:40:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:40:14:40:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
-| J.cs:43:18:43:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
-| J.cs:43:36:43:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:43:36:43:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
-| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
-| J.cs:44:14:44:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
-| J.cs:44:14:44:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:44:14:44:21 | access to property Prop1 | semmle.label | access to property Prop1 |
-| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
-| J.cs:45:14:45:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
-| J.cs:45:14:45:21 | access to property Prop2 | semmle.label | access to property Prop2 |
-| J.cs:45:14:45:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
+| J.cs:14:26:14:30 | field : Object | semmle.label | field : Object |
+| J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
+| J.cs:14:40:14:43 | prop : Object | semmle.label | prop : Object |
+| J.cs:14:50:14:54 | [post] this access [field Field] : Object | semmle.label | [post] this access [field Field] : Object |
+| J.cs:14:50:14:54 | [post] this access [field Field] : Object | semmle.label | [post] this access [field Field] : Object |
+| J.cs:14:57:14:60 | [post] this access [property Prop] : Object | semmle.label | [post] this access [property Prop] : Object |
+| J.cs:14:57:14:60 | [post] this access [property Prop] : Object | semmle.label | [post] this access [property Prop] : Object |
+| J.cs:14:66:14:70 | access to parameter field : Object | semmle.label | access to parameter field : Object |
+| J.cs:14:66:14:70 | access to parameter field : Object | semmle.label | access to parameter field : Object |
+| J.cs:14:73:14:76 | access to parameter prop : Object | semmle.label | access to parameter prop : Object |
+| J.cs:14:73:14:76 | access to parameter prop : Object | semmle.label | access to parameter prop : Object |
+| J.cs:21:17:21:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:21:17:21:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass [property Prop1] : Object |
+| J.cs:22:18:22:41 | object creation of type RecordClass [property Prop1] : Object | semmle.label | object creation of type RecordClass [property Prop1] : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:22:34:22:34 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
+| J.cs:23:14:23:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
+| J.cs:23:14:23:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:23:14:23:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
+| J.cs:27:14:27:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
+| J.cs:27:14:27:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:27:14:27:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
+| J.cs:30:18:30:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
+| J.cs:30:36:30:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:30:36:30:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
+| J.cs:31:14:31:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
+| J.cs:31:14:31:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:31:14:31:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
+| J.cs:32:14:32:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
+| J.cs:32:14:32:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:32:14:32:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:41:17:41:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:41:17:41:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct [property Prop1] : Object |
+| J.cs:42:18:42:42 | object creation of type RecordStruct [property Prop1] : Object | semmle.label | object creation of type RecordStruct [property Prop1] : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:42:35:42:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
+| J.cs:43:14:43:15 | access to local variable r1 [property Prop1] : Object | semmle.label | access to local variable r1 [property Prop1] : Object |
+| J.cs:43:14:43:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:43:14:43:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
+| J.cs:47:14:47:15 | access to local variable r2 [property Prop1] : Object | semmle.label | access to local variable r2 [property Prop1] : Object |
+| J.cs:47:14:47:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:47:14:47:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
+| J.cs:50:18:50:54 | ... with { ... } [property Prop2] : Object | semmle.label | ... with { ... } [property Prop2] : Object |
+| J.cs:50:36:50:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:50:36:50:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
+| J.cs:51:14:51:15 | access to local variable r3 [property Prop1] : Object | semmle.label | access to local variable r3 [property Prop1] : Object |
+| J.cs:51:14:51:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:51:14:51:21 | access to property Prop1 | semmle.label | access to property Prop1 |
+| J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
+| J.cs:52:14:52:15 | access to local variable r3 [property Prop2] : Object | semmle.label | access to local variable r3 [property Prop2] : Object |
+| J.cs:52:14:52:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:52:14:52:21 | access to property Prop2 | semmle.label | access to property Prop2 |
+| J.cs:61:17:61:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:61:17:61:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | semmle.label | object creation of type Struct [field Field] : Object |
+| J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object | semmle.label | object creation of type Struct [field Field] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | semmle.label | access to local variable s2 [field Field] : Object |
+| J.cs:65:14:65:15 | access to local variable s2 [field Field] : Object | semmle.label | access to local variable s2 [field Field] : Object |
+| J.cs:65:14:65:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:65:14:65:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | semmle.label | ... with { ... } [property Prop] : Object |
+| J.cs:68:18:68:53 | ... with { ... } [property Prop] : Object | semmle.label | ... with { ... } [property Prop] : Object |
+| J.cs:68:35:68:51 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:68:35:68:51 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
+| J.cs:69:14:69:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
+| J.cs:69:14:69:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:69:14:69:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
+| J.cs:70:14:70:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
+| J.cs:70:14:70:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:70:14:70:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:79:17:79:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:79:17:79:33 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | semmle.label | object creation of type Struct [property Prop] : Object |
+| J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object | semmle.label | object creation of type Struct [property Prop] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | semmle.label | access to local variable s2 [property Prop] : Object |
+| J.cs:84:14:84:15 | access to local variable s2 [property Prop] : Object | semmle.label | access to local variable s2 [property Prop] : Object |
+| J.cs:84:14:84:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:84:14:84:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | semmle.label | ... with { ... } [field Field] : Object |
+| J.cs:86:18:86:54 | ... with { ... } [field Field] : Object | semmle.label | ... with { ... } [field Field] : Object |
+| J.cs:86:36:86:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:86:36:86:52 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
+| J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
+| J.cs:87:14:87:15 | access to local variable s3 [field Field] : Object | semmle.label | access to local variable s3 [field Field] : Object |
+| J.cs:87:14:87:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:87:14:87:21 | access to field Field | semmle.label | access to field Field |
+| J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
+| J.cs:88:14:88:15 | access to local variable s3 [property Prop] : Object | semmle.label | access to local variable s3 [property Prop] : Object |
+| J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
+| J.cs:88:14:88:20 | access to property Prop | semmle.label | access to property Prop |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B [field c] : C | A.cs:6:17:6:25 | call to method Make [field c] : C |
@@ -1810,6 +1914,10 @@ subpaths
 | H.cs:147:25:147:38 | call to method Source<A> : A | H.cs:138:27:138:27 | o : A | H.cs:142:16:142:34 | access to field FieldB : A | H.cs:147:17:147:39 | call to method Through : A |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object |
 | H.cs:164:22:164:22 | access to local variable o : Object | H.cs:153:32:153:32 | o : Object | H.cs:157:9:157:9 | [post] access to parameter a [field FieldA, field FieldB] : Object | H.cs:164:19:164:19 | [post] access to local variable a [field FieldA, field FieldB] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
+| J.cs:62:29:62:29 | access to local variable o : Object | J.cs:14:26:14:30 | field : Object | J.cs:14:50:14:54 | [post] this access [field Field] : Object | J.cs:62:18:62:36 | object creation of type Struct [field Field] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
+| J.cs:80:35:80:35 | access to local variable o : Object | J.cs:14:40:14:43 | prop : Object | J.cs:14:57:14:60 | [post] this access [property Prop] : Object | J.cs:80:18:80:36 | object creation of type Struct [property Prop] : Object |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:28 | call to method Source<C> : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:28 | call to method Source<C> : C | call to method Source<C> : C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:29 | call to method Source<C1> : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:29 | call to method Source<C1> : C1 | call to method Source<C1> : C1 |
@@ -1863,11 +1971,17 @@ subpaths
 | I.cs:23:14:23:21 | access to field Field1 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:23:14:23:21 | access to field Field1 | $@ | I.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | I.cs:27:14:27:21 | access to field Field1 | I.cs:7:18:7:34 | call to method Source<Object> : Object | I.cs:27:14:27:21 | access to field Field1 | $@ | I.cs:7:18:7:34 | call to method Source<Object> : Object | call to method Source<Object> : Object |
 | I.cs:40:14:40:21 | access to field Field1 | I.cs:31:13:31:29 | call to method Source<Object> : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:31:13:31:29 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:16:14:16:21 | access to property Prop1 | J.cs:14:17:14:33 | call to method Source<Object> : Object | J.cs:16:14:16:21 | access to property Prop1 | $@ | J.cs:14:17:14:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:20:14:20:21 | access to property Prop1 | J.cs:14:17:14:33 | call to method Source<Object> : Object | J.cs:20:14:20:21 | access to property Prop1 | $@ | J.cs:14:17:14:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:24:14:24:21 | access to property Prop1 | J.cs:14:17:14:33 | call to method Source<Object> : Object | J.cs:24:14:24:21 | access to property Prop1 | $@ | J.cs:14:17:14:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:25:14:25:21 | access to property Prop2 | J.cs:23:36:23:52 | call to method Source<Object> : Object | J.cs:25:14:25:21 | access to property Prop2 | $@ | J.cs:23:36:23:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:36:14:36:21 | access to property Prop1 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:36:14:36:21 | access to property Prop1 | $@ | J.cs:34:17:34:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:40:14:40:21 | access to property Prop1 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:40:14:40:21 | access to property Prop1 | $@ | J.cs:34:17:34:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:44:14:44:21 | access to property Prop1 | J.cs:34:17:34:33 | call to method Source<Object> : Object | J.cs:44:14:44:21 | access to property Prop1 | $@ | J.cs:34:17:34:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
-| J.cs:45:14:45:21 | access to property Prop2 | J.cs:43:36:43:52 | call to method Source<Object> : Object | J.cs:45:14:45:21 | access to property Prop2 | $@ | J.cs:43:36:43:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:23:14:23:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:23:14:23:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:27:14:27:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:27:14:27:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:31:14:31:21 | access to property Prop1 | J.cs:21:17:21:33 | call to method Source<Object> : Object | J.cs:31:14:31:21 | access to property Prop1 | $@ | J.cs:21:17:21:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:32:14:32:21 | access to property Prop2 | J.cs:30:36:30:52 | call to method Source<Object> : Object | J.cs:32:14:32:21 | access to property Prop2 | $@ | J.cs:30:36:30:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:43:14:43:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:43:14:43:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:47:14:47:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:47:14:47:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:51:14:51:21 | access to property Prop1 | J.cs:41:17:41:33 | call to method Source<Object> : Object | J.cs:51:14:51:21 | access to property Prop1 | $@ | J.cs:41:17:41:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:52:14:52:21 | access to property Prop2 | J.cs:50:36:50:52 | call to method Source<Object> : Object | J.cs:52:14:52:21 | access to property Prop2 | $@ | J.cs:50:36:50:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:65:14:65:21 | access to field Field | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:65:14:65:21 | access to field Field | $@ | J.cs:61:17:61:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:69:14:69:21 | access to field Field | J.cs:61:17:61:33 | call to method Source<Object> : Object | J.cs:69:14:69:21 | access to field Field | $@ | J.cs:61:17:61:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:70:14:70:20 | access to property Prop | J.cs:68:35:68:51 | call to method Source<Object> : Object | J.cs:70:14:70:20 | access to property Prop | $@ | J.cs:68:35:68:51 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:84:14:84:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:84:14:84:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:87:14:87:21 | access to field Field | J.cs:86:36:86:52 | call to method Source<Object> : Object | J.cs:87:14:87:21 | access to field Field | $@ | J.cs:86:36:86:52 | call to method Source<Object> : Object | call to method Source<Object> : Object |
+| J.cs:88:14:88:20 | access to property Prop | J.cs:79:17:79:33 | call to method Source<Object> : Object | J.cs:88:14:88:20 | access to property Prop | $@ | J.cs:79:17:79:33 | call to method Source<Object> : Object | call to method Source<Object> : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/J.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/J.cs
@@ -7,6 +7,13 @@ public record class RecordClass(object Prop1, object Prop2) { }
 
 public record struct RecordStruct(object Prop1, object Prop2) { }
 
+public struct Struct
+{
+    public object Field;
+    public object Prop { get; init; }
+    public Struct(object field, object prop) => (Field, Prop) = (field, prop);
+}
+
 public class J
 {
     private void M1()
@@ -47,6 +54,42 @@ public class J
         var r4 = r1 with { Prop1 = null };
         Sink(r4.Prop1); // no flow
         Sink(r4.Prop2); // no flow
+    }
+
+    private void M3()
+    {
+        var o = Source<object>(3);
+        var s1 = new Struct(o, null);
+
+        var s2 = s1 with { };
+        Sink(s2.Field); // $ hasValueFlow=3
+        Sink(s2.Prop); // no flow
+
+        var s3 = s1 with { Prop = Source<object>(4) };
+        Sink(s3.Field); // $ hasValueFlow=3
+        Sink(s3.Prop); // $ hasValueFlow=4
+
+        var s4 = s1 with { Field = null };
+        Sink(s4.Field); // no flow
+        Sink(s4.Prop); // no flow
+    }
+
+    private void M4()
+    {
+        var o = Source<object>(5);
+        var s1 = new Struct(null, o);
+
+        var s2 = s1 with { };
+        Sink(s2.Field); // $ no flow
+        Sink(s2.Prop); // $ hasValueFlow=5
+
+        var s3 = s1 with { Field = Source<object>(6) };
+        Sink(s3.Field); // $ hasValueFlow=6
+        Sink(s3.Prop); // $ hasValueFlow=5
+
+        var s4 = s1 with { Prop = null };
+        Sink(s4.Field); // no flow
+        Sink(s4.Prop); // no flow
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/J.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/J.cs
@@ -35,6 +35,18 @@ public class J
         var r1 = new RecordStruct(o, null);
         Sink(r1.Prop1); // $ hasValueFlow=2
         Sink(r1.Prop2); // no flow
+
+        var r2 = r1 with { };
+        Sink(r2.Prop1); // $ hasValueFlow=2
+        Sink(r2.Prop2); // no flow
+
+        var r3 = r1 with { Prop2 = Source<object>(3) };
+        Sink(r3.Prop1); // $ hasValueFlow=2
+        Sink(r3.Prop2); // $ hasValueFlow=3
+
+        var r4 = r1 with { Prop1 = null };
+        Sink(r4.Prop1); // no flow
+        Sink(r4.Prop2); // no flow
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/J.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/J.cs
@@ -92,6 +92,25 @@ public class J
         Sink(s4.Prop); // no flow
     }
 
+    private void M5()
+    {
+        var o = Source<object>(7);
+        object @null = null;
+        var a1 = new { X = o, Y = @null };
+
+        var a2 = a1 with { };
+        Sink(a2.X); // $ hasValueFlow=7
+        Sink(a2.Y); // no flow
+
+        var a3 = a1 with { Y = Source<object>(8) };
+        Sink(a3.X); // $ hasValueFlow=7
+        Sink(a3.Y); // $ hasValueFlow=8
+
+        var a4 = a1 with { X = @null };
+        Sink(a4.X); // no flow
+        Sink(a4.Y); // no flow
+    }
+
     public static void Sink(object o) { }
 
     static T Source<T>(object source) => throw null;


### PR DESCRIPTION
In this PR we make

- Support for user declared default constructors for structs (test-only).
- Support for with expressions for structs, anonymous types and record structs (test only).
- Flow tests for the type of with expressions.
- Support for flow via anonymous type object initializer.