### PR TITLE
C++: Fix FPs for cpp/cleartext-storage-file

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextFileWrite.ql
@@ -65,6 +65,7 @@ where
   midNode.getNode().asExpr() = mid and
   mid = w.getASource() and
   dest = w.getDest() and
+  not dest.(VariableAccess).getTarget().getName() = ["stdin", "stdout", "stderr"] and // exclude calls with standard streams
   not isFileName(globalValueNumber(source)) and // file names are not passwords
   not exists(string convChar | convChar = w.getSourceConvChar(mid) | not convChar = ["s", "S"]) // ignore things written with other conversion characters
 select w, sourceNode, midNode,

--- a/cpp/ql/src/change-notes/2022-01-28-cleartext-storage-file.md
+++ b/cpp/ql/src/change-notes/2022-01-28-cleartext-storage-file.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/cleartext-storage-file` query has been improved, removing false positives where data is written to a standard output stream.


### PR DESCRIPTION
Fix the FPs for `cpp/cleartext-storage-file` that we discovered on `kamailio/kamailio`, where the 'file' was in fact `stderr`.

The code I've used is simple compared to the exclusions in `cpp/cleartext-transmission`, but I found this simple solution worked well in practice.

Diff query: https://lgtm.com/query/1738869787752851711/