### PR TITLE
Merge rc/3.3 into rc/3.4

### DIFF
--- a/docs/codeql/support/conf.py
+++ b/docs/codeql/support/conf.py
@@ -43,10 +43,10 @@ project = u'Supported languages and frameworks for LGTM Enterprise'
 # The short X.Y version.
 
 # LGTM Enterprise release
-release = u'1.28'
+release = u'1.30'
 
 # CodeQL CLI version used by LGTM Enterprise release
-version = u'2.5.9'
+version = u'2.7.6'
 
 # -- Project-specifc options for HTML output ----------------------------------------------
 

--- a/docs/codeql/support/framework-support.rst
+++ b/docs/codeql/support/framework-support.rst
@@ -5,6 +5,12 @@ LGTM Enterprise |release| includes CodeQL CLI |version|. The CodeQL libraries an
 
 .. pull-quote::
 
+    Note
+
+    For details of framework and library support in the most recent release of the CodeQL CLI, see `Supported languages and frameworks <https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/>`__ in the CodeQL CLI documentation.
+
+.. pull-quote::
+
     Tip
     
     If you're interested in other libraries or frameworks, you can extend the analysis to cover them. 

--- a/docs/codeql/support/language-support.rst
+++ b/docs/codeql/support/language-support.rst
@@ -3,6 +3,12 @@ Languages and compilers
 
 LGTM Enterprise |release| includes CodeQL CLI |version|. LGTM Enterprise supports analysis of the following languages compiled by the following compilers.
 
+.. pull-quote::
+
+    Note
+
+    For details of language and compiler support in the most recent release of the CodeQL CLI, see `Supported languages and frameworks <https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/>`__ in the CodeQL CLI documentation.
+
 Note that where there are several versions or dialects of a language, the supported variants are listed.
 If your code requires a particular version of a compiler, check that this version is included below. 
 If you have any questions about language and compiler support, you can find help on the `GitHub Security Lab discussions board <https://github.com/github/securitylab/discussions>`__.


### PR DESCRIPTION
@felicitymay this brings your help changes for the LGTM 1.29 docs into the LGTM 1.30 docs.

Conflicts in `*-support.rst` resolved in favour of `rc/3.3`, which has a new paragraph.
Enterprise version numbers updated to LGTM Enterprise 1.30 and CodeQL 2.7.6.
