### PR TITLE
Ruby: add Parameter.getLogicalPosition()

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/Parameter.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/Parameter.qll
@@ -19,6 +19,27 @@ class Parameter extends AstNode, TParameter {
   /** Gets the zero-based position of this parameter. */
   final int getPosition() { this = any(Callable c).getParameter(result) }
 
+  /** Holds if this parameter is declared after a positional `*splat` parameter. */
+  private predicate isAfterSplatParameter() {
+    exists(Callable c, int n |
+      c.getParameter(n) instanceof SplatParameter and
+      this = c.getParameter([n .. c.getNumberOfParameters() - 1])
+    )
+  }
+
+  /**
+   * Gets the zero-based position of this parameter, if it is a plain positional parameter.
+   *
+   * This corresponds to the index of a positional argument that can flow into this parameter.
+   *
+   * Has no result for non-positional parameters, splat parameters, or parameters declared after a splat parameter.
+   */
+  final int getLogicalPosition() {
+    (this instanceof SimpleParameter or this instanceof OptionalParameter) and
+    result = getPosition() and
+    not isAfterSplatParameter()
+  }
+
   /** Gets a variable introduced by this parameter. */
   LocalVariable getAVariable() { none() }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -379,7 +379,11 @@ private module ParameterNodes {
     override Parameter getParameter() { result = parameter }
 
     override predicate isSourceParameterOf(Callable c, ParameterPosition pos) {
-      exists(int i | pos.isPositional(i) and c.getParameter(i) = parameter |
+      exists(int i |
+        pos.isPositional(i) and
+        parameter = c.getAParameter() and
+        i = parameter.getLogicalPosition()
+      |
         parameter instanceof SimpleParameter
         or
         parameter instanceof OptionalParameter

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -383,10 +383,6 @@ private module ParameterNodes {
         pos.isPositional(i) and
         parameter = c.getAParameter() and
         i = parameter.getLogicalPosition()
-      |
-        parameter instanceof SimpleParameter
-        or
-        parameter instanceof OptionalParameter
       )
       or
       parameter =

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -379,17 +379,12 @@ private module ParameterNodes {
     override Parameter getParameter() { result = parameter }
 
     override predicate isSourceParameterOf(Callable c, ParameterPosition pos) {
-      exists(int i |
-        pos.isPositional(i) and
-        parameter = c.getAParameter() and
-        i = parameter.getLogicalPosition()
+      parameter = c.getAParameter() and
+      (
+        pos.isPositional(parameter.getLogicalPosition())
+        or
+        pos.isKeyword(parameter.(KeywordParameter).getName())
       )
-      or
-      parameter =
-        any(KeywordParameter kp |
-          c.getAParameter() = kp and
-          pos.isKeyword(kp.getName())
-        )
     }
 
     override CfgScope getCfgScope() { result = parameter.getCallable() }

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -1,4 +1,6 @@
 track
+| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker with call steps | type_tracker.rb:18:1:22:3 | self in foo |
+| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type tracker without call steps | type_tracker.rb:1:1:10:3 | self (type_tracker.rb) |
 | type_tracker.rb:2:5:5:7 | &block | type tracker without call steps | type_tracker.rb:2:5:5:7 | &block |
 | type_tracker.rb:2:5:5:7 | field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | field= |
 | type_tracker.rb:2:5:5:7 | return return in field= | type tracker without call steps | type_tracker.rb:2:5:5:7 | return return in field= |
@@ -66,7 +68,58 @@ track
 | type_tracker.rb:15:10:15:12 | [post] var | type tracker without call steps | type_tracker.rb:15:10:15:12 | [post] var |
 | type_tracker.rb:15:10:15:18 | [post] call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | [post] call to field |
 | type_tracker.rb:15:10:15:18 | call to field | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
+| type_tracker.rb:18:1:22:3 | &block | type tracker without call steps | type_tracker.rb:18:1:22:3 | &block |
+| type_tracker.rb:18:1:22:3 | foo | type tracker without call steps | type_tracker.rb:18:1:22:3 | foo |
+| type_tracker.rb:18:1:22:3 | return return in foo | type tracker without call steps | type_tracker.rb:18:1:22:3 | return return in foo |
+| type_tracker.rb:18:1:22:3 | return return in foo | type tracker without call steps | type_tracker.rb:24:1:24:25 | call to foo |
+| type_tracker.rb:18:1:22:3 | self (foo) | type tracker without call steps | type_tracker.rb:18:1:22:3 | self (foo) |
+| type_tracker.rb:18:1:22:3 | self in foo | type tracker without call steps | type_tracker.rb:18:1:22:3 | self in foo |
+| type_tracker.rb:18:9:18:9 | a | type tracker with call steps | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:9:18:9 | a | type tracker without call steps | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:9:18:9 | a | type tracker without call steps | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:9:18:9 | a | type tracker without call steps | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:13:18:13 | b | type tracker without call steps | type_tracker.rb:18:13:18:13 | b |
+| type_tracker.rb:18:13:18:13 | b | type tracker without call steps | type_tracker.rb:18:13:18:13 | b |
+| type_tracker.rb:18:16:18:16 | c | type tracker with call steps | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:18:16:18:16 | c | type tracker without call steps | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:18:16:18:16 | c | type tracker without call steps | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:18:16:18:16 | c | type tracker without call steps | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:19:5:19:10 | [post] self | type tracker without call steps | type_tracker.rb:19:5:19:10 | [post] self |
+| type_tracker.rb:19:5:19:10 | call to puts | type tracker without call steps | type_tracker.rb:19:5:19:10 | call to puts |
+| type_tracker.rb:19:5:19:10 | self | type tracker without call steps | type_tracker.rb:19:5:19:10 | self |
+| type_tracker.rb:19:10:19:10 | [post] a | type tracker without call steps | type_tracker.rb:19:10:19:10 | [post] a |
+| type_tracker.rb:19:10:19:10 | a | type tracker without call steps | type_tracker.rb:19:10:19:10 | a |
+| type_tracker.rb:20:5:20:10 | [post] self | type tracker without call steps | type_tracker.rb:20:5:20:10 | [post] self |
+| type_tracker.rb:20:5:20:10 | call to puts | type tracker without call steps | type_tracker.rb:20:5:20:10 | call to puts |
+| type_tracker.rb:20:5:20:10 | self | type tracker without call steps | type_tracker.rb:20:5:20:10 | self |
+| type_tracker.rb:20:10:20:10 | [post] b | type tracker without call steps | type_tracker.rb:20:10:20:10 | [post] b |
+| type_tracker.rb:20:10:20:10 | b | type tracker without call steps | type_tracker.rb:20:10:20:10 | b |
+| type_tracker.rb:21:5:21:10 | [post] self | type tracker without call steps | type_tracker.rb:21:5:21:10 | [post] self |
+| type_tracker.rb:21:5:21:10 | call to puts | type tracker without call steps | type_tracker.rb:18:1:22:3 | return return in foo |
+| type_tracker.rb:21:5:21:10 | call to puts | type tracker without call steps | type_tracker.rb:21:5:21:10 | call to puts |
+| type_tracker.rb:21:5:21:10 | call to puts | type tracker without call steps | type_tracker.rb:24:1:24:25 | call to foo |
+| type_tracker.rb:21:5:21:10 | self | type tracker without call steps | type_tracker.rb:21:5:21:10 | self |
+| type_tracker.rb:21:10:21:10 | [post] c | type tracker without call steps | type_tracker.rb:21:10:21:10 | [post] c |
+| type_tracker.rb:21:10:21:10 | c | type tracker without call steps | type_tracker.rb:21:10:21:10 | c |
+| type_tracker.rb:24:1:24:25 | [post] self | type tracker without call steps | type_tracker.rb:24:1:24:25 | [post] self |
+| type_tracker.rb:24:1:24:25 | call to foo | type tracker without call steps | type_tracker.rb:24:1:24:25 | call to foo |
+| type_tracker.rb:24:1:24:25 | self | type tracker with call steps | type_tracker.rb:18:1:22:3 | self in foo |
+| type_tracker.rb:24:1:24:25 | self | type tracker without call steps | type_tracker.rb:24:1:24:25 | self |
+| type_tracker.rb:24:5:24:7 | "a" | type tracker with call steps | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:24:5:24:7 | "a" | type tracker with call steps | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:24:5:24:7 | "a" | type tracker without call steps | type_tracker.rb:24:5:24:7 | "a" |
+| type_tracker.rb:24:5:24:7 | [post] "a" | type tracker without call steps | type_tracker.rb:24:5:24:7 | [post] "a" |
+| type_tracker.rb:24:10:24:13 | "b1" | type tracker without call steps | type_tracker.rb:24:10:24:13 | "b1" |
+| type_tracker.rb:24:10:24:13 | [post] "b1" | type tracker without call steps | type_tracker.rb:24:10:24:13 | [post] "b1" |
+| type_tracker.rb:24:16:24:19 | "b2" | type tracker with call steps | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:24:16:24:19 | "b2" | type tracker with call steps | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:24:16:24:19 | "b2" | type tracker without call steps | type_tracker.rb:24:16:24:19 | "b2" |
+| type_tracker.rb:24:16:24:19 | [post] "b2" | type tracker without call steps | type_tracker.rb:24:16:24:19 | [post] "b2" |
+| type_tracker.rb:24:22:24:24 | "c" | type tracker without call steps | type_tracker.rb:24:22:24:24 | "c" |
+| type_tracker.rb:24:22:24:24 | [post] "c" | type tracker without call steps | type_tracker.rb:24:22:24:24 | [post] "c" |
 trackEnd
+| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:1:1:10:3 | self (type_tracker.rb) |
+| type_tracker.rb:1:1:10:3 | self (type_tracker.rb) | type_tracker.rb:18:1:22:3 | self in foo |
 | type_tracker.rb:2:5:5:7 | &block | type_tracker.rb:2:5:5:7 | &block |
 | type_tracker.rb:2:5:5:7 | field= | type_tracker.rb:2:5:5:7 | field= |
 | type_tracker.rb:2:5:5:7 | return return in field= | type_tracker.rb:2:5:5:7 | return return in field= |
@@ -132,3 +185,52 @@ trackEnd
 | type_tracker.rb:15:10:15:12 | [post] var | type_tracker.rb:15:10:15:12 | [post] var |
 | type_tracker.rb:15:10:15:18 | [post] call to field | type_tracker.rb:15:10:15:18 | [post] call to field |
 | type_tracker.rb:15:10:15:18 | call to field | type_tracker.rb:15:10:15:18 | call to field |
+| type_tracker.rb:18:1:22:3 | &block | type_tracker.rb:18:1:22:3 | &block |
+| type_tracker.rb:18:1:22:3 | foo | type_tracker.rb:18:1:22:3 | foo |
+| type_tracker.rb:18:1:22:3 | return return in foo | type_tracker.rb:18:1:22:3 | return return in foo |
+| type_tracker.rb:18:1:22:3 | return return in foo | type_tracker.rb:24:1:24:25 | call to foo |
+| type_tracker.rb:18:1:22:3 | self (foo) | type_tracker.rb:18:1:22:3 | self (foo) |
+| type_tracker.rb:18:1:22:3 | self in foo | type_tracker.rb:18:1:22:3 | self in foo |
+| type_tracker.rb:18:9:18:9 | a | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:9:18:9 | a | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:9:18:9 | a | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:9:18:9 | a | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:18:13:18:13 | b | type_tracker.rb:18:13:18:13 | b |
+| type_tracker.rb:18:13:18:13 | b | type_tracker.rb:18:13:18:13 | b |
+| type_tracker.rb:18:16:18:16 | c | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:18:16:18:16 | c | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:18:16:18:16 | c | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:18:16:18:16 | c | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:19:5:19:10 | [post] self | type_tracker.rb:19:5:19:10 | [post] self |
+| type_tracker.rb:19:5:19:10 | call to puts | type_tracker.rb:19:5:19:10 | call to puts |
+| type_tracker.rb:19:5:19:10 | self | type_tracker.rb:19:5:19:10 | self |
+| type_tracker.rb:19:10:19:10 | [post] a | type_tracker.rb:19:10:19:10 | [post] a |
+| type_tracker.rb:19:10:19:10 | a | type_tracker.rb:19:10:19:10 | a |
+| type_tracker.rb:20:5:20:10 | [post] self | type_tracker.rb:20:5:20:10 | [post] self |
+| type_tracker.rb:20:5:20:10 | call to puts | type_tracker.rb:20:5:20:10 | call to puts |
+| type_tracker.rb:20:5:20:10 | self | type_tracker.rb:20:5:20:10 | self |
+| type_tracker.rb:20:10:20:10 | [post] b | type_tracker.rb:20:10:20:10 | [post] b |
+| type_tracker.rb:20:10:20:10 | b | type_tracker.rb:20:10:20:10 | b |
+| type_tracker.rb:21:5:21:10 | [post] self | type_tracker.rb:21:5:21:10 | [post] self |
+| type_tracker.rb:21:5:21:10 | call to puts | type_tracker.rb:18:1:22:3 | return return in foo |
+| type_tracker.rb:21:5:21:10 | call to puts | type_tracker.rb:21:5:21:10 | call to puts |
+| type_tracker.rb:21:5:21:10 | call to puts | type_tracker.rb:24:1:24:25 | call to foo |
+| type_tracker.rb:21:5:21:10 | self | type_tracker.rb:21:5:21:10 | self |
+| type_tracker.rb:21:10:21:10 | [post] c | type_tracker.rb:21:10:21:10 | [post] c |
+| type_tracker.rb:21:10:21:10 | c | type_tracker.rb:21:10:21:10 | c |
+| type_tracker.rb:24:1:24:25 | [post] self | type_tracker.rb:24:1:24:25 | [post] self |
+| type_tracker.rb:24:1:24:25 | call to foo | type_tracker.rb:24:1:24:25 | call to foo |
+| type_tracker.rb:24:1:24:25 | self | type_tracker.rb:18:1:22:3 | self in foo |
+| type_tracker.rb:24:1:24:25 | self | type_tracker.rb:24:1:24:25 | self |
+| type_tracker.rb:24:5:24:7 | "a" | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:24:5:24:7 | "a" | type_tracker.rb:18:9:18:9 | a |
+| type_tracker.rb:24:5:24:7 | "a" | type_tracker.rb:24:5:24:7 | "a" |
+| type_tracker.rb:24:5:24:7 | [post] "a" | type_tracker.rb:24:5:24:7 | [post] "a" |
+| type_tracker.rb:24:10:24:13 | "b1" | type_tracker.rb:24:10:24:13 | "b1" |
+| type_tracker.rb:24:10:24:13 | [post] "b1" | type_tracker.rb:24:10:24:13 | [post] "b1" |
+| type_tracker.rb:24:16:24:19 | "b2" | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:24:16:24:19 | "b2" | type_tracker.rb:18:16:18:16 | c |
+| type_tracker.rb:24:16:24:19 | "b2" | type_tracker.rb:24:16:24:19 | "b2" |
+| type_tracker.rb:24:16:24:19 | [post] "b2" | type_tracker.rb:24:16:24:19 | [post] "b2" |
+| type_tracker.rb:24:22:24:24 | "c" | type_tracker.rb:24:22:24:24 | "c" |
+| type_tracker.rb:24:22:24:24 | [post] "c" | type_tracker.rb:24:22:24:24 | [post] "c" |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -111,8 +111,6 @@ track
 | type_tracker.rb:24:5:24:7 | [post] "a" | type tracker without call steps | type_tracker.rb:24:5:24:7 | [post] "a" |
 | type_tracker.rb:24:10:24:13 | "b1" | type tracker without call steps | type_tracker.rb:24:10:24:13 | "b1" |
 | type_tracker.rb:24:10:24:13 | [post] "b1" | type tracker without call steps | type_tracker.rb:24:10:24:13 | [post] "b1" |
-| type_tracker.rb:24:16:24:19 | "b2" | type tracker with call steps | type_tracker.rb:18:16:18:16 | c |
-| type_tracker.rb:24:16:24:19 | "b2" | type tracker with call steps | type_tracker.rb:18:16:18:16 | c |
 | type_tracker.rb:24:16:24:19 | "b2" | type tracker without call steps | type_tracker.rb:24:16:24:19 | "b2" |
 | type_tracker.rb:24:16:24:19 | [post] "b2" | type tracker without call steps | type_tracker.rb:24:16:24:19 | [post] "b2" |
 | type_tracker.rb:24:22:24:24 | "c" | type tracker without call steps | type_tracker.rb:24:22:24:24 | "c" |
@@ -228,8 +226,6 @@ trackEnd
 | type_tracker.rb:24:5:24:7 | [post] "a" | type_tracker.rb:24:5:24:7 | [post] "a" |
 | type_tracker.rb:24:10:24:13 | "b1" | type_tracker.rb:24:10:24:13 | "b1" |
 | type_tracker.rb:24:10:24:13 | [post] "b1" | type_tracker.rb:24:10:24:13 | [post] "b1" |
-| type_tracker.rb:24:16:24:19 | "b2" | type_tracker.rb:18:16:18:16 | c |
-| type_tracker.rb:24:16:24:19 | "b2" | type_tracker.rb:18:16:18:16 | c |
 | type_tracker.rb:24:16:24:19 | "b2" | type_tracker.rb:24:16:24:19 | "b2" |
 | type_tracker.rb:24:16:24:19 | [post] "b2" | type_tracker.rb:24:16:24:19 | [post] "b2" |
 | type_tracker.rb:24:22:24:24 | "c" | type_tracker.rb:24:22:24:24 | "c" |

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/type_tracker.rb
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/type_tracker.rb
@@ -14,3 +14,11 @@ def m()
     var.field = "hello"
     puts var.field
 end
+
+def foo(a, *b, c)
+    puts a
+    puts b
+    puts c
+end
+
+foo('a', 'b1', 'b2', 'c')


### PR DESCRIPTION
Adds `Parameter.getLogicalPosition()` as a way to get the index of a positional argument, while taking into account that it may be declared after a splat parameter (and therefore have a non-constant logical index).

Commit-by-commit review recommended.