### PR TITLE
C++: Upgrade cpp/cleartext-storage-buffer

### DIFF
--- a/cpp/ql/src/change-notes/2022-01-25-cleartext-storage-buffer.md
+++ b/cpp/ql/src/change-notes/2022-01-25-cleartext-storage-buffer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/cleartext-storage-buffer` query has been updated to use the `semmle.code.cpp.dataflow.TaintTracking` library.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextBufferWrite.expected
@@ -1,18 +1,8 @@
 edges
 | test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input |
-| test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input |
-| test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input |
-| test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input |
-| test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input indirection |
-| test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input indirection |
-subpaths
 nodes
 | test.cpp:54:17:54:20 | argv | semmle.label | argv |
-| test.cpp:54:17:54:20 | argv | semmle.label | argv |
 | test.cpp:58:25:58:29 | input | semmle.label | input |
-| test.cpp:58:25:58:29 | input | semmle.label | input |
-| test.cpp:58:25:58:29 | input | semmle.label | input |
-| test.cpp:58:25:58:29 | input indirection | semmle.label | input indirection |
-| test.cpp:58:25:58:29 | input indirection | semmle.label | input indirection |
+subpaths
 #select
 | test.cpp:58:3:58:9 | call to sprintf | test.cpp:54:17:54:20 | argv | test.cpp:58:25:58:29 | input | This write into buffer 'passwd' may contain unencrypted data from $@ | test.cpp:54:17:54:20 | argv | user input (argv) |


### PR DESCRIPTION
Resolves a bit more of the inconsistency between `cpp/cleartext-transmission`, `cpp/cleartext-storage-file` and `cpp/cleartext-storage-buffer` by upgrading the third one from security to AST taint flow.

We still use the old security library's `isUserInput` to identify inputs, that could be upgraded as well but may have a bigger impact on results.

LGTM diff query: https://lgtm.com/query/6710910426361157574/ (sparse results, no differences)