### PR TITLE
Ruby: Model calls to `constantize` as code executions

### DIFF
--- a/ruby/ql/lib/codeql/ruby/Frameworks.qll
+++ b/ruby/ql/lib/codeql/ruby/Frameworks.qll
@@ -6,6 +6,7 @@ private import codeql.ruby.frameworks.ActionController
 private import codeql.ruby.frameworks.ActiveRecord
 private import codeql.ruby.frameworks.ActiveStorage
 private import codeql.ruby.frameworks.ActionView
+private import codeql.ruby.frameworks.ActiveSupport
 private import codeql.ruby.frameworks.GraphQL
 private import codeql.ruby.frameworks.Rails
 private import codeql.ruby.frameworks.StandardLibrary

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
@@ -1,0 +1,37 @@
+/**
+ * Modeling for `ActiveSupport`, which is a utility gem that ships with Rails.
+ * https://rubygems.org/gems/activesupport
+ */
+
+import codeql.ruby.Concepts
+import codeql.ruby.DataFlow
+import codeql.ruby.frameworks.StandardLibrary
+
+/**
+ * Modeling for `ActiveSupport`.
+ */
+module ActiveSupport {
+  /**
+   * Extensions to core classes
+   */
+  module CoreExtensions {
+    /**
+     * Extensions to the `String` class
+     */
+    module String {
+      /**
+       * A call to `String#constantize`, which tries to find a declared constant with the given name.
+       * Passing user input to this method may result in instantiation of arbitrary Ruby classes.
+       */
+      class Constantize extends CodeExecution::Range, DataFlow::CallNode {
+        // We treat this an `UnknownMethodCall` in order to match every call to `constantize` that isn't overridden.
+        // We can't (yet) rely on API Graphs or dataflow to tell us that the receiver is a String.
+        Constantize() {
+          this.asExpr().getExpr().(UnknownMethodCall).getMethodName() = "constantize"
+        }
+
+        override DataFlow::Node getCode() { result = this.getReceiver() }
+      }
+    }
+  }
+}

--- a/ruby/ql/test/library-tests/frameworks/ActiveSupport.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActiveSupport.expected
@@ -1,0 +1,2 @@
+| active_support.rb:1:1:1:22 | call to constantize | active_support.rb:1:1:1:10 | "Foo::Bar" |
+| active_support.rb:3:1:3:13 | call to constantize | active_support.rb:3:1:3:1 | call to a |

--- a/ruby/ql/test/library-tests/frameworks/ActiveSupport.ql
+++ b/ruby/ql/test/library-tests/frameworks/ActiveSupport.ql
@@ -1,0 +1,5 @@
+import codeql.ruby.frameworks.ActiveSupport
+
+query DataFlow::Node constantizeCalls(ActiveSupport::CoreExtensions::String::Constantize c) {
+  result = c.getCode()
+}

--- a/ruby/ql/test/library-tests/frameworks/active_support.rb
+++ b/ruby/ql/test/library-tests/frameworks/active_support.rb
@@ -1,0 +1,3 @@
+"Foo::Bar".constantize
+
+a.constantize


### PR DESCRIPTION
[`constantize`](https://api.rubyonrails.org/classes/String.html#method-i-constantize) is an ActiveSupport extension on `String` that attempts to look up a constant with the same name as the receiver. It has similar issues to [`Module#const_get`](https://docs.ruby-lang.org/en/3.1/Module.html#method-i-const_get).