### PR TITLE
Ruby: Update `StringConstArrayInclusionCall` barrier guard

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/BarrierGuards.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/BarrierGuards.qll
@@ -64,7 +64,8 @@ class StringConstArrayInclusionCall extends DataFlow::BarrierGuard,
   StringConstArrayInclusionCall() {
     exists(ArrayLiteral aLit |
       this.getExpr().getMethodName() = "include?" and
-      this.getExpr().getReceiver() = aLit
+      [this.getExpr().getReceiver(), this.getExpr().getReceiver().(ConstantReadAccess).getValue()] =
+        aLit
     |
       forall(Expr elem | elem = aLit.getAnElement() | elem instanceof StringLiteral) and
       this.getArgument(0) = checkedNode

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
@@ -3,3 +3,4 @@
 | barrier-guards.rb:15:4:15:15 | ... != ... | barrier-guards.rb:18:5:18:7 | foo | barrier-guards.rb:15:4:15:6 | foo | false |
 | barrier-guards.rb:21:8:21:19 | ... == ... | barrier-guards.rb:24:5:24:7 | foo | barrier-guards.rb:21:8:21:10 | foo | true |
 | barrier-guards.rb:27:8:27:19 | ... != ... | barrier-guards.rb:28:5:28:7 | foo | barrier-guards.rb:27:8:27:10 | foo | false |
+| barrier-guards.rb:37:4:37:20 | call to include? | barrier-guards.rb:38:5:38:7 | foo | barrier-guards.rb:37:17:37:19 | foo | true |

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.rb
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.rb
@@ -31,3 +31,11 @@ else
 end
 
 foo
+
+FOO = ["foo"]
+
+if FOO.include?(foo)
+    foo
+else
+    foo
+end


### PR DESCRIPTION
This change recognises guards like `FOO.include?`, where `FOO` is an array
constant. For example:

```ruby
FOO = ["a", "b"]

if FOO.include?(x)
  # ...
else
  # ...
end
```
