### PR TITLE
QL: Add should-be-non-member query

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -456,12 +456,6 @@ class FormatLiteral extends Literal {
   Type getWideCharType() { result = this.getUse().getTarget().getWideCharType() }
 
   /**
-   * Holds if this `FormatLiteral` is in a context that supports
-   * Microsoft rules and extensions.
-   */
-  predicate isMicrosoft() { anyFileCompiledAsMicrosoft() }
-
-  /**
    * Gets the format string, with '%%' and '%@' replaced by '_' (to avoid processing
    * them as format specifiers).
    */
@@ -491,7 +485,7 @@ class FormatLiteral extends Literal {
   }
 
   private string getFlagRegexp() {
-    if this.isMicrosoft() then result = "[-+ #0']*" else result = "[-+ #0'I]*"
+    if anyFileCompiledAsMicrosoft() then result = "[-+ #0']*" else result = "[-+ #0'I]*"
   }
 
   private string getFieldWidthRegexp() { result = "(?:[1-9][0-9]*|\\*|\\*[0-9]+\\$)?" }
@@ -499,13 +493,13 @@ class FormatLiteral extends Literal {
   private string getPrecRegexp() { result = "(?:\\.(?:[0-9]*|\\*|\\*[0-9]+\\$))?" }
 
   private string getLengthRegexp() {
-    if this.isMicrosoft()
+    if anyFileCompiledAsMicrosoft()
     then result = "(?:hh?|ll?|L|q|j|z|t|w|I32|I64|I)?"
     else result = "(?:hh?|ll?|L|q|j|z|Z|t)?"
   }
 
   private string getConvCharRegexp() {
-    if this.isMicrosoft()
+    if anyFileCompiledAsMicrosoft()
     then result = "[aAcCdeEfFgGimnopsSuxXZ@]"
     else result = "[aAcCdeEfFgGimnopsSuxX@]"
   }

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -47,12 +47,6 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
   override string getAPrimaryQlClass() { result = "FormattingFunction" }
 
   /**
-   * Holds if this `FormattingFunction` is in a context that supports
-   * Microsoft rules and extensions.
-   */
-  predicate isMicrosoft() { anyFileCompiledAsMicrosoft() }
-
-  /**
    * Holds if the default meaning of `%s` is a `wchar_t *`, rather than
    * a `char *` (either way, `%S` will have the opposite meaning).
    *
@@ -75,10 +69,10 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
    * `char` or `wchar_t`.
    */
   Type getDefaultCharType() {
-    isMicrosoft() and
+    anyFileCompiledAsMicrosoft() and
     result = getFormatCharType()
     or
-    not isMicrosoft() and
+    not anyFileCompiledAsMicrosoft() and
     result instanceof PlainCharType
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1743,15 +1743,15 @@ string ppReprType(DataFlowType t) { result = t.toString() }
 
 private class DataFlowNullType extends DataFlowType {
   DataFlowNullType() { this = Gvn::getGlobalValueNumber(any(NullType nt)) }
-
-  pragma[noinline]
-  predicate isConvertibleTo(DataFlowType t) {
-    defaultNullConversion(_, any(Type t0 | t = Gvn::getGlobalValueNumber(t0)))
-  }
 }
 
 private class DataFlowUnknownType extends DataFlowType {
   DataFlowUnknownType() { this = Gvn::getGlobalValueNumber(any(UnknownType ut)) }
+}
+
+pragma[noinline]
+private predicate isConvertibleToNull(DataFlowType t) {
+  defaultNullConversion(_, any(Type t0 | t = Gvn::getGlobalValueNumber(t0)))
 }
 
 /**
@@ -1766,9 +1766,9 @@ predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
   or
   commonSubTypeUnifiableLeft(t2, t1)
   or
-  t1.(DataFlowNullType).isConvertibleTo(t2)
+  t1 instanceof DataFlowNullType and isConvertibleToNull(t2)
   or
-  t2.(DataFlowNullType).isConvertibleTo(t1)
+  t2 instanceof DataFlowNullType and isConvertibleToNull(t1)
   or
   t1 instanceof Gvn::TypeParameterGvnType
   or

--- a/java/ql/lib/semmle/code/java/metrics/MetricRefType.qll
+++ b/java/ql/lib/semmle/code/java/metrics/MetricRefType.qll
@@ -265,7 +265,7 @@ class MetricRefType extends RefType, MetricElement {
    * Exclusions from the number of overriding methods,
    * for use with the specialization index metric.
    */
-  predicate ignoreOverride(Method c) {
+  private predicate ignoreOverride(Method c) {
     c.hasStringSignature(["equals(Object)", "hashCode()", "toString()", "finalize()", "clone()"])
   }
 

--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/query17.qll
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/query17.qll
@@ -9,19 +9,19 @@ class PasswordTracker extends DataFlow::Configuration {
   override predicate isSource(DataFlow::Node nd) { nd.asExpr() instanceof StringLiteral }
 
   override predicate isSink(DataFlow::Node nd) { passwordVarAssign(_, nd) }
+}
 
-  predicate passwordVarAssign(Variable v, DataFlow::Node nd) {
-    exists(SsaExplicitDefinition def |
-      nd = DataFlow::ssaDefinitionNode(def) and
-      def.getSourceVariable() = v and
-      v.getName().toLowerCase() = "password"
-    )
-  }
+predicate passwordVarAssign(Variable v, DataFlow::Node nd) {
+  exists(SsaExplicitDefinition def |
+    nd = DataFlow::ssaDefinitionNode(def) and
+    def.getSourceVariable() = v and
+    v.getName().toLowerCase() = "password"
+  )
 }
 
 query predicate test_query17(DataFlow::Node sink, string res) {
   exists(PasswordTracker pt, DataFlow::Node source, Variable v |
-    pt.hasFlow(source, sink) and pt.passwordVarAssign(v, sink)
+    pt.hasFlow(source, sink) and passwordVarAssign(v, sink)
   |
     res = "Password variable " + v.toString() + " is assigned a constant string."
   )

--- a/python/ql/lib/semmle/python/Metrics.qll
+++ b/python/ql/lib/semmle/python/Metrics.qll
@@ -163,7 +163,7 @@ class ClassMetrics extends Class {
    */
 
   /** should function f be excluded from the cohesion computation? */
-  predicate ignoreLackOfCohesion(Function f) { f.isInitMethod() or f.isSpecialMethod() }
+  private predicate ignoreLackOfCohesion(Function f) { f.isInitMethod() or f.isSpecialMethod() }
 
   private predicate methodPair(Function m1, Function m2) {
     m1.getScope() = this and

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.ql
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.ql
@@ -9,7 +9,7 @@ class ModificationOfParameterWithDefaultTest extends InlineExpectationsTest {
 
   override string getARelevantTag() { result = "modification" }
 
-  predicate relevant_node(DataFlow::Node sink) {
+  private predicate relevant_node(DataFlow::Node sink) {
     exists(ModificationOfParameterWithDefault::Configuration cfg | cfg.hasFlowTo(sink))
   }
 

--- a/ql/ql/src/queries/performance/ShouldBeNonMember.ql
+++ b/ql/ql/src/queries/performance/ShouldBeNonMember.ql
@@ -1,0 +1,45 @@
+/**
+ * @name Should be non-member predicate
+ * @description A predicate that does not use `this` nor any fields should be a non-member predicate instead.
+ * @kind problem
+ * @problem.severity recommendation
+ * @id ql/should-be-non-member
+ * @precision medium
+ */
+
+import ql
+
+from ClassPredicate p
+where
+  // no this/super/field access
+  not exists(ThisAccess t | t.getEnclosingPredicate() = p) and
+  not exists(Super s | s.getEnclosingPredicate() = p) and
+  not exists(FieldAccess f | f.getEnclosingPredicate() = p) and
+  // doesn't call a "this" method using an implicit this.
+  not exists(PredicateCall call |
+    call.getEnclosingPredicate() = p and
+    call.getTarget().(ClassPredicate).getParent().getType() =
+      p.getParent().getType().getASuperType*()
+  ) and
+  // not a trivial predicate
+  not p.getBody() instanceof NoneCall and
+  not p.getBody() instanceof AnyCall and
+  exists(p.getBody()) and
+  not p.getBody().(ComparisonFormula).getOperator() = "=" and // single "assignment"
+  not p.getBody() instanceof InstanceOf and // just a single "assignment" using instanceof
+  // not an override, and is not overriden
+  not p.isOverride() and // isn't an override
+  not exists(ClassPredicate other | other.overrides(p)) and // and isn't overridden
+  // location stuff is fine
+  not p.getName() = ["hasLocationInfo", "getLocation"] and
+  // private is OK - it's usually an internal utility predicate
+  not p.isPrivate() and
+  // if it's called from another file, having it inside a class works as "name-spacing".
+  not exists(Call c | c.getTarget() = p | c.getLocation().getFile() != p.getLocation().getFile()) and
+  // if multiple predicates have the same name in the same file, keeping them in the class works as "name-spcaing"
+  not exists(Predicate other |
+    other.getName() = p.getName() and
+    other.getLocation().getFile() = p.getLocation().getFile() and
+    other != p
+  )
+select p, p.getParent().getName() + "." + p.getName() + " could be a non-member predicate instead."


### PR DESCRIPTION
Identifies predicates defined inside a class that don't use the `this` pointer in any way.  

There is a whole bunch of benign patterns excluded.  

Edit. I don't like the results anyway, closing. 