### PR TITLE
C++: Recognize password struct fields.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -27,6 +27,7 @@ class SensitiveNode extends DataFlow::Node {
     this.asExpr() = any(SensitiveVariable sv).getInitializer().getExpr() or
     this.asExpr().(VariableAccess).getTarget() =
       any(SensitiveVariable sv).(GlobalOrNamespaceVariable) or
+    this.asExpr().(VariableAccess).getTarget() = any(SensitiveVariable v | v instanceof Field) or
     this.asUninitialized() instanceof SensitiveVariable or
     this.asParameter() instanceof SensitiveVariable or
     this.asExpr().(FunctionCall).getTarget() instanceof SensitiveFunction

--- a/cpp/ql/src/change-notes/2022-01-22-cleartext-transmission.md
+++ b/cpp/ql/src/change-notes/2022-01-22-cleartext-transmission.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Cleartext transmission of sensitive information" (`cpp/cleartext-transmission`) query now finds more results, where a password is stored in a struct field or class member variable.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -1,4 +1,5 @@
 edges
+| test2.cpp:63:24:63:31 | password | test2.cpp:63:16:63:20 | call to crypt |
 | test3.cpp:17:28:17:36 | password1 | test3.cpp:22:15:22:23 | password1 |
 | test3.cpp:17:51:17:59 | password2 | test3.cpp:26:15:26:23 | password2 |
 | test3.cpp:45:8:45:15 | password | test3.cpp:47:15:47:22 | password |
@@ -89,11 +90,15 @@ edges
 | test3.cpp:398:18:398:25 | password | test3.cpp:400:15:400:23 | & ... |
 | test3.cpp:398:18:398:25 | password | test3.cpp:400:16:400:23 | password |
 | test3.cpp:398:18:398:25 | password | test3.cpp:400:33:400:40 | password |
+| test3.cpp:421:21:421:28 | password | test3.cpp:421:3:421:17 | call to decrypt_inplace |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:29:76:39 | thePassword |
 nodes
+| test2.cpp:63:16:63:20 | call to crypt | semmle.label | call to crypt |
+| test2.cpp:63:24:63:31 | password | semmle.label | password |
+| test2.cpp:63:24:63:31 | password | semmle.label | password |
 | test3.cpp:17:28:17:36 | password1 | semmle.label | password1 |
 | test3.cpp:17:51:17:59 | password2 | semmle.label | password2 |
 | test3.cpp:22:15:22:23 | password1 | semmle.label | password1 |
@@ -208,6 +213,11 @@ nodes
 | test3.cpp:400:15:400:23 | & ... | semmle.label | & ... |
 | test3.cpp:400:16:400:23 | password | semmle.label | password |
 | test3.cpp:400:33:400:40 | password | semmle.label | password |
+| test3.cpp:414:17:414:24 | password | semmle.label | password |
+| test3.cpp:420:17:420:24 | password | semmle.label | password |
+| test3.cpp:421:3:421:17 | call to decrypt_inplace | semmle.label | call to decrypt_inplace |
+| test3.cpp:421:21:421:28 | password | semmle.label | password |
+| test3.cpp:421:21:421:28 | password | semmle.label | password |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -238,3 +248,5 @@ subpaths
 | test3.cpp:300:2:300:5 | call to send | test3.cpp:308:58:308:66 | password2 | test3.cpp:300:14:300:17 | data | This operation transmits 'data', which may contain unencrypted sensitive data from $@ | test3.cpp:308:58:308:66 | password2 | password2 |
 | test3.cpp:341:4:341:7 | call to recv | test3.cpp:339:9:339:16 | password | test3.cpp:341:16:341:23 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:339:9:339:16 | password | password |
 | test3.cpp:388:3:388:6 | call to recv | test3.cpp:386:8:386:15 | password | test3.cpp:388:15:388:22 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:386:8:386:15 | password | password |
+| test3.cpp:414:3:414:6 | call to recv | test3.cpp:414:17:414:24 | password | test3.cpp:414:17:414:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:414:17:414:24 | password | password |
+| test3.cpp:420:3:420:6 | call to recv | test3.cpp:420:17:420:24 | password | test3.cpp:420:17:420:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:420:17:420:24 | password | password |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -411,13 +411,13 @@ void test_member_password()
 	{
 		packet p;
 
-		recv(val(), p.password, 256, val()); // BAD: not encrypted [NOT DETECTED]
+		recv(val(), p.password, 256, val()); // BAD: not encrypted
 	}
 
 	{
 		packet p;
 
-		recv(val(), p.password, 256, val()); // GOOD: password is encrypted
+		recv(val(), p.password, 256, val()); // GOOD: password is encrypted [FALSE POSITIVE]
 		decrypt_inplace(p.password); // proof that `password` was in fact encrypted
 	}
 }


### PR DESCRIPTION
This is an enhancement to `cpp/cleartext-transmission` that allows it to spot passwords that are struct or class fields (much more reliably).  I've weeded out a lot of false positive results in previous PRs, but I wanted to address one of the causes of _missing_ results so that we don't just end up having very few results overall.

Note that the `SensitiveNode` isn't a perfect implementation; it tries to avoid matching all accesses to a `SensitiveVariable` to reduce duplicate results where a variable is accessed multiple times, but this is not done in an especially principled or reliable manner.  Happy to take suggestions on how to pick the right `Node` better.

New results: https://lgtm.com/query/6627472974229539370/
All results: https://lgtm.com/query/7344851133823789124/