### PR TITLE
Data flow: Restructure `RequiredSummaryComponentStack`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/FlowSummary.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/FlowSummary.qll
@@ -153,15 +153,11 @@ private class SummarizedCallableDefaultClearsContent extends Impl::Public::Summa
 class RequiredSummaryComponentStack = Impl::Public::RequiredSummaryComponentStack;
 
 private class RecordConstructorFlowRequiredSummaryComponentStack extends RequiredSummaryComponentStack {
-  private SummaryComponent head;
-
-  RecordConstructorFlowRequiredSummaryComponentStack() {
+  override predicate required(SummaryComponent head, SummaryComponentStack tail) {
     exists(Property p |
       recordConstructorFlow(_, _, p) and
       head = SummaryComponent::property(p) and
-      this = SummaryComponentStack::return()
+      tail = SummaryComponentStack::return()
     )
   }
-
-  override predicate required(SummaryComponent c) { c = head }
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -171,15 +171,20 @@ module Public {
     )
   }
 
+  private newtype TRequiredSummaryComponentStack = MkRequiredSummaryComponentStack()
+
   /**
    * A class that exists for QL technical reasons only (the IPA type used
    * to represent component stacks needs to be bounded).
    */
-  abstract class RequiredSummaryComponentStack extends SummaryComponentStack {
+  class RequiredSummaryComponentStack extends TRequiredSummaryComponentStack {
+    /** Gets a textual representation of this element. */
+    string toString() { none() }
+
     /**
      * Holds if the stack obtained by pushing `head` onto `tail` is required.
      */
-    abstract predicate required(SummaryComponent c);
+    predicate required(SummaryComponent head, SummaryComponentStack tail) { none() }
   }
 
   /** A callable with a flow summary. */
@@ -240,9 +245,9 @@ module Private {
   newtype TSummaryComponentStack =
     TSingletonSummaryComponentStack(SummaryComponent c) or
     TConsSummaryComponentStack(SummaryComponent head, SummaryComponentStack tail) {
-      tail.(RequiredSummaryComponentStack).required(head)
+      any(RequiredSummaryComponentStack x).required(head, tail)
       or
-      tail.(RequiredSummaryComponentStack).required(TParameterSummaryComponent(_)) and
+      any(RequiredSummaryComponentStack x).required(TParameterSummaryComponent(_), tail) and
       head = thisParam()
       or
       derivedFluentFlowPush(_, _, _, head, tail, _)
@@ -890,9 +895,9 @@ module Private {
     }
 
     private class MkStack extends RequiredSummaryComponentStack {
-      MkStack() { interpretSpec(_, _, _, this) }
-
-      override predicate required(SummaryComponent c) { interpretSpec(_, _, c, this) }
+      override predicate required(SummaryComponent head, SummaryComponentStack tail) {
+        interpretSpec(_, _, head, tail)
+      }
     }
 
     private class SummarizedCallableExternal extends SummarizedCallable {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -171,20 +171,15 @@ module Public {
     )
   }
 
-  private newtype TRequiredSummaryComponentStack = MkRequiredSummaryComponentStack()
-
   /**
    * A class that exists for QL technical reasons only (the IPA type used
    * to represent component stacks needs to be bounded).
    */
-  class RequiredSummaryComponentStack extends TRequiredSummaryComponentStack {
-    /** Gets a textual representation of this element. */
-    string toString() { none() }
-
+  class RequiredSummaryComponentStack extends Unit {
     /**
      * Holds if the stack obtained by pushing `head` onto `tail` is required.
      */
-    predicate required(SummaryComponent head, SummaryComponentStack tail) { none() }
+    abstract predicate required(SummaryComponent head, SummaryComponentStack tail);
   }
 
   /** A callable with a flow summary. */

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/EntityFramework.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/EntityFramework.qll
@@ -91,14 +91,10 @@ module EntityFramework {
   abstract class EFSummarizedCallable extends SummarizedCallable { }
 
   private class DbSetAddOrUpdateRequiredSummaryComponentStack extends RequiredSummaryComponentStack {
-    private SummaryComponent head;
-
-    DbSetAddOrUpdateRequiredSummaryComponentStack() {
-      this = SummaryComponentStack::argument([-1, 0]) and
-      head = SummaryComponent::element()
+    override predicate required(SummaryComponent head, SummaryComponentStack tail) {
+      head = SummaryComponent::element() and
+      tail = SummaryComponentStack::argument([-1, 0])
     }
-
-    override predicate required(SummaryComponent c) { c = head }
   }
 
   private class DbSetAddOrUpdate extends EFSummarizedCallable {
@@ -462,14 +458,12 @@ module EntityFramework {
   }
 
   private class DbContextSaveChangesRequiredSummaryComponentStack extends RequiredSummaryComponentStack {
-    private Content head;
-
-    DbContextSaveChangesRequiredSummaryComponentStack() {
-      any(DbContextClass c).requiresComponentStackIn(head, _, this, _)
-      or
-      any(DbContextClass c).requiresComponentStackOut(head, _, this, _)
+    override predicate required(SummaryComponent head, SummaryComponentStack tail) {
+      exists(Content c | head = SummaryComponent::content(c) |
+        any(DbContextClass cls).requiresComponentStackIn(c, _, tail, _)
+        or
+        any(DbContextClass cls).requiresComponentStackOut(c, _, tail, _)
+      )
     }
-
-    override predicate required(SummaryComponent c) { c = SummaryComponent::content(head) }
   }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -171,15 +171,20 @@ module Public {
     )
   }
 
+  private newtype TRequiredSummaryComponentStack = MkRequiredSummaryComponentStack()
+
   /**
    * A class that exists for QL technical reasons only (the IPA type used
    * to represent component stacks needs to be bounded).
    */
-  abstract class RequiredSummaryComponentStack extends SummaryComponentStack {
+  class RequiredSummaryComponentStack extends TRequiredSummaryComponentStack {
+    /** Gets a textual representation of this element. */
+    string toString() { none() }
+
     /**
      * Holds if the stack obtained by pushing `head` onto `tail` is required.
      */
-    abstract predicate required(SummaryComponent c);
+    predicate required(SummaryComponent head, SummaryComponentStack tail) { none() }
   }
 
   /** A callable with a flow summary. */
@@ -240,9 +245,9 @@ module Private {
   newtype TSummaryComponentStack =
     TSingletonSummaryComponentStack(SummaryComponent c) or
     TConsSummaryComponentStack(SummaryComponent head, SummaryComponentStack tail) {
-      tail.(RequiredSummaryComponentStack).required(head)
+      any(RequiredSummaryComponentStack x).required(head, tail)
       or
-      tail.(RequiredSummaryComponentStack).required(TParameterSummaryComponent(_)) and
+      any(RequiredSummaryComponentStack x).required(TParameterSummaryComponent(_), tail) and
       head = thisParam()
       or
       derivedFluentFlowPush(_, _, _, head, tail, _)
@@ -890,9 +895,9 @@ module Private {
     }
 
     private class MkStack extends RequiredSummaryComponentStack {
-      MkStack() { interpretSpec(_, _, _, this) }
-
-      override predicate required(SummaryComponent c) { interpretSpec(_, _, c, this) }
+      override predicate required(SummaryComponent head, SummaryComponentStack tail) {
+        interpretSpec(_, _, head, tail)
+      }
     }
 
     private class SummarizedCallableExternal extends SummarizedCallable {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -171,20 +171,15 @@ module Public {
     )
   }
 
-  private newtype TRequiredSummaryComponentStack = MkRequiredSummaryComponentStack()
-
   /**
    * A class that exists for QL technical reasons only (the IPA type used
    * to represent component stacks needs to be bounded).
    */
-  class RequiredSummaryComponentStack extends TRequiredSummaryComponentStack {
-    /** Gets a textual representation of this element. */
-    string toString() { none() }
-
+  class RequiredSummaryComponentStack extends Unit {
     /**
      * Holds if the stack obtained by pushing `head` onto `tail` is required.
      */
-    predicate required(SummaryComponent head, SummaryComponentStack tail) { none() }
+    abstract predicate required(SummaryComponent head, SummaryComponentStack tail);
   }
 
   /** A callable with a flow summary. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -171,15 +171,20 @@ module Public {
     )
   }
 
+  private newtype TRequiredSummaryComponentStack = MkRequiredSummaryComponentStack()
+
   /**
    * A class that exists for QL technical reasons only (the IPA type used
    * to represent component stacks needs to be bounded).
    */
-  abstract class RequiredSummaryComponentStack extends SummaryComponentStack {
+  class RequiredSummaryComponentStack extends TRequiredSummaryComponentStack {
+    /** Gets a textual representation of this element. */
+    string toString() { none() }
+
     /**
      * Holds if the stack obtained by pushing `head` onto `tail` is required.
      */
-    abstract predicate required(SummaryComponent c);
+    predicate required(SummaryComponent head, SummaryComponentStack tail) { none() }
   }
 
   /** A callable with a flow summary. */
@@ -240,9 +245,9 @@ module Private {
   newtype TSummaryComponentStack =
     TSingletonSummaryComponentStack(SummaryComponent c) or
     TConsSummaryComponentStack(SummaryComponent head, SummaryComponentStack tail) {
-      tail.(RequiredSummaryComponentStack).required(head)
+      any(RequiredSummaryComponentStack x).required(head, tail)
       or
-      tail.(RequiredSummaryComponentStack).required(TParameterSummaryComponent(_)) and
+      any(RequiredSummaryComponentStack x).required(TParameterSummaryComponent(_), tail) and
       head = thisParam()
       or
       derivedFluentFlowPush(_, _, _, head, tail, _)
@@ -890,9 +895,9 @@ module Private {
     }
 
     private class MkStack extends RequiredSummaryComponentStack {
-      MkStack() { interpretSpec(_, _, _, this) }
-
-      override predicate required(SummaryComponent c) { interpretSpec(_, _, c, this) }
+      override predicate required(SummaryComponent head, SummaryComponentStack tail) {
+        interpretSpec(_, _, head, tail)
+      }
     }
 
     private class SummarizedCallableExternal extends SummarizedCallable {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -171,20 +171,15 @@ module Public {
     )
   }
 
-  private newtype TRequiredSummaryComponentStack = MkRequiredSummaryComponentStack()
-
   /**
    * A class that exists for QL technical reasons only (the IPA type used
    * to represent component stacks needs to be bounded).
    */
-  class RequiredSummaryComponentStack extends TRequiredSummaryComponentStack {
-    /** Gets a textual representation of this element. */
-    string toString() { none() }
-
+  class RequiredSummaryComponentStack extends Unit {
     /**
      * Holds if the stack obtained by pushing `head` onto `tail` is required.
      */
-    predicate required(SummaryComponent head, SummaryComponentStack tail) { none() }
+    abstract predicate required(SummaryComponent head, SummaryComponentStack tail);
   }
 
   /** A callable with a flow summary. */


### PR DESCRIPTION
This avoids non-linear recursion through a self-join of `interpretSpec`:

```
[2022-01-21 09:04:55] (24s) Tuple counts for dom#FlowSummaryImpl::Private::TConsSummaryComponentStack#ff/2@i28#07224gwr after 14.1s:
                      0         ~0%         {2} r1 = SCAN FlowSummaryImpl::Private::derivedFluentFlowPush#ffffff#reorder_3_4_5_0_1_2#prev_delta OUTPUT In.1 'tail', In.0 'head'
                      
                      110216000 ~6471%      {2} r2 = JOIN FlowSummaryImpl::Private::External::interpretSpec#ffff#reorder_3_2_0_1#prev_delta WITH FlowSummaryImpl::Private::External::interpretSpec#ffff#reorder_3_2_0_1#prev ON FIRST 1 OUTPUT Lhs.0 'tail', Rhs.1 'head'
                      
                      110215000 ~6471%      {2} r3 = JOIN FlowSummaryImpl::Private::External::interpretSpec#ffff#reorder_3_2_0_1#prev WITH FlowSummaryImpl::Private::External::interpretSpec#ffff#reorder_3_2_0_1#prev_delta ON FIRST 1 OUTPUT Lhs.0, Rhs.1
                      
                      220431000 ~13042%     {2} r4 = r2 UNION r3
                      220431000 ~13042%     {2} r5 = r1 UNION r4
                      6027000   ~259%       {2} r6 = r5 AND NOT dom#FlowSummaryImpl::Private::TConsSummaryComponentStack#ff#prev(Lhs.1 'head', Lhs.0 'tail')
                      6027000   ~269%       {2} r7 = SCAN r6 OUTPUT In.1 'head', In.0 'tail'
                                            return r7
```