### PR TITLE
Fix issues with downgrade pack releases

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -4,6 +4,7 @@
         "*/ql/lib/qlpack.yml",
         "*/ql/test/qlpack.yml",
         "*/ql/examples/qlpack.yml",
+        "*/downgrades/qlpack.yml",
         "cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml",
         "javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml",
         "javascript/ql/experimental/adaptivethreatmodeling/src/qlpack.yml",

--- a/csharp/downgrades/qlpack.yml
+++ b/csharp/downgrades/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/csharp-downgrades
 groups: csharp
-version: 0.0.6-dev
+version: 0.0.8-dev
 downgrades: .
 library: true


### PR DESCRIPTION
This PR fixes two issues with the release process for downgrade packs:

1. An existing downgrade pack has a version number lower than the others because it didn't make it into the release branch and therefore didn't get released when the others did. Bump it to bring it back in sync.
2. The automation for releasing packs isn't picking up downgrade ones because they aren't listed in our `.codeqlmanifest.json`, so even if it _had_ been on the release branch it would not have been released correctly as things stand.