### PR TITLE
simplify expressions that could be type-casts

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Class.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Class.qll
@@ -206,9 +206,7 @@ class Class extends UserType {
    * it is callable by a particular caller. For C++11, there's also a question
    * of whether to include members that are defaulted or deleted.
    */
-  deprecated predicate hasCopyConstructor() {
-    exists(CopyConstructor cc | cc = this.getAMemberFunction())
-  }
+  deprecated predicate hasCopyConstructor() { this.getAMemberFunction() instanceof CopyConstructor }
 
   /**
    * Holds if this class has a copy assignment operator that is either
@@ -224,7 +222,7 @@ class Class extends UserType {
    * or deleted.
    */
   deprecated predicate hasCopyAssignmentOperator() {
-    exists(CopyAssignmentOperator coa | coa = this.getAMemberFunction())
+    this.getAMemberFunction() instanceof CopyAssignmentOperator
   }
 
   /**
@@ -887,7 +885,7 @@ class NestedClass extends Class {
  * pure virtual function.
  */
 class AbstractClass extends Class {
-  AbstractClass() { exists(PureVirtualFunction f | this.getAMemberFunction() = f) }
+  AbstractClass() { this.getAMemberFunction() instanceof PureVirtualFunction }
 
   override string getAPrimaryQlClass() { result = "AbstractClass" }
 }

--- a/cpp/ql/lib/semmle/code/cpp/Specifier.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Specifier.qll
@@ -286,13 +286,13 @@ class AttributeArgument extends Element, @attribute_arg {
   override Location getLocation() { attribute_args(underlyingElement(this), _, _, _, result) }
 
   override string toString() {
-    if exists(@attribute_arg_empty self | self = underlyingElement(this))
+    if underlyingElement(this) instanceof @attribute_arg_empty
     then result = "empty argument"
     else
       exists(string prefix, string tail |
         (if exists(this.getName()) then prefix = this.getName() + "=" else prefix = "") and
         (
-          if exists(@attribute_arg_type self | self = underlyingElement(this))
+          if underlyingElement(this) instanceof @attribute_arg_type
           then tail = this.getValueType().getName()
           else tail = this.getValueText()
         ) and

--- a/cpp/ql/lib/semmle/code/cpp/XML.qll
+++ b/cpp/ql/lib/semmle/code/cpp/XML.qll
@@ -233,7 +233,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
-  predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
+  predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
 
   /** Gets the value of the attribute with the specified `name`, if any. */
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }

--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -29,7 +29,7 @@ class GuardCondition extends Expr {
     exists(IRGuardCondition ir | this = ir.getUnconvertedResultExpression())
     or
     // no binary operators in the IR
-    exists(GuardCondition gc | this.(BinaryLogicalOperation).getAnOperand() = gc)
+    this.(BinaryLogicalOperation).getAnOperand() instanceof GuardCondition
     or
     // the IR short-circuits if(!x)
     // don't produce a guard condition for `y = !x` and other non-short-circuited cases
@@ -98,7 +98,7 @@ class GuardCondition extends Expr {
  */
 private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
   GuardConditionFromBinaryLogicalOperator() {
-    exists(GuardCondition gc | this.(BinaryLogicalOperation).getAnOperand() = gc)
+    this.(BinaryLogicalOperation).getAnOperand() instanceof GuardCondition
   }
 
   override predicate controls(BasicBlock controlled, boolean testIsTrue) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -48,7 +48,7 @@ private class Argument extends Expr {
  */
 class ArgumentNode extends Node {
   ArgumentNode() {
-    exists(Argument arg | this.asExpr() = arg) or
+    this.asExpr() instanceof Argument or
     this = getInstanceArgument(_)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Access.qll
@@ -84,8 +84,8 @@ class VariableAccess extends Access, @varaccess {
     exists(Assignment a | a.getLValue() = this) or
     exists(CrementOperation c | c.getOperand() = this) or
     exists(AddressOfExpr addof | addof.getOperand() = this) or
-    exists(ReferenceToExpr rte | this.getConversion() = rte) or
-    exists(ArrayToPointerConversion atpc | this.getConversion() = atpc)
+    this.getConversion() instanceof ReferenceToExpr or
+    this.getConversion() instanceof ArrayToPointerConversion
   }
 
   /**
@@ -104,8 +104,8 @@ class VariableAccess extends Access, @varaccess {
   predicate isRValue() {
     not exists(AssignExpr ae | ae.getLValue() = this) and
     not exists(AddressOfExpr addof | addof.getOperand() = this) and
-    not exists(ReferenceToExpr rte | this.getConversion() = rte) and
-    not exists(ArrayToPointerConversion atpc | this.getConversion() = atpc)
+    not this.getConversion() instanceof ReferenceToExpr and
+    not this.getConversion() instanceof ArrayToPointerConversion
   }
 
   /**
@@ -218,9 +218,7 @@ class PointerFieldAccess extends FieldAccess {
 class DotFieldAccess extends FieldAccess {
   override string getAPrimaryQlClass() { result = "DotFieldAccess" }
 
-  DotFieldAccess() {
-    exists(Class c | c = this.getQualifier().getFullyConverted().getUnspecifiedType())
-  }
+  DotFieldAccess() { this.getQualifier().getFullyConverted().getUnspecifiedType() instanceof Class }
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Call.qll
@@ -35,7 +35,7 @@ class Call extends Expr, NameQualifiableElement, TCall {
    *
    * For example, `ptr->f()` has a qualifier, whereas plain `f()` does not.
    */
-  predicate hasQualifier() { exists(Expr e | this.getChild(-1) = e) }
+  predicate hasQualifier() { exists(this.getChild(-1)) }
 
   /**
    * Gets the expression to the left of the function name or function pointer variable name.

--- a/cpp/ql/lib/semmle/code/cpp/exprs/Cast.qll
+++ b/cpp/ql/lib/semmle/code/cpp/exprs/Cast.qll
@@ -724,7 +724,7 @@ class SizeofOperator extends Expr, @runtime_sizeof {
  * ```
  */
 class SizeofExprOperator extends SizeofOperator {
-  SizeofExprOperator() { exists(Expr e | this.getChild(0) = e) }
+  SizeofExprOperator() { exists(this.getChild(0)) }
 
   override string getAPrimaryQlClass() { result = "SizeofExprOperator" }
 
@@ -787,7 +787,7 @@ class AlignofOperator extends Expr, @runtime_alignof {
  * ```
  */
 class AlignofExprOperator extends AlignofOperator {
-  AlignofExprOperator() { exists(Expr e | this.getChild(0) = e) }
+  AlignofExprOperator() { exists(this.getChild(0)) }
 
   /**
    * Gets the contained expression.

--- a/cpp/ql/lib/semmle/code/cpp/metrics/MetricClass.qll
+++ b/cpp/ql/lib/semmle/code/cpp/metrics/MetricClass.qll
@@ -308,45 +308,45 @@ class MetricClass extends Class {
   }
 
   private string getAUsedHalsteadN1Operator() {
-    exists(CommaExpr e | e = this.getAnEnclosedExpression()) and result = "comma"
+    this.getAnEnclosedExpression() instanceof CommaExpr and result = "comma"
     or
-    exists(ReferenceToExpr e | e = this.getAnEnclosedExpression()) and result = "refTo"
+    this.getAnEnclosedExpression() instanceof ReferenceToExpr and result = "refTo"
     or
-    exists(PointerDereferenceExpr e | e = this.getAnEnclosedExpression()) and result = "dereference"
+    this.getAnEnclosedExpression() instanceof PointerDereferenceExpr and result = "dereference"
     or
-    exists(CStyleCast e | e = this.getAnEnclosedExpression()) and result = "cCast"
+    this.getAnEnclosedExpression() instanceof CStyleCast and result = "cCast"
     or
-    exists(StaticCast e | e = this.getAnEnclosedExpression()) and result = "staticCast"
+    this.getAnEnclosedExpression() instanceof StaticCast and result = "staticCast"
     or
-    exists(ConstCast e | e = this.getAnEnclosedExpression()) and result = "constCast"
+    this.getAnEnclosedExpression() instanceof ConstCast and result = "constCast"
     or
-    exists(ReinterpretCast e | e = this.getAnEnclosedExpression()) and result = "reinterpretCast"
+    this.getAnEnclosedExpression() instanceof ReinterpretCast and result = "reinterpretCast"
     or
-    exists(DynamicCast e | e = this.getAnEnclosedExpression()) and result = "dynamicCast"
+    this.getAnEnclosedExpression() instanceof DynamicCast and result = "dynamicCast"
     or
-    exists(SizeofExprOperator e | e = this.getAnEnclosedExpression()) and result = "sizeofExpr"
+    this.getAnEnclosedExpression() instanceof SizeofExprOperator and result = "sizeofExpr"
     or
-    exists(SizeofTypeOperator e | e = this.getAnEnclosedExpression()) and result = "sizeofType"
+    this.getAnEnclosedExpression() instanceof SizeofTypeOperator and result = "sizeofType"
     or
-    exists(IfStmt e | e = this.getAnEnclosedStmt()) and result = "ifVal"
+    this.getAnEnclosedStmt() instanceof IfStmt and result = "ifVal"
     or
-    exists(SwitchStmt e | e = this.getAnEnclosedStmt()) and result = "switchVal"
+    this.getAnEnclosedStmt() instanceof SwitchStmt and result = "switchVal"
     or
-    exists(ForStmt e | e = this.getAnEnclosedStmt()) and result = "forVal"
+    this.getAnEnclosedStmt() instanceof ForStmt and result = "forVal"
     or
-    exists(DoStmt e | e = this.getAnEnclosedStmt()) and result = "doVal"
+    this.getAnEnclosedStmt() instanceof DoStmt and result = "doVal"
     or
-    exists(WhileStmt e | e = this.getAnEnclosedStmt()) and result = "whileVal"
+    this.getAnEnclosedStmt() instanceof WhileStmt and result = "whileVal"
     or
-    exists(GotoStmt e | e = this.getAnEnclosedStmt()) and result = "gotoVal"
+    this.getAnEnclosedStmt() instanceof GotoStmt and result = "gotoVal"
     or
-    exists(ContinueStmt e | e = this.getAnEnclosedStmt()) and result = "continueVal"
+    this.getAnEnclosedStmt() instanceof ContinueStmt and result = "continueVal"
     or
-    exists(BreakStmt e | e = this.getAnEnclosedStmt()) and result = "breakVal"
+    this.getAnEnclosedStmt() instanceof BreakStmt and result = "breakVal"
     or
-    exists(ReturnStmt e | e = this.getAnEnclosedStmt()) and result = "returnVal"
+    this.getAnEnclosedStmt() instanceof ReturnStmt and result = "returnVal"
     or
-    exists(SwitchCase e | e = this.getAnEnclosedStmt()) and result = "caseVal"
+    this.getAnEnclosedStmt() instanceof SwitchCase and result = "caseVal"
     or
     exists(IfStmt s | s = this.getAnEnclosedStmt() and s.hasElse()) and
     result = "elseVal"

--- a/cpp/ql/lib/semmle/code/cpp/padding/Padding.qll
+++ b/cpp/ql/lib/semmle/code/cpp/padding/Padding.qll
@@ -397,7 +397,7 @@ class PaddedType extends Class {
     // Support only single inheritance for now. If multiple inheritance is
     // supported, be sure to fix up the calls to getABaseClass*() to correctly
     // handle the presence of multiple base class subojects with the same type.
-    not exists(ClassDerivation cd | cd = this.getDerivation(1))
+    not exists(this.getDerivation(1))
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/pointsto/PointsTo.qll
+++ b/cpp/ql/lib/semmle/code/cpp/pointsto/PointsTo.qll
@@ -72,7 +72,7 @@ predicate lvalue(Element e) {
   or
   exists(Cast c | lvalue(c) and e.(Expr).getConversion() = c)
   or
-  exists(ReferenceToExpr toref | e.(Expr).getConversion() = toref)
+  e.(Expr).getConversion() instanceof ReferenceToExpr
   or
   // If f is a function-pointer, then the following two
   // calls are equivalent:  f()  and  (*f)()

--- a/cpp/ql/lib/semmle/code/cpp/security/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/TaintTrackingImpl.qll
@@ -258,7 +258,7 @@ private predicate insideFunctionValueMoveTo(Element src, Element dest) {
           format.getConversionChar(sourceArg - ffc.getTarget().getNumberOfParameters()) = ["s", "S"]
         )
         or
-        not exists(FormatLiteral fl | fl = c.(FormattingFunctionCall).getFormat())
+        not c.(FormattingFunctionCall).getFormat() instanceof FormatLiteral
         or
         not c instanceof FormattingFunctionCall
       ) and

--- a/cpp/ql/lib/semmle/code/cpp/stmts/Stmt.qll
+++ b/cpp/ql/lib/semmle/code/cpp/stmts/Stmt.qll
@@ -271,7 +271,7 @@ class IfStmt extends ConditionalStmt, @stmt_if {
    * if (b) { x = 1; }
    * ```
    */
-  predicate hasElse() { exists(Stmt s | this.getElse() = s) }
+  predicate hasElse() { exists(this.getElse()) }
 
   override string toString() { result = "if (...) ... " }
 
@@ -357,7 +357,7 @@ class ConstexprIfStmt extends ConditionalStmt, @stmt_constexpr_if {
    * if constexpr (b) { x = 1; }
    * ```
    */
-  predicate hasElse() { exists(Stmt s | this.getElse() = s) }
+  predicate hasElse() { exists(this.getElse()) }
 
   override string toString() { result = "if constexpr (...) ... " }
 

--- a/cpp/ql/src/Critical/DeadCodeGoto.ql
+++ b/cpp/ql/src/Critical/DeadCodeGoto.ql
@@ -30,8 +30,8 @@ where
   // the next statement isn't breaking out of a switch
   not s.(BreakStmt).getBreakable() instanceof SwitchStmt and
   // the next statement isn't a loop that can be jumped into
-  not exists(LabelStmt ls | s.(Loop).getStmt().getAChild*() = ls) and
-  not exists(SwitchCase sc | s.(Loop).getStmt().getAChild*() = sc) and
+  not s.(Loop).getStmt().getAChild*() instanceof LabelStmt and
+  not s.(Loop).getStmt().getAChild*() instanceof SwitchCase and
   // no preprocessor logic applies
   not functionContainsPreprocCode(js.getEnclosingFunction())
 select js, "This statement makes $@ unreachable.", s, s.toString()

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qll
@@ -55,7 +55,7 @@ abstract class LeapYearFieldAccess extends YearFieldAccess {
       op.getAnOperand() = this and
       (
         op instanceof AssignArithmeticOperation or
-        exists(BinaryArithmeticOperation bao | bao = op.getAnOperand()) or
+        op.getAnOperand() instanceof BinaryArithmeticOperation or
         op instanceof CrementOperation
       )
     )
@@ -212,9 +212,7 @@ class ChecksForLeapYearFunctionCall extends FunctionCall {
 class LeapYearCheckConfiguration extends DataFlow::Configuration {
   LeapYearCheckConfiguration() { this = "LeapYearCheckConfiguration" }
 
-  override predicate isSource(DataFlow::Node source) {
-    exists(VariableAccess va | va = source.asExpr())
-  }
+  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof VariableAccess }
 
   override predicate isSink(DataFlow::Node sink) {
     exists(ChecksForLeapYearFunctionCall fc | sink.asExpr() = fc.getAnArgument())

--- a/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/UnsafeDaclSecurityDescriptor.ql
@@ -34,9 +34,7 @@ class SetSecurityDescriptorDaclFunctionCall extends FunctionCall {
 class NullDaclConfig extends DataFlow::Configuration {
   NullDaclConfig() { this = "NullDaclConfig" }
 
-  override predicate isSource(DataFlow::Node source) {
-    exists(NullValue nullExpr | source.asExpr() = nullExpr)
-  }
+  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NullValue }
 
   override predicate isSink(DataFlow::Node sink) {
     exists(SetSecurityDescriptorDaclFunctionCall call, VariableAccess val | val = sink.asExpr() |

--- a/cpp/ql/src/experimental/Security/CWE/CWE-1041/FindWrapperFunctions.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-1041/FindWrapperFunctions.ql
@@ -24,10 +24,10 @@ class CallUsedToHandleErrors extends FunctionCall {
     not exists(this.(ControlFlowNode).getASuccessor())
     or
     // call throwing an exception
-    exists(ThrowExpr tex | tex = this.(ControlFlowNode).getASuccessor())
+    this.(ControlFlowNode).getASuccessor() instanceof ThrowExpr
     or
     // call logging a message, possibly an error
-    exists(FormattingFunction ff | ff = this.(ControlFlowNode).getASuccessor())
+    this.(ControlFlowNode).getASuccessor() instanceof FormattingFunction
     or
     // enabling recursive search
     exists(CallUsedToHandleErrors fr | getTarget() = fr.getEnclosingFunction())
@@ -37,9 +37,9 @@ class CallUsedToHandleErrors extends FunctionCall {
 /** Holds if the conditions for a call outside the wrapper function are met. */
 predicate conditionsOutsideWrapper(FunctionCall fcp) {
   fcp.getNumberOfArguments() > 0 and
-  not exists(ConditionalStmt cdtmp | fcp.getEnclosingStmt().getParentStmt*() = cdtmp) and
-  not exists(Loop lptmp | fcp.getEnclosingStmt().getParentStmt*() = lptmp) and
-  not exists(ReturnStmt rttmp | fcp.getEnclosingStmt().getParentStmt*() = rttmp) and
+  not fcp.getEnclosingStmt().getParentStmt*() instanceof ConditionalStmt and
+  not fcp.getEnclosingStmt().getParentStmt*() instanceof Loop and
+  not fcp.getEnclosingStmt().getParentStmt*() instanceof ReturnStmt and
   not exists(FunctionCall fctmp2 | fcp = fctmp2.getAnArgument().getAChild*()) and
   not exists(Assignment astmp | fcp = astmp.getRValue().getAChild*()) and
   not exists(Initializer intmp | fcp = intmp.getExpr().getAChild*()) and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-675/DoubleRelease.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-675/DoubleRelease.ql
@@ -26,7 +26,7 @@ class CallMayNotReturn extends FunctionCall {
     // call to another function that may not return
     exists(CallMayNotReturn exit | getTarget() = exit.getEnclosingFunction())
     or
-    exists(ThrowExpr tex | tex = this.(ControlFlowNode).getASuccessor())
+    this.(ControlFlowNode).getASuccessor() instanceof ThrowExpr
   }
 }
 
@@ -127,7 +127,7 @@ predicate similarArguments(FunctionCall fc, FunctionCall fc1) {
 
 from FunctionCall fc, FunctionCall fc1
 where
-  not exists(CallMayNotReturn fctmp | fctmp = fc.getASuccessor*()) and
+  not fc.getASuccessor*() instanceof CallMayNotReturn and
   not exists(IfStmt ifs | ifs.getCondition().getAChild*() = fc) and
   (
     // detecting a repeated call situation within one function

--- a/cpp/ql/src/jsf/4.10 Classes/AV Rule 97.1.ql
+++ b/cpp/ql/src/jsf/4.10 Classes/AV Rule 97.1.ql
@@ -15,6 +15,6 @@ from EqualityOperation e, PointerToMemberType t, Class c
 where
   e.getAnOperand().getType() = t and
   t.getClass() = c and
-  exists(VirtualFunction f | c.getAMemberFunction() = f)
+  c.getAMemberFunction() instanceof VirtualFunction
 select e,
   "AV Rule 97.1: Neither operand of an equality operator shall be a pointer to a virtual member function."

--- a/csharp/ql/lib/Linq/Helpers.qll
+++ b/csharp/ql/lib/Linq/Helpers.qll
@@ -46,7 +46,7 @@ predicate missedAllOpportunity(ForeachStmt fes) {
       bl = a.getRValue() and
       bl.toString() = "false"
     ) and
-    exists(BreakStmt bs | bs = is.getThen().getAChild*())
+    is.getThen().getAChild*() instanceof BreakStmt
   )
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/XML.qll
+++ b/csharp/ql/lib/semmle/code/csharp/XML.qll
@@ -233,7 +233,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
-  predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
+  predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
 
   /** Gets the value of the attribute with the specified `name`, if any. */
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -292,7 +292,7 @@ private module Internal {
     pragma[nomagic]
     predicate hasSubsumedQualifierTypeOverridden(Gvn::GvnType t, OverridableCallable c) {
       this.hasSubsumedQualifierType(t) and
-      hasCallable(t, c, any(OverridableCallable oc | oc = this.getAStaticTargetExt()))
+      hasCallable(t, c, this.getAStaticTargetExt())
     }
 
     /**

--- a/csharp/ql/src/Likely Bugs/Statements/UseBraces.ql
+++ b/csharp/ql/src/Likely Bugs/Statements/UseBraces.ql
@@ -26,11 +26,11 @@ Stmt getASuccessorStmt(Stmt s) {
 }
 
 class IfThenStmt extends IfStmt {
-  IfThenStmt() { not exists(Stmt s | getElse() = s) }
+  IfThenStmt() { not exists(getElse()) }
 }
 
 class IfThenElseStmt extends IfStmt {
-  IfThenElseStmt() { exists(Stmt s | getElse() = s) }
+  IfThenElseStmt() { exists(getElse()) }
 }
 
 Stmt getTrailingBody(Stmt s) {

--- a/csharp/ql/src/experimental/ir/internal/IRGuards.qll
+++ b/csharp/ql/src/experimental/ir/internal/IRGuards.qll
@@ -24,7 +24,7 @@ class GuardCondition extends Expr {
     exists(IRGuardCondition ir | this = ir.getUnconvertedResultExpression())
     or
     // no binary operators in the IR
-    exists(GuardCondition gc | this.(BinaryLogicalOperation).getAnOperand() = gc)
+    this.(BinaryLogicalOperation).getAnOperand() instanceof GuardCondition
     or
     // the IR short-circuits if(!x)
     // don't produce a guard condition for `y = !x` and other non-short-circuited cases
@@ -124,7 +124,7 @@ private predicate impliesValue(
  */
 private class GuardConditionFromBinaryLogicalOperator extends GuardCondition {
   GuardConditionFromBinaryLogicalOperator() {
-    exists(GuardCondition gc | this.(BinaryLogicalOperation).getAnOperand() = gc)
+    this.(BinaryLogicalOperation).getAnOperand() instanceof GuardCondition
   }
 
   override predicate controls(BasicBlock controlled, boolean testIsTrue) {

--- a/docs/codeql/writing-codeql-queries/river-crossing.ql
+++ b/docs/codeql/writing-codeql-queries/river-crossing.ql
@@ -95,7 +95,7 @@ class State extends string {
     exists(string pathSoFar, string visitedStatesSoFar, Cargo cargo |
       result = this.reachesVia(pathSoFar, visitedStatesSoFar).safeFerry(cargo) and
       // The resulting state has not yet been visited.
-      not exists(int i | i = visitedStatesSoFar.indexOf(result)) and
+      not exists(visitedStatesSoFar.indexOf(result)) and
       visitedStates = visitedStatesSoFar + "/" + result and
       path = pathSoFar + "\n Ferry " + cargo
     )
@@ -115,4 +115,3 @@ class GoalState extends State {
 from string path
 where any(InitialState i).reachesVia(path, _) = any(GoalState g)
 select path
-

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -1750,7 +1750,7 @@ class TypeAccess extends Expr, Annotatable, @typeaccess {
   Expr getQualifier() { result.isNthChildOf(this, -1) }
 
   /** Holds if this type access has a qualifier. */
-  predicate hasQualifier() { exists(Expr e | e = this.getQualifier()) }
+  predicate hasQualifier() { exists(this.getQualifier()) }
 
   /** Gets a type argument supplied to this type access. */
   Expr getATypeArgument() { result.getIndex() >= 0 and result.getParent() = this }
@@ -1762,7 +1762,7 @@ class TypeAccess extends Expr, Annotatable, @typeaccess {
   }
 
   /** Holds if this type access has a type argument. */
-  predicate hasTypeArgument() { exists(Expr e | e = this.getATypeArgument()) }
+  predicate hasTypeArgument() { exists(this.getATypeArgument()) }
 
   /** Gets the compilation unit in which this type access occurs. */
   override CompilationUnit getCompilationUnit() { result = Expr.super.getCompilationUnit() }

--- a/java/ql/lib/semmle/code/java/Generics.qll
+++ b/java/ql/lib/semmle/code/java/Generics.qll
@@ -101,7 +101,7 @@ class GenericInterface extends GenericType, Interface {
  */
 abstract class BoundedType extends RefType, @boundedtype {
   /** Holds if this type is bounded. */
-  predicate hasTypeBound() { exists(TypeBound tb | tb = this.getATypeBound()) }
+  predicate hasTypeBound() { exists(this.getATypeBound()) }
 
   /** Gets a type bound for this type, if any. */
   TypeBound getATypeBound() { result.getBoundedType() = this }

--- a/java/ql/lib/semmle/code/java/Statement.qll
+++ b/java/ql/lib/semmle/code/java/Statement.qll
@@ -636,7 +636,7 @@ class BreakStmt extends Stmt, @breakstmt {
   string getLabel() { namestrings(result, _, this) }
 
   /** Holds if this `break` statement has an explicit label. */
-  predicate hasLabel() { exists(string s | s = this.getLabel()) }
+  predicate hasLabel() { exists(this.getLabel()) }
 
   override string pp() {
     if this.hasLabel() then result = "break " + this.getLabel() else result = "break"
@@ -673,7 +673,7 @@ class ContinueStmt extends Stmt, @continuestmt {
   string getLabel() { namestrings(result, _, this) }
 
   /** Holds if this `continue` statement has an explicit label. */
-  predicate hasLabel() { exists(string s | s = this.getLabel()) }
+  predicate hasLabel() { exists(this.getLabel()) }
 
   override string pp() {
     if this.hasLabel() then result = "continue " + this.getLabel() else result = "continue"

--- a/java/ql/lib/semmle/code/java/controlflow/UnreachableBlocks.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/UnreachableBlocks.qll
@@ -212,7 +212,7 @@ class UnreachableBasicBlock extends BasicBlock {
     not exists(Callable c | c.getBody() = this) and
     not this instanceof Callable and
     not exists(Annotation a | a.getAChildExpr*() = this) and
-    not exists(AssertStmt a | a = this.(Expr).getEnclosingStmt()) and
+    not this.(Expr).getEnclosingStmt() instanceof AssertStmt and
     not this instanceof CatchClause
     or
     // Switch statements with a constant comparison expression may have unreachable cases.

--- a/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/FlowSources.qll
@@ -109,7 +109,7 @@ private class MessageBodyReaderParameterSource extends RemoteFlowSource {
 }
 
 private class PlayParameterSource extends RemoteFlowSource {
-  PlayParameterSource() { exists(PlayActionMethodQueryParameter p | p = this.asParameter()) }
+  PlayParameterSource() { this.asParameter() instanceof PlayActionMethodQueryParameter }
 
   override string getSourceType() { result = "Play Query Parameters" }
 }

--- a/java/ql/lib/semmle/code/java/deadcode/DeadEnumConstant.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/DeadEnumConstant.qll
@@ -60,7 +60,7 @@ predicate exception(EnumConstant e) {
     )
     or
     // Entire `Enum` annotated with reflective annotation.
-    exists(ReflectiveAccessAnnotation ann | ann = t.getAnAnnotation())
+    t.getAnAnnotation() instanceof ReflectiveAccessAnnotation
   )
   or
   // Enum field annotated with reflective annotation.

--- a/java/ql/lib/semmle/code/java/deadcode/frameworks/CamelEntryPoints.qll
+++ b/java/ql/lib/semmle/code/java/deadcode/frameworks/CamelEntryPoints.qll
@@ -12,6 +12,6 @@ import semmle.code.java.frameworks.Camel
 class CamelMessageCallableEntryPoint extends CallableEntryPoint {
   CamelMessageCallableEntryPoint() {
     exists(CamelTargetClass camelTargetClass | this = camelTargetClass.getACamelCalledMethod()) or
-    exists(CamelConsumeMethod consumeMethod | this = consumeMethod)
+    this instanceof CamelConsumeMethod
   }
 }

--- a/java/ql/lib/semmle/code/java/frameworks/Mockito.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Mockito.qll
@@ -357,7 +357,7 @@ class MockitoSettableField extends Field {
   MockitoSettableField() {
     not this.isFinal() and
     not this.isStatic() and
-    exists(MockitoMockInjectedClass injectedClass | injectedClass = this.getDeclaringType())
+    this.getDeclaringType() instanceof MockitoMockInjectedClass
   }
 
   /**

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringBean.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringBean.qll
@@ -233,7 +233,7 @@ class SpringBean extends SpringXMLElement {
   SpringBean getBeanParent() { result.getBeanIdentifier() = this.getBeanParentName() }
 
   /** Holds if this bean has a parent bean. */
-  predicate hasBeanParent() { exists(SpringBean b | b = this.getBeanParent()) }
+  predicate hasBeanParent() { exists(this.getBeanParent()) }
 
   predicate hasBeanAncestor(SpringBean ancestor) {
     ancestor = this.getBeanParent() or

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringBeanFile.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringBeanFile.qll
@@ -58,7 +58,7 @@ class SpringBeanFile extends XMLFile {
 
   /** Gets the `default-dependency-check` value for this file. */
   string getDefaultDependencyCheck() {
-    if exists(XMLAttribute a | this.getBeansElement().getAttribute("default-dependency-check") = a)
+    if exists(this.getBeansElement().getAttribute("default-dependency-check"))
     then result = this.getBeansElement().getAttributeValue("default-dependency-check")
     else result = "none"
   }
@@ -70,7 +70,7 @@ class SpringBeanFile extends XMLFile {
 
   /** Holds if this file has a `default-destroy-method` value. */
   predicate hasDefaultDestroyMethod() {
-    exists(XMLAttribute a | this.getBeansElement().getAttribute("default-destroy-method") = a)
+    exists(this.getBeansElement().getAttribute("default-destroy-method"))
   }
 
   /** Gets the `default-init-method` value for this file. */
@@ -80,7 +80,7 @@ class SpringBeanFile extends XMLFile {
 
   /** Holds if the file has a `default-destroy-method` value. */
   predicate hasDefaultInitMethod() {
-    exists(XMLAttribute a | this.getBeansElement().getAttribute("default-init-method") = a)
+    exists(this.getBeansElement().getAttribute("default-init-method"))
   }
 
   /** Holds if `default-lazy-init` is specified to be `true` for this file. */

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringXMLElement.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringXMLElement.qll
@@ -18,7 +18,7 @@ class SpringXMLElement extends XMLElement {
    */
   string getAttributeValueWithDefault(string attributeName) {
     this.hasAttribute(attributeName) and
-    if exists(XMLAttribute a | a = this.getAttribute(attributeName))
+    if exists(this.getAttribute(attributeName))
     then result = this.getAttributeValue(attributeName)
     else result = "default"
   }

--- a/java/ql/lib/semmle/code/java/metrics/MetricElement.qll
+++ b/java/ql/lib/semmle/code/java/metrics/MetricElement.qll
@@ -43,11 +43,11 @@ class MetricElement extends Element {
     this.fromSource() and
     not this.getADependencySrc+() = this and
     (
-      not exists(MetricElement t | t = this.getADependency()) and
+      not exists(this.getADependency()) and
       result = 0
       or
       not this.getADependency().fromSource() and
-      exists(MetricElement e | this.getADependency() = e) and
+      exists(this.getADependency()) and
       result = 1
       or
       result = this.getADependency().getALevel() + 1

--- a/java/ql/lib/semmle/code/java/metrics/MetricStmt.qll
+++ b/java/ql/lib/semmle/code/java/metrics/MetricStmt.qll
@@ -18,7 +18,7 @@ class MetricStmt extends Stmt {
 
   /** Gets the nested depth of this statement. */
   int getNestedDepth() {
-    not exists(Stmt s | s = this.getParent()) and result = 0
+    not this.getParent() instanceof Stmt and result = 0
     or
     exists(MetricStmt s | s = this.getParent() and result = s.getNestedDepth() + 1)
   }

--- a/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/UnsafeDeserializationQuery.qll
@@ -312,7 +312,7 @@ MethodAccess getASafeFlexjsonUseCall() {
     result.getArgument(0) instanceof NullLiteral
     or
     result.getMethod().getParameterType(0) instanceof FlexjsonObjectFactory and
-    exists(NullLiteral e | e = result.getAnArgument())
+    result.getAnArgument() instanceof NullLiteral
   )
 }
 

--- a/java/ql/lib/semmle/code/xml/XML.qll
+++ b/java/ql/lib/semmle/code/xml/XML.qll
@@ -233,7 +233,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
-  predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
+  predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
 
   /** Gets the value of the attribute with the specified `name`, if any. */
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }

--- a/java/ql/src/Architecture/Dependencies/UnusedMavenDependencyBinary.ql
+++ b/java/ql/src/Architecture/Dependencies/UnusedMavenDependencyBinary.ql
@@ -23,7 +23,7 @@ where
   source.getADependency() = d and
   // There is not a Pom file for the target of this dependency, so we assume that it was resolved by
   // a binary file in the local maven repository.
-  not exists(Pom target | target = d.getPom()) and
+  not exists(d.getPom()) and
   // In order to accurately identify whether this binary dependency is required, we must have identified
   // a Maven repository. If we have not found a repository, it's likely that it has a custom path of
   // which we are unaware, so do not report any problems.

--- a/java/ql/src/DeadCode/DeadField.ql
+++ b/java/ql/src/DeadCode/DeadField.ql
@@ -16,12 +16,9 @@ import semmle.code.java.deadcode.DeadCode
 from DeadField f, Element origin, string reason
 where
   not f.isInDeadScope() and
-  if exists(FieldRead read | read = f.getAnAccess())
+  if f.getAnAccess() instanceof FieldRead
   then (
-    if
-      exists(DeadRoot root |
-        root = getADeadRoot(f.getAnAccess().(FieldRead).getEnclosingCallable())
-      )
+    if exists(getADeadRoot(f.getAnAccess().(FieldRead).getEnclosingCallable()))
     then (
       origin = getADeadRoot(f.getAnAccess().(FieldRead).getEnclosingCallable()) and
       reason = " is only read from dead code originating at $@."

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseSetterInjection.ql
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseSetterInjection.ql
@@ -14,5 +14,5 @@ import java
 import semmle.code.java.frameworks.spring.Spring
 
 from SpringBean b
-where exists(SpringConstructorArg carg | b.getASpringChild() = carg)
+where b.getASpringChild() instanceof SpringConstructorArg
 select b, "Use setter injection instead of constructor injection."

--- a/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseShortcutForms.ql
+++ b/java/ql/src/Frameworks/Spring/Violations of Best Practice/UseShortcutForms.ql
@@ -15,12 +15,12 @@ import semmle.code.java.frameworks.spring.Spring
 class SpringConstructorArgUseShortcut extends SpringConstructorArg {
   SpringConstructorArgUseShortcut() {
     not this.hasArgValueString() and
-    exists(SpringValue val | val = this.getASpringChild())
+    this.getASpringChild() instanceof SpringValue
   }
 
   string getMessage() {
     not this.hasArgValueString() and
-    exists(SpringValue val | val = this.getASpringChild()) and
+    this.getASpringChild() instanceof SpringValue and
     result = "Use the shortcut \"value\" attribute instead of a nested <value> element."
   }
 }
@@ -28,12 +28,12 @@ class SpringConstructorArgUseShortcut extends SpringConstructorArg {
 class SpringEntryUseShortcut extends SpringEntry {
   SpringEntryUseShortcut() {
     not this.hasValueStringRaw() and
-    exists(SpringValue val | val = this.getASpringChild())
+    this.getASpringChild() instanceof SpringValue
   }
 
   string getMessage() {
     not this.hasValueStringRaw() and
-    exists(SpringValue val | val = this.getASpringChild()) and
+    this.getASpringChild() instanceof SpringValue and
     result = "Use the shortcut \"value\" attribute instead of a nested <value> element."
   }
 }
@@ -41,12 +41,12 @@ class SpringEntryUseShortcut extends SpringEntry {
 class SpringPropertyUseShortcut extends SpringProperty {
   SpringPropertyUseShortcut() {
     not this.hasPropertyValueString() and
-    exists(SpringValue val | val = this.getASpringChild())
+    this.getASpringChild() instanceof SpringValue
   }
 
   string getMessage() {
     not this.hasPropertyValueString() and
-    exists(SpringValue val | val = this.getASpringChild()) and
+    this.getASpringChild() instanceof SpringValue and
     result = "Use the shortcut \"value\" attribute instead of a nested <value> element."
   }
 }

--- a/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
+++ b/java/ql/src/Likely Bugs/Cloning/MissingMethodClone.ql
@@ -16,7 +16,7 @@ from Class t, TypeCloneable cloneable
 where
   t.hasSupertype+(cloneable) and
   not t.isAbstract() and
-  not exists(CloneMethod m | t.getAMethod() = m) and
+  not t.getAMethod() instanceof CloneMethod and
   exists(Field f | f.getDeclaringType() = t and not f.isStatic()) and
   t.fromSource()
 select t, "No clone method, yet implements Cloneable."

--- a/java/ql/src/Likely Bugs/Concurrency/WaitOutsideLoop.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/WaitOutsideLoop.ql
@@ -23,5 +23,5 @@ class WaitMethod extends Method {
 from MethodAccess ma
 where
   ma.getMethod() instanceof WaitMethod and
-  not exists(LoopStmt s | ma.getEnclosingStmt().getEnclosingStmt*() = s)
+  not ma.getEnclosingStmt().getEnclosingStmt*() instanceof LoopStmt
 select ma, "To avoid spurious wake-ups, 'wait' should only be called inside a loop."

--- a/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
+++ b/java/ql/src/Likely Bugs/Serialization/IncorrectSerialVersionUID.ql
@@ -21,5 +21,5 @@ where
     not f.isStatic() or
     not f.getType().hasName("long")
   ) and
-  exists(TypeSerializable serializable | f.getDeclaringType().getASupertype+() = serializable)
+  f.getDeclaringType().getASupertype+() instanceof TypeSerializable
 select f, "serialVersionUID should be final, static, and of type long."

--- a/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
+++ b/java/ql/src/Likely Bugs/Serialization/NonSerializableInnerClass.ql
@@ -14,7 +14,7 @@
 import java
 import semmle.code.java.JDKAnnotations
 
-predicate isSerializable(RefType t) { exists(TypeSerializable ts | ts = t.getASupertype*()) }
+predicate isSerializable(RefType t) { t.getASupertype*() instanceof TypeSerializable }
 
 predicate withinStaticContext(NestedClass c) {
   c.isStatic() or

--- a/java/ql/src/Violations of Best Practice/Implementation Hiding/StaticArray.ql
+++ b/java/ql/src/Violations of Best Practice/Implementation Hiding/StaticArray.ql
@@ -16,7 +16,7 @@ predicate nonEmptyArrayLiteralOrNull(Expr e) {
   exists(ArrayCreationExpr arr | arr = e |
     // Array initializer expressions such as `{1, 2, 3}`.
     // Array is empty if the initializer expression is empty.
-    exists(Expr arrayValue | arrayValue = arr.getInit().getAnInit())
+    exists(arr.getInit().getAnInit())
     or
     // Array creation with dimensions (but without initializers).
     // Empty if the first dimension is 0.

--- a/java/ql/src/experimental/Security/CWE/CWE-094/SpringImplicitViewManipulation.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/SpringImplicitViewManipulation.ql
@@ -58,7 +58,7 @@ where
   not m.getParameterType(_) instanceof HttpServletResponse and
   // A spring request mapping method which does not have response body annotation applied to it
   m.getAnAnnotation().getType() instanceof SpringRequestMappingAnnotationType and
-  not exists(SpringResponseBodyAnnotationType t | t = m.getAnAnnotation().getType()) and
+  not m.getAnAnnotation().getType() instanceof SpringResponseBodyAnnotationType and
   // `@RestController` inherits `@ResponseBody` internally so it should be ignored.
   not m.getDeclaringType() instanceof SpringRestController
 select m, "This method may be vulnerable to spring view manipulation vulnerabilities"

--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidFileIntentSource.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidFileIntentSource.qll
@@ -32,9 +32,7 @@ class GetContentIntent extends ClassInstanceExpr {
 class GetContentIntentConfig extends TaintTracking2::Configuration {
   GetContentIntentConfig() { this = "GetContentIntentConfig" }
 
-  override predicate isSource(DataFlow2::Node src) {
-    exists(GetContentIntent gi | src.asExpr() = gi)
-  }
+  override predicate isSource(DataFlow2::Node src) { src.asExpr() instanceof GetContentIntent }
 
   override predicate isSink(DataFlow2::Node sink) {
     exists(MethodAccess ma |

--- a/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -52,7 +52,7 @@ class KeyGeneratorInitConfiguration extends TaintTracking::Configuration {
   KeyGeneratorInitConfiguration() { this = "KeyGeneratorInitConfiguration" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(JavaxCryptoKeyGenerator jcg | jcg = source.asExpr())
+    source.asExpr() instanceof JavaxCryptoKeyGenerator
   }
 
   override predicate isSink(DataFlow::Node sink) {
@@ -68,7 +68,7 @@ class KeyPairGeneratorInitConfiguration extends TaintTracking::Configuration {
   KeyPairGeneratorInitConfiguration() { this = "KeyPairGeneratorInitConfiguration" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(JavaSecurityKeyPairGenerator jkg | jkg = source.asExpr())
+    source.asExpr() instanceof JavaSecurityKeyPairGenerator
   }
 
   override predicate isSink(DataFlow::Node sink) {

--- a/javascript/ql/lib/semmle/javascript/XML.qll
+++ b/javascript/ql/lib/semmle/javascript/XML.qll
@@ -233,7 +233,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
-  predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
+  predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
 
   /** Gets the value of the attribute with the specified `name`, if any. */
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Files.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Files.qll
@@ -433,9 +433,7 @@ private class LibraryAccess extends FileSystemAccess, DataFlow::InvokeNode {
       or
       this =
         DataFlow::moduleMember("node-dir",
-          any(string s |
-            s = ["readFiles", "readFilesStream", "files", "promiseFiles", "subdirs", "paths"]
-          )).getACall()
+          ["readFiles", "readFilesStream", "files", "promiseFiles", "subdirs", "paths"]).getACall()
     )
     or
     pathArgument = 0 and

--- a/javascript/ql/src/experimental/Security/CWE-020/PostMessageNoOriginCheck.ql
+++ b/javascript/ql/src/experimental/Security/CWE-020/PostMessageNoOriginCheck.ql
@@ -53,9 +53,7 @@ class PostMessageEvent extends DataFlow::SourceNode {
    * Holds if there is an insufficient method call (i.e indexOf) used to verify `MessageEvent.origin`
    */
   predicate hasOriginInsufficientlyChecked() {
-    exists(InsufficientOriginChecks insufficientChecks |
-      this.getAPropertyRead("origin").getAMethodCall*() = insufficientChecks
-    )
+    this.getAPropertyRead("origin").getAMethodCall*() instanceof InsufficientOriginChecks
   }
 }
 

--- a/javascript/ql/test/testUtilities/ConsistencyChecking.qll
+++ b/javascript/ql/test/testUtilities/ConsistencyChecking.qll
@@ -71,7 +71,7 @@ private DataFlow::Node getASink() { exists(DataFlow::Configuration cfg | cfg.has
  * Gets all the alerts for consistency consistency checking from a configuration `conf`.
  */
 private DataFlow::Node alerts(Conf conf) {
-  result = any(ConsistencyConfiguration res | res = conf).getAnAlert()
+  result = conf.(ConsistencyConfiguration).getAnAlert()
   or
   not exists(ConsistencyConfiguration r) and
   result = getASink() and
@@ -131,7 +131,7 @@ private File getATestFile(string conf) {
   result = any(LineComment comment).getFile() and
   conf = ""
   or
-  result = any(ConsistencyConfiguration res | res = conf).getAFile()
+  result = conf.(ConsistencyConfiguration).getAFile()
 }
 
 /**

--- a/python/ql/lib/semmle/python/Comment.qll
+++ b/python/ql/lib/semmle/python/Comment.qll
@@ -40,7 +40,7 @@ class Comment extends @py_comment {
 
 private predicate comment_block_part(Comment start, Comment part, int i) {
   not exists(Comment prev | prev.getFollowing() = part) and
-  exists(Comment following | part.getFollowing() = following) and
+  exists(part.getFollowing()) and
   start = part and
   i = 1
   or

--- a/python/ql/lib/semmle/python/Function.qll
+++ b/python/ql/lib/semmle/python/Function.qll
@@ -18,7 +18,7 @@ class Function extends Function_, Scope, AstNode {
   override Scope getScope() { result = this.getEnclosingScope() }
 
   /** Whether this function is declared in a class */
-  predicate isMethod() { exists(Class cls | this.getEnclosingScope() = cls) }
+  predicate isMethod() { this.getEnclosingScope() instanceof Class }
 
   /** Whether this is a special method, that is does its name have the form `__xxx__` (except `__init__`) */
   predicate isSpecialMethod() {

--- a/python/ql/lib/semmle/python/Variables.qll
+++ b/python/ql/lib/semmle/python/Variables.qll
@@ -57,7 +57,7 @@ class LocalVariable extends Variable {
   override string toString() { result = "Local Variable " + this.getId() }
 
   /** Whether this variable is a parameter */
-  override predicate isParameter() { exists(Parameter p | this.getAnAccess() = p) }
+  override predicate isParameter() { this.getAnAccess() instanceof Parameter }
 
   /** Holds if this variable is the first parameter of a method. It is not necessarily called "self" */
   override predicate isSelf() {
@@ -87,7 +87,7 @@ class NameLocalVariable extends LocalVariable {
 
 /** A global (module-level) variable */
 class GlobalVariable extends Variable {
-  GlobalVariable() { exists(Module m | m = this.getScope()) }
+  GlobalVariable() { this.getScope() instanceof Module }
 
   override string toString() { result = "Global Variable " + this.getId() }
 }

--- a/python/ql/lib/semmle/python/dataflow/new/internal/PrintNode.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/PrintNode.qll
@@ -67,6 +67,6 @@ string prettyNodeForInlineTest(DataFlow::Node node) {
   )
   or
   not exists(node.asExpr()) and
-  not exists(Expr e | e = node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr()) and
+  not exists(node.(DataFlow::PostUpdateNode).getPreUpdateNode().asExpr()) and
   result = node.toString()
 }

--- a/python/ql/lib/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/lib/semmle/python/pointsto/PointsTo.qll
@@ -916,7 +916,7 @@ private module InterModulePointsTo {
   private predicate exportsSubmodule(Folder folder, string name) {
     name.regexpMatch("\\p{L}(\\p{L}|\\d|_)*") and
     (
-      exists(Folder child | child = folder.getChildContainer(name))
+      folder.getChildContainer(name) instanceof Folder
       or
       exists(folder.getFile(name + ".py"))
     )

--- a/python/ql/lib/semmle/python/types/Exceptions.qll
+++ b/python/ql/lib/semmle/python/types/Exceptions.qll
@@ -83,7 +83,7 @@ class RaisingNode extends ControlFlowNode {
         result = this.innateException_objectapi()
       )
       or
-      not exists(ExceptFlowNode except | except = this.getAnExceptionalSuccessor()) and
+      not this.getAnExceptionalSuccessor() instanceof ExceptFlowNode and
       sequence_or_mapping(this) and
       result = theLookupErrorType()
       or
@@ -110,7 +110,7 @@ class RaisingNode extends ControlFlowNode {
         result = this.innateException()
       )
       or
-      not exists(ExceptFlowNode except | except = this.getAnExceptionalSuccessor()) and
+      not this.getAnExceptionalSuccessor() instanceof ExceptFlowNode and
       sequence_or_mapping(this) and
       result = ClassValue::lookupError()
       or

--- a/python/ql/lib/semmle/python/xml/XML.qll
+++ b/python/ql/lib/semmle/python/xml/XML.qll
@@ -233,7 +233,7 @@ class XMLElement extends @xmlelement, XMLParent, XMLLocatable {
   XMLAttribute getAttribute(string name) { result.getElement() = this and result.getName() = name }
 
   /** Holds if this XML element has an attribute with the specified `name`. */
-  predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
+  predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
 
   /** Gets the value of the attribute with the specified `name`, if any. */
   string getAttributeValue(string name) { result = this.getAttribute(name).getValue() }

--- a/python/ql/src/Statements/MismatchInMultipleAssignment.ql
+++ b/python/ql/src/Statements/MismatchInMultipleAssignment.ql
@@ -46,7 +46,7 @@ predicate mismatched_tuple_rhs(Assign a, int lcount, int rcount, Location loc) {
     lcount = len(l) and
     rcount = r.length() and
     lcount != rcount and
-    not exists(Starred s | l.getAnItem() = s)
+    not l.getAnItem() instanceof Starred
   )
 }
 

--- a/python/ql/src/Variables/UndefinedExport.ql
+++ b/python/ql/src/Variables/UndefinedExport.ql
@@ -49,7 +49,7 @@ predicate mutates_globals(ModuleValue m) {
       or
       // In Python 3.8, Enum._convert_ is implemented using a metaclass, and our points-to
       // analysis doesn't handle that well enough. So we need a special case for this
-      not exists(Value enum_convert | enum_convert = enum_class.attr("_convert")) and
+      not exists(enum_class.attr("_convert")) and
       exists(CallNode call | call.getScope() = m.getScope() |
         call.getFunction().(AttrNode).getObject(["_convert", "_convert_"]).pointsTo() = enum_class
       )

--- a/python/ql/src/Variables/UndefinedGlobal.ql
+++ b/python/ql/src/Variables/UndefinedGlobal.ql
@@ -68,7 +68,7 @@ predicate undefined_use_in_function(Name u) {
 
 predicate undefined_use_in_class_or_module(Name u) {
   exists(GlobalVariable v | u.uses(v)) and
-  not exists(Function f | u.getScope().getScope*() = f) and
+  not u.getScope().getScope*() instanceof Function and
   exists(SsaVariable var | var.getAUse().getNode() = u | var.maybeUndefined()) and
   not guarded_against_name_error(u) and
   not exists(ModuleValue m | m.getScope() = u.getEnclosingModule() | m.hasAttribute(u.getId())) and

--- a/python/ql/src/analysis/Efficiency.ql
+++ b/python/ql/src/analysis/Efficiency.ql
@@ -8,7 +8,7 @@ import semmle.python.pointsto.PointsTo
 import semmle.python.pointsto.PointsToContext
 
 predicate trivial(ControlFlowNode f) {
-  exists(Parameter p | p = f.getNode())
+  f.getNode() instanceof Parameter
   or
   f instanceof NameConstantNode
   or

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -147,9 +147,7 @@ private Expr sqlFragmentArgument(MethodCall call) {
 // part of an argument to an SQL executing method
 private predicate unsafeSqlExpr(Expr sqlFragmentExpr) {
   // Literals containing an interpolated value
-  exists(StringInterpolationComponent interpolated |
-    interpolated = sqlFragmentExpr.(StringlikeLiteral).getComponent(_)
-  )
+  sqlFragmentExpr.(StringlikeLiteral).getComponent(_) instanceof StringInterpolationComponent
   or
   // String concatenations
   sqlFragmentExpr instanceof AddExpr

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -39,7 +39,7 @@ class HttpartyRequest extends HTTP::Client::Request::Range {
     exists(DataFlow::Node r | r = requestNode.getAMethodCall("body") | result = r)
     or
     // Otherwise, treat the response as the response body.
-    not exists(DataFlow::Node r | r = requestNode.getAMethodCall("body")) and
+    not exists(requestNode.getAMethodCall("body")) and
     result = requestUse
   }
 

--- a/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
+++ b/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
@@ -48,7 +48,7 @@ class PermissivePermissionsConfig extends DataFlow::Configuration {
   PermissivePermissionsConfig() { this = "PermissivePermissionsConfig" }
 
   override predicate isSource(DataFlow::Node source) {
-    exists(PermissivePermissionsExpr ppe | source.asExpr().getExpr() = ppe)
+    source.asExpr().getExpr() instanceof PermissivePermissionsExpr
   }
 
   override predicate isSink(DataFlow::Node sink) {


### PR DESCRIPTION
Fixes the issues identified by [this QL-for-QL query](https://github.com/github/codeql/pull/7472). 

--- 

Consider the below: 
```CodeQL
predicate even(int i) { exists(Even even | even = i) }
```
That is basically just a type-cast, so we might as well simplify it as such:  
```CodeQL
predicate even(int i) { i instanceof Even }
```

--- 

There are also some cases where the resulting type-cast would be redundant. 
Here's an example: 
```CodeQL
predicate hasAttribute(string name) { exists(XMLAttribute a | a = this.getAttribute(name)) }
```
The `getAttribute` predicate has `XMLAttribute` as its result type, so adding a type-cast would be redundant. 
It is therefore simplified as follows:  
```CodeQL
predicate hasAttribute(string name) { exists(this.getAttribute(name)) }
```

--- 

The commit was generated automatically by a tool. 
(GitHub people: you can see how in the backref below). 