### PR TITLE
Ruby: Replace `getValueText` with `getConstantValue`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -239,7 +239,7 @@ module HTTP {
         string getUrlPattern() {
           exists(CfgNodes::ExprNodes::StringlikeLiteralCfgNode strNode |
             this.getUrlPatternArg().getALocalSource() = DataFlow::exprNode(strNode) and
-            result = strNode.getExpr().getConstantValue().getString()
+            result = strNode.getExpr().getConstantValue().getStringOrSymbol()
           )
         }
 
@@ -364,7 +364,7 @@ module HTTP {
         string getMimetype() {
           exists(CfgNodes::ExprNodes::StringlikeLiteralCfgNode strNode |
             this.getMimetypeOrContentTypeArg().getALocalSource() = DataFlow::exprNode(strNode) and
-            result = strNode.getExpr().getConstantValue().getString().splitAt(";", 0)
+            result = strNode.getExpr().getConstantValue().getStringOrSymbol().splitAt(";", 0)
           )
           or
           not exists(this.getMimetypeOrContentTypeArg()) and

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -239,7 +239,7 @@ module HTTP {
         string getUrlPattern() {
           exists(CfgNodes::ExprNodes::StringlikeLiteralCfgNode strNode |
             this.getUrlPatternArg().getALocalSource() = DataFlow::exprNode(strNode) and
-            result = strNode.getExpr().getValueText()
+            result = strNode.getExpr().getConstantValue().getString()
           )
         }
 
@@ -364,7 +364,7 @@ module HTTP {
         string getMimetype() {
           exists(CfgNodes::ExprNodes::StringlikeLiteralCfgNode strNode |
             this.getMimetypeOrContentTypeArg().getALocalSource() = DataFlow::exprNode(strNode) and
-            result = strNode.getExpr().getValueText().splitAt(";", 0)
+            result = strNode.getExpr().getConstantValue().getString().splitAt(";", 0)
           )
           or
           not exists(this.getMimetypeOrContentTypeArg()) and

--- a/ruby/ql/lib/codeql/ruby/ast/Call.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Call.qll
@@ -41,7 +41,7 @@ class Call extends Expr instanceof CallImpl {
   final Expr getKeywordArgument(string keyword) {
     exists(Pair p |
       p = this.getAnArgument() and
-      p.getKey().(SymbolLiteral).getValueText() = keyword and
+      p.getKey().(SymbolLiteral).getConstantValue().isString(keyword) and
       result = p.getValue()
     )
   }

--- a/ruby/ql/lib/codeql/ruby/ast/Call.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Call.qll
@@ -41,7 +41,7 @@ class Call extends Expr instanceof CallImpl {
   final Expr getKeywordArgument(string keyword) {
     exists(Pair p |
       p = this.getAnArgument() and
-      p.getKey().(SymbolLiteral).getConstantValue().isString(keyword) and
+      p.getKey().getConstantValue().isSymbol(keyword) and
       result = p.getValue()
     )
   }

--- a/ruby/ql/lib/codeql/ruby/ast/Constant.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Constant.qll
@@ -25,6 +25,8 @@ class ConstantValue extends TConstantValue {
     or
     result = this.getString()
     or
+    result = ":" + this.getSymbol()
+    or
     result = this.getBoolean().toString()
     or
     this.isNil() and result = "nil"
@@ -54,6 +56,18 @@ class ConstantValue extends TConstantValue {
   /** Holds if this is the string value `s`. */
   predicate isString(string s) { s = this.getString() }
 
+  /** Gets the symbol value (exluding the `:` prefix), if this is a symbol. */
+  string getSymbol() { this = TSymbol(result) }
+
+  /** Holds if this is the symbol value `:s`. */
+  predicate isSymbol(string s) { s = this.getSymbol() }
+
+  /** Gets the string or symbol value, if any. */
+  string getStringOrSymbol() { result = [this.getString(), this.getSymbol()] }
+
+  /** Holds if this is the string value `s` or the symbol value `:s`. */
+  predicate isStringOrSymbol(string s) { s = this.getStringOrSymbol() }
+
   /** Gets the Boolean value, if this is a Boolean. */
   boolean getBoolean() { this = TBoolean(result) }
 
@@ -80,6 +94,9 @@ module ConstantValue {
 
   /** A constant string value. */
   class ConstantStringValue extends ConstantValue, TString { }
+
+  /** A constant symbol value. */
+  class ConstantSymbolValue extends ConstantValue, TSymbol { }
 
   /** A constant Boolean value. */
   class ConstantBooleanValue extends ConstantValue, TBoolean { }

--- a/ruby/ql/lib/codeql/ruby/ast/Constant.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Constant.qll
@@ -1,8 +1,92 @@
 private import codeql.ruby.AST
 private import internal.AST
+private import internal.Constant
 private import internal.Module
 private import internal.Variable
 private import internal.TreeSitter
+
+/** A constant value. */
+class ConstantValue extends TConstantValue {
+  /** Gets a textual representation of this constant value. */
+  final string toString() {
+    result = this.getInt().toString()
+    or
+    result = this.getFloat().toString()
+    or
+    exists(int numerator, int denominator |
+      this.isRational(numerator, denominator) and
+      result = numerator + "/" + denominator
+    )
+    or
+    exists(float real, float imaginary |
+      this.isComplex(real, imaginary) and
+      result = real + "+" + imaginary + "i"
+    )
+    or
+    result = this.getString()
+    or
+    result = this.getBoolean().toString()
+    or
+    this.isNil() and result = "nil"
+  }
+
+  /** Gets the integer value, if this is an integer. */
+  int getInt() { this = TInt(result) }
+
+  /** Holds if this is the integer value `i`. */
+  predicate isInt(int i) { i = this.getInt() }
+
+  /** Gets the float value, if this is a float. */
+  float getFloat() { this = TFloat(result) }
+
+  /** Holds if this is the float value `f`. */
+  predicate isFloat(float f) { f = this.getFloat() }
+
+  /** Holds if this is the rational value `numerator / denominator`. */
+  predicate isRational(int numerator, int denominator) { this = TRational(numerator, denominator) }
+
+  /** Holds if this is the complex value `real + imaginary * i`. */
+  predicate isComplex(float real, float imaginary) { this = TComplex(real, imaginary) }
+
+  /** Gets the string value, if this is a string. */
+  string getString() { this = TString(result) }
+
+  /** Holds if this is the string value `s`. */
+  predicate isString(string s) { s = this.getString() }
+
+  /** Gets the Boolean value, if this is a Boolean. */
+  boolean getBoolean() { this = TBoolean(result) }
+
+  /** Holds if this is the Boolean value `b`. */
+  predicate isBoolean(boolean b) { b = this.getBoolean() }
+
+  /** Holds if this is the `nil` value. */
+  predicate isNil() { this = TNil() }
+}
+
+/** Provides different sub classes of `ConstantValue`. */
+module ConstantValue {
+  /** A constant integer value. */
+  class ConstantIntegerValue extends ConstantValue, TInt { }
+
+  /** A constant float value. */
+  class ConstantFloatValue extends ConstantValue, TFloat { }
+
+  /** A constant rational value. */
+  class ConstantRationalValue extends ConstantValue, TRational { }
+
+  /** A constant complex value. */
+  class ConstantComplexValue extends ConstantValue, TComplex { }
+
+  /** A constant string value. */
+  class ConstantStringValue extends ConstantValue, TString { }
+
+  /** A constant Boolean value. */
+  class ConstantBooleanValue extends ConstantValue, TBoolean { }
+
+  /** A constant `nil` value. */
+  class ConstantNilValue extends ConstantValue, TNil { }
+}
 
 /** An access to a constant. */
 class ConstantAccess extends Expr, TConstantAccess {
@@ -139,7 +223,7 @@ class ConstantReadAccess extends ConstantAccess {
     result = lookupConst(resolveConstantReadAccess(this.getScopeExpr()), this.getName())
   }
 
-  override string getValueText() { result = this.getValue().getValueText() }
+  final override ConstantValue getConstantValue() { result = this.getValue().getConstantValue() }
 
   final override string getAPrimaryQlClass() { result = "ConstantReadAccess" }
 }

--- a/ruby/ql/lib/codeql/ruby/ast/Expr.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Expr.qll
@@ -464,10 +464,12 @@ class StringConcatenation extends Expr, TStringConcatenation {
    * ```
    */
   final string getConcatenatedValueText() {
-    forall(StringLiteral c | c = this.getString(_) | exists(c.getConstantValue().getString())) and
+    forall(StringLiteral c | c = this.getString(_) |
+      exists(c.getConstantValue().getStringOrSymbol())
+    ) and
     result =
       concat(string valueText, int i |
-        valueText = this.getString(i).getConstantValue().getString()
+        valueText = this.getString(i).getConstantValue().getStringOrSymbol()
       |
         valueText order by i
       )

--- a/ruby/ql/lib/codeql/ruby/ast/Expr.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Expr.qll
@@ -1,5 +1,6 @@
 private import codeql.ruby.AST
 private import codeql.ruby.CFG
+private import codeql.ruby.ast.Constant
 private import internal.AST
 private import internal.Expr
 private import internal.TreeSitter
@@ -10,9 +11,16 @@ private import internal.TreeSitter
  * This is the root QL class for all expressions.
  */
 class Expr extends Stmt, TExpr {
-  /** Gets the textual (constant) value of this expression, if any. */
-  string getValueText() {
-    forex(CfgNodes::ExprCfgNode n | n = this.getAControlFlowNode() | result = n.getValueText())
+  /**
+   * DEPRECATED: Use `getConstantValue` instead.
+   *
+   * Gets the textual (constant) value of this expression, if any.
+   */
+  deprecated string getValueText() { result = this.getConstantValue().toString() }
+
+  /** Gets the constant value of this expression, if any. */
+  ConstantValue getConstantValue() {
+    forex(CfgNodes::ExprCfgNode n | n = this.getAControlFlowNode() | result = n.getConstantValue())
   }
 }
 
@@ -456,10 +464,10 @@ class StringConcatenation extends Expr, TStringConcatenation {
    * ```
    */
   final string getConcatenatedValueText() {
-    forall(StringLiteral c | c = this.getString(_) | exists(c.getValueText())) and
+    forall(StringLiteral c | c = this.getString(_) | exists(c.getConstantValue().getString())) and
     result =
       concat(string valueText, int i |
-        valueText = this.getString(i).getValueText()
+        valueText = this.getString(i).getConstantValue().getString()
       |
         valueText order by i
       )

--- a/ruby/ql/lib/codeql/ruby/ast/Literal.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Literal.qll
@@ -761,8 +761,8 @@ class SymbolLiteral extends StringlikeLiteral, TSymbolLiteral {
 // Tree-sitter gives us value text including the colon, which we skip.
 private string getSimpleSymbolValue(Ruby::SimpleSymbol ss) { result = ss.getValue().suffix(1) }
 
-private class RequiredStringConstantValue7 extends RequiredConstantValue {
-  override predicate requiredString(string s) { s = getSimpleSymbolValue(_) }
+private class RequiredSymbolConstantValue extends RequiredConstantValue {
+  override predicate requiredSymbol(string s) { s = getSimpleSymbolValue(_) }
 }
 
 private class SimpleSymbolLiteral extends SymbolLiteral, TSimpleSymbolLiteral {
@@ -770,8 +770,8 @@ private class SimpleSymbolLiteral extends SymbolLiteral, TSimpleSymbolLiteral {
 
   SimpleSymbolLiteral() { this = TSimpleSymbolLiteral(g) }
 
-  final override ConstantValue::ConstantStringValue getConstantValue() {
-    result.isString(getSimpleSymbolValue(g))
+  final override ConstantValue::ConstantSymbolValue getConstantValue() {
+    result.isSymbol(getSimpleSymbolValue(g))
   }
 
   final override string toString() { result = g.getValue() }
@@ -795,8 +795,8 @@ private class BareSymbolLiteral extends ComplexSymbolLiteral, TBareSymbolLiteral
   final override StringComponent getComponent(int i) { toGenerated(result) = g.getChild(i) }
 }
 
-private class RequiredStringConstantValue8 extends RequiredConstantValue {
-  override predicate requiredString(string s) { s = any(Ruby::HashKeySymbol h).getValue() }
+private class RequiredSymbolConstantValue2 extends RequiredConstantValue {
+  override predicate requiredSymbol(string s) { s = any(Ruby::HashKeySymbol h).getValue() }
 }
 
 private class HashKeySymbolLiteral extends SymbolLiteral, THashKeySymbolLiteral {
@@ -804,8 +804,8 @@ private class HashKeySymbolLiteral extends SymbolLiteral, THashKeySymbolLiteral 
 
   HashKeySymbolLiteral() { this = THashKeySymbolLiteral(g) }
 
-  final override ConstantValue::ConstantStringValue getConstantValue() {
-    result.isString(g.getValue())
+  final override ConstantValue::ConstantSymbolValue getConstantValue() {
+    result.isSymbol(g.getValue())
   }
 
   final override string toString() { result = ":" + g.getValue() }
@@ -829,7 +829,7 @@ class SubshellLiteral extends StringlikeLiteral, TSubshellLiteral {
   final override StringComponent getComponent(int i) { toGenerated(result) = g.getChild(i) }
 }
 
-private class RequiredStringConstantValue9 extends RequiredConstantValue {
+private class RequiredStringConstantValue7 extends RequiredConstantValue {
   override predicate requiredString(string s) { s = any(Ruby::Character c).getValue() }
 }
 
@@ -1131,7 +1131,7 @@ private string getMethodName(MethodName::Token t) {
   result = t.(Ruby::Setter).getName().getValue() + "="
 }
 
-private class RequiredStringConstantValue10 extends RequiredConstantValue {
+private class RequiredStringConstantValue8 extends RequiredConstantValue {
   override predicate requiredString(string s) { s = getMethodName(_) }
 }
 

--- a/ruby/ql/lib/codeql/ruby/ast/Literal.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Literal.qll
@@ -48,37 +48,41 @@ class IntegerLiteral extends NumericLiteral, TIntegerLiteral {
 }
 
 private int parseInteger(Ruby::Integer i) {
-  exists(string s, string values, string str |
-    s = i.getValue().toLowerCase() and
-    (
+  exists(string s | s = i.getValue().toLowerCase().replaceAll("_", "") |
+    s.charAt(0) != "0" and
+    result = s.toInt()
+    or
+    exists(string str, string values, int shift |
       s.matches("0b%") and
       values = "01" and
-      str = s.suffix(2)
+      str = s.suffix(2) and
+      shift = 1
       or
       s.matches("0x%") and
       values = "0123456789abcdef" and
-      str = s.suffix(2)
+      str = s.suffix(2) and
+      shift = 4
       or
       s.charAt(0) = "0" and
       not s.charAt(1) = ["b", "x", "o"] and
       values = "01234567" and
-      str = s.suffix(1)
+      str = s.suffix(1) and
+      shift = 3
       or
       s.matches("0o%") and
       values = "01234567" and
-      str = s.suffix(2)
-      or
-      s.charAt(0) != "0" and values = "0123456789" and str = s
+      str = s.suffix(2) and
+      shift = 3
+    |
+      result =
+        sum(int index, string c, int v, int exp |
+          c = str.charAt(index) and
+          v = values.indexOf(c.toLowerCase()) and
+          exp = str.length() - index - 1
+        |
+          v.bitShiftLeft((str.length() - index - 1) * shift)
+        )
     )
-  |
-    result =
-      sum(int index, string c, int v, int exp |
-        c = str.replaceAll("_", "").charAt(index) and
-        v = values.indexOf(c.toLowerCase()) and
-        exp = str.replaceAll("_", "").length() - index - 1
-      |
-        v * values.length().pow(exp).floor()
-      )
   )
 }
 

--- a/ruby/ql/lib/codeql/ruby/ast/Literal.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Literal.qll
@@ -77,12 +77,12 @@ private int parseInteger(Ruby::Integer i) {
         v = values.indexOf(c.toLowerCase()) and
         exp = str.replaceAll("_", "").length() - index - 1
       |
-        v * values.length().pow(exp)
+        v * values.length().pow(exp).floor()
       )
   )
 }
 
-private class RequiredIntegerConstantValue extends RequiredConstantValue {
+private class RequiredIntegerLiteralConstantValue extends RequiredConstantValue {
   override predicate requiredInt(int i) { i = any(IntegerLiteral il).getValue() }
 }
 
@@ -277,7 +277,7 @@ private class FalseLiteral extends BooleanLiteral, TFalseLiteral {
   final override predicate isFalse() { any() }
 }
 
-private class RequiredStringConstantValue extends RequiredConstantValue {
+private class RequiredEncodingLiteralConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) { s = "UTF-8" }
 }
 
@@ -293,7 +293,7 @@ class EncodingLiteral extends Literal, TEncoding {
   override ConstantValue::ConstantStringValue getConstantValue() { result.isString("UTF-8") }
 }
 
-private class RequiredIntegerConstantValue2 extends RequiredConstantValue {
+private class RequiredLineLiteralConstantValue extends RequiredConstantValue {
   override predicate requiredInt(int i) { i = any(LineLiteral ll).getLocation().getStartLine() }
 }
 
@@ -310,7 +310,7 @@ class LineLiteral extends Literal, TLine {
   }
 }
 
-private class RequiredStringConstantValue2 extends RequiredConstantValue {
+private class RequiredFileLiteralConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) {
     s = any(FileLiteral fl).getLocation().getFile().getAbsolutePath()
   }
@@ -346,7 +346,7 @@ class StringComponent extends AstNode, TStringComponent {
   ConstantValue::ConstantStringValue getConstantValue() { none() }
 }
 
-private class RequiredStringConstantValue3 extends RequiredConstantValue {
+private class RequiredStringTextComponentConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) {
     s = any(Ruby::Token t | exists(TStringTextComponentNonRegexp(t))).getValue()
   }
@@ -378,7 +378,7 @@ class StringTextComponent extends StringComponent, TStringTextComponentNonRegexp
   final override string getAPrimaryQlClass() { result = "StringTextComponent" }
 }
 
-private class RequiredStringConstantValue4 extends RequiredConstantValue {
+private class RequiredStringEscapeSequenceComponentConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) {
     s = any(Ruby::Token t | exists(TStringEscapeSequenceComponentNonRegexp(t))).getValue()
   }
@@ -450,7 +450,7 @@ private string getRegExpTextComponentValue(RegExpTextComponent c) {
   )
 }
 
-private class RequiredStringConstantValue5 extends RequiredConstantValue {
+private class RequiredRegExpTextComponentConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) { s = getRegExpTextComponentValue(_) }
 }
 
@@ -490,7 +490,7 @@ private string getRegExpEscapeSequenceComponentValue(RegExpEscapeSequenceCompone
   )
 }
 
-private class RequiredStringConstantValue6 extends RequiredConstantValue {
+private class RequiredRegExpEscapeSequenceComponentConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) { s = getRegExpEscapeSequenceComponentValue(_) }
 }
 
@@ -761,7 +761,7 @@ class SymbolLiteral extends StringlikeLiteral, TSymbolLiteral {
 // Tree-sitter gives us value text including the colon, which we skip.
 private string getSimpleSymbolValue(Ruby::SimpleSymbol ss) { result = ss.getValue().suffix(1) }
 
-private class RequiredSymbolConstantValue extends RequiredConstantValue {
+private class RequiredSimpleSymbolConstantValue extends RequiredConstantValue {
   override predicate requiredSymbol(string s) { s = getSimpleSymbolValue(_) }
 }
 
@@ -795,7 +795,7 @@ private class BareSymbolLiteral extends ComplexSymbolLiteral, TBareSymbolLiteral
   final override StringComponent getComponent(int i) { toGenerated(result) = g.getChild(i) }
 }
 
-private class RequiredSymbolConstantValue2 extends RequiredConstantValue {
+private class RequiredHashKeySymbolConstantValue extends RequiredConstantValue {
   override predicate requiredSymbol(string s) { s = any(Ruby::HashKeySymbol h).getValue() }
 }
 
@@ -829,7 +829,7 @@ class SubshellLiteral extends StringlikeLiteral, TSubshellLiteral {
   final override StringComponent getComponent(int i) { toGenerated(result) = g.getChild(i) }
 }
 
-private class RequiredStringConstantValue7 extends RequiredConstantValue {
+private class RequiredCharacterConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) { s = any(Ruby::Character c).getValue() }
 }
 
@@ -1131,7 +1131,7 @@ private string getMethodName(MethodName::Token t) {
   result = t.(Ruby::Setter).getName().getValue() + "="
 }
 
-private class RequiredStringConstantValue8 extends RequiredConstantValue {
+private class RequiredMethodNameConstantValue extends RequiredConstantValue {
   override predicate requiredString(string s) { s = getMethodName(_) }
 }
 

--- a/ruby/ql/lib/codeql/ruby/ast/Literal.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Literal.qll
@@ -1,6 +1,7 @@
 private import codeql.ruby.AST
 private import codeql.ruby.security.performance.RegExpTreeView as RETV
 private import internal.AST
+private import internal.Constant
 private import internal.Scope
 private import internal.TreeSitter
 private import codeql.ruby.controlflow.CfgNodes
@@ -39,9 +40,50 @@ class IntegerLiteral extends NumericLiteral, TIntegerLiteral {
   /** Gets the numerical value of this integer literal. */
   int getValue() { none() }
 
-  final override string toString() { result = this.getValueText() }
+  final override ConstantValue::ConstantIntegerValue getConstantValue() {
+    result.isInt(this.getValue())
+  }
 
   final override string getAPrimaryQlClass() { result = "IntegerLiteral" }
+}
+
+private int parseInteger(Ruby::Integer i) {
+  exists(string s, string values, string str |
+    s = i.getValue().toLowerCase() and
+    (
+      s.matches("0b%") and
+      values = "01" and
+      str = s.suffix(2)
+      or
+      s.matches("0x%") and
+      values = "0123456789abcdef" and
+      str = s.suffix(2)
+      or
+      s.charAt(0) = "0" and
+      not s.charAt(1) = ["b", "x", "o"] and
+      values = "01234567" and
+      str = s.suffix(1)
+      or
+      s.matches("0o%") and
+      values = "01234567" and
+      str = s.suffix(2)
+      or
+      s.charAt(0) != "0" and values = "0123456789" and str = s
+    )
+  |
+    result =
+      sum(int index, string c, int v, int exp |
+        c = str.replaceAll("_", "").charAt(index) and
+        v = values.indexOf(c.toLowerCase()) and
+        exp = str.replaceAll("_", "").length() - index - 1
+      |
+        v * values.length().pow(exp)
+      )
+  )
+}
+
+private class RequiredIntegerConstantValue extends RequiredConstantValue {
+  override predicate requiredInt(int i) { i = any(IntegerLiteral il).getValue() }
 }
 
 private class IntegerLiteralReal extends IntegerLiteral, TIntegerLiteralReal {
@@ -49,42 +91,9 @@ private class IntegerLiteralReal extends IntegerLiteral, TIntegerLiteralReal {
 
   IntegerLiteralReal() { this = TIntegerLiteralReal(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override int getValue() { result = parseInteger(g) }
 
-  final override int getValue() {
-    exists(string s, string values, string str |
-      s = this.getValueText().toLowerCase() and
-      (
-        s.matches("0b%") and
-        values = "01" and
-        str = s.suffix(2)
-        or
-        s.matches("0x%") and
-        values = "0123456789abcdef" and
-        str = s.suffix(2)
-        or
-        s.charAt(0) = "0" and
-        not s.charAt(1) = ["b", "x", "o"] and
-        values = "01234567" and
-        str = s.suffix(1)
-        or
-        s.matches("0o%") and
-        values = "01234567" and
-        str = s.suffix(2)
-        or
-        s.charAt(0) != "0" and values = "0123456789" and str = s
-      )
-    |
-      result =
-        sum(int index, string c, int v, int exp |
-          c = str.replaceAll("_", "").charAt(index) and
-          v = values.indexOf(c.toLowerCase()) and
-          exp = str.replaceAll("_", "").length() - index - 1
-        |
-          v * values.length().pow(exp)
-        )
-    )
-  }
+  final override string toString() { result = g.getValue() }
 }
 
 private class IntegerLiteralSynth extends IntegerLiteral, TIntegerLiteralSynth {
@@ -92,9 +101,16 @@ private class IntegerLiteralSynth extends IntegerLiteral, TIntegerLiteralSynth {
 
   IntegerLiteralSynth() { this = TIntegerLiteralSynth(_, _, value) }
 
-  final override string getValueText() { result = value.toString() }
-
   final override int getValue() { result = value }
+
+  final override string toString() { result = value.toString() }
+}
+
+// TODO: implement properly
+private float parseFloat(Ruby::Float f) { result = f.getValue().toFloat() }
+
+private class RequiredFloatConstantValue extends RequiredConstantValue {
+  override predicate requiredFloat(float f) { f = parseFloat(_) }
 }
 
 /**
@@ -110,11 +126,33 @@ class FloatLiteral extends NumericLiteral, TFloatLiteral {
 
   FloatLiteral() { this = TFloatLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantFloatValue getConstantValue() {
+    result.isFloat(parseFloat(g))
+  }
 
-  final override string toString() { result = this.getValueText() }
+  final override string toString() { result = g.getValue() }
 
   final override string getAPrimaryQlClass() { result = "FloatLiteral" }
+}
+
+private predicate isRationalValue(Ruby::Rational r, int numerator, int denominator) {
+  numerator = parseInteger(r.getChild()) and
+  denominator = 1
+  or
+  exists(Ruby::Float f, string regex, string before, string after |
+    f = r.getChild() and
+    regex = "([^.]*)\\.(.*)" and
+    before = f.getValue().regexpCapture(regex, 1) and
+    after = f.getValue().regexpCapture(regex, 2) and
+    numerator = before.toInt() * denominator + after.toInt() and
+    denominator = 10.pow(after.length())
+  )
+}
+
+private class RequiredRationalConstantValue extends RequiredConstantValue {
+  override predicate requiredRational(int numerator, int denominator) {
+    isRationalValue(_, numerator, denominator)
+  }
 }
 
 /**
@@ -129,11 +167,30 @@ class RationalLiteral extends NumericLiteral, TRationalLiteral {
 
   RationalLiteral() { this = TRationalLiteral(g) }
 
-  final override string getValueText() { result = g.getChild().(Ruby::Token).getValue() + "r" }
+  final override ConstantValue::ConstantRationalValue getConstantValue() {
+    exists(int numerator, int denominator |
+      isRationalValue(g, numerator, denominator) and
+      result.isRational(numerator, denominator)
+    )
+  }
 
-  final override string toString() { result = this.getValueText() }
+  final override string toString() { result = g.getChild().(Ruby::Token).getValue() + "r" }
 
   final override string getAPrimaryQlClass() { result = "RationalLiteral" }
+}
+
+private float getComplexValue(Ruby::Complex c) {
+  exists(string s |
+    s = c.getValue() and
+    result = s.prefix(s.length() - 1).toFloat()
+  )
+}
+
+private class RequiredComplexConstantValue extends RequiredConstantValue {
+  override predicate requiredComplex(float real, float imaginary) {
+    real = 0 and
+    imaginary = getComplexValue(_)
+  }
 }
 
 /**
@@ -148,9 +205,11 @@ class ComplexLiteral extends NumericLiteral, TComplexLiteral {
 
   ComplexLiteral() { this = TComplexLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantComplexValue getConstantValue() {
+    result.isComplex(0, getComplexValue(g))
+  }
 
-  final override string toString() { result = this.getValueText() }
+  final override string toString() { result = g.getValue() }
 
   final override string getAPrimaryQlClass() { result = "ComplexLiteral" }
 }
@@ -161,9 +220,9 @@ class NilLiteral extends Literal, TNilLiteral {
 
   NilLiteral() { this = TNilLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantNilValue getConstantValue() { any() }
 
-  final override string toString() { result = this.getValueText() }
+  final override string toString() { result = g.getValue() }
 
   final override string getAPrimaryQlClass() { result = "NilLiteral" }
 }
@@ -180,8 +239,6 @@ class NilLiteral extends Literal, TNilLiteral {
 class BooleanLiteral extends Literal, TBooleanLiteral {
   final override string getAPrimaryQlClass() { result = "BooleanLiteral" }
 
-  final override string toString() { result = this.getValueText() }
-
   /** Holds if the Boolean literal is `true` or `TRUE`. */
   predicate isTrue() { none() }
 
@@ -194,6 +251,10 @@ class BooleanLiteral extends Literal, TBooleanLiteral {
     or
     this.isFalse() and result = false
   }
+
+  final override ConstantValue::ConstantBooleanValue getConstantValue() {
+    result.isBoolean(this.getValue())
+  }
 }
 
 private class TrueLiteral extends BooleanLiteral, TTrueLiteral {
@@ -201,7 +262,7 @@ private class TrueLiteral extends BooleanLiteral, TTrueLiteral {
 
   TrueLiteral() { this = TTrueLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override string toString() { result = g.getValue() }
 
   final override predicate isTrue() { any() }
 }
@@ -211,9 +272,13 @@ private class FalseLiteral extends BooleanLiteral, TFalseLiteral {
 
   FalseLiteral() { this = TFalseLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override string toString() { result = g.getValue() }
 
   final override predicate isFalse() { any() }
+}
+
+private class RequiredStringConstantValue extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = "UTF-8" }
 }
 
 /**
@@ -225,7 +290,11 @@ class EncodingLiteral extends Literal, TEncoding {
   final override string toString() { result = "__ENCODING__" }
 
   // TODO: return the encoding defined by a magic encoding: comment, if any.
-  override string getValueText() { result = "UTF-8" }
+  override ConstantValue::ConstantStringValue getConstantValue() { result.isString("UTF-8") }
+}
+
+private class RequiredIntegerConstantValue2 extends RequiredConstantValue {
+  override predicate requiredInt(int i) { i = any(LineLiteral ll).getLocation().getStartLine() }
 }
 
 /**
@@ -236,7 +305,15 @@ class LineLiteral extends Literal, TLine {
 
   final override string toString() { result = "__LINE__" }
 
-  override string getValueText() { result = this.getLocation().getStartLine().toString() }
+  final override ConstantValue::ConstantIntegerValue getConstantValue() {
+    result.isInt(this.getLocation().getStartLine())
+  }
+}
+
+private class RequiredStringConstantValue2 extends RequiredConstantValue {
+  override predicate requiredString(string s) {
+    s = any(FileLiteral fl).getLocation().getFile().getAbsolutePath()
+  }
 }
 
 /**
@@ -247,7 +324,9 @@ class FileLiteral extends Literal, TFile {
 
   final override string toString() { result = "__FILE__" }
 
-  override string getValueText() { result = this.getLocation().getFile().getAbsolutePath() }
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(this.getLocation().getFile().getAbsolutePath())
+  }
 }
 
 /**
@@ -256,17 +335,28 @@ class FileLiteral extends Literal, TFile {
  */
 class StringComponent extends AstNode, TStringComponent {
   /**
+   * DEPRECATED: Use `getConstantValue` instead.
+   *
    * Gets the source text for this string component. Has no result if this is
    * a `StringInterpolationComponent`.
    */
-  string getValueText() { none() }
+  deprecated string getValueText() { result = this.getConstantValue().toString() }
+
+  /** Gets the constant value of this string component, if any. */
+  ConstantValue::ConstantStringValue getConstantValue() { none() }
+}
+
+private class RequiredStringConstantValue3 extends RequiredConstantValue {
+  override predicate requiredString(string s) {
+    s = any(Ruby::Token t | exists(TStringTextComponentNonRegexp(t))).getValue()
+  }
 }
 
 /**
  * A component of a string (or string-like) literal that is simply text.
  *
  * For example, the following string literals all contain `StringTextComponent`
- * components whose `getValueText()` returns `"foo"`:
+ * components whose `getConstantValue()` returns `"foo"`:
  *
  * ```rb
  * 'foo'
@@ -281,9 +371,17 @@ class StringTextComponent extends StringComponent, TStringTextComponentNonRegexp
 
   final override string toString() { result = g.getValue() }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(g.getValue())
+  }
 
   final override string getAPrimaryQlClass() { result = "StringTextComponent" }
+}
+
+private class RequiredStringConstantValue4 extends RequiredConstantValue {
+  override predicate requiredString(string s) {
+    s = any(Ruby::Token t | exists(TStringEscapeSequenceComponentNonRegexp(t))).getValue()
+  }
 }
 
 /**
@@ -296,7 +394,9 @@ class StringEscapeSequenceComponent extends StringComponent, TStringEscapeSequen
 
   final override string toString() { result = g.getValue() }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(g.getValue())
+  }
 
   final override string getAPrimaryQlClass() { result = "StringEscapeSequenceComponent" }
 }
@@ -314,7 +414,9 @@ class StringInterpolationComponent extends StringComponent, StmtSequence,
 
   final override Stmt getStmt(int n) { toGenerated(result) = g.getChild(n) }
 
-  final override string getValueText() { none() }
+  deprecated final override string getValueText() { none() }
+
+  final override ConstantValue::ConstantStringValue getConstantValue() { none() }
 
   final override string getAPrimaryQlClass() { result = "StringInterpolationComponent" }
 }
@@ -327,15 +429,36 @@ private class TRegExpComponent =
  * The base class for a component of a regular expression literal.
  */
 class RegExpComponent extends AstNode, TRegExpComponent {
-  /** Gets the source text for this regex component, if any. */
-  string getValueText() { none() }
+  /**
+   * DEPRECATED: Use `getConstantValue` instead.
+   *
+   * Gets the source text for this regex component, if any.
+   */
+  deprecated string getValueText() { result = this.getConstantValue().toString() }
+
+  /** Gets the constant value of this regex component, if any. */
+  ConstantValue::ConstantStringValue getConstantValue() { none() }
+}
+
+// Exclude components that are children of a free-spacing regex.
+// We do this because `ParseRegExp.qll` cannot handle free-spacing regexes.
+private string getRegExpTextComponentValue(RegExpTextComponent c) {
+  exists(Ruby::Token t |
+    c = TStringTextComponentRegexp(t) and
+    not c.getParent().(RegExpLiteral).hasFreeSpacingFlag() and
+    result = t.getValue()
+  )
+}
+
+private class RequiredStringConstantValue5 extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = getRegExpTextComponentValue(_) }
 }
 
 /**
  * A component of a regex literal that is simply text.
  *
  * For example, the following regex literals all contain `RegExpTextComponent`
- * components whose `getValueText()` returns `"foo"`:
+ * components whose `getConstantValue()` returns `"foo"`:
  *
  * ```rb
  * 'foo'
@@ -350,13 +473,25 @@ class RegExpTextComponent extends RegExpComponent, TStringTextComponentRegexp {
 
   final override string toString() { result = g.getValue() }
 
-  // Exclude components that are children of a free-spacing regex.
-  // We do this because `ParseRegExp.qll` cannot handle free-spacing regexes.
-  final override string getValueText() {
-    not this.getParent().(RegExpLiteral).hasFreeSpacingFlag() and result = g.getValue()
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(getRegExpTextComponentValue(this))
   }
 
   final override string getAPrimaryQlClass() { result = "RegExpTextComponent" }
+}
+
+// Exclude components that are children of a free-spacing regex.
+// We do this because `ParseRegExp.qll` cannot handle free-spacing regexes.
+private string getRegExpEscapeSequenceComponentValue(RegExpEscapeSequenceComponent c) {
+  exists(Ruby::EscapeSequence e |
+    c = TStringEscapeSequenceComponentRegexp(e) and
+    not c.getParent().(RegExpLiteral).hasFreeSpacingFlag() and
+    result = e.getValue()
+  )
+}
+
+private class RequiredStringConstantValue6 extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = getRegExpEscapeSequenceComponentValue(_) }
 }
 
 /**
@@ -369,10 +504,8 @@ class RegExpEscapeSequenceComponent extends RegExpComponent, TStringEscapeSequen
 
   final override string toString() { result = g.getValue() }
 
-  // Exclude components that are children of a free-spacing regex.
-  // We do this because `ParseRegExp.qll` cannot handle free-spacing regexes.
-  final override string getValueText() {
-    not this.getParent().(RegExpLiteral).hasFreeSpacingFlag() and result = g.getValue()
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(getRegExpEscapeSequenceComponentValue(this))
   }
 
   final override string getAPrimaryQlClass() { result = "RegExpEscapeSequenceComponent" }
@@ -391,7 +524,9 @@ class RegExpInterpolationComponent extends RegExpComponent, StmtSequence,
 
   final override Stmt getStmt(int n) { toGenerated(result) = g.getChild(n) }
 
-  final override string getValueText() { none() }
+  deprecated final override string getValueText() { none() }
+
+  final override ConstantValue::ConstantStringValue getConstantValue() { none() }
 
   final override string getAPrimaryQlClass() { result = "RegExpInterpolationComponent" }
 }
@@ -623,13 +758,21 @@ class SymbolLiteral extends StringlikeLiteral, TSymbolLiteral {
   }
 }
 
+// Tree-sitter gives us value text including the colon, which we skip.
+private string getSimpleSymbolValue(Ruby::SimpleSymbol ss) { result = ss.getValue().suffix(1) }
+
+private class RequiredStringConstantValue7 extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = getSimpleSymbolValue(_) }
+}
+
 private class SimpleSymbolLiteral extends SymbolLiteral, TSimpleSymbolLiteral {
   private Ruby::SimpleSymbol g;
 
   SimpleSymbolLiteral() { this = TSimpleSymbolLiteral(g) }
 
-  // Tree-sitter gives us value text including the colon, which we skip.
-  final override string getValueText() { result = g.getValue().suffix(1) }
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(getSimpleSymbolValue(g))
+  }
 
   final override string toString() { result = g.getValue() }
 }
@@ -652,14 +795,20 @@ private class BareSymbolLiteral extends ComplexSymbolLiteral, TBareSymbolLiteral
   final override StringComponent getComponent(int i) { toGenerated(result) = g.getChild(i) }
 }
 
+private class RequiredStringConstantValue8 extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = any(Ruby::HashKeySymbol h).getValue() }
+}
+
 private class HashKeySymbolLiteral extends SymbolLiteral, THashKeySymbolLiteral {
   private Ruby::HashKeySymbol g;
 
   HashKeySymbolLiteral() { this = THashKeySymbolLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(g.getValue())
+  }
 
-  final override string toString() { result = ":" + this.getValueText() }
+  final override string toString() { result = ":" + g.getValue() }
 }
 
 /**
@@ -680,6 +829,10 @@ class SubshellLiteral extends StringlikeLiteral, TSubshellLiteral {
   final override StringComponent getComponent(int i) { toGenerated(result) = g.getChild(i) }
 }
 
+private class RequiredStringConstantValue9 extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = any(Ruby::Character c).getValue() }
+}
+
 /**
  * A character literal.
  *
@@ -693,7 +846,9 @@ class CharacterLiteral extends Literal, TCharacterLiteral {
 
   CharacterLiteral() { this = TCharacterLiteral(g) }
 
-  final override string getValueText() { result = g.getValue() }
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(g.getValue())
+  }
 
   final override string toString() { result = g.getValue() }
 
@@ -970,16 +1125,24 @@ class MethodName extends Literal {
   final override string getAPrimaryQlClass() { result = "MethodName" }
 }
 
+private string getMethodName(MethodName::Token t) {
+  result = t.(Ruby::Token).getValue()
+  or
+  result = t.(Ruby::Setter).getName().getValue() + "="
+}
+
+private class RequiredStringConstantValue10 extends RequiredConstantValue {
+  override predicate requiredString(string s) { s = getMethodName(_) }
+}
+
 private class TokenMethodName extends MethodName, TTokenMethodName {
   private MethodName::Token g;
 
   TokenMethodName() { this = TTokenMethodName(g) }
 
-  final override string getValueText() {
-    result = g.(Ruby::Token).getValue()
-    or
-    result = g.(Ruby::Setter).getName().getValue() + "="
+  final override ConstantValue::ConstantStringValue getConstantValue() {
+    result.isString(getMethodName(g))
   }
 
-  final override string toString() { result = this.getValueText() }
+  final override string toString() { result = getMethodName(g) }
 }

--- a/ruby/ql/lib/codeql/ruby/ast/Method.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Method.qll
@@ -53,7 +53,7 @@ private class MethodModifier extends MethodCall {
   predicate modifiesMethod(Namespace n, string name) {
     this = n.getAStmt() and
     [
-      this.getMethodArgument().(StringlikeLiteral).getValueText(),
+      this.getMethodArgument().(StringlikeLiteral).getConstantValue().getString(),
       this.getMethodArgument().(MethodBase).getName()
     ] = name
   }

--- a/ruby/ql/lib/codeql/ruby/ast/Method.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Method.qll
@@ -53,7 +53,7 @@ private class MethodModifier extends MethodCall {
   predicate modifiesMethod(Namespace n, string name) {
     this = n.getAStmt() and
     [
-      this.getMethodArgument().(StringlikeLiteral).getConstantValue().getString(),
+      this.getMethodArgument().getConstantValue().getStringOrSymbol(),
       this.getMethodArgument().(MethodBase).getName()
     ] = name
   }

--- a/ruby/ql/lib/codeql/ruby/ast/Pattern.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Pattern.qll
@@ -271,7 +271,9 @@ class HashPattern extends CasePattern, THashPattern {
 
   /** Gets the value for a given key name. */
   CasePattern getValueByKey(string key) {
-    exists(int i | this.getKey(i).getConstantValue().isString(key) and result = this.getValue(i))
+    exists(int i |
+      this.getKey(i).getConstantValue().isStringOrSymbol(key) and result = this.getValue(i)
+    )
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/ast/Pattern.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Pattern.qll
@@ -271,7 +271,7 @@ class HashPattern extends CasePattern, THashPattern {
 
   /** Gets the value for a given key name. */
   CasePattern getValueByKey(string key) {
-    exists(int i | key = this.getKey(i).getValueText() and result = this.getValue(i))
+    exists(int i | this.getKey(i).getConstantValue().isString(key) and result = this.getValue(i))
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
@@ -9,6 +9,7 @@ newtype TConstantValue =
     any(RequiredConstantValue x).requiredComplex(real, imaginary)
   } or
   TString(string s) { any(RequiredConstantValue x).requiredString(s) } or
+  TSymbol(string s) { any(RequiredConstantValue x).requiredSymbol(s) } or
   TBoolean(boolean b) { b in [false, true] } or
   TNil()
 
@@ -26,4 +27,6 @@ class RequiredConstantValue extends MkRequiredConstantValue {
   predicate requiredComplex(float real, float imaginary) { none() }
 
   predicate requiredString(string s) { none() }
+
+  predicate requiredSymbol(string s) { none() }
 }

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
@@ -1,0 +1,29 @@
+cached
+newtype TConstantValue =
+  TInt(int i) { any(RequiredConstantValue x).requiredInt(i) } or
+  TFloat(float f) { any(RequiredConstantValue x).requiredFloat(f) } or
+  TRational(int numerator, int denominator) {
+    any(RequiredConstantValue x).requiredRational(numerator, denominator)
+  } or
+  TComplex(float real, float imaginary) {
+    any(RequiredConstantValue x).requiredComplex(real, imaginary)
+  } or
+  TString(string s) { any(RequiredConstantValue x).requiredString(s) } or
+  TBoolean(boolean b) { b in [false, true] } or
+  TNil()
+
+private newtype TRequiredConstantValue = MkRequiredConstantValue()
+
+class RequiredConstantValue extends MkRequiredConstantValue {
+  string toString() { none() }
+
+  predicate requiredInt(int i) { none() }
+
+  predicate requiredFloat(float f) { none() }
+
+  predicate requiredRational(int numerator, int denominator) { none() }
+
+  predicate requiredComplex(float real, float imaginary) { none() }
+
+  predicate requiredString(string s) { none() }
+}

--- a/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Constant.qll
@@ -15,6 +15,10 @@ newtype TConstantValue =
 
 private newtype TRequiredConstantValue = MkRequiredConstantValue()
 
+/**
+ * A class that exists for QL technical reasons only (the IPA type used
+ * to represent constant values needs to be bounded).
+ */
 class RequiredConstantValue extends MkRequiredConstantValue {
   string toString() { none() }
 

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -458,7 +458,7 @@ module ExprNodes {
     final ExprCfgNode getKeywordArgument(string keyword) {
       exists(PairCfgNode n |
         e.hasCfgChild(e.getAnArgument(), this, n) and
-        n.getKey().getExpr().(SymbolLiteral).getConstantValue().isString(keyword) and
+        n.getKey().getExpr().getConstantValue().isSymbol(keyword) and
         result = n.getValue()
       )
     }
@@ -643,7 +643,19 @@ module ExprNodes {
   }
 
   private class RequiredStringConstantValue extends RequiredConstantValue {
-    override predicate requiredString(string s) { s = getStringlikeLiteralCfgNodeValue(_) }
+    override predicate requiredString(string s) {
+      exists(StringlikeLiteralCfgNode n |
+        s = getStringlikeLiteralCfgNodeValue(n) and
+        not n.getExpr() instanceof SymbolLiteral
+      )
+    }
+
+    override predicate requiredSymbol(string s) {
+      exists(StringlikeLiteralCfgNode n |
+        s = getStringlikeLiteralCfgNodeValue(n) and
+        n.getExpr() instanceof SymbolLiteral
+      )
+    }
   }
 
   /** A control-flow node that wraps a `StringlikeLiteral` AST expression. */
@@ -658,8 +670,10 @@ module ExprNodes {
     /** Gets a component of this `StringlikeLiteral` */
     StringComponentCfgNode getAComponent() { result = this.getComponent(_) }
 
-    final override ConstantValue::ConstantStringValue getConstantValue() {
-      result.isString(getStringlikeLiteralCfgNodeValue(this))
+    final override ConstantValue getConstantValue() {
+      if this.getExpr() instanceof SymbolLiteral
+      then result.isSymbol(getStringlikeLiteralCfgNodeValue(this))
+      else result.isString(getStringlikeLiteralCfgNodeValue(this))
     }
   }
 

--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -272,6 +272,7 @@ module ExprNodes {
     final ExprCfgNode getOperand() { e.hasCfgChild(uo.getOperand(), this, result) }
 
     final override ConstantValue getConstantValue() {
+      // TODO: Implement support for complex numbers and rational numbers
       exists(string op, ConstantValue value | unaryConstFold(this, op, value) |
         op = "+" and
         result = value
@@ -373,6 +374,7 @@ module ExprNodes {
     final ExprCfgNode getRightOperand() { e.hasCfgChild(bo.getRightOperand(), this, result) }
 
     final override ConstantValue getConstantValue() {
+      // TODO: Implement support for complex numbers and rational numbers
       exists(string op, ConstantValue left, ConstantValue right |
         binaryConstFold(this, op, left, right)
       |
@@ -642,7 +644,7 @@ module ExprNodes {
       )
   }
 
-  private class RequiredStringConstantValue extends RequiredConstantValue {
+  private class RequiredStringlikeLiteralConstantValue extends RequiredConstantValue {
     override predicate requiredString(string s) {
       exists(StringlikeLiteralCfgNode n |
         s = getStringlikeLiteralCfgNodeValue(n) and
@@ -703,7 +705,7 @@ module ExprNodes {
       )
   }
 
-  private class RequiredStringConstantValue2 extends RequiredConstantValue {
+  private class RequiredRexExpLiteralConstantValue extends RequiredConstantValue {
     override predicate requiredString(string s) { s = getRegExpLiteralCfgNodeValue(_) }
   }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -167,14 +167,14 @@ private class Argument extends CfgNodes::ExprCfgNode {
     exists(int i |
       this = call.getArgument(i) and
       not this.getExpr() instanceof BlockArgument and
-      not exists(this.getExpr().(Pair).getKey().getValueText()) and
+      not exists(this.getExpr().(Pair).getKey().getConstantValue().getString()) and
       arg.isPositional(i)
     )
     or
     exists(CfgNodes::ExprNodes::PairCfgNode p |
       p = call.getArgument(_) and
       this = p.getValue() and
-      arg.isKeyword(p.getKey().getValueText())
+      arg.isKeyword(p.getKey().getConstantValue().getString())
     )
     or
     this = call.getReceiver() and arg.isSelf()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -167,14 +167,14 @@ private class Argument extends CfgNodes::ExprCfgNode {
     exists(int i |
       this = call.getArgument(i) and
       not this.getExpr() instanceof BlockArgument and
-      not exists(this.getExpr().(Pair).getKey().getConstantValue().getString()) and
+      not exists(this.getExpr().(Pair).getKey().getConstantValue().getSymbol()) and
       arg.isPositional(i)
     )
     or
     exists(CfgNodes::ExprNodes::PairCfgNode p |
       p = call.getArgument(_) and
       this = p.getValue() and
-      arg.isKeyword(p.getKey().getConstantValue().getString())
+      arg.isKeyword(p.getKey().getConstantValue().getSymbol())
     )
     or
     this = call.getReceiver() and arg.isSelf()

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -176,7 +176,7 @@ class RedirectToCall extends ActionControllerContextCall {
   /** Gets the `ActionControllerActionMethod` to redirect to, if any */
   ActionControllerActionMethod getRedirectActionMethod() {
     exists(string methodName |
-      methodName = this.getKeywordArgument("action").(StringlikeLiteral).getValueText() and
+      this.getKeywordArgument("action").getConstantValue().isString(methodName) and
       methodName = result.getName() and
       result.getEnclosingModule() = this.getControllerClass()
     )
@@ -225,7 +225,7 @@ class ActionControllerHelperMethod extends Method {
     this.getEnclosingModule() = controllerClass and
     exists(MethodCall helperMethodMarker |
       helperMethodMarker.getMethodName() = "helper_method" and
-      helperMethodMarker.getAnArgument().(StringlikeLiteral).getValueText() = this.getName() and
+      helperMethodMarker.getAnArgument().getConstantValue().isString(this.getName()) and
       helperMethodMarker.getEnclosingModule() = controllerClass
     )
   }
@@ -291,7 +291,7 @@ class ActionControllerSkipForgeryProtectionCall extends CSRFProtectionSetting::R
       call.getMethodName() = "skip_forgery_protection"
       or
       call.getMethodName() = "skip_before_action" and
-      call.getAnArgument().(SymbolLiteral).getValueText() = "verify_authenticity_token"
+      call.getAnArgument().getConstantValue().isString("verify_authenticity_token")
     )
   }
 
@@ -309,7 +309,9 @@ private class ActionControllerProtectFromForgeryCall extends CSRFProtectionSetti
     callExpr.getMethodName() = "protect_from_forgery"
   }
 
-  private string getWithValueText() { result = callExpr.getKeywordArgument("with").getValueText() }
+  private string getWithValueText() {
+    result = callExpr.getKeywordArgument("with").getConstantValue().getString()
+  }
 
   // Calls without `with: :exception` can allow for bypassing CSRF protection
   // in some scenarios.

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -176,7 +176,7 @@ class RedirectToCall extends ActionControllerContextCall {
   /** Gets the `ActionControllerActionMethod` to redirect to, if any */
   ActionControllerActionMethod getRedirectActionMethod() {
     exists(string methodName |
-      this.getKeywordArgument("action").getConstantValue().isString(methodName) and
+      this.getKeywordArgument("action").getConstantValue().isStringOrSymbol(methodName) and
       methodName = result.getName() and
       result.getEnclosingModule() = this.getControllerClass()
     )
@@ -225,7 +225,7 @@ class ActionControllerHelperMethod extends Method {
     this.getEnclosingModule() = controllerClass and
     exists(MethodCall helperMethodMarker |
       helperMethodMarker.getMethodName() = "helper_method" and
-      helperMethodMarker.getAnArgument().getConstantValue().isString(this.getName()) and
+      helperMethodMarker.getAnArgument().getConstantValue().isStringOrSymbol(this.getName()) and
       helperMethodMarker.getEnclosingModule() = controllerClass
     )
   }
@@ -291,7 +291,7 @@ class ActionControllerSkipForgeryProtectionCall extends CSRFProtectionSetting::R
       call.getMethodName() = "skip_forgery_protection"
       or
       call.getMethodName() = "skip_before_action" and
-      call.getAnArgument().getConstantValue().isString("verify_authenticity_token")
+      call.getAnArgument().getConstantValue().isStringOrSymbol("verify_authenticity_token")
     )
   }
 
@@ -310,7 +310,7 @@ private class ActionControllerProtectFromForgeryCall extends CSRFProtectionSetti
   }
 
   private string getWithValueText() {
-    result = callExpr.getKeywordArgument("with").getConstantValue().getString()
+    result = callExpr.getKeywordArgument("with").getConstantValue().getSymbol()
   }
 
   // Calls without `with: :exception` can allow for bypassing CSRF protection

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
@@ -82,7 +82,7 @@ abstract class RenderCall extends MethodCall {
   }
 
   private string getTemplatePathValue() {
-    result = this.getTemplatePathArgument().getConstantValue().getString()
+    result = this.getTemplatePathArgument().getConstantValue().getStringOrSymbol()
   }
 
   // everything up to and including the final slash, but ignoring any leading slash

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionView.qll
@@ -81,7 +81,9 @@ abstract class RenderCall extends MethodCall {
     result = [this.getKeywordArgument(["partial", "template", "action"]), this.getArgument(0)]
   }
 
-  private string getTemplatePathValue() { result = this.getTemplatePathArgument().getValueText() }
+  private string getTemplatePathValue() {
+    result = this.getTemplatePathArgument().getConstantValue().getString()
+  }
 
   // everything up to and including the final slash, but ignoring any leading slash
   private string getSubPath() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -28,7 +28,7 @@ private DataFlow::Node ioInstance() {
 // will execute a shell command and read its output rather than reading from the
 // filesystem.
 private predicate pathArgSpawnsSubprocess(Expr arg) {
-  arg.getConstantValue().getString().charAt(0) = "|"
+  arg.getConstantValue().getStringOrSymbol().charAt(0) = "|"
 }
 
 private DataFlow::Node fileInstanceInstantiation() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Files.qll
@@ -28,7 +28,7 @@ private DataFlow::Node ioInstance() {
 // will execute a shell command and read its output rather than reading from the
 // filesystem.
 private predicate pathArgSpawnsSubprocess(Expr arg) {
-  arg.(StringlikeLiteral).getValueText().charAt(0) = "|"
+  arg.getConstantValue().getString().charAt(0) = "|"
 }
 
 private DataFlow::Node fileInstanceInstantiation() {

--- a/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
@@ -300,7 +300,7 @@ class GraphqlFieldDefinitionMethodCall extends GraphqlSchemaObjectClassMethodCal
   GraphqlFieldDefinitionMethodCall() { this.getMethodName() = "field" }
 
   /** Gets the name of this GraphQL field. */
-  string getFieldName() { result = this.getArgument(0).getValueText() }
+  string getFieldName() { result = this.getArgument(0).getConstantValue().getString() }
 }
 
 /**
@@ -336,7 +336,7 @@ private class GraphqlFieldArgumentDefinitionMethodCall extends GraphqlSchemaObje
   string getFieldName() { result = this.getFieldDefinition().getFieldName() }
 
   /** Gets the name of the argument (i.e. the first argument to this `argument` method call) */
-  string getArgumentName() { result = this.getArgument(0).(SymbolLiteral).getValueText() }
+  string getArgumentName() { result = this.getArgument(0).getConstantValue().getString() }
 }
 
 /**
@@ -385,7 +385,7 @@ class GraphqlFieldResolutionMethod extends Method, HTTP::Server::RequestHandler:
     exists(GraphqlFieldDefinitionMethodCall defn |
       // field :foo, resolver_method: :custom_method
       // def custom_method(...)
-      defn.getKeywordArgument("resolver_method").(SymbolLiteral).getValueText() = this.getName()
+      defn.getKeywordArgument("resolver_method").getConstantValue().isString(this.getName())
       or
       // field :foo
       // def foo(...)
@@ -396,7 +396,7 @@ class GraphqlFieldResolutionMethod extends Method, HTTP::Server::RequestHandler:
 
   /** Gets the method call which is the definition of the field corresponding to this resolver method. */
   GraphqlFieldDefinitionMethodCall getDefinition() {
-    result.getKeywordArgument("resolver_method").(SymbolLiteral).getValueText() = this.getName()
+    result.getKeywordArgument("resolver_method").getConstantValue().isString(this.getName())
     or
     not exists(result.getKeywordArgument("resolver_method").(SymbolLiteral)) and
     result.getFieldName() = this.getName()

--- a/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/GraphQL.qll
@@ -300,7 +300,7 @@ class GraphqlFieldDefinitionMethodCall extends GraphqlSchemaObjectClassMethodCal
   GraphqlFieldDefinitionMethodCall() { this.getMethodName() = "field" }
 
   /** Gets the name of this GraphQL field. */
-  string getFieldName() { result = this.getArgument(0).getConstantValue().getString() }
+  string getFieldName() { result = this.getArgument(0).getConstantValue().getStringOrSymbol() }
 }
 
 /**
@@ -336,7 +336,7 @@ private class GraphqlFieldArgumentDefinitionMethodCall extends GraphqlSchemaObje
   string getFieldName() { result = this.getFieldDefinition().getFieldName() }
 
   /** Gets the name of the argument (i.e. the first argument to this `argument` method call) */
-  string getArgumentName() { result = this.getArgument(0).getConstantValue().getString() }
+  string getArgumentName() { result = this.getArgument(0).getConstantValue().getStringOrSymbol() }
 }
 
 /**
@@ -385,7 +385,7 @@ class GraphqlFieldResolutionMethod extends Method, HTTP::Server::RequestHandler:
     exists(GraphqlFieldDefinitionMethodCall defn |
       // field :foo, resolver_method: :custom_method
       // def custom_method(...)
-      defn.getKeywordArgument("resolver_method").getConstantValue().isString(this.getName())
+      defn.getKeywordArgument("resolver_method").getConstantValue().isStringOrSymbol(this.getName())
       or
       // field :foo
       // def foo(...)
@@ -396,7 +396,7 @@ class GraphqlFieldResolutionMethod extends Method, HTTP::Server::RequestHandler:
 
   /** Gets the method call which is the definition of the field corresponding to this resolver method. */
   GraphqlFieldDefinitionMethodCall getDefinition() {
-    result.getKeywordArgument("resolver_method").getConstantValue().isString(this.getName())
+    result.getKeywordArgument("resolver_method").getConstantValue().isStringOrSymbol(this.getName())
     or
     not exists(result.getKeywordArgument("resolver_method").(SymbolLiteral)) and
     result.getFieldName() = this.getName()

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -173,10 +173,11 @@ private module Settings {
   class NillableStringlikeSetting extends LiteralSetting {
     NillableStringlikeSetting() {
       value instanceof ConstantValue::ConstantStringValue or
+      value instanceof ConstantValue::ConstantSymbolValue or
       value instanceof ConstantValue::ConstantNilValue
     }
 
-    string getStringValue() { result = value.getString() }
+    string getStringValue() { result = value.getStringOrSymbol() }
 
     predicate isNilValue() { value.isNil() }
   }

--- a/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Rails.qll
@@ -137,16 +137,16 @@ private module Settings {
   }
 
   private class LiteralSetting extends Setting {
-    Literal valueLiteral;
+    ConstantValue value;
 
     LiteralSetting() {
       exists(DataFlow::LocalSourceNode lsn |
-        lsn.asExpr().getExpr() = valueLiteral and
+        lsn.asExpr().getConstantValue() = value and
         lsn.flowsTo(this.getArgument(0))
       )
     }
 
-    string getValueText() { result = valueLiteral.getValueText() }
+    string getValueText() { result = value.toString() }
 
     string getSettingString() { result = this.getMethodName() + this.getValueText() }
   }
@@ -155,16 +155,16 @@ private module Settings {
    * A node that sets a boolean value.
    */
   class BooleanSetting extends LiteralSetting {
-    override BooleanLiteral valueLiteral;
+    override ConstantValue::ConstantBooleanValue value;
 
-    boolean getValue() { result = valueLiteral.getValue() }
+    boolean getValue() { result = value.getBoolean() }
   }
 
   /**
    * A node that sets a Stringlike value.
    */
   class StringlikeSetting extends LiteralSetting {
-    override StringlikeLiteral valueLiteral;
+    override ConstantValue::ConstantStringValue value;
   }
 
   /**
@@ -172,13 +172,13 @@ private module Settings {
    */
   class NillableStringlikeSetting extends LiteralSetting {
     NillableStringlikeSetting() {
-      valueLiteral instanceof StringlikeLiteral or
-      valueLiteral instanceof NilLiteral
+      value instanceof ConstantValue::ConstantStringValue or
+      value instanceof ConstantValue::ConstantNilValue
     }
 
-    string getStringValue() { result = valueLiteral.(StringlikeLiteral).getValueText() }
+    string getStringValue() { result = value.getString() }
 
-    predicate isNilValue() { valueLiteral instanceof NilLiteral }
+    predicate isNilValue() { value.isNil() }
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/StandardLibrary.qll
@@ -484,7 +484,7 @@ private class ArrayIndex extends int {
 module Array {
   bindingset[arg]
   private DataFlow::Content::KnownArrayElementContent getKnownArrayElementContent(Expr arg) {
-    result.getIndex() = arg.getValueText().toInt()
+    result.getIndex() = arg.getConstantValue().getInt()
   }
 
   bindingset[arg]
@@ -915,9 +915,9 @@ module Array {
   private string getDigArg(MethodCall dig, int i) {
     dig.getMethodName() = "dig" and
     exists(Expr arg | arg = dig.getArgument(i) |
-      result = arg.getValueText().toInt().toString()
+      result = arg.getConstantValue().getInt().toString()
       or
-      not exists(arg.getValueText()) and
+      not exists(arg.getConstantValue()) and
       result = "?"
     )
   }
@@ -1271,7 +1271,7 @@ module Enumerable {
 
     DropKnownSummary() {
       this = "drop(" + i + ")" and
-      i = mc.getArgument(0).getValueText().toInt()
+      i = mc.getArgument(0).getConstantValue().getInt()
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
@@ -1291,7 +1291,7 @@ module Enumerable {
   private class DropUnknownSummary extends DropSummary {
     DropUnknownSummary() {
       this = "drop(index)" and
-      not exists(mc.getArgument(0).getValueText().toInt())
+      not exists(mc.getArgument(0).getConstantValue().getInt())
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
@@ -1462,7 +1462,7 @@ module Enumerable {
     private int n;
 
     FirstArgKnownSummary() {
-      this = "first(" + n + ")" and n = mc.getArgument(0).getValueText().toInt()
+      this = "first(" + n + ")" and n = mc.getArgument(0).getConstantValue().getInt()
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
@@ -1484,7 +1484,7 @@ module Enumerable {
     FirstArgUnknownSummary() {
       this = "first(?)" and
       mc.getNumberOfArguments() > 0 and
-      not exists(mc.getArgument(0).getValueText().toInt())
+      not exists(mc.getArgument(0).getConstantValue().getInt())
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {

--- a/ruby/ql/lib/codeql/ruby/frameworks/XmlParsing.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/XmlParsing.qll
@@ -54,7 +54,7 @@ private class LibXmlRubyXmlParserCall extends XmlParserCall::Range, DataFlow::Ca
   override predicate externalEntitiesEnabled() {
     exists(Pair pair |
       pair = this.getArgument(1).asExpr().getExpr().(HashLiteral).getAKeyValuePair() and
-      pair.getKey().(Literal).getValueText() = "options" and
+      pair.getKey().getConstantValue().isString("options") and
       pair.getValue() =
         [
           trackEnableFeature(TNOENT()), trackEnableFeature(TDTDLOAD()),

--- a/ruby/ql/lib/codeql/ruby/frameworks/XmlParsing.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/XmlParsing.qll
@@ -54,7 +54,7 @@ private class LibXmlRubyXmlParserCall extends XmlParserCall::Range, DataFlow::Ca
   override predicate externalEntitiesEnabled() {
     exists(Pair pair |
       pair = this.getArgument(1).asExpr().getExpr().(HashLiteral).getAKeyValuePair() and
-      pair.getKey().getConstantValue().isString("options") and
+      pair.getKey().getConstantValue().isStringOrSymbol("options") and
       pair.getValue() =
         [
           trackEnableFeature(TNOENT()), trackEnableFeature(TDTDLOAD()),

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -119,7 +119,7 @@ private predicate setsDefaultVerification(DataFlow::CallNode callNode, boolean v
 
 private predicate isSslVerifyPeerLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().(SymbolLiteral).getValueText() = "ssl_verify_peer" and
+    literal.asExpr().getExpr().getConstantValue().isString("ssl_verify_peer") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -119,7 +119,7 @@ private predicate setsDefaultVerification(DataFlow::CallNode callNode, boolean v
 
 private predicate isSslVerifyPeerLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().getConstantValue().isString("ssl_verify_peer") and
+    literal.asExpr().getExpr().getConstantValue().isStringOrSymbol("ssl_verify_peer") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
@@ -90,7 +90,7 @@ private predicate isSslOptionsPairDisablingValidation(Pair p) {
 /** Holds if `node` represents the symbol literal with the given `valueText`. */
 private predicate isSymbolLiteral(DataFlow::Node node, string valueText) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().(SymbolLiteral).getValueText() = valueText and
+    literal.asExpr().getExpr().getConstantValue().isString(valueText) and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
@@ -90,7 +90,7 @@ private predicate isSslOptionsPairDisablingValidation(Pair p) {
 /** Holds if `node` represents the symbol literal with the given `valueText`. */
 private predicate isSymbolLiteral(DataFlow::Node node, string valueText) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().getConstantValue().isString(valueText) and
+    literal.asExpr().getExpr().getConstantValue().isStringOrSymbol(valueText) and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -72,7 +72,7 @@ class HttpartyRequest extends HTTP::Client::Request::Range {
 /** Holds if `node` represents the symbol literal `verify` or `verify_peer`. */
 private predicate isVerifyLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().getConstantValue().isString(["verify", "verify_peer"]) and
+    literal.asExpr().getExpr().getConstantValue().isStringOrSymbol(["verify", "verify_peer"]) and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -72,7 +72,7 @@ class HttpartyRequest extends HTTP::Client::Request::Range {
 /** Holds if `node` represents the symbol literal `verify` or `verify_peer`. */
 private predicate isVerifyLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().(SymbolLiteral).getValueText() = ["verify", "verify_peer"] and
+    literal.asExpr().getExpr().getConstantValue().isString(["verify", "verify_peer"]) and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -111,7 +111,7 @@ private predicate isSslVerifyModeNonePair(Pair p) {
 /** Holds if `node` can represent the symbol literal `:ssl_verify_mode`. */
 private predicate isSslVerifyModeLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().(SymbolLiteral).getValueText() = "ssl_verify_mode" and
+    literal.asExpr().getExpr().getConstantValue().isString("ssl_verify_mode") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -111,7 +111,7 @@ private predicate isSslVerifyModeNonePair(Pair p) {
 /** Holds if `node` can represent the symbol literal `:ssl_verify_mode`. */
 private predicate isSslVerifyModeLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().getConstantValue().isString("ssl_verify_mode") and
+    literal.asExpr().getExpr().getConstantValue().isStringOrSymbol("ssl_verify_mode") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
@@ -80,7 +80,7 @@ private predicate isVerifySslNonePair(Pair p) {
 /** Holds if `node` can represent the symbol literal `:verify_ssl`. */
 private predicate isSslVerifyModeLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().getConstantValue().isString("verify_ssl") and
+    literal.asExpr().getExpr().getConstantValue().isStringOrSymbol("verify_ssl") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
@@ -80,7 +80,7 @@ private predicate isVerifySslNonePair(Pair p) {
 /** Holds if `node` can represent the symbol literal `:verify_ssl`. */
 private predicate isSslVerifyModeLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().(SymbolLiteral).getValueText() = "verify_ssl" and
+    literal.asExpr().getExpr().getConstantValue().isString("verify_ssl") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -62,7 +62,7 @@ private predicate isSslVerifyPeerFalsePair(Pair p) {
 /** Holds if `node` represents the symbol literal `verify` or `verify_peer`. */
 private predicate isSslVerifyPeerLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().(SymbolLiteral).getValueText() = "ssl_verifypeer" and
+    literal.asExpr().getExpr().getConstantValue().isString("ssl_verifypeer") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -62,7 +62,7 @@ private predicate isSslVerifyPeerFalsePair(Pair p) {
 /** Holds if `node` represents the symbol literal `verify` or `verify_peer`. */
 private predicate isSslVerifyPeerLiteral(DataFlow::Node node) {
   exists(DataFlow::LocalSourceNode literal |
-    literal.asExpr().getExpr().getConstantValue().isString("ssl_verifypeer") and
+    literal.asExpr().getExpr().getConstantValue().isStringOrSymbol("ssl_verifypeer") and
     literal.flowsTo(node)
   )
 }

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationCustomizations.qll
@@ -74,9 +74,9 @@ module UnsafeDeserialization {
   }
 
   private predicate isOjModePair(Pair p, string modeValue) {
-    p.getKey().getValueText() = "mode" and
+    p.getKey().getConstantValue().isString("mode") and
     exists(DataFlow::LocalSourceNode symbolLiteral, DataFlow::Node value |
-      symbolLiteral.asExpr().getExpr().(SymbolLiteral).getValueText() = modeValue and
+      symbolLiteral.asExpr().getExpr().getConstantValue().isString(modeValue) and
       symbolLiteral.flowsTo(value) and
       value.asExpr().getExpr() = p.getValue()
     )

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationCustomizations.qll
@@ -74,9 +74,9 @@ module UnsafeDeserialization {
   }
 
   private predicate isOjModePair(Pair p, string modeValue) {
-    p.getKey().getConstantValue().isString("mode") and
+    p.getKey().getConstantValue().isStringOrSymbol("mode") and
     exists(DataFlow::LocalSourceNode symbolLiteral, DataFlow::Node value |
-      symbolLiteral.asExpr().getExpr().getConstantValue().isString(modeValue) and
+      symbolLiteral.asExpr().getExpr().getConstantValue().isSymbol(modeValue) and
       symbolLiteral.flowsTo(value) and
       value.asExpr().getExpr() = p.getValue()
     )

--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -141,7 +141,7 @@ private module Shared {
     exists(RenderCall call, Pair kvPair |
       call.getLocals().getAKeyValuePair() = kvPair and
       kvPair.getValue() = value and
-      kvPair.getKey().getConstantValue().isString(hashKey) and
+      kvPair.getKey().getConstantValue().isStringOrSymbol(hashKey) and
       call.getTemplateFile() = erb
     )
   }
@@ -154,7 +154,7 @@ private module Shared {
       argNode.asExpr() = refNode.getArgument(0) and
       refNode.getReceiver().getExpr().(MethodCall).getMethodName() = "local_assigns" and
       argNode.getALocalSource() = DataFlow::exprNode(strNode) and
-      strNode.getExpr().getConstantValue().isString(hashKey) and
+      strNode.getExpr().getConstantValue().isStringOrSymbol(hashKey) and
       erb = refNode.getFile()
     )
   }

--- a/ruby/ql/lib/codeql/ruby/security/XSS.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XSS.qll
@@ -141,7 +141,7 @@ private module Shared {
     exists(RenderCall call, Pair kvPair |
       call.getLocals().getAKeyValuePair() = kvPair and
       kvPair.getValue() = value and
-      kvPair.getKey().getValueText() = hashKey and
+      kvPair.getKey().getConstantValue().isString(hashKey) and
       call.getTemplateFile() = erb
     )
   }
@@ -154,7 +154,7 @@ private module Shared {
       argNode.asExpr() = refNode.getArgument(0) and
       refNode.getReceiver().getExpr().(MethodCall).getMethodName() = "local_assigns" and
       argNode.getALocalSource() = DataFlow::exprNode(strNode) and
-      strNode.getExpr().getValueText() = hashKey and
+      strNode.getExpr().getConstantValue().isString(hashKey) and
       erb = refNode.getFile()
     )
   }

--- a/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
@@ -203,7 +203,7 @@ class RegExp extends AST::RegExpLiteral {
   }
 
   /** Gets the text of this regex */
-  string getText() { result = this.getValueText() }
+  string getText() { result = this.getConstantValue().getString() }
 
   string getChar(int i) { result = this.getText().charAt(i) }
 

--- a/ruby/ql/src/experimental/performance/UseDetect.ql
+++ b/ruby/ql/src/experimental/performance/UseDetect.ql
@@ -24,7 +24,7 @@ class EndCall extends MethodCall {
       this.getNumberOfArguments() = 0
       or
       this.getNumberOfArguments() = 1 and
-      this.getArgument(0).(IntegerLiteral).getValueText() = "0"
+      this.getArgument(0).getConstantValue().isInt(0)
     )
     or
     detect = "reverse_detect" and
@@ -33,7 +33,7 @@ class EndCall extends MethodCall {
       this.getNumberOfArguments() = 0
       or
       this.getNumberOfArguments() = 1 and
-      this.getArgument(0).(UnaryMinusExpr).getOperand().(IntegerLiteral).getValueText() = "1"
+      this.getArgument(0).getConstantValue().isInt(-1)
     )
   }
 

--- a/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
+++ b/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
@@ -40,7 +40,10 @@ class PermissivePermissionsExpr extends Expr {
     )
     or
     // adding/setting read or write permissions for all/group/other
-    this.(StringLiteral).getValueText().regexpMatch(".*[ago][^-=+]*[+=][xXst]*[rw].*")
+    this.(StringLiteral)
+        .getConstantValue()
+        .getString()
+        .regexpMatch(".*[ago][^-=+]*[+=][xXst]*[rw].*")
   }
 }
 

--- a/ruby/ql/test/TestUtilities/InlineFlowTest.qll
+++ b/ruby/ql/test/TestUtilities/InlineFlowTest.qll
@@ -68,7 +68,7 @@ class DefaultTaintFlowConf extends TaintTracking::Configuration {
 
 private string getSourceArgString(DataFlow::Node src) {
   defaultSource(src) and
-  src.asExpr().getExpr().(MethodCall).getAnArgument().getValueText() = result
+  src.asExpr().getExpr().(MethodCall).getAnArgument().getConstantValue().toString() = result
 }
 
 class InlineFlowTest extends InlineExpectationsTest {

--- a/ruby/ql/test/library-tests/ast/ValueText.expected
+++ b/ruby/ql/test/library-tests/ast/ValueText.expected
@@ -367,6 +367,8 @@
 | literals/literals.rb:12:1:12:1 | 0 | 0 |
 | literals/literals.rb:13:1:13:5 | 0d900 | 0 |
 | literals/literals.rb:16:1:16:6 | 0x1234 | 4660 |
+| literals/literals.rb:17:1:17:10 | 0xdeadbeef | -559038737 |
+| literals/literals.rb:18:1:18:11 | 0xF00D_face | -267519282 |
 | literals/literals.rb:21:1:21:4 | 0123 | 83 |
 | literals/literals.rb:22:1:22:5 | 0o234 | 156 |
 | literals/literals.rb:23:1:23:6 | 0O45_6 | 302 |

--- a/ruby/ql/test/library-tests/ast/ValueText.expected
+++ b/ruby/ql/test/library-tests/ast/ValueText.expected
@@ -214,7 +214,9 @@
 | control/cases.rb:101:18:101:19 | 10 | 10 |
 | control/cases.rb:102:6:102:9 | :foo | foo |
 | control/cases.rb:103:6:103:15 | :"foo bar" | foo bar |
+| control/cases.rb:104:6:104:7 | - ... | -5 |
 | control/cases.rb:104:7:104:7 | 5 | 5 |
+| control/cases.rb:104:11:104:13 | + ... | 10 |
 | control/cases.rb:104:12:104:13 | 10 | 10 |
 | control/cases.rb:105:7:105:7 | 1 | 1 |
 | control/cases.rb:106:7:106:7 | 0 | 0 |
@@ -355,29 +357,27 @@
 | gems/test.gemspec:9:3:9:12 | __synth__0 | https://github.com/github/codeql-ruby |
 | gems/test.gemspec:9:19:9:57 | "https://github.com/github/cod..." | https://github.com/github/codeql-ruby |
 | literals/literals.rb:2:1:2:3 | nil | nil |
-| literals/literals.rb:3:1:3:3 | NIL | NIL |
+| literals/literals.rb:3:1:3:3 | NIL | nil |
 | literals/literals.rb:4:1:4:5 | false | false |
-| literals/literals.rb:5:1:5:5 | FALSE | FALSE |
+| literals/literals.rb:5:1:5:5 | FALSE | false |
 | literals/literals.rb:6:1:6:4 | true | true |
-| literals/literals.rb:7:1:7:4 | TRUE | TRUE |
+| literals/literals.rb:7:1:7:4 | TRUE | true |
 | literals/literals.rb:10:1:10:4 | 1234 | 1234 |
-| literals/literals.rb:11:1:11:5 | 5_678 | 5_678 |
+| literals/literals.rb:11:1:11:5 | 5_678 | 5678 |
 | literals/literals.rb:12:1:12:1 | 0 | 0 |
-| literals/literals.rb:13:1:13:5 | 0d900 | 0d900 |
-| literals/literals.rb:16:1:16:6 | 0x1234 | 0x1234 |
-| literals/literals.rb:17:1:17:10 | 0xdeadbeef | 0xdeadbeef |
-| literals/literals.rb:18:1:18:11 | 0xF00D_face | 0xF00D_face |
-| literals/literals.rb:21:1:21:4 | 0123 | 0123 |
-| literals/literals.rb:22:1:22:5 | 0o234 | 0o234 |
-| literals/literals.rb:23:1:23:6 | 0O45_6 | 0O45_6 |
-| literals/literals.rb:26:1:26:10 | 0b10010100 | 0b10010100 |
-| literals/literals.rb:27:1:27:11 | 0B011_01101 | 0B011_01101 |
+| literals/literals.rb:13:1:13:5 | 0d900 | 0 |
+| literals/literals.rb:16:1:16:6 | 0x1234 | 4660 |
+| literals/literals.rb:21:1:21:4 | 0123 | 83 |
+| literals/literals.rb:22:1:22:5 | 0o234 | 156 |
+| literals/literals.rb:23:1:23:6 | 0O45_6 | 302 |
+| literals/literals.rb:26:1:26:10 | 0b10010100 | 148 |
+| literals/literals.rb:27:1:27:11 | 0B011_01101 | 109 |
 | literals/literals.rb:30:1:30:5 | 12.34 | 12.34 |
-| literals/literals.rb:31:1:31:7 | 1234e-2 | 1234e-2 |
-| literals/literals.rb:32:1:32:7 | 1.234E1 | 1.234E1 |
-| literals/literals.rb:35:1:35:3 | 23r | 23r |
-| literals/literals.rb:36:1:36:5 | 9.85r | 9.85r |
-| literals/literals.rb:39:1:39:2 | 2i | 2i |
+| literals/literals.rb:31:1:31:7 | 1234e-2 | 12.34 |
+| literals/literals.rb:32:1:32:7 | 1.234E1 | 12.34 |
+| literals/literals.rb:35:1:35:3 | 23r | 23/1 |
+| literals/literals.rb:36:1:36:5 | 9.85r | 985/100 |
+| literals/literals.rb:39:1:39:2 | 2i | 0+2i |
 | literals/literals.rb:46:1:46:2 | "" |  |
 | literals/literals.rb:47:1:47:2 | "" |  |
 | literals/literals.rb:48:1:48:7 | "hello" | hello |
@@ -633,7 +633,9 @@
 | operations/operations.rb:20:5:20:5 | 0 | 0 |
 | operations/operations.rb:23:2:23:2 | a | 0 |
 | operations/operations.rb:24:5:24:5 | b | 0 |
+| operations/operations.rb:25:1:25:3 | + ... | 14 |
 | operations/operations.rb:25:2:25:3 | 14 | 14 |
+| operations/operations.rb:26:1:26:2 | - ... | -7 |
 | operations/operations.rb:26:2:26:2 | 7 | 7 |
 | operations/operations.rb:27:2:27:2 | x | 0 |
 | operations/operations.rb:28:10:28:12 | foo | 0 |
@@ -674,9 +676,9 @@
 | operations/operations.rb:47:1:47:1 | y | 0 |
 | operations/operations.rb:47:6:47:7 | 16 | 16 |
 | operations/operations.rb:48:1:48:3 | foo | 0 |
-| operations/operations.rb:48:7:48:10 | 0xff | 0xff |
+| operations/operations.rb:48:7:48:10 | 0xff | 255 |
 | operations/operations.rb:49:1:49:3 | bar | 0 |
-| operations/operations.rb:49:7:49:10 | 0x02 | 0x02 |
+| operations/operations.rb:49:7:49:10 | 0x02 | 2 |
 | operations/operations.rb:50:1:50:3 | baz | 0 |
 | operations/operations.rb:50:7:50:9 | qux | 0 |
 | operations/operations.rb:53:1:53:1 | x | 0 |
@@ -724,7 +726,7 @@
 | operations/operations.rb:82:8:82:8 | 3 | 3 |
 | operations/operations.rb:83:9:83:12 | mask | 0 |
 | operations/operations.rb:84:2:84:4 | bar | 0 |
-| operations/operations.rb:84:9:84:12 | 0x01 | 0x01 |
+| operations/operations.rb:84:9:84:12 | 0x01 | 1 |
 | operations/operations.rb:85:2:85:4 | baz | 0 |
 | operations/operations.rb:85:9:85:11 | qux | 0 |
 | operations/operations.rb:88:8:88:8 | 1 | 1 |

--- a/ruby/ql/test/library-tests/ast/ValueText.expected
+++ b/ruby/ql/test/library-tests/ast/ValueText.expected
@@ -9,8 +9,8 @@
 | calls/calls.rb:26:7:26:7 | 1 | 1 |
 | calls/calls.rb:36:9:36:11 | 100 | 100 |
 | calls/calls.rb:36:14:36:16 | 200 | 200 |
-| calls/calls.rb:278:5:278:8 | :blah | blah |
-| calls/calls.rb:279:5:279:8 | :blah | blah |
+| calls/calls.rb:278:5:278:8 | :blah | :blah |
+| calls/calls.rb:279:5:279:8 | :blah | :blah |
 | calls/calls.rb:288:11:288:16 | "blah" | blah |
 | calls/calls.rb:289:11:289:11 | 1 | 1 |
 | calls/calls.rb:289:14:289:14 | 2 | 2 |
@@ -142,20 +142,20 @@
 | control/cases.rb:49:12:49:12 | 4 | 4 |
 | control/cases.rb:50:9:50:9 | 3 | 3 |
 | control/cases.rb:51:10:51:10 | 3 | 3 |
-| control/cases.rb:52:6:52:6 | :a | a |
-| control/cases.rb:53:6:53:6 | :a | a |
+| control/cases.rb:52:6:52:6 | :a | :a |
+| control/cases.rb:53:6:53:6 | :a | :a |
 | control/cases.rb:53:9:53:9 | 5 | 5 |
-| control/cases.rb:54:6:54:6 | :a | a |
+| control/cases.rb:54:6:54:6 | :a | :a |
 | control/cases.rb:54:9:54:9 | 5 | 5 |
-| control/cases.rb:55:6:55:6 | :a | a |
+| control/cases.rb:55:6:55:6 | :a | :a |
 | control/cases.rb:55:9:55:9 | 5 | 5 |
-| control/cases.rb:55:12:55:12 | :b | b |
-| control/cases.rb:56:6:56:6 | :a | a |
+| control/cases.rb:55:12:55:12 | :b | :b |
+| control/cases.rb:56:6:56:6 | :a | :a |
 | control/cases.rb:56:9:56:9 | 5 | 5 |
-| control/cases.rb:56:12:56:12 | :b | b |
-| control/cases.rb:57:6:57:6 | :a | a |
+| control/cases.rb:56:12:56:12 | :b | :b |
+| control/cases.rb:57:6:57:6 | :a | :a |
 | control/cases.rb:57:9:57:9 | 5 | 5 |
-| control/cases.rb:57:12:57:12 | :b | b |
+| control/cases.rb:57:12:57:12 | :b | :b |
 | control/cases.rb:59:7:59:7 | 5 | 5 |
 | control/cases.rb:60:7:60:7 | 5 | 5 |
 | control/cases.rb:61:7:61:7 | 1 | 1 |
@@ -177,28 +177,28 @@
 | control/cases.rb:68:14:68:14 | 4 | 4 |
 | control/cases.rb:69:10:69:10 | 3 | 3 |
 | control/cases.rb:70:11:70:11 | 3 | 3 |
-| control/cases.rb:71:7:71:7 | :a | a |
-| control/cases.rb:72:7:72:7 | :a | a |
+| control/cases.rb:71:7:71:7 | :a | :a |
+| control/cases.rb:72:7:72:7 | :a | :a |
 | control/cases.rb:72:10:72:10 | 5 | 5 |
-| control/cases.rb:73:7:73:7 | :a | a |
+| control/cases.rb:73:7:73:7 | :a | :a |
 | control/cases.rb:73:10:73:10 | 5 | 5 |
-| control/cases.rb:74:7:74:7 | :a | a |
+| control/cases.rb:74:7:74:7 | :a | :a |
 | control/cases.rb:74:10:74:10 | 5 | 5 |
-| control/cases.rb:74:13:74:13 | :b | b |
-| control/cases.rb:75:7:75:7 | :a | a |
+| control/cases.rb:74:13:74:13 | :b | :b |
+| control/cases.rb:75:7:75:7 | :a | :a |
 | control/cases.rb:75:10:75:10 | 5 | 5 |
-| control/cases.rb:75:13:75:13 | :b | b |
-| control/cases.rb:76:7:76:7 | :a | a |
+| control/cases.rb:75:13:75:13 | :b | :b |
+| control/cases.rb:76:7:76:7 | :a | :a |
 | control/cases.rb:76:10:76:10 | 5 | 5 |
-| control/cases.rb:76:13:76:13 | :b | b |
+| control/cases.rb:76:13:76:13 | :b | :b |
 | control/cases.rb:84:7:84:8 | 42 | 42 |
 | control/cases.rb:87:6:87:6 | 5 | 5 |
 | control/cases.rb:88:7:88:9 | foo | 42 |
 | control/cases.rb:89:6:89:13 | "string" | string |
 | control/cases.rb:90:9:90:11 | "foo" | foo |
 | control/cases.rb:90:13:90:15 | "bar" | bar |
-| control/cases.rb:91:9:91:11 | :"foo" | foo |
-| control/cases.rb:91:13:91:15 | :"bar" | bar |
+| control/cases.rb:91:9:91:11 | :"foo" | :foo |
+| control/cases.rb:91:13:91:15 | :"bar" | :bar |
 | control/cases.rb:92:6:92:17 | /.*abc[0-9]/ | .*abc[0-9] |
 | control/cases.rb:93:6:93:6 | 5 | 5 |
 | control/cases.rb:93:11:93:12 | 10 | 10 |
@@ -212,8 +212,8 @@
 | control/cases.rb:100:45:100:52 | __FILE__ | control/cases.rb |
 | control/cases.rb:100:56:100:67 | __ENCODING__ | UTF-8 |
 | control/cases.rb:101:18:101:19 | 10 | 10 |
-| control/cases.rb:102:6:102:9 | :foo | foo |
-| control/cases.rb:103:6:103:15 | :"foo bar" | foo bar |
+| control/cases.rb:102:6:102:9 | :foo | :foo |
+| control/cases.rb:103:6:103:15 | :"foo bar" | :foo bar |
 | control/cases.rb:104:6:104:7 | - ... | -5 |
 | control/cases.rb:104:7:104:7 | 5 | 5 |
 | control/cases.rb:104:11:104:13 | + ... | 10 |
@@ -227,14 +227,14 @@
 | control/cases.rb:130:11:130:11 | 1 | 1 |
 | control/cases.rb:130:14:130:14 | 2 | 2 |
 | control/cases.rb:131:18:131:18 | 1 | 1 |
-| control/cases.rb:139:7:139:7 | :x | x |
-| control/cases.rb:140:16:140:16 | :x | x |
+| control/cases.rb:139:7:139:7 | :x | :x |
+| control/cases.rb:140:16:140:16 | :x | :x |
 | control/cases.rb:140:18:140:18 | 1 | 1 |
-| control/cases.rb:141:16:141:16 | :x | x |
+| control/cases.rb:141:16:141:16 | :x | :x |
 | control/cases.rb:141:18:141:18 | 1 | 1 |
-| control/cases.rb:141:21:141:21 | :a | a |
-| control/cases.rb:142:11:142:11 | :y | y |
-| control/cases.rb:144:11:144:11 | :a | a |
+| control/cases.rb:141:21:141:21 | :a | :a |
+| control/cases.rb:142:11:142:11 | :y | :y |
+| control/cases.rb:144:11:144:11 | :a | :a |
 | control/cases.rb:144:14:144:14 | 1 | 1 |
 | control/conditionals.rb:2:5:2:5 | 0 | 0 |
 | control/conditionals.rb:3:5:3:5 | 0 | 0 |
@@ -301,15 +301,15 @@
 | control/loops.rb:16:13:16:14 | 10 | 10 |
 | control/loops.rb:22:5:22:7 | 0 | 0 |
 | control/loops.rb:22:10:22:14 | 1 | 1 |
-| control/loops.rb:22:20:22:22 | :foo | foo |
+| control/loops.rb:22:20:22:22 | :foo | :foo |
 | control/loops.rb:22:25:22:25 | 0 | 0 |
-| control/loops.rb:22:28:22:30 | :bar | bar |
+| control/loops.rb:22:28:22:30 | :bar | :bar |
 | control/loops.rb:22:33:22:33 | 1 | 1 |
 | control/loops.rb:28:6:28:8 | 0 | 0 |
 | control/loops.rb:28:11:28:15 | 1 | 1 |
-| control/loops.rb:28:22:28:24 | :foo | foo |
+| control/loops.rb:28:22:28:24 | :foo | :foo |
 | control/loops.rb:28:27:28:27 | 0 | 0 |
-| control/loops.rb:28:30:28:32 | :bar | bar |
+| control/loops.rb:28:30:28:32 | :bar | :bar |
 | control/loops.rb:28:35:28:35 | 1 | 1 |
 | control/loops.rb:35:11:35:11 | y | 0 |
 | control/loops.rb:36:8:36:8 | 1 | 1 |
@@ -436,22 +436,22 @@
 | literals/literals.rb:79:1:79:5 | ?\\M-a | ?\\M-a |
 | literals/literals.rb:80:1:80:8 | ?\\M-\\C-a | ?\\M-\\C-a |
 | literals/literals.rb:81:1:81:8 | ?\\C-\\M-a | ?\\C-\\M-a |
-| literals/literals.rb:84:1:84:3 | :"" |  |
-| literals/literals.rb:85:1:85:6 | :hello | hello |
-| literals/literals.rb:86:1:86:10 | :"foo bar" | foo bar |
-| literals/literals.rb:87:1:87:10 | :"bar baz" | bar baz |
-| literals/literals.rb:88:3:88:5 | :foo | foo |
+| literals/literals.rb:84:1:84:3 | :"" | : |
+| literals/literals.rb:85:1:85:6 | :hello | :hello |
+| literals/literals.rb:86:1:86:10 | :"foo bar" | :foo bar |
+| literals/literals.rb:87:1:87:10 | :"bar baz" | :bar baz |
+| literals/literals.rb:88:3:88:5 | :foo | :foo |
 | literals/literals.rb:88:8:88:12 | "bar" | bar |
-| literals/literals.rb:89:1:89:10 | :"wibble" | wibble |
-| literals/literals.rb:90:1:90:17 | :"wibble wobble" | wibble wobble |
-| literals/literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | foo_4_bar_bar |
+| literals/literals.rb:89:1:89:10 | :"wibble" | :wibble |
+| literals/literals.rb:90:1:90:17 | :"wibble wobble" | :wibble wobble |
+| literals/literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | :foo_4_bar_bar |
 | literals/literals.rb:91:10:91:10 | 2 | 2 |
 | literals/literals.rb:91:10:91:14 | ... + ... | 4 |
 | literals/literals.rb:91:14:91:14 | 2 | 2 |
 | literals/literals.rb:91:19:91:21 | bar | bar |
 | literals/literals.rb:91:26:91:28 | BAR | bar |
-| literals/literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | foo_#{ 2 + 2}_#{bar}_#{BAR} |
-| literals/literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | foo_#{ 3 - 2 } |
+| literals/literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | :foo_#{ 2 + 2}_#{bar}_#{BAR} |
+| literals/literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | :foo_#{ 3 - 2 } |
 | literals/literals.rb:97:2:97:2 | 1 | 1 |
 | literals/literals.rb:97:5:97:5 | 2 | 2 |
 | literals/literals.rb:97:8:97:8 | 3 | 3 |
@@ -484,38 +484,38 @@
 | literals/literals.rb:106:18:106:23 | "#{bar}" | #{bar} |
 | literals/literals.rb:106:25:106:30 | "#{BAR}" | #{BAR} |
 | literals/literals.rb:106:32:106:34 | "baz" | baz |
-| literals/literals.rb:110:4:110:6 | :"foo" | foo |
-| literals/literals.rb:110:8:110:10 | :"bar" | bar |
-| literals/literals.rb:110:12:110:14 | :"baz" | baz |
-| literals/literals.rb:111:4:111:6 | :"foo" | foo |
-| literals/literals.rb:111:8:111:10 | :"bar" | bar |
-| literals/literals.rb:111:12:111:14 | :"baz" | baz |
-| literals/literals.rb:112:4:112:6 | :"foo" | foo |
-| literals/literals.rb:112:8:112:20 | :"bar#{...}" | bar6 |
+| literals/literals.rb:110:4:110:6 | :"foo" | :foo |
+| literals/literals.rb:110:8:110:10 | :"bar" | :bar |
+| literals/literals.rb:110:12:110:14 | :"baz" | :baz |
+| literals/literals.rb:111:4:111:6 | :"foo" | :foo |
+| literals/literals.rb:111:8:111:10 | :"bar" | :bar |
+| literals/literals.rb:111:12:111:14 | :"baz" | :baz |
+| literals/literals.rb:112:4:112:6 | :"foo" | :foo |
+| literals/literals.rb:112:8:112:20 | :"bar#{...}" | :bar6 |
 | literals/literals.rb:112:14:112:14 | 2 | 2 |
 | literals/literals.rb:112:14:112:18 | ... + ... | 6 |
 | literals/literals.rb:112:18:112:18 | 4 | 4 |
-| literals/literals.rb:112:22:112:27 | :"#{...}" | bar |
+| literals/literals.rb:112:22:112:27 | :"#{...}" | :bar |
 | literals/literals.rb:112:24:112:26 | bar | bar |
-| literals/literals.rb:112:29:112:34 | :"#{...}" | bar |
+| literals/literals.rb:112:29:112:34 | :"#{...}" | :bar |
 | literals/literals.rb:112:31:112:33 | BAR | bar |
-| literals/literals.rb:112:36:112:38 | :"baz" | baz |
-| literals/literals.rb:113:4:113:6 | :"foo" | foo |
-| literals/literals.rb:113:8:113:12 | :"bar#{" | bar#{ |
-| literals/literals.rb:113:14:113:14 | :"2" | 2 |
-| literals/literals.rb:113:16:113:16 | :"+" | + |
-| literals/literals.rb:113:18:113:18 | :"4" | 4 |
-| literals/literals.rb:113:20:113:20 | :"}" | } |
-| literals/literals.rb:113:22:113:27 | :"#{bar}" | #{bar} |
-| literals/literals.rb:113:29:113:34 | :"#{BAR}" | #{BAR} |
-| literals/literals.rb:113:36:113:38 | :"baz" | baz |
-| literals/literals.rb:117:3:117:5 | :foo | foo |
+| literals/literals.rb:112:36:112:38 | :"baz" | :baz |
+| literals/literals.rb:113:4:113:6 | :"foo" | :foo |
+| literals/literals.rb:113:8:113:12 | :"bar#{" | :bar#{ |
+| literals/literals.rb:113:14:113:14 | :"2" | :2 |
+| literals/literals.rb:113:16:113:16 | :"+" | :+ |
+| literals/literals.rb:113:18:113:18 | :"4" | :4 |
+| literals/literals.rb:113:20:113:20 | :"}" | :} |
+| literals/literals.rb:113:22:113:27 | :"#{bar}" | :#{bar} |
+| literals/literals.rb:113:29:113:34 | :"#{BAR}" | :#{BAR} |
+| literals/literals.rb:113:36:113:38 | :"baz" | :baz |
+| literals/literals.rb:117:3:117:5 | :foo | :foo |
 | literals/literals.rb:117:8:117:8 | 1 | 1 |
-| literals/literals.rb:117:11:117:14 | :bar | bar |
+| literals/literals.rb:117:11:117:14 | :bar | :bar |
 | literals/literals.rb:117:19:117:19 | 2 | 2 |
 | literals/literals.rb:117:22:117:26 | "baz" | baz |
 | literals/literals.rb:117:31:117:31 | 3 | 3 |
-| literals/literals.rb:118:3:118:5 | :foo | foo |
+| literals/literals.rb:118:3:118:5 | :foo | :foo |
 | literals/literals.rb:118:8:118:8 | 7 | 7 |
 | literals/literals.rb:121:2:121:2 | 1 | 1 |
 | literals/literals.rb:121:5:121:6 | 10 | 10 |
@@ -572,11 +572,11 @@
 | misc/misc.erb:2:15:2:37 | "main_include_admin.js" | main_include_admin.js |
 | misc/misc.rb:1:7:1:11 | "bar" | bar |
 | misc/misc.rb:3:7:3:9 | foo | foo |
-| misc/misc.rb:3:12:3:15 | :foo | foo |
+| misc/misc.rb:3:12:3:15 | :foo | :foo |
 | misc/misc.rb:3:18:3:21 | foo= | foo= |
 | misc/misc.rb:3:24:3:25 | [] | [] |
 | misc/misc.rb:3:28:3:30 | []= | []= |
-| misc/misc.rb:4:7:4:19 | :"foo_#{...}" | foo_bar |
+| misc/misc.rb:4:7:4:19 | :"foo_#{...}" | :foo_bar |
 | misc/misc.rb:4:15:4:17 | bar | bar |
 | misc/misc.rb:5:7:5:9 | nil | nil |
 | misc/misc.rb:5:12:5:15 | true | true |
@@ -584,15 +584,15 @@
 | misc/misc.rb:5:25:5:29 | super | super |
 | misc/misc.rb:5:32:5:35 | self | self |
 | misc/misc.rb:7:7:7:9 | new | new |
-| misc/misc.rb:7:11:7:14 | :old | old |
+| misc/misc.rb:7:11:7:14 | :old | :old |
 | misc/misc.rb:8:7:8:10 | foo= | foo= |
 | misc/misc.rb:8:12:8:14 | []= | []= |
 | misc/misc.rb:9:7:9:11 | super | super |
 | misc/misc.rb:9:13:9:16 | self | self |
-| misc/misc.rb:10:7:10:17 | :"\\n#{...}" | \\nbar |
+| misc/misc.rb:10:7:10:17 | :"\\n#{...}" | :\\nbar |
 | misc/misc.rb:10:13:10:15 | bar | bar |
-| misc/misc.rb:10:19:10:24 | :"foo" | foo |
-| modules/classes.rb:11:28:11:31 | :baz | baz |
+| misc/misc.rb:10:19:10:24 | :"foo" | :foo |
+| modules/classes.rb:11:28:11:31 | :baz | :baz |
 | modules/classes.rb:22:10:22:12 | "a" | a |
 | modules/classes.rb:26:10:26:12 | "b" | b |
 | modules/classes.rb:30:17:30:19 | 123 | 123 |
@@ -641,11 +641,11 @@
 | operations/operations.rb:28:10:28:12 | foo | 0 |
 | operations/operations.rb:29:17:29:17 | 1 | 1 |
 | operations/operations.rb:29:22:29:22 | 2 | 2 |
-| operations/operations.rb:29:26:29:26 | :a | a |
+| operations/operations.rb:29:26:29:26 | :a | :a |
 | operations/operations.rb:29:28:29:28 | 3 | 3 |
-| operations/operations.rb:29:34:29:34 | :b | b |
+| operations/operations.rb:29:34:29:34 | :b | :b |
 | operations/operations.rb:29:36:29:36 | 4 | 4 |
-| operations/operations.rb:29:39:29:39 | :c | c |
+| operations/operations.rb:29:39:29:39 | :c | :c |
 | operations/operations.rb:29:41:29:41 | 5 | 5 |
 | operations/operations.rb:32:1:32:1 | w | 0 |
 | operations/operations.rb:32:1:32:7 | ... + ... | 234 |
@@ -736,9 +736,9 @@
 | operations/operations.rb:95:15:95:15 | 5 | 5 |
 | operations/operations.rb:96:16:96:16 | 6 | 6 |
 | params/params.rb:41:46:41:46 | 7 | 7 |
-| params/params.rb:47:19:47:21 | :bar | bar |
+| params/params.rb:47:19:47:21 | :bar | :bar |
 | params/params.rb:47:24:47:24 | 2 | 2 |
-| params/params.rb:47:27:47:29 | :foo | foo |
+| params/params.rb:47:27:47:29 | :foo | :foo |
 | params/params.rb:47:32:47:32 | 3 | 3 |
 | params/params.rb:49:37:49:39 | 100 | 100 |
 | params/params.rb:53:44:53:44 | 3 | 3 |

--- a/ruby/ql/test/library-tests/ast/ValueText.ql
+++ b/ruby/ql/test/library-tests/ast/ValueText.ql
@@ -1,4 +1,4 @@
 import ruby
 
 from Expr e
-select e, e.getValueText()
+select e, e.getConstantValue()

--- a/ruby/ql/test/library-tests/ast/literals/literals.expected
+++ b/ruby/ql/test/library-tests/ast/literals/literals.expected
@@ -10,8 +10,8 @@ allLiterals
 | literals.rb:12:1:12:1 | 0 | IntegerLiteral | 0 |
 | literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0 |
 | literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 4660 |
-| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | <none> |
-| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | <none> |
+| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | -559038737 |
+| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | -267519282 |
 | literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 83 |
 | literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 156 |
 | literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 302 |
@@ -739,8 +739,8 @@ numericLiterals
 | literals.rb:12:1:12:1 | 0 | IntegerLiteral | 0 |
 | literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0 |
 | literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 4660 |
-| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | <none> |
-| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | <none> |
+| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | -559038737 |
+| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | -267519282 |
 | literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 83 |
 | literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 156 |
 | literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 302 |
@@ -808,8 +808,8 @@ integerLiterals
 | literals.rb:12:1:12:1 | 0 | IntegerLiteral | 0 |
 | literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0 |
 | literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 4660 |
-| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | <none> |
-| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | <none> |
+| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | -559038737 |
+| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | -267519282 |
 | literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 83 |
 | literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 156 |
 | literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 302 |

--- a/ruby/ql/test/library-tests/ast/literals/literals.expected
+++ b/ruby/ql/test/library-tests/ast/literals/literals.expected
@@ -1,28 +1,28 @@
 allLiterals
 | literals.rb:2:1:2:3 | nil | NilLiteral | nil |
-| literals.rb:3:1:3:3 | NIL | NilLiteral | NIL |
+| literals.rb:3:1:3:3 | NIL | NilLiteral | nil |
 | literals.rb:4:1:4:5 | false | BooleanLiteral | false |
-| literals.rb:5:1:5:5 | FALSE | BooleanLiteral | FALSE |
+| literals.rb:5:1:5:5 | FALSE | BooleanLiteral | false |
 | literals.rb:6:1:6:4 | true | BooleanLiteral | true |
-| literals.rb:7:1:7:4 | TRUE | BooleanLiteral | TRUE |
+| literals.rb:7:1:7:4 | TRUE | BooleanLiteral | true |
 | literals.rb:10:1:10:4 | 1234 | IntegerLiteral | 1234 |
-| literals.rb:11:1:11:5 | 5_678 | IntegerLiteral | 5_678 |
+| literals.rb:11:1:11:5 | 5_678 | IntegerLiteral | 5678 |
 | literals.rb:12:1:12:1 | 0 | IntegerLiteral | 0 |
-| literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0d900 |
-| literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 0x1234 |
-| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | 0xdeadbeef |
-| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | 0xF00D_face |
-| literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 0123 |
-| literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 0o234 |
-| literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 0O45_6 |
-| literals.rb:26:1:26:10 | 0b10010100 | IntegerLiteral | 0b10010100 |
-| literals.rb:27:1:27:11 | 0B011_01101 | IntegerLiteral | 0B011_01101 |
+| literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0 |
+| literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 4660 |
+| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | <none> |
+| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | <none> |
+| literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 83 |
+| literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 156 |
+| literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 302 |
+| literals.rb:26:1:26:10 | 0b10010100 | IntegerLiteral | 148 |
+| literals.rb:27:1:27:11 | 0B011_01101 | IntegerLiteral | 109 |
 | literals.rb:30:1:30:5 | 12.34 | FloatLiteral | 12.34 |
-| literals.rb:31:1:31:7 | 1234e-2 | FloatLiteral | 1234e-2 |
-| literals.rb:32:1:32:7 | 1.234E1 | FloatLiteral | 1.234E1 |
-| literals.rb:35:1:35:3 | 23r | RationalLiteral | 23r |
-| literals.rb:36:1:36:5 | 9.85r | RationalLiteral | 9.85r |
-| literals.rb:39:1:39:2 | 2i | ComplexLiteral | 2i |
+| literals.rb:31:1:31:7 | 1234e-2 | FloatLiteral | 12.34 |
+| literals.rb:32:1:32:7 | 1.234E1 | FloatLiteral | 12.34 |
+| literals.rb:35:1:35:3 | 23r | RationalLiteral | 23/1 |
+| literals.rb:36:1:36:5 | 9.85r | RationalLiteral | 985/100 |
+| literals.rb:39:1:39:2 | 2i | ComplexLiteral | 0+2i |
 | literals.rb:46:1:46:2 | "" | StringLiteral |  |
 | literals.rb:47:1:47:2 | "" | StringLiteral |  |
 | literals.rb:48:1:48:7 | "hello" | StringLiteral | hello |
@@ -735,23 +735,23 @@ exclusiveRangeLiterals
 | literals.rb:122:2:122:7 | _ ... _ |
 numericLiterals
 | literals.rb:10:1:10:4 | 1234 | IntegerLiteral | 1234 |
-| literals.rb:11:1:11:5 | 5_678 | IntegerLiteral | 5_678 |
+| literals.rb:11:1:11:5 | 5_678 | IntegerLiteral | 5678 |
 | literals.rb:12:1:12:1 | 0 | IntegerLiteral | 0 |
-| literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0d900 |
-| literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 0x1234 |
-| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | 0xdeadbeef |
-| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | 0xF00D_face |
-| literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 0123 |
-| literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 0o234 |
-| literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 0O45_6 |
-| literals.rb:26:1:26:10 | 0b10010100 | IntegerLiteral | 0b10010100 |
-| literals.rb:27:1:27:11 | 0B011_01101 | IntegerLiteral | 0B011_01101 |
+| literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0 |
+| literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 4660 |
+| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | <none> |
+| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | <none> |
+| literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 83 |
+| literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 156 |
+| literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 302 |
+| literals.rb:26:1:26:10 | 0b10010100 | IntegerLiteral | 148 |
+| literals.rb:27:1:27:11 | 0B011_01101 | IntegerLiteral | 109 |
 | literals.rb:30:1:30:5 | 12.34 | FloatLiteral | 12.34 |
-| literals.rb:31:1:31:7 | 1234e-2 | FloatLiteral | 1234e-2 |
-| literals.rb:32:1:32:7 | 1.234E1 | FloatLiteral | 1.234E1 |
-| literals.rb:35:1:35:3 | 23r | RationalLiteral | 23r |
-| literals.rb:36:1:36:5 | 9.85r | RationalLiteral | 9.85r |
-| literals.rb:39:1:39:2 | 2i | ComplexLiteral | 2i |
+| literals.rb:31:1:31:7 | 1234e-2 | FloatLiteral | 12.34 |
+| literals.rb:32:1:32:7 | 1.234E1 | FloatLiteral | 12.34 |
+| literals.rb:35:1:35:3 | 23r | RationalLiteral | 23/1 |
+| literals.rb:36:1:36:5 | 9.85r | RationalLiteral | 985/100 |
+| literals.rb:39:1:39:2 | 2i | ComplexLiteral | 0+2i |
 | literals.rb:58:13:58:13 | 2 | IntegerLiteral | 2 |
 | literals.rb:58:17:58:17 | 2 | IntegerLiteral | 2 |
 | literals.rb:59:15:59:15 | 3 | IntegerLiteral | 3 |
@@ -804,17 +804,17 @@ numericLiterals
 | literals.rb:146:14:146:14 | 1 | IntegerLiteral | 1 |
 integerLiterals
 | literals.rb:10:1:10:4 | 1234 | IntegerLiteral | 1234 |
-| literals.rb:11:1:11:5 | 5_678 | IntegerLiteral | 5_678 |
+| literals.rb:11:1:11:5 | 5_678 | IntegerLiteral | 5678 |
 | literals.rb:12:1:12:1 | 0 | IntegerLiteral | 0 |
-| literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0d900 |
-| literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 0x1234 |
-| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | 0xdeadbeef |
-| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | 0xF00D_face |
-| literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 0123 |
-| literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 0o234 |
-| literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 0O45_6 |
-| literals.rb:26:1:26:10 | 0b10010100 | IntegerLiteral | 0b10010100 |
-| literals.rb:27:1:27:11 | 0B011_01101 | IntegerLiteral | 0B011_01101 |
+| literals.rb:13:1:13:5 | 0d900 | IntegerLiteral | 0 |
+| literals.rb:16:1:16:6 | 0x1234 | IntegerLiteral | 4660 |
+| literals.rb:17:1:17:10 | 0xdeadbeef | IntegerLiteral | <none> |
+| literals.rb:18:1:18:11 | 0xF00D_face | IntegerLiteral | <none> |
+| literals.rb:21:1:21:4 | 0123 | IntegerLiteral | 83 |
+| literals.rb:22:1:22:5 | 0o234 | IntegerLiteral | 156 |
+| literals.rb:23:1:23:6 | 0O45_6 | IntegerLiteral | 302 |
+| literals.rb:26:1:26:10 | 0b10010100 | IntegerLiteral | 148 |
+| literals.rb:27:1:27:11 | 0B011_01101 | IntegerLiteral | 109 |
 | literals.rb:58:13:58:13 | 2 | IntegerLiteral | 2 |
 | literals.rb:58:17:58:17 | 2 | IntegerLiteral | 2 |
 | literals.rb:59:15:59:15 | 3 | IntegerLiteral | 3 |
@@ -867,10 +867,10 @@ integerLiterals
 | literals.rb:146:14:146:14 | 1 | IntegerLiteral | 1 |
 floatLiterals
 | literals.rb:30:1:30:5 | 12.34 | FloatLiteral | 12.34 |
-| literals.rb:31:1:31:7 | 1234e-2 | FloatLiteral | 1234e-2 |
-| literals.rb:32:1:32:7 | 1.234E1 | FloatLiteral | 1.234E1 |
+| literals.rb:31:1:31:7 | 1234e-2 | FloatLiteral | 12.34 |
+| literals.rb:32:1:32:7 | 1.234E1 | FloatLiteral | 12.34 |
 rationalLiterals
-| literals.rb:35:1:35:3 | 23r | RationalLiteral | 23r |
-| literals.rb:36:1:36:5 | 9.85r | RationalLiteral | 9.85r |
+| literals.rb:35:1:35:3 | 23r | RationalLiteral | 23/1 |
+| literals.rb:36:1:36:5 | 9.85r | RationalLiteral | 985/100 |
 complexLiterals
-| literals.rb:39:1:39:2 | 2i | ComplexLiteral | 2i |
+| literals.rb:39:1:39:2 | 2i | ComplexLiteral | 0+2i |

--- a/ruby/ql/test/library-tests/ast/literals/literals.expected
+++ b/ruby/ql/test/library-tests/ast/literals/literals.expected
@@ -74,20 +74,20 @@ allLiterals
 | literals.rb:79:1:79:5 | ?\\M-a | CharacterLiteral | ?\\M-a |
 | literals.rb:80:1:80:8 | ?\\M-\\C-a | CharacterLiteral | ?\\M-\\C-a |
 | literals.rb:81:1:81:8 | ?\\C-\\M-a | CharacterLiteral | ?\\C-\\M-a |
-| literals.rb:84:1:84:3 | :"" | SymbolLiteral |  |
-| literals.rb:85:1:85:6 | :hello | SymbolLiteral | hello |
-| literals.rb:86:1:86:10 | :"foo bar" | SymbolLiteral | foo bar |
-| literals.rb:87:1:87:10 | :"bar baz" | SymbolLiteral | bar baz |
+| literals.rb:84:1:84:3 | :"" | SymbolLiteral | : |
+| literals.rb:85:1:85:6 | :hello | SymbolLiteral | :hello |
+| literals.rb:86:1:86:10 | :"foo bar" | SymbolLiteral | :foo bar |
+| literals.rb:87:1:87:10 | :"bar baz" | SymbolLiteral | :bar baz |
 | literals.rb:88:1:88:14 | {...} | HashLiteral | <none> |
-| literals.rb:88:3:88:5 | :foo | SymbolLiteral | foo |
+| literals.rb:88:3:88:5 | :foo | SymbolLiteral | :foo |
 | literals.rb:88:8:88:12 | "bar" | StringLiteral | bar |
-| literals.rb:89:1:89:10 | :"wibble" | SymbolLiteral | wibble |
-| literals.rb:90:1:90:17 | :"wibble wobble" | SymbolLiteral | wibble wobble |
-| literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | SymbolLiteral | foo_4_bar_bar |
+| literals.rb:89:1:89:10 | :"wibble" | SymbolLiteral | :wibble |
+| literals.rb:90:1:90:17 | :"wibble wobble" | SymbolLiteral | :wibble wobble |
+| literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | SymbolLiteral | :foo_4_bar_bar |
 | literals.rb:91:10:91:10 | 2 | IntegerLiteral | 2 |
 | literals.rb:91:14:91:14 | 2 | IntegerLiteral | 2 |
-| literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | SymbolLiteral | foo_#{ 2 + 2}_#{bar}_#{BAR} |
-| literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | SymbolLiteral | foo_#{ 3 - 2 } |
+| literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | SymbolLiteral | :foo_#{ 2 + 2}_#{bar}_#{BAR} |
+| literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | SymbolLiteral | :foo_#{ 3 - 2 } |
 | literals.rb:96:1:96:2 | [...] | ArrayLiteral | <none> |
 | literals.rb:97:1:97:9 | [...] | ArrayLiteral | <none> |
 | literals.rb:97:2:97:2 | 1 | IntegerLiteral | 1 |
@@ -128,41 +128,41 @@ allLiterals
 | literals.rb:106:32:106:34 | "baz" | StringLiteral | baz |
 | literals.rb:109:1:109:4 | %i(...) | ArrayLiteral | <none> |
 | literals.rb:110:1:110:15 | %i(...) | ArrayLiteral | <none> |
-| literals.rb:110:4:110:6 | :"foo" | SymbolLiteral | foo |
-| literals.rb:110:8:110:10 | :"bar" | SymbolLiteral | bar |
-| literals.rb:110:12:110:14 | :"baz" | SymbolLiteral | baz |
+| literals.rb:110:4:110:6 | :"foo" | SymbolLiteral | :foo |
+| literals.rb:110:8:110:10 | :"bar" | SymbolLiteral | :bar |
+| literals.rb:110:12:110:14 | :"baz" | SymbolLiteral | :baz |
 | literals.rb:111:1:111:15 | %i(...) | ArrayLiteral | <none> |
-| literals.rb:111:4:111:6 | :"foo" | SymbolLiteral | foo |
-| literals.rb:111:8:111:10 | :"bar" | SymbolLiteral | bar |
-| literals.rb:111:12:111:14 | :"baz" | SymbolLiteral | baz |
+| literals.rb:111:4:111:6 | :"foo" | SymbolLiteral | :foo |
+| literals.rb:111:8:111:10 | :"bar" | SymbolLiteral | :bar |
+| literals.rb:111:12:111:14 | :"baz" | SymbolLiteral | :baz |
 | literals.rb:112:1:112:39 | %i(...) | ArrayLiteral | <none> |
-| literals.rb:112:4:112:6 | :"foo" | SymbolLiteral | foo |
-| literals.rb:112:8:112:20 | :"bar#{...}" | SymbolLiteral | bar6 |
+| literals.rb:112:4:112:6 | :"foo" | SymbolLiteral | :foo |
+| literals.rb:112:8:112:20 | :"bar#{...}" | SymbolLiteral | :bar6 |
 | literals.rb:112:14:112:14 | 2 | IntegerLiteral | 2 |
 | literals.rb:112:18:112:18 | 4 | IntegerLiteral | 4 |
-| literals.rb:112:22:112:27 | :"#{...}" | SymbolLiteral | bar |
-| literals.rb:112:29:112:34 | :"#{...}" | SymbolLiteral | bar |
-| literals.rb:112:36:112:38 | :"baz" | SymbolLiteral | baz |
+| literals.rb:112:22:112:27 | :"#{...}" | SymbolLiteral | :bar |
+| literals.rb:112:29:112:34 | :"#{...}" | SymbolLiteral | :bar |
+| literals.rb:112:36:112:38 | :"baz" | SymbolLiteral | :baz |
 | literals.rb:113:1:113:39 | %i(...) | ArrayLiteral | <none> |
-| literals.rb:113:4:113:6 | :"foo" | SymbolLiteral | foo |
-| literals.rb:113:8:113:12 | :"bar#{" | SymbolLiteral | bar#{ |
-| literals.rb:113:14:113:14 | :"2" | SymbolLiteral | 2 |
-| literals.rb:113:16:113:16 | :"+" | SymbolLiteral | + |
-| literals.rb:113:18:113:18 | :"4" | SymbolLiteral | 4 |
-| literals.rb:113:20:113:20 | :"}" | SymbolLiteral | } |
-| literals.rb:113:22:113:27 | :"#{bar}" | SymbolLiteral | #{bar} |
-| literals.rb:113:29:113:34 | :"#{BAR}" | SymbolLiteral | #{BAR} |
-| literals.rb:113:36:113:38 | :"baz" | SymbolLiteral | baz |
+| literals.rb:113:4:113:6 | :"foo" | SymbolLiteral | :foo |
+| literals.rb:113:8:113:12 | :"bar#{" | SymbolLiteral | :bar#{ |
+| literals.rb:113:14:113:14 | :"2" | SymbolLiteral | :2 |
+| literals.rb:113:16:113:16 | :"+" | SymbolLiteral | :+ |
+| literals.rb:113:18:113:18 | :"4" | SymbolLiteral | :4 |
+| literals.rb:113:20:113:20 | :"}" | SymbolLiteral | :} |
+| literals.rb:113:22:113:27 | :"#{bar}" | SymbolLiteral | :#{bar} |
+| literals.rb:113:29:113:34 | :"#{BAR}" | SymbolLiteral | :#{BAR} |
+| literals.rb:113:36:113:38 | :"baz" | SymbolLiteral | :baz |
 | literals.rb:116:1:116:2 | {...} | HashLiteral | <none> |
 | literals.rb:117:1:117:33 | {...} | HashLiteral | <none> |
-| literals.rb:117:3:117:5 | :foo | SymbolLiteral | foo |
+| literals.rb:117:3:117:5 | :foo | SymbolLiteral | :foo |
 | literals.rb:117:8:117:8 | 1 | IntegerLiteral | 1 |
-| literals.rb:117:11:117:14 | :bar | SymbolLiteral | bar |
+| literals.rb:117:11:117:14 | :bar | SymbolLiteral | :bar |
 | literals.rb:117:19:117:19 | 2 | IntegerLiteral | 2 |
 | literals.rb:117:22:117:26 | "baz" | StringLiteral | baz |
 | literals.rb:117:31:117:31 | 3 | IntegerLiteral | 3 |
 | literals.rb:118:1:118:17 | {...} | HashLiteral | <none> |
-| literals.rb:118:3:118:5 | :foo | SymbolLiteral | foo |
+| literals.rb:118:3:118:5 | :foo | SymbolLiteral | :foo |
 | literals.rb:118:8:118:8 | 7 | IntegerLiteral | 7 |
 | literals.rb:121:2:121:2 | 1 | IntegerLiteral | 1 |
 | literals.rb:121:2:121:6 | _ .. _ | RangeLiteral | <none> |
@@ -250,17 +250,17 @@ stringlikeLiterals
 | literals.rb:68:7:68:11 | "bar" | bar |
 | literals.rb:69:1:69:14 | "foo #{...}" | foo bar |
 | literals.rb:70:1:70:14 | "foo #{...}" | foo bar |
-| literals.rb:84:1:84:3 | :"" |  |
-| literals.rb:85:1:85:6 | :hello | hello |
-| literals.rb:86:1:86:10 | :"foo bar" | foo bar |
-| literals.rb:87:1:87:10 | :"bar baz" | bar baz |
-| literals.rb:88:3:88:5 | :foo | foo |
+| literals.rb:84:1:84:3 | :"" | : |
+| literals.rb:85:1:85:6 | :hello | :hello |
+| literals.rb:86:1:86:10 | :"foo bar" | :foo bar |
+| literals.rb:87:1:87:10 | :"bar baz" | :bar baz |
+| literals.rb:88:3:88:5 | :foo | :foo |
 | literals.rb:88:8:88:12 | "bar" | bar |
-| literals.rb:89:1:89:10 | :"wibble" | wibble |
-| literals.rb:90:1:90:17 | :"wibble wobble" | wibble wobble |
-| literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | foo_4_bar_bar |
-| literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | foo_#{ 2 + 2}_#{bar}_#{BAR} |
-| literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | foo_#{ 3 - 2 } |
+| literals.rb:89:1:89:10 | :"wibble" | :wibble |
+| literals.rb:90:1:90:17 | :"wibble wobble" | :wibble wobble |
+| literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | :foo_4_bar_bar |
+| literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | :foo_#{ 2 + 2}_#{bar}_#{BAR} |
+| literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | :foo_#{ 3 - 2 } |
 | literals.rb:103:4:103:6 | "foo" | foo |
 | literals.rb:103:8:103:10 | "bar" | bar |
 | literals.rb:103:12:103:14 | "baz" | baz |
@@ -277,30 +277,30 @@ stringlikeLiterals
 | literals.rb:106:18:106:23 | "#{bar}" | #{bar} |
 | literals.rb:106:25:106:30 | "#{BAR}" | #{BAR} |
 | literals.rb:106:32:106:34 | "baz" | baz |
-| literals.rb:110:4:110:6 | :"foo" | foo |
-| literals.rb:110:8:110:10 | :"bar" | bar |
-| literals.rb:110:12:110:14 | :"baz" | baz |
-| literals.rb:111:4:111:6 | :"foo" | foo |
-| literals.rb:111:8:111:10 | :"bar" | bar |
-| literals.rb:111:12:111:14 | :"baz" | baz |
-| literals.rb:112:4:112:6 | :"foo" | foo |
-| literals.rb:112:8:112:20 | :"bar#{...}" | bar6 |
-| literals.rb:112:22:112:27 | :"#{...}" | bar |
-| literals.rb:112:29:112:34 | :"#{...}" | bar |
-| literals.rb:112:36:112:38 | :"baz" | baz |
-| literals.rb:113:4:113:6 | :"foo" | foo |
-| literals.rb:113:8:113:12 | :"bar#{" | bar#{ |
-| literals.rb:113:14:113:14 | :"2" | 2 |
-| literals.rb:113:16:113:16 | :"+" | + |
-| literals.rb:113:18:113:18 | :"4" | 4 |
-| literals.rb:113:20:113:20 | :"}" | } |
-| literals.rb:113:22:113:27 | :"#{bar}" | #{bar} |
-| literals.rb:113:29:113:34 | :"#{BAR}" | #{BAR} |
-| literals.rb:113:36:113:38 | :"baz" | baz |
-| literals.rb:117:3:117:5 | :foo | foo |
-| literals.rb:117:11:117:14 | :bar | bar |
+| literals.rb:110:4:110:6 | :"foo" | :foo |
+| literals.rb:110:8:110:10 | :"bar" | :bar |
+| literals.rb:110:12:110:14 | :"baz" | :baz |
+| literals.rb:111:4:111:6 | :"foo" | :foo |
+| literals.rb:111:8:111:10 | :"bar" | :bar |
+| literals.rb:111:12:111:14 | :"baz" | :baz |
+| literals.rb:112:4:112:6 | :"foo" | :foo |
+| literals.rb:112:8:112:20 | :"bar#{...}" | :bar6 |
+| literals.rb:112:22:112:27 | :"#{...}" | :bar |
+| literals.rb:112:29:112:34 | :"#{...}" | :bar |
+| literals.rb:112:36:112:38 | :"baz" | :baz |
+| literals.rb:113:4:113:6 | :"foo" | :foo |
+| literals.rb:113:8:113:12 | :"bar#{" | :bar#{ |
+| literals.rb:113:14:113:14 | :"2" | :2 |
+| literals.rb:113:16:113:16 | :"+" | :+ |
+| literals.rb:113:18:113:18 | :"4" | :4 |
+| literals.rb:113:20:113:20 | :"}" | :} |
+| literals.rb:113:22:113:27 | :"#{bar}" | :#{bar} |
+| literals.rb:113:29:113:34 | :"#{BAR}" | :#{BAR} |
+| literals.rb:113:36:113:38 | :"baz" | :baz |
+| literals.rb:117:3:117:5 | :foo | :foo |
+| literals.rb:117:11:117:14 | :bar | :bar |
 | literals.rb:117:22:117:26 | "baz" | baz |
-| literals.rb:118:3:118:5 | :foo | foo |
+| literals.rb:118:3:118:5 | :foo | :foo |
 | literals.rb:130:1:130:7 | `ls -l` | ls -l |
 | literals.rb:131:1:131:9 | `ls -l` | ls -l |
 | literals.rb:132:1:132:32 | `du -d #{...} #{...} #{...}` | du -d 2 bar bar |
@@ -402,39 +402,39 @@ regExpInterpolations
 | literals.rb:146:20:146:25 | #{...} | 0 | literals.rb:146:22:146:24 | bar | LocalVariableAccess |
 | literals.rb:146:26:146:31 | #{...} | 0 | literals.rb:146:28:146:30 | BAR | ConstantReadAccess |
 symbolLiterals
-| literals.rb:84:1:84:3 | :"" |  |
-| literals.rb:85:1:85:6 | :hello | hello |
-| literals.rb:86:1:86:10 | :"foo bar" | foo bar |
-| literals.rb:87:1:87:10 | :"bar baz" | bar baz |
-| literals.rb:88:3:88:5 | :foo | foo |
-| literals.rb:89:1:89:10 | :"wibble" | wibble |
-| literals.rb:90:1:90:17 | :"wibble wobble" | wibble wobble |
-| literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | foo_4_bar_bar |
-| literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | foo_#{ 2 + 2}_#{bar}_#{BAR} |
-| literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | foo_#{ 3 - 2 } |
-| literals.rb:110:4:110:6 | :"foo" | foo |
-| literals.rb:110:8:110:10 | :"bar" | bar |
-| literals.rb:110:12:110:14 | :"baz" | baz |
-| literals.rb:111:4:111:6 | :"foo" | foo |
-| literals.rb:111:8:111:10 | :"bar" | bar |
-| literals.rb:111:12:111:14 | :"baz" | baz |
-| literals.rb:112:4:112:6 | :"foo" | foo |
-| literals.rb:112:8:112:20 | :"bar#{...}" | bar6 |
-| literals.rb:112:22:112:27 | :"#{...}" | bar |
-| literals.rb:112:29:112:34 | :"#{...}" | bar |
-| literals.rb:112:36:112:38 | :"baz" | baz |
-| literals.rb:113:4:113:6 | :"foo" | foo |
-| literals.rb:113:8:113:12 | :"bar#{" | bar#{ |
-| literals.rb:113:14:113:14 | :"2" | 2 |
-| literals.rb:113:16:113:16 | :"+" | + |
-| literals.rb:113:18:113:18 | :"4" | 4 |
-| literals.rb:113:20:113:20 | :"}" | } |
-| literals.rb:113:22:113:27 | :"#{bar}" | #{bar} |
-| literals.rb:113:29:113:34 | :"#{BAR}" | #{BAR} |
-| literals.rb:113:36:113:38 | :"baz" | baz |
-| literals.rb:117:3:117:5 | :foo | foo |
-| literals.rb:117:11:117:14 | :bar | bar |
-| literals.rb:118:3:118:5 | :foo | foo |
+| literals.rb:84:1:84:3 | :"" | : |
+| literals.rb:85:1:85:6 | :hello | :hello |
+| literals.rb:86:1:86:10 | :"foo bar" | :foo bar |
+| literals.rb:87:1:87:10 | :"bar baz" | :bar baz |
+| literals.rb:88:3:88:5 | :foo | :foo |
+| literals.rb:89:1:89:10 | :"wibble" | :wibble |
+| literals.rb:90:1:90:17 | :"wibble wobble" | :wibble wobble |
+| literals.rb:91:1:91:30 | :"foo_#{...}_#{...}_#{...}" | :foo_4_bar_bar |
+| literals.rb:92:1:92:30 | :"foo_#{ 2 + 2}_#{bar}_#{BAR}" | :foo_#{ 2 + 2}_#{bar}_#{BAR} |
+| literals.rb:93:1:93:18 | :"foo_#{ 3 - 2 }" | :foo_#{ 3 - 2 } |
+| literals.rb:110:4:110:6 | :"foo" | :foo |
+| literals.rb:110:8:110:10 | :"bar" | :bar |
+| literals.rb:110:12:110:14 | :"baz" | :baz |
+| literals.rb:111:4:111:6 | :"foo" | :foo |
+| literals.rb:111:8:111:10 | :"bar" | :bar |
+| literals.rb:111:12:111:14 | :"baz" | :baz |
+| literals.rb:112:4:112:6 | :"foo" | :foo |
+| literals.rb:112:8:112:20 | :"bar#{...}" | :bar6 |
+| literals.rb:112:22:112:27 | :"#{...}" | :bar |
+| literals.rb:112:29:112:34 | :"#{...}" | :bar |
+| literals.rb:112:36:112:38 | :"baz" | :baz |
+| literals.rb:113:4:113:6 | :"foo" | :foo |
+| literals.rb:113:8:113:12 | :"bar#{" | :bar#{ |
+| literals.rb:113:14:113:14 | :"2" | :2 |
+| literals.rb:113:16:113:16 | :"+" | :+ |
+| literals.rb:113:18:113:18 | :"4" | :4 |
+| literals.rb:113:20:113:20 | :"}" | :} |
+| literals.rb:113:22:113:27 | :"#{bar}" | :#{bar} |
+| literals.rb:113:29:113:34 | :"#{BAR}" | :#{BAR} |
+| literals.rb:113:36:113:38 | :"baz" | :baz |
+| literals.rb:117:3:117:5 | :foo | :foo |
+| literals.rb:117:11:117:14 | :bar | :bar |
+| literals.rb:118:3:118:5 | :foo | :foo |
 subshellLiterals
 | literals.rb:130:1:130:7 | `ls -l` | ls -l |
 | literals.rb:131:1:131:9 | `ls -l` | ls -l |

--- a/ruby/ql/test/library-tests/ast/literals/literals.ql
+++ b/ruby/ql/test/library-tests/ast/literals/literals.ql
@@ -3,16 +3,16 @@ import ruby
 query predicate allLiterals(Literal l, string pClass, string valueText) {
   pClass = l.getAPrimaryQlClass() and
   (
-    valueText = l.getValueText()
+    valueText = l.getConstantValue().toString()
     or
-    not exists(l.getValueText()) and valueText = "<none>"
+    not exists(l.getConstantValue()) and valueText = "<none>"
   )
 }
 
 query predicate stringlikeLiterals(StringlikeLiteral l, string valueText) {
-  valueText = l.getValueText()
+  valueText = l.getConstantValue().toString()
   or
-  not exists(l.getValueText()) and valueText = "<none>"
+  not exists(l.getConstantValue()) and valueText = "<none>"
 }
 
 query predicate stringLiterals(StringLiteral l, string valueText) {

--- a/ruby/ql/test/library-tests/ast/misc/misc.ql
+++ b/ruby/ql/test/library-tests/ast/misc/misc.ql
@@ -1,9 +1,9 @@
 import ruby
 
 private string getValueText(MethodName m) {
-  result = m.getValueText()
+  result = m.getConstantValue().getString()
   or
-  not exists(m.getValueText()) and result = "(none)"
+  not exists(m.getConstantValue()) and result = "(none)"
 }
 
 query predicate undef(UndefStmt u, int i, MethodName m, string name, string pClass) {

--- a/ruby/ql/test/library-tests/ast/misc/misc.ql
+++ b/ruby/ql/test/library-tests/ast/misc/misc.ql
@@ -1,7 +1,7 @@
 import ruby
 
 private string getValueText(MethodName m) {
-  result = m.getConstantValue().getString()
+  result = m.getConstantValue().getStringOrSymbol()
   or
   not exists(m.getConstantValue()) and result = "(none)"
 }

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.ql
@@ -10,7 +10,7 @@ class Conf extends DataFlow::Configuration {
   Conf() { this = "Conf" }
 
   override predicate isSource(DataFlow::Node src) {
-    src.asExpr().getExpr().(StringLiteral).getValueText() = "taint"
+    src.asExpr().getExpr().(StringLiteral).getConstantValue().isString("taint")
   }
 
   override predicate isSink(DataFlow::Node sink) {

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -67,7 +67,7 @@ class Conf extends TaintTracking::Configuration {
   Conf() { this = "FlowSummaries" }
 
   override predicate isSource(DataFlow::Node src) {
-    src.asExpr().getExpr().(StringLiteral).getValueText() = "taint"
+    src.asExpr().getExpr().(StringLiteral).getConstantValue().isString("taint")
   }
 
   override predicate isSink(DataFlow::Node sink) {


### PR DESCRIPTION
This PR replaces `string getValueText()` with a typed `ConstantValue getConstantValue()` predicate. `ConstantValue` is a union type consisting of integers, floats, rationals, complex numbers, strings, Booleans, and `nil`.

Existing `getValueText` overloads have been replaced with appropriate `getConstantValue` overloads (e.g., `IntegerLiteral` now returns a `ConstantValue::ConstantIntegerValue`, as opposed to merely a string). This means that we can implement constant folding for binary operations appropriately, and I have also implemented constant folding for unary operations (`+x` and `-x`). As discussed on previous occasions, I have also removed the logic for truncating string concatenations `x + y`, and now such concatenations will simply have no value if the combined length exceeds 10,000.