### PR TITLE
C++: Add query for missing mode argument in `open`/`openat` calls

### DIFF
--- a/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
+++ b/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* he `cpp/world-writable-file-creation` query now only detects `open` and `openat` calls with the `O_CREAT` or `O_TMPFILE` flag.
+* The `cpp/world-writable-file-creation` query now only detects `open` and `openat` calls with the `O_CREAT` or `O_TMPFILE` flag.

--- a/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
+++ b/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `cpp/world-writable-file-creation` query now only detects `open` and `openat` calls with both the `O_CREAT` and `O_TMPFILE` flag, irrespective of whether the `mode` argument is present.
+* he `cpp/world-writable-file-creation` query now only detects `open` and `openat` calls with the `O_CREAT` or `O_TMPFILE` flag.

--- a/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
+++ b/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `cpp/world-writable-file-creation` query now only detects `openat` calls with the `O_CREAT` flag, irrespective of whether the `mode` argument is present.
+* The `cpp/world-writable-file-creation` query now only detects `open` and `openat` calls with both the `O_CREAT` and `O_TMPFILE` flag, irrespective of whether the `mode` argument is present.

--- a/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
+++ b/cpp/ql/lib/change-notes/2022-02-02-detect-creat-in-openat.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/world-writable-file-creation` query now only detects `openat` calls with the `O_CREAT` flag, irrespective of whether the `mode` argument is present.

--- a/cpp/ql/lib/change-notes/2022-02-02-detect-missing-mode-argument-for-open.md
+++ b/cpp/ql/lib/change-notes/2022-02-02-detect-missing-mode-argument-for-open.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `open-call-with-mode-argument`, to detect when `open` or `openat` is called with the `O_CREAT` flag but when the `mode` argument is omitted.

--- a/cpp/ql/lib/change-notes/2022-02-02-detect-missing-mode-argument-for-open.md
+++ b/cpp/ql/lib/change-notes/2022-02-02-detect-missing-mode-argument-for-open.md
@@ -1,4 +1,4 @@
 ---
 category: newQuery
 ---
-* Added a new query, `open-call-with-mode-argument`, to detect when `open` or `openat` is called with the `O_CREAT` flag but when the `mode` argument is omitted.
+* Added a new query, `cpp/open-call-with-mode-argument`, to detect when `open` or `openat` is called with the `O_CREAT` or `O_TMPFILE` flag but when the `mode` argument is omitted.

--- a/cpp/ql/lib/semmle/code/cpp/commons/unix/Constants.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/unix/Constants.qll
@@ -11,10 +11,10 @@ import cpp
  */
 bindingset[input]
 int parseOctal(string input) {
-  input.charAt(0) = "0" and
+  input.regexpMatch("0[0-7]+") and
   result =
-    strictsum(int ix |
-      ix in [0 .. input.length()]
+    sum(int ix |
+      ix in [1 .. input.length()]
     |
       8.pow(input.length() - (ix + 1)) * input.charAt(ix).toInt()
     )

--- a/cpp/ql/lib/semmle/code/cpp/commons/unix/Constants.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/unix/Constants.qll
@@ -13,7 +13,7 @@ bindingset[input]
 int parseOctal(string input) {
   input.regexpMatch("0[0-7]+") and
   result =
-    sum(int ix |
+    strictsum(int ix |
       ix in [1 .. input.length()]
     |
       8.pow(input.length() - (ix + 1)) * input.charAt(ix).toInt()

--- a/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
@@ -12,17 +12,16 @@
 
 import cpp
 import FilePermissions
-import semmle.code.cpp.commons.unix.Constants
 
 predicate worldWritableCreation(FileCreationExpr fc, int mode) {
   mode = localUmask(fc).mask(fc.getMode()) and
-  sets(mode, s_iwoth())
+  sets(mode, UnixConstants::s_iwoth())
 }
 
 predicate setWorldWritable(FunctionCall fc, int mode) {
   fc.getTarget().getName() = ["chmod", "fchmod", "_chmod", "_wchmod"] and
   mode = fc.getArgument(1).getValue().toInt() and
-  sets(mode, s_iwoth())
+  sets(mode, UnixConstants::s_iwoth())
 }
 
 from Expr fc, int mode, string message

--- a/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
@@ -15,13 +15,13 @@ import FilePermissions
 
 predicate worldWritableCreation(FileCreationExpr fc, int mode) {
   mode = localUmask(fc).mask(fc.getMode()) and
-  sets(mode, UnixConstants::s_iwoth())
+  setsAnyBits(mode, UnixConstants::s_iwoth())
 }
 
 predicate setWorldWritable(FunctionCall fc, int mode) {
   fc.getTarget().getName() = ["chmod", "fchmod", "_chmod", "_wchmod"] and
   mode = fc.getArgument(1).getValue().toInt() and
-  sets(mode, UnixConstants::s_iwoth())
+  setsAnyBits(mode, UnixConstants::s_iwoth())
 }
 
 from Expr fc, int mode, string message

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -6,7 +6,7 @@ int parseHex(string input) {
   exists(string lowerCaseInput | lowerCaseInput = input.toLowerCase() |
     lowerCaseInput.regexpMatch("0x[0-9a-f]+") and
     result =
-      sum(int ix |
+      strictsum(int ix |
         ix in [2 .. input.length()]
       |
         16.pow(input.length() - (ix + 1)) * "0123456789abcdef".indexOf(lowerCaseInput.charAt(ix))
@@ -14,6 +14,10 @@ int parseHex(string input) {
   )
 }
 
+/**
+ * Gets the value defined by the `O_CREAT` macro if the macro
+ * exists and if every definition defines the same value.
+ */
 int o_creat() {
   result =
     unique(int v |
@@ -23,6 +27,10 @@ int o_creat() {
     )
 }
 
+/**
+ * Gets the value defined by the `O_TMPFILE` macro if the macro
+ * exists and if every definition defines the same value.
+ */
 int o_tmpfile() {
   result =
     unique(int v |

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -3,7 +3,7 @@ import semmle.code.cpp.commons.unix.Constants
 
 bindingset[input]
 int parseHex(string input) {
-  input.prefix(2) = "0x" and
+  input.matches("0x%") and
   result =
     strictsum(int ix |
       ix in [2 .. input.length()]

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -134,7 +134,7 @@ abstract class FileCreationWithOptionalModeExpr extends FileCreationExpr {
 
 class OpenCreationExpr extends FileCreationWithOptionalModeExpr {
   OpenCreationExpr() {
-    this.getTarget().getName() = ["open", "_open", "_wopen"] and
+    this.getTarget().hasGlobalOrStdName(["open", "_open", "_wopen"]) and
     exists(int flag | flag = this.getArgument(1).getValue().toInt() |
       setsFlag(flag, o_creat()) or setsFlag(flag, o_tmpfile())
     )
@@ -163,7 +163,7 @@ class CreatCreationExpr extends FileCreationExpr {
 
 class OpenatCreationExpr extends FileCreationWithOptionalModeExpr {
   OpenatCreationExpr() {
-    this.getTarget().getName() = "openat" and
+    this.getTarget().hasGlobalOrStdName("openat") and
     exists(int flag | flag = this.getArgument(2).getValue().toInt() |
       setsFlag(flag, o_creat()) or setsFlag(flag, o_tmpfile())
     )

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -98,7 +98,7 @@ class OpenCreationExpr extends FileCreationWithOptionalModeExpr {
   override predicate hasModeArgument() { exists(this.getArgument(2)) }
 
   override int getMode() {
-    if hasModeArgument()
+    if this.hasModeArgument()
     then result = this.getArgument(2).getValue().toInt()
     else
       // assume anything is permitted
@@ -125,7 +125,7 @@ class OpenatCreationExpr extends FileCreationWithOptionalModeExpr {
   override predicate hasModeArgument() { exists(this.getArgument(3)) }
 
   override int getMode() {
-    if hasModeArgument()
+    if this.hasModeArgument()
     then result = this.getArgument(3).getValue().toInt()
     else
       // assume anything is permitted

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -1,6 +1,11 @@
 import cpp
 import semmle.code.cpp.commons.unix.Constants as UnixConstants
 
+/**
+ * Gets the number corresponding to the contents of `input` in base-16.
+ * Note: the first two characters of `input` must be `0x`. For example:
+ * `parseHex("0x123abc") = 1194684`.
+ */
 bindingset[input]
 int parseHex(string input) {
   exists(string lowerCaseInput | lowerCaseInput = input.toLowerCase() |

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -111,12 +111,18 @@ class CreatCreationExpr extends FileCreationExpr {
 class OpenatCreationExpr extends FileCreationExpr {
   OpenatCreationExpr() {
     this.getTarget().getName() = "openat" and
-    this.getNumberOfArguments() = 4
+    sets(this.getArgument(2).getValue().toInt(), o_creat())
   }
 
   override Expr getPath() { result = this.getArgument(1) }
 
-  override int getMode() { result = this.getArgument(3).getValue().toInt() }
+  override int getMode() {
+    if exists(this.getArgument(3))
+    then result = this.getArgument(3).getValue().toInt()
+    else
+      // assume anything is permitted
+      result = 0.bitNot()
+  }
 }
 
 private int fopenMode() {

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -15,15 +15,21 @@ int parseHex(string input) {
 }
 
 int o_creat() {
-  exists(Macro m | m.getName() = "O_CREAT" |
-    result = parseHex(m.getBody()) or result = UnixConstants::parseOctal(m.getBody())
-  )
+  result =
+    unique(int v |
+      exists(Macro m | m.getName() = "O_CREAT" |
+        v = parseHex(m.getBody()) or v = UnixConstants::parseOctal(m.getBody())
+      )
+    )
 }
 
 int o_tmpfile() {
-  exists(Macro m | m.getName() = "O_TMPFILE" |
-    result = parseHex(m.getBody()) or result = UnixConstants::parseOctal(m.getBody())
-  )
+  result =
+    unique(int v |
+      exists(Macro m | m.getName() = "O_TMPFILE" |
+        v = parseHex(m.getBody()) or v = UnixConstants::parseOctal(m.getBody())
+      )
+    )
 }
 
 bindingset[n, digit]

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -46,10 +46,16 @@ string octalFileMode(int mode) {
 }
 
 /**
+ * Holds if the bitmask `value` sets the bits in `flag`.
+ */
+bindingset[value, flag]
+predicate setsFlag(int value, int flag) { value.bitAnd(flag) = flag }
+
+/**
  * Holds if the bitmask `mask` sets any of the bit fields in `fields`.
  */
 bindingset[mask, fields]
-predicate sets(int mask, int fields) { mask.bitAnd(fields) != 0 }
+predicate setsAnyBits(int mask, int fields) { mask.bitAnd(fields) != 0 }
 
 /**
  * Gets the value that `fc` sets the umask to, if `fc` is a call to
@@ -116,7 +122,7 @@ class OpenCreationExpr extends FileCreationWithOptionalModeExpr {
   OpenCreationExpr() {
     this.getTarget().getName() = ["open", "_open", "_wopen"] and
     exists(int flag | flag = this.getArgument(1).getValue().toInt() |
-      sets(flag, o_creat()) or sets(flag, o_tmpfile())
+      setsFlag(flag, o_creat()) or setsFlag(flag, o_tmpfile())
     )
   }
 
@@ -145,7 +151,7 @@ class OpenatCreationExpr extends FileCreationWithOptionalModeExpr {
   OpenatCreationExpr() {
     this.getTarget().getName() = "openat" and
     exists(int flag | flag = this.getArgument(2).getValue().toInt() |
-      sets(flag, o_creat()) or sets(flag, o_tmpfile())
+      setsFlag(flag, o_creat()) or setsFlag(flag, o_tmpfile())
     )
   }
 

--- a/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
+++ b/cpp/ql/src/Security/CWE/CWE-732/FilePermissions.qll
@@ -83,7 +83,11 @@ abstract class FileCreationExpr extends FunctionCall {
   abstract int getMode();
 }
 
-class OpenCreationExpr extends FileCreationExpr {
+abstract class FileCreationWithOptionalModeExpr extends FileCreationExpr {
+  abstract predicate hasModeArgument();
+}
+
+class OpenCreationExpr extends FileCreationWithOptionalModeExpr {
   OpenCreationExpr() {
     this.getTarget().getName() = ["open", "_open", "_wopen"] and
     sets(this.getArgument(1).getValue().toInt(), o_creat())
@@ -91,8 +95,10 @@ class OpenCreationExpr extends FileCreationExpr {
 
   override Expr getPath() { result = this.getArgument(0) }
 
+  override predicate hasModeArgument() { exists(this.getArgument(2)) }
+
   override int getMode() {
-    if exists(this.getArgument(2))
+    if hasModeArgument()
     then result = this.getArgument(2).getValue().toInt()
     else
       // assume anything is permitted
@@ -108,7 +114,7 @@ class CreatCreationExpr extends FileCreationExpr {
   override int getMode() { result = this.getArgument(1).getValue().toInt() }
 }
 
-class OpenatCreationExpr extends FileCreationExpr {
+class OpenatCreationExpr extends FileCreationWithOptionalModeExpr {
   OpenatCreationExpr() {
     this.getTarget().getName() = "openat" and
     sets(this.getArgument(2).getValue().toInt(), o_creat())
@@ -116,8 +122,10 @@ class OpenatCreationExpr extends FileCreationExpr {
 
   override Expr getPath() { result = this.getArgument(1) }
 
+  override predicate hasModeArgument() { exists(this.getArgument(3)) }
+
   override int getMode() {
-    if exists(this.getArgument(3))
+    if hasModeArgument()
     then result = this.getArgument(3).getValue().toInt()
     else
       // assume anything is permitted

--- a/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
+++ b/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
@@ -1,0 +1,9 @@
+int open_file_bad() {
+	// BAD - this uses arbitrary bytes from the stack as mode argument
+        return open(FILE, O_CREAT)
+}
+
+int open_file_good() {
+	// GOOD - the mode argument is supplied
+        return open(FILE, O_CREAT, S_IRUSR | S_IWUSR)
+}

--- a/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.qhelp
@@ -1,0 +1,31 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+When opening a file with the <code>O_CREAT</code> flag, the <code>mode</code> must be supplied. If the
+<code>mode</code> argument is omitted, some arbitrary bytes from the stack will be used as the file mode.
+This leaks some bits from the stack into the permissions of the file.
+</p>
+</overview>
+
+<recommendation>
+<p>
+The <code>mode</code> must be supplied when <code>O_CREAT</code> is specified.
+</p>
+</recommendation>
+
+<example>
+<p>
+The first example opens a file with the <code>O_CREAT</code> flag without supplying the <code>mode</code>
+argument. In this case arbitrary bytes from the stack will be used as <code>mode</code> argument. The
+second example correctly supplies the <code>mode</code> argument and creates a file that is user readable
+and writable.
+</p>
+
+<sample src="OpenCallMissingModeArgument.c" />
+
+</example>
+</qhelp>

--- a/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.qhelp
@@ -5,15 +5,15 @@
 
 <overview>
 <p>
-When opening a file with the <code>O_CREAT</code> flag, the <code>mode</code> must be supplied. If the
-<code>mode</code> argument is omitted, some arbitrary bytes from the stack will be used as the file mode.
-This leaks some bits from the stack into the permissions of the file.
+When opening a file with the <code>O_CREAT</code> or <code>O_TMPFILE</code> flag, the <code>mode</code> must
+be supplied. If the <code>mode</code> argument is omitted, some arbitrary bytes from the stack will be used
+as the file mode. This leaks some bits from the stack into the permissions of the file.
 </p>
 </overview>
 
 <recommendation>
 <p>
-The <code>mode</code> must be supplied when <code>O_CREAT</code> is specified.
+The <code>mode</code> must be supplied when <code>O_CREAT</code> or <code>O_TMPFILE</code> is specified.
 </p>
 </recommendation>
 

--- a/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.ql
@@ -2,7 +2,7 @@
  * @name File opened with O_CREAT flag but without mode argument
  * @description Opening a file with the O_CREAT flag but without mode argument reads arbitrary bytes from the stack.
  * @kind problem
- * @problem.severity warning
+ * @problem.severity error
  * @security-severity 7.8
  * @precision medium
  * @id cpp/open-call-with-mode-argument
@@ -16,4 +16,4 @@ import FilePermissions
 from FileCreationWithOptionalModeExpr fc
 where not fc.hasModeArgument()
 select fc,
-  "A file is created here without providing a mode argument, which may leak bits from the stack"
+  "A file is created here without providing a mode argument, which may leak bits from the stack."

--- a/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.ql
@@ -1,0 +1,19 @@
+/**
+ * @name File opened with O_CREAT flag but without mode argument
+ * @description Opening a file with the O_CREAT flag but without mode argument reads arbitrary bytes from the stack.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 7.8
+ * @precision medium
+ * @id cpp/open-call-with-mode-argument
+ * @tags security
+ *       external/cwe/cwe-732
+ */
+
+import cpp
+import FilePermissions
+
+from FileCreationWithOptionalModeExpr fc
+where not fc.hasModeArgument()
+select fc,
+  "A file is created here without providing a mode argument, which may leak bits from the stack"

--- a/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/OpenCallMissingModeArgument.ql
@@ -4,7 +4,7 @@
  * @kind problem
  * @problem.severity error
  * @security-severity 7.8
- * @precision medium
+ * @precision high
  * @id cpp/open-call-with-mode-argument
  * @tags security
  *       external/cwe/cwe-732

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
@@ -1,7 +1,8 @@
 typedef unsigned int mode_t;
 
-#define O_APPEND 0010
-#define O_CREAT  0100
+#define O_APPEND  0x0020
+#define O_CREAT   0x0200
+#define O_TMPFILE 0x2000
 
 int open(const char *pathname, int flags, ...);
 
@@ -13,7 +14,11 @@ void test_open() {
   open(a_file, O_APPEND); // GOOD
   open(a_file, O_CREAT); // BAD
   open(a_file, O_CREAT, 0); // GOOD
+  open(a_file, O_TMPFILE); // BAD
+  open(a_file, O_TMPFILE, 0); // GOOD
   openat(0, a_file, O_APPEND); // GOOD
   openat(0, a_file, O_CREAT); // BAD
   openat(0, a_file, O_CREAT, 0); // GOOD
+  openat(0, a_file, O_TMPFILE); // BAD
+  openat(0, a_file, O_TMPFILE, 0); // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
@@ -1,0 +1,16 @@
+typedef unsigned int mode_t;
+
+#define O_CREAT 0100
+
+int open(const char *pathname, int flags, ...);
+
+int openat(int dirfd, const char *pathname, int flags, ...);
+
+const char *a_file = "/a_file";
+
+void test_open() {
+  open(a_file, O_CREAT);
+  open(a_file, O_CREAT, 0);
+  openat(0, a_file, O_CREAT);
+  openat(0, a_file, O_CREAT, 0);
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
@@ -1,8 +1,11 @@
 typedef unsigned int mode_t;
 
-#define O_APPEND  0x0020
-#define O_CREAT   0x0200
-#define O_TMPFILE 0x2000
+#define O_RDWR     0x0002
+#define O_CLOEXEC  0x0040
+#define O_NONBLOCK 0x0080
+#define O_CREAT    0x0200
+#define O_APPEND   0x0800
+#define O_TMPFILE  0x2000
 
 int open(const char *pathname, int flags, ...);
 
@@ -11,6 +14,8 @@ int openat(int dirfd, const char *pathname, int flags, ...);
 const char *a_file = "/a_file";
 
 void test_open() {
+  open(a_file, O_NONBLOCK); // GOOD
+  open(a_file, O_RDWR | O_CLOEXEC); // GOOD
   open(a_file, O_APPEND); // GOOD
   open(a_file, O_CREAT); // BAD
   open(a_file, O_CREAT, 0); // GOOD

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.c
@@ -1,6 +1,7 @@
 typedef unsigned int mode_t;
 
-#define O_CREAT 0100
+#define O_APPEND 0010
+#define O_CREAT  0100
 
 int open(const char *pathname, int flags, ...);
 
@@ -9,8 +10,10 @@ int openat(int dirfd, const char *pathname, int flags, ...);
 const char *a_file = "/a_file";
 
 void test_open() {
-  open(a_file, O_CREAT);
-  open(a_file, O_CREAT, 0);
-  openat(0, a_file, O_CREAT);
-  openat(0, a_file, O_CREAT, 0);
+  open(a_file, O_APPEND); // GOOD
+  open(a_file, O_CREAT); // BAD
+  open(a_file, O_CREAT, 0); // GOOD
+  openat(0, a_file, O_APPEND); // GOOD
+  openat(0, a_file, O_CREAT); // BAD
+  openat(0, a_file, O_CREAT, 0); // GOOD
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
@@ -1,0 +1,2 @@
+| OpenCallMissingModeArgument.c:12:3:12:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack |
+| OpenCallMissingModeArgument.c:14:3:14:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
@@ -1,2 +1,2 @@
-| OpenCallMissingModeArgument.c:12:3:12:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack |
-| OpenCallMissingModeArgument.c:14:3:14:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack |
+| OpenCallMissingModeArgument.c:14:3:14:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:17:3:17:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
@@ -1,2 +1,4 @@
-| OpenCallMissingModeArgument.c:14:3:14:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
-| OpenCallMissingModeArgument.c:17:3:17:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:15:3:15:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:17:3:17:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:20:3:20:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:22:3:22:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.expected
@@ -1,4 +1,4 @@
-| OpenCallMissingModeArgument.c:15:3:15:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
-| OpenCallMissingModeArgument.c:17:3:17:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
-| OpenCallMissingModeArgument.c:20:3:20:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |
-| OpenCallMissingModeArgument.c:22:3:22:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:20:3:20:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:22:3:22:6 | call to open | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:25:3:25:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |
+| OpenCallMissingModeArgument.c:27:3:27:8 | call to openat | A file is created here without providing a mode argument, which may leak bits from the stack. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-732/OpenCallMissingModeArgument.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-732/OpenCallMissingModeArgument.ql


### PR DESCRIPTION
When calling `open`/`openat` with the `O_CREAT` flag, the mode argument must be supplied. The query introduced in this PR checks for this.

The meta-data on the query is wrong. Some guidelines on getting this correct are appreciated.