### PR TITLE
QL: upload sarif as part of the QL-for-QL workflow

### DIFF
--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -189,4 +189,11 @@ jobs:
         uses: github/codeql-action/analyze@erik-krogh/ql
         with: 
           category: "ql-for-ql-${{ matrix.folder }}"
+      - name: Copy sarif file to CWD
+        run: cp ../results/ql.sarif ./${{ matrix.folder }}.sarif
+      - name: Sarif as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.folder }}.sarif
+          path: ${{ matrix.folder }}.sarif
 


### PR DESCRIPTION
Code-scanning doesn't provide a nice way of splitting the results based on which run produced them.  

So now we keep a .sarif file for each language implementation as an artifact.  

If you open the .sarif file in VSCode (and install the recommended extension), then you can nicely view and directly fix the results. 