### PR TITLE
JS: Move experimental notice to the bottom of the ML-powered query help

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/src/NosqlInjectionATM.md
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/NosqlInjectionATM.md
@@ -1,7 +1,7 @@
 # NoSQL database query built from user-controlled sources (experimental)
-This is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
-
 If a database query (such as a SQL or NoSQL query) is built from user-provided data without sufficient sanitization, a malicious user may be able to run malicious database queries.
+
+Note: This CodeQL query is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
 
 
 ## Recommendation

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/SqlInjectionATM.md
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/SqlInjectionATM.md
@@ -1,7 +1,7 @@
 # SQL database query built from user-controlled sources (experimental)
-This is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
-
 If a database query (such as a SQL or NoSQL query) is built from user-provided data without sufficient sanitization, a malicious user may be able to run malicious database queries.
+
+Note: This CodeQL query is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
 
 
 ## Recommendation

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/TaintedPathATM.md
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/TaintedPathATM.md
@@ -1,7 +1,7 @@
 # Uncontrolled data used in path expression (experimental)
-This is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
-
 Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.
+
+Note: This CodeQL query is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
 
 
 ## Recommendation

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.md
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/XssATM.md
@@ -1,9 +1,9 @@
 # Client-side cross-site scripting (experimental)
-This is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
-
 Directly writing user input (for example, a URL query parameter) to a webpage without properly sanitizing the input first, allows for a cross-site scripting vulnerability.
 
 This kind of vulnerability is also called *DOM-based* cross-site scripting, to distinguish it from other types of cross-site scripting.
+
+Note: This CodeQL query is an experimental query. Experimental queries generate alerts using machine learning. They might include more false positives but they will improve over time.
 
 
 ## Recommendation


### PR DESCRIPTION
The Code Scanning UI shows just the first paragraph of the query help as a summary, until a user chooses to expand the help. We decided it was more useful to display the standard query help in this summary compared to the experimental query notice, since there is already a notice about experimental queries on the alert show page.