### PR TITLE
C++: Improve cpp/cleartext-transmission

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Gets.qll
@@ -65,4 +65,6 @@ private class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunctio
   }
 
   override predicate hasArrayOutput(int bufParam) { bufParam = 0 }
+
+  override predicate hasSocketInput(FunctionInput input) { input.isParameter(2) }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -20,8 +20,9 @@ abstract class RemoteFlowSourceFunction extends Function {
   abstract predicate hasRemoteFlowSource(FunctionOutput output, string description);
 
   /**
-   * Holds if remote data from this source comes from a socket described by
-   * `input`. There is no result if a socket is not specified.
+   * Holds if remote data from this source comes from a socket or stream
+   * described by `input`. There is no result if none is specified by a
+   * parameter.
    */
   predicate hasSocketInput(FunctionInput input) { none() }
 }
@@ -59,8 +60,9 @@ abstract class RemoteFlowSinkFunction extends Function {
   abstract predicate hasRemoteFlowSink(FunctionInput input, string description);
 
   /**
-   * Holds if data put into this sink is transmitted through a socket described
-   * by `input`. There is no result if a socket is not specified.
+   * Holds if data put into this sink is transmitted through a socket or stream
+   * described by `input`. There is no result if none is specified by a
+   * parameter.
    */
   predicate hasSocketInput(FunctionInput input) { none() }
 }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -147,13 +147,18 @@ class NetworkRecv extends NetworkSendRecv {
 }
 
 /**
- * An expression that is an argument or return value from an encryption or
- * decryption call.
+ * An expression that is an argument or return value from an encryption /
+ * decryption call. This is quite inclusive to minimize false positives, for
+ * example `SecureZeroMemory` is not an encryption routine but a clue that
+ * encryption may be present.
  */
 class Encrypted extends Expr {
   Encrypted() {
     exists(FunctionCall fc |
-      fc.getTarget().getName().toLowerCase().regexpMatch(".*(crypt|encode|decode).*") and
+      fc.getTarget()
+          .getName()
+          .toLowerCase()
+          .regexpMatch(".*(crypt|encode|decode|hash|securezero).*") and
       (
         this = fc or
         this = fc.getAnArgument()

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -105,8 +105,8 @@ class Recv extends SendRecv instanceof RemoteFlowSourceFunction {
  * practice it usually isn't very important which query reports a result as
  * long as its reported exactly once.
  *
- * We do exclude function calls that specify a constant socket, which is
- * likely to mean standard input, standard output or a similar channel.
+ * We do exclude function calls that specify an apparently constant socket,
+ * which is likely to mean standard input, standard output or a similar channel.
  */
 abstract class NetworkSendRecv extends FunctionCall {
   SendRecv target;
@@ -125,6 +125,16 @@ abstract class NetworkSendRecv extends FunctionCall {
           v.getInitializer().getExpr() instanceof Literal and
           g = globalValueNumber(v.getAnAccess())
         )
+        or 
+        // result of a function call with literal inputs (likely constant)
+        exists(FunctionCall fc |
+          forex(Expr arg |
+            arg = fc.getAnArgument() |
+            arg instanceof Literal
+          ) and
+          g = globalValueNumber(fc)
+        )
+        // (this is far from exhaustive)
       )
     )
   }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -125,13 +125,10 @@ abstract class NetworkSendRecv extends FunctionCall {
           v.getInitializer().getExpr() instanceof Literal and
           g = globalValueNumber(v.getAnAccess())
         )
-        or 
+        or
         // result of a function call with literal inputs (likely constant)
         exists(FunctionCall fc |
-          forex(Expr arg |
-            arg = fc.getAnArgument() |
-            arg instanceof Literal
-          ) and
+          forex(Expr arg | arg = fc.getAnArgument() | arg instanceof Literal) and
           g = globalValueNumber(fc)
         )
         // (this is far from exhaustive)

--- a/cpp/ql/src/change-notes/2022-01-19-cleartext-transmission.md
+++ b/cpp/ql/src/change-notes/2022-01-19-cleartext-transmission.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Cleartext transmission of sensitive information" (`cpp/cleartext-transmission`) query has been improved in several ways to reduce false positive results.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -39,7 +39,6 @@ edges
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:15:219:26 | password_ptr |
 | test3.cpp:225:34:225:41 | password | test3.cpp:228:26:228:33 | password |
 | test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password |
-| test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password |
 | test3.cpp:252:8:252:16 | password1 | test3.cpp:254:15:254:23 | password1 |
 | test3.cpp:252:8:252:16 | password1 | test3.cpp:256:3:256:19 | call to decrypt_to_buffer |
 | test3.cpp:252:8:252:16 | password1 | test3.cpp:256:21:256:29 | password1 |
@@ -149,7 +148,6 @@ nodes
 | test3.cpp:228:26:228:33 | password | semmle.label | password |
 | test3.cpp:239:7:239:14 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
-| test3.cpp:242:8:242:15 | password | semmle.label | password |
 | test3.cpp:252:8:252:16 | password1 | semmle.label | password1 |
 | test3.cpp:252:24:252:32 | password2 | semmle.label | password2 |
 | test3.cpp:254:15:254:23 | password1 | semmle.label | password1 |
@@ -225,7 +223,6 @@ subpaths
 | test3.cpp:159:3:159:6 | call to send | test3.cpp:152:29:152:36 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:152:29:152:36 | password | password |
 | test3.cpp:228:2:228:5 | call to send | test3.cpp:225:34:225:41 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:225:34:225:41 | password | password |
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
-| test3.cpp:242:2:242:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
 | test3.cpp:272:3:272:6 | call to send | test3.cpp:268:19:268:26 | password | test3.cpp:272:15:272:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:268:19:268:26 | password | password |
 | test3.cpp:295:2:295:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -37,7 +37,6 @@ edges
 | test3.cpp:214:8:214:15 | password | test3.cpp:217:30:217:37 | password |
 | test3.cpp:214:8:214:15 | password | test3.cpp:219:15:219:26 | password_ptr |
 | test3.cpp:217:18:217:28 | call to rtn_encrypt | test3.cpp:219:15:219:26 | password_ptr |
-| test3.cpp:225:34:225:41 | password | test3.cpp:227:22:227:29 | password |
 | test3.cpp:225:34:225:41 | password | test3.cpp:228:26:228:33 | password |
 | test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password |
 | test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password |
@@ -147,7 +146,6 @@ nodes
 | test3.cpp:217:30:217:37 | password | semmle.label | password |
 | test3.cpp:219:15:219:26 | password_ptr | semmle.label | password_ptr |
 | test3.cpp:225:34:225:41 | password | semmle.label | password |
-| test3.cpp:227:22:227:29 | password | semmle.label | password |
 | test3.cpp:228:26:228:33 | password | semmle.label | password |
 | test3.cpp:239:7:239:14 | password | semmle.label | password |
 | test3.cpp:241:8:241:15 | password | semmle.label | password |
@@ -225,7 +223,6 @@ subpaths
 | test3.cpp:140:3:140:6 | call to send | test3.cpp:129:39:129:47 | password1 | test3.cpp:140:15:140:17 | ptr | This operation transmits 'ptr', which may contain unencrypted sensitive data from $@ | test3.cpp:129:39:129:47 | password1 | password1 |
 | test3.cpp:146:3:146:6 | call to send | test3.cpp:126:9:126:23 | global_password | test3.cpp:146:15:146:18 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:126:9:126:23 | global_password | global_password |
 | test3.cpp:159:3:159:6 | call to send | test3.cpp:152:29:152:36 | password | test3.cpp:159:15:159:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:152:29:152:36 | password | password |
-| test3.cpp:227:2:227:5 | call to send | test3.cpp:225:34:225:41 | password | test3.cpp:227:22:227:29 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:225:34:225:41 | password | password |
 | test3.cpp:228:2:228:5 | call to send | test3.cpp:225:34:225:41 | password | test3.cpp:228:26:228:33 | password | This operation transmits 'password', which may contain unencrypted sensitive data from $@ | test3.cpp:225:34:225:41 | password | password |
 | test3.cpp:241:2:241:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:241:8:241:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |
 | test3.cpp:242:2:242:6 | call to fgets | test3.cpp:239:7:239:14 | password | test3.cpp:242:8:242:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:239:7:239:14 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -85,6 +85,8 @@ edges
 | test3.cpp:350:9:350:16 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
 | test3.cpp:350:9:350:16 | password | test3.cpp:353:20:353:27 | password |
 | test3.cpp:366:8:366:15 | password | test3.cpp:368:15:368:22 | password |
+| test3.cpp:366:8:366:15 | password | test3.cpp:374:3:374:18 | call to SecureZeroBuffer |
+| test3.cpp:366:8:366:15 | password | test3.cpp:374:20:374:27 | password |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -198,6 +200,8 @@ nodes
 | test3.cpp:353:20:353:27 | password | semmle.label | password |
 | test3.cpp:366:8:366:15 | password | semmle.label | password |
 | test3.cpp:368:15:368:22 | password | semmle.label | password |
+| test3.cpp:374:3:374:18 | call to SecureZeroBuffer | semmle.label | call to SecureZeroBuffer |
+| test3.cpp:374:20:374:27 | password | semmle.label | password |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -229,4 +233,3 @@ subpaths
 | test3.cpp:295:2:295:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |
-| test3.cpp:368:3:368:6 | call to recv | test3.cpp:366:8:366:15 | password | test3.cpp:368:15:368:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:366:8:366:15 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -84,6 +84,7 @@ edges
 | test3.cpp:350:9:350:16 | password | test3.cpp:352:16:352:23 | password |
 | test3.cpp:350:9:350:16 | password | test3.cpp:353:4:353:18 | call to decrypt_inplace |
 | test3.cpp:350:9:350:16 | password | test3.cpp:353:20:353:27 | password |
+| test3.cpp:366:8:366:15 | password | test3.cpp:368:15:368:22 | password |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -195,6 +196,8 @@ nodes
 | test3.cpp:352:16:352:23 | password | semmle.label | password |
 | test3.cpp:353:4:353:18 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
 | test3.cpp:353:20:353:27 | password | semmle.label | password |
+| test3.cpp:366:8:366:15 | password | semmle.label | password |
+| test3.cpp:368:15:368:22 | password | semmle.label | password |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -226,3 +229,4 @@ subpaths
 | test3.cpp:295:2:295:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |
+| test3.cpp:368:3:368:6 | call to recv | test3.cpp:366:8:366:15 | password | test3.cpp:368:15:368:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:366:8:366:15 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -239,7 +239,7 @@ void test_fgets(FILE *stream)
 	char password[128];
 
 	fgets(password, 128, stream); // BAD
-	fgets(password, 128, STDIN_STREAM); // GOOD: `STDIN_STREAM` is probably standard input [FALSE POSITIVE]
+	fgets(password, 128, STDIN_STREAM); // GOOD: `STDIN_STREAM` is probably standard input
 }
 
 void encrypt_to_buffer(const char *input, char* output);

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -365,7 +365,7 @@ void test_securezero()
 	{
 		char password[256];
 
-		recv(val(), password, 256, val()); // GOOD: password is (probably) encrypted [FALSE POSITIVE]
+		recv(val(), password, 256, val()); // GOOD: password is (probably) encrypted
 
 		DoDisguisedOperation(password, 256); // decryption (disguised)
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -224,7 +224,7 @@ int get_socket(int from);
 
 void test_more_stdio(const char *password)
 {
-	send(get_socket(1), password, 128, val()); // GOOD: `getsocket(1)` is probably standard output [FALSE POSITIVE]
+	send(get_socket(1), password, 128, val()); // GOOD: `getsocket(1)` is probably standard output
 	send(get_socket(val()), password, 128, val()); // BAD
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -356,3 +356,21 @@ void test_loops()
 		}
 	}
 }
+
+void DoDisguisedOperation(char *buffer, size_t size);
+void SecureZeroBuffer(char *buffer, size_t size);
+
+void test_securezero()
+{
+	{
+		char password[256];
+
+		recv(val(), password, 256, val()); // GOOD: password is (probably) encrypted [FALSE POSITIVE]
+
+		DoDisguisedOperation(password, 256); // decryption (disguised)
+
+		// ...
+
+		SecureZeroBuffer(password, 256); // evidence we may have been doing decryption
+	}
+}


### PR DESCRIPTION
This PR is a collection of simple improvements to `cpp/cleartext-transmission`, each ruling out a small source of false positive results.  There may be more work to be done before upping the query to `@precision high`, but we're getting closer.