### PR TITLE
QL: add unused-field query

### DIFF
--- a/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
+++ b/java/ql/lib/semmle/code/java/security/IntentUriPermissionManipulation.qll
@@ -96,8 +96,6 @@ private class IntentFlagsOrDataChangedSanitizer extends IntentUriPermissionManip
  * ```
  */
 private class IntentFlagsOrDataCheckedGuard extends IntentUriPermissionManipulationGuard {
-  Expr condition;
-
   IntentFlagsOrDataCheckedGuard() { intentFlagsOrDataChecked(this, _, _) }
 
   override predicate checks(Expr e, boolean branch) { intentFlagsOrDataChecked(this, e, branch) }

--- a/java/ql/src/experimental/semmle/code/java/PathSanitizer.qll
+++ b/java/ql/src/experimental/semmle/code/java/PathSanitizer.qll
@@ -136,8 +136,6 @@ private predicate isDisallowedWord(CompileTimeConstantExpr word) {
 
 /** A complementary guard that protects against path traversal, by looking for the literal `..`. */
 class PathTraversalGuard extends Guard instanceof MethodAccess {
-  Expr checked;
-
   PathTraversalGuard() {
     super.getMethod().getDeclaringType() instanceof TypeString and
     super.getMethod().hasName(["contains", "indexOf"]) and

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -330,8 +330,6 @@ module ClientRequest {
      * A model of a URL request made using `require("needle")(...)`.
      */
     class PromisedNeedleRequest extends ClientRequest::Range {
-      DataFlow::Node url;
-
       PromisedNeedleRequest() { this = DataFlow::moduleImport("needle").getACall() }
 
       override DataFlow::Node getUrl() { result = this.getArgument(1) }

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -683,8 +683,6 @@ private module ExpressJwt {
  */
 private module NodeRsa {
   private class CreateKey extends CryptographicKeyCreation, API::InvokeNode {
-    CryptographicAlgorithm algorithm;
-
     CreateKey() {
       this = API::moduleImport("node-rsa").getAnInstantiation()
       or

--- a/python/ql/src/experimental/semmle/python/frameworks/Flask.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Flask.qll
@@ -75,7 +75,10 @@ module ExperimentalFlask {
   private class FlaskResponse extends DataFlow::CallCfgNode, HeaderDeclaration::Range {
     KeyValuePair item;
 
-    FlaskResponse() { this = Flask::Response::classRef().getACall() }
+    FlaskResponse() {
+      this = Flask::Response::classRef().getACall() and
+      item = this.getArg(_).asExpr().(Dict).getAnItem()
+    }
 
     override DataFlow::Node getNameArg() { result.asExpr() = item.getKey() }
 

--- a/python/ql/test/experimental/query-tests/Security/CWE-113/HeaderInjection.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-113/HeaderInjection.expected
@@ -13,8 +13,6 @@ edges
 | flask_bad.py:35:18:35:24 | ControlFlowNode for request | flask_bad.py:35:18:35:29 | ControlFlowNode for Attribute |
 | flask_bad.py:35:18:35:29 | ControlFlowNode for Attribute | flask_bad.py:35:18:35:43 | ControlFlowNode for Subscript |
 | flask_bad.py:35:18:35:43 | ControlFlowNode for Subscript | flask_bad.py:38:24:38:33 | ControlFlowNode for rfs_header |
-| flask_bad.py:44:44:44:50 | ControlFlowNode for request | flask_bad.py:44:44:44:55 | ControlFlowNode for Attribute |
-| flask_bad.py:44:44:44:55 | ControlFlowNode for Attribute | flask_bad.py:44:44:44:69 | ControlFlowNode for Subscript |
 nodes
 | django_bad.py:5:18:5:58 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | django_bad.py:7:40:7:49 | ControlFlowNode for rfs_header | semmle.label | ControlFlowNode for rfs_header |
@@ -36,9 +34,6 @@ nodes
 | flask_bad.py:35:18:35:29 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
 | flask_bad.py:35:18:35:43 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
 | flask_bad.py:38:24:38:33 | ControlFlowNode for rfs_header | semmle.label | ControlFlowNode for rfs_header |
-| flask_bad.py:44:44:44:50 | ControlFlowNode for request | semmle.label | ControlFlowNode for request |
-| flask_bad.py:44:44:44:55 | ControlFlowNode for Attribute | semmle.label | ControlFlowNode for Attribute |
-| flask_bad.py:44:44:44:69 | ControlFlowNode for Subscript | semmle.label | ControlFlowNode for Subscript |
 subpaths
 #select
 | django_bad.py:7:40:7:49 | ControlFlowNode for rfs_header | django_bad.py:5:18:5:58 | ControlFlowNode for Attribute() | django_bad.py:7:40:7:49 | ControlFlowNode for rfs_header | $@ HTTP header is constructed from a $@. | django_bad.py:7:40:7:49 | ControlFlowNode for rfs_header | This | django_bad.py:5:18:5:58 | ControlFlowNode for Attribute() | user-provided value |
@@ -47,4 +42,3 @@ subpaths
 | flask_bad.py:21:38:21:47 | ControlFlowNode for rfs_header | flask_bad.py:19:18:19:24 | ControlFlowNode for request | flask_bad.py:21:38:21:47 | ControlFlowNode for rfs_header | $@ HTTP header is constructed from a $@. | flask_bad.py:21:38:21:47 | ControlFlowNode for rfs_header | This | flask_bad.py:19:18:19:24 | ControlFlowNode for request | user-provided value |
 | flask_bad.py:29:34:29:43 | ControlFlowNode for rfs_header | flask_bad.py:27:18:27:24 | ControlFlowNode for request | flask_bad.py:29:34:29:43 | ControlFlowNode for rfs_header | $@ HTTP header is constructed from a $@. | flask_bad.py:29:34:29:43 | ControlFlowNode for rfs_header | This | flask_bad.py:27:18:27:24 | ControlFlowNode for request | user-provided value |
 | flask_bad.py:38:24:38:33 | ControlFlowNode for rfs_header | flask_bad.py:35:18:35:24 | ControlFlowNode for request | flask_bad.py:38:24:38:33 | ControlFlowNode for rfs_header | $@ HTTP header is constructed from a $@. | flask_bad.py:38:24:38:33 | ControlFlowNode for rfs_header | This | flask_bad.py:35:18:35:24 | ControlFlowNode for request | user-provided value |
-| flask_bad.py:44:44:44:69 | ControlFlowNode for Subscript | flask_bad.py:44:44:44:50 | ControlFlowNode for request | flask_bad.py:44:44:44:69 | ControlFlowNode for Subscript | $@ HTTP header is constructed from a $@. | flask_bad.py:44:44:44:69 | ControlFlowNode for Subscript | This | flask_bad.py:44:44:44:50 | ControlFlowNode for request | user-provided value |

--- a/ql/ql/src/queries/performance/UnusedField.ql
+++ b/ql/ql/src/queries/performance/UnusedField.ql
@@ -31,13 +31,6 @@ where
       access.getEnclosingPredicate() = p
     )
   ) and
-  (if clz = implClz then extraMsg = "." else extraMsg = " of any class between it and $@.") and
-  // The `implClz` does not override `field` with a more specific type.
-  not exists(FieldDecl override |
-    override = implClz.getDeclaration().getAField() and
-    override.getName() = field.getName() and
-    override.hasAnnotation("override") and
-    override.getVarDecl().getType() != field.getVarDecl().getType()
-  )
+  (if clz = implClz then extraMsg = "." else extraMsg = " of any class between it and $@.")
 select clz, "The field $@ declared in $@ is not used in the characteristic predicate" + extraMsg,
   field, field.getName(), clz, clz.getName(), implClz, implClz.getName()

--- a/ql/ql/src/queries/performance/UnusedField.ql
+++ b/ql/ql/src/queries/performance/UnusedField.ql
@@ -16,8 +16,7 @@ where
   implClz.getASuperType*() = clz and
   // The field is not accessed in the charpred (of any of the classes)
   not exists(FieldAccess access |
-    access.getEnclosingPredicate() =
-      [clz.getDeclaration().getCharPred(), implClz.getDeclaration().getCharPred()]
+    access.getEnclosingPredicate() = [clz, implClz].getDeclaration().getCharPred()
   ) and
   // The implementation class is not abstract, and the field is not an override
   not implClz.getDeclaration().isAbstract() and

--- a/ql/ql/src/queries/performance/UnusedField.ql
+++ b/ql/ql/src/queries/performance/UnusedField.ql
@@ -1,0 +1,43 @@
+/**
+ * @name UnusedField
+ * @description A field that is not used in the characteristic predicate will contain every value
+ *              of its type when accessed in other predicates, which is probably not intended.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/unused-field
+ * @precision high
+ */
+
+import ql
+
+from ClassType clz, ClassType implClz, FieldDecl field, string extraMsg
+where
+  clz.getDeclaration().getAField() = field and
+  implClz.getASuperType*() = clz and
+  // The field is not accessed in the charpred (of any of the classes)
+  not exists(FieldAccess access |
+    access.getEnclosingPredicate() =
+      [clz.getDeclaration().getCharPred(), implClz.getDeclaration().getCharPred()]
+  ) and
+  // The implementation class is not abstract, and the field is not an override
+  not implClz.getDeclaration().isAbstract() and
+  not field.isOverride() and
+  // There doesn't exist a class in between `clz` and `implClz` that binds `field`.
+  not exists(ClassType c, CharPred p |
+    c.getASuperType*() = clz and
+    implClz.getASuperType*() = c and
+    p = c.getDeclaration().getCharPred() and
+    exists(FieldAccess access | access.getDeclaration() = field |
+      access.getEnclosingPredicate() = p
+    )
+  ) and
+  (if clz = implClz then extraMsg = "." else extraMsg = " of any class between it and $@.") and
+  // The `implClz` does not override `field` with a more specific type.
+  not exists(FieldDecl override |
+    override = implClz.getDeclaration().getAField() and
+    override.getName() = field.getName() and
+    override.hasAnnotation("override") and
+    override.getVarDecl().getType() != field.getVarDecl().getType()
+  )
+select clz, "The field $@ declared in $@ is not used in the characteristic predicate" + extraMsg,
+  field, field.getName(), clz, clz.getName(), implClz, implClz.getName()

--- a/ql/ql/src/queries/performance/UnusedField.ql
+++ b/ql/ql/src/queries/performance/UnusedField.ql
@@ -27,7 +27,7 @@ where
     c.getASuperType*() = clz and
     implClz.getASuperType*() = c and
     p = c.getDeclaration().getCharPred() and
-    exists(FieldAccess access | access.getDeclaration() = field |
+    exists(FieldAccess access | access.getName() = field.getName() |
       access.getEnclosingPredicate() = p
     )
   ) and


### PR DESCRIPTION
Inspired by a recent code-review. 

Detects when a field is not bound by the charpred.  
Also handles the cases where the field is defined in an abstract super-class. 

I fixed all five errors detected by the query. They were pretty benign except for the Python warning in `Flask.qll`.  
(I think the error in `Flask.qll` was from not copy-pasting a line from the above class, so I did that). 