### PR TITLE
C#: Desugar property patterns that uses member access syntax.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PropertyPattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/PropertyPattern.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Semmle.Extraction.Kinds;
 using Semmle.Extraction.Entities;
@@ -10,17 +12,91 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
             base(new ExpressionInfo(cx, null, cx.CreateLocation(pp.GetLocation()), ExprKind.PROPERTY_PATTERN, parent, child, false, null))
         {
             child = 0;
-            var trapFile = cx.TrapWriter.Writer;
             foreach (var sub in pp.Subpatterns)
             {
-                var p = Expressions.Pattern.Create(cx, sub.Pattern, this, child++);
-                if (sub.NameColon is null)
+                if (sub.ExpressionColon is null)
                 {
-                    Context.ModelError(sub, "Expected to find 'Name:' in pattern.");
+                    Context.ModelError(sub, "Expected to find 'Expression:' in pattern.");
                     continue;
                 }
-                trapFile.exprorstmt_name(p, sub.NameColon.Name.ToString());
+                MakeExpressions(cx, this, sub, child++);
             }
+        }
+
+        private class AccessStep
+        {
+            public readonly string Identifier;
+            public readonly Microsoft.CodeAnalysis.Location Location;
+
+            public AccessStep(string identifier, Microsoft.CodeAnalysis.Location location)
+            {
+                Identifier = identifier;
+                Location = location;
+            }
+        }
+
+        private class AccessStepPack
+        {
+            public readonly List<AccessStep> Prefix = new List<AccessStep>();
+            public AccessStep Last { get; private set; }
+
+            public AccessStepPack Add(string identifier, Microsoft.CodeAnalysis.Location location)
+            {
+                Prefix.Add(Last);
+                Last = new AccessStep(identifier, location);
+                return this;
+            }
+
+            public AccessStepPack(string identifier, Microsoft.CodeAnalysis.Location location)
+            {
+                Last = new AccessStep(identifier, location);
+            }
+        }
+
+        private static AccessStepPack GetAccessStepPack(ExpressionSyntax syntax)
+        {
+            switch (syntax)
+            {
+                case MemberAccessExpressionSyntax memberAccess:
+                    return GetAccessStepPack(memberAccess.Expression).Add(memberAccess.Name.Identifier.ValueText, memberAccess.Name.Identifier.GetLocation());
+                case IdentifierNameSyntax identifier:
+                    return new AccessStepPack(identifier.Identifier.Text, identifier.GetLocation());
+                default:
+                    throw new InternalError(syntax, "Unexpected expression syntax in property patterns.");
+            }
+        }
+
+        private static AccessStepPack GetAccessStepPack(BaseExpressionColonSyntax syntax)
+        {
+            switch (syntax)
+            {
+                case NameColonSyntax ncs:
+                    return new AccessStepPack(ncs.Name.ToString(), ncs.Name.GetLocation());
+                case ExpressionColonSyntax ecs:
+                    return GetAccessStepPack(ecs.Expression);
+                default:
+                    throw new InternalError(syntax, "Unsupported expression colon in property pattern.");
+            };
+        }
+
+        private static Expression CreateSyntheticExp(Context cx, Microsoft.CodeAnalysis.Location location, IExpressionParentEntity parent, int child) =>
+            new Expression(new ExpressionInfo(cx, null, cx.CreateLocation(location), ExprKind.PROPERTY_PATTERN, parent, child, false, null));
+
+        private static void MakeExpressions(Context cx, IExpressionParentEntity parent, SubpatternSyntax syntax, int child)
+        {
+            var trapFile = cx.TrapWriter.Writer;
+            var pack = GetAccessStepPack(syntax.ExpressionColon!);
+
+            foreach (var step in pack.Prefix)
+            {
+                var exp = CreateSyntheticExp(cx, step.Location, parent, child);
+                trapFile.exprorstmt_name(exp, step.Identifier);
+                parent = exp;
+                child = 0;
+            }
+
+            var p = Expressions.Pattern.Create(cx, syntax.Pattern, parent, child);
+            trapFile.exprorstmt_name(p, pack.Last.Identifier);
         }
     }
 }

--- a/csharp/ql/lib/change-notes/2022-01-25-extended-property-patterns.md
+++ b/csharp/ql/lib/change-notes/2022-01-25-extended-property-patterns.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Added support for C# 10 [Extended property patterns](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#extended-property-patterns).

