### PR TITLE
JS: Add codeowners for ML-powered queries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,9 @@
 /python/**/experimental/**/* @github/codeql-python @xcorail
 /ruby/**/experimental/**/* @github/codeql-ruby @xcorail
 
+# ML-powered queries
+/javascript/ql/experimental/adaptivethreatmodeling/ @github/codeql-ml-powered-queries-reviewers
+
 # Notify members of codeql-go about PRs to the shared data-flow library files
 /java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll @github/codeql-java @github/codeql-go
 /java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll @github/codeql-java @github/codeql-go


### PR DESCRIPTION
This PR introduces a new reviewers team @github/codeql-ml-powered-queries-reviewers for reviewing ML-powered queries and the associated CodeQL libraries.