### PR TITLE
Ruby: Add File.open as a FileSystemAccess

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -213,6 +213,15 @@ module File {
   }
 
   /**
+   * A call to `File.open`, considered as a `FileSystemAccess`.
+   */
+  class FileOpen extends DataFlow::CallNode, FileSystemAccess::Range {
+    FileOpen() { this = API::getTopLevelMember("File").getAMethodCall("open") }
+
+    override DataFlow::Node getAPathArgument() { result = this.getArgument(0) }
+  }
+
+  /**
    * A read using the `File` module, e.g. the `f.read` call in
    *
    * ```rb

--- a/ruby/ql/test/library-tests/frameworks/files/Files.expected
+++ b/ruby/ql/test/library-tests/frameworks/files/Files.expected
@@ -13,6 +13,8 @@ fileInstances
 | Files.rb:23:19:23:33 | call to open |
 | Files.rb:24:1:24:40 | ... = ... |
 | Files.rb:24:19:24:40 | call to open |
+| Files.rb:37:1:37:33 | ... = ... |
+| Files.rb:37:14:37:33 | call to open |
 ioInstances
 | Files.rb:2:1:2:30 | ... = ... |
 | Files.rb:2:1:2:30 | ... = ... |
@@ -36,6 +38,8 @@ ioInstances
 | Files.rb:24:19:24:40 | call to open |
 | Files.rb:35:1:35:56 | ... = ... |
 | Files.rb:35:13:35:56 | call to open |
+| Files.rb:37:1:37:33 | ... = ... |
+| Files.rb:37:14:37:33 | call to open |
 fileModuleReaders
 | Files.rb:7:13:7:32 | call to readlines |
 ioReaders
@@ -55,6 +59,11 @@ fileSystemReadAccesses
 | Files.rb:7:13:7:32 | call to readlines |
 | Files.rb:20:13:20:25 | call to read |
 | Files.rb:29:12:29:29 | call to read |
+fileSystemAccesses
+| Files.rb:7:13:7:32 | call to readlines |
+| Files.rb:20:13:20:25 | call to read |
+| Files.rb:29:12:29:29 | call to read |
+| Files.rb:37:14:37:33 | call to open |
 fileNameSources
 | Files.rb:10:6:10:18 | call to path |
 | Files.rb:11:6:11:21 | call to to_path |

--- a/ruby/ql/test/library-tests/frameworks/files/Files.ql
+++ b/ruby/ql/test/library-tests/frameworks/files/Files.ql
@@ -18,4 +18,6 @@ query predicate fileUtilsFilenameSources(FileUtils::FileUtilsFilenameSource s) {
 
 query predicate fileSystemReadAccesses(FileSystemReadAccess a) { any() }
 
+query predicate fileSystemAccesses(FileSystemAccess a) { any() }
+
 query predicate fileNameSources(FileNameSource s) { any() }

--- a/ruby/ql/test/library-tests/frameworks/files/Files.rb
+++ b/ruby/ql/test/library-tests/frameworks/files/Files.rb
@@ -33,3 +33,5 @@ date = IO.read("|date")
 
 # `rand_open` is an `IO` instance
 rand_open = IO.open(IO.sysopen("/dev/random", "r"), "r")
+
+foo_file_3 = File.open("foo.txt")


### PR DESCRIPTION
Add calls to `File.open` as `FileSystemAccess`es.
