### PR TITLE
JS: add CWE-471 to the prototype-pollution queries

### DIFF
--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingAssignment.ql
@@ -13,6 +13,7 @@
  *       external/cwe/cwe-079
  *       external/cwe/cwe-094
  *       external/cwe/cwe-400
+ *       external/cwe/cwe-471
  *       external/cwe/cwe-915
  */
 

--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingFunction.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingFunction.ql
@@ -12,6 +12,7 @@
  *       external/cwe/cwe-079
  *       external/cwe/cwe-094
  *       external/cwe/cwe-400
+ *       external/cwe/cwe-471
  *       external/cwe/cwe-915
  */
 

--- a/javascript/ql/src/Security/CWE-915/PrototypePollutingMergeCall.ql
+++ b/javascript/ql/src/Security/CWE-915/PrototypePollutingMergeCall.ql
@@ -13,6 +13,7 @@
  *       external/cwe/cwe-079
  *       external/cwe/cwe-094
  *       external/cwe/cwe-400
+ *       external/cwe/cwe-471
  *       external/cwe/cwe-915
  */
 


### PR DESCRIPTION
All the [CWE-471 CVEs in the advisory db](https://github.com/advisories?query=cwe%3A471) are prototype-pollution CVEs.  

So I've added CWE-471 to the prototype-pollution queries. 