### PR TITLE
Java: Fix recursion in `entrypointFieldStep`

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -92,8 +92,6 @@ private module Cached {
     )
     or
     FlowSummaryImpl::Private::Steps::summaryLocalStep(src, sink, false)
-    or
-    entrypointFieldStep(src, sink)
   }
 
   /**
@@ -103,6 +101,7 @@ private module Cached {
   cached
   predicate defaultAdditionalTaintStep(DataFlow::Node src, DataFlow::Node sink) {
     localAdditionalTaintStep(src, sink) or
+    entrypointFieldStep(src, sink) or
     any(AdditionalTaintStep a).step(src, sink)
   }
 


### PR DESCRIPTION
This PR fixes a non-monotonic recursion introduced in github/codeql#6098 that reproduces under specific conditions.

When using local taint tracking to define a `RemoteFlowSource`, a recursion is created because `entrypointFieldStep` adds new `RemoteFlowSource`s, and is a local taint step at the same time.

This is fixed by converting `entrypointFieldStep` into a `defaultAdditionalTaintStep` instead of a `localAdditionalTaintStep`, i.e. it will only affect global taint tracking from now on.

Credits to @aschackmull for the final solution.