### PR TITLE
JS: add a predicate to recognize path arguments in calls to the fs-extra lib

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -408,7 +408,7 @@ module NodeJSLib {
 
   /**
    * Holds if the `i`th parameter of method `methodName` of the Node.js
-   * `fs` module or the `fs-extra` might represent a file path.
+   * `fs` module or the `fs-extra` module might represent a file path.
    *
    * For `fs`, we determine this by looking for an externs declaration for
    * `fs.methodName` where the `i`th parameter's name is `filename` or
@@ -435,13 +435,13 @@ module NodeJSLib {
    * method might represent a file path.
    */
   private predicate fsExtraExtensionFileParam(string methodName, int i) {
-    methodName = ["copy", "copySync", "copyFile"] and i = [0 .. 1]
+    methodName = ["copy", "copySync", "copyFile"] and i = [0, 1]
     or
-    methodName = ["move", "moveSync"] and i = [0 .. 1]
+    methodName = ["move", "moveSync"] and i = [0, 1]
     or
     methodName = ["createFile", "createFileSync"] and i = 0
     or
-    methodName = ["createSymLink", "createSymlinkSync"] and i = [0 .. 1]
+    methodName = ["createSymLink", "createSymlinkSync"] and i = [0, 1]
     or
     methodName = ["ensureDir", "ensureDirSync"] and i = 0
     or

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -408,11 +408,13 @@ module NodeJSLib {
 
   /**
    * Holds if the `i`th parameter of method `methodName` of the Node.js
-   * `fs` module might represent a file path.
+   * `fs` module or the `fs-extra` might represent a file path.
    *
-   * We determine this by looking for an externs declaration for
+   * For `fs`, we determine this by looking for an externs declaration for
    * `fs.methodName` where the `i`th parameter's name is `filename` or
    * `path` or a variation thereof.
+   *
+   * For `fs-extra`, we use the `fsExtraExtensionFileParam` predicate.
    */
   private predicate fsFileParam(string methodName, int i) {
     exists(ExternalMemberDecl decl, Function f, JSDocParamTag p, string n |
@@ -423,6 +425,47 @@ module NodeJSLib {
     |
       n = "filename" or n.regexpMatch("(old|new|src|dst|)path")
     )
+    or
+    fsExtraExtensionFileParam(methodName, i)
+  }
+
+  /**
+   * Holds if `methodName` is a function defined in the `fs-extra` library
+   * as an extension to node.js' `fs` module and parameter `i` of of the
+   * method might represent a file path.
+   */
+  private predicate fsExtraExtensionFileParam(string methodName, int i) {
+    methodName = ["copy", "copySync", "copyFile"] and i = [0 .. 1]
+    or
+    methodName = ["move", "moveSync"] and i = [0 .. 1]
+    or
+    methodName = ["createFile", "createFileSync"] and i = 0
+    or
+    methodName = ["createSymLink", "createSymlinkSync"] and i = [0 .. 1]
+    or
+    methodName = ["ensureDir", "ensureDirSync"] and i = 0
+    or
+    methodName = ["mkdirs", "mkdirp", "mkdirsSync", "mkdirpSync"] and i = 0
+    or
+    methodName = ["outputFile", "outputFileSync"] and i = 0
+    or
+    methodName = ["readJson", "readJSON", "readJsonSync", "readJSONSync"] and i = 0
+    or
+    methodName = ["remove", "removeSync"] and i = 0
+    or
+    methodName =
+      ["outputJSON", "outputJson", "writeJSON", "writeJson", "writeJSONSync", "writeJsonSync"] and
+    i = 0
+    or
+    methodName = ["ensureFile", "ensureFileSync"] and i = 0
+    or
+    methodName = ["ensureLink", "createLink", "ensureLinkSync", "createLinkSync"] and i = [0, 1]
+    or
+    methodName = ["ensureSymlink", "ensureSymlinkSync"] and i = [0, 1]
+    or
+    methodName = ["emptyDir", "emptyDirSync"] and i = 0
+    or
+    methodName = ["pathExists", "pathExistsSync"] and i = 0
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -414,7 +414,7 @@ module NodeJSLib {
    * `fs.methodName` where the `i`th parameter's name is `filename` or
    * `path` or a variation thereof.
    *
-   * For `fs-extra`, we use the `fsExtraExtensionFileParam` predicate.
+   * For `fs-extra`, we use a manually maintained list.
    */
   private predicate fsFileParam(string methodName, int i) {
     exists(ExternalMemberDecl decl, Function f, JSDocParamTag p, string n |


### PR DESCRIPTION
I'm sending this PR because the lack of complete support for `fs-extra` (ca 60.000.000 downloads weekly) has led to at least one false negative (see here: https://lgtm.com/projects/g/strongloop/strong-arc/snapshot/ac18d2c147b10c94552f215b1016216bb580d3ff/files/client/test/test-server.js?sort=name&dir=ASC&mode=heatmap#L89, it's a FN since fs.remove is not currently recognized as a sink. This PR fixes the problem.)