### PR TITLE
JS: add a js/samesite-none-cookie cookie

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
@@ -110,6 +110,23 @@ private string getCookieValue(string s, string attribute) {
 }
 
 /**
+ * Gets the "SameSite" value for a given `node`.
+ * Converts boolean values to the corresponding string value.
+ *
+ * Not all libraries support boolean values for the `SameSite` attribute,
+ * but here we assume that they do.
+ */
+private string getSameSiteValue(DataFlow::Node node) {
+  node.mayHaveStringValue(result)
+  or
+  node.mayHaveBooleanValue(true) and
+  result = "Strict"
+  or
+  node.mayHaveBooleanValue(false) and
+  result = "Lax"
+}
+
+/**
  * A model of the `js-cookie` library (https://github.com/js-cookie/js-cookie).
  */
 private module JsCookie {
@@ -150,7 +167,7 @@ private module JsCookie {
     override predicate isSensitive() { canHaveSensitiveCookie(this.getArgument(0)) }
 
     override string getSameSite() {
-      this.getOptionArgument(2, "sameSite").mayHaveStringValue(result)
+      result = getSameSiteValue(this.getOptionArgument(2, "sameSite"))
     }
   }
 }
@@ -195,7 +212,7 @@ private module BrowserCookies {
     override predicate isSensitive() { canHaveSensitiveCookie(this.getArgument(0)) }
 
     override string getSameSite() {
-      this.getOptionArgument(2, "samesite").mayHaveStringValue(result)
+      result = getSameSiteValue(this.getOptionArgument(2, "samesite"))
       or
       // or, an explicit default has been set
       DataFlow::moduleMember("browser-cookies", "defaults")
@@ -242,10 +259,7 @@ private module LibCookie {
     override predicate isSensitive() { canHaveSensitiveCookie(this.getArgument(0)) }
 
     override string getSameSite() {
-      this.getOptionArgument(2, "sameSite").mayHaveStringValue(result)
-      or
-      this.getOptionArgument(2, "sameSite").mayHaveBooleanValue(true) and
-      result = "Strict"
+      result = getSameSiteValue(this.getOptionArgument(2, "sameSite"))
     }
   }
 }
@@ -280,10 +294,7 @@ private module ExpressCookies {
     }
 
     override string getSameSite() {
-      this.getOptionArgument(2, "sameSite").mayHaveStringValue(result)
-      or
-      this.getOptionArgument(2, "sameSite").mayHaveBooleanValue(true) and
-      result = "Strict"
+      result = getSameSiteValue(this.getOptionArgument(2, "sameSite"))
     }
   }
 
@@ -312,12 +323,7 @@ private module ExpressCookies {
       not this.getCookieFlagValue(CookieWrites::httpOnly()).mayHaveBooleanValue(false)
     }
 
