### PR TITLE
js: add support for the 'node:' prefix for importing internal modules

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -741,7 +741,10 @@ module ModuleImportNode {
  * This predicate can be extended by subclassing `ModuleImportNode::Range`.
  */
 cached
-ModuleImportNode moduleImport(string path) { Stages::Imports::ref() and result.getPath() = path }
+ModuleImportNode moduleImport(string path) {
+  // NB. internal modules may be imported with a "node:" prefix
+  Stages::Imports::ref() and result.getPath() = ["node:" + path, path]
+}
 
 /**
  * Gets a (default) import of the given dependency `dep`, such as

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -3121,6 +3121,92 @@ nodes
 | tainted-access-paths.js:31:23:31:30 | obj.sub4 |
 | tainted-access-paths.js:31:23:31:30 | obj.sub4 |
 | tainted-access-paths.js:31:23:31:30 | obj.sub4 |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:24:39:30 | req.url |
+| tainted-access-paths.js:39:24:39:30 | req.url |
+| tainted-access-paths.js:39:24:39:30 | req.url |
+| tainted-access-paths.js:39:24:39:30 | req.url |
+| tainted-access-paths.js:39:24:39:30 | req.url |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:40:23:40:26 | path |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
@@ -8501,6 +8587,118 @@ edges
 | tainted-access-paths.js:31:23:31:25 | obj | tainted-access-paths.js:31:23:31:30 | obj.sub4 |
 | tainted-access-paths.js:31:23:31:25 | obj | tainted-access-paths.js:31:23:31:30 | obj.sub4 |
 | tainted-access-paths.js:31:23:31:25 | obj | tainted-access-paths.js:31:23:31:30 | obj.sub4 |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:7:39:48 | path | tainted-access-paths.js:40:23:40:26 | path |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:37 | url.par ... , true) | tainted-access-paths.js:39:14:39:43 | url.par ... ).query |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:43 | url.par ... ).query | tainted-access-paths.js:39:14:39:48 | url.par ... ry.path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:14:39:48 | url.par ... ry.path | tainted-access-paths.js:39:7:39:48 | path |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
+| tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:39:14:39:37 | url.par ... , true) |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:12:29:12:47 | req.param("module") | tainted-require.js:12:29:12:47 | req.param("module") |
 | tainted-require.js:14:11:14:29 | req.param("module") | tainted-require.js:14:11:14:29 | req.param("module") |
@@ -9739,6 +9937,7 @@ edges
 | tainted-access-paths.js:29:21:29:28 | obj.sub4 | tainted-access-paths.js:6:24:6:30 | req.url | tainted-access-paths.js:29:21:29:28 | obj.sub4 | This path depends on $@. | tainted-access-paths.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-access-paths.js:30:23:30:30 | obj.sub4 | tainted-access-paths.js:6:24:6:30 | req.url | tainted-access-paths.js:30:23:30:30 | obj.sub4 | This path depends on $@. | tainted-access-paths.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-access-paths.js:31:23:31:30 | obj.sub4 | tainted-access-paths.js:6:24:6:30 | req.url | tainted-access-paths.js:31:23:31:30 | obj.sub4 | This path depends on $@. | tainted-access-paths.js:6:24:6:30 | req.url | a user-provided value |
+| tainted-access-paths.js:40:23:40:26 | path | tainted-access-paths.js:39:24:39:30 | req.url | tainted-access-paths.js:40:23:40:26 | path | This path depends on $@. | tainted-access-paths.js:39:24:39:30 | req.url | a user-provided value |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | This path depends on $@. | tainted-require.js:7:19:7:37 | req.param("module") | a user-provided value |
 | tainted-require.js:12:29:12:47 | req.param("module") | tainted-require.js:12:29:12:47 | req.param("module") | tainted-require.js:12:29:12:47 | req.param("module") | This path depends on $@. | tainted-require.js:12:29:12:47 | req.param("module") | a user-provided value |
 | tainted-require.js:14:11:14:29 | req.param("module") | tainted-require.js:14:11:14:29 | req.param("module") | tainted-require.js:14:11:14:29 | req.param("module") | This path depends on $@. | tainted-require.js:14:11:14:29 | req.param("module") | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/tainted-access-paths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/tainted-access-paths.js
@@ -1,4 +1,4 @@
-var fs = require('node:fs'),
+var fs = require('fs'),
     http = require('http'),
     url = require('url');
 
@@ -32,3 +32,12 @@ var server = http.createServer(function(req, res) {
 });
 
 server.listen();
+
+var nodefs = require('node:fs');
+
+var server2 = http.createServer(function(req, res) {
+  let path = url.parse(req.url, true).query.path;
+  nodefs.readFileSync(path); // NOT OK
+});
+
+server2.listen();

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/tainted-access-paths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/tainted-access-paths.js
@@ -1,4 +1,4 @@
-var fs = require('fs'),
+var fs = require('node:fs'),
     http = require('http'),
     url = require('url');
 


### PR DESCRIPTION
# Context
```
import fs from 'node:fs/promises';
```
Is equivalent to

```
import fs from 'fs/promises';
```

if there is no `node_modules/fs` folder (which would be extremely bad practice).

# References
https://nodejs.org/api/esm.html#node-imports
https://2ality.com/2021/12/node-protocol-imports.html