### PR TITLE
Python: Remove usernames as sensitive source for cleartext queries

### DIFF
--- a/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
@@ -40,6 +40,10 @@ module CleartextLogging {
    * A source of sensitive data, considered as a flow source.
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
+    SensitiveDataSourceAsSource() {
+      not SensitiveDataSource.super.getClassification() = SensitiveDataClassification::id()
+    }
+
     override SensitiveDataClassification getClassification() {
       result = SensitiveDataSource.super.getClassification()
     }

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
@@ -39,6 +39,10 @@ module CleartextStorage {
    * A source of sensitive data, considered as a flow source.
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
+    SensitiveDataSourceAsSource() {
+      not SensitiveDataSource.super.getClassification() = SensitiveDataClassification::id()
+    }
+
     override SensitiveDataClassification getClassification() {
       result = SensitiveDataSource.super.getClassification()
     }

--- a/python/ql/src/change-notes/2021-01-19-remove-cleartext-fps.md
+++ b/python/ql/src/change-notes/2021-01-19-remove-cleartext-fps.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* No longer consider usernames or other account information as sensitive data for the queries `py/clear-text-logging-sensitive-data` and `py/clear-text-storage-sensitive-data`, since this has lead to many false positives.

--- a/python/ql/src/change-notes/2021-01-19-remove-cleartext-fps.md
+++ b/python/ql/src/change-notes/2021-01-19-remove-cleartext-fps.md
@@ -1,4 +1,4 @@
 ---
 category: majorAnalysis
 ---
-* No longer consider usernames or other account information as sensitive data for the queries `py/clear-text-logging-sensitive-data` and `py/clear-text-storage-sensitive-data`, since this has lead to many false positives.
+* User names and other account information is no longer considered to be sensitive data for the queries `py/clear-text-logging-sensitive-data` and `py/clear-text-storage-sensitive-data`, since this lead to many false positives.

--- a/python/ql/test/experimental/dataflow/sensitive-data/test.py
+++ b/python/ql/test/experimental/dataflow/sensitive-data/test.py
@@ -112,3 +112,16 @@ print(foo) # $ SensitiveUse=password
 harmless = lambda: "bar"
 bar = call_wrapper(harmless)
 print(bar) # $ SPURIOUS: SensitiveUse=password
+
+# ------------------------------------------------------------------------------
+# cross-talk in dictionary.
+# ------------------------------------------------------------------------------
+
+from unknown_settings import password # $ SensitiveDataSource=password
+
+print(password) # $ SensitiveUse=password
+_config = {"sleep_timer": 5, "mysql_password": password}
+
+# since we have taint-step from store of `password`, we will consider any item in the
+# dictionary to be a password :(
+print(_config["sleep_timer"]) # $ SPURIOUS: SensitiveUse=password

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/CleartextLogging.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/CleartextLogging.expected
@@ -4,9 +4,6 @@ edges
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:23:58:23:65 | ControlFlowNode for password |
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:27:40:27:47 | ControlFlowNode for password |
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:30:58:30:65 | ControlFlowNode for password |
-| test.py:43:9:43:15 | ControlFlowNode for account | test.py:46:11:46:17 | ControlFlowNode for account |
-| test.py:43:18:43:27 | ControlFlowNode for account_id | test.py:50:18:50:51 | ControlFlowNode for Fstring |
-| test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | test.py:56:11:56:11 | ControlFlowNode for x |
 | test.py:65:14:68:5 | ControlFlowNode for Dict | test.py:69:11:69:31 | ControlFlowNode for Subscript |
 | test.py:67:21:67:37 | ControlFlowNode for Attribute | test.py:65:14:68:5 | ControlFlowNode for Dict |
 nodes
@@ -20,13 +17,6 @@ nodes
 | test.py:37:11:37:24 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:39:22:39:35 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:40:22:40:35 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
-| test.py:43:9:43:15 | ControlFlowNode for account | semmle.label | ControlFlowNode for account |
-| test.py:43:18:43:27 | ControlFlowNode for account_id | semmle.label | ControlFlowNode for account_id |
-| test.py:46:11:46:17 | ControlFlowNode for account | semmle.label | ControlFlowNode for account |
-| test.py:50:18:50:51 | ControlFlowNode for Fstring | semmle.label | ControlFlowNode for Fstring |
-| test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | semmle.label | ControlFlowNode for generate_uuid4() |
-| test.py:56:11:56:11 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
-| test.py:60:50:60:70 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
 | test.py:65:14:68:5 | ControlFlowNode for Dict | semmle.label | ControlFlowNode for Dict |
 | test.py:67:21:67:37 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
 | test.py:69:11:69:31 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
@@ -41,8 +31,4 @@ subpaths
 | test.py:37:11:37:24 | ControlFlowNode for get_password() | test.py:37:11:37:24 | ControlFlowNode for get_password() | test.py:37:11:37:24 | ControlFlowNode for get_password() | $@ is logged here. | test.py:37:11:37:24 | ControlFlowNode for get_password() | Sensitive data (password) |
 | test.py:39:22:39:35 | ControlFlowNode for get_password() | test.py:39:22:39:35 | ControlFlowNode for get_password() | test.py:39:22:39:35 | ControlFlowNode for get_password() | $@ is logged here. | test.py:39:22:39:35 | ControlFlowNode for get_password() | Sensitive data (password) |
 | test.py:40:22:40:35 | ControlFlowNode for get_password() | test.py:40:22:40:35 | ControlFlowNode for get_password() | test.py:40:22:40:35 | ControlFlowNode for get_password() | $@ is logged here. | test.py:40:22:40:35 | ControlFlowNode for get_password() | Sensitive data (password) |
-| test.py:46:11:46:17 | ControlFlowNode for account | test.py:43:9:43:15 | ControlFlowNode for account | test.py:46:11:46:17 | ControlFlowNode for account | $@ is logged here. | test.py:43:9:43:15 | ControlFlowNode for account | Sensitive data (id) |
-| test.py:50:18:50:51 | ControlFlowNode for Fstring | test.py:43:18:43:27 | ControlFlowNode for account_id | test.py:50:18:50:51 | ControlFlowNode for Fstring | $@ is logged here. | test.py:43:18:43:27 | ControlFlowNode for account_id | Sensitive data (id) |
-| test.py:56:11:56:11 | ControlFlowNode for x | test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | test.py:56:11:56:11 | ControlFlowNode for x | $@ is logged here. | test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | Sensitive data (id) |
-| test.py:60:50:60:70 | ControlFlowNode for Attribute | test.py:60:50:60:70 | ControlFlowNode for Attribute | test.py:60:50:60:70 | ControlFlowNode for Attribute | $@ is logged here. | test.py:60:50:60:70 | ControlFlowNode for Attribute | Sensitive data (id) |
 | test.py:69:11:69:31 | ControlFlowNode for Subscript | test.py:67:21:67:37 | ControlFlowNode for Attribute | test.py:69:11:69:31 | ControlFlowNode for Subscript | $@ is logged here. | test.py:67:21:67:37 | ControlFlowNode for Attribute | Sensitive data (password) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/CleartextLogging.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/CleartextLogging.expected
@@ -4,6 +4,11 @@ edges
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:23:58:23:65 | ControlFlowNode for password |
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:27:40:27:47 | ControlFlowNode for password |
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:30:58:30:65 | ControlFlowNode for password |
+| test.py:43:9:43:15 | ControlFlowNode for account | test.py:46:11:46:17 | ControlFlowNode for account |
+| test.py:43:18:43:27 | ControlFlowNode for account_id | test.py:50:18:50:51 | ControlFlowNode for Fstring |
+| test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | test.py:56:11:56:11 | ControlFlowNode for x |
+| test.py:65:14:68:5 | ControlFlowNode for Dict | test.py:69:11:69:31 | ControlFlowNode for Subscript |
+| test.py:67:21:67:37 | ControlFlowNode for Attribute | test.py:65:14:68:5 | ControlFlowNode for Dict |
 nodes
 | test.py:19:16:19:29 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:20:48:20:55 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
@@ -15,6 +20,16 @@ nodes
 | test.py:37:11:37:24 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:39:22:39:35 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:40:22:40:35 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
+| test.py:43:9:43:15 | ControlFlowNode for account | semmle.label | ControlFlowNode for account |
+| test.py:43:18:43:27 | ControlFlowNode for account_id | semmle.label | ControlFlowNode for account_id |
+| test.py:46:11:46:17 | ControlFlowNode for account | semmle.label | ControlFlowNode for account |
+| test.py:50:18:50:51 | ControlFlowNode for Fstring | semmle.label | ControlFlowNode for Fstring |
+| test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | semmle.label | ControlFlowNode for generate_uuid4() |
+| test.py:56:11:56:11 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
+| test.py:60:50:60:70 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
+| test.py:65:14:68:5 | ControlFlowNode for Dict | semmle.label | ControlFlowNode for Dict |
+| test.py:67:21:67:37 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
+| test.py:69:11:69:31 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
 subpaths
 #select
 | test.py:20:48:20:55 | ControlFlowNode for password | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:20:48:20:55 | ControlFlowNode for password | $@ is logged here. | test.py:19:16:19:29 | ControlFlowNode for get_password() | Sensitive data (password) |
@@ -26,3 +41,8 @@ subpaths
 | test.py:37:11:37:24 | ControlFlowNode for get_password() | test.py:37:11:37:24 | ControlFlowNode for get_password() | test.py:37:11:37:24 | ControlFlowNode for get_password() | $@ is logged here. | test.py:37:11:37:24 | ControlFlowNode for get_password() | Sensitive data (password) |
 | test.py:39:22:39:35 | ControlFlowNode for get_password() | test.py:39:22:39:35 | ControlFlowNode for get_password() | test.py:39:22:39:35 | ControlFlowNode for get_password() | $@ is logged here. | test.py:39:22:39:35 | ControlFlowNode for get_password() | Sensitive data (password) |
 | test.py:40:22:40:35 | ControlFlowNode for get_password() | test.py:40:22:40:35 | ControlFlowNode for get_password() | test.py:40:22:40:35 | ControlFlowNode for get_password() | $@ is logged here. | test.py:40:22:40:35 | ControlFlowNode for get_password() | Sensitive data (password) |
+| test.py:46:11:46:17 | ControlFlowNode for account | test.py:43:9:43:15 | ControlFlowNode for account | test.py:46:11:46:17 | ControlFlowNode for account | $@ is logged here. | test.py:43:9:43:15 | ControlFlowNode for account | Sensitive data (id) |
+| test.py:50:18:50:51 | ControlFlowNode for Fstring | test.py:43:18:43:27 | ControlFlowNode for account_id | test.py:50:18:50:51 | ControlFlowNode for Fstring | $@ is logged here. | test.py:43:18:43:27 | ControlFlowNode for account_id | Sensitive data (id) |
+| test.py:56:11:56:11 | ControlFlowNode for x | test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | test.py:56:11:56:11 | ControlFlowNode for x | $@ is logged here. | test.py:55:9:55:24 | ControlFlowNode for generate_uuid4() | Sensitive data (id) |
+| test.py:60:50:60:70 | ControlFlowNode for Attribute | test.py:60:50:60:70 | ControlFlowNode for Attribute | test.py:60:50:60:70 | ControlFlowNode for Attribute | $@ is logged here. | test.py:60:50:60:70 | ControlFlowNode for Attribute | Sensitive data (id) |
+| test.py:69:11:69:31 | ControlFlowNode for Subscript | test.py:67:21:67:37 | ControlFlowNode for Attribute | test.py:69:11:69:31 | ControlFlowNode for Subscript | $@ is logged here. | test.py:67:21:67:37 | ControlFlowNode for Attribute | Sensitive data (password) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/test.py
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/test.py
@@ -39,6 +39,36 @@ def print_password():
     sys.stdout.write(get_password()) # NOT OK
     sys.stderr.write(get_password()) # NOT OK
 
+
+def FPs(account, account_id):
+    # we assume that any account parameter is sensitive (id/username)
+    # https://github.com/github/codeql/issues/6363
+    print(account) # OK
+
+    # https://github.com/github/codeql/issues/6927
+    arn = f"arn:aws:iam::{account_id}:role/cfripper-access"
+    logging.info(f"Preparing to assume role: {arn}") # OK
+
+    # Harmless UUIDs
+    # https://github.com/github/codeql/issues/6726
+    # https://github.com/github/codeql/issues/7497
+    x = generate_uuid4()
+    print(x) # OK
+
+    # username not considered sensitive
+    # https://github.com/github/codeql/issues/7116
+    logging.error("Misc Exception. User %s: %s", request.user.username)
+
+    # dictionary taint-flow corss-talk
+    # https://github.com/github/codeql/issues/6380
+    import settings
+    config = {
+        "sleep_timer": 5,
+        "password": settings.password
+    }
+    print(config["sleep_timer"]) # OK
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     log_password()

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/test.py
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/test.py
@@ -59,7 +59,7 @@ def FPs(account, account_id):
     # https://github.com/github/codeql/issues/7116
     logging.error("Misc Exception. User %s: %s", request.user.username)
 
-    # dictionary taint-flow corss-talk
+    # dictionary taint-flow cross-talk
     # https://github.com/github/codeql/issues/6380
     import settings
     config = {

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/CleartextStorage.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/CleartextStorage.expected
@@ -4,6 +4,7 @@ edges
 | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:8:20:8:23 | ControlFlowNode for cert |
 | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:9:17:9:29 | ControlFlowNode for List |
 | test.py:9:17:9:29 | ControlFlowNode for List | test.py:10:25:10:29 | ControlFlowNode for lines |
+| test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | test.py:21:20:21:20 | ControlFlowNode for x |
 nodes
 | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
@@ -13,9 +14,12 @@ nodes
 | test.py:8:20:8:23 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
 | test.py:9:17:9:29 | ControlFlowNode for List | semmle.label | ControlFlowNode for List |
 | test.py:10:25:10:29 | ControlFlowNode for lines | semmle.label | ControlFlowNode for lines |
+| test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | semmle.label | ControlFlowNode for generate_uuid4() |
+| test.py:21:20:21:20 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 subpaths
 #select
 | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | $@ is stored here. | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | Sensitive data (password) |
 | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | $@ is stored here. | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | Sensitive data (password) |
 | test.py:8:20:8:23 | ControlFlowNode for cert | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:8:20:8:23 | ControlFlowNode for cert | $@ is stored here. | test.py:6:12:6:21 | ControlFlowNode for get_cert() | Sensitive data (certificate) |
 | test.py:10:25:10:29 | ControlFlowNode for lines | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:10:25:10:29 | ControlFlowNode for lines | $@ is stored here. | test.py:6:12:6:21 | ControlFlowNode for get_cert() | Sensitive data (certificate) |
+| test.py:21:20:21:20 | ControlFlowNode for x | test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | test.py:21:20:21:20 | ControlFlowNode for x | $@ is stored here. | test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | Sensitive data (id) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/CleartextStorage.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/CleartextStorage.expected
@@ -4,7 +4,6 @@ edges
 | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:8:20:8:23 | ControlFlowNode for cert |
 | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:9:17:9:29 | ControlFlowNode for List |
 | test.py:9:17:9:29 | ControlFlowNode for List | test.py:10:25:10:29 | ControlFlowNode for lines |
-| test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | test.py:21:20:21:20 | ControlFlowNode for x |
 nodes
 | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
@@ -14,12 +13,9 @@ nodes
 | test.py:8:20:8:23 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
 | test.py:9:17:9:29 | ControlFlowNode for List | semmle.label | ControlFlowNode for List |
 | test.py:10:25:10:29 | ControlFlowNode for lines | semmle.label | ControlFlowNode for lines |
-| test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | semmle.label | ControlFlowNode for generate_uuid4() |
-| test.py:21:20:21:20 | ControlFlowNode for x | semmle.label | ControlFlowNode for x |
 subpaths
 #select
 | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | $@ is stored here. | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | Sensitive data (password) |
 | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | $@ is stored here. | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | Sensitive data (password) |
 | test.py:8:20:8:23 | ControlFlowNode for cert | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:8:20:8:23 | ControlFlowNode for cert | $@ is stored here. | test.py:6:12:6:21 | ControlFlowNode for get_cert() | Sensitive data (certificate) |
 | test.py:10:25:10:29 | ControlFlowNode for lines | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:10:25:10:29 | ControlFlowNode for lines | $@ is stored here. | test.py:6:12:6:21 | ControlFlowNode for get_cert() | Sensitive data (certificate) |
-| test.py:21:20:21:20 | ControlFlowNode for x | test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | test.py:21:20:21:20 | ControlFlowNode for x | $@ is stored here. | test.py:20:13:20:28 | ControlFlowNode for generate_uuid4() | Sensitive data (id) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/test.py
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/test.py
@@ -8,3 +8,14 @@ def write_cert(filename):
         file.write(cert) # NOT OK
         lines = [cert + "\n"]
         file.writelines(lines) # NOT OK
+
+def FPs():
+    # just like for cleartext-logging see that file for more elaborate tests
+    #
+    # this part is just to make sure the two queries are in line with what is considered
+    # sensitive information.
+
+    with open(filename, "w") as file:
+        # Harmless UUIDs
+        x = generate_uuid4()
+        file.write(x) # OK


### PR DESCRIPTION
Draft while double checking that we wouldn't loose any important current results from this.