-    override string getSameSite() {
-      this.getCookieFlagValue("sameSite").mayHaveStringValue(result)
-      or
-      this.getCookieFlagValue("sameSite").mayHaveBooleanValue(true) and
-      result = "Strict"
-    }
+    override string getSameSite() { result = getSameSiteValue(this.getCookieFlagValue("sameSite")) }
   }
 
   /**
@@ -348,12 +354,7 @@ private module ExpressCookies {
       not this.getCookieFlagValue(CookieWrites::httpOnly()).mayHaveBooleanValue(false)
     }
 
-    override string getSameSite() {
-      this.getCookieFlagValue("sameSite").mayHaveStringValue(result)
-      or
-      this.getCookieFlagValue("sameSite").mayHaveBooleanValue(true) and
-      result = "Strict"
-    }
+    override string getSameSite() { result = getSameSiteValue(this.getCookieFlagValue("sameSite")) }
   }
 }
 

--- a/javascript/ql/src/Security/CWE-1004/ClientExposedCookie.qhelp
+++ b/javascript/ql/src/Security/CWE-1004/ClientExposedCookie.qhelp
@@ -23,12 +23,12 @@ Set the <code>httpOnly</code> flag on all cookies that are not needed by the cli
 The following example stores an authentication token in a cookie that can 
 be viewed by the client.
 </p>
-<sample src="examples/ClientExposedCookieGood.js"/>
+<sample src="examples/ClientExposedCookieBad.js"/>
 <p>
 To force the cookie to be transmitted using SSL, set the <code>secure</code>
 attribute on the cookie.
 </p>
-<sample src="examples/ClientExposedCookieBad.js"/>
+<sample src="examples/ClientExposedCookieGood.js"/>
 </example>
 
 <references>

--- a/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.qhelp
+++ b/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.qhelp
@@ -6,11 +6,11 @@
 <overview>
 <p>
 Authentication cookies where the SameSite attribute is set to "None" can 
-potentially be used to perform cross-site request forgery (CSRF) attacks 
+potentially be used to perform Cross-Site Request Forgery (CSRF) attacks 
 if no other CSRF protections are in place.
 </p>
 <p>
-With SameSite set to "None" a third party website may create an authorized cross-site request
+With SameSite set to "None", a third party website may create an authorized cross-site request
 that includes the cookie.
 Such a cross-site request can allow that website to perform actions on behalf of a user.
 </p>

--- a/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.qhelp
+++ b/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.qhelp
@@ -1,0 +1,43 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Authentication cookies where the SameSite attribute is set to "None" can 
+potentially be used to perform cross-site request forgery (CSRF) attacks 
+if no other CSRF protections are in place.
+</p>
+<p>
+With SameSite set to "None" a third party website may create an authorized cross-site request
+that includes the cookie.
+Such a cross-site request can allow that website to perform actions on behalf of a user.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Set the <code>SameSite</code> attribute to <code>Strict</code> on all sensitive cookies.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example stores an authentication token in a cookie where the <code>SameSite</code>
+attribute is set to <code>None</code>.
+</p>
+<sample src="examples/SameSiteCookieBad.js"/>
+<p>
+To prevent the cookie from being included in cross-site requests, set the <code>SameSite</code>
+attribute to <code>Strict</code>.
+</p>
+<sample src="examples/SameSiteCookieGood.js"/>
+</example>
+
+<references>
+<li>MDN Web Docs: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite">SameSite cookies</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/SameSite">SameSite</a>.</li>
+</references>
+
+</qhelp>

--- a/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.ql
+++ b/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.ql
@@ -1,7 +1,7 @@
 /**
  * @name Sensitive cookie without SameSite restrictions
  * @description Sensitive cookies where the SameSite attribute is set to "None" can
- *              in some cases allow for Cross-site request forgery (CSRF) attacks.
+ *              in some cases allow for Cross-Site Request Forgery (CSRF) attacks.
  * @kind problem
  * @problem.severity warning
  * @security-severity 5.0

--- a/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.ql
+++ b/javascript/ql/src/Security/CWE-1275/SameSiteNoneCookie.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Sensitive cookie without SameSite restrictions
+ * @description Sensitive cookies where the SameSite attribute is set to "None" can
+ *              in some cases allow for Cross-site request forgery (CSRF) attacks.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 5.0
+ * @precision medium
+ * @id js/samesite-none-cookie
+ * @tags security
+ *       external/cwe/cwe-1275
+ */
+
+import javascript
+
+from CookieWrites::CookieWrite cookie
+where
+  cookie.isSensitive() and
+  cookie.isSecure() and // `js/clear-text-cookie` will report it if the cookie is not secure.
+  cookie.getSameSite().toLowerCase() = "none"
+select cookie, "Sensitive cookie with SameSite set to 'None'"

--- a/javascript/ql/src/Security/CWE-1275/examples/SameSiteCookieBad.js
+++ b/javascript/ql/src/Security/CWE-1275/examples/SameSiteCookieBad.js
@@ -1,0 +1,7 @@
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+    res.setHeader("Set-Cookie", `authKey=${makeAuthkey()}; secure; httpOnly; SameSite=None`);
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<h2>Hello world</h2>');
+});

--- a/javascript/ql/src/Security/CWE-1275/examples/SameSiteCookieGood.js
+++ b/javascript/ql/src/Security/CWE-1275/examples/SameSiteCookieGood.js
@@ -1,0 +1,7 @@
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+    res.setHeader("Set-Cookie", `authKey=${makeAuthkey()}; secure; httpOnly; SameSite=Strict`);
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end('<h2>Hello world</h2>');
+});

--- a/javascript/ql/src/change-notes/2022-01-24-samesite-cookie.md
+++ b/javascript/ql/src/change-notes/2022-01-24-samesite-cookie.md
@@ -1,4 +1,4 @@
 ---
 category: newQuery
 ---
-* A new query `js/samesite-none-cookie` has been added. The query detects when the SameSite attribute on a sensitive cookie is set to None.
+* A new query `js/samesite-none-cookie` has been added. The query detects when the SameSite attribute is set to None on a sensitive cookie.

--- a/javascript/ql/src/change-notes/2022-01-24-samesite-cookie.md
+++ b/javascript/ql/src/change-notes/2022-01-24-samesite-cookie.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* A new query `js/samesite-none-cookie` has been added. The query detects when the SameSite attribute on a sensitive cookie is set to None.

--- a/javascript/ql/test/query-tests/Security/CWE-1275/SameSiteNoneCookie.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-1275/SameSiteNoneCookie.expected
@@ -1,0 +1,8 @@
+| tst-sameSite.js:4:3:8:4 | Cookies ... OK\\n  }) | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:20:3:25:4 | cookies ... OK\\n  }) | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:38:19:43:4 | cookie. ... ",\\n  }) | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:58:3:63:4 | res.coo ... OK\\n  }) | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:76:3:82:4 | session ... OK\\n  }) | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:98:3:106:4 | express ... },\\n  }) | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:126:33:126:70 | "authKe ... Secure" | Sensitive cookie with SameSite set to 'None' |
+| tst-sameSite.js:134:3:134:17 | document.cookie | Sensitive cookie with SameSite set to 'None' |

