### PR TITLE
C++: Upgrade cpp/cleartext-storage-file

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -2,7 +2,7 @@
  * @name Cleartext storage of sensitive information in file
  * @description Storing sensitive information in cleartext can expose it
  *              to an attacker.
- * @kind problem
+ * @kind path-problem
  * @problem.severity warning
  * @security-severity 7.5
  * @precision high
@@ -18,6 +18,7 @@ import semmle.code.cpp.security.FileWrite
 import semmle.code.cpp.dataflow.DataFlow
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.dataflow.TaintTracking
+import DataFlow::PathGraph
 
 /**
  * Taint flow from a sensitive expression to a `FileWrite` sink.
@@ -27,9 +28,7 @@ class FromSensitiveConfiguration extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof SensitiveExpr }
 
-  override predicate isSink(DataFlow::Node sink) {
-    any(FileWrite w).getASource() = sink.asExpr()
-  }
+  override predicate isSink(DataFlow::Node sink) { any(FileWrite w).getASource() = sink.asExpr() }
 }
 
 /**
@@ -57,16 +56,17 @@ predicate isFileName(GVN gvn) {
   )
 }
 
-from FromSensitiveConfiguration config, SensitiveExpr source, Expr mid, FileWrite w, Expr dest
+from
+  FromSensitiveConfiguration config, SensitiveExpr source, DataFlow::PathNode sourceNode, Expr mid,
+  DataFlow::PathNode midNode, FileWrite w, Expr dest
 where
-  exists(DataFlow::PathNode s, DataFlow::PathNode m |
-    config.hasFlowPath(s, m) and
-    s.getNode().asExpr() = source and
-    m.getNode().asExpr() = mid
-  ) and
+  config.hasFlowPath(sourceNode, midNode) and
+  sourceNode.getNode().asExpr() = source and
+  midNode.getNode().asExpr() = mid and
   mid = w.getASource() and
   dest = w.getDest() and
   not isFileName(globalValueNumber(source)) and // file names are not passwords
   not exists(string convChar | convChar = w.getSourceConvChar(mid) | not convChar = ["s", "S"]) // ignore things written with other conversion characters
-select w, "This write into file '" + dest.toString() + "' may contain unencrypted data from $@",
-  source, "this source."
+select w, sourceNode, midNode,
+  "This write into file '" + dest.toString() + "' may contain unencrypted data from $@", source,
+  "this source."

--- a/cpp/ql/src/change-notes/2022-01-24-cleartext-storage-file.md
+++ b/cpp/ql/src/change-notes/2022-01-24-cleartext-storage-file.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/cleartext-storage-file` query has been upgraded with non-local taint flow and has been converted to a `path-problem` query.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -7,7 +7,7 @@
 | test2.cpp:65:3:65:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
 | test2.cpp:73:3:73:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
 | test2.cpp:76:3:76:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:92:3:92:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:91:45:91:52 | password | this source. |
+| test2.cpp:99:3:99:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:98:45:98:52 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -5,6 +5,9 @@
 | test2.cpp:55:2:55:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |
 | test2.cpp:57:2:57:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:57:39:57:49 | call to getPassword | this source. |
 | test2.cpp:65:3:65:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
+| test2.cpp:73:3:73:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:76:3:76:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:92:3:92:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:91:45:91:52 | password | this source. |
 | test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
 | test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
 | test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -1,13 +1,42 @@
-| test2.cpp:43:2:43:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:36:43:43 | password | this source. |
-| test2.cpp:44:2:44:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:44:37:44:45 | thepasswd | this source. |
-| test2.cpp:50:2:50:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:41:50:53 | passwd_config | this source. |
-| test2.cpp:54:2:54:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:54:41:54:52 | widepassword | this source. |
-| test2.cpp:55:2:55:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |
-| test2.cpp:57:2:57:8 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:57:39:57:49 | call to getPassword | this source. |
-| test2.cpp:65:3:65:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
-| test2.cpp:73:3:73:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:76:3:76:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
-| test2.cpp:99:3:99:9 | call to fprintf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:98:45:98:52 | password | this source. |
-| test.cpp:45:3:45:7 | call to fputs | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
-| test.cpp:70:35:70:35 | call to operator<< | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
-| test.cpp:73:37:73:41 | call to write | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |
+edges
+| test2.cpp:52:44:52:57 | password_tries | test2.cpp:52:40:52:58 | * ... |
+| test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 |
+| test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf |
+| test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf |
+| test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer |
+nodes
+| test2.cpp:43:36:43:43 | password | semmle.label | password |
+| test2.cpp:44:37:44:45 | thepasswd | semmle.label | thepasswd |
+| test2.cpp:50:41:50:53 | passwd_config | semmle.label | passwd_config |
+| test2.cpp:52:40:52:58 | * ... | semmle.label | * ... |
+| test2.cpp:52:44:52:57 | password_tries | semmle.label | password_tries |
+| test2.cpp:54:41:54:52 | widepassword | semmle.label | widepassword |
+| test2.cpp:55:40:55:51 | widepassword | semmle.label | widepassword |
+| test2.cpp:57:39:57:49 | call to getPassword | semmle.label | call to getPassword |
+| test2.cpp:62:18:62:25 | password | semmle.label | password |
+| test2.cpp:65:31:65:34 | cpy1 | semmle.label | cpy1 |
+| test2.cpp:72:17:72:24 | password | semmle.label | password |
+| test2.cpp:73:30:73:32 | buf | semmle.label | buf |
+| test2.cpp:76:30:76:32 | buf | semmle.label | buf |
+| test2.cpp:86:36:86:43 | password | semmle.label | password |
+| test2.cpp:91:50:91:63 | passwd_config2 | semmle.label | passwd_config2 |
+| test2.cpp:98:45:98:52 | password | semmle.label | password |
+| test2.cpp:99:27:99:32 | buffer | semmle.label | buffer |
+| test.cpp:45:9:45:19 | thePassword | semmle.label | thePassword |
+| test.cpp:70:38:70:48 | thePassword | semmle.label | thePassword |
+| test.cpp:73:43:73:53 | thePassword | semmle.label | thePassword |
+subpaths
+#select
+| test2.cpp:43:2:43:8 | call to fprintf | test2.cpp:43:36:43:43 | password | test2.cpp:43:36:43:43 | password | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:36:43:43 | password | this source. |
+| test2.cpp:44:2:44:8 | call to fprintf | test2.cpp:44:37:44:45 | thepasswd | test2.cpp:44:37:44:45 | thepasswd | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:44:37:44:45 | thepasswd | this source. |
+| test2.cpp:50:2:50:8 | call to fprintf | test2.cpp:50:41:50:53 | passwd_config | test2.cpp:50:41:50:53 | passwd_config | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:41:50:53 | passwd_config | this source. |
+| test2.cpp:54:2:54:8 | call to fprintf | test2.cpp:54:41:54:52 | widepassword | test2.cpp:54:41:54:52 | widepassword | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:54:41:54:52 | widepassword | this source. |
+| test2.cpp:55:2:55:8 | call to fprintf | test2.cpp:55:40:55:51 | widepassword | test2.cpp:55:40:55:51 | widepassword | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |
+| test2.cpp:57:2:57:8 | call to fprintf | test2.cpp:57:39:57:49 | call to getPassword | test2.cpp:57:39:57:49 | call to getPassword | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:57:39:57:49 | call to getPassword | this source. |
+| test2.cpp:65:3:65:9 | call to fprintf | test2.cpp:62:18:62:25 | password | test2.cpp:65:31:65:34 | cpy1 | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:62:18:62:25 | password | this source. |
+| test2.cpp:73:3:73:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:73:30:73:32 | buf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:76:3:76:9 | call to fprintf | test2.cpp:72:17:72:24 | password | test2.cpp:76:30:76:32 | buf | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:72:17:72:24 | password | this source. |
+| test2.cpp:99:3:99:9 | call to fprintf | test2.cpp:98:45:98:52 | password | test2.cpp:99:27:99:32 | buffer | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:98:45:98:52 | password | this source. |
+| test.cpp:45:3:45:7 | call to fputs | test.cpp:45:9:45:19 | thePassword | test.cpp:45:9:45:19 | thePassword | This write into file 'file' may contain unencrypted data from $@ | test.cpp:45:9:45:19 | thePassword | this source. |
+| test.cpp:70:35:70:35 | call to operator<< | test.cpp:70:38:70:48 | thePassword | test.cpp:70:38:70:48 | thePassword | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:70:38:70:48 | thePassword | this source. |
+| test.cpp:73:37:73:41 | call to write | test.cpp:73:43:73:53 | thePassword | test.cpp:73:43:73:53 | thePassword | This write into file 'mystream' may contain unencrypted data from $@ | test.cpp:73:43:73:53 | thePassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -70,10 +70,10 @@ void tests(FILE *log, myStruct &s)
 		char buf[1024];
 
 		strcpy(buf, s.password);
-		fprintf(log, "buf = %s\n", buf); // BAD [NOT DETECTED]
+		fprintf(log, "buf = %s\n", buf); // BAD
 		
 		strcpy(buf, s.password_hash);
-		fprintf(log, "buf = %s\n", buf); // GOOD
+		fprintf(log, "buf = %s\n", buf); // GOOD [FALSE POSITIVE]
 	}
 
 	fprintf(log, "password = %p\n", s.password); // GOOD
@@ -89,6 +89,6 @@ void tests(FILE *log, myStruct &s)
 		char buffer[1024];
 
 		snprintf(buffer, 1024, "password = %s", s.password);
-		fprintf(log, "log: %s", buffer); // BAD [NOT DETECTED]
+		fprintf(log, "log: %s", buffer); // BAD
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -76,6 +76,13 @@ void tests(FILE *log, myStruct &s)
 		fprintf(log, "buf = %s\n", buf); // GOOD [FALSE POSITIVE]
 	}
 
+	{
+		char buf[1024];
+
+		strcpy(buf, s.password_hash);
+		fprintf(log, "buf = %s\n", buf); // GOOD
+	}
+
 	fprintf(log, "password = %p\n", s.password); // GOOD
 
 	{


### PR DESCRIPTION
Resolves some of the inconsistency between `cpp/cleartext-transmission`, `cpp/cleartext-storage-file` and `cpp/cleartext-storage-buffer` by upgrading the second one to non-local taint flow (with paths).

LGTM run: https://lgtm.com/query/834234913031404157/
LGTM diff query: https://lgtm.com/query/495444284760597175/

As you can see above, this makes the query a little noisier, but the quality of results seems to be similar to before.