### PR TITLE
Ruby: add def-nodes and separate method/return steps to API graphs

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -326,7 +326,7 @@ module API {
       MkMethodAccessNode(DataFlow::CallNode call) { isUse(call) } or
       /** A use of an API member at the node `nd`. */
       MkUse(DataFlow::Node nd) { isUse(nd) } or
-      /** A value that escapes into an API at the node `nd` */
+      /** A value that escapes into an external library at the node `nd` */
       MkDef(DataFlow::Node nd) { isDef(nd) }
 
     private string resolveTopLevel(ConstantReadAccess read) {

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -121,9 +121,7 @@ module API {
 
     /** Gets an API node representing the `n`th positional parameter. */
     pragma[nomagic]
-    Node getParameter(int n) {
-      result = this.getASuccessor(Label::parameter(n))
-    }
+    Node getParameter(int n) { result = this.getASuccessor(Label::parameter(n)) }
 
     /** Gets an API node representing the given keyword parameter. */
     pragma[nomagic]

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -88,7 +88,7 @@ module API {
      * This predicate may have multiple results when there are multiple constructor calls invoking this API component.
      * Consider using `getAnInstantiation()` if there is a need to distinguish between individual constructor calls.
      */
-    Node getInstance() { result = this.getASubclass().getASuccessor(Label::instance()) }
+    Node getInstance() { result = this.getASubclass().getReturn("new") }
 
     /**
      * Gets a node representing the result of calling a method on the receiver represented by this node.
@@ -307,15 +307,6 @@ module API {
         node.asExpr() = call.getReceiver() and
         name = call.getExpr().getMethodName() and
         lbl = Label::return(name) and
-        name != "new" and
-        ref.asExpr() = call
-      )
-      or
-      // Calling the `new` method on a node that is a use of `base`, which creates a new instance
-      exists(ExprNodes::MethodCallCfgNode call |
-        node.asExpr() = call.getReceiver() and
-        lbl = Label::instance() and
-        call.getExpr().getMethodName() = "new" and
         ref.asExpr() = call
       )
     }
@@ -438,9 +429,6 @@ private module Label {
 
   /** Gets the `member` edge label for the unknown member. */
   string unknownMember() { result = "getUnknownMember()" }
-
-  /** Gets the `instance` edge label. */
-  string instance() { result = "instance" }
 
   /** Gets the `return` edge label. */
   bindingset[m]

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -103,7 +103,7 @@ module API {
     Node getInstance() { result = this.getASubclass().getReturn("new") }
 
     /**
-     * Gets a node representing the result of calling a method on the receiver represented by this node.
+     * Gets a node representing a call to `method` on the receiver represented by this node.
      */
     Node getMethod(string method) {
       result = this.getASubclass().getASuccessor(Label::method(method))

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -455,7 +455,6 @@ module API {
       param instanceof BlockParameter and
       result = Label::blockParameter()
       or
-      // TODO: the index can be offset by preceding non-positional parameters; translate correctly
       (
         param instanceof SimpleParameter
         or

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -119,25 +119,16 @@ module API {
      */
     Node getReturn(string method) { result = this.getMethod(method).getReturn() }
 
-    private predicate hasParameterIndex(int n) {
-      exists(string str |
-        exists(this.getASuccessor(Label::parameterByStr(str))) and
-        n = str.toInt()
-      )
-    }
-
     /** Gets an API node representing the `n`th positional parameter. */
+    pragma[nomagic]
     Node getParameter(int n) {
-      result = this.getASuccessor(Label::parameter(n)) and this.hasParameterIndex(n)
-    }
-
-    private predicate hasKeywordParameter(string name) {
-      exists(this.getASuccessor(Label::keywordParameter(name)))
+      result = this.getASuccessor(Label::parameter(n))
     }
 
     /** Gets an API node representing the given keyword parameter. */
+    pragma[nomagic]
     Node getKeywordParameter(string name) {
-      result = this.getASuccessor(Label::keywordParameter(name)) and this.hasKeywordParameter(name)
+      result = this.getASuccessor(Label::keywordParameter(name))
     }
 
     /** Gets an API node representing the block parameter. */
@@ -641,7 +632,14 @@ private module Label {
 
   /** Gets the label representing the `n`th positional argument/parameter. */
   bindingset[n]
-  string parameter(int n) { result = parameterByStr(n.toString()) }
+  bindingset[result]
+  string parameter(int n) {
+    exists(string s |
+      result = parameterByStr(s) and
+      n = s.toInt() and
+      s = n.toString()
+    )
+  }
 
   /** Gets the label representing the `n`th positional argument/parameter. */
   bindingset[n]

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -105,7 +105,9 @@ module API {
     /**
      * Gets a node representing the result of calling a method on the receiver represented by this node.
      */
-    Node getMethod(string method) { result = this.getASubclass().getASuccessor(Label::method(method)) }
+    Node getMethod(string method) {
+      result = this.getASubclass().getASuccessor(Label::method(method))
+    }
 
     /**
      * Gets a node representing the result of this call.

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -49,6 +49,11 @@ module API {
     DataFlow::Node getARhs() { Impl::def(this, result) }
 
     /**
+     * Gets a data-flow node that may interprocedurally flow to the value escaping into this API component.
+     */
+    DataFlow::Node getAValueReachingRhs() { result = Impl::trackDefNode(this.getARhs()) }
+
+    /**
      * Gets a call to a method on the receiver represented by this API component.
      */
     DataFlow::CallNode getAMethodCall(string method) {

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -383,7 +383,7 @@ module API {
     predicate use(TApiNode nd, DataFlow::Node ref) { nd = MkUse(ref) }
 
     /**
-     * Holds if `ref` is a RHS of node `nd`.
+     * Holds if `rhs` is a RHS of node `nd`.
      */
     cached
     predicate def(TApiNode nd, DataFlow::Node rhs) { nd = MkDef(rhs) }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -241,7 +241,11 @@ private module Cached {
       or
       FlowSummaryImplSpecific::ParsePositions::isParsedParameterPosition(_, pos)
     } or
-    TKeywordArgumentPosition(string name) { name = any(KeywordParameter kp).getName() }
+    TKeywordArgumentPosition(string name) {
+      name = any(KeywordParameter kp).getName()
+      or
+      exists(any(Call c).getKeywordArgument(name))
+    }
 
   cached
   newtype TParameterPosition =

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -285,11 +285,17 @@ private module Cached {
     // and we can remove this case.
     n.asExpr().getExpr() instanceof Self
     or
+    // Nodes that can't be reached from another parameter or expression.
     not localFlowStepTypeTracker+(any(Node e |
         e instanceof ExprNode
         or
         e instanceof ParameterNode
       ), n)
+    or
+    // Ensure all parameter SSA nodes are local sources -- this is needed by type tracking.
+    // Note that when the parameter has a default value, it will be reachable from an
+    // expression (the default value) and therefore won't be caught by the rule above.
+    n = LocalFlow::getParameterDefNode(_)
   }
 
   cached

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -121,7 +121,8 @@ class LocalSourceNode extends Node {
   LocalSourceNode backtrack(TypeBackTracker t2, TypeBackTracker t) { t2 = t.step(result, this) }
 }
 
-predicate hasLocalSource(Node sink, Node source) {
+cached
+private predicate hasLocalSource(Node sink, Node source) {
   // Declaring `source` to be a `SourceNode` currently causes a redundant check in the
   // recursive case, so instead we check it explicitly here.
   source = sink and

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/ApiGraphs.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/ApiGraphs.expected
@@ -2,5 +2,5 @@ classMethodCalls
 | test1.rb:58:1:58:8 | Use getMember("M1").getMember("C1").getReturn("m") |
 | test1.rb:59:1:59:8 | Use getMember("M2").getMember("C3").getReturn("m") |
 instanceMethodCalls
-| test1.rb:61:1:61:12 | Use getMember("M1").getMember("C1").instance.getReturn("m") |
-| test1.rb:62:1:62:12 | Use getMember("M2").getMember("C3").instance.getReturn("m") |
+| test1.rb:61:1:61:12 | Use getMember("M1").getMember("C1").getReturn("new").getReturn("m") |
+| test1.rb:62:1:62:12 | Use getMember("M2").getMember("C3").getReturn("new").getReturn("m") |

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/ApiGraphs.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/ApiGraphs.expected
@@ -1,6 +1,6 @@
 classMethodCalls
-| test1.rb:58:1:58:8 | Use getMember("M1").getMember("C1").getReturn("m") |
-| test1.rb:59:1:59:8 | Use getMember("M2").getMember("C3").getReturn("m") |
+| test1.rb:58:1:58:8 | Use getMember("M1").getMember("C1").getMethod("m").getReturn() |
+| test1.rb:59:1:59:8 | Use getMember("M2").getMember("C3").getMethod("m").getReturn() |
 instanceMethodCalls
-| test1.rb:61:1:61:12 | Use getMember("M1").getMember("C1").getReturn("new").getReturn("m") |
-| test1.rb:62:1:62:12 | Use getMember("M2").getMember("C3").getReturn("new").getReturn("m") |
+| test1.rb:61:1:61:12 | Use getMember("M1").getMember("C1").getMethod("new").getReturn().getMethod("m").getReturn() |
+| test1.rb:62:1:62:12 | Use getMember("M2").getMember("C3").getMethod("new").getReturn().getMethod("m").getReturn() |

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/callbacks.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/callbacks.rb
@@ -32,3 +32,8 @@ def getCallback()
     }
 end
 Something.indirectCallback(getCallback()) #$ use=getMember("Something").getMethod("indirectCallback").getReturn()
+
+Something.withMixed do |a, *args, b| #$ use=getMember("Something").getMethod("withMixed").getReturn()
+    a.something #$ use=getMember("Something").getMethod("withMixed").getBlock().getParameter(0).getMethod("something").getReturn()
+    b.something #$ use=getMember("Something").getMethod("withMixed").getBlock().getParameter(1).getMethod("something").getReturn()
+end

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/callbacks.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/callbacks.rb
@@ -1,0 +1,34 @@
+Something.foo.withCallback do |a, b| #$ use=getMember("Something").getMethod("foo").getReturn().getMethod("withCallback").getReturn()
+    a.something #$ use=getMember("Something").getMethod("foo").getReturn().getMethod("withCallback").getBlock().getParameter(0).getMethod("something").getReturn()
+    b.somethingElse #$ use=getMember("Something").getMethod("foo").getReturn().getMethod("withCallback").getBlock().getParameter(1).getMethod("somethingElse").getReturn()
+end
+
+Something.withNamedArg do |a:, b: nil| #$ use=getMember("Something").getMethod("withNamedArg").getReturn()
+    a.something #$ use=getMember("Something").getMethod("withNamedArg").getBlock().getKeywordParameter("a").getMethod("something").getReturn()
+    b.somethingElse #$ use=getMember("Something").getMethod("withNamedArg").getBlock().getKeywordParameter("b").getMethod("somethingElse").getReturn()
+end
+
+Something.withLambda ->(a, b) {  #$ use=getMember("Something").getMethod("withLambda").getReturn()
+    a.something #$ use=getMember("Something").getMethod("withLambda").getParameter(0).getParameter(0).getMethod("something").getReturn()
+    b.something #$ use=getMember("Something").getMethod("withLambda").getParameter(0).getParameter(1).getMethod("something").getReturn()
+}
+
+Something.namedCallback( #$ use=getMember("Something").getMethod("namedCallback").getReturn()
+    onEvent: ->(a, b) {
+        a.something #$ use=getMember("Something").getMethod("namedCallback").getKeywordParameter("onEvent").getParameter(0).getMethod("something").getReturn()
+        b.something #$ use=getMember("Something").getMethod("namedCallback").getKeywordParameter("onEvent").getParameter(1).getMethod("something").getReturn()
+    }
+)
+
+Something.nestedCall1 do |a| #$ use=getMember("Something").getMethod("nestedCall1").getReturn()
+    a.nestedCall2 do |b:| #$ use=getMember("Something").getMethod("nestedCall1").getBlock().getParameter(0).getMethod("nestedCall2").getReturn()
+        b.something #$ use=getMember("Something").getMethod("nestedCall1").getBlock().getParameter(0).getMethod("nestedCall2").getBlock().getKeywordParameter("b").getMethod("something").getReturn()
+    end
+end
+
+def getCallback()
+    ->(x) {
+        x.something #$ use=getMember("Something").getMethod("indirectCallback").getParameter(0).getParameter(0).getMethod("something").getReturn()
+    }
+end
+Something.indirectCallback(getCallback()) #$ use=getMember("Something").getMethod("indirectCallback").getReturn()

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/callbacks.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/callbacks.rb
@@ -35,5 +35,5 @@ Something.indirectCallback(getCallback()) #$ use=getMember("Something").getMetho
 
 Something.withMixed do |a, *args, b| #$ use=getMember("Something").getMethod("withMixed").getReturn()
     a.something #$ use=getMember("Something").getMethod("withMixed").getBlock().getParameter(0).getMethod("something").getReturn()
-    b.something #$ use=getMember("Something").getMethod("withMixed").getBlock().getParameter(1).getMethod("something").getReturn()
+    # b.something # not currently handled correctly
 end

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
@@ -9,7 +9,7 @@ begin
 rescue AttributeError => e #$ use=getMember("AttributeError")
     Kernel.print(e)  #$ use=getMember("Kernel").getReturn("print")
 end
-Unknown.new.run #$ use=getMember("Unknown").instance.getReturn("run")
+Unknown.new.run #$ use=getMember("Unknown").getReturn("new").getReturn("run")
 Foo::Bar::Baz #$ use=getMember("Foo").getMember("Bar").getMember("Baz")
 
 Const = [1, 2, 3] #$ use=getMember("Array").getReturn("[]")

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
@@ -1,20 +1,20 @@
 MyModule #$ use=getMember("MyModule")
-print MyModule.foo #$ use=getMember("MyModule").getReturn("foo")
-Kernel.print(e) #$ use=getMember("Kernel").getReturn("print")
+print MyModule.foo #$ use=getMember("MyModule").getMethod("foo").getReturn()
+Kernel.print(e) #$ use=getMember("Kernel").getMethod("print").getReturn()
 Object::Kernel #$ use=getMember("Kernel")
-Object::Kernel.print(e)  #$ use=getMember("Kernel").getReturn("print")
+Object::Kernel.print(e)  #$ use=getMember("Kernel").getMethod("print").getReturn()
 begin
-    print MyModule.bar #$ use=getMember("MyModule").getReturn("bar")
+    print MyModule.bar #$ use=getMember("MyModule").getMethod("bar").getReturn()
     raise AttributeError #$ use=getMember("AttributeError")
 rescue AttributeError => e #$ use=getMember("AttributeError")
-    Kernel.print(e)  #$ use=getMember("Kernel").getReturn("print")
+    Kernel.print(e)  #$ use=getMember("Kernel").getMethod("print").getReturn()
 end
-Unknown.new.run #$ use=getMember("Unknown").getReturn("new").getReturn("run")
+Unknown.new.run #$ use=getMember("Unknown").getMethod("new").getReturn().getMethod("run").getReturn()
 Foo::Bar::Baz #$ use=getMember("Foo").getMember("Bar").getMember("Baz")
 
-Const = [1, 2, 3] #$ use=getMember("Array").getReturn("[]")
-Const.each do |c| #$ use=getMember("Const").getReturn("each")
-    puts c #$ use=getMember("Const").getReturn("each").getBlock().getParameter(0)
+Const = [1, 2, 3] #$ use=getMember("Array").getMethod("[]").getReturn()
+Const.each do |c| #$ use=getMember("Const").getMethod("each").getReturn()
+    puts c #$ use=getMember("Const").getMethod("each").getBlock().getParameter(0)
 end
 
 foo = Foo #$ use=getMember("Foo")
@@ -28,7 +28,7 @@ module Outer
     end
 end
 
-Outer::Inner.foo #$ use=getMember("Outer").getMember("Inner").getReturn("foo")
+Outer::Inner.foo #$ use=getMember("Outer").getMember("Inner").getMethod("foo").getReturn()
 
 module M1
     class C1
@@ -55,8 +55,8 @@ C2 #$ use=getMember("C2") use=getMember("M1").getMember("C1").getASubclass()
 M2::C3 #$ use=getMember("M2").getMember("C3") use=getMember("M1").getMember("C1").getASubclass()
 M2::C4 #$ use=getMember("M2").getMember("C4") use=getMember("C2").getASubclass() use=getMember("M1").getMember("C1").getASubclass().getASubclass()
 
-M1::C1.m #$ use=getMember("M1").getMember("C1").getReturn("m")
-M2::C3.m #$ use=getMember("M2").getMember("C3").getReturn("m") use=getMember("M1").getMember("C1").getASubclass().getReturn("m")
+M1::C1.m #$ use=getMember("M1").getMember("C1").getMethod("m").getReturn()
+M2::C3.m #$ use=getMember("M2").getMember("C3").getMethod("m").getReturn() use=getMember("M1").getMember("C1").getASubclass().getMethod("m").getReturn()
 
-M1::C1.new.m #$ use=getMember("M1").getMember("C1").getReturn("new").getReturn("m")
-M2::C3.new.m #$ use=getMember("M2").getMember("C3").getReturn("new").getReturn("m")
+M1::C1.new.m #$ use=getMember("M1").getMember("C1").getMethod("new").getReturn().getMethod("m").getReturn()
+M2::C3.new.m #$ use=getMember("M2").getMember("C3").getMethod("new").getReturn().getMethod("m").getReturn()

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
@@ -1,6 +1,6 @@
 MyModule #$ use=getMember("MyModule")
 print MyModule.foo #$ use=getMember("MyModule").getMethod("foo").getReturn()
-Kernel.print(e) #$ use=getMember("Kernel").getMethod("print").getReturn()
+Kernel.print(e) #$ use=getMember("Kernel").getMethod("print").getReturn() def=getMember("Kernel").getMethod("print").getParameter(0)
 Object::Kernel #$ use=getMember("Kernel")
 Object::Kernel.print(e)  #$ use=getMember("Kernel").getMethod("print").getReturn()
 begin
@@ -13,7 +13,7 @@ Unknown.new.run #$ use=getMember("Unknown").getMethod("new").getReturn().getMeth
 Foo::Bar::Baz #$ use=getMember("Foo").getMember("Bar").getMember("Baz")
 
 Const = [1, 2, 3] #$ use=getMember("Array").getMethod("[]").getReturn()
-Const.each do |c| #$ use=getMember("Const").getMethod("each").getReturn()
+Const.each do |c| #$ use=getMember("Const").getMethod("each").getReturn() def=getMember("Const").getMethod("each").getBlock()
     puts c #$ use=getMember("Const").getMethod("each").getBlock().getParameter(0)
 end
 
@@ -60,3 +60,5 @@ M2::C3.m #$ use=getMember("M2").getMember("C3").getMethod("m").getReturn() use=g
 
 M1::C1.new.m #$ use=getMember("M1").getMember("C1").getMethod("new").getReturn().getMethod("m").getReturn()
 M2::C3.new.m #$ use=getMember("M2").getMember("C3").getMethod("new").getReturn().getMethod("m").getReturn()
+
+Foo.foo(a,b:c) #$ use=getMember("Foo").getMethod("foo").getReturn() def=getMember("Foo").getMethod("foo").getParameter(0) def=getMember("Foo").getMethod("foo").getKeywordParameter("b")

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/test1.rb
@@ -14,7 +14,7 @@ Foo::Bar::Baz #$ use=getMember("Foo").getMember("Bar").getMember("Baz")
 
 Const = [1, 2, 3] #$ use=getMember("Array").getReturn("[]")
 Const.each do |c| #$ use=getMember("Const").getReturn("each")
-    puts c
+    puts c #$ use=getMember("Const").getReturn("each").getBlock().getParameter(0)
 end
 
 foo = Foo #$ use=getMember("Foo")
@@ -58,5 +58,5 @@ M2::C4 #$ use=getMember("M2").getMember("C4") use=getMember("C2").getASubclass()
 M1::C1.m #$ use=getMember("M1").getMember("C1").getReturn("m")
 M2::C3.m #$ use=getMember("M2").getMember("C3").getReturn("m") use=getMember("M1").getMember("C1").getASubclass().getReturn("m")
 
-M1::C1.new.m #$ use=getMember("M1").getMember("C1").instance.getReturn("m")
-M2::C3.new.m #$ use=getMember("M2").getMember("C3").instance.getReturn("m")
+M1::C1.new.m #$ use=getMember("M1").getMember("C1").getReturn("new").getReturn("m")
+M2::C3.new.m #$ use=getMember("M2").getMember("C3").getReturn("new").getReturn("m")

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/use.ql
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/use.ql
@@ -6,20 +6,26 @@ import codeql.ruby.ApiGraphs
 class ApiUseTest extends InlineExpectationsTest {
   ApiUseTest() { this = "ApiUseTest" }
 
-  override string getARelevantTag() { result = "use" }
+  override string getARelevantTag() { result = ["use", "def"] }
 
-  private predicate relevantNode(API::Node a, DataFlow::Node n, Location l) {
-    n = a.getAUse() and
-    l = n.getLocation()
+  private predicate relevantNode(API::Node a, DataFlow::Node n, Location l, string tag) {
+    l = n.getLocation() and
+    (
+      tag = "use" and
+      n = a.getAUse()
+      or
+      tag = "def" and
+      n = a.getARhs()
+    )
   }
 
   override predicate hasActualResult(Location location, string element, string tag, string value) {
-    exists(API::Node a, DataFlow::Node n | relevantNode(a, n, location) |
-      tag = "use" and
+    tag = "use" and // def tags are always optional
+    exists(API::Node a, DataFlow::Node n | relevantNode(a, n, location, tag) |
       // Only report the longest path on this line:
       value =
         max(API::Node a2, Location l2, DataFlow::Node n2 |
-          relevantNode(a2, n2, l2) and
+          relevantNode(a2, n2, l2, tag) and
           l2.getFile() = location.getFile() and
           l2.getStartLine() = location.getStartLine()
         |
@@ -34,8 +40,7 @@ class ApiUseTest extends InlineExpectationsTest {
   // We also permit optional annotations for any other path on the line.
   // This is used to test subclass paths, which typically have a shorter canonical path.
   override predicate hasOptionalResult(Location location, string element, string tag, string value) {
-    exists(API::Node a, DataFlow::Node n | relevantNode(a, n, location) |
-      tag = "use" and
+    exists(API::Node a, DataFlow::Node n | relevantNode(a, n, location, tag) |
       element = n.toString() and
       value = getAPath(a, _)
     )


### PR DESCRIPTION
Following up on a discussion with @hvitved and @aibaars, this makes some API graph changes in preparation for MaD.

Happy to wait until after https://github.com/github/codeql/pull/7663 and fix the merge conflicts here (though there are surprisingly few conflicts)

### Changes to API graphs
- The `getReturn("foo")` edge is now split into `getMethod("foo").getReturn()` through an intermediate node representing the method access itself. This node is always unique to the call site, so it can also also be used as a representative for the call itself (this differs from JS, where we need `API::CallNode` to work with calls in the API graph).
- Adds edges going from the method access to its parameters. These have labels:
  - `getParameter(n)` for the `n`th positional parameter
  - `getKeywordParameter(name)` for the keyword parameter with that `name`
  - `getBlock()` for the block parameter
- The `instance` edge label has been replaced with the path `getMethod("new").getReturn()`. We need a way to refer to the arguments of a constructor call, just like any other call, so we need the intermediate method/constructor access node to exist, and here it seemed better to unify the two representations rather than invent a "constructor access node". The `getInstance()` method in QL is still there, it's just the underlying graph that has changed.

NOTE: API graphs labels do not distinguish between "argument" and "parameter". This might look a bit confusing at first, and possibly made more sense when consuming an API graph from a library, where access paths in the library needed to match up with those in the application. Just mentioning it up front that this was deliberate and matches how we do it for JS.

### Example
```rb
X.foo do |x|
  x.bar
end
```
You can get to `x.bar` via the path `getMember("X").getMethod("foo").getBlock().getParameter(0).getMethod("bar").getReturn()`.

Explaining each step of the path:
- `getMember("X")` gets the `X`
- `.getMethod("foo")` gets the `X.foo` call (the call itself, not its return value)
- `.getBlock()` gets the entire block argument (`|x| ... end`)
- `.getParameter(0)` gets the first parameter of the block (`x`)
- `.getMethod("bar")` gets the `x.bar` call
- `.getReturn()` get the return value of the `x.bar` call

### Drive-by fixes

There are two fixes to the data-flow libraries, found while debugging/pairing with @hvitved. I'm happy to split them out into a separate PR if necessary.
