### PR TITLE
C++: Fix re-evaluation in `cpp/return-stack-allocated-memory`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -14,6 +14,9 @@
  */
 
 import cpp
+// We don't actually use the global value numbering library in this query, but without it we end up
+// recomputing the IR.
+private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.dataflow.DataFlow::DataFlow
 


### PR DESCRIPTION
We were, once again, hit by the IR re-evaluation problem because we didn't import `semmle.code.cpp.valuenumbering.GlobalValueNumbering` before we imported the IR.