### PR TITLE
C++: Add `security` tag to `cpp/return-stack-allocated-memory`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @precision high
  * @tags reliability
+ *       security
  *       external/cwe/cwe-825
  */
 

--- a/cpp/ql/src/change-notes/2022-01-24-return-stack-allocated-memory.md
+++ b/cpp/ql/src/change-notes/2022-01-24-return-stack-allocated-memory.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* The `security` tag has been added to the `cpp/return-stack-allocated-memory` query. As a result, its results will now appear by default.


### PR DESCRIPTION
The query was rewritten to be more robust in https://github.com/github/codeql/pull/7682 and https://github.com/github/codeql/pull/7701 removed all of the FPs that I've seen on LGTM, so I think this query is ready to go into the Code Scanning suite.

This will make the results of `cpp/return-stack-allocated-memory` show up by default.

Before we merge this I'll run a DCA to make sure we don't get any unintended IR re-evaluations.