### PR TITLE
C#: Workaround Roslyn bug in `INamedTypeSymbol.TupleElements`

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -90,7 +90,11 @@ namespace Semmle.Extraction.CSharp.Entities
                     var tts = (TupleTypeSyntax)syntax;
                     var tt = (TupleType)type;
                     Emit(trapFile, loc ?? syntax.GetLocation(), parent, type);
-                    tts.Elements.Zip(tt.TupleElements, (s, t) => Create(Context, s.Type, this, t.Type)).Enumerate();
+                    foreach (var (s, t) in tts.Elements.Zip(tt.TupleElements, (s, t) => (s, t?.Type)))
+                    {
+                        if (t is not null)
+                            Create(Context, s.Type, this, t);
+                    }
                     return;
                 case SyntaxKind.GenericName:
                     Emit(trapFile, loc ?? syntax.GetLocation(), parent, type);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         private TupleType(Context cx, INamedTypeSymbol init) : base(cx, init)
         {
-            tupleElementsLazy = new Lazy<Field[]>(() => Symbol.TupleElementsAdjusted().Select(t => Field.Create(cx, t)).ToArray());
+            tupleElementsLazy = new Lazy<Field?[]>(() => Symbol.GetTupleElementsMaybeNull().Select(t => t is null ? null : Field.Create(cx, t)).ToArray());
         }
 
         // All tuple types are "local types"
@@ -47,7 +47,10 @@ namespace Semmle.Extraction.CSharp.Entities
 
             var index = 0;
             foreach (var element in TupleElements)
-                trapFile.tuple_element(this, index++, element);
+            {
+                if (element is not null)
+                    trapFile.tuple_element(this, index++, element);
+            }
 
             // Note: symbol.Locations seems to be very inconsistent
             // about what locations are available for a tuple type.
@@ -56,9 +59,10 @@ namespace Semmle.Extraction.CSharp.Entities
                 trapFile.type_location(this, Context.CreateLocation(l));
         }
 
-        private readonly Lazy<Field[]> tupleElementsLazy;
-        public Field[] TupleElements => tupleElementsLazy.Value;
+        private readonly Lazy<Field?[]> tupleElementsLazy;
+        public Field?[] TupleElements => tupleElementsLazy.Value;
 
-        public override IEnumerable<Type> TypeMentions => TupleElements.Select(e => e.Type);
+        public override IEnumerable<Type> TypeMentions =>
+            TupleElements.OfType<Field>().Select(e => e.Type);
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         private TupleType(Context cx, INamedTypeSymbol init) : base(cx, init)
         {
-            tupleElementsLazy = new Lazy<Field[]>(() => Symbol.TupleElements.Select(t => Field.Create(cx, t)).ToArray());
+            tupleElementsLazy = new Lazy<Field[]>(() => Symbol.TupleElementsAdjusted().Select(t => Field.Create(cx, t)).ToArray());
         }
 
         // All tuple types are "local types"

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -280,12 +280,18 @@ namespace Semmle.Extraction.CSharp
         private static void BuildFunctionPointerTypeId(this IFunctionPointerTypeSymbol funptr, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined) =>
             BuildFunctionPointerSignature(funptr, trapFile, s => s.BuildOrWriteId(cx, trapFile, symbolBeingDefined));
 
