### PR TITLE
JS: add file sources from `jszip` to `js/zip-slip`

### DIFF
--- a/javascript/ql/lib/change-notes/2022-02-04-jszip
+++ b/javascript/ql/lib/change-notes/2022-02-04-jszip
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added sources from the [`jszip`](https://www.npmjs.com/package/jszip) library to the `js/zipslip` query.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ZipSlipCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ZipSlipCustomizations.qll
@@ -97,6 +97,29 @@ module ZipSlip {
     }
   }
 
+  private import semmle.javascript.DynamicPropertyAccess as DynamicPropertyAccess
+
+  /** A object key in the JSZip files object */
+  class JSZipFilesSource extends Source instanceof DynamicPropertyAccess::EnumeratedPropName {
+    JSZipFilesSource() {
+      super.getSourceObject() =
+        API::moduleImport("jszip").getInstance().getMember("files").getAnImmediateUse()
+    }
+  }
+
+  /** A relative path from iterating the files in the JSZip object */
+  class JSZipFileSource extends Source {
+    JSZipFileSource() {
+      this =
+        API::moduleImport("jszip")
+            .getInstance()
+            .getMember(["forEach", "filter"])
+            .getParameter(0)
+            .getParameter(0)
+            .getAnImmediateUse()
+    }
+  }
+
   /** A call to `fs.createWriteStream`, as a sink for unsafe archive extraction. */
   class CreateWriteStreamSink extends Sink {
     CreateWriteStreamSink() {

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
@@ -45,6 +45,18 @@ nodes
 | ZipSlipBad.js:23:28:23:35 | fileName |
 | ZipSlipBad.js:23:28:23:35 | fileName |
 | ZipSlipBad.js:23:28:23:35 | fileName |
+| ZipSlipBad.js:29:14:29:17 | name |
+| ZipSlipBad.js:29:14:29:17 | name |
+| ZipSlipBad.js:29:14:29:17 | name |
+| ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name |
+| ZipSlipBad.js:33:16:33:19 | name |
+| ZipSlipBad.js:33:16:33:19 | name |
+| ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:34:26:34:29 | name |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
 | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path |
@@ -91,6 +103,20 @@ edges
 | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:22:11:22:31 | fileName |
 | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:22:11:22:31 | fileName |
 | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:22:11:22:31 | fileName |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
@@ -107,4 +133,6 @@ edges
 | ZipSlipBad.js:8:37:8:44 | fileName | ZipSlipBad.js:7:22:7:31 | entry.path | ZipSlipBad.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:7:22:7:31 | entry.path | item path |
 | ZipSlipBad.js:16:30:16:37 | fileName | ZipSlipBad.js:15:22:15:31 | entry.path | ZipSlipBad.js:16:30:16:37 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:15:22:15:31 | entry.path | item path |
 | ZipSlipBad.js:23:28:23:35 | fileName | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:23:28:23:35 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:22:22:22:31 | entry.path | item path |
+| ZipSlipBad.js:30:26:30:29 | name | ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:29:14:29:17 | name | item path |
+| ZipSlipBad.js:34:26:34:29 | name | ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:33:16:33:19 | name | item path |
 | ZipSlipBadUnzipper.js:8:37:8:44 | fileName | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | ZipSlipBadUnzipper.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | item path |

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlipBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlipBad.js
@@ -22,3 +22,15 @@ fs.createReadStream('archive.zip')
     const fileName = entry.path;
     var file = fs.openSync(fileName, "w");
   });
+
+const JSZip = require('jszip');
+const zip = new JSZip();
+function doZipSlip() {
+  for (const name in zip.files) {
+    fs.createWriteStream(name);
+  }
+
+  zip.forEach((name, file) => {
+    fs.createWriteStream(name);
+  });
+}


### PR DESCRIPTION
Gets a TP for CVE-2021-23484 

Evaluation underway, but I doubt it will show anything. 