### PR TITLE
Add test checking that inheritence is noticed even with annotations present

### DIFF
--- a/java/ql/test/library-tests/method-signatures/Test.java
+++ b/java/ql/test/library-tests/method-signatures/Test.java
@@ -1,0 +1,13 @@
+import java.lang.annotation.*;
+
+public class Test {
+
+  @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+  @interface NotNull { }
+
+  class Inner { }
+
+  public void annotations(@NotNull byte[] b1, byte @NotNull [] b2, @NotNull String s, Class<@NotNull String> c, @NotNull Test.Inner ti, Class<? extends @NotNull String> wc, Class<String>[] classes, @NotNull byte b, @NotNull String[] sArray, String @NotNull [] sArray2) { }
+
+}
+

--- a/java/ql/test/library-tests/method-signatures/signatures.expected
+++ b/java/ql/test/library-tests/method-signatures/signatures.expected
@@ -1,0 +1,1 @@
+| Test.java:10:15:10:25 | annotations | annotations(byte[],byte[],java.lang.String,java.lang.Class,Test.Inner,java.lang.Class,java.lang.Class[],byte,java.lang.String[],java.lang.String[]) |

--- a/java/ql/test/library-tests/method-signatures/signatures.ql
+++ b/java/ql/test/library-tests/method-signatures/signatures.ql
@@ -1,0 +1,5 @@
+import java
+
+from Method m
+where m.getFile().getBaseName() = "Test.java"
+select m, m.getSignature()

--- a/java/ql/test/query-tests/InefficientOutputStream/InefficientOutputStreamAnnotations.java
+++ b/java/ql/test/query-tests/InefficientOutputStream/InefficientOutputStreamAnnotations.java
@@ -1,0 +1,24 @@
+import java.io.*;
+import java.lang.annotation.*;
+
+public class Test {
+
+  @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
+  @interface NotNull { }
+
+  public static void test() {
+
+        OutputStream stream = new OutputStream() {
+          @Override
+          public void write(int b) throws IOException {
+            OutputStream otherStream = null;
+            otherStream.write(1);            
+          }
+          @Override
+          public void write(byte @NotNull [] b, int off, int len) throws IOException { // GOOD: even with the annotation @NotNull, this overrides write(byte[], int, int).
+          }
+        };
+
+  }
+
+}

--- a/java/ql/test/query-tests/InefficientOutputStream/InefficientOutputStreamAnnotations.java
+++ b/java/ql/test/query-tests/InefficientOutputStream/InefficientOutputStreamAnnotations.java
@@ -1,7 +1,7 @@
 import java.io.*;
 import java.lang.annotation.*;
 
-public class Test {
+public class InefficientOutputStreamAnnotations {
 
   @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.TYPE_USE})
   @interface NotNull { }


### PR DESCRIPTION
This is based on the scenario raised in https://github.com/github/codeql/issues/7610, and tests that annotations do not interfere with comparing method signatures to determine inheritance. This is expected to fail until an extractor fix is landed.