### PR TITLE
C++: replace ReturnValue nodes in flow paths

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1698,7 +1698,8 @@ private module LocalFlowBigStep {
   private class FlowCheckNode extends NodeEx {
     FlowCheckNode() {
       castNode(this.asNode()) or
-      clearsContentCached(this.asNode(), _)
+      clearsContentCached(this.asNode(), _) or
+      nodeIsShown(this.asNode())
     }
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1698,7 +1698,8 @@ private module LocalFlowBigStep {
   private class FlowCheckNode extends NodeEx {
     FlowCheckNode() {
       castNode(this.asNode()) or
-      clearsContentCached(this.asNode(), _)
+      clearsContentCached(this.asNode(), _) or
+      nodeIsShown(this.asNode())
     }
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1698,7 +1698,8 @@ private module LocalFlowBigStep {
   private class FlowCheckNode extends NodeEx {
     FlowCheckNode() {
       castNode(this.asNode()) or
-      clearsContentCached(this.asNode(), _)
+      clearsContentCached(this.asNode(), _) or
+      nodeIsShown(this.asNode())
     }
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1698,7 +1698,8 @@ private module LocalFlowBigStep {
   private class FlowCheckNode extends NodeEx {
     FlowCheckNode() {
       castNode(this.asNode()) or
-      clearsContentCached(this.asNode(), _)
+      clearsContentCached(this.asNode(), _) or
+      nodeIsShown(this.asNode())
     }
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -354,6 +354,14 @@ predicate nodeIsHidden(Node n) {
   ReadNodeFlow::flowThrough(n, _) and
   not ReadNodeFlow::flowOutOf(n, _) and
   not ReadNodeFlow::flowInto(_, n)
+  or
+  n.asInstruction() instanceof ReturnValueInstruction
+}
+
+predicate nodeIsShown(Node n) {
+  exists(ReturnStmt r |
+    n.asExpr() = r.getExpr()
+  )
 }
 
 class LambdaCallKind = Unit;


### PR DESCRIPTION
Improves data flow path readability for C++ by hiding the per-function `ReturnValue` nodes and forcing the nodes created for each `ReturnStmt` to be included in the displayed path. This also adds a new `nodeIsShown` predicate to the data flow library's per-language interface.