--- a/csharp/ql/test/library-tests/csharp10/PropertyPatterns.cs
+++ b/csharp/ql/test/library-tests/csharp10/PropertyPatterns.cs
@@ -1,0 +1,56 @@
+using System;
+
+public record Point(int X, int Y);
+public record Line(Point P1, Point P2);
+public record Wrap(Line L);
+
+public class PropertyPatterns
+{
+    private static Line l = new Line(new Point(1, 2), new Point(3, 6));
+    private static Wrap w = new Wrap(l);
+
+    public void M1()
+    {
+        if (l is { P1: { X: 1 } })
+        {
+        }
+
+        if (l is { P1.X: 2 })
+        {
+        }
+    }
+
+    public void M2()
+    {
+        if (w is { L: { P2: { Y: 3 } } })
+        {
+        }
+
+        if (w is { L.P2.Y: 4 })
+        {
+        }
+    }
+
+    public void M3()
+    {
+        if (w is { L: { P2.Y: 5 } })
+        {
+        }
+
+        if (w is { L.P2: { Y: 6 } })
+        {
+        }
+    }
+
+    public void M4()
+    {
+        if (l is { P1: { X: 7 }, P1: { Y: 8 } })
+        {
+        }
+
+        if (l is { P1.X: 9, P1.Y: 10 })
+        {
+        }
+    }
+}
+

--- a/csharp/ql/test/library-tests/csharp10/propertyPatterns.expected
+++ b/csharp/ql/test/library-tests/csharp10/propertyPatterns.expected
@@ -1,0 +1,73 @@
+propertyPatterns
+| PropertyPatterns.cs:14:18:14:33 | { ... } |
+| PropertyPatterns.cs:14:24:14:31 | { ... } |
+| PropertyPatterns.cs:18:18:18:28 | { ... } |
+| PropertyPatterns.cs:18:20:18:21 | { ... } |
+| PropertyPatterns.cs:25:18:25:40 | { ... } |
+| PropertyPatterns.cs:25:23:25:38 | { ... } |
+| PropertyPatterns.cs:25:29:25:36 | { ... } |
+| PropertyPatterns.cs:29:18:29:30 | { ... } |
+| PropertyPatterns.cs:29:20:29:20 | { ... } |
+| PropertyPatterns.cs:29:22:29:23 | { ... } |
+| PropertyPatterns.cs:36:18:36:35 | { ... } |
+| PropertyPatterns.cs:36:23:36:33 | { ... } |
+| PropertyPatterns.cs:36:25:36:26 | { ... } |
+| PropertyPatterns.cs:40:18:40:35 | { ... } |
+| PropertyPatterns.cs:40:20:40:20 | { ... } |
+| PropertyPatterns.cs:40:26:40:33 | { ... } |
+| PropertyPatterns.cs:47:18:47:47 | { ... } |
+| PropertyPatterns.cs:47:24:47:31 | { ... } |
+| PropertyPatterns.cs:47:38:47:45 | { ... } |
+| PropertyPatterns.cs:51:18:51:38 | { ... } |
+| PropertyPatterns.cs:51:20:51:21 | { ... } |
+| PropertyPatterns.cs:51:29:51:30 | { ... } |
+propertyPatternChild
+| PropertyPatterns.cs:14:18:14:33 | { ... } | 0 | PropertyPatterns.cs:14:24:14:31 | { ... } |
+| PropertyPatterns.cs:14:24:14:31 | { ... } | 0 | PropertyPatterns.cs:14:29:14:29 | 1 |
+| PropertyPatterns.cs:18:18:18:28 | { ... } | 0 | PropertyPatterns.cs:18:20:18:21 | { ... } |
+| PropertyPatterns.cs:18:20:18:21 | { ... } | 0 | PropertyPatterns.cs:18:26:18:26 | 2 |
+| PropertyPatterns.cs:25:18:25:40 | { ... } | 0 | PropertyPatterns.cs:25:23:25:38 | { ... } |
+| PropertyPatterns.cs:25:23:25:38 | { ... } | 0 | PropertyPatterns.cs:25:29:25:36 | { ... } |
+| PropertyPatterns.cs:25:29:25:36 | { ... } | 0 | PropertyPatterns.cs:25:34:25:34 | 3 |
+| PropertyPatterns.cs:29:18:29:30 | { ... } | 0 | PropertyPatterns.cs:29:20:29:20 | { ... } |
+| PropertyPatterns.cs:29:20:29:20 | { ... } | 0 | PropertyPatterns.cs:29:22:29:23 | { ... } |
+| PropertyPatterns.cs:29:22:29:23 | { ... } | 0 | PropertyPatterns.cs:29:28:29:28 | 4 |
+| PropertyPatterns.cs:36:18:36:35 | { ... } | 0 | PropertyPatterns.cs:36:23:36:33 | { ... } |
+| PropertyPatterns.cs:36:23:36:33 | { ... } | 0 | PropertyPatterns.cs:36:25:36:26 | { ... } |
+| PropertyPatterns.cs:36:25:36:26 | { ... } | 0 | PropertyPatterns.cs:36:31:36:31 | 5 |
+| PropertyPatterns.cs:40:18:40:35 | { ... } | 0 | PropertyPatterns.cs:40:20:40:20 | { ... } |
+| PropertyPatterns.cs:40:20:40:20 | { ... } | 0 | PropertyPatterns.cs:40:26:40:33 | { ... } |
+| PropertyPatterns.cs:40:26:40:33 | { ... } | 0 | PropertyPatterns.cs:40:31:40:31 | 6 |
+| PropertyPatterns.cs:47:18:47:47 | { ... } | 0 | PropertyPatterns.cs:47:24:47:31 | { ... } |
+| PropertyPatterns.cs:47:18:47:47 | { ... } | 1 | PropertyPatterns.cs:47:38:47:45 | { ... } |
+| PropertyPatterns.cs:47:24:47:31 | { ... } | 0 | PropertyPatterns.cs:47:29:47:29 | 7 |
+| PropertyPatterns.cs:47:38:47:45 | { ... } | 0 | PropertyPatterns.cs:47:43:47:43 | 8 |
+| PropertyPatterns.cs:51:18:51:38 | { ... } | 0 | PropertyPatterns.cs:51:20:51:21 | { ... } |
+| PropertyPatterns.cs:51:18:51:38 | { ... } | 1 | PropertyPatterns.cs:51:29:51:30 | { ... } |
+| PropertyPatterns.cs:51:20:51:21 | { ... } | 0 | PropertyPatterns.cs:51:26:51:26 | 9 |
+| PropertyPatterns.cs:51:29:51:30 | { ... } | 0 | PropertyPatterns.cs:51:35:51:36 | 10 |
+propertyPatternLabels
+| PropertyPatterns.cs:14:24:14:31 | { ... } | P1 |
+| PropertyPatterns.cs:14:29:14:29 | 1 | X |
+| PropertyPatterns.cs:18:20:18:21 | { ... } | P1 |
+| PropertyPatterns.cs:18:26:18:26 | 2 | X |
+| PropertyPatterns.cs:25:23:25:38 | { ... } | L |
+| PropertyPatterns.cs:25:29:25:36 | { ... } | P2 |
+| PropertyPatterns.cs:25:34:25:34 | 3 | Y |
+| PropertyPatterns.cs:29:20:29:20 | { ... } | L |
+| PropertyPatterns.cs:29:22:29:23 | { ... } | P2 |
+| PropertyPatterns.cs:29:28:29:28 | 4 | Y |
+| PropertyPatterns.cs:36:23:36:33 | { ... } | L |
+| PropertyPatterns.cs:36:25:36:26 | { ... } | P2 |
+| PropertyPatterns.cs:36:31:36:31 | 5 | Y |
+| PropertyPatterns.cs:40:20:40:20 | { ... } | L |
+| PropertyPatterns.cs:40:26:40:33 | { ... } | P2 |
+| PropertyPatterns.cs:40:31:40:31 | 6 | Y |
+| PropertyPatterns.cs:47:24:47:31 | { ... } | P1 |
+| PropertyPatterns.cs:47:29:47:29 | 7 | X |
+| PropertyPatterns.cs:47:38:47:45 | { ... } | P1 |
+| PropertyPatterns.cs:47:43:47:43 | 8 | Y |
+| PropertyPatterns.cs:51:20:51:21 | { ... } | P1 |
+| PropertyPatterns.cs:51:26:51:26 | 9 | X |
+| PropertyPatterns.cs:51:29:51:30 | { ... } | P1 |
+| PropertyPatterns.cs:51:35:51:36 | 10 | Y |

