### PR TITLE
C#: Exclude extractor arguments from `compilation_args` relation

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
@@ -86,9 +86,9 @@ namespace Semmle.Extraction.CSharp
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            Entities.Compilation.Settings = (Directory.GetCurrentDirectory(), args);
+            var options = Options.CreateWithEnvironment(args);
+            Entities.Compilation.Settings = (Directory.GetCurrentDirectory(), options.CompilerArguments.ToArray());
 
-            var options = Options.CreateWithEnvironment(Entities.Compilation.Settings.Args);
             var fileLogger = new FileLogger(options.Verbosity, GetCSharpLogPath());
             using var logger = options.Console
                 ? new CombinedLogger(new ConsoleLogger(options.Verbosity), fileLogger)

--- a/csharp/ql/test/library-tests/compilations/Compilations.expected
+++ b/csharp/ql/test/library-tests/compilations/Compilations.expected
@@ -13,10 +13,7 @@ compilationArguments
 | compilation | 5 | /r:System.Core.dll |
 | compilation | 6 | /r:System.Runtime.dll |
 | compilation | 7 | /r:System.Console.dll |
-| compilation | 8 | --console |
-| compilation | 9 | --verbosity |
-| compilation | 10 | 2 |
-| compilation | 11 | Program.cs |
+| compilation | 8 | Program.cs |
 compilationFiles
 | compilation | 0 | Program.cs:0:0:0:0 | Program.cs |
 compilationFolder


### PR DESCRIPTION
The relation is only supposed to contain the arguments of the C# compilation call.