### PR TITLE
Java: Remove some JNDI Injection sinks

### DIFF
--- a/java/ql/lib/semmle/code/java/security/JndiInjection.qll
+++ b/java/ql/lib/semmle/code/java/security/JndiInjection.qll
@@ -88,7 +88,12 @@ private class DefaultJndiInjectionSinkModel extends SinkModelCsv {
         // Spring
         "org.springframework.jndi;JndiTemplate;false;lookup;;;Argument[0];jndi-injection",
         // spring-ldap 1.2.x and newer
-        "org.springframework.ldap.core;LdapOperations;true;lookup;;;Argument[0];jndi-injection",
+        "org.springframework.ldap.core;LdapOperations;true;lookup;(Name);;Argument[0];jndi-injection",
+        "org.springframework.ldap.core;LdapOperations;true;lookup;(Name,ContextMapper);;Argument[0];jndi-injection",
+        "org.springframework.ldap.core;LdapOperations;true;lookup;(Name,String[],ContextMapper);;Argument[0];jndi-injection",
+        "org.springframework.ldap.core;LdapOperations;true;lookup;(String);;Argument[0];jndi-injection",
+        "org.springframework.ldap.core;LdapOperations;true;lookup;(String,ContextMapper);;Argument[0];jndi-injection",
+        "org.springframework.ldap.core;LdapOperations;true;lookup;(String,String[],ContextMapper);;Argument[0];jndi-injection",
         "org.springframework.ldap.core;LdapOperations;true;lookupContext;;;Argument[0];jndi-injection",
         "org.springframework.ldap.core;LdapOperations;true;findByDn;;;Argument[0];jndi-injection",
         "org.springframework.ldap.core;LdapOperations;true;rename;;;Argument[0];jndi-injection",

--- a/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.java
+++ b/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.java
@@ -110,7 +110,17 @@ public class JndiInjectionTest {
     LdapTemplate ctx = new LdapTemplate();
     Name name = new CompositeName().add(nameStr);
 
+    ctx.lookup(name); // $hasJndiInjection
+    ctx.lookup(name, (AttributesMapper) null); // Safe
+    ctx.lookup(name, (ContextMapper) null); // $hasJndiInjection
+    ctx.lookup(name, new String[] {}, (AttributesMapper) null); // Safe
+    ctx.lookup(name, new String[] {}, (ContextMapper) null); // $hasJndiInjection
     ctx.lookup(nameStr); // $hasJndiInjection
+    ctx.lookup(nameStr, (AttributesMapper) null); // Safe
+    ctx.lookup(nameStr, (ContextMapper) null); // $hasJndiInjection
+    ctx.lookup(nameStr, new String[] {}, (AttributesMapper) null); // Safe
+    ctx.lookup(nameStr, new String[] {}, (ContextMapper) null); // $hasJndiInjection
+    ctx.lookupContext(name); // $hasJndiInjection
     ctx.lookupContext(nameStr); // $hasJndiInjection
     ctx.findByDn(name, null); // $hasJndiInjection
     ctx.rename(name, null); // $hasJndiInjection

--- a/java/ql/test/query-tests/security/CWE-074/options
+++ b/java/ql/test/query-tests/security/CWE-074/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.3.8:${testdir}/../../../stubs/shiro-core-1.5.2:${testdir}/../../../stubs/spring-ldap-2.3.2:${testdir}/../../../stubs/Saxon-HE-9.9.1-7
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.3.8:${testdir}/../../../stubs/shiro-core-1.5.2:${testdir}/../../../stubs/spring-ldap-2.3.2:${testdir}/../../../stubs/Saxon-HE-9.9.1-7:${testdir}/../../../stubs/apache-commons-logging-1.2

--- a/java/ql/test/stubs/shiro-core-1.5.2/org/apache/shiro/jndi/JndiCallback.java
+++ b/java/ql/test/stubs/shiro-core-1.5.2/org/apache/shiro/jndi/JndiCallback.java
@@ -1,0 +1,10 @@
+// Generated automatically from org.apache.shiro.jndi.JndiCallback for testing purposes
+
+package org.apache.shiro.jndi;
+
+import javax.naming.Context;
+
+public interface JndiCallback
+{
+    Object doInContext(Context p0);
+}

--- a/java/ql/test/stubs/shiro-core-1.5.2/org/apache/shiro/jndi/JndiTemplate.java
+++ b/java/ql/test/stubs/shiro-core-1.5.2/org/apache/shiro/jndi/JndiTemplate.java
@@ -1,13 +1,22 @@
+// Generated automatically from org.apache.shiro.jndi.JndiTemplate for testing purposes
+
 package org.apache.shiro.jndi;
 
-import javax.naming.NamingException;
+import java.util.Properties;
+import javax.naming.Context;
+import org.apache.shiro.jndi.JndiCallback;
 
-public class JndiTemplate {
-  public Object lookup(final String name) throws NamingException {
-    return new Object();
-  }
-  
-  public Object lookup(String name, Class requiredType) throws NamingException {
-    return new Object();
-  }
+public class JndiTemplate
+{
+    protected Context createInitialContext(){ return null; }
+    public JndiTemplate(){}
+    public JndiTemplate(Properties p0){}
+    public Object execute(JndiCallback p0){ return null; }
+    public Object lookup(String p0){ return null; }
+    public Object lookup(String p0, Class p1){ return null; }
+    public Properties getEnvironment(){ return null; }
+    public void bind(String p0, Object p1){}
+    public void rebind(String p0, Object p1){}
+    public void setEnvironment(Properties p0){}
+    public void unbind(String p0){}
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/LdapDataEntry.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/LdapDataEntry.java
@@ -1,0 +1,25 @@
+// Generated automatically from org.springframework.LdapDataEntry for testing purposes
+
+package org.springframework;
+
+import java.util.SortedSet;
+import javax.naming.Name;
+import javax.naming.directory.Attributes;
+
+public interface LdapDataEntry
+{
+    Attributes getAttributes();
+    Name getDn();
+    Object getObjectAttribute(String p0);
+    Object[] getObjectAttributes(String p0);
+    SortedSet<String> getAttributeSortedStringSet(String p0);
+    String getStringAttribute(String p0);
+    String[] getStringAttributes(String p0);
+    boolean attributeExists(String p0);
+    void addAttributeValue(String p0, Object p1);
+    void addAttributeValue(String p0, Object p1, boolean p2);
+    void removeAttributeValue(String p0, Object p1);
+    void setAttributeValue(String p0, Object p1);
+    void setAttributeValues(String p0, Object[] p1);
+    void setAttributeValues(String p0, Object[] p1, boolean p2);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AttributeModificationsAware.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AttributeModificationsAware.java
@@ -1,0 +1,10 @@
+// Generated automatically from org.springframework.ldap.core.AttributeModificationsAware for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.directory.ModificationItem;
+
+public interface AttributeModificationsAware
+{
+    ModificationItem[] getModificationItems();
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AttributesMapper.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AttributesMapper.java
@@ -1,3 +1,10 @@
+// Generated automatically from org.springframework.ldap.core.AttributesMapper for testing purposes
+
 package org.springframework.ldap.core;
 
-public interface AttributesMapper<T> {}
+import javax.naming.directory.Attributes;
+
+public interface AttributesMapper<T>
+{
+    T mapFromAttributes(Attributes p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AuthenticatedLdapEntryContextCallback.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AuthenticatedLdapEntryContextCallback.java
@@ -1,0 +1,11 @@
+// Generated automatically from org.springframework.ldap.core.AuthenticatedLdapEntryContextCallback for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.directory.DirContext;
+import org.springframework.ldap.core.LdapEntryIdentification;
+
+public interface AuthenticatedLdapEntryContextCallback
+{
+    void executeWithContext(DirContext p0, LdapEntryIdentification p1);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AuthenticatedLdapEntryContextMapper.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AuthenticatedLdapEntryContextMapper.java
@@ -1,0 +1,11 @@
+// Generated automatically from org.springframework.ldap.core.AuthenticatedLdapEntryContextMapper for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.directory.DirContext;
+import org.springframework.ldap.core.LdapEntryIdentification;
+
+public interface AuthenticatedLdapEntryContextMapper<T>
+{
+    T mapWithContext(DirContext p0, LdapEntryIdentification p1);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AuthenticationErrorCallback.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AuthenticationErrorCallback.java
@@ -1,0 +1,9 @@
+// Generated automatically from org.springframework.ldap.core.AuthenticationErrorCallback for testing purposes
+
+package org.springframework.ldap.core;
+
+
+public interface AuthenticationErrorCallback
+{
+    void execute(Exception p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextExecutor.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextExecutor.java
@@ -1,0 +1,10 @@
+// Generated automatically from org.springframework.ldap.core.ContextExecutor for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.directory.DirContext;
+
+public interface ContextExecutor<T>
+{
+    T executeWithContext(DirContext p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextMapper.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextMapper.java
@@ -1,4 +1,9 @@
+// Generated automatically from org.springframework.ldap.core.ContextMapper for testing purposes
+
 package org.springframework.ldap.core;
 
-public interface ContextMapper<T> {
+
+public interface ContextMapper<T>
+{
+    T mapFromContext(Object p0);
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextSource.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextSource.java
@@ -1,0 +1,12 @@
+// Generated automatically from org.springframework.ldap.core.ContextSource for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.directory.DirContext;
+
+public interface ContextSource
+{
+    DirContext getContext(String p0, String p1);
+    DirContext getReadOnlyContext();
+    DirContext getReadWriteContext();
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextOperations.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextOperations.java
@@ -1,4 +1,19 @@
+// Generated automatically from org.springframework.ldap.core.DirContextOperations for testing purposes
+
 package org.springframework.ldap.core;
 
-public interface DirContextOperations {
+import javax.naming.Name;
+import javax.naming.directory.DirContext;
+import org.springframework.LdapDataEntry;
+import org.springframework.ldap.core.AttributeModificationsAware;
+
+public interface DirContextOperations extends AttributeModificationsAware, DirContext, LdapDataEntry
+{
+    String getNameInNamespace();
+    String getReferralUrl();
+    String[] getNamesOfModifiedAttributes();
+    boolean isReferral();
+    boolean isUpdateMode();
+    void setDn(Name p0);
+    void update();
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextProcessor.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextProcessor.java
@@ -1,3 +1,11 @@
+// Generated automatically from org.springframework.ldap.core.DirContextProcessor for testing purposes
+
 package org.springframework.ldap.core;
 
-public interface DirContextProcessor {}
+import javax.naming.directory.DirContext;
+
+public interface DirContextProcessor
+{
+    void postProcess(DirContext p0);
+    void preProcess(DirContext p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DistinguishedName.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DistinguishedName.java
@@ -1,0 +1,60 @@
+// Generated automatically from org.springframework.ldap.core.DistinguishedName for testing purposes
+
+package org.springframework.ldap.core;
+
+import java.util.Enumeration;
+import java.util.List;
+import javax.naming.Name;
+import org.springframework.ldap.core.LdapRdn;
+
+public class DistinguishedName implements Name
+{
+    protected final void parse(String p0){}
+    public DistinguishedName append(DistinguishedName p0){ return null; }
+    public DistinguishedName append(String p0, String p1){ return null; }
+    public DistinguishedName immutableDistinguishedName(){ return null; }
+    public DistinguishedName(){}
+    public DistinguishedName(List p0){}
+    public DistinguishedName(Name p0){}
+    public DistinguishedName(String p0){}
+    public Enumeration getAll(){ return null; }
+    public LdapRdn getLdapRdn(String p0){ return null; }
+    public LdapRdn getLdapRdn(int p0){ return null; }
+    public LdapRdn removeFirst(){ return null; }
+    public LdapRdn removeLast(){ return null; }
+    public List getNames(){ return null; }
+    public Name add(String p0){ return null; }
+    public Name add(int p0, String p1){ return null; }
+    public Name addAll(Name p0){ return null; }
+    public Name addAll(int p0, Name p1){ return null; }
+    public Name getPrefix(int p0){ return null; }
+    public Name getSuffix(int p0){ return null; }
+    public Object clone(){ return null; }
+    public Object remove(int p0){ return null; }
+    public String encode(){ return null; }
+    public String get(int p0){ return null; }
+    public String getValue(String p0){ return null; }
+    public String toCompactString(){ return null; }
+    public String toString(){ return null; }
+    public String toUrl(){ return null; }
+    public boolean contains(DistinguishedName p0){ return false; }
+    public boolean endsWith(Name p0){ return false; }
+    public boolean equals(Object p0){ return false; }
+    public boolean isEmpty(){ return false; }
+    public boolean startsWith(Name p0){ return false; }
+    public int compareTo(Object p0){ return 0; }
+    public int hashCode(){ return 0; }
+    public int size(){ return 0; }
+    public static DistinguishedName EMPTY_PATH = null;
+    public static DistinguishedName immutableDistinguishedName(String p0){ return null; }
+    public static String KEY_CASE_FOLD_LOWER = null;
+    public static String KEY_CASE_FOLD_NONE = null;
+    public static String KEY_CASE_FOLD_PROPERTY = null;
+    public static String KEY_CASE_FOLD_UPPER = null;
+    public static String SPACED_DN_FORMAT_PROPERTY = null;
+    public void add(LdapRdn p0){}
+    public void add(String p0, String p1){}
+    public void add(int p0, LdapRdn p1){}
+    public void prepend(DistinguishedName p0){}
+    public void removeFirst(Name p0){}
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapEntryIdentification.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapEntryIdentification.java
@@ -1,0 +1,19 @@
+// Generated automatically from org.springframework.ldap.core.LdapEntryIdentification for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.ldap.LdapName;
+import org.springframework.ldap.core.DistinguishedName;
+
+public class LdapEntryIdentification
+{
+    protected LdapEntryIdentification() {}
+    public DistinguishedName getAbsoluteDn(){ return null; }
+    public DistinguishedName getRelativeDn(){ return null; }
+    public LdapEntryIdentification(DistinguishedName p0, DistinguishedName p1){}
+    public LdapEntryIdentification(LdapName p0, LdapName p1){}
+    public LdapName getAbsoluteName(){ return null; }
+    public LdapName getRelativeName(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public int hashCode(){ return 0; }
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapOperations.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapOperations.java
@@ -1,84 +1,129 @@
+// Generated automatically from org.springframework.ldap.core.LdapOperations for testing purposes
+
 package org.springframework.ldap.core;
 
-import java.util.*;
-
+import java.util.List;
 import javax.naming.Name;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchControls;
-
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.AuthenticatedLdapEntryContextCallback;
+import org.springframework.ldap.core.AuthenticatedLdapEntryContextMapper;
+import org.springframework.ldap.core.AuthenticationErrorCallback;
+import org.springframework.ldap.core.ContextExecutor;
+import org.springframework.ldap.core.ContextMapper;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.DirContextProcessor;
+import org.springframework.ldap.core.NameClassPairCallbackHandler;
+import org.springframework.ldap.core.NameClassPairMapper;
+import org.springframework.ldap.core.SearchExecutor;
 import org.springframework.ldap.filter.Filter;
-
+import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
 import org.springframework.ldap.query.LdapQuery;
 
-public interface LdapOperations {
-    void authenticate(LdapQuery query, String password);
-
-    boolean authenticate(Name base, String filter, String password);
-
-    <T> List<T> find(Name base, Filter filter, SearchControls searchControls, final Class<T> clazz);
-
-    <T> List<T> find(LdapQuery query, Class<T> clazz);
-
-    <T> T findOne(LdapQuery query, Class<T> clazz);
-
-    void search(String base, String filter, int searchScope, boolean returningObjFlag,
-            NameClassPairCallbackHandler handler);
-
-    void search(final String base, final String filter, final SearchControls controls,
-            NameClassPairCallbackHandler handler);
-
-    void search(final String base, final String filter, final SearchControls controls,
-            NameClassPairCallbackHandler handler, DirContextProcessor processor);
-
-    void search(String base, String filter, NameClassPairCallbackHandler handler);
-
-    <T> List<T> search(String base, String filter, int searchScope, String[] attrs,
-            AttributesMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, int searchScope, AttributesMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, AttributesMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, int searchScope, String[] attrs,
-            ContextMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, int searchScope, ContextMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, ContextMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, SearchControls controls,
-            ContextMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, SearchControls controls,
-            AttributesMapper<T> mapper);
-
-    <T> List<T> search(String base, String filter, SearchControls controls,
-            AttributesMapper<T> mapper, DirContextProcessor processor);
-
-    <T> List<T> search(String base, String filter, SearchControls controls, ContextMapper<T> mapper,
-            DirContextProcessor processor);
-
-    DirContextOperations searchForContext(LdapQuery query);
-
-    <T> T searchForObject(Name base, String filter, ContextMapper<T> mapper);
-
-    <T> T searchForObject(String base, String filter, ContextMapper<T> mapper);
-
-    <T> T searchForObject(String base, String filter, SearchControls searchControls,
-            ContextMapper<T> mapper);
-
-    Object lookup(final String dn);
-
-    DirContextOperations lookupContext(String dn);
-
-    <T> T findByDn(Name dn, final Class<T> clazz);
-
-    void rename(final Name oldDn, final Name newDn);
-
-    List<String> list(final Name base);
-
-    List<String> listBindings(final Name base);
-
-    void unbind(final String dn);
-
-    void unbind(final String dn, boolean recursive);
+public interface LdapOperations
+{
+    <T> List<T> find(LdapQuery p0, Class<T> p1);
+    <T> List<T> find(Name p0, Filter p1, SearchControls p2, Class<T> p3);
+    <T> List<T> findAll(Class<T> p0);
+    <T> List<T> findAll(Name p0, SearchControls p1, Class<T> p2);
+    <T> List<T> list(Name p0, NameClassPairMapper<T> p1);
+    <T> List<T> list(String p0, NameClassPairMapper<T> p1);
+    <T> List<T> listBindings(Name p0, ContextMapper<T> p1);
+    <T> List<T> listBindings(Name p0, NameClassPairMapper<T> p1);
+    <T> List<T> listBindings(String p0, ContextMapper<T> p1);
+    <T> List<T> listBindings(String p0, NameClassPairMapper<T> p1);
+    <T> List<T> search(LdapQuery p0, AttributesMapper<T> p1);
+    <T> List<T> search(LdapQuery p0, ContextMapper<T> p1);
+    <T> List<T> search(Name p0, String p1, AttributesMapper<T> p2);
+    <T> List<T> search(Name p0, String p1, ContextMapper<T> p2);
+    <T> List<T> search(Name p0, String p1, SearchControls p2, AttributesMapper<T> p3);
+    <T> List<T> search(Name p0, String p1, SearchControls p2, AttributesMapper<T> p3, DirContextProcessor p4);
+    <T> List<T> search(Name p0, String p1, SearchControls p2, ContextMapper<T> p3);
+    <T> List<T> search(Name p0, String p1, SearchControls p2, ContextMapper<T> p3, DirContextProcessor p4);
+    <T> List<T> search(Name p0, String p1, int p2, AttributesMapper<T> p3);
+    <T> List<T> search(Name p0, String p1, int p2, ContextMapper<T> p3);
+    <T> List<T> search(Name p0, String p1, int p2, String[] p3, AttributesMapper<T> p4);
+    <T> List<T> search(Name p0, String p1, int p2, String[] p3, ContextMapper<T> p4);
+    <T> List<T> search(String p0, String p1, AttributesMapper<T> p2);
+    <T> List<T> search(String p0, String p1, ContextMapper<T> p2);
+    <T> List<T> search(String p0, String p1, SearchControls p2, AttributesMapper<T> p3);
+    <T> List<T> search(String p0, String p1, SearchControls p2, AttributesMapper<T> p3, DirContextProcessor p4);
+    <T> List<T> search(String p0, String p1, SearchControls p2, ContextMapper<T> p3);
+    <T> List<T> search(String p0, String p1, SearchControls p2, ContextMapper<T> p3, DirContextProcessor p4);
+    <T> List<T> search(String p0, String p1, int p2, AttributesMapper<T> p3);
+    <T> List<T> search(String p0, String p1, int p2, ContextMapper<T> p3);
+    <T> List<T> search(String p0, String p1, int p2, String[] p3, AttributesMapper<T> p4);
+    <T> List<T> search(String p0, String p1, int p2, String[] p3, ContextMapper<T> p4);
+    <T> T authenticate(LdapQuery p0, String p1, AuthenticatedLdapEntryContextMapper<T> p2);
+    <T> T executeReadOnly(ContextExecutor<T> p0);
+    <T> T executeReadWrite(ContextExecutor<T> p0);
+    <T> T findByDn(Name p0, Class<T> p1);
+    <T> T findOne(LdapQuery p0, Class<T> p1);
+    <T> T lookup(Name p0, AttributesMapper<T> p1);
+    <T> T lookup(Name p0, ContextMapper<T> p1);
+    <T> T lookup(Name p0, String[] p1, AttributesMapper<T> p2);
+    <T> T lookup(Name p0, String[] p1, ContextMapper<T> p2);
+    <T> T lookup(String p0, AttributesMapper<T> p1);
+    <T> T lookup(String p0, ContextMapper<T> p1);
+    <T> T lookup(String p0, String[] p1, AttributesMapper<T> p2);
+    <T> T lookup(String p0, String[] p1, ContextMapper<T> p2);
+    <T> T searchForObject(LdapQuery p0, ContextMapper<T> p1);
+    <T> T searchForObject(Name p0, String p1, ContextMapper<T> p2);
+    <T> T searchForObject(Name p0, String p1, SearchControls p2, ContextMapper<T> p3);
+    <T> T searchForObject(String p0, String p1, ContextMapper<T> p2);
+    <T> T searchForObject(String p0, String p1, SearchControls p2, ContextMapper<T> p3);
+    DirContextOperations lookupContext(Name p0);
+    DirContextOperations lookupContext(String p0);
+    DirContextOperations searchForContext(LdapQuery p0);
+    List<String> list(Name p0);
+    List<String> list(String p0);
+    List<String> listBindings(Name p0);
+    List<String> listBindings(String p0);
+    Object lookup(Name p0);
+    Object lookup(String p0);
+    ObjectDirectoryMapper getObjectDirectoryMapper();
+    boolean authenticate(Name p0, String p1, String p2);
+    boolean authenticate(Name p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3);
+    boolean authenticate(Name p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3, AuthenticationErrorCallback p4);
+    boolean authenticate(Name p0, String p1, String p2, AuthenticationErrorCallback p3);
+    boolean authenticate(String p0, String p1, String p2);
+    boolean authenticate(String p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3);
+    boolean authenticate(String p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3, AuthenticationErrorCallback p4);
+    boolean authenticate(String p0, String p1, String p2, AuthenticationErrorCallback p3);
+    void authenticate(LdapQuery p0, String p1);
+    void bind(DirContextOperations p0);
+    void bind(Name p0, Object p1, Attributes p2);
+    void bind(String p0, Object p1, Attributes p2);
+    void create(Object p0);
+    void delete(Object p0);
+    void list(Name p0, NameClassPairCallbackHandler p1);
+    void list(String p0, NameClassPairCallbackHandler p1);
+    void listBindings(Name p0, NameClassPairCallbackHandler p1);
+    void listBindings(String p0, NameClassPairCallbackHandler p1);
+    void modifyAttributes(DirContextOperations p0);
+    void modifyAttributes(Name p0, ModificationItem[] p1);
+    void modifyAttributes(String p0, ModificationItem[] p1);
+    void rebind(DirContextOperations p0);
+    void rebind(Name p0, Object p1, Attributes p2);
+    void rebind(String p0, Object p1, Attributes p2);
+    void rename(Name p0, Name p1);
+    void rename(String p0, String p1);
+    void search(LdapQuery p0, NameClassPairCallbackHandler p1);
+    void search(Name p0, String p1, NameClassPairCallbackHandler p2);
+    void search(Name p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3);
+    void search(Name p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3, DirContextProcessor p4);
+    void search(Name p0, String p1, int p2, boolean p3, NameClassPairCallbackHandler p4);
+    void search(SearchExecutor p0, NameClassPairCallbackHandler p1);
+    void search(SearchExecutor p0, NameClassPairCallbackHandler p1, DirContextProcessor p2);
+    void search(String p0, String p1, NameClassPairCallbackHandler p2);
+    void search(String p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3);
+    void search(String p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3, DirContextProcessor p4);
+    void search(String p0, String p1, int p2, boolean p3, NameClassPairCallbackHandler p4);
+    void unbind(Name p0);
+    void unbind(Name p0, boolean p1);
+    void unbind(String p0);
+    void unbind(String p0, boolean p1);
+    void update(Object p0);
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapRdn.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapRdn.java
@@ -1,0 +1,28 @@
+// Generated automatically from org.springframework.ldap.core.LdapRdn for testing purposes
+
+package org.springframework.ldap.core;
+
+import java.io.Serializable;
+import java.util.List;
+import org.springframework.ldap.core.LdapRdnComponent;
+
+public class LdapRdn implements Comparable, Serializable
+{
+    public LdapRdn immutableLdapRdn(){ return null; }
+    public LdapRdn(){}
+    public LdapRdn(String p0){}
+    public LdapRdn(String p0, String p1){}
+    public LdapRdnComponent getComponent(){ return null; }
+    public LdapRdnComponent getComponent(int p0){ return null; }
+    public List getComponents(){ return null; }
+    public String encodeUrl(){ return null; }
+    public String getKey(){ return null; }
+    public String getLdapEncoded(){ return null; }
+    public String getValue(){ return null; }
+    public String getValue(String p0){ return null; }
+    public String toString(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public int compareTo(Object p0){ return 0; }
+    public int hashCode(){ return 0; }
+    public void addComponent(LdapRdnComponent p0){}
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapRdnComponent.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapRdnComponent.java
@@ -1,0 +1,25 @@
+// Generated automatically from org.springframework.ldap.core.LdapRdnComponent for testing purposes
+
+package org.springframework.ldap.core;
+
+import java.io.Serializable;
+
+public class LdapRdnComponent implements Comparable, Serializable
+{
+    protected LdapRdnComponent() {}
+    protected String encodeLdap(){ return null; }
+    public LdapRdnComponent immutableLdapRdnComponent(){ return null; }
+    public LdapRdnComponent(String p0, String p1){}
+    public LdapRdnComponent(String p0, String p1, boolean p2){}
+    public String encodeUrl(){ return null; }
+    public String getKey(){ return null; }
+    public String getLdapEncoded(){ return null; }
+    public String getValue(){ return null; }
+    public String toString(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public int compareTo(Object p0){ return 0; }
+    public int hashCode(){ return 0; }
+    public static boolean DONT_DECODE_VALUE = false;
+    public void setKey(String p0){}
+    public void setValue(String p0){}
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapTemplate.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapTemplate.java
@@ -1,76 +1,146 @@
+// Generated automatically from org.springframework.ldap.core.LdapTemplate for testing purposes
+
 package org.springframework.ldap.core;
 
-import org.springframework.beans.factory.InitializingBean;
-
-import java.util.*;
-
+import java.util.List;
 import javax.naming.Name;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchControls;
-
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.AuthenticatedLdapEntryContextCallback;
+import org.springframework.ldap.core.AuthenticatedLdapEntryContextMapper;
+import org.springframework.ldap.core.AuthenticationErrorCallback;
+import org.springframework.ldap.core.ContextExecutor;
+import org.springframework.ldap.core.ContextMapper;
+import org.springframework.ldap.core.ContextSource;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.DirContextProcessor;
+import org.springframework.ldap.core.LdapOperations;
+import org.springframework.ldap.core.NameClassPairCallbackHandler;
+import org.springframework.ldap.core.NameClassPairMapper;
+import org.springframework.ldap.core.SearchExecutor;
 import org.springframework.ldap.filter.Filter;
-
+import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
 import org.springframework.ldap.query.LdapQuery;
 
-public class LdapTemplate implements LdapOperations, InitializingBean {
-  public void authenticate(LdapQuery query, String password) { }
-
-  public boolean authenticate(Name base, String filter, String password) { return true; }
-
-  public <T> List<T> find(Name base, Filter filter, SearchControls searchControls, final Class<T> clazz) { return null; }
-
-  public <T> List<T> find(LdapQuery query, Class<T> clazz) { return null; }
-
-  public <T> T findOne(LdapQuery query, Class<T> clazz) { return null; }
-
-  public void search(String base, String filter, int searchScope, boolean returningObjFlag, NameClassPairCallbackHandler handler) { }
-
-  public void search(final String base, final String filter, final SearchControls controls, NameClassPairCallbackHandler handler) {}
-
-  public void search(final String base, final String filter, final SearchControls controls, NameClassPairCallbackHandler handler, DirContextProcessor processor) {}
-
-  public void search(String base, String filter, NameClassPairCallbackHandler handler) {}
-
-  public <T> List<T> search(String base, String filter, int searchScope, String[] attrs, AttributesMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, int searchScope, AttributesMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, AttributesMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, int searchScope, String[] attrs, ContextMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, int searchScope, ContextMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, ContextMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, SearchControls controls, ContextMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, SearchControls controls, AttributesMapper<T> mapper) { return null; }
-
-  public <T> List<T> search(String base, String filter, SearchControls controls, AttributesMapper<T> mapper, DirContextProcessor processor) { return null; }
-
-  public <T> List<T> search(String base, String filter, SearchControls controls, ContextMapper<T> mapper, DirContextProcessor processor) { return null; }
-
-  public DirContextOperations searchForContext(LdapQuery query) { return null; }
-
-  public <T> T searchForObject(Name base, String filter, ContextMapper<T> mapper) { return null; }
-
-  public <T> T searchForObject(String base, String filter, ContextMapper<T> mapper) { return null; }
-
-  public <T> T searchForObject(String base, String filter, SearchControls searchControls, ContextMapper<T> mapper) { return null; }
-
-  public Object lookup(final String dn) { return new Object(); }
-
-  public DirContextOperations lookupContext(String dn) { return null; }
-
-  public <T> T findByDn(Name dn, final Class<T> clazz) { return null; }
-
-  public void rename(final Name oldDn, final Name newDn) {}
-
-  public List<String> list(final Name base) { return null; }
-
-  public List<String> listBindings(final Name base) { return null; }
-
-  public void unbind(final String dn) {}
-
-  public void unbind(final String dn, boolean recursive) {}
+public class LdapTemplate implements InitializingBean, LdapOperations
+{
+    protected void deleteRecursively(DirContext p0, Name p1){}
+    public <T> List<T> find(LdapQuery p0, Class<T> p1){ return null; }
+    public <T> List<T> find(Name p0, Filter p1, SearchControls p2, Class<T> p3){ return null; }
+    public <T> List<T> findAll(Class<T> p0){ return null; }
+    public <T> List<T> findAll(Name p0, SearchControls p1, Class<T> p2){ return null; }
+    public <T> List<T> list(Name p0, NameClassPairMapper<T> p1){ return null; }
+    public <T> List<T> list(String p0, NameClassPairMapper<T> p1){ return null; }
+    public <T> List<T> listBindings(Name p0, ContextMapper<T> p1){ return null; }
+    public <T> List<T> listBindings(Name p0, NameClassPairMapper<T> p1){ return null; }
+    public <T> List<T> listBindings(String p0, ContextMapper<T> p1){ return null; }
+    public <T> List<T> listBindings(String p0, NameClassPairMapper<T> p1){ return null; }
+    public <T> List<T> search(LdapQuery p0, AttributesMapper<T> p1){ return null; }
+    public <T> List<T> search(LdapQuery p0, ContextMapper<T> p1){ return null; }
+    public <T> List<T> search(Name p0, String p1, AttributesMapper<T> p2){ return null; }
+    public <T> List<T> search(Name p0, String p1, ContextMapper<T> p2){ return null; }
+    public <T> List<T> search(Name p0, String p1, SearchControls p2, AttributesMapper<T> p3){ return null; }
+    public <T> List<T> search(Name p0, String p1, SearchControls p2, AttributesMapper<T> p3, DirContextProcessor p4){ return null; }
+    public <T> List<T> search(Name p0, String p1, SearchControls p2, ContextMapper<T> p3){ return null; }
+    public <T> List<T> search(Name p0, String p1, SearchControls p2, ContextMapper<T> p3, DirContextProcessor p4){ return null; }
+    public <T> List<T> search(Name p0, String p1, int p2, AttributesMapper<T> p3){ return null; }
+    public <T> List<T> search(Name p0, String p1, int p2, ContextMapper<T> p3){ return null; }
+    public <T> List<T> search(Name p0, String p1, int p2, String[] p3, AttributesMapper<T> p4){ return null; }
+    public <T> List<T> search(Name p0, String p1, int p2, String[] p3, ContextMapper<T> p4){ return null; }
+    public <T> List<T> search(String p0, String p1, AttributesMapper<T> p2){ return null; }
+    public <T> List<T> search(String p0, String p1, ContextMapper<T> p2){ return null; }
+    public <T> List<T> search(String p0, String p1, SearchControls p2, AttributesMapper<T> p3){ return null; }
+    public <T> List<T> search(String p0, String p1, SearchControls p2, AttributesMapper<T> p3, DirContextProcessor p4){ return null; }
+    public <T> List<T> search(String p0, String p1, SearchControls p2, ContextMapper<T> p3){ return null; }
+    public <T> List<T> search(String p0, String p1, SearchControls p2, ContextMapper<T> p3, DirContextProcessor p4){ return null; }
+    public <T> List<T> search(String p0, String p1, int p2, AttributesMapper<T> p3){ return null; }
+    public <T> List<T> search(String p0, String p1, int p2, ContextMapper<T> p3){ return null; }
+    public <T> List<T> search(String p0, String p1, int p2, String[] p3, AttributesMapper<T> p4){ return null; }
+    public <T> List<T> search(String p0, String p1, int p2, String[] p3, ContextMapper<T> p4){ return null; }
+    public <T> T authenticate(LdapQuery p0, String p1, AuthenticatedLdapEntryContextMapper<T> p2){ return null; }
+    public <T> T executeReadOnly(ContextExecutor<T> p0){ return null; }
+    public <T> T executeReadWrite(ContextExecutor<T> p0){ return null; }
+    public <T> T findByDn(Name p0, Class<T> p1){ return null; }
+    public <T> T findOne(LdapQuery p0, Class<T> p1){ return null; }
+    public <T> T lookup(Name p0, AttributesMapper<T> p1){ return null; }
+    public <T> T lookup(Name p0, ContextMapper<T> p1){ return null; }
+    public <T> T lookup(Name p0, String[] p1, AttributesMapper<T> p2){ return null; }
+    public <T> T lookup(Name p0, String[] p1, ContextMapper<T> p2){ return null; }
+    public <T> T lookup(String p0, AttributesMapper<T> p1){ return null; }
+    public <T> T lookup(String p0, ContextMapper<T> p1){ return null; }
+    public <T> T lookup(String p0, String[] p1, AttributesMapper<T> p2){ return null; }
+    public <T> T lookup(String p0, String[] p1, ContextMapper<T> p2){ return null; }
+    public <T> T searchForObject(LdapQuery p0, ContextMapper<T> p1){ return null; }
+    public <T> T searchForObject(Name p0, String p1, ContextMapper<T> p2){ return null; }
+    public <T> T searchForObject(Name p0, String p1, SearchControls p2, ContextMapper<T> p3){ return null; }
+    public <T> T searchForObject(String p0, String p1, ContextMapper<T> p2){ return null; }
+    public <T> T searchForObject(String p0, String p1, SearchControls p2, ContextMapper<T> p3){ return null; }
+    public ContextSource getContextSource(){ return null; }
+    public DirContextOperations lookupContext(Name p0){ return null; }
+    public DirContextOperations lookupContext(String p0){ return null; }
+    public DirContextOperations searchForContext(LdapQuery p0){ return null; }
+    public LdapTemplate(){}
+    public LdapTemplate(ContextSource p0){}
+    public List<String> list(Name p0){ return null; }
+    public List<String> list(String p0){ return null; }
+    public List<String> listBindings(Name p0){ return null; }
+    public List<String> listBindings(String p0){ return null; }
+    public Object lookup(Name p0){ return null; }
+    public Object lookup(String p0){ return null; }
+    public ObjectDirectoryMapper getObjectDirectoryMapper(){ return null; }
+    public boolean authenticate(Name p0, String p1, String p2){ return false; }
+    public boolean authenticate(Name p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3){ return false; }
+    public boolean authenticate(Name p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3, AuthenticationErrorCallback p4){ return false; }
+    public boolean authenticate(Name p0, String p1, String p2, AuthenticationErrorCallback p3){ return false; }
+    public boolean authenticate(String p0, String p1, String p2){ return false; }
+    public boolean authenticate(String p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3){ return false; }
+    public boolean authenticate(String p0, String p1, String p2, AuthenticatedLdapEntryContextCallback p3, AuthenticationErrorCallback p4){ return false; }
+    public boolean authenticate(String p0, String p1, String p2, AuthenticationErrorCallback p3){ return false; }
+    public void afterPropertiesSet(){}
+    public void authenticate(LdapQuery p0, String p1){}
+    public void bind(DirContextOperations p0){}
+    public void bind(Name p0, Object p1, Attributes p2){}
+    public void bind(String p0, Object p1, Attributes p2){}
+    public void create(Object p0){}
+    public void delete(Object p0){}
+    public void list(Name p0, NameClassPairCallbackHandler p1){}
+    public void list(String p0, NameClassPairCallbackHandler p1){}
+    public void listBindings(Name p0, NameClassPairCallbackHandler p1){}
+    public void listBindings(String p0, NameClassPairCallbackHandler p1){}
+    public void modifyAttributes(DirContextOperations p0){}
+    public void modifyAttributes(Name p0, ModificationItem[] p1){}
+    public void modifyAttributes(String p0, ModificationItem[] p1){}
+    public void rebind(DirContextOperations p0){}
+    public void rebind(Name p0, Object p1, Attributes p2){}
+    public void rebind(String p0, Object p1, Attributes p2){}
+    public void rename(Name p0, Name p1){}
+    public void rename(String p0, String p1){}
+    public void search(LdapQuery p0, NameClassPairCallbackHandler p1){}
+    public void search(Name p0, String p1, NameClassPairCallbackHandler p2){}
+    public void search(Name p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3){}
+    public void search(Name p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3, DirContextProcessor p4){}
+    public void search(Name p0, String p1, int p2, boolean p3, NameClassPairCallbackHandler p4){}
+    public void search(SearchExecutor p0, NameClassPairCallbackHandler p1){}
+    public void search(SearchExecutor p0, NameClassPairCallbackHandler p1, DirContextProcessor p2){}
+    public void search(String p0, String p1, NameClassPairCallbackHandler p2){}
+    public void search(String p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3){}
+    public void search(String p0, String p1, SearchControls p2, NameClassPairCallbackHandler p3, DirContextProcessor p4){}
+    public void search(String p0, String p1, int p2, boolean p3, NameClassPairCallbackHandler p4){}
+    public void setContextSource(ContextSource p0){}
+    public void setDefaultCountLimit(int p0){}
+    public void setDefaultSearchScope(int p0){}
+    public void setDefaultTimeLimit(int p0){}
+    public void setIgnoreNameNotFoundException(boolean p0){}
+    public void setIgnorePartialResultException(boolean p0){}
+    public void setIgnoreSizeLimitExceededException(boolean p0){}
+    public void setObjectDirectoryMapper(ObjectDirectoryMapper p0){}
+    public void unbind(Name p0){}
+    public void unbind(Name p0, boolean p1){}
+    public void unbind(String p0){}
+    public void unbind(String p0, boolean p1){}
+    public void update(Object p0){}
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/NameClassPairCallbackHandler.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/NameClassPairCallbackHandler.java
@@ -1,3 +1,10 @@
+// Generated automatically from org.springframework.ldap.core.NameClassPairCallbackHandler for testing purposes
+
 package org.springframework.ldap.core;
 
-public interface NameClassPairCallbackHandler { }
+import javax.naming.NameClassPair;
+
+public interface NameClassPairCallbackHandler
+{
+    void handleNameClassPair(NameClassPair p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/NameClassPairMapper.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/NameClassPairMapper.java
@@ -1,0 +1,10 @@
+// Generated automatically from org.springframework.ldap.core.NameClassPairMapper for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.NameClassPair;
+
+public interface NameClassPairMapper<T>
+{
+    T mapFromNameClassPair(NameClassPair p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/SearchExecutor.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/SearchExecutor.java
@@ -1,0 +1,11 @@
+// Generated automatically from org.springframework.ldap.core.SearchExecutor for testing purposes
+
+package org.springframework.ldap.core;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.DirContext;
+
+public interface SearchExecutor
+{
+    NamingEnumeration executeSearch(DirContext p0);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/EqualsFilter.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/EqualsFilter.java
@@ -2,4 +2,8 @@ package org.springframework.ldap.filter;
 
 public class EqualsFilter implements Filter {
   public EqualsFilter(String attribute, String value) { }
+  public String encode() { return null; }
+  public StringBuffer encode(StringBuffer p0) { return null; }
+  public boolean equals(Object p0) { return false; }
+  public int hashCode() { return 0; }
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/Filter.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/Filter.java
@@ -1,4 +1,12 @@
+// Generated automatically from org.springframework.ldap.filter.Filter for testing purposes
+
 package org.springframework.ldap.filter;
 
-public interface Filter {
+
+public interface Filter
+{
+    String encode();
+    StringBuffer encode(StringBuffer p0);
+    boolean equals(Object p0);
+    int hashCode();
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/HardcodedFilter.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/HardcodedFilter.java
@@ -2,6 +2,9 @@ package org.springframework.ldap.filter;
 
 public class HardcodedFilter implements Filter {
   public HardcodedFilter(String filter) { }
+  public String encode() { return null; }
   public StringBuffer encode(StringBuffer buff) { return buff; }
   public String toString() { return ""; }
+  public boolean equals(Object p0) { return false; }
+  public int hashCode() { return 0; }
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/odm/core/ObjectDirectoryMapper.java
@@ -1,0 +1,19 @@
+// Generated automatically from org.springframework.ldap.odm.core.ObjectDirectoryMapper for testing purposes
+
+package org.springframework.ldap.odm.core;
+
+import javax.naming.Name;
+import org.springframework.LdapDataEntry;
+import org.springframework.ldap.filter.Filter;
+
+public interface ObjectDirectoryMapper
+{
+    <T> T mapFromLdapDataEntry(LdapDataEntry p0, Class<T> p1);
+    Filter filterFor(Class<? extends Object> p0, Filter p1);
+    Name getCalculatedId(Object p0);
+    Name getId(Object p0);
+    String attributeFor(Class<? extends Object> p0, String p1);
+    String[] manageClass(Class<? extends Object> p0);
+    void mapToLdapDataEntry(Object p0, LdapDataEntry p1);
+    void setId(Object p0, Name p1);
+}

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/LdapQuery.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/LdapQuery.java
@@ -1,4 +1,17 @@
+// Generated automatically from org.springframework.ldap.query.LdapQuery for testing purposes
+
 package org.springframework.ldap.query;
 
-public interface LdapQuery {
+import javax.naming.Name;
+import org.springframework.ldap.filter.Filter;
+import org.springframework.ldap.query.SearchScope;
+
+public interface LdapQuery
+{
+    Filter filter();
+    Integer countLimit();
+    Integer timeLimit();
+    Name base();
+    SearchScope searchScope();
+    String[] attributes();
 }

--- a/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/SearchScope.java
+++ b/java/ql/test/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/SearchScope.java
@@ -1,0 +1,11 @@
+// Generated automatically from org.springframework.ldap.query.SearchScope for testing purposes
+
+package org.springframework.ldap.query;
+
+
+public enum SearchScope
+{
+    OBJECT, ONELEVEL, SUBTREE;
+    private SearchScope() {}
+    public int getId(){ return 0; }
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/jndi/JndiCallback.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/jndi/JndiCallback.java
@@ -1,0 +1,10 @@
+// Generated automatically from org.springframework.jndi.JndiCallback for testing purposes
+
+package org.springframework.jndi;
+
+import javax.naming.Context;
+
+public interface JndiCallback<T>
+{
+    T doInContext(Context p0);
+}

--- a/java/ql/test/stubs/springframework-5.3.8/org/springframework/jndi/JndiTemplate.java
+++ b/java/ql/test/stubs/springframework-5.3.8/org/springframework/jndi/JndiTemplate.java
@@ -1,21 +1,50 @@
+// Generated automatically from org.springframework.jndi.JndiTemplate for testing purposes
+
 package org.springframework.jndi;
 
 import java.util.Properties;
-import javax.naming.NamingException;
+import javax.naming.Context;
+import org.apache.commons.logging.Log;
+import org.springframework.jndi.JndiCallback;
 
 public class JndiTemplate {
-	public JndiTemplate() {}
+    protected Context createInitialContext() {
+        return null;
+    }
 
-	public JndiTemplate(Properties environment) {}
+    protected final Log logger = null;
 
-  public Object lookup(final String name) throws NamingException {
-		return new Object();
-	}
+    public <T> T execute(JndiCallback<T> p0) {
+        return null;
+    }
 
-	@SuppressWarnings("unchecked")
-	public <T> T lookup(String name, Class<T> requiredType) throws NamingException {
-		return (T) new Object();
-	}
-	
-	public void setEnvironment(Properties environment) {}
+    public <T> T lookup(String p0, Class<T> p1) {
+        return null;
+    }
+
+    public Context getContext() {
+        return null;
+    }
+
+    public JndiTemplate() {}
+
+    public JndiTemplate(Properties p0) {}
+
+    public Object lookup(String p0) {
+        return null;
+    }
+
+    public Properties getEnvironment() {
+        return null;
+    }
+
+    public void bind(String p0, Object p1) {}
+
+    public void rebind(String p0, Object p1) {}
+
+    public void releaseContext(Context p0) {}
+
+    public void setEnvironment(Properties p0) {}
+
+    public void unbind(String p0) {}
 }


### PR DESCRIPTION
Removes JNDI Injection sinks that were causing false positives: `LdapOperations.lookup` methods receiving an `AttributesMapper` parameter don't actually call `DirContext.lookup`, but only `DirContext.getAttributes`. Also, adds tests and stubs for these cases.

Fixes #7699.