### PR TITLE
JS: add CWE-80 to queries that detect bad HTML sanitizers

### DIFF
--- a/javascript/ql/src/Security/CWE-116/BadTagFilter.ql
+++ b/javascript/ql/src/Security/CWE-116/BadTagFilter.ql
@@ -8,8 +8,9 @@
  * @id js/bad-tag-filter
  * @tags correctness
  *       security
- *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-080
+ *       external/cwe/cwe-116
  *       external/cwe/cwe-185
  *       external/cwe/cwe-186
  */

--- a/javascript/ql/src/Security/CWE-116/IncompleteMultiCharacterSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteMultiCharacterSanitization.ql
@@ -8,8 +8,9 @@
  * @id js/incomplete-multi-character-sanitization
  * @tags correctness
  *       security
- *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-080
+ *       external/cwe/cwe-116
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.ql
@@ -9,8 +9,9 @@
  * @id js/incomplete-sanitization
  * @tags correctness
  *       security
- *       external/cwe/cwe-116
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-080
+ *       external/cwe/cwe-116
  */
 
 import javascript


### PR DESCRIPTION
I added [CWE-80: Improper Neutralization of Script-Related HTML Tags in a Web Page](https://cwe.mitre.org/data/definitions/80.html) to some queries that deal with sanitization of script tags.  

CWE-80 is a child of CWE-79, so I've not added CWE-80 to any query that was already tagged with the more general CWE-79. 

(I also sorted the CWE list on those queries). 