### PR TITLE
JS: Fix copy/paste error in XSS ML-powered queries results patterns

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.ql
@@ -23,5 +23,5 @@ where
   not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
   score = getScoreForFlow(source.getNode(), sink.getNode())
 select sink.getNode(), source, sink,
-  "(Experimental) This may be a cross-site scripting vulnerability due to $@. Identified using machine learning."
-    + "a user-provided value", score
+  "(Experimental) This may be a cross-site scripting vulnerability due to $@. Identified using machine learning.",
+  source.getNode(), "a user-provided value", score


### PR DESCRIPTION
We didn’t catch this because our unit tests test only library code due to the previous difficulty of running queries with an ML model (the ML models in packs work should fix that), and because the end-to-end evaluation runs separate queries that have different result patterns.

Going forward we should create unit tests for the queries themselves, which will require using the ML model in tests. We should also be able to catch this type of error using DCA.