### PR TITLE
C++: Add security-severity to `cpp/return-stack-allocated-memory`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -6,6 +6,7 @@
  * @kind path-problem
  * @id cpp/return-stack-allocated-memory
  * @problem.severity warning
+ * @security-severity 9.3
  * @precision high
  * @tags reliability
  *       security


### PR DESCRIPTION
I forgot to do this in https://github.com/github/codeql/pull/7718 when we added the query to Code Scanning.