### PR TITLE
Restrict AST nodes according to string length

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
@@ -133,7 +133,10 @@ int getNumCharsInFunction(Function f) {
     strictsum(ASTNode node | node = getAnASTNodeWithAFeature(f) | getTokenizedAstNode(node).length())
 }
 
-// Evaluator string limit is 5395415 characters. We choose a limit lower than this.
+/**
+ * The maximum number of characters a feature can be.
+ * The evaluator string limit is 5395415 characters. We choose a limit lower than this.
+ */
 private int getMaxChars() { result = 1000000 }
 
 /**

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
@@ -128,17 +128,15 @@ ASTNode getAnASTNodeWithAFeature(Function f) {
 }
 
 int getNumCharsInFunction(Function f) {
-    result = strictsum(int i |
-      exists(ASTNode node | node = getAnASTNodeWithAFeature(f) and i = getTokenizedAstNode(node).length()) |
-      i
-    )
+  result =
+    strictsum(ASTNode node | node = getAnASTNodeWithAFeature(f) | getTokenizedAstNode(node).length())
 }
 
 // Evaluator string limit is 5395415 characters. We choose a limit lower than this.
 private int getMaxChars() { result = 1000000 }
 
 Function getFeaturizableFunction(Function f) {
-   result = f and getNumCharsInFunction(f) <= getMaxChars()
+  result = f and getNumCharsInFunction(f) <= getMaxChars()
 }
 
 /**
@@ -146,10 +144,11 @@ Function getFeaturizableFunction(Function f) {
  * `enclosingFunctionBody` feature for an endpoint.
  */
 string getBodyTokensFeature(Function function) {
-  // Performance optimization: If a function has more than getMaxChars() characters in its body subtokens, 
+  // Performance optimization: If a function has more than getMaxChars() characters in its body subtokens,
   // then featurize it as absent.
   function = getFeaturizableFunction(function) and
-  result = strictconcat(Location l, string token |
+  result =
+    strictconcat(Location l, string token |
       // The use of a nested exists here allows us to avoid duplicates due to two AST nodes in the
       // same location featurizing to the same token. By using a nested exists, we take only unique
       // (location, token) pairs.

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
@@ -127,7 +127,7 @@ ASTNode getAnASTNodeWithAFeature(Function f) {
   result = getAnASTNodeToFeaturize(f)
 }
 
-/** Returns the number of source-code characters in a function.  */
+/** Returns the number of source-code characters in a function. */
 int getNumCharsInFunction(Function f) {
   result =
     strictsum(ASTNode node | node = getAnASTNodeWithAFeature(f) | getTokenizedAstNode(node).length())

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
@@ -144,6 +144,13 @@ Function getFeaturizableFunction(Function f) {
  * `enclosingFunctionBody` feature for an endpoint.
  */
 string getBodyTokensFeature(Function function) {
+  // Performance optimization: If a function has more than 256 body subtokens, then featurize it as
+  // absent. This approximates the behavior of the classifer on non-generic body features where
+  // large body features are replaced by the absent token.
+  strictcount(ASTNode node |
+    node = getAnASTNodeToFeaturize(function) and
+    exists(getTokenizedAstNode(node))
+  ) <= 256 and
   // Performance optimization: If a function has more than getMaxChars() characters in its body subtokens,
   // then featurize it as absent.
   function = getFeaturizableFunction(function) and

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
@@ -38,7 +38,9 @@ pragma[inline]
 ASTNode getAnASTNodeToFeaturize(Function f) {
   result.getParent*() = f and
   // Don't featurize the function name as part of the function body tokens
-  not result = f.getIdentifier()
+  not result = f.getIdentifier() and
+  // Don't include nodes with names that are too long (to avoid catastrophic error due to tokenized strings getting too long)
+  result.toString().length() < 500000
 }
 
 /**


### PR DESCRIPTION
Fix for the catastrophic error identified in https://github.com/github/ml-ql-adaptive-threat-modeling/issues/1618

The catastrophic error is `CatastrophicError "String too long (5395415 characters)"`, which occurs when we tokenize the string associated with the `ASTNode`. I've added a restriction to throw away strings that are longer than 1,000,000 characters before we attempt to tokenize them.