### PR TITLE
Python: Remove `RegExpTerm` from PrintAST

### DIFF
--- a/python/ql/lib/semmle/python/PrintAst.qll
+++ b/python/ql/lib/semmle/python/PrintAst.qll
@@ -53,9 +53,6 @@ private newtype TPrintAstNode =
     shouldPrint(list.getAnItem(), _) and
     not list = any(Module mod).getBody() and
     not forall(AstNode child | child = list.getAnItem() | isNotNeeded(child))
-  } or
-  TRegExpTermNode(RegExpTerm term) {
-    exists(StrConst str | term.getRootTerm() = getParsedRegExp(str) and shouldPrint(str, _))
   }
 
 /**
@@ -430,32 +427,6 @@ class ParameterNode extends AstElementNode {
  */
 class StrConstNode extends AstElementNode {
   override StrConst element;
-
-  override PrintAstNode getChild(int childIndex) {
-    childIndex = 0 and result.(RegExpTermNode).getTerm() = getParsedRegExp(element)
-  }
-}
-
-/**
- * A print node for a regular expression term.
- */
-class RegExpTermNode extends TRegExpTermNode, PrintAstNode {
-  RegExpTerm term;
-
-  RegExpTermNode() { this = TRegExpTermNode(term) }
-
-  /** Gets the `RegExpTerm` for this node. */
-  RegExpTerm getTerm() { result = term }
-
-  override PrintAstNode getChild(int childIndex) {
-    result.(RegExpTermNode).getTerm() = term.getChild(childIndex)
-  }
-
-  override string toString() {
-    result = "[" + strictconcat(term.getPrimaryQLClass(), " | ") + "] " + term.toString()
-  }
-
-  override Location getLocation() { result = term.getLocation() }
 }
 
 /**

--- a/python/ql/src/change-notes/2021-01-19-remove-regexp-from-printast.md
+++ b/python/ql/src/change-notes/2021-01-19-remove-regexp-from-printast.md
@@ -1,4 +1,4 @@
 ---
 category: fix
 ---
-* The [View AST functionality](https://codeql.github.com/docs/codeql-for-visual-studio-code/exploring-the-structure-of-your-source-code/) no longer prints detailed information about regular expression, greatly improving performance.
+* The [View AST functionality](https://codeql.github.com/docs/codeql-for-visual-studio-code/exploring-the-structure-of-your-source-code/) no longer prints detailed information about regular expressions, greatly improving performance.

--- a/python/ql/src/change-notes/2021-01-19-remove-regexp-from-printast.md
+++ b/python/ql/src/change-notes/2021-01-19-remove-regexp-from-printast.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* The [View AST functionality](https://codeql.github.com/docs/codeql-for-visual-studio-code/exploring-the-structure-of-your-source-code/) no longer prints detailed information about regular expression, greatly improving performance.


### PR DESCRIPTION
Since this caused bad performance (as we had to evaluate points-to).

Fixes https://github.com/github/codeql/issues/6964

This approach was motivated by the comment on the issue from @tausbn:

> We discussed this internally in the CodeQL Python team, and have
> agreed that the best approach for now is to disable the printing of
> regex ASTs.

I tried to keep our RegExpTerm logic, but doing the fix below did not
work, and still evaluated RegExpTerm :| I guess we will just have to
revert this PR if we want it back

```diff
   TRegExpTermNode(RegExpTerm term) {
+    none() and
     exists(StrConst str | term.getRootTerm() = getParsedRegExp(str) and shouldPrint(str, _))
   }
```