### PR TITLE
Data flow: Reduce non-linear recursion in `SummaryComponentStack::bottom`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -90,7 +90,9 @@ module Public {
     predicate contains(SummaryComponent c) { c = this.drop(_).head() }
 
     /** Gets the bottom element of this stack. */
-    SummaryComponent bottom() { result = this.drop(this.length() - 1).head() }
+    SummaryComponent bottom() {
+      this = TSingletonSummaryComponentStack(result) or result = this.tail().bottom()
+    }
 
     /** Gets a textual representation of this stack. */
     string toString() {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -90,7 +90,9 @@ module Public {
     predicate contains(SummaryComponent c) { c = this.drop(_).head() }
 
     /** Gets the bottom element of this stack. */
-    SummaryComponent bottom() { result = this.drop(this.length() - 1).head() }
+    SummaryComponent bottom() {
+      this = TSingletonSummaryComponentStack(result) or result = this.tail().bottom()
+    }
 
     /** Gets a textual representation of this stack. */
     string toString() {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -90,7 +90,9 @@ module Public {
     predicate contains(SummaryComponent c) { c = this.drop(_).head() }
 
     /** Gets the bottom element of this stack. */
-    SummaryComponent bottom() { result = this.drop(this.length() - 1).head() }
+    SummaryComponent bottom() {
+      this = TSingletonSummaryComponentStack(result) or result = this.tail().bottom()
+    }
 
     /** Gets a textual representation of this stack. */
     string toString() {


### PR DESCRIPTION
Before:
```
[2022-01-28 09:45:34] (449s) Tuple counts for FlowSummaryImpl::Public::SummaryComponentStack::bottom_dispred#ff/2@i23#25a5eew4 after 432ms:
                      0       ~0%     {2} r1 = SCAN FlowSummaryImpl::Public::SummaryComponentStack::length#ff#prev_delta OUTPUT In.0 'this', (In.1 - 1)
                      0       ~0%     {2} r2 = JOIN r1 WITH FlowSummaryImpl::Public::SummaryComponentStack::drop#fff#prev ON FIRST 2 OUTPUT Rhs.2, Lhs.0 'this'
                      0       ~0%     {2} r3 = JOIN r2 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff#prev ON FIRST 1 OUTPUT Lhs.1 'this', Rhs.1 'result'

                      4171589 ~5%     {2} r4 = SCAN FlowSummaryImpl::Public::SummaryComponentStack::length#ff#prev OUTPUT In.0 'this', (In.1 - 1)
                      4171589 ~0%     {2} r5 = JOIN r4 WITH FlowSummaryImpl::Public::SummaryComponentStack::drop#fff#prev ON FIRST 2 OUTPUT Rhs.2, Lhs.0 'this'
                      0       ~0%     {2} r6 = JOIN r5 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff#prev_delta ON FIRST 1 OUTPUT Lhs.1 'this', Rhs.1 'result'

                      62238   ~0%     {3} r7 = SCAN FlowSummaryImpl::Public::SummaryComponentStack::drop#fff#prev_delta OUTPUT In.2, In.0 'this', In.1
                      62238   ~8%     {3} r8 = JOIN r7 WITH FlowSummaryImpl::Public::SummaryComponentStack::head_dispred#ff#prev ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.2, Rhs.1 'result'
                      62238   ~5%     {5} r9 = JOIN r8 WITH FlowSummaryImpl::Public::SummaryComponentStack::length#ff#prev ON FIRST 1 OUTPUT Lhs.0 'this', Lhs.1, Lhs.2 'result', Rhs.1, (Rhs.1 - 1)
                      10373   ~6%     {5} r10 = SELECT r9 ON In.4 = In.1
                      10373   ~0%     {2} r11 = SCAN r10 OUTPUT In.0 'this', In.2 'result'

                      10373   ~0%     {2} r12 = r6 UNION r11
                      10373   ~0%     {2} r13 = r3 UNION r12
                      10373   ~0%     {2} r14 = r13 AND NOT FlowSummaryImpl::Public::SummaryComponentStack::bottom_dispred#ff#prev(Lhs.0 'this', Lhs.1 'result')
                                      return r14
```

After:
```
[2022-01-28 09:52:48] (6s) Tuple counts for FlowSummaryImpl::Public::SummaryComponentStack::bottom#ff/2@i21#6243afwv after 5ms:
                      0     ~0%     {2} r1 = JOIN FlowSummaryImpl::Public::SummaryComponentStack::bottom#ff#prev_delta WITH FlowSummaryImpl::Private::TConsSummaryComponentStack#fff#reorder_1_0_2#prev ON FIRST 1 OUTPUT Lhs.1 'result', Rhs.2 'this'

                      10373 ~3%     {2} r2 = SCAN FlowSummaryImpl::Private::TConsSummaryComponentStack#fff#prev_delta OUTPUT In.1, In.2 'this'
                      10373 ~2%     {2} r3 = JOIN r2 WITH FlowSummaryImpl::Public::SummaryComponentStack::bottom#ff#prev ON FIRST 1 OUTPUT Rhs.1 'result', Lhs.1 'this'

                      10373 ~2%     {2} r4 = r1 UNION r3
                      10373 ~2%     {2} r5 = r4 AND NOT FlowSummaryImpl::Public::SummaryComponentStack::bottom#ff#prev(Lhs.1 'this', Lhs.0 'result')
                      10373 ~0%     {2} r6 = SCAN r5 OUTPUT In.1 'this', In.0 'result'
                                    return r6
```