### PR TITLE
VSCode: Autosave when running query

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "omnisharp.autoStart": false
+    "omnisharp.autoStart": false,
+    "codeQL.runningQueries.autoSave": true
 }


### PR DESCRIPTION
Configure VS Code to autosave when running a query from within the IDE. This prevents an annoying pop-up every time you attempt to execute a CodeQL query from a file that hasn't been saved yet. It also guarntees that what you're seeing in the IDE will be what gets exceuted by the CodeQL plugin.