### PR TITLE
Misc: Streamline `consistency-queries/qlpack.yml`

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -4,6 +4,7 @@
         "*/ql/lib/qlpack.yml",
         "*/ql/test/qlpack.yml",
         "*/ql/examples/qlpack.yml",
+        "*/ql/consistency-queries/qlpack.yml",
         "cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/tainted/qlpack.yml",
         "javascript/ql/experimental/adaptivethreatmodeling/lib/qlpack.yml",
         "javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/qlpack.yml",
@@ -14,8 +15,6 @@
         "misc/legacy-support/*/qlpack.yml",
         "misc/suite-helpers/qlpack.yml",
         "ruby/extractor-pack/codeql-extractor.yml",
-        "ruby/ql/consistency-queries/qlpack.yml",
-        "ql/ql/consistency-queries/qlpack.yml",
         "ql/extractor-pack/codeql-extractor.yml"
     ],
     "versionPolicies": {

--- a/csharp/ql/consistency-queries/qlpack.yml
+++ b/csharp/ql/consistency-queries/qlpack.yml
@@ -1,4 +1,5 @@
 name: codeql-csharp-consistency-queries
+groups: [csharp, test, consistency-queries]
 dependencies:
   codeql/csharp-all: "*"
 extractor: csharp

--- a/csharp/ql/consistency-queries/qlpack.yml
+++ b/csharp/ql/consistency-queries/qlpack.yml
@@ -1,5 +1,4 @@
 name: codeql-csharp-consistency-queries
 dependencies:
   codeql/csharp-all: "*"
-  codeql/csharp-queries: "*"
 extractor: csharp

--- a/csharp/ql/consistency-queries/qlpack.yml
+++ b/csharp/ql/consistency-queries/qlpack.yml
@@ -1,6 +1,5 @@
 name: codeql-csharp-consistency-queries
-version: 0.0.0
-libraryPathDependencies:
-  - codeql/csharp-all
-  - codeql/csharp-queries
+dependencies:
+  codeql/csharp-all: "*"
+  codeql/csharp-queries: "*"
 extractor: csharp

--- a/python/ql/consistency-queries/qlpack.yml
+++ b/python/ql/consistency-queries/qlpack.yml
@@ -1,0 +1,5 @@
+name: codeql/python-consistency-queries
+groups: [python, consistency-queries]
+dependencies:
+    codeql/python-all: "*"
+extractor: python

--- a/python/ql/consistency-queries/qlpack.yml
+++ b/python/ql/consistency-queries/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/python-consistency-queries
-groups: [python, consistency-queries]
+groups: [python, test, consistency-queries]
 dependencies:
     codeql/python-all: "*"
 extractor: python

--- a/ql/ql/consistency-queries/qlpack.yml
+++ b/ql/ql/consistency-queries/qlpack.yml
@@ -1,4 +1,5 @@
 name: codeql/ql-consistency-queries
+groups: [ql, test, consistency-queries]
 dependencies:
   codeql-ql: "*"
 extractor: ql

--- a/ql/ql/consistency-queries/qlpack.yml
+++ b/ql/ql/consistency-queries/qlpack.yml
@@ -1,5 +1,4 @@
-name: codeql-ql-consistency-queries
-version: 0.0.0
-libraryPathDependencies:
-  - codeql-ql
+name: codeql/ql-consistency-queries
+dependencies:
+  codeql-ql: "*"
 extractor: ql

--- a/ruby/ql/consistency-queries/qlpack.yml
+++ b/ruby/ql/consistency-queries/qlpack.yml
@@ -1,5 +1,3 @@
 name: codeql/ruby-consistency-queries
-version: 0.0.1
 dependencies:
-  codeql/ruby-all: 0.0.1
-
+  codeql/ruby-all: "*"

--- a/ruby/ql/consistency-queries/qlpack.yml
+++ b/ruby/ql/consistency-queries/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql/ruby-consistency-queries
+groups: [ruby, test, consistency-queries]
 dependencies:
   codeql/ruby-all: "*"


### PR DESCRIPTION
Wanted to add this for Python, so that was the day I learned about `.codeqlmanifest.json` :open_mouth: 

I looked at the `qlpack.yml` for the other languages, and since they were all slightly different, I decided to streamline them. I also made them all use the preferred `dependencies` instead of `libraryPathDependencies`.