### PR TITLE
Ruby: Introduce `TAnyArrayElementContent`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -47,9 +47,7 @@ module SummaryComponent {
    * index or known index. This predicate should never be used in the output specification
    * of a flow summary; use `arrayElementUnknown()` instead.
    */
-  SummaryComponent arrayElementAny() {
-    result in [arrayElementUnknown(), SC::content(TKnownArrayElementContent(_))]
-  }
+  SummaryComponent arrayElementAny() { result = SC::content(TAnyArrayElementContent()) }
 
   /** Gets a summary component that represents the return value of a call. */
   SummaryComponent return() { result = SC::return(any(NormalReturnKind rk)) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -296,7 +296,8 @@ private module Cached {
   cached
   newtype TContent =
     TKnownArrayElementContent(int i) { i in [0 .. 10] } or
-    TUnknownArrayElementContent()
+    TUnknownArrayElementContent() or
+    TAnyArrayElementContent()
 }
 
 class TArrayElementContent = TKnownArrayElementContent or TUnknownArrayElementContent;
@@ -736,7 +737,13 @@ predicate storeStep(Node node1, Content c, Node node2) {
 }
 
 predicate readStep(Node node1, Content c, Node node2) {
-  FlowSummaryImpl::Private::Steps::summaryReadStep(node1, c, node2)
+  exists(Content c0 | FlowSummaryImpl::Private::Steps::summaryReadStep(node1, c0, node2) |
+    if c0 = TAnyArrayElementContent()
+    then
+      c instanceof TUnknownArrayElementContent or
+      c instanceof TKnownArrayElementContent
+    else c = c0
+  )
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -189,9 +189,16 @@ module Content {
 
   /** An element in an array at an unknown index. */
   class UnknownArrayElementContent extends ArrayElementContent, TUnknownArrayElementContent {
-    UnknownArrayElementContent() { this = TUnknownArrayElementContent() }
-
     override string toString() { result = "array element" }
+  }
+
+  /**
+   * Used internally only, to represent the union of `KnownArrayElementContent`
+   * and `UnknownArrayElementContent`, to avoid combinatorial explosions in
+   * `SummaryComponentStack`s in flow summaries.
+   */
+  private class AnyArrayElementContent extends Content, TAnyArrayElementContent {
+    override string toString() { result = "any array element" }
   }
 }
 


### PR DESCRIPTION
This avoids potential combinatorial explosion in `SummaryComponentStack`s. Until now it has not been a problem, since array indices are limited to `0..5`, but with this change we should be able to track arbitrary known indices.

One example is the `dig` method, where `dig(x, y, z)` (with unknowns `x`, `y`, and `z`) yields 6^3 `SummaryComponentStack`s. With this change it yields just a single `SummaryComponentStack`, regardless of whether we increase the precision of which indices to track.