--- a/csharp/ql/test/library-tests/csharp10/propertyPatterns.ql
+++ b/csharp/ql/test/library-tests/csharp10/propertyPatterns.ql
@@ -1,0 +1,11 @@
+import csharp
+
+query predicate propertyPatterns(PropertyPatternExpr exp) { any() }
+
+query predicate propertyPatternChild(PropertyPatternExpr pp, int n, PatternExpr child) {
+  child = pp.getPattern(n)
+}
+
+query predicate propertyPatternLabels(LabeledPatternExpr exp, string label) {
+  label = exp.getLabel()
+}

--- a/csharp/ql/test/library-tests/csharp10/recordTypes.expected
+++ b/csharp/ql/test/library-tests/csharp10/recordTypes.expected
@@ -1,4 +1,7 @@
 recordTypes
+| PropertyPatterns.cs:3:1:3:34 | Point |
+| PropertyPatterns.cs:4:1:4:39 | Line |
+| PropertyPatterns.cs:5:1:5:27 | Wrap |
 | RecordTypes.cs:3:1:6:2 | MyEntry |
 | RecordTypes.cs:8:1:8:53 | MyClassRecord |
 | RecordTypes.cs:10:1:10:70 | MyReadonlyRecordStruct |
@@ -9,5 +12,8 @@ recordStructs
 | RecordTypes.cs:12:1:12:51 | MyRecordStruct1 |
 | WithExpression.cs:9:1:9:47 | MyRecordStruct2 |
 recordClass
+| PropertyPatterns.cs:3:1:3:34 | Point |
+| PropertyPatterns.cs:4:1:4:39 | Line |
+| PropertyPatterns.cs:5:1:5:27 | Wrap |
 | RecordTypes.cs:3:1:6:2 | MyEntry |
 | RecordTypes.cs:8:1:8:53 | MyClassRecord |


### PR DESCRIPTION
In this PR we make support for [Extended property patterns](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/extended-property-patterns).
The idea is that the new form is *de-sugared* into a pattern expression in the old form. The only difference will be some slightly different locations.