### PR TITLE
JS: add CWE-184 to incomplete-scheme-check and bad-tag-filter

### DIFF
--- a/javascript/ql/src/Security/CWE-020/IncompleteUrlSchemeCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncompleteUrlSchemeCheck.ql
@@ -10,6 +10,7 @@
  * @tags security
  *       correctness
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-184
  */
 
 import javascript

--- a/javascript/ql/src/Security/CWE-116/BadTagFilter.ql
+++ b/javascript/ql/src/Security/CWE-116/BadTagFilter.ql
@@ -11,6 +11,7 @@
  *       external/cwe/cwe-020
  *       external/cwe/cwe-080
  *       external/cwe/cwe-116
+ *       external/cwe/cwe-184
  *       external/cwe/cwe-185
  *       external/cwe/cwe-186
  */


### PR DESCRIPTION
[CWE-184: Incomplete List of Disallowed Inputs](https://cwe.mitre.org/data/definitions/184.html).  

As I interpret it: CWE-184 is when you have a working sanitizer, except there's a case it doesn't cover.

That matches incomplete-scheme-check and bad-tag-filter. 
We have plenty of other queries that detect various broken sanitizers, but they don't seem to follow the pattern of "incomplete list". 