--- a/javascript/ql/test/query-tests/Security/CWE-1275/SameSiteNoneCookie.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-1275/SameSiteNoneCookie.qlref
@@ -1,0 +1,1 @@
+Security/CWE-1275/SameSiteNoneCookie.ql

--- a/javascript/ql/test/query-tests/Security/CWE-1275/tst-sameSite.js
+++ b/javascript/ql/test/query-tests/Security/CWE-1275/tst-sameSite.js
@@ -1,0 +1,137 @@
+import * as Cookies from "es-cookie";
+
+function esCookies() {
+  Cookies.set("authkey", "value", {
+    secure: true,
+    httpOnly: true,
+    sameSite: "None", // NOT OK
+  });
+
+  Cookies.set("authkey", "value", {
+    secure: true,
+    httpOnly: true,
+    sameSite: "Strict", // OK
+  });
+}
+
+function browserCookies() {
+  var cookies = require("browser-cookies");
+
+  cookies.set("authkey", "value", {
+    expires: 365,
+    secure: true,
+    httponly: true,
+    samesite: "None", // NOT OK
+  });
+
+  cookies.set("authkey", "value", {
+    expires: 365,
+    secure: true,
+    httponly: true,
+    samesite: "Strict", // OK
+  });
+}
+
+function cookie() {
+  var cookie = require("cookie");
+
+  var setCookie = cookie.serialize("authkey", "value", {
+    maxAge: 9000000000,
+    httpOnly: true,
+    secure: true,
+    sameSite: "None",
+  });
+
+  var setCookie = cookie.serialize("authkey", "value", {
+    maxAge: 9000000000,
+    httpOnly: true,
+    secure: true,
+    sameSite: true, // OK
+  });
+}
+
+const express = require("express");
+const app = express();
+const session = require("cookie-session");
+
+app.get("/a", function (req, res, next) {
+  res.cookie("authkey", "value", {
+    maxAge: 9000000000,
+    httpOnly: true,
+    secure: true,
+    sameSite: "None", // NOT OK
+  });
+
+  res.cookie("session", "value", {
+    maxAge: 9000000000,
+    httpOnly: true,
+    secure: true,
+    sameSite: "Strict", // OK
+  });
+
+  res.end("ok");
+});
+
+app.use(
+  session({
+    name: "session",
+    keys: ["key1", "key2"],
+    httpOnly: true,
+    secure: true,
+    sameSite: "None", // NOT OK
+  })
+);
+
+app.use(
+  session({
+    name: "session",
+    keys: ["key1", "key2"],
+    httpOnly: true,
+    secure: true,
+    sameSite: "Strict", // OK
+  })
+);
+
+const expressSession = require("express-session");
+
+app.use(
+  expressSession({
+    name: "session",
+    keys: ["key1", "key2"],
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      sameSite: "None", // NOT OK
+    },
+  })
+);
+
+app.use(
+  expressSession({
+    name: "session",
+    keys: ["key1", "key2"],
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      sameSite: "Strict", // OK
+    },
+  })
+);
+
+const http = require("http");
+
+function test1() {
+  const server = http.createServer((req, res) => {
+    res.setHeader("Content-Type", "text/html");
+    res.setHeader("Set-Cookie", "authKey=ninja; SameSite=None; Secure"); // NOT OK
+    res.setHeader("Set-Cookie", "authKey=ninja; SameSite=Strict; Secure"); // OK
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("ok");
+  });
+}
+
+function documentCookie() {
+  document.cookie = "authKey=ninja; SameSite=None; Secure"; // NOT OK
+  document.cookie = "authKey=ninja; SameSite=Strict; Secure"; // OK
+}
+


### PR DESCRIPTION
[MDN Web Docs: SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite). 

I've set the `@precision` to `medium`, because `SameSite=None` is only an issue if there isn't any other CSRF protection.  
And the query makes no attempt to detect the existence of CSRF protection. 

The default value for `SameSite` is `Lax`. 
The `Lax` setting is not great, but also not terrible, so I don't want to flag that. 
(Also: The `SameSite` attribute is somewhat recent. E.g. there is no IE version that supports it). 

[Evaluation shows no new results, and a constant slow-down caused by having to compile the new query](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/CWE-1275__default__CustomSuite/reports).  
/cc @esbena: This is at least the second time I've seen an evaluation where a new query is compiled by `codeql-action/analyze` because it didn't hit anything in the cache.  