### PR TITLE
JS: Bump ML-powered query packs to v0.0.6

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/javascript-experimental-atm-lib
-version: 0.0.5
+version: 0.0.6
 extractor: javascript
 library: true
 groups:

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml
@@ -1,6 +1,6 @@
 name: codeql/javascript-experimental-atm-queries
 language: javascript
-version: 0.0.5
+version: 0.0.6
 suites: codeql-suites
 defaultSuiteFile: codeql-suites/javascript-atm-code-scanning.qls
 groups:


### PR DESCRIPTION
We've released 0.0.5, so bump the version numbers to 0.0.6.