### PR TITLE
JS: add CWE-219 to js/exposure-of-private-files

### DIFF
--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
@@ -8,6 +8,7 @@
  * @id js/exposure-of-private-files
  * @tags security
  *       external/cwe/cwe-200
+ *       external/cwe/cwe-219
  *       external/cwe/cwe-548
  * @precision high
  */


### PR DESCRIPTION
[CWE-219: Storage of File with Sensitive Data Under Web Root](https://cwe.mitre.org/data/definitions/219.html).  

The CWE is that a sensitive file as been placed under a web-root. 
And the query is that a web-root has been placed somewhere that contains sensitive files.  
I think that's close enough. 