### PR TITLE
C#: Make `TypeParameterConstraints` a `CachedEntity`

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
@@ -1,7 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Semmle.Extraction.Entities;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -21,33 +19,9 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void Populate(TextWriter trapFile)
         {
-            var constraints = new TypeParameterConstraints(Context);
-            trapFile.type_parameter_constraints(constraints, this);
-
-            if (Symbol.HasReferenceTypeConstraint)
-                trapFile.general_type_parameter_constraints(constraints, 1);
-
-            if (Symbol.HasValueTypeConstraint)
-                trapFile.general_type_parameter_constraints(constraints, 2);
-
-            if (Symbol.HasConstructorConstraint)
-                trapFile.general_type_parameter_constraints(constraints, 3);
-
-            if (Symbol.HasUnmanagedTypeConstraint)
-                trapFile.general_type_parameter_constraints(constraints, 4);
-
-            if (Symbol.ReferenceTypeConstraintNullableAnnotation == NullableAnnotation.Annotated)
-                trapFile.general_type_parameter_constraints(constraints, 5);
-
-            foreach (var abase in Symbol.GetAnnotatedTypeConstraints())
-            {
-                var t = Create(Context, abase.Symbol);
-                trapFile.specific_type_parameter_constraints(constraints, t.TypeRef);
-                if (!abase.HasObliviousNullability())
-                    trapFile.specific_type_parameter_nullability(constraints, t.TypeRef, NullabilityEntity.Create(Context, Nullability.Create(abase)));
-            }
-
             trapFile.types(this, Kinds.TypeKind.TYPE_PARAMETER, Symbol.Name);
+
+            TypeParameterConstraints.Create(Context, this);
 
             var parentNs = Namespace.Create(Context, Symbol.TypeParameterKind == TypeParameterKind.Method ? Context.Compilation.GlobalNamespace : Symbol.ContainingNamespace);
             trapFile.parent_namespace(this, parentNs);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
@@ -1,14 +1,65 @@
+using Microsoft.CodeAnalysis;
 using System.IO;
 
 namespace Semmle.Extraction.CSharp.Entities
 {
-    internal class TypeParameterConstraints : FreshEntity
+    internal class TypeParameterConstraints : CachedEntity<ITypeParameterSymbol>
     {
-        public TypeParameterConstraints(Context cx)
-            : base(cx) { }
+        private readonly TypeParameter parent;
 
-        protected override void Populate(TextWriter trapFile)
+        public TypeParameterConstraints(Context cx, TypeParameter parent)
+            : base(cx, parent.Symbol)
         {
+            this.parent = parent;
+        }
+
+        public override void WriteId(EscapingTextWriter trapFile)
+        {
+            trapFile.WriteSubId(parent);
+            trapFile.Write(";typeparameterconstraints");
+        }
+
+        public override bool NeedsPopulation => true;
+
+        public override void Populate(TextWriter trapFile)
+        {
+            trapFile.type_parameter_constraints(this, parent);
+
+            if (Symbol.HasReferenceTypeConstraint)
+                trapFile.general_type_parameter_constraints(this, 1);
+
+            if (Symbol.HasValueTypeConstraint)
+                trapFile.general_type_parameter_constraints(this, 2);
+
+            if (Symbol.HasConstructorConstraint)
+                trapFile.general_type_parameter_constraints(this, 3);
+
+            if (Symbol.HasUnmanagedTypeConstraint)
+                trapFile.general_type_parameter_constraints(this, 4);
+
+            if (Symbol.ReferenceTypeConstraintNullableAnnotation == NullableAnnotation.Annotated)
+                trapFile.general_type_parameter_constraints(this, 5);
+
+            foreach (var abase in Symbol.GetAnnotatedTypeConstraints())
+            {
+                var t = Type.Create(Context, abase.Symbol);
+                trapFile.specific_type_parameter_constraints(this, t.TypeRef);
+                if (!abase.HasObliviousNullability())
+                    trapFile.specific_type_parameter_nullability(this, t.TypeRef, NullabilityEntity.Create(Context, Nullability.Create(abase)));
+            }
+        }
+
+        public override Location? ReportingLocation => null;
+
+        public static TypeParameterConstraints Create(Context cx, TypeParameter p) =>
+            TypeParameterConstraintsFactory.Instance.CreateEntity(cx, (typeof(TypeParameterConstraints), p), p);
+
+        private class TypeParameterConstraintsFactory : CachedEntityFactory<TypeParameter, TypeParameterConstraints>
+        {
+            public static TypeParameterConstraintsFactory Instance { get; } = new TypeParameterConstraintsFactory();
+
+            public override TypeParameterConstraints Create(Context cx, TypeParameter init) => new(cx, init);
         }
     }
 }
+


### PR DESCRIPTION
Extracted from https://github.com/github/codeql/pull/7456, in preparation for shared extraction.