+        /// <summary>
+        /// Workaround for a Roslyn bug: https://github.com/dotnet/roslyn/issues/53943
+        /// </summary>
+        public static IEnumerable<IFieldSymbol> TupleElementsAdjusted(this INamedTypeSymbol type) =>
+            type.TupleElements.Where(f => f is not null && f.Type is not null);
+
         private static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined, bool constructUnderlyingTupleType)
         {
             if (!constructUnderlyingTupleType && named.IsTupleType)
             {
                 trapFile.Write('(');
-                trapFile.BuildList(",", named.TupleElements,
+                trapFile.BuildList(",", named.TupleElementsAdjusted(),
                     f =>
                     {
                         trapFile.Write((f.CorrespondingTupleField ?? f).Name);
@@ -464,7 +470,7 @@ namespace Semmle.Extraction.CSharp
                 trapFile.Write('(');
                 trapFile.BuildList(
                     ",",
-                    namedType.TupleElements.Select(f => f.Type),
+                    namedType.TupleElementsAdjusted().Select(f => f.Type),
                     t => t.BuildDisplayName(cx, trapFile));
                 trapFile.Write(")");
                 return;

--- a/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
@@ -232,19 +232,33 @@ namespace Semmle.Extraction
         /// <param name="items">The list of items.</param>
         /// <param name="action">The action on each item.</param>
         /// <returns>The original trap builder (fluent interface).</returns>
-        public static T1 BuildList<T1, T2>(this T1 trapFile, string separator, IEnumerable<T2> items, Action<T2> action)
+        public static T1 BuildList<T1, T2>(this T1 trapFile, string separator, IEnumerable<T2> items, Action<int, T2> action)
             where T1 : TextWriter
         {
             var first = true;
+            var i = 0;
             foreach (var item in items)
             {
                 if (first)
                     first = false;
                 else
                     trapFile.Write(separator);
-                action(item);
+                action(i++, item);
             }
             return trapFile;
         }
+
+        /// <summary>
+        /// Builds a trap builder using a separator and an action for each item in the list.
+        /// </summary>
+        /// <typeparam name="T">The type of the items.</typeparam>
+        /// <param name="trapFile">The trap builder to append to.</param>
+        /// <param name="separator">The separator string (e.g. ",")</param>
+        /// <param name="items">The list of items.</param>
+        /// <param name="action">The action on each item.</param>
+        /// <returns>The original trap builder (fluent interface).</returns>
+        public static T1 BuildList<T1, T2>(this T1 trapFile, string separator, IEnumerable<T2> items, Action<T2> action)
+            where T1 : TextWriter =>
+            trapFile.BuildList(separator, items, (_, item) => action(item));
     }
 }


### PR DESCRIPTION
We occasionally see errors like this:

```
Unhandled exception generating id: Object reference not set to an instance of an object. in Label.ToString()    at Semmle.Extraction.CSharp.SymbolExtensions.<>c__DisplayClass11_0.<BuildNamedTypeId>b__0(IFieldSymbol f) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs:line 293
   at Semmle.Extraction.TrapExtensions.BuildList[T1,T2](T1 trapFile, String separator, IEnumerable`1 items, Action`1 action) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/TrapExtensions.cs:line 232
   at Semmle.Extraction.CSharp.SymbolExtensions.BuildNamedTypeId(INamedTypeSymbol named, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined, Boolean constructUnderlyingTupleType) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs:line 340
   at Semmle.Extraction.CSharp.SymbolExtensions.BuildTypeId(ITypeSymbol type, Context cx, EscapingTextWriter trapFile, ISymbol symbolBeingDefined, Boolean constructUnderlyingTupleType) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs:line 203
   at Semmle.Extraction.CSharp.Entities.TupleType.WriteId(EscapingTextWriter trapFile) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs:line 34
   at Semmle.Extraction.Entity.WriteQuotedId(EscapingTextWriter trapFile) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Entities/Base/Entity.cs:line 25
   at Semmle.Extraction.Entity.DefineLabel(TextWriter trapFile, Extractor extractor) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Entities/Base/Entity.cs:line 47
```

and

```
Uncaught exception. Object reference not set to an instance of an object.    at Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor.AddTupleTypeName(INamedTypeSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor.AddNameAndTypeArgumentsOrParameters(INamedTypeSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor.MinimallyQualify(INamedTypeSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor.VisitNamedTypeWithoutNullability(INamedTypeSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor.VisitNamedType(INamedTypeSymbol symbol)
   at Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.NamedTypeSymbol.Accept(SymbolVisitor visitor)
   at Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.Symbol.Microsoft.CodeAnalysis.ISymbol.Accept(SymbolVisitor visitor)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplay.ToDisplayParts(ISymbol symbol, SemanticModel semanticModelOpt, Int32 positionOpt, SymbolDisplayFormat format, Boolean minimal)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplay.ToDisplayParts(ISymbol symbol, SymbolDisplayFormat format)
   at Microsoft.CodeAnalysis.CSharp.SymbolDisplay.ToDisplayString(ISymbol symbol, SymbolDisplayFormat format)
   at Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.Symbol.ToString()
   at Semmle.Extraction.Message.Create(Context cx, String text, ISymbol symbol, String stackTrace, Severity severity) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Message.cs:line 31
   at Semmle.Extraction.Context.Try(SyntaxNode node, ISymbol symbol, Action a) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Context.cs:line 543
   at Semmle.Extraction.Context.<>c__DisplayClass41_0.<Populate>b__2() in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Context.cs:line 385
   at Semmle.Extraction.Context.Populate(ISymbol optionalSymbol, CachedEntity entity) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Context.cs:line 390
   at Semmle.Extraction.Context.<>c__DisplayClass41_0.<Populate>b__0() in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Context.cs:line 343
   at Semmle.Extraction.ContextShared.WithWriter(TextWriter trapFile, Action a) in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/ContextShared.cs:line 133
   at Semmle.Extraction.Context.<>c__DisplayClass28_0.<PopulateLater>b__1() in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Context.cs:line 226
   at Semmle.Extraction.Context.PopulateAll() in /home/runner/work/semmle-code/semmle-code/ql/csharp/extractor/Semmle.Extraction/Context.cs:line 245
```

It appears to be the same issue as discussed in https://github.com/dotnet/roslyn/issues/53943.