### PR TITLE
C++: Another improvement to cpp/cleartext-transmission

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -171,6 +171,11 @@ class Encrypted extends Expr {
         this = fc.getAnArgument()
       )
     )
+    or
+    exists(Type t |
+      this.getType().refersTo(t) and
+      t.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
+    )
   }
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -85,6 +85,8 @@ edges
 | test3.cpp:366:8:366:15 | password | test3.cpp:368:15:368:22 | password |
 | test3.cpp:366:8:366:15 | password | test3.cpp:374:3:374:18 | call to SecureZeroBuffer |
 | test3.cpp:366:8:366:15 | password | test3.cpp:374:20:374:27 | password |
+| test3.cpp:386:8:386:15 | password | test3.cpp:388:15:388:22 | password |
+| test3.cpp:398:18:398:25 | password | test3.cpp:400:15:400:23 | & ... |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -198,6 +200,10 @@ nodes
 | test3.cpp:368:15:368:22 | password | semmle.label | password |
 | test3.cpp:374:3:374:18 | call to SecureZeroBuffer | semmle.label | call to SecureZeroBuffer |
 | test3.cpp:374:20:374:27 | password | semmle.label | password |
+| test3.cpp:386:8:386:15 | password | semmle.label | password |
+| test3.cpp:388:15:388:22 | password | semmle.label | password |
+| test3.cpp:398:18:398:25 | password | semmle.label | password |
+| test3.cpp:400:15:400:23 | & ... | semmle.label | & ... |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -227,3 +233,5 @@ subpaths
 | test3.cpp:295:2:295:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:295:14:295:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |
+| test3.cpp:388:3:388:6 | call to recv | test3.cpp:386:8:386:15 | password | test3.cpp:388:15:388:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:386:8:386:15 | password | password |
+| test3.cpp:400:3:400:6 | call to recv | test3.cpp:398:18:398:25 | password | test3.cpp:400:15:400:23 | & ... | This operation receives into '& ...', which may put unencrypted sensitive data into $@ | test3.cpp:398:18:398:25 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -87,6 +87,8 @@ edges
 | test3.cpp:366:8:366:15 | password | test3.cpp:374:20:374:27 | password |
 | test3.cpp:386:8:386:15 | password | test3.cpp:388:15:388:22 | password |
 | test3.cpp:398:18:398:25 | password | test3.cpp:400:15:400:23 | & ... |
+| test3.cpp:398:18:398:25 | password | test3.cpp:400:16:400:23 | password |
+| test3.cpp:398:18:398:25 | password | test3.cpp:400:33:400:40 | password |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -204,6 +206,8 @@ nodes
 | test3.cpp:388:15:388:22 | password | semmle.label | password |
 | test3.cpp:398:18:398:25 | password | semmle.label | password |
 | test3.cpp:400:15:400:23 | & ... | semmle.label | & ... |
+| test3.cpp:400:16:400:23 | password | semmle.label | password |
+| test3.cpp:400:33:400:40 | password | semmle.label | password |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -234,4 +238,3 @@ subpaths
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |
 | test3.cpp:388:3:388:6 | call to recv | test3.cpp:386:8:386:15 | password | test3.cpp:388:15:388:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:386:8:386:15 | password | password |
-| test3.cpp:400:3:400:6 | call to recv | test3.cpp:398:18:398:25 | password | test3.cpp:400:15:400:23 | & ... | This operation receives into '& ...', which may put unencrypted sensitive data into $@ | test3.cpp:398:18:398:25 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -397,7 +397,7 @@ void test_more_clues()
 	{
 		encrypted_data password;
 
-		recv(val(), &password, sizeof(password), val()); // GOOD: password is (probably) encrypted [FALSE POSITIVE]
+		recv(val(), &password, sizeof(password), val()); // GOOD: password is (probably) encrypted
 	}
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -374,3 +374,50 @@ void test_securezero()
 		SecureZeroBuffer(password, 256); // evidence we may have been doing decryption
 	}
 }
+
+struct encrypted_data
+{
+	char data[256];
+};
+
+void test_more_clues()
+{
+	{
+		char password[256];
+
+		recv(val(), password, 256, val()); // BAD: not encrypted
+	}
+
+	{
+		char encrypted_password[256];
+
+		recv(val(), encrypted_password, 256, val()); // GOOD: password is (probably) encrypted
+	}
+
+	{
+		encrypted_data password;
+
+		recv(val(), &password, sizeof(password), val()); // GOOD: password is (probably) encrypted [FALSE POSITIVE]
+	}
+}
+
+struct packet
+{
+	char password[256];
+};
+
+void test_member_password()
+{
+	{
+		packet p;
+
+		recv(val(), p.password, 256, val()); // BAD: not encrypted [NOT DETECTED]
+	}
+
+	{
+		packet p;
+
+		recv(val(), p.password, 256, val()); // GOOD: password is encrypted
+		decrypt_inplace(p.password); // proof that `password` was in fact encrypted
+	}
+}


### PR DESCRIPTION
This fixes the false positive we can see in https://lgtm.com/query/301759231708277869/ (note the type `cencrypted_v2_password_header`).  Its fairly narrow, but we need to do all we can to get this query up to `@precision high`.

No change note because its close enough to https://github.com/github/codeql/pull/7650 and covered by the change note there.