### PR TITLE
Ruby: put AST node locations in a single table

### DIFF
--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_comment_directive_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_comment_directive_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @erb_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where erb_comment_directive_def(id, child) and erb_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_directive_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_directive_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @erb_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where erb_directive_def(id, child) and erb_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_graphql_directive_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_graphql_directive_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @erb_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where erb_graphql_directive_def(id, child) and erb_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_output_directive_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_output_directive_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @erb_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where erb_output_directive_def(id, child) and erb_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_template_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_template_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @erb_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where erb_template_def(id) and erb_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_tokeninfo.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/erb_tokeninfo.ql
@@ -1,0 +1,11 @@
+class AstNode extends @erb_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, int kind, string value, Location loc
+where erb_tokeninfo(id, kind, value) and erb_ast_node_info(id, _, _, loc)
+select id, kind, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/old.dbscheme
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/old.dbscheme
@@ -1,0 +1,1393 @@
+// CodeQL database schema for Ruby
+// Automatically generated from the tree-sitter grammar; do not edit
+
+@location = @location_default
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int start_line: int ref,
+  int start_column: int ref,
+  int end_line: int ref,
+  int end_column: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+sourceLocationPrefix(
+  string prefix: string ref
+);
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+
+@ruby_underscore_arg = @ruby_assignment | @ruby_binary | @ruby_conditional | @ruby_operator_assignment | @ruby_range | @ruby_unary | @ruby_underscore_primary
+
+@ruby_underscore_expression = @ruby_assignment | @ruby_binary | @ruby_break | @ruby_call | @ruby_next | @ruby_operator_assignment | @ruby_return | @ruby_unary | @ruby_underscore_arg | @ruby_yield
+
+@ruby_underscore_lhs = @ruby_call | @ruby_element_reference | @ruby_scope_resolution | @ruby_token_false | @ruby_token_nil | @ruby_token_true | @ruby_underscore_variable
+
+@ruby_underscore_method_name = @ruby_delimited_symbol | @ruby_setter | @ruby_token_constant | @ruby_token_identifier | @ruby_token_operator | @ruby_token_simple_symbol | @ruby_underscore_nonlocal_variable
+
+@ruby_underscore_nonlocal_variable = @ruby_token_class_variable | @ruby_token_global_variable | @ruby_token_instance_variable
+
+@ruby_underscore_pattern_constant = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_underscore_pattern_expr = @ruby_alternative_pattern | @ruby_as_pattern | @ruby_underscore_pattern_expr_basic
+
+@ruby_underscore_pattern_expr_basic = @ruby_array_pattern | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_parenthesized_pattern | @ruby_range | @ruby_token_identifier | @ruby_underscore_pattern_constant | @ruby_underscore_pattern_primitive | @ruby_variable_reference_pattern
+
+@ruby_underscore_pattern_primitive = @ruby_delimited_symbol | @ruby_lambda | @ruby_regex | @ruby_string__ | @ruby_string_array | @ruby_symbol_array | @ruby_token_encoding | @ruby_token_false | @ruby_token_file | @ruby_token_line | @ruby_token_nil | @ruby_token_self | @ruby_token_simple_symbol | @ruby_token_true | @ruby_unary | @ruby_underscore_simple_numeric
+
+@ruby_underscore_pattern_top_expr_body = @ruby_array_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_underscore_pattern_expr
+
+@ruby_underscore_primary = @ruby_array | @ruby_begin | @ruby_break | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_delimited_symbol | @ruby_for | @ruby_hash | @ruby_if | @ruby_lambda | @ruby_method | @ruby_module | @ruby_next | @ruby_parenthesized_statements | @ruby_redo | @ruby_regex | @ruby_retry | @ruby_return | @ruby_singleton_class | @ruby_singleton_method | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_symbol_array | @ruby_token_character | @ruby_token_heredoc_beginning | @ruby_token_simple_symbol | @ruby_unary | @ruby_underscore_lhs | @ruby_underscore_simple_numeric | @ruby_unless | @ruby_until | @ruby_while | @ruby_yield
+
+@ruby_underscore_simple_numeric = @ruby_rational | @ruby_token_complex | @ruby_token_float | @ruby_token_integer
+
+@ruby_underscore_statement = @ruby_alias | @ruby_begin_block | @ruby_end_block | @ruby_if_modifier | @ruby_rescue_modifier | @ruby_undef | @ruby_underscore_expression | @ruby_unless_modifier | @ruby_until_modifier | @ruby_while_modifier
+
+@ruby_underscore_variable = @ruby_token_constant | @ruby_token_identifier | @ruby_token_self | @ruby_token_super | @ruby_underscore_nonlocal_variable
+
+ruby_alias_def(
+  unique int id: @ruby_alias,
+  int alias: @ruby_underscore_method_name ref,
+  int name: @ruby_underscore_method_name ref
+);
+
+#keyset[ruby_alternative_pattern, index]
+ruby_alternative_pattern_alternatives(
+  int ruby_alternative_pattern: @ruby_alternative_pattern ref,
+  int index: int ref,
+  unique int alternatives: @ruby_underscore_pattern_expr_basic ref
+);
+
+ruby_alternative_pattern_def(
+  unique int id: @ruby_alternative_pattern
+);
+
+@ruby_argument_list_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_argument_list, index]
+ruby_argument_list_child(
+  int ruby_argument_list: @ruby_argument_list ref,
+  int index: int ref,
+  unique int child: @ruby_argument_list_child_type ref
+);
+
+ruby_argument_list_def(
+  unique int id: @ruby_argument_list
+);
+
+@ruby_array_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_array, index]
+ruby_array_child(
+  int ruby_array: @ruby_array ref,
+  int index: int ref,
+  unique int child: @ruby_array_child_type ref
+);
+
+ruby_array_def(
+  unique int id: @ruby_array
+);
+
+ruby_array_pattern_class(
+  unique int ruby_array_pattern: @ruby_array_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_array_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_array_pattern, index]
+ruby_array_pattern_child(
+  int ruby_array_pattern: @ruby_array_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_array_pattern_child_type ref
+);
+
+ruby_array_pattern_def(
+  unique int id: @ruby_array_pattern
+);
+
+ruby_as_pattern_def(
+  unique int id: @ruby_as_pattern,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_pattern_expr ref
+);
+
+@ruby_assignment_left_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+@ruby_assignment_right_type = @ruby_right_assignment_list | @ruby_splat_argument | @ruby_underscore_expression
+
+ruby_assignment_def(
+  unique int id: @ruby_assignment,
+  int left: @ruby_assignment_left_type ref,
+  int right: @ruby_assignment_right_type ref
+);
+
+@ruby_bare_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_string, index]
+ruby_bare_string_child(
+  int ruby_bare_string: @ruby_bare_string ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string_child_type ref
+);
+
+ruby_bare_string_def(
+  unique int id: @ruby_bare_string
+);
+
+@ruby_bare_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_symbol, index]
+ruby_bare_symbol_child(
+  int ruby_bare_symbol: @ruby_bare_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol_child_type ref
+);
+
+ruby_bare_symbol_def(
+  unique int id: @ruby_bare_symbol
+);
+
+@ruby_begin_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin, index]
+ruby_begin_child(
+  int ruby_begin: @ruby_begin ref,
+  int index: int ref,
+  unique int child: @ruby_begin_child_type ref
+);
+
+ruby_begin_def(
+  unique int id: @ruby_begin
+);
+
+@ruby_begin_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin_block, index]
+ruby_begin_block_child(
+  int ruby_begin_block: @ruby_begin_block ref,
+  int index: int ref,
+  unique int child: @ruby_begin_block_child_type ref
+);
+
+ruby_begin_block_def(
+  unique int id: @ruby_begin_block
+);
+
+case @ruby_binary.operator of
+  0 = @ruby_binary_bangequal
+| 1 = @ruby_binary_bangtilde
+| 2 = @ruby_binary_percent
+| 3 = @ruby_binary_ampersand
+| 4 = @ruby_binary_ampersandampersand
+| 5 = @ruby_binary_star
+| 6 = @ruby_binary_starstar
+| 7 = @ruby_binary_plus
+| 8 = @ruby_binary_minus
+| 9 = @ruby_binary_slash
+| 10 = @ruby_binary_langle
+| 11 = @ruby_binary_langlelangle
+| 12 = @ruby_binary_langleequal
+| 13 = @ruby_binary_langleequalrangle
+| 14 = @ruby_binary_equalequal
+| 15 = @ruby_binary_equalequalequal
+| 16 = @ruby_binary_equaltilde
+| 17 = @ruby_binary_rangle
+| 18 = @ruby_binary_rangleequal
+| 19 = @ruby_binary_ranglerangle
+| 20 = @ruby_binary_caret
+| 21 = @ruby_binary_and
+| 22 = @ruby_binary_or
+| 23 = @ruby_binary_pipe
+| 24 = @ruby_binary_pipepipe
+;
+
+
+ruby_binary_def(
+  unique int id: @ruby_binary,
+  int left: @ruby_underscore_expression ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref
+);
+
+ruby_block_parameters(
+  unique int ruby_block: @ruby_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_block, index]
+ruby_block_child(
+  int ruby_block: @ruby_block ref,
+  int index: int ref,
+  unique int child: @ruby_block_child_type ref
+);
+
+ruby_block_def(
+  unique int id: @ruby_block
+);
+
+ruby_block_argument_child(
+  unique int ruby_block_argument: @ruby_block_argument ref,
+  unique int child: @ruby_underscore_arg ref
+);
+
+ruby_block_argument_def(
+  unique int id: @ruby_block_argument
+);
+
+ruby_block_parameter_name(
+  unique int ruby_block_parameter: @ruby_block_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_block_parameter_def(
+  unique int id: @ruby_block_parameter
+);
+
+@ruby_block_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_block_parameters, index]
+ruby_block_parameters_child(
+  int ruby_block_parameters: @ruby_block_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_block_parameters_child_type ref
+);
+
+ruby_block_parameters_def(
+  unique int id: @ruby_block_parameters
+);
+
+ruby_break_child(
+  unique int ruby_break: @ruby_break ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_break_def(
+  unique int id: @ruby_break
+);
+
+ruby_call_arguments(
+  unique int ruby_call: @ruby_call ref,
+  unique int arguments: @ruby_argument_list ref
+);
+
+@ruby_call_block_type = @ruby_block | @ruby_do_block
+
+ruby_call_block(
+  unique int ruby_call: @ruby_call ref,
+  unique int block: @ruby_call_block_type ref
+);
+
+@ruby_call_method_type = @ruby_argument_list | @ruby_scope_resolution | @ruby_token_operator | @ruby_underscore_variable
+
+@ruby_call_receiver_type = @ruby_call | @ruby_underscore_primary
+
+ruby_call_receiver(
+  unique int ruby_call: @ruby_call ref,
+  unique int receiver: @ruby_call_receiver_type ref
+);
+
+ruby_call_def(
+  unique int id: @ruby_call,
+  int method: @ruby_call_method_type ref
+);
+
+ruby_case_value(
+  unique int ruby_case__: @ruby_case__ ref,
+  unique int value: @ruby_underscore_statement ref
+);
+
+@ruby_case_child_type = @ruby_else | @ruby_when
+
+#keyset[ruby_case__, index]
+ruby_case_child(
+  int ruby_case__: @ruby_case__ ref,
+  int index: int ref,
+  unique int child: @ruby_case_child_type ref
+);
+
+ruby_case_def(
+  unique int id: @ruby_case__
+);
+
+#keyset[ruby_case_match, index]
+ruby_case_match_clauses(
+  int ruby_case_match: @ruby_case_match ref,
+  int index: int ref,
+  unique int clauses: @ruby_in_clause ref
+);
+
+ruby_case_match_else(
+  unique int ruby_case_match: @ruby_case_match ref,
+  unique int else: @ruby_else ref
+);
+
+ruby_case_match_def(
+  unique int id: @ruby_case_match,
+  int value: @ruby_underscore_statement ref
+);
+
+#keyset[ruby_chained_string, index]
+ruby_chained_string_child(
+  int ruby_chained_string: @ruby_chained_string ref,
+  int index: int ref,
+  unique int child: @ruby_string__ ref
+);
+
+ruby_chained_string_def(
+  unique int id: @ruby_chained_string
+);
+
+@ruby_class_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+ruby_class_superclass(
+  unique int ruby_class: @ruby_class ref,
+  unique int superclass: @ruby_superclass ref
+);
+
+@ruby_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_class, index]
+ruby_class_child(
+  int ruby_class: @ruby_class ref,
+  int index: int ref,
+  unique int child: @ruby_class_child_type ref
+);
+
+ruby_class_def(
+  unique int id: @ruby_class,
+  int name: @ruby_class_name_type ref
+);
+
+ruby_conditional_def(
+  unique int id: @ruby_conditional,
+  int alternative: @ruby_underscore_arg ref,
+  int condition: @ruby_underscore_arg ref,
+  int consequence: @ruby_underscore_arg ref
+);
+
+@ruby_delimited_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_delimited_symbol, index]
+ruby_delimited_symbol_child(
+  int ruby_delimited_symbol: @ruby_delimited_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_delimited_symbol_child_type ref
+);
+
+ruby_delimited_symbol_def(
+  unique int id: @ruby_delimited_symbol
+);
+
+@ruby_destructured_left_assignment_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_destructured_left_assignment, index]
+ruby_destructured_left_assignment_child(
+  int ruby_destructured_left_assignment: @ruby_destructured_left_assignment ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_left_assignment_child_type ref
+);
+
+ruby_destructured_left_assignment_def(
+  unique int id: @ruby_destructured_left_assignment
+);
+
+@ruby_destructured_parameter_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_destructured_parameter, index]
+ruby_destructured_parameter_child(
+  int ruby_destructured_parameter: @ruby_destructured_parameter ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_parameter_child_type ref
+);
+
+ruby_destructured_parameter_def(
+  unique int id: @ruby_destructured_parameter
+);
+
+@ruby_do_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do, index]
+ruby_do_child(
+  int ruby_do: @ruby_do ref,
+  int index: int ref,
+  unique int child: @ruby_do_child_type ref
+);
+
+ruby_do_def(
+  unique int id: @ruby_do
+);
+
+ruby_do_block_parameters(
+  unique int ruby_do_block: @ruby_do_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_do_block_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do_block, index]
+ruby_do_block_child(
+  int ruby_do_block: @ruby_do_block ref,
+  int index: int ref,
+  unique int child: @ruby_do_block_child_type ref
+);
+
+ruby_do_block_def(
+  unique int id: @ruby_do_block
+);
+
+@ruby_element_reference_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_element_reference, index]
+ruby_element_reference_child(
+  int ruby_element_reference: @ruby_element_reference ref,
+  int index: int ref,
+  unique int child: @ruby_element_reference_child_type ref
+);
+
+ruby_element_reference_def(
+  unique int id: @ruby_element_reference,
+  int object: @ruby_underscore_primary ref
+);
+
+@ruby_else_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_else, index]
+ruby_else_child(
+  int ruby_else: @ruby_else ref,
+  int index: int ref,
+  unique int child: @ruby_else_child_type ref
+);
+
+ruby_else_def(
+  unique int id: @ruby_else
+);
+
+@ruby_elsif_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_elsif_alternative(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int alternative: @ruby_elsif_alternative_type ref
+);
+
+ruby_elsif_consequence(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_elsif_def(
+  unique int id: @ruby_elsif,
+  int condition: @ruby_underscore_statement ref
+);
+
+@ruby_end_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_end_block, index]
+ruby_end_block_child(
+  int ruby_end_block: @ruby_end_block ref,
+  int index: int ref,
+  unique int child: @ruby_end_block_child_type ref
+);
+
+ruby_end_block_def(
+  unique int id: @ruby_end_block
+);
+
+@ruby_ensure_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_ensure, index]
+ruby_ensure_child(
+  int ruby_ensure: @ruby_ensure ref,
+  int index: int ref,
+  unique int child: @ruby_ensure_child_type ref
+);
+
+ruby_ensure_def(
+  unique int id: @ruby_ensure
+);
+
+ruby_exception_variable_def(
+  unique int id: @ruby_exception_variable,
+  int child: @ruby_underscore_lhs ref
+);
+
+@ruby_exceptions_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_exceptions, index]
+ruby_exceptions_child(
+  int ruby_exceptions: @ruby_exceptions ref,
+  int index: int ref,
+  unique int child: @ruby_exceptions_child_type ref
+);
+
+ruby_exceptions_def(
+  unique int id: @ruby_exceptions
+);
+
+ruby_expression_reference_pattern_def(
+  unique int id: @ruby_expression_reference_pattern,
+  int value: @ruby_underscore_expression ref
+);
+
+ruby_find_pattern_class(
+  unique int ruby_find_pattern: @ruby_find_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_find_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_find_pattern, index]
+ruby_find_pattern_child(
+  int ruby_find_pattern: @ruby_find_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_find_pattern_child_type ref
+);
+
+ruby_find_pattern_def(
+  unique int id: @ruby_find_pattern
+);
+
+@ruby_for_pattern_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+ruby_for_def(
+  unique int id: @ruby_for,
+  int body: @ruby_do ref,
+  int pattern: @ruby_for_pattern_type ref,
+  int value: @ruby_in ref
+);
+
+@ruby_hash_child_type = @ruby_hash_splat_argument | @ruby_pair
+
+#keyset[ruby_hash, index]
+ruby_hash_child(
+  int ruby_hash: @ruby_hash ref,
+  int index: int ref,
+  unique int child: @ruby_hash_child_type ref
+);
+
+ruby_hash_def(
+  unique int id: @ruby_hash
+);
+
+ruby_hash_pattern_class(
+  unique int ruby_hash_pattern: @ruby_hash_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_hash_pattern_child_type = @ruby_hash_splat_parameter | @ruby_keyword_pattern | @ruby_token_hash_splat_nil
+
+#keyset[ruby_hash_pattern, index]
+ruby_hash_pattern_child(
+  int ruby_hash_pattern: @ruby_hash_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_hash_pattern_child_type ref
+);
+
+ruby_hash_pattern_def(
+  unique int id: @ruby_hash_pattern
+);
+
+ruby_hash_splat_argument_def(
+  unique int id: @ruby_hash_splat_argument,
+  int child: @ruby_underscore_arg ref
+);
+
+ruby_hash_splat_parameter_name(
+  unique int ruby_hash_splat_parameter: @ruby_hash_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_hash_splat_parameter_def(
+  unique int id: @ruby_hash_splat_parameter
+);
+
+@ruby_heredoc_body_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_heredoc_content | @ruby_token_heredoc_end
+
+#keyset[ruby_heredoc_body, index]
+ruby_heredoc_body_child(
+  int ruby_heredoc_body: @ruby_heredoc_body ref,
+  int index: int ref,
+  unique int child: @ruby_heredoc_body_child_type ref
+);
+
+ruby_heredoc_body_def(
+  unique int id: @ruby_heredoc_body
+);
+
+@ruby_if_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_if_alternative(
+  unique int ruby_if: @ruby_if ref,
+  unique int alternative: @ruby_if_alternative_type ref
+);
+
+ruby_if_consequence(
+  unique int ruby_if: @ruby_if ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_if_def(
+  unique int id: @ruby_if,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_if_guard_def(
+  unique int id: @ruby_if_guard,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_if_modifier_def(
+  unique int id: @ruby_if_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_in_def(
+  unique int id: @ruby_in,
+  int child: @ruby_underscore_arg ref
+);
+
+ruby_in_clause_body(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int body: @ruby_then ref
+);
+
+@ruby_in_clause_guard_type = @ruby_if_guard | @ruby_unless_guard
+
+ruby_in_clause_guard(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int guard: @ruby_in_clause_guard_type ref
+);
+
+ruby_in_clause_def(
+  unique int id: @ruby_in_clause,
+  int pattern: @ruby_underscore_pattern_top_expr_body ref
+);
+
+@ruby_interpolation_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_interpolation, index]
+ruby_interpolation_child(
+  int ruby_interpolation: @ruby_interpolation ref,
+  int index: int ref,
+  unique int child: @ruby_interpolation_child_type ref
+);
+
+ruby_interpolation_def(
+  unique int id: @ruby_interpolation
+);
+
+ruby_keyword_parameter_value(
+  unique int ruby_keyword_parameter: @ruby_keyword_parameter ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_keyword_parameter_def(
+  unique int id: @ruby_keyword_parameter,
+  int name: @ruby_token_identifier ref
+);
+
+@ruby_keyword_pattern_key_type = @ruby_string__ | @ruby_token_hash_key_symbol
+
+ruby_keyword_pattern_value(
+  unique int ruby_keyword_pattern: @ruby_keyword_pattern ref,
+  unique int value: @ruby_underscore_pattern_expr ref
+);
+
+ruby_keyword_pattern_def(
+  unique int id: @ruby_keyword_pattern,
+  int key__: @ruby_keyword_pattern_key_type ref
+);
+
+@ruby_lambda_body_type = @ruby_block | @ruby_do_block
+
+ruby_lambda_parameters(
+  unique int ruby_lambda: @ruby_lambda ref,
+  unique int parameters: @ruby_lambda_parameters ref
+);
+
+ruby_lambda_def(
+  unique int id: @ruby_lambda,
+  int body: @ruby_lambda_body_type ref
+);
+
+@ruby_lambda_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_lambda_parameters, index]
+ruby_lambda_parameters_child(
+  int ruby_lambda_parameters: @ruby_lambda_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_lambda_parameters_child_type ref
+);
+
+ruby_lambda_parameters_def(
+  unique int id: @ruby_lambda_parameters
+);
+
+@ruby_left_assignment_list_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_left_assignment_list, index]
+ruby_left_assignment_list_child(
+  int ruby_left_assignment_list: @ruby_left_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_left_assignment_list_child_type ref
+);
+
+ruby_left_assignment_list_def(
+  unique int id: @ruby_left_assignment_list
+);
+
+ruby_method_parameters(
+  unique int ruby_method: @ruby_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_method, index]
+ruby_method_child(
+  int ruby_method: @ruby_method ref,
+  int index: int ref,
+  unique int child: @ruby_method_child_type ref
+);
+
+ruby_method_def(
+  unique int id: @ruby_method,
+  int name: @ruby_underscore_method_name ref
+);
+
+@ruby_method_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_method_parameters, index]
+ruby_method_parameters_child(
+  int ruby_method_parameters: @ruby_method_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_method_parameters_child_type ref
+);
+
+ruby_method_parameters_def(
+  unique int id: @ruby_method_parameters
+);
+
+@ruby_module_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_module_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_module, index]
+ruby_module_child(
+  int ruby_module: @ruby_module ref,
+  int index: int ref,
+  unique int child: @ruby_module_child_type ref
+);
+
+ruby_module_def(
+  unique int id: @ruby_module,
+  int name: @ruby_module_name_type ref
+);
+
+ruby_next_child(
+  unique int ruby_next: @ruby_next ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_next_def(
+  unique int id: @ruby_next
+);
+
+case @ruby_operator_assignment.operator of
+  0 = @ruby_operator_assignment_percentequal
+| 1 = @ruby_operator_assignment_ampersandampersandequal
+| 2 = @ruby_operator_assignment_ampersandequal
+| 3 = @ruby_operator_assignment_starstarequal
+| 4 = @ruby_operator_assignment_starequal
+| 5 = @ruby_operator_assignment_plusequal
+| 6 = @ruby_operator_assignment_minusequal
+| 7 = @ruby_operator_assignment_slashequal
+| 8 = @ruby_operator_assignment_langlelangleequal
+| 9 = @ruby_operator_assignment_ranglerangleequal
+| 10 = @ruby_operator_assignment_caretequal
+| 11 = @ruby_operator_assignment_pipeequal
+| 12 = @ruby_operator_assignment_pipepipeequal
+;
+
+
+ruby_operator_assignment_def(
+  unique int id: @ruby_operator_assignment,
+  int left: @ruby_underscore_lhs ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref
+);
+
+ruby_optional_parameter_def(
+  unique int id: @ruby_optional_parameter,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_arg ref
+);
+
+@ruby_pair_key_type = @ruby_string__ | @ruby_token_hash_key_symbol | @ruby_underscore_arg
+
+ruby_pair_value(
+  unique int ruby_pair: @ruby_pair ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_pair_def(
+  unique int id: @ruby_pair,
+  int key__: @ruby_pair_key_type ref
+);
+
+ruby_parenthesized_pattern_def(
+  unique int id: @ruby_parenthesized_pattern,
+  int child: @ruby_underscore_pattern_expr ref
+);
+
+@ruby_parenthesized_statements_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_parenthesized_statements, index]
+ruby_parenthesized_statements_child(
+  int ruby_parenthesized_statements: @ruby_parenthesized_statements ref,
+  int index: int ref,
+  unique int child: @ruby_parenthesized_statements_child_type ref
+);
+
+ruby_parenthesized_statements_def(
+  unique int id: @ruby_parenthesized_statements
+);
+
+@ruby_pattern_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+ruby_pattern_def(
+  unique int id: @ruby_pattern,
+  int child: @ruby_pattern_child_type ref
+);
+
+@ruby_program_child_type = @ruby_token_empty_statement | @ruby_token_uninterpreted | @ruby_underscore_statement
+
+#keyset[ruby_program, index]
+ruby_program_child(
+  int ruby_program: @ruby_program ref,
+  int index: int ref,
+  unique int child: @ruby_program_child_type ref
+);
+
+ruby_program_def(
+  unique int id: @ruby_program
+);
+
+@ruby_range_begin_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_begin(
+  unique int ruby_range: @ruby_range ref,
+  unique int begin: @ruby_range_begin_type ref
+);
+
+@ruby_range_end_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_end(
+  unique int ruby_range: @ruby_range ref,
+  unique int end: @ruby_range_end_type ref
+);
+
+case @ruby_range.operator of
+  0 = @ruby_range_dotdot
+| 1 = @ruby_range_dotdotdot
+;
+
+
+ruby_range_def(
+  unique int id: @ruby_range,
+  int operator: int ref
+);
+
+@ruby_rational_child_type = @ruby_token_float | @ruby_token_integer
+
+ruby_rational_def(
+  unique int id: @ruby_rational,
+  int child: @ruby_rational_child_type ref
+);
+
+ruby_redo_child(
+  unique int ruby_redo: @ruby_redo ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_redo_def(
+  unique int id: @ruby_redo
+);
+
+@ruby_regex_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_regex, index]
+ruby_regex_child(
+  int ruby_regex: @ruby_regex ref,
+  int index: int ref,
+  unique int child: @ruby_regex_child_type ref
+);
+
+ruby_regex_def(
+  unique int id: @ruby_regex
+);
+
+ruby_rescue_body(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int body: @ruby_then ref
+);
+
+ruby_rescue_exceptions(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int exceptions: @ruby_exceptions ref
+);
+
+ruby_rescue_variable(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int variable: @ruby_exception_variable ref
+);
+
+ruby_rescue_def(
+  unique int id: @ruby_rescue
+);
+
+@ruby_rescue_modifier_body_type = @ruby_underscore_arg | @ruby_underscore_statement
+
+ruby_rescue_modifier_def(
+  unique int id: @ruby_rescue_modifier,
+  int body: @ruby_rescue_modifier_body_type ref,
+  int handler: @ruby_underscore_expression ref
+);
+
+ruby_rest_assignment_child(
+  unique int ruby_rest_assignment: @ruby_rest_assignment ref,
+  unique int child: @ruby_underscore_lhs ref
+);
+
+ruby_rest_assignment_def(
+  unique int id: @ruby_rest_assignment
+);
+
+ruby_retry_child(
+  unique int ruby_retry: @ruby_retry ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_retry_def(
+  unique int id: @ruby_retry
+);
+
+ruby_return_child(
+  unique int ruby_return: @ruby_return ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_return_def(
+  unique int id: @ruby_return
+);
+
+@ruby_right_assignment_list_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_right_assignment_list, index]
+ruby_right_assignment_list_child(
+  int ruby_right_assignment_list: @ruby_right_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_right_assignment_list_child_type ref
+);
+
+ruby_right_assignment_list_def(
+  unique int id: @ruby_right_assignment_list
+);
+
+@ruby_scope_resolution_name_type = @ruby_token_constant | @ruby_token_identifier
+
+@ruby_scope_resolution_scope_type = @ruby_underscore_pattern_constant | @ruby_underscore_primary
+
+ruby_scope_resolution_scope(
+  unique int ruby_scope_resolution: @ruby_scope_resolution ref,
+  unique int scope: @ruby_scope_resolution_scope_type ref
+);
+
+ruby_scope_resolution_def(
+  unique int id: @ruby_scope_resolution,
+  int name: @ruby_scope_resolution_name_type ref
+);
+
+ruby_setter_def(
+  unique int id: @ruby_setter,
+  int name: @ruby_token_identifier ref
+);
+
+@ruby_singleton_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_singleton_class, index]
+ruby_singleton_class_child(
+  int ruby_singleton_class: @ruby_singleton_class ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_class_child_type ref
+);
+
+ruby_singleton_class_def(
+  unique int id: @ruby_singleton_class,
+  int value: @ruby_underscore_arg ref
+);
+
+@ruby_singleton_method_object_type = @ruby_underscore_arg | @ruby_underscore_variable
+
+ruby_singleton_method_parameters(
+  unique int ruby_singleton_method: @ruby_singleton_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_singleton_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_singleton_method, index]
+ruby_singleton_method_child(
+  int ruby_singleton_method: @ruby_singleton_method ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_method_child_type ref
+);
+
+ruby_singleton_method_def(
+  unique int id: @ruby_singleton_method,
+  int name: @ruby_underscore_method_name ref,
+  int object: @ruby_singleton_method_object_type ref
+);
+
+ruby_splat_argument_def(
+  unique int id: @ruby_splat_argument,
+  int child: @ruby_underscore_arg ref
+);
+
+ruby_splat_parameter_name(
+  unique int ruby_splat_parameter: @ruby_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_splat_parameter_def(
+  unique int id: @ruby_splat_parameter
+);
+
+@ruby_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_string__, index]
+ruby_string_child(
+  int ruby_string__: @ruby_string__ ref,
+  int index: int ref,
+  unique int child: @ruby_string_child_type ref
+);
+
+ruby_string_def(
+  unique int id: @ruby_string__
+);
+
+#keyset[ruby_string_array, index]
+ruby_string_array_child(
+  int ruby_string_array: @ruby_string_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string ref
+);
+
+ruby_string_array_def(
+  unique int id: @ruby_string_array
+);
+
+@ruby_subshell_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_subshell, index]
+ruby_subshell_child(
+  int ruby_subshell: @ruby_subshell ref,
+  int index: int ref,
+  unique int child: @ruby_subshell_child_type ref
+);
+
+ruby_subshell_def(
+  unique int id: @ruby_subshell
+);
+
+ruby_superclass_def(
+  unique int id: @ruby_superclass,
+  int child: @ruby_underscore_expression ref
+);
+
+#keyset[ruby_symbol_array, index]
+ruby_symbol_array_child(
+  int ruby_symbol_array: @ruby_symbol_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol ref
+);
+
+ruby_symbol_array_def(
+  unique int id: @ruby_symbol_array
+);
+
+@ruby_then_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_then, index]
+ruby_then_child(
+  int ruby_then: @ruby_then ref,
+  int index: int ref,
+  unique int child: @ruby_then_child_type ref
+);
+
+ruby_then_def(
+  unique int id: @ruby_then
+);
+
+@ruby_unary_operand_type = @ruby_parenthesized_statements | @ruby_underscore_expression | @ruby_underscore_simple_numeric
+
+case @ruby_unary.operator of
+  0 = @ruby_unary_bang
+| 1 = @ruby_unary_plus
+| 2 = @ruby_unary_minus
+| 3 = @ruby_unary_definedquestion
+| 4 = @ruby_unary_not
+| 5 = @ruby_unary_tilde
+;
+
+
+ruby_unary_def(
+  unique int id: @ruby_unary,
+  int operand: @ruby_unary_operand_type ref,
+  int operator: int ref
+);
+
+#keyset[ruby_undef, index]
+ruby_undef_child(
+  int ruby_undef: @ruby_undef ref,
+  int index: int ref,
+  unique int child: @ruby_underscore_method_name ref
+);
+
+ruby_undef_def(
+  unique int id: @ruby_undef
+);
+
+@ruby_unless_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_unless_alternative(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int alternative: @ruby_unless_alternative_type ref
+);
+
+ruby_unless_consequence(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_unless_def(
+  unique int id: @ruby_unless,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_unless_guard_def(
+  unique int id: @ruby_unless_guard,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_unless_modifier_def(
+  unique int id: @ruby_unless_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_until_def(
+  unique int id: @ruby_until,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_until_modifier_def(
+  unique int id: @ruby_until_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+@ruby_variable_reference_pattern_name_type = @ruby_token_identifier | @ruby_underscore_nonlocal_variable
+
+ruby_variable_reference_pattern_def(
+  unique int id: @ruby_variable_reference_pattern,
+  int name: @ruby_variable_reference_pattern_name_type ref
+);
+
+ruby_when_body(
+  unique int ruby_when: @ruby_when ref,
+  unique int body: @ruby_then ref
+);
+
+#keyset[ruby_when, index]
+ruby_when_pattern(
+  int ruby_when: @ruby_when ref,
+  int index: int ref,
+  unique int pattern: @ruby_pattern ref
+);
+
+ruby_when_def(
+  unique int id: @ruby_when
+);
+
+ruby_while_def(
+  unique int id: @ruby_while,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_while_modifier_def(
+  unique int id: @ruby_while_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_yield_child(
+  unique int ruby_yield: @ruby_yield ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_yield_def(
+  unique int id: @ruby_yield
+);
+
+ruby_tokeninfo(
+  unique int id: @ruby_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @ruby_token.kind of
+  0 = @ruby_reserved_word
+| 1 = @ruby_token_character
+| 2 = @ruby_token_class_variable
+| 3 = @ruby_token_comment
+| 4 = @ruby_token_complex
+| 5 = @ruby_token_constant
+| 6 = @ruby_token_empty_statement
+| 7 = @ruby_token_encoding
+| 8 = @ruby_token_escape_sequence
+| 9 = @ruby_token_false
+| 10 = @ruby_token_file
+| 11 = @ruby_token_float
+| 12 = @ruby_token_forward_argument
+| 13 = @ruby_token_forward_parameter
+| 14 = @ruby_token_global_variable
+| 15 = @ruby_token_hash_key_symbol
+| 16 = @ruby_token_hash_splat_nil
+| 17 = @ruby_token_heredoc_beginning
+| 18 = @ruby_token_heredoc_content
+| 19 = @ruby_token_heredoc_end
+| 20 = @ruby_token_identifier
+| 21 = @ruby_token_instance_variable
+| 22 = @ruby_token_integer
+| 23 = @ruby_token_line
+| 24 = @ruby_token_nil
+| 25 = @ruby_token_operator
+| 26 = @ruby_token_self
+| 27 = @ruby_token_simple_symbol
+| 28 = @ruby_token_string_content
+| 29 = @ruby_token_super
+| 30 = @ruby_token_true
+| 31 = @ruby_token_uninterpreted
+;
+
+
+@ruby_ast_node = @ruby_alias | @ruby_alternative_pattern | @ruby_argument_list | @ruby_array | @ruby_array_pattern | @ruby_as_pattern | @ruby_assignment | @ruby_bare_string | @ruby_bare_symbol | @ruby_begin | @ruby_begin_block | @ruby_binary | @ruby_block | @ruby_block_argument | @ruby_block_parameter | @ruby_block_parameters | @ruby_break | @ruby_call | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_conditional | @ruby_delimited_symbol | @ruby_destructured_left_assignment | @ruby_destructured_parameter | @ruby_do | @ruby_do_block | @ruby_element_reference | @ruby_else | @ruby_elsif | @ruby_end_block | @ruby_ensure | @ruby_exception_variable | @ruby_exceptions | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_for | @ruby_hash | @ruby_hash_pattern | @ruby_hash_splat_argument | @ruby_hash_splat_parameter | @ruby_heredoc_body | @ruby_if | @ruby_if_guard | @ruby_if_modifier | @ruby_in | @ruby_in_clause | @ruby_interpolation | @ruby_keyword_parameter | @ruby_keyword_pattern | @ruby_lambda | @ruby_lambda_parameters | @ruby_left_assignment_list | @ruby_method | @ruby_method_parameters | @ruby_module | @ruby_next | @ruby_operator_assignment | @ruby_optional_parameter | @ruby_pair | @ruby_parenthesized_pattern | @ruby_parenthesized_statements | @ruby_pattern | @ruby_program | @ruby_range | @ruby_rational | @ruby_redo | @ruby_regex | @ruby_rescue | @ruby_rescue_modifier | @ruby_rest_assignment | @ruby_retry | @ruby_return | @ruby_right_assignment_list | @ruby_scope_resolution | @ruby_setter | @ruby_singleton_class | @ruby_singleton_method | @ruby_splat_argument | @ruby_splat_parameter | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_superclass | @ruby_symbol_array | @ruby_then | @ruby_token | @ruby_unary | @ruby_undef | @ruby_unless | @ruby_unless_guard | @ruby_unless_modifier | @ruby_until | @ruby_until_modifier | @ruby_variable_reference_pattern | @ruby_when | @ruby_while | @ruby_while_modifier | @ruby_yield
+
+@ruby_ast_node_parent = @file | @ruby_ast_node
+
+#keyset[parent, parent_index]
+ruby_ast_node_info(
+  int node: @ruby_ast_node ref,
+  int parent: @ruby_ast_node_parent ref,
+  int parent_index: int ref,
+  int loc: @location ref
+);
+
+erb_comment_directive_def(
+  unique int id: @erb_comment_directive,
+  int child: @erb_token_comment ref
+);
+
+erb_directive_def(
+  unique int id: @erb_directive,
+  int child: @erb_token_code ref
+);
+
+erb_graphql_directive_def(
+  unique int id: @erb_graphql_directive,
+  int child: @erb_token_code ref
+);
+
+erb_output_directive_def(
+  unique int id: @erb_output_directive,
+  int child: @erb_token_code ref
+);
+
+@erb_template_child_type = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_token_content
+
+#keyset[erb_template, index]
+erb_template_child(
+  int erb_template: @erb_template ref,
+  int index: int ref,
+  unique int child: @erb_template_child_type ref
+);
+
+erb_template_def(
+  unique int id: @erb_template
+);
+
+erb_tokeninfo(
+  unique int id: @erb_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @erb_token.kind of
+  0 = @erb_reserved_word
+| 1 = @erb_token_code
+| 2 = @erb_token_comment
+| 3 = @erb_token_content
+;
+
+
+@erb_ast_node = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_template | @erb_token
+
+@erb_ast_node_parent = @erb_ast_node | @file
+
+#keyset[parent, parent_index]
+erb_ast_node_info(
+  int node: @erb_ast_node ref,
+  int parent: @erb_ast_node_parent ref,
+  int parent_index: int ref,
+  int loc: @location ref
+);
+

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby.dbscheme
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby.dbscheme
@@ -1,0 +1,1497 @@
+// CodeQL database schema for Ruby
+// Automatically generated from the tree-sitter grammar; do not edit
+
+@location = @location_default
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int start_line: int ref,
+  int start_column: int ref,
+  int end_line: int ref,
+  int end_column: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+sourceLocationPrefix(
+  string prefix: string ref
+);
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+
+@ruby_underscore_arg = @ruby_assignment | @ruby_binary | @ruby_conditional | @ruby_operator_assignment | @ruby_range | @ruby_unary | @ruby_underscore_primary
+
+@ruby_underscore_expression = @ruby_assignment | @ruby_binary | @ruby_break | @ruby_call | @ruby_next | @ruby_operator_assignment | @ruby_return | @ruby_unary | @ruby_underscore_arg | @ruby_yield
+
+@ruby_underscore_lhs = @ruby_call | @ruby_element_reference | @ruby_scope_resolution | @ruby_token_false | @ruby_token_nil | @ruby_token_true | @ruby_underscore_variable
+
+@ruby_underscore_method_name = @ruby_delimited_symbol | @ruby_setter | @ruby_token_constant | @ruby_token_identifier | @ruby_token_operator | @ruby_token_simple_symbol | @ruby_underscore_nonlocal_variable
+
+@ruby_underscore_nonlocal_variable = @ruby_token_class_variable | @ruby_token_global_variable | @ruby_token_instance_variable
+
+@ruby_underscore_pattern_constant = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_underscore_pattern_expr = @ruby_alternative_pattern | @ruby_as_pattern | @ruby_underscore_pattern_expr_basic
+
+@ruby_underscore_pattern_expr_basic = @ruby_array_pattern | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_parenthesized_pattern | @ruby_range | @ruby_token_identifier | @ruby_underscore_pattern_constant | @ruby_underscore_pattern_primitive | @ruby_variable_reference_pattern
+
+@ruby_underscore_pattern_primitive = @ruby_delimited_symbol | @ruby_lambda | @ruby_regex | @ruby_string__ | @ruby_string_array | @ruby_symbol_array | @ruby_token_encoding | @ruby_token_false | @ruby_token_file | @ruby_token_line | @ruby_token_nil | @ruby_token_self | @ruby_token_simple_symbol | @ruby_token_true | @ruby_unary | @ruby_underscore_simple_numeric
+
+@ruby_underscore_pattern_top_expr_body = @ruby_array_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_underscore_pattern_expr
+
+@ruby_underscore_primary = @ruby_array | @ruby_begin | @ruby_break | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_delimited_symbol | @ruby_for | @ruby_hash | @ruby_if | @ruby_lambda | @ruby_method | @ruby_module | @ruby_next | @ruby_parenthesized_statements | @ruby_redo | @ruby_regex | @ruby_retry | @ruby_return | @ruby_singleton_class | @ruby_singleton_method | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_symbol_array | @ruby_token_character | @ruby_token_heredoc_beginning | @ruby_token_simple_symbol | @ruby_unary | @ruby_underscore_lhs | @ruby_underscore_simple_numeric | @ruby_unless | @ruby_until | @ruby_while | @ruby_yield
+
+@ruby_underscore_simple_numeric = @ruby_rational | @ruby_token_complex | @ruby_token_float | @ruby_token_integer
+
+@ruby_underscore_statement = @ruby_alias | @ruby_begin_block | @ruby_end_block | @ruby_if_modifier | @ruby_rescue_modifier | @ruby_undef | @ruby_underscore_expression | @ruby_unless_modifier | @ruby_until_modifier | @ruby_while_modifier
+
+@ruby_underscore_variable = @ruby_token_constant | @ruby_token_identifier | @ruby_token_self | @ruby_token_super | @ruby_underscore_nonlocal_variable
+
+ruby_alias_def(
+  unique int id: @ruby_alias,
+  int alias: @ruby_underscore_method_name ref,
+  int name: @ruby_underscore_method_name ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_alternative_pattern, index]
+ruby_alternative_pattern_alternatives(
+  int ruby_alternative_pattern: @ruby_alternative_pattern ref,
+  int index: int ref,
+  unique int alternatives: @ruby_underscore_pattern_expr_basic ref
+);
+
+ruby_alternative_pattern_def(
+  unique int id: @ruby_alternative_pattern,
+  int loc: @location ref
+);
+
+@ruby_argument_list_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_argument_list, index]
+ruby_argument_list_child(
+  int ruby_argument_list: @ruby_argument_list ref,
+  int index: int ref,
+  unique int child: @ruby_argument_list_child_type ref
+);
+
+ruby_argument_list_def(
+  unique int id: @ruby_argument_list,
+  int loc: @location ref
+);
+
+@ruby_array_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_array, index]
+ruby_array_child(
+  int ruby_array: @ruby_array ref,
+  int index: int ref,
+  unique int child: @ruby_array_child_type ref
+);
+
+ruby_array_def(
+  unique int id: @ruby_array,
+  int loc: @location ref
+);
+
+ruby_array_pattern_class(
+  unique int ruby_array_pattern: @ruby_array_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_array_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_array_pattern, index]
+ruby_array_pattern_child(
+  int ruby_array_pattern: @ruby_array_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_array_pattern_child_type ref
+);
+
+ruby_array_pattern_def(
+  unique int id: @ruby_array_pattern,
+  int loc: @location ref
+);
+
+ruby_as_pattern_def(
+  unique int id: @ruby_as_pattern,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_pattern_expr ref,
+  int loc: @location ref
+);
+
+@ruby_assignment_left_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+@ruby_assignment_right_type = @ruby_right_assignment_list | @ruby_splat_argument | @ruby_underscore_expression
+
+ruby_assignment_def(
+  unique int id: @ruby_assignment,
+  int left: @ruby_assignment_left_type ref,
+  int right: @ruby_assignment_right_type ref,
+  int loc: @location ref
+);
+
+@ruby_bare_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_string, index]
+ruby_bare_string_child(
+  int ruby_bare_string: @ruby_bare_string ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string_child_type ref
+);
+
+ruby_bare_string_def(
+  unique int id: @ruby_bare_string,
+  int loc: @location ref
+);
+
+@ruby_bare_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_symbol, index]
+ruby_bare_symbol_child(
+  int ruby_bare_symbol: @ruby_bare_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol_child_type ref
+);
+
+ruby_bare_symbol_def(
+  unique int id: @ruby_bare_symbol,
+  int loc: @location ref
+);
+
+@ruby_begin_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin, index]
+ruby_begin_child(
+  int ruby_begin: @ruby_begin ref,
+  int index: int ref,
+  unique int child: @ruby_begin_child_type ref
+);
+
+ruby_begin_def(
+  unique int id: @ruby_begin,
+  int loc: @location ref
+);
+
+@ruby_begin_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin_block, index]
+ruby_begin_block_child(
+  int ruby_begin_block: @ruby_begin_block ref,
+  int index: int ref,
+  unique int child: @ruby_begin_block_child_type ref
+);
+
+ruby_begin_block_def(
+  unique int id: @ruby_begin_block,
+  int loc: @location ref
+);
+
+case @ruby_binary.operator of
+  0 = @ruby_binary_bangequal
+| 1 = @ruby_binary_bangtilde
+| 2 = @ruby_binary_percent
+| 3 = @ruby_binary_ampersand
+| 4 = @ruby_binary_ampersandampersand
+| 5 = @ruby_binary_star
+| 6 = @ruby_binary_starstar
+| 7 = @ruby_binary_plus
+| 8 = @ruby_binary_minus
+| 9 = @ruby_binary_slash
+| 10 = @ruby_binary_langle
+| 11 = @ruby_binary_langlelangle
+| 12 = @ruby_binary_langleequal
+| 13 = @ruby_binary_langleequalrangle
+| 14 = @ruby_binary_equalequal
+| 15 = @ruby_binary_equalequalequal
+| 16 = @ruby_binary_equaltilde
+| 17 = @ruby_binary_rangle
+| 18 = @ruby_binary_rangleequal
+| 19 = @ruby_binary_ranglerangle
+| 20 = @ruby_binary_caret
+| 21 = @ruby_binary_and
+| 22 = @ruby_binary_or
+| 23 = @ruby_binary_pipe
+| 24 = @ruby_binary_pipepipe
+;
+
+
+ruby_binary_def(
+  unique int id: @ruby_binary,
+  int left: @ruby_underscore_expression ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_block_parameters(
+  unique int ruby_block: @ruby_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_block, index]
+ruby_block_child(
+  int ruby_block: @ruby_block ref,
+  int index: int ref,
+  unique int child: @ruby_block_child_type ref
+);
+
+ruby_block_def(
+  unique int id: @ruby_block,
+  int loc: @location ref
+);
+
+ruby_block_argument_child(
+  unique int ruby_block_argument: @ruby_block_argument ref,
+  unique int child: @ruby_underscore_arg ref
+);
+
+ruby_block_argument_def(
+  unique int id: @ruby_block_argument,
+  int loc: @location ref
+);
+
+ruby_block_parameter_name(
+  unique int ruby_block_parameter: @ruby_block_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_block_parameter_def(
+  unique int id: @ruby_block_parameter,
+  int loc: @location ref
+);
+
+@ruby_block_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_block_parameters, index]
+ruby_block_parameters_child(
+  int ruby_block_parameters: @ruby_block_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_block_parameters_child_type ref
+);
+
+ruby_block_parameters_def(
+  unique int id: @ruby_block_parameters,
+  int loc: @location ref
+);
+
+ruby_break_child(
+  unique int ruby_break: @ruby_break ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_break_def(
+  unique int id: @ruby_break,
+  int loc: @location ref
+);
+
+ruby_call_arguments(
+  unique int ruby_call: @ruby_call ref,
+  unique int arguments: @ruby_argument_list ref
+);
+
+@ruby_call_block_type = @ruby_block | @ruby_do_block
+
+ruby_call_block(
+  unique int ruby_call: @ruby_call ref,
+  unique int block: @ruby_call_block_type ref
+);
+
+@ruby_call_method_type = @ruby_argument_list | @ruby_scope_resolution | @ruby_token_operator | @ruby_underscore_variable
+
+@ruby_call_receiver_type = @ruby_call | @ruby_underscore_primary
+
+ruby_call_receiver(
+  unique int ruby_call: @ruby_call ref,
+  unique int receiver: @ruby_call_receiver_type ref
+);
+
+ruby_call_def(
+  unique int id: @ruby_call,
+  int method: @ruby_call_method_type ref,
+  int loc: @location ref
+);
+
+ruby_case_value(
+  unique int ruby_case__: @ruby_case__ ref,
+  unique int value: @ruby_underscore_statement ref
+);
+
+@ruby_case_child_type = @ruby_else | @ruby_when
+
+#keyset[ruby_case__, index]
+ruby_case_child(
+  int ruby_case__: @ruby_case__ ref,
+  int index: int ref,
+  unique int child: @ruby_case_child_type ref
+);
+
+ruby_case_def(
+  unique int id: @ruby_case__,
+  int loc: @location ref
+);
+
+#keyset[ruby_case_match, index]
+ruby_case_match_clauses(
+  int ruby_case_match: @ruby_case_match ref,
+  int index: int ref,
+  unique int clauses: @ruby_in_clause ref
+);
+
+ruby_case_match_else(
+  unique int ruby_case_match: @ruby_case_match ref,
+  unique int else: @ruby_else ref
+);
+
+ruby_case_match_def(
+  unique int id: @ruby_case_match,
+  int value: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_chained_string, index]
+ruby_chained_string_child(
+  int ruby_chained_string: @ruby_chained_string ref,
+  int index: int ref,
+  unique int child: @ruby_string__ ref
+);
+
+ruby_chained_string_def(
+  unique int id: @ruby_chained_string,
+  int loc: @location ref
+);
+
+@ruby_class_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+ruby_class_superclass(
+  unique int ruby_class: @ruby_class ref,
+  unique int superclass: @ruby_superclass ref
+);
+
+@ruby_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_class, index]
+ruby_class_child(
+  int ruby_class: @ruby_class ref,
+  int index: int ref,
+  unique int child: @ruby_class_child_type ref
+);
+
+ruby_class_def(
+  unique int id: @ruby_class,
+  int name: @ruby_class_name_type ref,
+  int loc: @location ref
+);
+
+ruby_conditional_def(
+  unique int id: @ruby_conditional,
+  int alternative: @ruby_underscore_arg ref,
+  int condition: @ruby_underscore_arg ref,
+  int consequence: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+@ruby_delimited_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_delimited_symbol, index]
+ruby_delimited_symbol_child(
+  int ruby_delimited_symbol: @ruby_delimited_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_delimited_symbol_child_type ref
+);
+
+ruby_delimited_symbol_def(
+  unique int id: @ruby_delimited_symbol,
+  int loc: @location ref
+);
+
+@ruby_destructured_left_assignment_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_destructured_left_assignment, index]
+ruby_destructured_left_assignment_child(
+  int ruby_destructured_left_assignment: @ruby_destructured_left_assignment ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_left_assignment_child_type ref
+);
+
+ruby_destructured_left_assignment_def(
+  unique int id: @ruby_destructured_left_assignment,
+  int loc: @location ref
+);
+
+@ruby_destructured_parameter_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_destructured_parameter, index]
+ruby_destructured_parameter_child(
+  int ruby_destructured_parameter: @ruby_destructured_parameter ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_parameter_child_type ref
+);
+
+ruby_destructured_parameter_def(
+  unique int id: @ruby_destructured_parameter,
+  int loc: @location ref
+);
+
+@ruby_do_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do, index]
+ruby_do_child(
+  int ruby_do: @ruby_do ref,
+  int index: int ref,
+  unique int child: @ruby_do_child_type ref
+);
+
+ruby_do_def(
+  unique int id: @ruby_do,
+  int loc: @location ref
+);
+
+ruby_do_block_parameters(
+  unique int ruby_do_block: @ruby_do_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_do_block_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do_block, index]
+ruby_do_block_child(
+  int ruby_do_block: @ruby_do_block ref,
+  int index: int ref,
+  unique int child: @ruby_do_block_child_type ref
+);
+
+ruby_do_block_def(
+  unique int id: @ruby_do_block,
+  int loc: @location ref
+);
+
+@ruby_element_reference_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_element_reference, index]
+ruby_element_reference_child(
+  int ruby_element_reference: @ruby_element_reference ref,
+  int index: int ref,
+  unique int child: @ruby_element_reference_child_type ref
+);
+
+ruby_element_reference_def(
+  unique int id: @ruby_element_reference,
+  int object: @ruby_underscore_primary ref,
+  int loc: @location ref
+);
+
+@ruby_else_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_else, index]
+ruby_else_child(
+  int ruby_else: @ruby_else ref,
+  int index: int ref,
+  unique int child: @ruby_else_child_type ref
+);
+
+ruby_else_def(
+  unique int id: @ruby_else,
+  int loc: @location ref
+);
+
+@ruby_elsif_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_elsif_alternative(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int alternative: @ruby_elsif_alternative_type ref
+);
+
+ruby_elsif_consequence(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_elsif_def(
+  unique int id: @ruby_elsif,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+@ruby_end_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_end_block, index]
+ruby_end_block_child(
+  int ruby_end_block: @ruby_end_block ref,
+  int index: int ref,
+  unique int child: @ruby_end_block_child_type ref
+);
+
+ruby_end_block_def(
+  unique int id: @ruby_end_block,
+  int loc: @location ref
+);
+
+@ruby_ensure_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_ensure, index]
+ruby_ensure_child(
+  int ruby_ensure: @ruby_ensure ref,
+  int index: int ref,
+  unique int child: @ruby_ensure_child_type ref
+);
+
+ruby_ensure_def(
+  unique int id: @ruby_ensure,
+  int loc: @location ref
+);
+
+ruby_exception_variable_def(
+  unique int id: @ruby_exception_variable,
+  int child: @ruby_underscore_lhs ref,
+  int loc: @location ref
+);
+
+@ruby_exceptions_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_exceptions, index]
+ruby_exceptions_child(
+  int ruby_exceptions: @ruby_exceptions ref,
+  int index: int ref,
+  unique int child: @ruby_exceptions_child_type ref
+);
+
+ruby_exceptions_def(
+  unique int id: @ruby_exceptions,
+  int loc: @location ref
+);
+
+ruby_expression_reference_pattern_def(
+  unique int id: @ruby_expression_reference_pattern,
+  int value: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_find_pattern_class(
+  unique int ruby_find_pattern: @ruby_find_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_find_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_find_pattern, index]
+ruby_find_pattern_child(
+  int ruby_find_pattern: @ruby_find_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_find_pattern_child_type ref
+);
+
+ruby_find_pattern_def(
+  unique int id: @ruby_find_pattern,
+  int loc: @location ref
+);
+
+@ruby_for_pattern_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+ruby_for_def(
+  unique int id: @ruby_for,
+  int body: @ruby_do ref,
+  int pattern: @ruby_for_pattern_type ref,
+  int value: @ruby_in ref,
+  int loc: @location ref
+);
+
+@ruby_hash_child_type = @ruby_hash_splat_argument | @ruby_pair
+
+#keyset[ruby_hash, index]
+ruby_hash_child(
+  int ruby_hash: @ruby_hash ref,
+  int index: int ref,
+  unique int child: @ruby_hash_child_type ref
+);
+
+ruby_hash_def(
+  unique int id: @ruby_hash,
+  int loc: @location ref
+);
+
+ruby_hash_pattern_class(
+  unique int ruby_hash_pattern: @ruby_hash_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_hash_pattern_child_type = @ruby_hash_splat_parameter | @ruby_keyword_pattern | @ruby_token_hash_splat_nil
+
+#keyset[ruby_hash_pattern, index]
+ruby_hash_pattern_child(
+  int ruby_hash_pattern: @ruby_hash_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_hash_pattern_child_type ref
+);
+
+ruby_hash_pattern_def(
+  unique int id: @ruby_hash_pattern,
+  int loc: @location ref
+);
+
+ruby_hash_splat_argument_def(
+  unique int id: @ruby_hash_splat_argument,
+  int child: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+ruby_hash_splat_parameter_name(
+  unique int ruby_hash_splat_parameter: @ruby_hash_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_hash_splat_parameter_def(
+  unique int id: @ruby_hash_splat_parameter,
+  int loc: @location ref
+);
+
+@ruby_heredoc_body_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_heredoc_content | @ruby_token_heredoc_end
+
+#keyset[ruby_heredoc_body, index]
+ruby_heredoc_body_child(
+  int ruby_heredoc_body: @ruby_heredoc_body ref,
+  int index: int ref,
+  unique int child: @ruby_heredoc_body_child_type ref
+);
+
+ruby_heredoc_body_def(
+  unique int id: @ruby_heredoc_body,
+  int loc: @location ref
+);
+
+@ruby_if_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_if_alternative(
+  unique int ruby_if: @ruby_if ref,
+  unique int alternative: @ruby_if_alternative_type ref
+);
+
+ruby_if_consequence(
+  unique int ruby_if: @ruby_if ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_if_def(
+  unique int id: @ruby_if,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_if_guard_def(
+  unique int id: @ruby_if_guard,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_if_modifier_def(
+  unique int id: @ruby_if_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_in_def(
+  unique int id: @ruby_in,
+  int child: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+ruby_in_clause_body(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int body: @ruby_then ref
+);
+
+@ruby_in_clause_guard_type = @ruby_if_guard | @ruby_unless_guard
+
+ruby_in_clause_guard(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int guard: @ruby_in_clause_guard_type ref
+);
+
+ruby_in_clause_def(
+  unique int id: @ruby_in_clause,
+  int pattern: @ruby_underscore_pattern_top_expr_body ref,
+  int loc: @location ref
+);
+
+@ruby_interpolation_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_interpolation, index]
+ruby_interpolation_child(
+  int ruby_interpolation: @ruby_interpolation ref,
+  int index: int ref,
+  unique int child: @ruby_interpolation_child_type ref
+);
+
+ruby_interpolation_def(
+  unique int id: @ruby_interpolation,
+  int loc: @location ref
+);
+
+ruby_keyword_parameter_value(
+  unique int ruby_keyword_parameter: @ruby_keyword_parameter ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_keyword_parameter_def(
+  unique int id: @ruby_keyword_parameter,
+  int name: @ruby_token_identifier ref,
+  int loc: @location ref
+);
+
+@ruby_keyword_pattern_key_type = @ruby_string__ | @ruby_token_hash_key_symbol
+
+ruby_keyword_pattern_value(
+  unique int ruby_keyword_pattern: @ruby_keyword_pattern ref,
+  unique int value: @ruby_underscore_pattern_expr ref
+);
+
+ruby_keyword_pattern_def(
+  unique int id: @ruby_keyword_pattern,
+  int key__: @ruby_keyword_pattern_key_type ref,
+  int loc: @location ref
+);
+
+@ruby_lambda_body_type = @ruby_block | @ruby_do_block
+
+ruby_lambda_parameters(
+  unique int ruby_lambda: @ruby_lambda ref,
+  unique int parameters: @ruby_lambda_parameters ref
+);
+
+ruby_lambda_def(
+  unique int id: @ruby_lambda,
+  int body: @ruby_lambda_body_type ref,
+  int loc: @location ref
+);
+
+@ruby_lambda_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_lambda_parameters, index]
+ruby_lambda_parameters_child(
+  int ruby_lambda_parameters: @ruby_lambda_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_lambda_parameters_child_type ref
+);
+
+ruby_lambda_parameters_def(
+  unique int id: @ruby_lambda_parameters,
+  int loc: @location ref
+);
+
+@ruby_left_assignment_list_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_left_assignment_list, index]
+ruby_left_assignment_list_child(
+  int ruby_left_assignment_list: @ruby_left_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_left_assignment_list_child_type ref
+);
+
+ruby_left_assignment_list_def(
+  unique int id: @ruby_left_assignment_list,
+  int loc: @location ref
+);
+
+ruby_method_parameters(
+  unique int ruby_method: @ruby_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_method, index]
+ruby_method_child(
+  int ruby_method: @ruby_method ref,
+  int index: int ref,
+  unique int child: @ruby_method_child_type ref
+);
+
+ruby_method_def(
+  unique int id: @ruby_method,
+  int name: @ruby_underscore_method_name ref,
+  int loc: @location ref
+);
+
+@ruby_method_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_method_parameters, index]
+ruby_method_parameters_child(
+  int ruby_method_parameters: @ruby_method_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_method_parameters_child_type ref
+);
+
+ruby_method_parameters_def(
+  unique int id: @ruby_method_parameters,
+  int loc: @location ref
+);
+
+@ruby_module_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_module_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_module, index]
+ruby_module_child(
+  int ruby_module: @ruby_module ref,
+  int index: int ref,
+  unique int child: @ruby_module_child_type ref
+);
+
+ruby_module_def(
+  unique int id: @ruby_module,
+  int name: @ruby_module_name_type ref,
+  int loc: @location ref
+);
+
+ruby_next_child(
+  unique int ruby_next: @ruby_next ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_next_def(
+  unique int id: @ruby_next,
+  int loc: @location ref
+);
+
+case @ruby_operator_assignment.operator of
+  0 = @ruby_operator_assignment_percentequal
+| 1 = @ruby_operator_assignment_ampersandampersandequal
+| 2 = @ruby_operator_assignment_ampersandequal
+| 3 = @ruby_operator_assignment_starstarequal
+| 4 = @ruby_operator_assignment_starequal
+| 5 = @ruby_operator_assignment_plusequal
+| 6 = @ruby_operator_assignment_minusequal
+| 7 = @ruby_operator_assignment_slashequal
+| 8 = @ruby_operator_assignment_langlelangleequal
+| 9 = @ruby_operator_assignment_ranglerangleequal
+| 10 = @ruby_operator_assignment_caretequal
+| 11 = @ruby_operator_assignment_pipeequal
+| 12 = @ruby_operator_assignment_pipepipeequal
+;
+
+
+ruby_operator_assignment_def(
+  unique int id: @ruby_operator_assignment,
+  int left: @ruby_underscore_lhs ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_optional_parameter_def(
+  unique int id: @ruby_optional_parameter,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+@ruby_pair_key_type = @ruby_string__ | @ruby_token_hash_key_symbol | @ruby_underscore_arg
+
+ruby_pair_value(
+  unique int ruby_pair: @ruby_pair ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_pair_def(
+  unique int id: @ruby_pair,
+  int key__: @ruby_pair_key_type ref,
+  int loc: @location ref
+);
+
+ruby_parenthesized_pattern_def(
+  unique int id: @ruby_parenthesized_pattern,
+  int child: @ruby_underscore_pattern_expr ref,
+  int loc: @location ref
+);
+
+@ruby_parenthesized_statements_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_parenthesized_statements, index]
+ruby_parenthesized_statements_child(
+  int ruby_parenthesized_statements: @ruby_parenthesized_statements ref,
+  int index: int ref,
+  unique int child: @ruby_parenthesized_statements_child_type ref
+);
+
+ruby_parenthesized_statements_def(
+  unique int id: @ruby_parenthesized_statements,
+  int loc: @location ref
+);
+
+@ruby_pattern_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+ruby_pattern_def(
+  unique int id: @ruby_pattern,
+  int child: @ruby_pattern_child_type ref,
+  int loc: @location ref
+);
+
+@ruby_program_child_type = @ruby_token_empty_statement | @ruby_token_uninterpreted | @ruby_underscore_statement
+
+#keyset[ruby_program, index]
+ruby_program_child(
+  int ruby_program: @ruby_program ref,
+  int index: int ref,
+  unique int child: @ruby_program_child_type ref
+);
+
+ruby_program_def(
+  unique int id: @ruby_program,
+  int loc: @location ref
+);
+
+@ruby_range_begin_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_begin(
+  unique int ruby_range: @ruby_range ref,
+  unique int begin: @ruby_range_begin_type ref
+);
+
+@ruby_range_end_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_end(
+  unique int ruby_range: @ruby_range ref,
+  unique int end: @ruby_range_end_type ref
+);
+
+case @ruby_range.operator of
+  0 = @ruby_range_dotdot
+| 1 = @ruby_range_dotdotdot
+;
+
+
+ruby_range_def(
+  unique int id: @ruby_range,
+  int operator: int ref,
+  int loc: @location ref
+);
+
+@ruby_rational_child_type = @ruby_token_float | @ruby_token_integer
+
+ruby_rational_def(
+  unique int id: @ruby_rational,
+  int child: @ruby_rational_child_type ref,
+  int loc: @location ref
+);
+
+ruby_redo_child(
+  unique int ruby_redo: @ruby_redo ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_redo_def(
+  unique int id: @ruby_redo,
+  int loc: @location ref
+);
+
+@ruby_regex_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_regex, index]
+ruby_regex_child(
+  int ruby_regex: @ruby_regex ref,
+  int index: int ref,
+  unique int child: @ruby_regex_child_type ref
+);
+
+ruby_regex_def(
+  unique int id: @ruby_regex,
+  int loc: @location ref
+);
+
+ruby_rescue_body(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int body: @ruby_then ref
+);
+
+ruby_rescue_exceptions(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int exceptions: @ruby_exceptions ref
+);
+
+ruby_rescue_variable(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int variable: @ruby_exception_variable ref
+);
+
+ruby_rescue_def(
+  unique int id: @ruby_rescue,
+  int loc: @location ref
+);
+
+@ruby_rescue_modifier_body_type = @ruby_underscore_arg | @ruby_underscore_statement
+
+ruby_rescue_modifier_def(
+  unique int id: @ruby_rescue_modifier,
+  int body: @ruby_rescue_modifier_body_type ref,
+  int handler: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_rest_assignment_child(
+  unique int ruby_rest_assignment: @ruby_rest_assignment ref,
+  unique int child: @ruby_underscore_lhs ref
+);
+
+ruby_rest_assignment_def(
+  unique int id: @ruby_rest_assignment,
+  int loc: @location ref
+);
+
+ruby_retry_child(
+  unique int ruby_retry: @ruby_retry ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_retry_def(
+  unique int id: @ruby_retry,
+  int loc: @location ref
+);
+
+ruby_return_child(
+  unique int ruby_return: @ruby_return ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_return_def(
+  unique int id: @ruby_return,
+  int loc: @location ref
+);
+
+@ruby_right_assignment_list_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_right_assignment_list, index]
+ruby_right_assignment_list_child(
+  int ruby_right_assignment_list: @ruby_right_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_right_assignment_list_child_type ref
+);
+
+ruby_right_assignment_list_def(
+  unique int id: @ruby_right_assignment_list,
+  int loc: @location ref
+);
+
+@ruby_scope_resolution_name_type = @ruby_token_constant | @ruby_token_identifier
+
+@ruby_scope_resolution_scope_type = @ruby_underscore_pattern_constant | @ruby_underscore_primary
+
+ruby_scope_resolution_scope(
+  unique int ruby_scope_resolution: @ruby_scope_resolution ref,
+  unique int scope: @ruby_scope_resolution_scope_type ref
+);
+
+ruby_scope_resolution_def(
+  unique int id: @ruby_scope_resolution,
+  int name: @ruby_scope_resolution_name_type ref,
+  int loc: @location ref
+);
+
+ruby_setter_def(
+  unique int id: @ruby_setter,
+  int name: @ruby_token_identifier ref,
+  int loc: @location ref
+);
+
+@ruby_singleton_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_singleton_class, index]
+ruby_singleton_class_child(
+  int ruby_singleton_class: @ruby_singleton_class ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_class_child_type ref
+);
+
+ruby_singleton_class_def(
+  unique int id: @ruby_singleton_class,
+  int value: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+@ruby_singleton_method_object_type = @ruby_underscore_arg | @ruby_underscore_variable
+
+ruby_singleton_method_parameters(
+  unique int ruby_singleton_method: @ruby_singleton_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_singleton_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_singleton_method, index]
+ruby_singleton_method_child(
+  int ruby_singleton_method: @ruby_singleton_method ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_method_child_type ref
+);
+
+ruby_singleton_method_def(
+  unique int id: @ruby_singleton_method,
+  int name: @ruby_underscore_method_name ref,
+  int object: @ruby_singleton_method_object_type ref,
+  int loc: @location ref
+);
+
+ruby_splat_argument_def(
+  unique int id: @ruby_splat_argument,
+  int child: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+ruby_splat_parameter_name(
+  unique int ruby_splat_parameter: @ruby_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_splat_parameter_def(
+  unique int id: @ruby_splat_parameter,
+  int loc: @location ref
+);
+
+@ruby_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_string__, index]
+ruby_string_child(
+  int ruby_string__: @ruby_string__ ref,
+  int index: int ref,
+  unique int child: @ruby_string_child_type ref
+);
+
+ruby_string_def(
+  unique int id: @ruby_string__,
+  int loc: @location ref
+);
+
+#keyset[ruby_string_array, index]
+ruby_string_array_child(
+  int ruby_string_array: @ruby_string_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string ref
+);
+
+ruby_string_array_def(
+  unique int id: @ruby_string_array,
+  int loc: @location ref
+);
+
+@ruby_subshell_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_subshell, index]
+ruby_subshell_child(
+  int ruby_subshell: @ruby_subshell ref,
+  int index: int ref,
+  unique int child: @ruby_subshell_child_type ref
+);
+
+ruby_subshell_def(
+  unique int id: @ruby_subshell,
+  int loc: @location ref
+);
+
+ruby_superclass_def(
+  unique int id: @ruby_superclass,
+  int child: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_symbol_array, index]
+ruby_symbol_array_child(
+  int ruby_symbol_array: @ruby_symbol_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol ref
+);
+
+ruby_symbol_array_def(
+  unique int id: @ruby_symbol_array,
+  int loc: @location ref
+);
+
+@ruby_then_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_then, index]
+ruby_then_child(
+  int ruby_then: @ruby_then ref,
+  int index: int ref,
+  unique int child: @ruby_then_child_type ref
+);
+
+ruby_then_def(
+  unique int id: @ruby_then,
+  int loc: @location ref
+);
+
+@ruby_unary_operand_type = @ruby_parenthesized_statements | @ruby_underscore_expression | @ruby_underscore_simple_numeric
+
+case @ruby_unary.operator of
+  0 = @ruby_unary_bang
+| 1 = @ruby_unary_plus
+| 2 = @ruby_unary_minus
+| 3 = @ruby_unary_definedquestion
+| 4 = @ruby_unary_not
+| 5 = @ruby_unary_tilde
+;
+
+
+ruby_unary_def(
+  unique int id: @ruby_unary,
+  int operand: @ruby_unary_operand_type ref,
+  int operator: int ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_undef, index]
+ruby_undef_child(
+  int ruby_undef: @ruby_undef ref,
+  int index: int ref,
+  unique int child: @ruby_underscore_method_name ref
+);
+
+ruby_undef_def(
+  unique int id: @ruby_undef,
+  int loc: @location ref
+);
+
+@ruby_unless_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_unless_alternative(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int alternative: @ruby_unless_alternative_type ref
+);
+
+ruby_unless_consequence(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_unless_def(
+  unique int id: @ruby_unless,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_unless_guard_def(
+  unique int id: @ruby_unless_guard,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_unless_modifier_def(
+  unique int id: @ruby_unless_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_until_def(
+  unique int id: @ruby_until,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_until_modifier_def(
+  unique int id: @ruby_until_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+@ruby_variable_reference_pattern_name_type = @ruby_token_identifier | @ruby_underscore_nonlocal_variable
+
+ruby_variable_reference_pattern_def(
+  unique int id: @ruby_variable_reference_pattern,
+  int name: @ruby_variable_reference_pattern_name_type ref,
+  int loc: @location ref
+);
+
+ruby_when_body(
+  unique int ruby_when: @ruby_when ref,
+  unique int body: @ruby_then ref
+);
+
+#keyset[ruby_when, index]
+ruby_when_pattern(
+  int ruby_when: @ruby_when ref,
+  int index: int ref,
+  unique int pattern: @ruby_pattern ref
+);
+
+ruby_when_def(
+  unique int id: @ruby_when,
+  int loc: @location ref
+);
+
+ruby_while_def(
+  unique int id: @ruby_while,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_while_modifier_def(
+  unique int id: @ruby_while_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_yield_child(
+  unique int ruby_yield: @ruby_yield ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_yield_def(
+  unique int id: @ruby_yield,
+  int loc: @location ref
+);
+
+ruby_tokeninfo(
+  unique int id: @ruby_token,
+  int kind: int ref,
+  string value: string ref,
+  int loc: @location ref
+);
+
+case @ruby_token.kind of
+  0 = @ruby_reserved_word
+| 1 = @ruby_token_character
+| 2 = @ruby_token_class_variable
+| 3 = @ruby_token_comment
+| 4 = @ruby_token_complex
+| 5 = @ruby_token_constant
+| 6 = @ruby_token_empty_statement
+| 7 = @ruby_token_encoding
+| 8 = @ruby_token_escape_sequence
+| 9 = @ruby_token_false
+| 10 = @ruby_token_file
+| 11 = @ruby_token_float
+| 12 = @ruby_token_forward_argument
+| 13 = @ruby_token_forward_parameter
+| 14 = @ruby_token_global_variable
+| 15 = @ruby_token_hash_key_symbol
+| 16 = @ruby_token_hash_splat_nil
+| 17 = @ruby_token_heredoc_beginning
+| 18 = @ruby_token_heredoc_content
+| 19 = @ruby_token_heredoc_end
+| 20 = @ruby_token_identifier
+| 21 = @ruby_token_instance_variable
+| 22 = @ruby_token_integer
+| 23 = @ruby_token_line
+| 24 = @ruby_token_nil
+| 25 = @ruby_token_operator
+| 26 = @ruby_token_self
+| 27 = @ruby_token_simple_symbol
+| 28 = @ruby_token_string_content
+| 29 = @ruby_token_super
+| 30 = @ruby_token_true
+| 31 = @ruby_token_uninterpreted
+;
+
+
+@ruby_ast_node = @ruby_alias | @ruby_alternative_pattern | @ruby_argument_list | @ruby_array | @ruby_array_pattern | @ruby_as_pattern | @ruby_assignment | @ruby_bare_string | @ruby_bare_symbol | @ruby_begin | @ruby_begin_block | @ruby_binary | @ruby_block | @ruby_block_argument | @ruby_block_parameter | @ruby_block_parameters | @ruby_break | @ruby_call | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_conditional | @ruby_delimited_symbol | @ruby_destructured_left_assignment | @ruby_destructured_parameter | @ruby_do | @ruby_do_block | @ruby_element_reference | @ruby_else | @ruby_elsif | @ruby_end_block | @ruby_ensure | @ruby_exception_variable | @ruby_exceptions | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_for | @ruby_hash | @ruby_hash_pattern | @ruby_hash_splat_argument | @ruby_hash_splat_parameter | @ruby_heredoc_body | @ruby_if | @ruby_if_guard | @ruby_if_modifier | @ruby_in | @ruby_in_clause | @ruby_interpolation | @ruby_keyword_parameter | @ruby_keyword_pattern | @ruby_lambda | @ruby_lambda_parameters | @ruby_left_assignment_list | @ruby_method | @ruby_method_parameters | @ruby_module | @ruby_next | @ruby_operator_assignment | @ruby_optional_parameter | @ruby_pair | @ruby_parenthesized_pattern | @ruby_parenthesized_statements | @ruby_pattern | @ruby_program | @ruby_range | @ruby_rational | @ruby_redo | @ruby_regex | @ruby_rescue | @ruby_rescue_modifier | @ruby_rest_assignment | @ruby_retry | @ruby_return | @ruby_right_assignment_list | @ruby_scope_resolution | @ruby_setter | @ruby_singleton_class | @ruby_singleton_method | @ruby_splat_argument | @ruby_splat_parameter | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_superclass | @ruby_symbol_array | @ruby_then | @ruby_token | @ruby_unary | @ruby_undef | @ruby_unless | @ruby_unless_guard | @ruby_unless_modifier | @ruby_until | @ruby_until_modifier | @ruby_variable_reference_pattern | @ruby_when | @ruby_while | @ruby_while_modifier | @ruby_yield
+
+@ruby_ast_node_parent = @file | @ruby_ast_node
+
+#keyset[parent, parent_index]
+ruby_ast_node_parent(
+  int child: @ruby_ast_node ref,
+  int parent: @ruby_ast_node_parent ref,
+  int parent_index: int ref
+);
+
+erb_comment_directive_def(
+  unique int id: @erb_comment_directive,
+  int child: @erb_token_comment ref,
+  int loc: @location ref
+);
+
+erb_directive_def(
+  unique int id: @erb_directive,
+  int child: @erb_token_code ref,
+  int loc: @location ref
+);
+
+erb_graphql_directive_def(
+  unique int id: @erb_graphql_directive,
+  int child: @erb_token_code ref,
+  int loc: @location ref
+);
+
+erb_output_directive_def(
+  unique int id: @erb_output_directive,
+  int child: @erb_token_code ref,
+  int loc: @location ref
+);
+
+@erb_template_child_type = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_token_content
+
+#keyset[erb_template, index]
+erb_template_child(
+  int erb_template: @erb_template ref,
+  int index: int ref,
+  unique int child: @erb_template_child_type ref
+);
+
+erb_template_def(
+  unique int id: @erb_template,
+  int loc: @location ref
+);
+
+erb_tokeninfo(
+  unique int id: @erb_token,
+  int kind: int ref,
+  string value: string ref,
+  int loc: @location ref
+);
+
+case @erb_token.kind of
+  0 = @erb_reserved_word
+| 1 = @erb_token_code
+| 2 = @erb_token_comment
+| 3 = @erb_token_content
+;
+
+
+@erb_ast_node = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_template | @erb_token
+
+@erb_ast_node_parent = @erb_ast_node | @file
+
+#keyset[parent, parent_index]
+erb_ast_node_parent(
+  int child: @erb_ast_node ref,
+  int parent: @erb_ast_node_parent ref,
+  int parent_index: int ref
+);
+

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_alias_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_alias_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode alias, AstNode name, Location loc
+where ruby_alias_def(id, alias, name) and ruby_ast_node_info(id, _, _, loc)
+select id, alias, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_alternative_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_alternative_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_alternative_pattern_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_argument_list_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_argument_list_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_argument_list_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_array_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_array_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_array_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_array_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_array_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_array_pattern_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_as_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_as_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, AstNode value, Location loc
+where ruby_as_pattern_def(id, name, value) and ruby_ast_node_info(id, _, _, loc)
+select id, name, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_assignment_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_assignment_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode left, AstNode right, Location loc
+where ruby_assignment_def(id, left, right) and ruby_ast_node_info(id, _, _, loc)
+select id, left, right, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_bare_string_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_bare_string_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_bare_string_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_bare_symbol_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_bare_symbol_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_bare_symbol_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_begin_block_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_begin_block_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_begin_block_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_begin_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_begin_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_begin_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_binary_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_binary_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode left, int operator, AstNode right, Location loc
+where ruby_binary_def(id, left, operator, right) and ruby_ast_node_info(id, _, _, loc)
+select id, left, operator, right, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_argument_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_argument_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_block_argument_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_block_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_parameter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_parameter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_block_parameter_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_parameters_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_block_parameters_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_block_parameters_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_break_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_break_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_break_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_call_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_call_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode method, Location loc
+where ruby_call_def(id, method) and ruby_ast_node_info(id, _, _, loc)
+select id, method, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_case_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_case_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_case_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_case_match_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_case_match_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode value, Location loc
+where ruby_case_match_def(id, value) and ruby_ast_node_info(id, _, _, loc)
+select id, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_chained_string_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_chained_string_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_chained_string_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_class_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_class_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_class_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_conditional_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_conditional_def.ql
@@ -1,0 +1,13 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode alternative, AstNode condition, AstNode consequence, Location loc
+where
+  ruby_conditional_def(id, alternative, condition, consequence) and
+  ruby_ast_node_info(id, _, _, loc)
+select id, alternative, condition, consequence, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_delimited_symbol_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_delimited_symbol_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_delimited_symbol_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_destructured_left_assignment_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_destructured_left_assignment_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_destructured_left_assignment_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_destructured_parameter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_destructured_parameter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_destructured_parameter_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_do_block_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_do_block_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_do_block_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_do_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_do_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_do_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_element_reference_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_element_reference_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode object, Location loc
+where ruby_element_reference_def(id, object) and ruby_ast_node_info(id, _, _, loc)
+select id, object, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_else_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_else_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_else_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_elsif_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_elsif_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode condition, Location loc
+where ruby_elsif_def(id, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_end_block_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_end_block_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_end_block_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_ensure_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_ensure_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_ensure_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_exception_variable_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_exception_variable_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_exception_variable_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_exceptions_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_exceptions_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_exceptions_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_expression_reference_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_expression_reference_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode value, Location loc
+where ruby_expression_reference_pattern_def(id, value) and ruby_ast_node_info(id, _, _, loc)
+select id, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_find_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_find_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_find_pattern_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_for_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_for_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode pattern, AstNode value, Location loc
+where ruby_for_def(id, body, pattern, value) and ruby_ast_node_info(id, _, _, loc)
+select id, body, pattern, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_hash_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_hash_pattern_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_splat_argument_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_splat_argument_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_hash_splat_argument_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_splat_parameter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_hash_splat_parameter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_hash_splat_parameter_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_heredoc_body_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_heredoc_body_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_heredoc_body_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_if_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_if_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode condition, Location loc
+where ruby_if_def(id, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_if_guard_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_if_guard_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode condition, Location loc
+where ruby_if_guard_def(id, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_if_modifier_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_if_modifier_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode condition, Location loc
+where ruby_if_modifier_def(id, body, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, body, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_in_clause_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_in_clause_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode pattern, Location loc
+where ruby_in_clause_def(id, pattern) and ruby_ast_node_info(id, _, _, loc)
+select id, pattern, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_in_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_in_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_in_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_interpolation_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_interpolation_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_interpolation_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_keyword_parameter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_keyword_parameter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_keyword_parameter_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_keyword_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_keyword_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode key__, Location loc
+where ruby_keyword_pattern_def(id, key__) and ruby_ast_node_info(id, _, _, loc)
+select id, key__, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_lambda_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_lambda_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, Location loc
+where ruby_lambda_def(id, body) and ruby_ast_node_info(id, _, _, loc)
+select id, body, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_lambda_parameters_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_lambda_parameters_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_lambda_parameters_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_left_assignment_list_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_left_assignment_list_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_left_assignment_list_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_method_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_method_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_method_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_method_parameters_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_method_parameters_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_method_parameters_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_module_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_module_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_module_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_next_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_next_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_next_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_operator_assignment_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_operator_assignment_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode left, int operator, AstNode right, Location loc
+where ruby_operator_assignment_def(id, left, operator, right) and ruby_ast_node_info(id, _, _, loc)
+select id, left, operator, right, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_optional_parameter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_optional_parameter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, AstNode value, Location loc
+where ruby_optional_parameter_def(id, name, value) and ruby_ast_node_info(id, _, _, loc)
+select id, name, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_pair_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_pair_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode key__, Location loc
+where ruby_pair_def(id, key__) and ruby_ast_node_info(id, _, _, loc)
+select id, key__, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_parenthesized_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_parenthesized_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_parenthesized_pattern_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_parenthesized_statements_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_parenthesized_statements_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_parenthesized_statements_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_pattern_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_program_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_program_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_program_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_range_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_range_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, int operator, Location loc
+where ruby_range_def(id, operator) and ruby_ast_node_info(id, _, _, loc)
+select id, operator, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rational_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rational_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_rational_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_redo_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_redo_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_redo_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_regex_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_regex_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_regex_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rescue_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rescue_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_rescue_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rescue_modifier_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rescue_modifier_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode handler, Location loc
+where ruby_rescue_modifier_def(id, body, handler) and ruby_ast_node_info(id, _, _, loc)
+select id, body, handler, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rest_assignment_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_rest_assignment_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_rest_assignment_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_retry_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_retry_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_retry_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_return_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_return_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_return_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_right_assignment_list_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_right_assignment_list_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_right_assignment_list_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_scope_resolution_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_scope_resolution_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_scope_resolution_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_setter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_setter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_setter_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_singleton_class_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_singleton_class_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode value, Location loc
+where ruby_singleton_class_def(id, value) and ruby_ast_node_info(id, _, _, loc)
+select id, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_singleton_method_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_singleton_method_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, AstNode object, Location loc
+where ruby_singleton_method_def(id, name, object) and ruby_ast_node_info(id, _, _, loc)
+select id, name, object, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_splat_argument_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_splat_argument_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_splat_argument_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_splat_parameter_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_splat_parameter_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_splat_parameter_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_string_array_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_string_array_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_string_array_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_string_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_string_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_string_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_subshell_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_subshell_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_subshell_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_superclass_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_superclass_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode child, Location loc
+where ruby_superclass_def(id, child) and ruby_ast_node_info(id, _, _, loc)
+select id, child, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_symbol_array_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_symbol_array_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_symbol_array_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_then_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_then_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_then_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_tokeninfo.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_tokeninfo.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, int kind, string value, Location loc
+where ruby_tokeninfo(id, kind, value) and ruby_ast_node_info(id, _, _, loc)
+select id, kind, value, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unary_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unary_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode operand, int operator, Location loc
+where ruby_unary_def(id, operand, operator) and ruby_ast_node_info(id, _, _, loc)
+select id, operand, operator, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_undef_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_undef_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_undef_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unless_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unless_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode condition, Location loc
+where ruby_unless_def(id, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unless_guard_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unless_guard_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode condition, Location loc
+where ruby_unless_guard_def(id, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unless_modifier_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_unless_modifier_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode condition, Location loc
+where ruby_unless_modifier_def(id, body, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, body, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_until_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_until_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode condition, Location loc
+where ruby_until_def(id, body, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, body, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_until_modifier_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_until_modifier_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode condition, Location loc
+where ruby_until_modifier_def(id, body, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, body, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_variable_reference_pattern_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_variable_reference_pattern_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode name, Location loc
+where ruby_variable_reference_pattern_def(id, name) and ruby_ast_node_info(id, _, _, loc)
+select id, name, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_when_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_when_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_when_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_while_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_while_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode condition, Location loc
+where ruby_while_def(id, body, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, body, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_while_modifier_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_while_modifier_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, AstNode body, AstNode condition, Location loc
+where ruby_while_modifier_def(id, body, condition) and ruby_ast_node_info(id, _, _, loc)
+select id, body, condition, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_yield_def.ql
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/ruby_yield_def.ql
@@ -1,0 +1,11 @@
+class AstNode extends @ruby_ast_node {
+  string toString() { none() }
+}
+
+class Location extends @location {
+  string toString() { none() }
+}
+
+from AstNode id, Location loc
+where ruby_yield_def(id) and ruby_ast_node_info(id, _, _, loc)
+select id, loc

--- a/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/upgrade.properties
+++ b/ruby/downgrades/fabe9e179ed1e3d0e45ccfab6ce94b4bab02dee5/upgrade.properties
@@ -1,0 +1,116 @@
+description: Revert: Move location columns to a single table
+compatibility: full
+
+erb_ast_node_parent.rel:  reorder erb_ast_node_info.rel  (int node, int parent, int parent_index, int loc) node parent parent_index
+ruby_ast_node_parent.rel: reorder ruby_ast_node_info.rel (int node, int parent, int parent_index, int loc) node parent parent_index
+
+erb_ast_node_info.rel:  delete
+ruby_ast_node_info.rel: delete
+
+erb_comment_directive_def.rel: run erb_comment_directive_def.qlo
+erb_directive_def.rel:         run erb_directive_def.qlo
+erb_graphql_directive_def.rel: run erb_graphql_directive_def.qlo
+erb_output_directive_def.rel:  run erb_output_directive_def.qlo
+erb_template_def.rel:          run erb_template_def.qlo
+erb_tokeninfo.rel:             run erb_tokeninfo.qlo
+
+ruby_alias_def.rel:                        run ruby_alias_def.qlo
+ruby_alternative_pattern_def.rel:          run ruby_alternative_pattern_def.qlo
+ruby_argument_list_def.rel:                run ruby_argument_list_def.qlo
+ruby_array_def.rel:                        run ruby_array_def.qlo
+ruby_array_pattern_def.rel:                run ruby_array_pattern_def.qlo
+ruby_as_pattern_def.rel:                   run ruby_as_pattern_def.qlo
+ruby_assignment_def.rel:                   run ruby_assignment_def.qlo
+ruby_bare_string_def.rel:                  run ruby_bare_string_def.qlo
+ruby_bare_symbol_def.rel:                  run ruby_bare_symbol_def.qlo
+ruby_begin_def.rel:                        run ruby_begin_def.qlo
+ruby_begin_block_def.rel:                  run ruby_begin_block_def.qlo
+ruby_binary_def.rel:                       run ruby_binary_def.qlo
+ruby_block_def.rel:                        run ruby_block_def.qlo
+ruby_block_argument_def.rel:               run ruby_block_argument_def.qlo
+ruby_block_parameter_def.rel:              run ruby_block_parameter_def.qlo
+ruby_block_parameters_def.rel:             run ruby_block_parameters_def.qlo
+ruby_break_def.rel:                        run ruby_break_def.qlo
+ruby_call_def.rel:                         run ruby_call_def.qlo
+ruby_case_def.rel:                         run ruby_case_def.qlo
+ruby_case_match_def.rel:                   run ruby_case_match_def.qlo
+ruby_chained_string_def.rel:               run ruby_chained_string_def.qlo
+ruby_class_def.rel:                        run ruby_class_def.qlo
+ruby_conditional_def.rel:                  run ruby_conditional_def.qlo
+ruby_delimited_symbol_def.rel:             run ruby_delimited_symbol_def.qlo
+ruby_destructured_left_assignment_def.rel: run ruby_destructured_left_assignment_def.qlo
+ruby_destructured_parameter_def.rel:       run ruby_destructured_parameter_def.qlo
+ruby_do_def.rel:                           run ruby_do_def.qlo
+ruby_do_block_def.rel:                     run ruby_do_block_def.qlo
+ruby_element_reference_def.rel:            run ruby_element_reference_def.qlo
+ruby_else_def.rel:                         run ruby_else_def.qlo
+ruby_elsif_def.rel:                        run ruby_elsif_def.qlo
+ruby_end_block_def.rel:                    run ruby_end_block_def.qlo
+ruby_ensure_def.rel:                       run ruby_ensure_def.qlo
+ruby_exception_variable_def.rel:           run ruby_exception_variable_def.qlo
+ruby_exceptions_def.rel:                   run ruby_exceptions_def.qlo
+ruby_expression_reference_pattern_def.rel: run ruby_expression_reference_pattern_def.qlo
+ruby_find_pattern_def.rel:                 run ruby_find_pattern_def.qlo
+ruby_for_def.rel:                          run ruby_for_def.qlo
+ruby_hash_def.rel:                         run ruby_hash_def.qlo
+ruby_hash_pattern_def.rel:                 run ruby_hash_pattern_def.qlo
+ruby_hash_splat_argument_def.rel:          run ruby_hash_splat_argument_def.qlo
+ruby_hash_splat_parameter_def.rel:         run ruby_hash_splat_parameter_def.qlo
+ruby_heredoc_body_def.rel:                 run ruby_heredoc_body_def.qlo
+ruby_if_def.rel:                           run ruby_if_def.qlo
+ruby_if_guard_def.rel:                     run ruby_if_guard_def.qlo
+ruby_if_modifier_def.rel:                  run ruby_if_modifier_def.qlo
+ruby_in_def.rel:                           run ruby_in_def.qlo
+ruby_in_clause_def.rel:                    run ruby_in_clause_def.qlo
+ruby_interpolation_def.rel:                run ruby_interpolation_def.qlo
+ruby_keyword_parameter_def.rel:            run ruby_keyword_parameter_def.qlo
+ruby_keyword_pattern_def.rel:              run ruby_keyword_pattern_def.qlo
+ruby_lambda_def.rel:                       run ruby_lambda_def.qlo
+ruby_lambda_parameters_def.rel:            run ruby_lambda_parameters_def.qlo
+ruby_left_assignment_list_def.rel:         run ruby_left_assignment_list_def.qlo
+ruby_method_def.rel:                       run ruby_method_def.qlo
+ruby_method_parameters_def.rel:            run ruby_method_parameters_def.qlo
+ruby_module_def.rel:                       run ruby_module_def.qlo
+ruby_next_def.rel:                         run ruby_next_def.qlo
+ruby_operator_assignment_def.rel:          run ruby_operator_assignment_def.qlo
+ruby_optional_parameter_def.rel:           run ruby_optional_parameter_def.qlo
+ruby_pair_def.rel:                         run ruby_pair_def.qlo
+ruby_parenthesized_pattern_def.rel:        run ruby_parenthesized_pattern_def.qlo
+ruby_parenthesized_statements_def.rel:     run ruby_parenthesized_statements_def.qlo
+ruby_pattern_def.rel:                      run ruby_pattern_def.qlo
+ruby_program_def.rel:                      run ruby_program_def.qlo
+ruby_range_def.rel:                        run ruby_range_def.qlo
+ruby_rational_def.rel:                     run ruby_rational_def.qlo
+ruby_redo_def.rel:                         run ruby_redo_def.qlo
+ruby_regex_def.rel:                        run ruby_regex_def.qlo
+ruby_rescue_def.rel:                       run ruby_rescue_def.qlo
+ruby_rescue_modifier_def.rel:              run ruby_rescue_modifier_def.qlo
+ruby_rest_assignment_def.rel:              run ruby_rest_assignment_def.qlo
+ruby_retry_def.rel:                        run ruby_retry_def.qlo
+ruby_return_def.rel:                       run ruby_return_def.qlo
+ruby_right_assignment_list_def.rel:        run ruby_right_assignment_list_def.qlo
+ruby_scope_resolution_def.rel:             run ruby_scope_resolution_def.qlo
+ruby_setter_def.rel:                       run ruby_setter_def.qlo
+ruby_singleton_class_def.rel:              run ruby_singleton_class_def.qlo
+ruby_singleton_method_def.rel:             run ruby_singleton_method_def.qlo
+ruby_splat_argument_def.rel:               run ruby_splat_argument_def.qlo
+ruby_splat_parameter_def.rel:              run ruby_splat_parameter_def.qlo
+ruby_string_def.rel:                       run ruby_string_def.qlo
+ruby_string_array_def.rel:                 run ruby_string_array_def.qlo
+ruby_subshell_def.rel:                     run ruby_subshell_def.qlo
+ruby_superclass_def.rel:                   run ruby_superclass_def.qlo
+ruby_symbol_array_def.rel:                 run ruby_symbol_array_def.qlo
+ruby_then_def.rel:                         run ruby_then_def.qlo
+ruby_unary_def.rel:                        run ruby_unary_def.qlo
+ruby_undef_def.rel:                        run ruby_undef_def.qlo
+ruby_unless_def.rel:                       run ruby_unless_def.qlo
+ruby_unless_guard_def.rel:                 run ruby_unless_guard_def.qlo
+ruby_unless_modifier_def.rel:              run ruby_unless_modifier_def.qlo
+ruby_until_def.rel:                        run ruby_until_def.qlo
+ruby_until_modifier_def.rel:               run ruby_until_modifier_def.qlo
+ruby_variable_reference_pattern_def.rel:   run ruby_variable_reference_pattern_def.qlo
+ruby_when_def.rel:                         run ruby_when_def.qlo
+ruby_while_def.rel:                        run ruby_while_def.qlo
+ruby_while_modifier_def.rel:               run ruby_while_modifier_def.qlo
+ruby_yield_def.rel:                        run ruby_yield_def.qlo
+ruby_tokeninfo.rel:                        run ruby_tokeninfo.qlo

--- a/ruby/extractor/src/extractor.rs
+++ b/ruby/extractor/src/extractor.rs
@@ -402,11 +402,12 @@ impl Visitor<'_> {
         match &table.kind {
             EntryKind::Token { kind_id, .. } => {
                 self.trap_writer.add_tuple(
-                    &format!("{}_ast_node_parent", self.language_prefix),
+                    &format!("{}_ast_node_info", self.language_prefix),
                     vec![
                         Arg::Label(id),
                         Arg::Label(parent_id),
                         Arg::Int(parent_index),
+                        Arg::Label(loc),
                     ],
                 );
                 self.trap_writer.add_tuple(
@@ -415,7 +416,6 @@ impl Visitor<'_> {
                         Arg::Label(id),
                         Arg::Int(*kind_id),
                         sliced_source_arg(self.source, node),
-                        Arg::Label(loc),
                     ],
                 );
             }
@@ -425,16 +425,16 @@ impl Visitor<'_> {
             } => {
                 if let Some(args) = self.complex_node(&node, fields, &child_nodes, id) {
                     self.trap_writer.add_tuple(
-                        &format!("{}_ast_node_parent", self.language_prefix),
+                        &format!("{}_ast_node_info", self.language_prefix),
                         vec![
                             Arg::Label(id),
                             Arg::Label(parent_id),
                             Arg::Int(parent_index),
+                            Arg::Label(loc),
                         ],
                     );
                     let mut all_args = vec![Arg::Label(id)];
                     all_args.extend(args);
-                    all_args.push(Arg::Label(loc));
                     self.trap_writer.add_tuple(table_name, all_args);
                 }
             }

--- a/ruby/generator/src/main.rs
+++ b/ruby/generator/src/main.rs
@@ -233,15 +233,6 @@ fn convert_nodes(
                     });
                 }
 
-                // Finally, the type's defining table also includes the location.
-                main_table.columns.push(dbscheme::Column {
-                    unique: false,
-                    db_type: dbscheme::DbColumnType::Int,
-                    name: "loc",
-                    ql_type: ql::Type::At("location"),
-                    ql_type_is_ref: true,
-                });
-
                 entries.push(dbscheme::Entry::Table(main_table));
             }
             node_types::EntryKind::Token { .. } => {}
@@ -251,18 +242,24 @@ fn convert_nodes(
     (entries, ast_node_members, token_kinds)
 }
 
-/// Creates a dbscheme table entry representing the parent relation for AST nodes.
+/// Creates a dbscheme table specifying the parent node and location for each
+/// AST node.
 ///
 /// # Arguments
-/// - `name` - the name of both the table to create and the node parent type.
+/// - `name` - the name of the table to create.
+/// - `parent_name` - the name of the parent type.
 /// - `ast_node_name` - the name of the node child type.
-fn create_ast_node_parent_table<'a>(name: &'a str, ast_node_name: &'a str) -> dbscheme::Table<'a> {
+fn create_ast_node_info_table<'a>(
+    name: &'a str,
+    parent_name: &'a str,
+    ast_node_name: &'a str,
+) -> dbscheme::Table<'a> {
     dbscheme::Table {
         name,
         columns: vec![
             dbscheme::Column {
                 db_type: dbscheme::DbColumnType::Int,
-                name: "child",
+                name: "node",
                 unique: false,
                 ql_type: ql::Type::At(ast_node_name),
                 ql_type_is_ref: true,
@@ -271,7 +268,7 @@ fn create_ast_node_parent_table<'a>(name: &'a str, ast_node_name: &'a str) -> db
                 db_type: dbscheme::DbColumnType::Int,
                 name: "parent",
                 unique: false,
-                ql_type: ql::Type::At(name),
+                ql_type: ql::Type::At(parent_name),
                 ql_type_is_ref: true,
             },
             dbscheme::Column {
@@ -279,6 +276,13 @@ fn create_ast_node_parent_table<'a>(name: &'a str, ast_node_name: &'a str) -> db
                 db_type: dbscheme::DbColumnType::Int,
                 name: "parent_index",
                 ql_type: ql::Type::Int,
+                ql_type_is_ref: true,
+            },
+            dbscheme::Column {
+                unique: false,
+                db_type: dbscheme::DbColumnType::Int,
+                name: "loc",
+                ql_type: ql::Type::At("location"),
                 ql_type_is_ref: true,
             },
         ],
@@ -310,13 +314,6 @@ fn create_tokeninfo<'a>(name: &'a str, type_name: &'a str) -> dbscheme::Table<'a
                 db_type: dbscheme::DbColumnType::String,
                 name: "value",
                 ql_type: ql::Type::String,
-                ql_type_is_ref: true,
-            },
-            dbscheme::Column {
-                unique: false,
-                db_type: dbscheme::DbColumnType::Int,
-                name: "loc",
-                ql_type: ql::Type::At("location"),
                 ql_type_is_ref: true,
             },
         ],
@@ -619,6 +616,7 @@ fn main() -> std::io::Result<()> {
     for language in languages {
         let prefix = node_types::to_snake_case(&language.name);
         let ast_node_name = format!("{}_ast_node", &prefix);
+        let node_info_table_name = format!("{}_ast_node_info", &prefix);
         let ast_node_parent_name = format!("{}_ast_node_parent", &prefix);
         let token_name = format!("{}_token", &prefix);
         let tokeninfo_name = format!("{}_tokeninfo", &prefix);
@@ -641,7 +639,8 @@ fn main() -> std::io::Result<()> {
                     name: &ast_node_parent_name,
                     members: [&ast_node_name, "file"].iter().cloned().collect(),
                 }),
-                dbscheme::Entry::Table(create_ast_node_parent_table(
+                dbscheme::Entry::Table(create_ast_node_info_table(
+                    &node_info_table_name,
                     &ast_node_parent_name,
                     &ast_node_name,
                 )),
@@ -651,7 +650,7 @@ fn main() -> std::io::Result<()> {
         let mut body = vec![
             ql::TopLevel::Class(ql_gen::create_ast_node_class(
                 &ast_node_name,
-                &ast_node_parent_name,
+                &node_info_table_name,
             )),
             ql::TopLevel::Class(ql_gen::create_token_class(&token_name, &tokeninfo_name)),
             ql::TopLevel::Class(ql_gen::create_reserved_word_class(&reserved_word_name)),

--- a/ruby/generator/src/ql.rs
+++ b/ruby/generator/src/ql.rs
@@ -68,6 +68,7 @@ impl<'a> fmt::Display for Class<'a> {
                     qldoc: None,
                     name: self.name,
                     overridden: false,
+                    is_final: false,
                     return_type: None,
                     formal_parameters: vec![],
                     body: charpred.clone(),
@@ -239,6 +240,7 @@ pub struct Predicate<'a> {
     pub qldoc: Option<String>,
     pub name: &'a str,
     pub overridden: bool,
+    pub is_final: bool,
     pub return_type: Option<Type<'a>>,
     pub formal_parameters: Vec<FormalParameter<'a>>,
     pub body: Expression<'a>,
@@ -248,6 +250,9 @@ impl<'a> fmt::Display for Predicate<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(qldoc) = &self.qldoc {
             write!(f, "/** {} */", qldoc)?;
+        }
+        if self.is_final {
+            write!(f, "final ")?;
         }
         if self.overridden {
             write!(f, "override ")?;

--- a/ruby/generator/src/ql_gen.rs
+++ b/ruby/generator/src/ql_gen.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 
 /// Creates the hard-coded `AstNode` class that acts as a supertype of all
 /// classes we generate.
-pub fn create_ast_node_class<'a>(ast_node: &'a str, ast_node_parent: &'a str) -> ql::Class<'a> {
+pub fn create_ast_node_class<'a>(ast_node: &'a str, node_info_table: &'a str) -> ql::Class<'a> {
     // Default implementation of `toString` calls `this.getAPrimaryQlClass()`
     let to_string = ql::Predicate {
         qldoc: Some(String::from(
@@ -22,12 +22,22 @@ pub fn create_ast_node_class<'a>(ast_node: &'a str, ast_node_parent: &'a str) ->
             )),
         ),
     };
-    let get_location = create_none_predicate(
-        Some(String::from("Gets the location of this element.")),
-        "getLocation",
-        false,
-        Some(ql::Type::Normal("L::Location")),
-    );
+    let get_location = ql::Predicate {
+        name: "getLocation",
+        qldoc: Some(String::from("Gets the location of this element.")),
+        overridden: false,
+        return_type: Some(ql::Type::Normal("L::Location")),
+        formal_parameters: vec![],
+        body: ql::Expression::Pred(
+            node_info_table,
+            vec![
+                ql::Expression::Var("this"),
+                ql::Expression::Var("_"),      // parent
+                ql::Expression::Var("_"),      // parent index
+                ql::Expression::Var("result"), // location
+            ],
+        ),
+    };
     let get_a_field_or_child = create_none_predicate(
         Some(String::from("Gets a field or child node of this node.")),
         "getAFieldOrChild",
@@ -41,11 +51,12 @@ pub fn create_ast_node_class<'a>(ast_node: &'a str, ast_node_parent: &'a str) ->
         return_type: Some(ql::Type::Normal("AstNode")),
         formal_parameters: vec![],
         body: ql::Expression::Pred(
-            ast_node_parent,
+            node_info_table,
             vec![
                 ql::Expression::Var("this"),
                 ql::Expression::Var("result"),
-                ql::Expression::Var("_"),
+                ql::Expression::Var("_"), // parent index
+                ql::Expression::Var("_"), // location
             ],
         ),
     };
@@ -58,11 +69,12 @@ pub fn create_ast_node_class<'a>(ast_node: &'a str, ast_node_parent: &'a str) ->
         return_type: Some(ql::Type::Int),
         formal_parameters: vec![],
         body: ql::Expression::Pred(
-            ast_node_parent,
+            node_info_table,
             vec![
                 ql::Expression::Var("this"),
-                ql::Expression::Var("_"),
-                ql::Expression::Var("result"),
+                ql::Expression::Var("_"),      // parent
+                ql::Expression::Var("result"), // parent index
+                ql::Expression::Var("_"),      // location
             ],
         ),
     };
@@ -123,7 +135,7 @@ pub fn create_ast_node_class<'a>(ast_node: &'a str, ast_node_parent: &'a str) ->
 }
 
 pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Class<'a> {
-    let tokeninfo_arity = 4;
+    let tokeninfo_arity = 3; // id, kind, value
     let get_value = ql::Predicate {
         qldoc: Some(String::from("Gets the value of this token.")),
         name: "getValue",
@@ -131,14 +143,6 @@ pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Cl
         return_type: Some(ql::Type::String),
         formal_parameters: vec![],
         body: create_get_field_expr_for_column_storage("result", tokeninfo, 1, tokeninfo_arity),
-    };
-    let get_location = ql::Predicate {
-        qldoc: Some(String::from("Gets the location of this token.")),
-        name: "getLocation",
-        overridden: true,
-        return_type: Some(ql::Type::Normal("L::Location")),
-        formal_parameters: vec![],
-        body: create_get_field_expr_for_column_storage("result", tokeninfo, 2, tokeninfo_arity),
     };
     let to_string = ql::Predicate {
         qldoc: Some(String::from(
@@ -167,7 +171,7 @@ pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Cl
         characteristic_predicate: None,
         predicates: vec![
             get_value,
-            get_location,
+            //get_location,
             to_string,
             create_get_a_primary_ql_class("Token"),
         ],
@@ -221,55 +225,6 @@ fn create_get_a_primary_ql_class(class_name: &str) -> ql::Predicate {
         body: ql::Expression::Equals(
             Box::new(ql::Expression::Var("result")),
             Box::new(ql::Expression::String(class_name)),
-        ),
-    }
-}
-
-/// Creates the `getLocation` predicate.
-///
-/// # Arguments
-///
-/// `def_table` - the name of the table that defines the entity and its location.
-/// `arity` - the total number of columns in the table
-fn create_get_location_predicate(def_table: &str, arity: usize) -> ql::Predicate {
-    ql::Predicate {
-        qldoc: Some(String::from("Gets the location of this element.")),
-        name: "getLocation",
-        overridden: true,
-        return_type: Some(ql::Type::Normal("L::Location")),
-        formal_parameters: vec![],
-        // body of the form: foo_bar_def(_, _, ..., result)
-        body: ql::Expression::Pred(
-            def_table,
-            [
-                vec![ql::Expression::Var("this")],
-                vec![ql::Expression::Var("_"); arity - 2],
-                vec![ql::Expression::Var("result")],
-            ]
-            .concat(),
-        ),
-    }
-}
-
-/// Creates the `getText` predicate for a leaf node.
-///
-/// # Arguments
-///
-/// `def_table` - the name of the table that defines the entity and its text.
-fn create_get_text_predicate(def_table: &str) -> ql::Predicate {
-    ql::Predicate {
-        qldoc: Some(String::from("Gets the text content of this element.")),
-        name: "getText",
-        overridden: false,
-        return_type: Some(ql::Type::String),
-        formal_parameters: vec![],
-        body: ql::Expression::Pred(
-            def_table,
-            vec![
-                ql::Expression::Var("this"),
-                ql::Expression::Var("result"),
-                ql::Expression::Var("_"),
-            ],
         ),
     }
 }
@@ -532,20 +487,17 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel> {
                 name: main_table_name,
                 fields,
             } => {
-                // Count how many columns there will be in the main table.
-                // There will be:
-                // - one for the id
-                // - one for the location
-                // - one for each field that's stored as a column
-                // - if there are no fields, one for the text column.
-                let main_table_arity = 2 + if fields.is_empty() {
-                    1
-                } else {
-                    fields
-                        .iter()
-                        .filter(|&f| matches!(f.storage, node_types::Storage::Column { .. }))
-                        .count()
-                };
+                if fields.is_empty() {
+                    panic!("Encountered node '{}' with no fields", type_name.kind);
+                }
+
+                // Count how many columns there will be in the main table. There
+                // will be one for the id, plus one for each field that's stored
+                // as a column.
+                let main_table_arity = 1 + fields
+                    .iter()
+                    .filter(|&f| matches!(f.storage, node_types::Storage::Column { .. }))
+                    .count();
 
                 let main_class_name = &node.ql_class_name;
                 let mut main_class = ql::Class {
@@ -559,47 +511,38 @@ pub fn convert_nodes(nodes: &node_types::NodeTypeMap) -> Vec<ql::TopLevel> {
                     .into_iter()
                     .collect(),
                     characteristic_predicate: None,
-                    predicates: vec![
-                        create_get_a_primary_ql_class(main_class_name),
-                        create_get_location_predicate(main_table_name, main_table_arity),
-                    ],
+                    predicates: vec![create_get_a_primary_ql_class(main_class_name)],
                 };
 
-                if fields.is_empty() {
-                    main_class
-                        .predicates
-                        .push(create_get_text_predicate(main_table_name));
-                } else {
-                    let mut main_table_column_index: usize = 0;
-                    let mut get_child_exprs: Vec<ql::Expression> = Vec::new();
+                let mut main_table_column_index: usize = 0;
+                let mut get_child_exprs: Vec<ql::Expression> = Vec::new();
 
-                    // Iterate through the fields, creating:
-                    // - classes to wrap union types if fields need them,
-                    // - predicates to access the fields,
-                    // - the QL expressions to access the fields that will be part of getAFieldOrChild.
-                    for field in fields {
-                        let (get_pred, get_child_expr) = create_field_getters(
-                            main_table_name,
-                            main_table_arity,
-                            &mut main_table_column_index,
-                            field,
-                            nodes,
-                        );
-                        main_class.predicates.push(get_pred);
-                        if let Some(get_child_expr) = get_child_expr {
-                            get_child_exprs.push(get_child_expr)
-                        }
+                // Iterate through the fields, creating:
+                // - classes to wrap union types if fields need them,
+                // - predicates to access the fields,
+                // - the QL expressions to access the fields that will be part of getAFieldOrChild.
+                for field in fields {
+                    let (get_pred, get_child_expr) = create_field_getters(
+                        main_table_name,
+                        main_table_arity,
+                        &mut main_table_column_index,
+                        field,
+                        nodes,
+                    );
+                    main_class.predicates.push(get_pred);
+                    if let Some(get_child_expr) = get_child_expr {
+                        get_child_exprs.push(get_child_expr)
                     }
-
-                    main_class.predicates.push(ql::Predicate {
-                        qldoc: Some(String::from("Gets a field or child node of this node.")),
-                        name: "getAFieldOrChild",
-                        overridden: true,
-                        return_type: Some(ql::Type::Normal("AstNode")),
-                        formal_parameters: vec![],
-                        body: ql::Expression::Or(get_child_exprs),
-                    });
                 }
+
+                main_class.predicates.push(ql::Predicate {
+                    qldoc: Some(String::from("Gets a field or child node of this node.")),
+                    name: "getAFieldOrChild",
+                    overridden: true,
+                    return_type: Some(ql::Type::Normal("AstNode")),
+                    formal_parameters: vec![],
+                    body: ql::Expression::Or(get_child_exprs),
+                });
 
                 classes.push(ql::TopLevel::Class(main_class));
             }

--- a/ruby/generator/src/ql_gen.rs
+++ b/ruby/generator/src/ql_gen.rs
@@ -179,7 +179,6 @@ pub fn create_token_class<'a>(token_type: &'a str, tokeninfo: &'a str) -> ql::Cl
         characteristic_predicate: None,
         predicates: vec![
             get_value,
-            //get_location,
             to_string,
             create_get_a_primary_ql_class("Token", false),
         ],

--- a/ruby/ql/lib/codeql/ruby/AST.qll
+++ b/ruby/ql/lib/codeql/ruby/AST.qll
@@ -126,7 +126,7 @@ class AstNode extends TAstNode {
 
 /** A Ruby source file */
 class RubyFile extends File {
-  RubyFile() { ruby_ast_node_parent(_, this, _) }
+  RubyFile() { ruby_ast_node_info(_, this, _, _) }
 
   /** Gets a token in this file. */
   private Ruby::Token getAToken() { result.getLocation().getFile() = this }

--- a/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
@@ -12,13 +12,13 @@ module Ruby {
     string toString() { result = this.getAPrimaryQlClass() }
 
     /** Gets the location of this element. */
-    L::Location getLocation() { none() }
+    L::Location getLocation() { ruby_ast_node_info(this, _, _, result) }
 
     /** Gets the parent of this element. */
-    AstNode getParent() { ruby_ast_node_parent(this, result, _) }
+    AstNode getParent() { ruby_ast_node_info(this, result, _, _) }
 
     /** Gets the index of this node among the children of its parent. */
-    int getParentIndex() { ruby_ast_node_parent(this, _, result) }
+    int getParentIndex() { ruby_ast_node_info(this, _, result, _) }
 
     /** Gets a field or child node of this node. */
     AstNode getAFieldOrChild() { none() }
@@ -33,10 +33,7 @@ module Ruby {
   /** A token. */
   class Token extends @ruby_token, AstNode {
     /** Gets the value of this token. */
-    string getValue() { ruby_tokeninfo(this, _, result, _) }
-
-    /** Gets the location of this token. */
-    override L::Location getLocation() { ruby_tokeninfo(this, _, _, result) }
+    string getValue() { ruby_tokeninfo(this, _, result) }
 
     /** Gets a string representation of this element. */
     override string toString() { result = this.getValue() }
@@ -84,18 +81,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Alias" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_alias_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `alias`. */
-    UnderscoreMethodName getAlias() { ruby_alias_def(this, result, _, _) }
+    UnderscoreMethodName getAlias() { ruby_alias_def(this, result, _) }
 
     /** Gets the node corresponding to the field `name`. */
-    UnderscoreMethodName getName() { ruby_alias_def(this, _, result, _) }
+    UnderscoreMethodName getName() { ruby_alias_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_alias_def(this, result, _, _) or ruby_alias_def(this, _, result, _)
+      ruby_alias_def(this, result, _) or ruby_alias_def(this, _, result)
     }
   }
 
@@ -103,9 +97,6 @@ module Ruby {
   class AlternativePattern extends @ruby_alternative_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "AlternativePattern" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_alternative_pattern_def(this, result) }
 
     /** Gets the node corresponding to the field `alternatives`. */
     UnderscorePatternExprBasic getAlternatives(int i) {
@@ -121,9 +112,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ArgumentList" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_argument_list_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_argument_list_child(this, i, result) }
 
@@ -136,9 +124,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Array" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_array_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_array_child(this, i, result) }
 
@@ -150,9 +135,6 @@ module Ruby {
   class ArrayPattern extends @ruby_array_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ArrayPattern" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_array_pattern_def(this, result) }
 
     /** Gets the node corresponding to the field `class`. */
     UnderscorePatternConstant getClass() { ruby_array_pattern_class(this, result) }
@@ -171,18 +153,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "AsPattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_as_pattern_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_as_pattern_def(this, result, _, _) }
+    Identifier getName() { ruby_as_pattern_def(this, result, _) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscorePatternExpr getValue() { ruby_as_pattern_def(this, _, result, _) }
+    UnderscorePatternExpr getValue() { ruby_as_pattern_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_as_pattern_def(this, result, _, _) or ruby_as_pattern_def(this, _, result, _)
+      ruby_as_pattern_def(this, result, _) or ruby_as_pattern_def(this, _, result)
     }
   }
 
@@ -191,18 +170,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Assignment" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_assignment_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `left`. */
-    AstNode getLeft() { ruby_assignment_def(this, result, _, _) }
+    AstNode getLeft() { ruby_assignment_def(this, result, _) }
 
     /** Gets the node corresponding to the field `right`. */
-    AstNode getRight() { ruby_assignment_def(this, _, result, _) }
+    AstNode getRight() { ruby_assignment_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_assignment_def(this, result, _, _) or ruby_assignment_def(this, _, result, _)
+      ruby_assignment_def(this, result, _) or ruby_assignment_def(this, _, result)
     }
   }
 
@@ -210,9 +186,6 @@ module Ruby {
   class BareString extends @ruby_bare_string, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "BareString" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_bare_string_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_bare_string_child(this, i, result) }
@@ -226,9 +199,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "BareSymbol" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_bare_symbol_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_bare_symbol_child(this, i, result) }
 
@@ -240,9 +210,6 @@ module Ruby {
   class Begin extends @ruby_begin, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Begin" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_begin_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_begin_child(this, i, result) }
@@ -256,9 +223,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "BeginBlock" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_begin_block_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_begin_block_child(this, i, result) }
 
@@ -271,15 +235,12 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Binary" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_binary_def(this, _, _, _, result) }
-
     /** Gets the node corresponding to the field `left`. */
-    UnderscoreExpression getLeft() { ruby_binary_def(this, result, _, _, _) }
+    UnderscoreExpression getLeft() { ruby_binary_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `operator`. */
     string getOperator() {
-      exists(int value | ruby_binary_def(this, _, value, _, _) |
+      exists(int value | ruby_binary_def(this, _, value, _) |
         result = "!=" and value = 0
         or
         result = "!~" and value = 1
@@ -333,11 +294,11 @@ module Ruby {
     }
 
     /** Gets the node corresponding to the field `right`. */
-    UnderscoreExpression getRight() { ruby_binary_def(this, _, _, result, _) }
+    UnderscoreExpression getRight() { ruby_binary_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_binary_def(this, result, _, _, _) or ruby_binary_def(this, _, _, result, _)
+      ruby_binary_def(this, result, _, _) or ruby_binary_def(this, _, _, result)
     }
   }
 
@@ -345,9 +306,6 @@ module Ruby {
   class Block extends @ruby_block, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Block" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_block_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     BlockParameters getParameters() { ruby_block_parameters(this, result) }
@@ -366,9 +324,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "BlockArgument" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_block_argument_def(this, result) }
-
     /** Gets the child of this node. */
     UnderscoreArg getChild() { ruby_block_argument_child(this, result) }
 
@@ -380,9 +335,6 @@ module Ruby {
   class BlockParameter extends @ruby_block_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "BlockParameter" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_block_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_block_parameter_name(this, result) }
@@ -396,9 +348,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "BlockParameters" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_block_parameters_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_block_parameters_child(this, i, result) }
 
@@ -410,9 +359,6 @@ module Ruby {
   class Break extends @ruby_break, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Break" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_break_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_break_child(this, result) }
@@ -426,9 +372,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Call" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_call_def(this, _, result) }
-
     /** Gets the node corresponding to the field `arguments`. */
     ArgumentList getArguments() { ruby_call_arguments(this, result) }
 
@@ -436,7 +379,7 @@ module Ruby {
     AstNode getBlock() { ruby_call_block(this, result) }
 
     /** Gets the node corresponding to the field `method`. */
-    AstNode getMethod() { ruby_call_def(this, result, _) }
+    AstNode getMethod() { ruby_call_def(this, result) }
 
     /** Gets the node corresponding to the field `receiver`. */
     AstNode getReceiver() { ruby_call_receiver(this, result) }
@@ -445,7 +388,7 @@ module Ruby {
     override AstNode getAFieldOrChild() {
       ruby_call_arguments(this, result) or
       ruby_call_block(this, result) or
-      ruby_call_def(this, result, _) or
+      ruby_call_def(this, result) or
       ruby_call_receiver(this, result)
     }
   }
@@ -454,9 +397,6 @@ module Ruby {
   class Case extends @ruby_case__, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Case" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_case_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
     UnderscoreStatement getValue() { ruby_case_value(this, result) }
@@ -475,9 +415,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "CaseMatch" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_case_match_def(this, _, result) }
-
     /** Gets the node corresponding to the field `clauses`. */
     InClause getClauses(int i) { ruby_case_match_clauses(this, i, result) }
 
@@ -485,13 +422,13 @@ module Ruby {
     Else getElse() { ruby_case_match_else(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreStatement getValue() { ruby_case_match_def(this, result, _) }
+    UnderscoreStatement getValue() { ruby_case_match_def(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
       ruby_case_match_clauses(this, _, result) or
       ruby_case_match_else(this, result) or
-      ruby_case_match_def(this, result, _)
+      ruby_case_match_def(this, result)
     }
   }
 
@@ -499,9 +436,6 @@ module Ruby {
   class ChainedString extends @ruby_chained_string, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ChainedString" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_chained_string_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     String getChild(int i) { ruby_chained_string_child(this, i, result) }
@@ -521,11 +455,8 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Class" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_class_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_class_def(this, result, _) }
+    AstNode getName() { ruby_class_def(this, result) }
 
     /** Gets the node corresponding to the field `superclass`. */
     Superclass getSuperclass() { ruby_class_superclass(this, result) }
@@ -535,7 +466,7 @@ module Ruby {
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_class_def(this, result, _) or
+      ruby_class_def(this, result) or
       ruby_class_superclass(this, result) or
       ruby_class_child(this, _, result)
     }
@@ -564,23 +495,20 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Conditional" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_conditional_def(this, _, _, _, result) }
-
     /** Gets the node corresponding to the field `alternative`. */
-    UnderscoreArg getAlternative() { ruby_conditional_def(this, result, _, _, _) }
+    UnderscoreArg getAlternative() { ruby_conditional_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreArg getCondition() { ruby_conditional_def(this, _, result, _, _) }
+    UnderscoreArg getCondition() { ruby_conditional_def(this, _, result, _) }
 
     /** Gets the node corresponding to the field `consequence`. */
-    UnderscoreArg getConsequence() { ruby_conditional_def(this, _, _, result, _) }
+    UnderscoreArg getConsequence() { ruby_conditional_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_conditional_def(this, result, _, _, _) or
-      ruby_conditional_def(this, _, result, _, _) or
-      ruby_conditional_def(this, _, _, result, _)
+      ruby_conditional_def(this, result, _, _) or
+      ruby_conditional_def(this, _, result, _) or
+      ruby_conditional_def(this, _, _, result)
     }
   }
 
@@ -595,9 +523,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "DelimitedSymbol" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_delimited_symbol_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_delimited_symbol_child(this, i, result) }
 
@@ -609,9 +534,6 @@ module Ruby {
   class DestructuredLeftAssignment extends @ruby_destructured_left_assignment, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "DestructuredLeftAssignment" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_destructured_left_assignment_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_destructured_left_assignment_child(this, i, result) }
@@ -625,9 +547,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "DestructuredParameter" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_destructured_parameter_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_destructured_parameter_child(this, i, result) }
 
@@ -640,9 +559,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Do" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_do_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_do_child(this, i, result) }
 
@@ -654,9 +570,6 @@ module Ruby {
   class DoBlock extends @ruby_do_block, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "DoBlock" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_do_block_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     BlockParameters getParameters() { ruby_do_block_parameters(this, result) }
@@ -675,18 +588,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ElementReference" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_element_reference_def(this, _, result) }
-
     /** Gets the node corresponding to the field `object`. */
-    UnderscorePrimary getObject() { ruby_element_reference_def(this, result, _) }
+    UnderscorePrimary getObject() { ruby_element_reference_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_element_reference_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_element_reference_def(this, result, _) or ruby_element_reference_child(this, _, result)
+      ruby_element_reference_def(this, result) or ruby_element_reference_child(this, _, result)
     }
   }
 
@@ -694,9 +604,6 @@ module Ruby {
   class Else extends @ruby_else, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Else" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_else_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_else_child(this, i, result) }
@@ -710,14 +617,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Elsif" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_elsif_def(this, _, result) }
-
     /** Gets the node corresponding to the field `alternative`. */
     AstNode getAlternative() { ruby_elsif_alternative(this, result) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_elsif_def(this, result, _) }
+    UnderscoreStatement getCondition() { ruby_elsif_def(this, result) }
 
     /** Gets the node corresponding to the field `consequence`. */
     Then getConsequence() { ruby_elsif_consequence(this, result) }
@@ -725,7 +629,7 @@ module Ruby {
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
       ruby_elsif_alternative(this, result) or
-      ruby_elsif_def(this, result, _) or
+      ruby_elsif_def(this, result) or
       ruby_elsif_consequence(this, result)
     }
   }
@@ -747,9 +651,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "EndBlock" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_end_block_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_end_block_child(this, i, result) }
 
@@ -761,9 +662,6 @@ module Ruby {
   class Ensure extends @ruby_ensure, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Ensure" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_ensure_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_ensure_child(this, i, result) }
@@ -783,23 +681,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ExceptionVariable" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_exception_variable_def(this, _, result) }
-
     /** Gets the child of this node. */
-    UnderscoreLhs getChild() { ruby_exception_variable_def(this, result, _) }
+    UnderscoreLhs getChild() { ruby_exception_variable_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_exception_variable_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_exception_variable_def(this, result) }
   }
 
   /** A class representing `exceptions` nodes. */
   class Exceptions extends @ruby_exceptions, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Exceptions" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_exceptions_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_exceptions_child(this, i, result) }
@@ -813,14 +705,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ExpressionReferencePattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_expression_reference_pattern_def(this, _, result) }
-
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreExpression getValue() { ruby_expression_reference_pattern_def(this, result, _) }
+    UnderscoreExpression getValue() { ruby_expression_reference_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_expression_reference_pattern_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_expression_reference_pattern_def(this, result) }
   }
 
   /** A class representing `false` tokens. */
@@ -839,9 +728,6 @@ module Ruby {
   class FindPattern extends @ruby_find_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "FindPattern" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_find_pattern_def(this, result) }
 
     /** Gets the node corresponding to the field `class`. */
     UnderscorePatternConstant getClass() { ruby_find_pattern_class(this, result) }
@@ -866,23 +752,20 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "For" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_for_def(this, _, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    Do getBody() { ruby_for_def(this, result, _, _, _) }
+    Do getBody() { ruby_for_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `pattern`. */
-    AstNode getPattern() { ruby_for_def(this, _, result, _, _) }
+    AstNode getPattern() { ruby_for_def(this, _, result, _) }
 
     /** Gets the node corresponding to the field `value`. */
-    In getValue() { ruby_for_def(this, _, _, result, _) }
+    In getValue() { ruby_for_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_for_def(this, result, _, _, _) or
-      ruby_for_def(this, _, result, _, _) or
-      ruby_for_def(this, _, _, result, _)
+      ruby_for_def(this, result, _, _) or
+      ruby_for_def(this, _, result, _) or
+      ruby_for_def(this, _, _, result)
     }
   }
 
@@ -909,9 +792,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Hash" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_hash_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_hash_child(this, i, result) }
 
@@ -930,9 +810,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "HashPattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_hash_pattern_def(this, result) }
-
     /** Gets the node corresponding to the field `class`. */
     UnderscorePatternConstant getClass() { ruby_hash_pattern_class(this, result) }
 
@@ -950,14 +827,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "HashSplatArgument" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_hash_splat_argument_def(this, _, result) }
-
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_hash_splat_argument_def(this, result, _) }
+    UnderscoreArg getChild() { ruby_hash_splat_argument_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_hash_splat_argument_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_hash_splat_argument_def(this, result) }
   }
 
   /** A class representing `hash_splat_nil` tokens. */
@@ -970,9 +844,6 @@ module Ruby {
   class HashSplatParameter extends @ruby_hash_splat_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "HashSplatParameter" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_hash_splat_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_hash_splat_parameter_name(this, result) }
@@ -991,9 +862,6 @@ module Ruby {
   class HeredocBody extends @ruby_heredoc_body, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "HeredocBody" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_heredoc_body_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_heredoc_body_child(this, i, result) }
@@ -1025,14 +893,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "If" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_if_def(this, _, result) }
-
     /** Gets the node corresponding to the field `alternative`. */
     AstNode getAlternative() { ruby_if_alternative(this, result) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_if_def(this, result, _) }
+    UnderscoreStatement getCondition() { ruby_if_def(this, result) }
 
     /** Gets the node corresponding to the field `consequence`. */
     Then getConsequence() { ruby_if_consequence(this, result) }
@@ -1040,7 +905,7 @@ module Ruby {
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
       ruby_if_alternative(this, result) or
-      ruby_if_def(this, result, _) or
+      ruby_if_def(this, result) or
       ruby_if_consequence(this, result)
     }
   }
@@ -1050,14 +915,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "IfGuard" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_if_guard_def(this, _, result) }
-
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_if_guard_def(this, result, _) }
+    UnderscoreExpression getCondition() { ruby_if_guard_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_if_guard_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_if_guard_def(this, result) }
   }
 
   /** A class representing `if_modifier` nodes. */
@@ -1065,18 +927,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "IfModifier" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_if_modifier_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_if_modifier_def(this, result, _, _) }
+    UnderscoreStatement getBody() { ruby_if_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_if_modifier_def(this, _, result, _) }
+    UnderscoreExpression getCondition() { ruby_if_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_if_modifier_def(this, result, _, _) or ruby_if_modifier_def(this, _, result, _)
+      ruby_if_modifier_def(this, result, _) or ruby_if_modifier_def(this, _, result)
     }
   }
 
@@ -1085,23 +944,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "In" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_in_def(this, _, result) }
-
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_in_def(this, result, _) }
+    UnderscoreArg getChild() { ruby_in_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_in_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_in_def(this, result) }
   }
 
   /** A class representing `in_clause` nodes. */
   class InClause extends @ruby_in_clause, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "InClause" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_in_clause_def(this, _, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Then getBody() { ruby_in_clause_body(this, result) }
@@ -1110,13 +963,13 @@ module Ruby {
     AstNode getGuard() { ruby_in_clause_guard(this, result) }
 
     /** Gets the node corresponding to the field `pattern`. */
-    UnderscorePatternTopExprBody getPattern() { ruby_in_clause_def(this, result, _) }
+    UnderscorePatternTopExprBody getPattern() { ruby_in_clause_def(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
       ruby_in_clause_body(this, result) or
       ruby_in_clause_guard(this, result) or
-      ruby_in_clause_def(this, result, _)
+      ruby_in_clause_def(this, result)
     }
   }
 
@@ -1137,9 +990,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Interpolation" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_interpolation_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_interpolation_child(this, i, result) }
 
@@ -1152,18 +1002,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "KeywordParameter" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_keyword_parameter_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_keyword_parameter_def(this, result, _) }
+    Identifier getName() { ruby_keyword_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
     UnderscoreArg getValue() { ruby_keyword_parameter_value(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_keyword_parameter_def(this, result, _) or ruby_keyword_parameter_value(this, result)
+      ruby_keyword_parameter_def(this, result) or ruby_keyword_parameter_value(this, result)
     }
   }
 
@@ -1172,18 +1019,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "KeywordPattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_keyword_pattern_def(this, _, result) }
-
     /** Gets the node corresponding to the field `key`. */
-    AstNode getKey() { ruby_keyword_pattern_def(this, result, _) }
+    AstNode getKey() { ruby_keyword_pattern_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
     UnderscorePatternExpr getValue() { ruby_keyword_pattern_value(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_keyword_pattern_def(this, result, _) or ruby_keyword_pattern_value(this, result)
+      ruby_keyword_pattern_def(this, result) or ruby_keyword_pattern_value(this, result)
     }
   }
 
@@ -1192,18 +1036,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Lambda" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_lambda_def(this, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    AstNode getBody() { ruby_lambda_def(this, result, _) }
+    AstNode getBody() { ruby_lambda_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     LambdaParameters getParameters() { ruby_lambda_parameters(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_lambda_def(this, result, _) or ruby_lambda_parameters(this, result)
+      ruby_lambda_def(this, result) or ruby_lambda_parameters(this, result)
     }
   }
 
@@ -1211,9 +1052,6 @@ module Ruby {
   class LambdaParameters extends @ruby_lambda_parameters, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "LambdaParameters" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_lambda_parameters_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_lambda_parameters_child(this, i, result) }
@@ -1226,9 +1064,6 @@ module Ruby {
   class LeftAssignmentList extends @ruby_left_assignment_list, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "LeftAssignmentList" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_left_assignment_list_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_left_assignment_list_child(this, i, result) }
@@ -1248,11 +1083,8 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Method" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_method_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    UnderscoreMethodName getName() { ruby_method_def(this, result, _) }
+    UnderscoreMethodName getName() { ruby_method_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     MethodParameters getParameters() { ruby_method_parameters(this, result) }
@@ -1262,7 +1094,7 @@ module Ruby {
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_method_def(this, result, _) or
+      ruby_method_def(this, result) or
       ruby_method_parameters(this, result) or
       ruby_method_child(this, _, result)
     }
@@ -1272,9 +1104,6 @@ module Ruby {
   class MethodParameters extends @ruby_method_parameters, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "MethodParameters" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_method_parameters_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_method_parameters_child(this, i, result) }
@@ -1288,18 +1117,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Module" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_module_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_module_def(this, result, _) }
+    AstNode getName() { ruby_module_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_module_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_module_def(this, result, _) or ruby_module_child(this, _, result)
+      ruby_module_def(this, result) or ruby_module_child(this, _, result)
     }
   }
 
@@ -1307,9 +1133,6 @@ module Ruby {
   class Next extends @ruby_next, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Next" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_next_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_next_child(this, result) }
@@ -1335,15 +1158,12 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "OperatorAssignment" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_operator_assignment_def(this, _, _, _, result) }
-
     /** Gets the node corresponding to the field `left`. */
-    UnderscoreLhs getLeft() { ruby_operator_assignment_def(this, result, _, _, _) }
+    UnderscoreLhs getLeft() { ruby_operator_assignment_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `operator`. */
     string getOperator() {
-      exists(int value | ruby_operator_assignment_def(this, _, value, _, _) |
+      exists(int value | ruby_operator_assignment_def(this, _, value, _) |
         result = "%=" and value = 0
         or
         result = "&&=" and value = 1
@@ -1373,12 +1193,12 @@ module Ruby {
     }
 
     /** Gets the node corresponding to the field `right`. */
-    UnderscoreExpression getRight() { ruby_operator_assignment_def(this, _, _, result, _) }
+    UnderscoreExpression getRight() { ruby_operator_assignment_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_operator_assignment_def(this, result, _, _, _) or
-      ruby_operator_assignment_def(this, _, _, result, _)
+      ruby_operator_assignment_def(this, result, _, _) or
+      ruby_operator_assignment_def(this, _, _, result)
     }
   }
 
@@ -1387,19 +1207,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "OptionalParameter" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_optional_parameter_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_optional_parameter_def(this, result, _, _) }
+    Identifier getName() { ruby_optional_parameter_def(this, result, _) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreArg getValue() { ruby_optional_parameter_def(this, _, result, _) }
+    UnderscoreArg getValue() { ruby_optional_parameter_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_optional_parameter_def(this, result, _, _) or
-      ruby_optional_parameter_def(this, _, result, _)
+      ruby_optional_parameter_def(this, result, _) or ruby_optional_parameter_def(this, _, result)
     }
   }
 
@@ -1408,18 +1224,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Pair" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_pair_def(this, _, result) }
-
     /** Gets the node corresponding to the field `key`. */
-    AstNode getKey() { ruby_pair_def(this, result, _) }
+    AstNode getKey() { ruby_pair_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
     UnderscoreArg getValue() { ruby_pair_value(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_pair_def(this, result, _) or ruby_pair_value(this, result)
+      ruby_pair_def(this, result) or ruby_pair_value(this, result)
     }
   }
 
@@ -1428,23 +1241,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ParenthesizedPattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_parenthesized_pattern_def(this, _, result) }
-
     /** Gets the child of this node. */
-    UnderscorePatternExpr getChild() { ruby_parenthesized_pattern_def(this, result, _) }
+    UnderscorePatternExpr getChild() { ruby_parenthesized_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_parenthesized_pattern_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_parenthesized_pattern_def(this, result) }
   }
 
   /** A class representing `parenthesized_statements` nodes. */
   class ParenthesizedStatements extends @ruby_parenthesized_statements, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ParenthesizedStatements" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_parenthesized_statements_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_parenthesized_statements_child(this, i, result) }
@@ -1458,23 +1265,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Pattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_pattern_def(this, _, result) }
-
     /** Gets the child of this node. */
-    AstNode getChild() { ruby_pattern_def(this, result, _) }
+    AstNode getChild() { ruby_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_pattern_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_pattern_def(this, result) }
   }
 
   /** A class representing `program` nodes. */
   class Program extends @ruby_program, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Program" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_program_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_program_child(this, i, result) }
@@ -1488,9 +1289,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Range" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_range_def(this, _, result) }
-
     /** Gets the node corresponding to the field `begin`. */
     AstNode getBegin() { ruby_range_begin(this, result) }
 
@@ -1499,7 +1297,7 @@ module Ruby {
 
     /** Gets the node corresponding to the field `operator`. */
     string getOperator() {
-      exists(int value | ruby_range_def(this, value, _) |
+      exists(int value | ruby_range_def(this, value) |
         result = ".." and value = 0
         or
         result = "..." and value = 1
@@ -1517,23 +1315,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Rational" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_rational_def(this, _, result) }
-
     /** Gets the child of this node. */
-    AstNode getChild() { ruby_rational_def(this, result, _) }
+    AstNode getChild() { ruby_rational_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_rational_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_rational_def(this, result) }
   }
 
   /** A class representing `redo` nodes. */
   class Redo extends @ruby_redo, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Redo" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_redo_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_redo_child(this, result) }
@@ -1547,9 +1339,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Regex" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_regex_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_regex_child(this, i, result) }
 
@@ -1561,9 +1350,6 @@ module Ruby {
   class Rescue extends @ruby_rescue, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Rescue" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_rescue_def(this, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Then getBody() { ruby_rescue_body(this, result) }
@@ -1587,18 +1373,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "RescueModifier" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_rescue_modifier_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    AstNode getBody() { ruby_rescue_modifier_def(this, result, _, _) }
+    AstNode getBody() { ruby_rescue_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `handler`. */
-    UnderscoreExpression getHandler() { ruby_rescue_modifier_def(this, _, result, _) }
+    UnderscoreExpression getHandler() { ruby_rescue_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_rescue_modifier_def(this, result, _, _) or ruby_rescue_modifier_def(this, _, result, _)
+      ruby_rescue_modifier_def(this, result, _) or ruby_rescue_modifier_def(this, _, result)
     }
   }
 
@@ -1606,9 +1389,6 @@ module Ruby {
   class RestAssignment extends @ruby_rest_assignment, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "RestAssignment" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_rest_assignment_def(this, result) }
 
     /** Gets the child of this node. */
     UnderscoreLhs getChild() { ruby_rest_assignment_child(this, result) }
@@ -1622,9 +1402,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Retry" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_retry_def(this, result) }
-
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_retry_child(this, result) }
 
@@ -1636,9 +1413,6 @@ module Ruby {
   class Return extends @ruby_return, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Return" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_return_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_return_child(this, result) }
@@ -1652,9 +1426,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "RightAssignmentList" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_right_assignment_list_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_right_assignment_list_child(this, i, result) }
 
@@ -1667,18 +1438,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "ScopeResolution" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_scope_resolution_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_scope_resolution_def(this, result, _) }
+    AstNode getName() { ruby_scope_resolution_def(this, result) }
 
     /** Gets the node corresponding to the field `scope`. */
     AstNode getScope() { ruby_scope_resolution_scope(this, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_scope_resolution_def(this, result, _) or ruby_scope_resolution_scope(this, result)
+      ruby_scope_resolution_def(this, result) or ruby_scope_resolution_scope(this, result)
     }
   }
 
@@ -1693,14 +1461,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Setter" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_setter_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_setter_def(this, result, _) }
+    Identifier getName() { ruby_setter_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_setter_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_setter_def(this, result) }
   }
 
   /** A class representing `simple_symbol` tokens. */
@@ -1714,18 +1479,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "SingletonClass" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_singleton_class_def(this, _, result) }
-
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreArg getValue() { ruby_singleton_class_def(this, result, _) }
+    UnderscoreArg getValue() { ruby_singleton_class_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_singleton_class_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_singleton_class_def(this, result, _) or ruby_singleton_class_child(this, _, result)
+      ruby_singleton_class_def(this, result) or ruby_singleton_class_child(this, _, result)
     }
   }
 
@@ -1734,14 +1496,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "SingletonMethod" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_singleton_method_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    UnderscoreMethodName getName() { ruby_singleton_method_def(this, result, _, _) }
+    UnderscoreMethodName getName() { ruby_singleton_method_def(this, result, _) }
 
     /** Gets the node corresponding to the field `object`. */
-    AstNode getObject() { ruby_singleton_method_def(this, _, result, _) }
+    AstNode getObject() { ruby_singleton_method_def(this, _, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
     MethodParameters getParameters() { ruby_singleton_method_parameters(this, result) }
@@ -1751,8 +1510,8 @@ module Ruby {
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_singleton_method_def(this, result, _, _) or
-      ruby_singleton_method_def(this, _, result, _) or
+      ruby_singleton_method_def(this, result, _) or
+      ruby_singleton_method_def(this, _, result) or
       ruby_singleton_method_parameters(this, result) or
       ruby_singleton_method_child(this, _, result)
     }
@@ -1763,23 +1522,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "SplatArgument" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_splat_argument_def(this, _, result) }
-
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_splat_argument_def(this, result, _) }
+    UnderscoreArg getChild() { ruby_splat_argument_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_splat_argument_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_splat_argument_def(this, result) }
   }
 
   /** A class representing `splat_parameter` nodes. */
   class SplatParameter extends @ruby_splat_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "SplatParameter" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_splat_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `name`. */
     Identifier getName() { ruby_splat_parameter_name(this, result) }
@@ -1793,9 +1546,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "String" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_string_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_string_child(this, i, result) }
 
@@ -1807,9 +1557,6 @@ module Ruby {
   class StringArray extends @ruby_string_array, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "StringArray" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_string_array_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     BareString getChild(int i) { ruby_string_array_child(this, i, result) }
@@ -1829,9 +1576,6 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Subshell" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_subshell_def(this, result) }
-
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_subshell_child(this, i, result) }
 
@@ -1850,23 +1594,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Superclass" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_superclass_def(this, _, result) }
-
     /** Gets the child of this node. */
-    UnderscoreExpression getChild() { ruby_superclass_def(this, result, _) }
+    UnderscoreExpression getChild() { ruby_superclass_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_superclass_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_superclass_def(this, result) }
   }
 
   /** A class representing `symbol_array` nodes. */
   class SymbolArray extends @ruby_symbol_array, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "SymbolArray" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_symbol_array_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     BareSymbol getChild(int i) { ruby_symbol_array_child(this, i, result) }
@@ -1879,9 +1617,6 @@ module Ruby {
   class Then extends @ruby_then, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Then" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_then_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { ruby_then_child(this, i, result) }
@@ -1901,15 +1636,12 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Unary" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_unary_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `operand`. */
-    AstNode getOperand() { ruby_unary_def(this, result, _, _) }
+    AstNode getOperand() { ruby_unary_def(this, result, _) }
 
     /** Gets the node corresponding to the field `operator`. */
     string getOperator() {
-      exists(int value | ruby_unary_def(this, _, value, _) |
+      exists(int value | ruby_unary_def(this, _, value) |
         result = "!" and value = 0
         or
         result = "+" and value = 1
@@ -1925,16 +1657,13 @@ module Ruby {
     }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_unary_def(this, result, _, _) }
+    override AstNode getAFieldOrChild() { ruby_unary_def(this, result, _) }
   }
 
   /** A class representing `undef` nodes. */
   class Undef extends @ruby_undef, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Undef" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_undef_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     UnderscoreMethodName getChild(int i) { ruby_undef_child(this, i, result) }
@@ -1954,14 +1683,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Unless" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_unless_def(this, _, result) }
-
     /** Gets the node corresponding to the field `alternative`. */
     AstNode getAlternative() { ruby_unless_alternative(this, result) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_unless_def(this, result, _) }
+    UnderscoreStatement getCondition() { ruby_unless_def(this, result) }
 
     /** Gets the node corresponding to the field `consequence`. */
     Then getConsequence() { ruby_unless_consequence(this, result) }
@@ -1969,7 +1695,7 @@ module Ruby {
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
       ruby_unless_alternative(this, result) or
-      ruby_unless_def(this, result, _) or
+      ruby_unless_def(this, result) or
       ruby_unless_consequence(this, result)
     }
   }
@@ -1979,14 +1705,11 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "UnlessGuard" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_unless_guard_def(this, _, result) }
-
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_unless_guard_def(this, result, _) }
+    UnderscoreExpression getCondition() { ruby_unless_guard_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_unless_guard_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_unless_guard_def(this, result) }
   }
 
   /** A class representing `unless_modifier` nodes. */
@@ -1994,18 +1717,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "UnlessModifier" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_unless_modifier_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_unless_modifier_def(this, result, _, _) }
+    UnderscoreStatement getBody() { ruby_unless_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_unless_modifier_def(this, _, result, _) }
+    UnderscoreExpression getCondition() { ruby_unless_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_unless_modifier_def(this, result, _, _) or ruby_unless_modifier_def(this, _, result, _)
+      ruby_unless_modifier_def(this, result, _) or ruby_unless_modifier_def(this, _, result)
     }
   }
 
@@ -2014,18 +1734,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Until" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_until_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    Do getBody() { ruby_until_def(this, result, _, _) }
+    Do getBody() { ruby_until_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_until_def(this, _, result, _) }
+    UnderscoreStatement getCondition() { ruby_until_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_until_def(this, result, _, _) or ruby_until_def(this, _, result, _)
+      ruby_until_def(this, result, _) or ruby_until_def(this, _, result)
     }
   }
 
@@ -2034,18 +1751,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "UntilModifier" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_until_modifier_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_until_modifier_def(this, result, _, _) }
+    UnderscoreStatement getBody() { ruby_until_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_until_modifier_def(this, _, result, _) }
+    UnderscoreExpression getCondition() { ruby_until_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_until_modifier_def(this, result, _, _) or ruby_until_modifier_def(this, _, result, _)
+      ruby_until_modifier_def(this, result, _) or ruby_until_modifier_def(this, _, result)
     }
   }
 
@@ -2054,23 +1768,17 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "VariableReferencePattern" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_variable_reference_pattern_def(this, _, result) }
-
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_variable_reference_pattern_def(this, result, _) }
+    AstNode getName() { ruby_variable_reference_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_variable_reference_pattern_def(this, result, _) }
+    override AstNode getAFieldOrChild() { ruby_variable_reference_pattern_def(this, result) }
   }
 
   /** A class representing `when` nodes. */
   class When extends @ruby_when, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "When" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_when_def(this, result) }
 
     /** Gets the node corresponding to the field `body`. */
     Then getBody() { ruby_when_body(this, result) }
@@ -2089,18 +1797,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "While" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_while_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    Do getBody() { ruby_while_def(this, result, _, _) }
+    Do getBody() { ruby_while_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_while_def(this, _, result, _) }
+    UnderscoreStatement getCondition() { ruby_while_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_while_def(this, result, _, _) or ruby_while_def(this, _, result, _)
+      ruby_while_def(this, result, _) or ruby_while_def(this, _, result)
     }
   }
 
@@ -2109,18 +1814,15 @@ module Ruby {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "WhileModifier" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_while_modifier_def(this, _, _, result) }
-
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_while_modifier_def(this, result, _, _) }
+    UnderscoreStatement getBody() { ruby_while_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_while_modifier_def(this, _, result, _) }
+    UnderscoreExpression getCondition() { ruby_while_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
     override AstNode getAFieldOrChild() {
-      ruby_while_modifier_def(this, result, _, _) or ruby_while_modifier_def(this, _, result, _)
+      ruby_while_modifier_def(this, result, _) or ruby_while_modifier_def(this, _, result)
     }
   }
 
@@ -2128,9 +1830,6 @@ module Ruby {
   class Yield extends @ruby_yield, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Yield" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { ruby_yield_def(this, result) }
 
     /** Gets the child of this node. */
     ArgumentList getChild() { ruby_yield_child(this, result) }
@@ -2147,13 +1846,13 @@ module Erb {
     string toString() { result = this.getAPrimaryQlClass() }
 
     /** Gets the location of this element. */
-    L::Location getLocation() { none() }
+    L::Location getLocation() { erb_ast_node_info(this, _, _, result) }
 
     /** Gets the parent of this element. */
-    AstNode getParent() { erb_ast_node_parent(this, result, _) }
+    AstNode getParent() { erb_ast_node_info(this, result, _, _) }
 
     /** Gets the index of this node among the children of its parent. */
-    int getParentIndex() { erb_ast_node_parent(this, _, result) }
+    int getParentIndex() { erb_ast_node_info(this, _, result, _) }
 
     /** Gets a field or child node of this node. */
     AstNode getAFieldOrChild() { none() }
@@ -2168,10 +1867,7 @@ module Erb {
   /** A token. */
   class Token extends @erb_token, AstNode {
     /** Gets the value of this token. */
-    string getValue() { erb_tokeninfo(this, _, result, _) }
-
-    /** Gets the location of this token. */
-    override L::Location getLocation() { erb_tokeninfo(this, _, _, result) }
+    string getValue() { erb_tokeninfo(this, _, result) }
 
     /** Gets a string representation of this element. */
     override string toString() { result = this.getValue() }
@@ -2203,14 +1899,11 @@ module Erb {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "CommentDirective" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { erb_comment_directive_def(this, _, result) }
-
     /** Gets the child of this node. */
-    Comment getChild() { erb_comment_directive_def(this, result, _) }
+    Comment getChild() { erb_comment_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_comment_directive_def(this, result, _) }
+    override AstNode getAFieldOrChild() { erb_comment_directive_def(this, result) }
   }
 
   /** A class representing `content` tokens. */
@@ -2224,14 +1917,11 @@ module Erb {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Directive" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { erb_directive_def(this, _, result) }
-
     /** Gets the child of this node. */
-    Code getChild() { erb_directive_def(this, result, _) }
+    Code getChild() { erb_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_directive_def(this, result, _) }
+    override AstNode getAFieldOrChild() { erb_directive_def(this, result) }
   }
 
   /** A class representing `graphql_directive` nodes. */
@@ -2239,14 +1929,11 @@ module Erb {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "GraphqlDirective" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { erb_graphql_directive_def(this, _, result) }
-
     /** Gets the child of this node. */
-    Code getChild() { erb_graphql_directive_def(this, result, _) }
+    Code getChild() { erb_graphql_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_graphql_directive_def(this, result, _) }
+    override AstNode getAFieldOrChild() { erb_graphql_directive_def(this, result) }
   }
 
   /** A class representing `output_directive` nodes. */
@@ -2254,23 +1941,17 @@ module Erb {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "OutputDirective" }
 
-    /** Gets the location of this element. */
-    override L::Location getLocation() { erb_output_directive_def(this, _, result) }
-
     /** Gets the child of this node. */
-    Code getChild() { erb_output_directive_def(this, result, _) }
+    Code getChild() { erb_output_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_output_directive_def(this, result, _) }
+    override AstNode getAFieldOrChild() { erb_output_directive_def(this, result) }
   }
 
   /** A class representing `template` nodes. */
   class Template extends @erb_template, AstNode {
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Template" }
-
-    /** Gets the location of this element. */
-    override L::Location getLocation() { erb_template_def(this, result) }
 
     /** Gets the `i`th child of this node. */
     AstNode getChild(int i) { erb_template_child(this, i, result) }

--- a/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
@@ -12,13 +12,13 @@ module Ruby {
     string toString() { result = this.getAPrimaryQlClass() }
 
     /** Gets the location of this element. */
-    L::Location getLocation() { ruby_ast_node_info(this, _, _, result) }
+    final L::Location getLocation() { ruby_ast_node_info(this, _, _, result) }
 
     /** Gets the parent of this element. */
-    AstNode getParent() { ruby_ast_node_info(this, result, _, _) }
+    final AstNode getParent() { ruby_ast_node_info(this, result, _, _) }
 
     /** Gets the index of this node among the children of its parent. */
-    int getParentIndex() { ruby_ast_node_info(this, _, result, _) }
+    final int getParentIndex() { ruby_ast_node_info(this, _, result, _) }
 
     /** Gets a field or child node of this node. */
     AstNode getAFieldOrChild() { none() }
@@ -33,10 +33,10 @@ module Ruby {
   /** A token. */
   class Token extends @ruby_token, AstNode {
     /** Gets the value of this token. */
-    string getValue() { ruby_tokeninfo(this, _, result) }
+    final string getValue() { ruby_tokeninfo(this, _, result) }
 
     /** Gets a string representation of this element. */
-    override string toString() { result = this.getValue() }
+    final override string toString() { result = this.getValue() }
 
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Token" }
@@ -45,7 +45,7 @@ module Ruby {
   /** A reserved word. */
   class ReservedWord extends @ruby_reserved_word, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ReservedWord" }
+    final override string getAPrimaryQlClass() { result = "ReservedWord" }
   }
 
   class UnderscoreArg extends @ruby_underscore_arg, AstNode { }
@@ -79,16 +79,16 @@ module Ruby {
   /** A class representing `alias` nodes. */
   class Alias extends @ruby_alias, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Alias" }
+    final override string getAPrimaryQlClass() { result = "Alias" }
 
     /** Gets the node corresponding to the field `alias`. */
-    UnderscoreMethodName getAlias() { ruby_alias_def(this, result, _) }
+    final UnderscoreMethodName getAlias() { ruby_alias_def(this, result, _) }
 
     /** Gets the node corresponding to the field `name`. */
-    UnderscoreMethodName getName() { ruby_alias_def(this, _, result) }
+    final UnderscoreMethodName getName() { ruby_alias_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_alias_def(this, result, _) or ruby_alias_def(this, _, result)
     }
   }
@@ -96,54 +96,56 @@ module Ruby {
   /** A class representing `alternative_pattern` nodes. */
   class AlternativePattern extends @ruby_alternative_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "AlternativePattern" }
+    final override string getAPrimaryQlClass() { result = "AlternativePattern" }
 
     /** Gets the node corresponding to the field `alternatives`. */
-    UnderscorePatternExprBasic getAlternatives(int i) {
+    final UnderscorePatternExprBasic getAlternatives(int i) {
       ruby_alternative_pattern_alternatives(this, i, result)
     }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_alternative_pattern_alternatives(this, _, result) }
+    final override AstNode getAFieldOrChild() {
+      ruby_alternative_pattern_alternatives(this, _, result)
+    }
   }
 
   /** A class representing `argument_list` nodes. */
   class ArgumentList extends @ruby_argument_list, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ArgumentList" }
+    final override string getAPrimaryQlClass() { result = "ArgumentList" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_argument_list_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_argument_list_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_argument_list_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_argument_list_child(this, _, result) }
   }
 
   /** A class representing `array` nodes. */
   class Array extends @ruby_array, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Array" }
+    final override string getAPrimaryQlClass() { result = "Array" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_array_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_array_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_array_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_array_child(this, _, result) }
   }
 
   /** A class representing `array_pattern` nodes. */
   class ArrayPattern extends @ruby_array_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ArrayPattern" }
+    final override string getAPrimaryQlClass() { result = "ArrayPattern" }
 
     /** Gets the node corresponding to the field `class`. */
-    UnderscorePatternConstant getClass() { ruby_array_pattern_class(this, result) }
+    final UnderscorePatternConstant getClass() { ruby_array_pattern_class(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_array_pattern_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_array_pattern_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_array_pattern_class(this, result) or ruby_array_pattern_child(this, _, result)
     }
   }
@@ -151,16 +153,16 @@ module Ruby {
   /** A class representing `as_pattern` nodes. */
   class AsPattern extends @ruby_as_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "AsPattern" }
+    final override string getAPrimaryQlClass() { result = "AsPattern" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_as_pattern_def(this, result, _) }
+    final Identifier getName() { ruby_as_pattern_def(this, result, _) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscorePatternExpr getValue() { ruby_as_pattern_def(this, _, result) }
+    final UnderscorePatternExpr getValue() { ruby_as_pattern_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_as_pattern_def(this, result, _) or ruby_as_pattern_def(this, _, result)
     }
   }
@@ -168,16 +170,16 @@ module Ruby {
   /** A class representing `assignment` nodes. */
   class Assignment extends @ruby_assignment, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Assignment" }
+    final override string getAPrimaryQlClass() { result = "Assignment" }
 
     /** Gets the node corresponding to the field `left`. */
-    AstNode getLeft() { ruby_assignment_def(this, result, _) }
+    final AstNode getLeft() { ruby_assignment_def(this, result, _) }
 
     /** Gets the node corresponding to the field `right`. */
-    AstNode getRight() { ruby_assignment_def(this, _, result) }
+    final AstNode getRight() { ruby_assignment_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_assignment_def(this, result, _) or ruby_assignment_def(this, _, result)
     }
   }
@@ -185,61 +187,61 @@ module Ruby {
   /** A class representing `bare_string` nodes. */
   class BareString extends @ruby_bare_string, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "BareString" }
+    final override string getAPrimaryQlClass() { result = "BareString" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_bare_string_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_bare_string_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_bare_string_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_bare_string_child(this, _, result) }
   }
 
   /** A class representing `bare_symbol` nodes. */
   class BareSymbol extends @ruby_bare_symbol, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "BareSymbol" }
+    final override string getAPrimaryQlClass() { result = "BareSymbol" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_bare_symbol_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_bare_symbol_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_bare_symbol_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_bare_symbol_child(this, _, result) }
   }
 
   /** A class representing `begin` nodes. */
   class Begin extends @ruby_begin, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Begin" }
+    final override string getAPrimaryQlClass() { result = "Begin" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_begin_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_begin_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_begin_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_begin_child(this, _, result) }
   }
 
   /** A class representing `begin_block` nodes. */
   class BeginBlock extends @ruby_begin_block, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "BeginBlock" }
+    final override string getAPrimaryQlClass() { result = "BeginBlock" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_begin_block_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_begin_block_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_begin_block_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_begin_block_child(this, _, result) }
   }
 
   /** A class representing `binary` nodes. */
   class Binary extends @ruby_binary, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Binary" }
+    final override string getAPrimaryQlClass() { result = "Binary" }
 
     /** Gets the node corresponding to the field `left`. */
-    UnderscoreExpression getLeft() { ruby_binary_def(this, result, _, _) }
+    final UnderscoreExpression getLeft() { ruby_binary_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `operator`. */
-    string getOperator() {
+    final string getOperator() {
       exists(int value | ruby_binary_def(this, _, value, _) |
         result = "!=" and value = 0
         or
@@ -294,10 +296,10 @@ module Ruby {
     }
 
     /** Gets the node corresponding to the field `right`. */
-    UnderscoreExpression getRight() { ruby_binary_def(this, _, _, result) }
+    final UnderscoreExpression getRight() { ruby_binary_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_binary_def(this, result, _, _) or ruby_binary_def(this, _, _, result)
     }
   }
@@ -305,16 +307,16 @@ module Ruby {
   /** A class representing `block` nodes. */
   class Block extends @ruby_block, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Block" }
+    final override string getAPrimaryQlClass() { result = "Block" }
 
     /** Gets the node corresponding to the field `parameters`. */
-    BlockParameters getParameters() { ruby_block_parameters(this, result) }
+    final BlockParameters getParameters() { ruby_block_parameters(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_block_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_block_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_block_parameters(this, result) or ruby_block_child(this, _, result)
     }
   }
@@ -322,70 +324,70 @@ module Ruby {
   /** A class representing `block_argument` nodes. */
   class BlockArgument extends @ruby_block_argument, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "BlockArgument" }
+    final override string getAPrimaryQlClass() { result = "BlockArgument" }
 
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_block_argument_child(this, result) }
+    final UnderscoreArg getChild() { ruby_block_argument_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_block_argument_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_block_argument_child(this, result) }
   }
 
   /** A class representing `block_parameter` nodes. */
   class BlockParameter extends @ruby_block_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "BlockParameter" }
+    final override string getAPrimaryQlClass() { result = "BlockParameter" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_block_parameter_name(this, result) }
+    final Identifier getName() { ruby_block_parameter_name(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_block_parameter_name(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_block_parameter_name(this, result) }
   }
 
   /** A class representing `block_parameters` nodes. */
   class BlockParameters extends @ruby_block_parameters, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "BlockParameters" }
+    final override string getAPrimaryQlClass() { result = "BlockParameters" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_block_parameters_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_block_parameters_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_block_parameters_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_block_parameters_child(this, _, result) }
   }
 
   /** A class representing `break` nodes. */
   class Break extends @ruby_break, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Break" }
+    final override string getAPrimaryQlClass() { result = "Break" }
 
     /** Gets the child of this node. */
-    ArgumentList getChild() { ruby_break_child(this, result) }
+    final ArgumentList getChild() { ruby_break_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_break_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_break_child(this, result) }
   }
 
   /** A class representing `call` nodes. */
   class Call extends @ruby_call, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Call" }
+    final override string getAPrimaryQlClass() { result = "Call" }
 
     /** Gets the node corresponding to the field `arguments`. */
-    ArgumentList getArguments() { ruby_call_arguments(this, result) }
+    final ArgumentList getArguments() { ruby_call_arguments(this, result) }
 
     /** Gets the node corresponding to the field `block`. */
-    AstNode getBlock() { ruby_call_block(this, result) }
+    final AstNode getBlock() { ruby_call_block(this, result) }
 
     /** Gets the node corresponding to the field `method`. */
-    AstNode getMethod() { ruby_call_def(this, result) }
+    final AstNode getMethod() { ruby_call_def(this, result) }
 
     /** Gets the node corresponding to the field `receiver`. */
-    AstNode getReceiver() { ruby_call_receiver(this, result) }
+    final AstNode getReceiver() { ruby_call_receiver(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_call_arguments(this, result) or
       ruby_call_block(this, result) or
       ruby_call_def(this, result) or
@@ -396,16 +398,16 @@ module Ruby {
   /** A class representing `case` nodes. */
   class Case extends @ruby_case__, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Case" }
+    final override string getAPrimaryQlClass() { result = "Case" }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreStatement getValue() { ruby_case_value(this, result) }
+    final UnderscoreStatement getValue() { ruby_case_value(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_case_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_case_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_case_value(this, result) or ruby_case_child(this, _, result)
     }
   }
@@ -413,19 +415,19 @@ module Ruby {
   /** A class representing `case_match` nodes. */
   class CaseMatch extends @ruby_case_match, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "CaseMatch" }
+    final override string getAPrimaryQlClass() { result = "CaseMatch" }
 
     /** Gets the node corresponding to the field `clauses`. */
-    InClause getClauses(int i) { ruby_case_match_clauses(this, i, result) }
+    final InClause getClauses(int i) { ruby_case_match_clauses(this, i, result) }
 
     /** Gets the node corresponding to the field `else`. */
-    Else getElse() { ruby_case_match_else(this, result) }
+    final Else getElse() { ruby_case_match_else(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreStatement getValue() { ruby_case_match_def(this, result) }
+    final UnderscoreStatement getValue() { ruby_case_match_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_case_match_clauses(this, _, result) or
       ruby_case_match_else(this, result) or
       ruby_case_match_def(this, result)
@@ -435,37 +437,37 @@ module Ruby {
   /** A class representing `chained_string` nodes. */
   class ChainedString extends @ruby_chained_string, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ChainedString" }
+    final override string getAPrimaryQlClass() { result = "ChainedString" }
 
     /** Gets the `i`th child of this node. */
-    String getChild(int i) { ruby_chained_string_child(this, i, result) }
+    final String getChild(int i) { ruby_chained_string_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_chained_string_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_chained_string_child(this, _, result) }
   }
 
   /** A class representing `character` tokens. */
   class Character extends @ruby_token_character, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Character" }
+    final override string getAPrimaryQlClass() { result = "Character" }
   }
 
   /** A class representing `class` nodes. */
   class Class extends @ruby_class, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Class" }
+    final override string getAPrimaryQlClass() { result = "Class" }
 
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_class_def(this, result) }
+    final AstNode getName() { ruby_class_def(this, result) }
 
     /** Gets the node corresponding to the field `superclass`. */
-    Superclass getSuperclass() { ruby_class_superclass(this, result) }
+    final Superclass getSuperclass() { ruby_class_superclass(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_class_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_class_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_class_def(this, result) or
       ruby_class_superclass(this, result) or
       ruby_class_child(this, _, result)
@@ -475,37 +477,37 @@ module Ruby {
   /** A class representing `class_variable` tokens. */
   class ClassVariable extends @ruby_token_class_variable, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ClassVariable" }
+    final override string getAPrimaryQlClass() { result = "ClassVariable" }
   }
 
   /** A class representing `comment` tokens. */
   class Comment extends @ruby_token_comment, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Comment" }
+    final override string getAPrimaryQlClass() { result = "Comment" }
   }
 
   /** A class representing `complex` tokens. */
   class Complex extends @ruby_token_complex, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Complex" }
+    final override string getAPrimaryQlClass() { result = "Complex" }
   }
 
   /** A class representing `conditional` nodes. */
   class Conditional extends @ruby_conditional, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Conditional" }
+    final override string getAPrimaryQlClass() { result = "Conditional" }
 
     /** Gets the node corresponding to the field `alternative`. */
-    UnderscoreArg getAlternative() { ruby_conditional_def(this, result, _, _) }
+    final UnderscoreArg getAlternative() { ruby_conditional_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreArg getCondition() { ruby_conditional_def(this, _, result, _) }
+    final UnderscoreArg getCondition() { ruby_conditional_def(this, _, result, _) }
 
     /** Gets the node corresponding to the field `consequence`. */
-    UnderscoreArg getConsequence() { ruby_conditional_def(this, _, _, result) }
+    final UnderscoreArg getConsequence() { ruby_conditional_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_conditional_def(this, result, _, _) or
       ruby_conditional_def(this, _, result, _) or
       ruby_conditional_def(this, _, _, result)
@@ -515,70 +517,72 @@ module Ruby {
   /** A class representing `constant` tokens. */
   class Constant extends @ruby_token_constant, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Constant" }
+    final override string getAPrimaryQlClass() { result = "Constant" }
   }
 
   /** A class representing `delimited_symbol` nodes. */
   class DelimitedSymbol extends @ruby_delimited_symbol, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "DelimitedSymbol" }
+    final override string getAPrimaryQlClass() { result = "DelimitedSymbol" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_delimited_symbol_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_delimited_symbol_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_delimited_symbol_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_delimited_symbol_child(this, _, result) }
   }
 
   /** A class representing `destructured_left_assignment` nodes. */
   class DestructuredLeftAssignment extends @ruby_destructured_left_assignment, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "DestructuredLeftAssignment" }
+    final override string getAPrimaryQlClass() { result = "DestructuredLeftAssignment" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_destructured_left_assignment_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_destructured_left_assignment_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_destructured_left_assignment_child(this, _, result) }
+    final override AstNode getAFieldOrChild() {
+      ruby_destructured_left_assignment_child(this, _, result)
+    }
   }
 
   /** A class representing `destructured_parameter` nodes. */
   class DestructuredParameter extends @ruby_destructured_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "DestructuredParameter" }
+    final override string getAPrimaryQlClass() { result = "DestructuredParameter" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_destructured_parameter_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_destructured_parameter_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_destructured_parameter_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_destructured_parameter_child(this, _, result) }
   }
 
   /** A class representing `do` nodes. */
   class Do extends @ruby_do, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Do" }
+    final override string getAPrimaryQlClass() { result = "Do" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_do_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_do_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_do_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_do_child(this, _, result) }
   }
 
   /** A class representing `do_block` nodes. */
   class DoBlock extends @ruby_do_block, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "DoBlock" }
+    final override string getAPrimaryQlClass() { result = "DoBlock" }
 
     /** Gets the node corresponding to the field `parameters`. */
-    BlockParameters getParameters() { ruby_do_block_parameters(this, result) }
+    final BlockParameters getParameters() { ruby_do_block_parameters(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_do_block_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_do_block_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_do_block_parameters(this, result) or ruby_do_block_child(this, _, result)
     }
   }
@@ -586,16 +590,16 @@ module Ruby {
   /** A class representing `element_reference` nodes. */
   class ElementReference extends @ruby_element_reference, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ElementReference" }
+    final override string getAPrimaryQlClass() { result = "ElementReference" }
 
     /** Gets the node corresponding to the field `object`. */
-    UnderscorePrimary getObject() { ruby_element_reference_def(this, result) }
+    final UnderscorePrimary getObject() { ruby_element_reference_def(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_element_reference_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_element_reference_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_element_reference_def(this, result) or ruby_element_reference_child(this, _, result)
     }
   }
@@ -603,31 +607,31 @@ module Ruby {
   /** A class representing `else` nodes. */
   class Else extends @ruby_else, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Else" }
+    final override string getAPrimaryQlClass() { result = "Else" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_else_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_else_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_else_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_else_child(this, _, result) }
   }
 
   /** A class representing `elsif` nodes. */
   class Elsif extends @ruby_elsif, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Elsif" }
+    final override string getAPrimaryQlClass() { result = "Elsif" }
 
     /** Gets the node corresponding to the field `alternative`. */
-    AstNode getAlternative() { ruby_elsif_alternative(this, result) }
+    final AstNode getAlternative() { ruby_elsif_alternative(this, result) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_elsif_def(this, result) }
+    final UnderscoreStatement getCondition() { ruby_elsif_def(this, result) }
 
     /** Gets the node corresponding to the field `consequence`. */
-    Then getConsequence() { ruby_elsif_consequence(this, result) }
+    final Then getConsequence() { ruby_elsif_consequence(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_elsif_alternative(this, result) or
       ruby_elsif_def(this, result) or
       ruby_elsif_consequence(this, result)
@@ -637,106 +641,108 @@ module Ruby {
   /** A class representing `empty_statement` tokens. */
   class EmptyStatement extends @ruby_token_empty_statement, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "EmptyStatement" }
+    final override string getAPrimaryQlClass() { result = "EmptyStatement" }
   }
 
   /** A class representing `encoding` tokens. */
   class Encoding extends @ruby_token_encoding, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Encoding" }
+    final override string getAPrimaryQlClass() { result = "Encoding" }
   }
 
   /** A class representing `end_block` nodes. */
   class EndBlock extends @ruby_end_block, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "EndBlock" }
+    final override string getAPrimaryQlClass() { result = "EndBlock" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_end_block_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_end_block_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_end_block_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_end_block_child(this, _, result) }
   }
 
   /** A class representing `ensure` nodes. */
   class Ensure extends @ruby_ensure, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Ensure" }
+    final override string getAPrimaryQlClass() { result = "Ensure" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_ensure_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_ensure_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_ensure_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_ensure_child(this, _, result) }
   }
 
   /** A class representing `escape_sequence` tokens. */
   class EscapeSequence extends @ruby_token_escape_sequence, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "EscapeSequence" }
+    final override string getAPrimaryQlClass() { result = "EscapeSequence" }
   }
 
   /** A class representing `exception_variable` nodes. */
   class ExceptionVariable extends @ruby_exception_variable, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ExceptionVariable" }
+    final override string getAPrimaryQlClass() { result = "ExceptionVariable" }
 
     /** Gets the child of this node. */
-    UnderscoreLhs getChild() { ruby_exception_variable_def(this, result) }
+    final UnderscoreLhs getChild() { ruby_exception_variable_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_exception_variable_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_exception_variable_def(this, result) }
   }
 
   /** A class representing `exceptions` nodes. */
   class Exceptions extends @ruby_exceptions, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Exceptions" }
+    final override string getAPrimaryQlClass() { result = "Exceptions" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_exceptions_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_exceptions_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_exceptions_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_exceptions_child(this, _, result) }
   }
 
   /** A class representing `expression_reference_pattern` nodes. */
   class ExpressionReferencePattern extends @ruby_expression_reference_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ExpressionReferencePattern" }
+    final override string getAPrimaryQlClass() { result = "ExpressionReferencePattern" }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreExpression getValue() { ruby_expression_reference_pattern_def(this, result) }
+    final UnderscoreExpression getValue() { ruby_expression_reference_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_expression_reference_pattern_def(this, result) }
+    final override AstNode getAFieldOrChild() {
+      ruby_expression_reference_pattern_def(this, result)
+    }
   }
 
   /** A class representing `false` tokens. */
   class False extends @ruby_token_false, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "False" }
+    final override string getAPrimaryQlClass() { result = "False" }
   }
 
   /** A class representing `file` tokens. */
   class File extends @ruby_token_file, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "File" }
+    final override string getAPrimaryQlClass() { result = "File" }
   }
 
   /** A class representing `find_pattern` nodes. */
   class FindPattern extends @ruby_find_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "FindPattern" }
+    final override string getAPrimaryQlClass() { result = "FindPattern" }
 
     /** Gets the node corresponding to the field `class`. */
-    UnderscorePatternConstant getClass() { ruby_find_pattern_class(this, result) }
+    final UnderscorePatternConstant getClass() { ruby_find_pattern_class(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_find_pattern_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_find_pattern_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_find_pattern_class(this, result) or ruby_find_pattern_child(this, _, result)
     }
   }
@@ -744,25 +750,25 @@ module Ruby {
   /** A class representing `float` tokens. */
   class Float extends @ruby_token_float, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Float" }
+    final override string getAPrimaryQlClass() { result = "Float" }
   }
 
   /** A class representing `for` nodes. */
   class For extends @ruby_for, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "For" }
+    final override string getAPrimaryQlClass() { result = "For" }
 
     /** Gets the node corresponding to the field `body`. */
-    Do getBody() { ruby_for_def(this, result, _, _) }
+    final Do getBody() { ruby_for_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `pattern`. */
-    AstNode getPattern() { ruby_for_def(this, _, result, _) }
+    final AstNode getPattern() { ruby_for_def(this, _, result, _) }
 
     /** Gets the node corresponding to the field `value`. */
-    In getValue() { ruby_for_def(this, _, _, result) }
+    final In getValue() { ruby_for_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_for_def(this, result, _, _) or
       ruby_for_def(this, _, result, _) or
       ruby_for_def(this, _, _, result)
@@ -772,52 +778,52 @@ module Ruby {
   /** A class representing `forward_argument` tokens. */
   class ForwardArgument extends @ruby_token_forward_argument, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ForwardArgument" }
+    final override string getAPrimaryQlClass() { result = "ForwardArgument" }
   }
 
   /** A class representing `forward_parameter` tokens. */
   class ForwardParameter extends @ruby_token_forward_parameter, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ForwardParameter" }
+    final override string getAPrimaryQlClass() { result = "ForwardParameter" }
   }
 
   /** A class representing `global_variable` tokens. */
   class GlobalVariable extends @ruby_token_global_variable, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "GlobalVariable" }
+    final override string getAPrimaryQlClass() { result = "GlobalVariable" }
   }
 
   /** A class representing `hash` nodes. */
   class Hash extends @ruby_hash, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Hash" }
+    final override string getAPrimaryQlClass() { result = "Hash" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_hash_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_hash_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_hash_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_hash_child(this, _, result) }
   }
 
   /** A class representing `hash_key_symbol` tokens. */
   class HashKeySymbol extends @ruby_token_hash_key_symbol, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HashKeySymbol" }
+    final override string getAPrimaryQlClass() { result = "HashKeySymbol" }
   }
 
   /** A class representing `hash_pattern` nodes. */
   class HashPattern extends @ruby_hash_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HashPattern" }
+    final override string getAPrimaryQlClass() { result = "HashPattern" }
 
     /** Gets the node corresponding to the field `class`. */
-    UnderscorePatternConstant getClass() { ruby_hash_pattern_class(this, result) }
+    final UnderscorePatternConstant getClass() { ruby_hash_pattern_class(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_hash_pattern_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_hash_pattern_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_hash_pattern_class(this, result) or ruby_hash_pattern_child(this, _, result)
     }
   }
@@ -825,85 +831,85 @@ module Ruby {
   /** A class representing `hash_splat_argument` nodes. */
   class HashSplatArgument extends @ruby_hash_splat_argument, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HashSplatArgument" }
+    final override string getAPrimaryQlClass() { result = "HashSplatArgument" }
 
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_hash_splat_argument_def(this, result) }
+    final UnderscoreArg getChild() { ruby_hash_splat_argument_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_hash_splat_argument_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_hash_splat_argument_def(this, result) }
   }
 
   /** A class representing `hash_splat_nil` tokens. */
   class HashSplatNil extends @ruby_token_hash_splat_nil, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HashSplatNil" }
+    final override string getAPrimaryQlClass() { result = "HashSplatNil" }
   }
 
   /** A class representing `hash_splat_parameter` nodes. */
   class HashSplatParameter extends @ruby_hash_splat_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HashSplatParameter" }
+    final override string getAPrimaryQlClass() { result = "HashSplatParameter" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_hash_splat_parameter_name(this, result) }
+    final Identifier getName() { ruby_hash_splat_parameter_name(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_hash_splat_parameter_name(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_hash_splat_parameter_name(this, result) }
   }
 
   /** A class representing `heredoc_beginning` tokens. */
   class HeredocBeginning extends @ruby_token_heredoc_beginning, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HeredocBeginning" }
+    final override string getAPrimaryQlClass() { result = "HeredocBeginning" }
   }
 
   /** A class representing `heredoc_body` nodes. */
   class HeredocBody extends @ruby_heredoc_body, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HeredocBody" }
+    final override string getAPrimaryQlClass() { result = "HeredocBody" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_heredoc_body_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_heredoc_body_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_heredoc_body_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_heredoc_body_child(this, _, result) }
   }
 
   /** A class representing `heredoc_content` tokens. */
   class HeredocContent extends @ruby_token_heredoc_content, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HeredocContent" }
+    final override string getAPrimaryQlClass() { result = "HeredocContent" }
   }
 
   /** A class representing `heredoc_end` tokens. */
   class HeredocEnd extends @ruby_token_heredoc_end, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "HeredocEnd" }
+    final override string getAPrimaryQlClass() { result = "HeredocEnd" }
   }
 
   /** A class representing `identifier` tokens. */
   class Identifier extends @ruby_token_identifier, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Identifier" }
+    final override string getAPrimaryQlClass() { result = "Identifier" }
   }
 
   /** A class representing `if` nodes. */
   class If extends @ruby_if, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "If" }
+    final override string getAPrimaryQlClass() { result = "If" }
 
     /** Gets the node corresponding to the field `alternative`. */
-    AstNode getAlternative() { ruby_if_alternative(this, result) }
+    final AstNode getAlternative() { ruby_if_alternative(this, result) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_if_def(this, result) }
+    final UnderscoreStatement getCondition() { ruby_if_def(this, result) }
 
     /** Gets the node corresponding to the field `consequence`. */
-    Then getConsequence() { ruby_if_consequence(this, result) }
+    final Then getConsequence() { ruby_if_consequence(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_if_alternative(this, result) or
       ruby_if_def(this, result) or
       ruby_if_consequence(this, result)
@@ -913,28 +919,28 @@ module Ruby {
   /** A class representing `if_guard` nodes. */
   class IfGuard extends @ruby_if_guard, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "IfGuard" }
+    final override string getAPrimaryQlClass() { result = "IfGuard" }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_if_guard_def(this, result) }
+    final UnderscoreExpression getCondition() { ruby_if_guard_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_if_guard_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_if_guard_def(this, result) }
   }
 
   /** A class representing `if_modifier` nodes. */
   class IfModifier extends @ruby_if_modifier, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "IfModifier" }
+    final override string getAPrimaryQlClass() { result = "IfModifier" }
 
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_if_modifier_def(this, result, _) }
+    final UnderscoreStatement getBody() { ruby_if_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_if_modifier_def(this, _, result) }
+    final UnderscoreExpression getCondition() { ruby_if_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_if_modifier_def(this, result, _) or ruby_if_modifier_def(this, _, result)
     }
   }
@@ -942,31 +948,31 @@ module Ruby {
   /** A class representing `in` nodes. */
   class In extends @ruby_in, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "In" }
+    final override string getAPrimaryQlClass() { result = "In" }
 
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_in_def(this, result) }
+    final UnderscoreArg getChild() { ruby_in_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_in_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_in_def(this, result) }
   }
 
   /** A class representing `in_clause` nodes. */
   class InClause extends @ruby_in_clause, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "InClause" }
+    final override string getAPrimaryQlClass() { result = "InClause" }
 
     /** Gets the node corresponding to the field `body`. */
-    Then getBody() { ruby_in_clause_body(this, result) }
+    final Then getBody() { ruby_in_clause_body(this, result) }
 
     /** Gets the node corresponding to the field `guard`. */
-    AstNode getGuard() { ruby_in_clause_guard(this, result) }
+    final AstNode getGuard() { ruby_in_clause_guard(this, result) }
 
     /** Gets the node corresponding to the field `pattern`. */
-    UnderscorePatternTopExprBody getPattern() { ruby_in_clause_def(this, result) }
+    final UnderscorePatternTopExprBody getPattern() { ruby_in_clause_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_in_clause_body(this, result) or
       ruby_in_clause_guard(this, result) or
       ruby_in_clause_def(this, result)
@@ -976,40 +982,40 @@ module Ruby {
   /** A class representing `instance_variable` tokens. */
   class InstanceVariable extends @ruby_token_instance_variable, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "InstanceVariable" }
+    final override string getAPrimaryQlClass() { result = "InstanceVariable" }
   }
 
   /** A class representing `integer` tokens. */
   class Integer extends @ruby_token_integer, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Integer" }
+    final override string getAPrimaryQlClass() { result = "Integer" }
   }
 
   /** A class representing `interpolation` nodes. */
   class Interpolation extends @ruby_interpolation, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Interpolation" }
+    final override string getAPrimaryQlClass() { result = "Interpolation" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_interpolation_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_interpolation_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_interpolation_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_interpolation_child(this, _, result) }
   }
 
   /** A class representing `keyword_parameter` nodes. */
   class KeywordParameter extends @ruby_keyword_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "KeywordParameter" }
+    final override string getAPrimaryQlClass() { result = "KeywordParameter" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_keyword_parameter_def(this, result) }
+    final Identifier getName() { ruby_keyword_parameter_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreArg getValue() { ruby_keyword_parameter_value(this, result) }
+    final UnderscoreArg getValue() { ruby_keyword_parameter_value(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_keyword_parameter_def(this, result) or ruby_keyword_parameter_value(this, result)
     }
   }
@@ -1017,16 +1023,16 @@ module Ruby {
   /** A class representing `keyword_pattern` nodes. */
   class KeywordPattern extends @ruby_keyword_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "KeywordPattern" }
+    final override string getAPrimaryQlClass() { result = "KeywordPattern" }
 
     /** Gets the node corresponding to the field `key`. */
-    AstNode getKey() { ruby_keyword_pattern_def(this, result) }
+    final AstNode getKey() { ruby_keyword_pattern_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscorePatternExpr getValue() { ruby_keyword_pattern_value(this, result) }
+    final UnderscorePatternExpr getValue() { ruby_keyword_pattern_value(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_keyword_pattern_def(this, result) or ruby_keyword_pattern_value(this, result)
     }
   }
@@ -1034,16 +1040,16 @@ module Ruby {
   /** A class representing `lambda` nodes. */
   class Lambda extends @ruby_lambda, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Lambda" }
+    final override string getAPrimaryQlClass() { result = "Lambda" }
 
     /** Gets the node corresponding to the field `body`. */
-    AstNode getBody() { ruby_lambda_def(this, result) }
+    final AstNode getBody() { ruby_lambda_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
-    LambdaParameters getParameters() { ruby_lambda_parameters(this, result) }
+    final LambdaParameters getParameters() { ruby_lambda_parameters(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_lambda_def(this, result) or ruby_lambda_parameters(this, result)
     }
   }
@@ -1051,49 +1057,49 @@ module Ruby {
   /** A class representing `lambda_parameters` nodes. */
   class LambdaParameters extends @ruby_lambda_parameters, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "LambdaParameters" }
+    final override string getAPrimaryQlClass() { result = "LambdaParameters" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_lambda_parameters_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_lambda_parameters_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_lambda_parameters_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_lambda_parameters_child(this, _, result) }
   }
 
   /** A class representing `left_assignment_list` nodes. */
   class LeftAssignmentList extends @ruby_left_assignment_list, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "LeftAssignmentList" }
+    final override string getAPrimaryQlClass() { result = "LeftAssignmentList" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_left_assignment_list_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_left_assignment_list_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_left_assignment_list_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_left_assignment_list_child(this, _, result) }
   }
 
   /** A class representing `line` tokens. */
   class Line extends @ruby_token_line, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Line" }
+    final override string getAPrimaryQlClass() { result = "Line" }
   }
 
   /** A class representing `method` nodes. */
   class Method extends @ruby_method, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Method" }
+    final override string getAPrimaryQlClass() { result = "Method" }
 
     /** Gets the node corresponding to the field `name`. */
-    UnderscoreMethodName getName() { ruby_method_def(this, result) }
+    final UnderscoreMethodName getName() { ruby_method_def(this, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
-    MethodParameters getParameters() { ruby_method_parameters(this, result) }
+    final MethodParameters getParameters() { ruby_method_parameters(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_method_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_method_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_method_def(this, result) or
       ruby_method_parameters(this, result) or
       ruby_method_child(this, _, result)
@@ -1103,28 +1109,28 @@ module Ruby {
   /** A class representing `method_parameters` nodes. */
   class MethodParameters extends @ruby_method_parameters, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "MethodParameters" }
+    final override string getAPrimaryQlClass() { result = "MethodParameters" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_method_parameters_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_method_parameters_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_method_parameters_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_method_parameters_child(this, _, result) }
   }
 
   /** A class representing `module` nodes. */
   class Module extends @ruby_module, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Module" }
+    final override string getAPrimaryQlClass() { result = "Module" }
 
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_module_def(this, result) }
+    final AstNode getName() { ruby_module_def(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_module_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_module_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_module_def(this, result) or ruby_module_child(this, _, result)
     }
   }
@@ -1132,37 +1138,37 @@ module Ruby {
   /** A class representing `next` nodes. */
   class Next extends @ruby_next, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Next" }
+    final override string getAPrimaryQlClass() { result = "Next" }
 
     /** Gets the child of this node. */
-    ArgumentList getChild() { ruby_next_child(this, result) }
+    final ArgumentList getChild() { ruby_next_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_next_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_next_child(this, result) }
   }
 
   /** A class representing `nil` tokens. */
   class Nil extends @ruby_token_nil, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Nil" }
+    final override string getAPrimaryQlClass() { result = "Nil" }
   }
 
   /** A class representing `operator` tokens. */
   class Operator extends @ruby_token_operator, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Operator" }
+    final override string getAPrimaryQlClass() { result = "Operator" }
   }
 
   /** A class representing `operator_assignment` nodes. */
   class OperatorAssignment extends @ruby_operator_assignment, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "OperatorAssignment" }
+    final override string getAPrimaryQlClass() { result = "OperatorAssignment" }
 
     /** Gets the node corresponding to the field `left`. */
-    UnderscoreLhs getLeft() { ruby_operator_assignment_def(this, result, _, _) }
+    final UnderscoreLhs getLeft() { ruby_operator_assignment_def(this, result, _, _) }
 
     /** Gets the node corresponding to the field `operator`. */
-    string getOperator() {
+    final string getOperator() {
       exists(int value | ruby_operator_assignment_def(this, _, value, _) |
         result = "%=" and value = 0
         or
@@ -1193,10 +1199,10 @@ module Ruby {
     }
 
     /** Gets the node corresponding to the field `right`. */
-    UnderscoreExpression getRight() { ruby_operator_assignment_def(this, _, _, result) }
+    final UnderscoreExpression getRight() { ruby_operator_assignment_def(this, _, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_operator_assignment_def(this, result, _, _) or
       ruby_operator_assignment_def(this, _, _, result)
     }
@@ -1205,16 +1211,16 @@ module Ruby {
   /** A class representing `optional_parameter` nodes. */
   class OptionalParameter extends @ruby_optional_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "OptionalParameter" }
+    final override string getAPrimaryQlClass() { result = "OptionalParameter" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_optional_parameter_def(this, result, _) }
+    final Identifier getName() { ruby_optional_parameter_def(this, result, _) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreArg getValue() { ruby_optional_parameter_def(this, _, result) }
+    final UnderscoreArg getValue() { ruby_optional_parameter_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_optional_parameter_def(this, result, _) or ruby_optional_parameter_def(this, _, result)
     }
   }
@@ -1222,16 +1228,16 @@ module Ruby {
   /** A class representing `pair` nodes. */
   class Pair extends @ruby_pair, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Pair" }
+    final override string getAPrimaryQlClass() { result = "Pair" }
 
     /** Gets the node corresponding to the field `key`. */
-    AstNode getKey() { ruby_pair_def(this, result) }
+    final AstNode getKey() { ruby_pair_def(this, result) }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreArg getValue() { ruby_pair_value(this, result) }
+    final UnderscoreArg getValue() { ruby_pair_value(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_pair_def(this, result) or ruby_pair_value(this, result)
     }
   }
@@ -1239,64 +1245,66 @@ module Ruby {
   /** A class representing `parenthesized_pattern` nodes. */
   class ParenthesizedPattern extends @ruby_parenthesized_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ParenthesizedPattern" }
+    final override string getAPrimaryQlClass() { result = "ParenthesizedPattern" }
 
     /** Gets the child of this node. */
-    UnderscorePatternExpr getChild() { ruby_parenthesized_pattern_def(this, result) }
+    final UnderscorePatternExpr getChild() { ruby_parenthesized_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_parenthesized_pattern_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_parenthesized_pattern_def(this, result) }
   }
 
   /** A class representing `parenthesized_statements` nodes. */
   class ParenthesizedStatements extends @ruby_parenthesized_statements, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ParenthesizedStatements" }
+    final override string getAPrimaryQlClass() { result = "ParenthesizedStatements" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_parenthesized_statements_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_parenthesized_statements_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_parenthesized_statements_child(this, _, result) }
+    final override AstNode getAFieldOrChild() {
+      ruby_parenthesized_statements_child(this, _, result)
+    }
   }
 
   /** A class representing `pattern` nodes. */
   class Pattern extends @ruby_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Pattern" }
+    final override string getAPrimaryQlClass() { result = "Pattern" }
 
     /** Gets the child of this node. */
-    AstNode getChild() { ruby_pattern_def(this, result) }
+    final AstNode getChild() { ruby_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_pattern_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_pattern_def(this, result) }
   }
 
   /** A class representing `program` nodes. */
   class Program extends @ruby_program, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Program" }
+    final override string getAPrimaryQlClass() { result = "Program" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_program_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_program_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_program_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_program_child(this, _, result) }
   }
 
   /** A class representing `range` nodes. */
   class Range extends @ruby_range, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Range" }
+    final override string getAPrimaryQlClass() { result = "Range" }
 
     /** Gets the node corresponding to the field `begin`. */
-    AstNode getBegin() { ruby_range_begin(this, result) }
+    final AstNode getBegin() { ruby_range_begin(this, result) }
 
     /** Gets the node corresponding to the field `end`. */
-    AstNode getEnd() { ruby_range_end(this, result) }
+    final AstNode getEnd() { ruby_range_end(this, result) }
 
     /** Gets the node corresponding to the field `operator`. */
-    string getOperator() {
+    final string getOperator() {
       exists(int value | ruby_range_def(this, value) |
         result = ".." and value = 0
         or
@@ -1305,7 +1313,7 @@ module Ruby {
     }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_range_begin(this, result) or ruby_range_end(this, result)
     }
   }
@@ -1313,55 +1321,55 @@ module Ruby {
   /** A class representing `rational` nodes. */
   class Rational extends @ruby_rational, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Rational" }
+    final override string getAPrimaryQlClass() { result = "Rational" }
 
     /** Gets the child of this node. */
-    AstNode getChild() { ruby_rational_def(this, result) }
+    final AstNode getChild() { ruby_rational_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_rational_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_rational_def(this, result) }
   }
 
   /** A class representing `redo` nodes. */
   class Redo extends @ruby_redo, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Redo" }
+    final override string getAPrimaryQlClass() { result = "Redo" }
 
     /** Gets the child of this node. */
-    ArgumentList getChild() { ruby_redo_child(this, result) }
+    final ArgumentList getChild() { ruby_redo_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_redo_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_redo_child(this, result) }
   }
 
   /** A class representing `regex` nodes. */
   class Regex extends @ruby_regex, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Regex" }
+    final override string getAPrimaryQlClass() { result = "Regex" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_regex_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_regex_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_regex_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_regex_child(this, _, result) }
   }
 
   /** A class representing `rescue` nodes. */
   class Rescue extends @ruby_rescue, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Rescue" }
+    final override string getAPrimaryQlClass() { result = "Rescue" }
 
     /** Gets the node corresponding to the field `body`. */
-    Then getBody() { ruby_rescue_body(this, result) }
+    final Then getBody() { ruby_rescue_body(this, result) }
 
     /** Gets the node corresponding to the field `exceptions`. */
-    Exceptions getExceptions() { ruby_rescue_exceptions(this, result) }
+    final Exceptions getExceptions() { ruby_rescue_exceptions(this, result) }
 
     /** Gets the node corresponding to the field `variable`. */
-    ExceptionVariable getVariable() { ruby_rescue_variable(this, result) }
+    final ExceptionVariable getVariable() { ruby_rescue_variable(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_rescue_body(this, result) or
       ruby_rescue_exceptions(this, result) or
       ruby_rescue_variable(this, result)
@@ -1371,16 +1379,16 @@ module Ruby {
   /** A class representing `rescue_modifier` nodes. */
   class RescueModifier extends @ruby_rescue_modifier, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "RescueModifier" }
+    final override string getAPrimaryQlClass() { result = "RescueModifier" }
 
     /** Gets the node corresponding to the field `body`. */
-    AstNode getBody() { ruby_rescue_modifier_def(this, result, _) }
+    final AstNode getBody() { ruby_rescue_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `handler`. */
-    UnderscoreExpression getHandler() { ruby_rescue_modifier_def(this, _, result) }
+    final UnderscoreExpression getHandler() { ruby_rescue_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_rescue_modifier_def(this, result, _) or ruby_rescue_modifier_def(this, _, result)
     }
   }
@@ -1388,64 +1396,64 @@ module Ruby {
   /** A class representing `rest_assignment` nodes. */
   class RestAssignment extends @ruby_rest_assignment, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "RestAssignment" }
+    final override string getAPrimaryQlClass() { result = "RestAssignment" }
 
     /** Gets the child of this node. */
-    UnderscoreLhs getChild() { ruby_rest_assignment_child(this, result) }
+    final UnderscoreLhs getChild() { ruby_rest_assignment_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_rest_assignment_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_rest_assignment_child(this, result) }
   }
 
   /** A class representing `retry` nodes. */
   class Retry extends @ruby_retry, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Retry" }
+    final override string getAPrimaryQlClass() { result = "Retry" }
 
     /** Gets the child of this node. */
-    ArgumentList getChild() { ruby_retry_child(this, result) }
+    final ArgumentList getChild() { ruby_retry_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_retry_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_retry_child(this, result) }
   }
 
   /** A class representing `return` nodes. */
   class Return extends @ruby_return, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Return" }
+    final override string getAPrimaryQlClass() { result = "Return" }
 
     /** Gets the child of this node. */
-    ArgumentList getChild() { ruby_return_child(this, result) }
+    final ArgumentList getChild() { ruby_return_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_return_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_return_child(this, result) }
   }
 
   /** A class representing `right_assignment_list` nodes. */
   class RightAssignmentList extends @ruby_right_assignment_list, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "RightAssignmentList" }
+    final override string getAPrimaryQlClass() { result = "RightAssignmentList" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_right_assignment_list_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_right_assignment_list_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_right_assignment_list_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_right_assignment_list_child(this, _, result) }
   }
 
   /** A class representing `scope_resolution` nodes. */
   class ScopeResolution extends @ruby_scope_resolution, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ScopeResolution" }
+    final override string getAPrimaryQlClass() { result = "ScopeResolution" }
 
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_scope_resolution_def(this, result) }
+    final AstNode getName() { ruby_scope_resolution_def(this, result) }
 
     /** Gets the node corresponding to the field `scope`. */
-    AstNode getScope() { ruby_scope_resolution_scope(this, result) }
+    final AstNode getScope() { ruby_scope_resolution_scope(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_scope_resolution_def(this, result) or ruby_scope_resolution_scope(this, result)
     }
   }
@@ -1453,40 +1461,40 @@ module Ruby {
   /** A class representing `self` tokens. */
   class Self extends @ruby_token_self, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Self" }
+    final override string getAPrimaryQlClass() { result = "Self" }
   }
 
   /** A class representing `setter` nodes. */
   class Setter extends @ruby_setter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Setter" }
+    final override string getAPrimaryQlClass() { result = "Setter" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_setter_def(this, result) }
+    final Identifier getName() { ruby_setter_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_setter_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_setter_def(this, result) }
   }
 
   /** A class representing `simple_symbol` tokens. */
   class SimpleSymbol extends @ruby_token_simple_symbol, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "SimpleSymbol" }
+    final override string getAPrimaryQlClass() { result = "SimpleSymbol" }
   }
 
   /** A class representing `singleton_class` nodes. */
   class SingletonClass extends @ruby_singleton_class, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "SingletonClass" }
+    final override string getAPrimaryQlClass() { result = "SingletonClass" }
 
     /** Gets the node corresponding to the field `value`. */
-    UnderscoreArg getValue() { ruby_singleton_class_def(this, result) }
+    final UnderscoreArg getValue() { ruby_singleton_class_def(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_singleton_class_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_singleton_class_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_singleton_class_def(this, result) or ruby_singleton_class_child(this, _, result)
     }
   }
@@ -1494,22 +1502,22 @@ module Ruby {
   /** A class representing `singleton_method` nodes. */
   class SingletonMethod extends @ruby_singleton_method, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "SingletonMethod" }
+    final override string getAPrimaryQlClass() { result = "SingletonMethod" }
 
     /** Gets the node corresponding to the field `name`. */
-    UnderscoreMethodName getName() { ruby_singleton_method_def(this, result, _) }
+    final UnderscoreMethodName getName() { ruby_singleton_method_def(this, result, _) }
 
     /** Gets the node corresponding to the field `object`. */
-    AstNode getObject() { ruby_singleton_method_def(this, _, result) }
+    final AstNode getObject() { ruby_singleton_method_def(this, _, result) }
 
     /** Gets the node corresponding to the field `parameters`. */
-    MethodParameters getParameters() { ruby_singleton_method_parameters(this, result) }
+    final MethodParameters getParameters() { ruby_singleton_method_parameters(this, result) }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_singleton_method_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_singleton_method_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_singleton_method_def(this, result, _) or
       ruby_singleton_method_def(this, _, result) or
       ruby_singleton_method_parameters(this, result) or
@@ -1520,127 +1528,127 @@ module Ruby {
   /** A class representing `splat_argument` nodes. */
   class SplatArgument extends @ruby_splat_argument, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "SplatArgument" }
+    final override string getAPrimaryQlClass() { result = "SplatArgument" }
 
     /** Gets the child of this node. */
-    UnderscoreArg getChild() { ruby_splat_argument_def(this, result) }
+    final UnderscoreArg getChild() { ruby_splat_argument_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_splat_argument_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_splat_argument_def(this, result) }
   }
 
   /** A class representing `splat_parameter` nodes. */
   class SplatParameter extends @ruby_splat_parameter, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "SplatParameter" }
+    final override string getAPrimaryQlClass() { result = "SplatParameter" }
 
     /** Gets the node corresponding to the field `name`. */
-    Identifier getName() { ruby_splat_parameter_name(this, result) }
+    final Identifier getName() { ruby_splat_parameter_name(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_splat_parameter_name(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_splat_parameter_name(this, result) }
   }
 
   /** A class representing `string` nodes. */
   class String extends @ruby_string__, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "String" }
+    final override string getAPrimaryQlClass() { result = "String" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_string_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_string_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_string_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_string_child(this, _, result) }
   }
 
   /** A class representing `string_array` nodes. */
   class StringArray extends @ruby_string_array, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "StringArray" }
+    final override string getAPrimaryQlClass() { result = "StringArray" }
 
     /** Gets the `i`th child of this node. */
-    BareString getChild(int i) { ruby_string_array_child(this, i, result) }
+    final BareString getChild(int i) { ruby_string_array_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_string_array_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_string_array_child(this, _, result) }
   }
 
   /** A class representing `string_content` tokens. */
   class StringContent extends @ruby_token_string_content, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "StringContent" }
+    final override string getAPrimaryQlClass() { result = "StringContent" }
   }
 
   /** A class representing `subshell` nodes. */
   class Subshell extends @ruby_subshell, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Subshell" }
+    final override string getAPrimaryQlClass() { result = "Subshell" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_subshell_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_subshell_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_subshell_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_subshell_child(this, _, result) }
   }
 
   /** A class representing `super` tokens. */
   class Super extends @ruby_token_super, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Super" }
+    final override string getAPrimaryQlClass() { result = "Super" }
   }
 
   /** A class representing `superclass` nodes. */
   class Superclass extends @ruby_superclass, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Superclass" }
+    final override string getAPrimaryQlClass() { result = "Superclass" }
 
     /** Gets the child of this node. */
-    UnderscoreExpression getChild() { ruby_superclass_def(this, result) }
+    final UnderscoreExpression getChild() { ruby_superclass_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_superclass_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_superclass_def(this, result) }
   }
 
   /** A class representing `symbol_array` nodes. */
   class SymbolArray extends @ruby_symbol_array, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "SymbolArray" }
+    final override string getAPrimaryQlClass() { result = "SymbolArray" }
 
     /** Gets the `i`th child of this node. */
-    BareSymbol getChild(int i) { ruby_symbol_array_child(this, i, result) }
+    final BareSymbol getChild(int i) { ruby_symbol_array_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_symbol_array_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_symbol_array_child(this, _, result) }
   }
 
   /** A class representing `then` nodes. */
   class Then extends @ruby_then, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Then" }
+    final override string getAPrimaryQlClass() { result = "Then" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { ruby_then_child(this, i, result) }
+    final AstNode getChild(int i) { ruby_then_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_then_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_then_child(this, _, result) }
   }
 
   /** A class representing `true` tokens. */
   class True extends @ruby_token_true, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "True" }
+    final override string getAPrimaryQlClass() { result = "True" }
   }
 
   /** A class representing `unary` nodes. */
   class Unary extends @ruby_unary, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Unary" }
+    final override string getAPrimaryQlClass() { result = "Unary" }
 
     /** Gets the node corresponding to the field `operand`. */
-    AstNode getOperand() { ruby_unary_def(this, result, _) }
+    final AstNode getOperand() { ruby_unary_def(this, result, _) }
 
     /** Gets the node corresponding to the field `operator`. */
-    string getOperator() {
+    final string getOperator() {
       exists(int value | ruby_unary_def(this, _, value) |
         result = "!" and value = 0
         or
@@ -1657,43 +1665,43 @@ module Ruby {
     }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_unary_def(this, result, _) }
+    final override AstNode getAFieldOrChild() { ruby_unary_def(this, result, _) }
   }
 
   /** A class representing `undef` nodes. */
   class Undef extends @ruby_undef, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Undef" }
+    final override string getAPrimaryQlClass() { result = "Undef" }
 
     /** Gets the `i`th child of this node. */
-    UnderscoreMethodName getChild(int i) { ruby_undef_child(this, i, result) }
+    final UnderscoreMethodName getChild(int i) { ruby_undef_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_undef_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { ruby_undef_child(this, _, result) }
   }
 
   /** A class representing `uninterpreted` tokens. */
   class Uninterpreted extends @ruby_token_uninterpreted, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Uninterpreted" }
+    final override string getAPrimaryQlClass() { result = "Uninterpreted" }
   }
 
   /** A class representing `unless` nodes. */
   class Unless extends @ruby_unless, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Unless" }
+    final override string getAPrimaryQlClass() { result = "Unless" }
 
     /** Gets the node corresponding to the field `alternative`. */
-    AstNode getAlternative() { ruby_unless_alternative(this, result) }
+    final AstNode getAlternative() { ruby_unless_alternative(this, result) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_unless_def(this, result) }
+    final UnderscoreStatement getCondition() { ruby_unless_def(this, result) }
 
     /** Gets the node corresponding to the field `consequence`. */
-    Then getConsequence() { ruby_unless_consequence(this, result) }
+    final Then getConsequence() { ruby_unless_consequence(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_unless_alternative(this, result) or
       ruby_unless_def(this, result) or
       ruby_unless_consequence(this, result)
@@ -1703,28 +1711,28 @@ module Ruby {
   /** A class representing `unless_guard` nodes. */
   class UnlessGuard extends @ruby_unless_guard, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "UnlessGuard" }
+    final override string getAPrimaryQlClass() { result = "UnlessGuard" }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_unless_guard_def(this, result) }
+    final UnderscoreExpression getCondition() { ruby_unless_guard_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_unless_guard_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_unless_guard_def(this, result) }
   }
 
   /** A class representing `unless_modifier` nodes. */
   class UnlessModifier extends @ruby_unless_modifier, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "UnlessModifier" }
+    final override string getAPrimaryQlClass() { result = "UnlessModifier" }
 
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_unless_modifier_def(this, result, _) }
+    final UnderscoreStatement getBody() { ruby_unless_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_unless_modifier_def(this, _, result) }
+    final UnderscoreExpression getCondition() { ruby_unless_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_unless_modifier_def(this, result, _) or ruby_unless_modifier_def(this, _, result)
     }
   }
@@ -1732,16 +1740,16 @@ module Ruby {
   /** A class representing `until` nodes. */
   class Until extends @ruby_until, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Until" }
+    final override string getAPrimaryQlClass() { result = "Until" }
 
     /** Gets the node corresponding to the field `body`. */
-    Do getBody() { ruby_until_def(this, result, _) }
+    final Do getBody() { ruby_until_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_until_def(this, _, result) }
+    final UnderscoreStatement getCondition() { ruby_until_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_until_def(this, result, _) or ruby_until_def(this, _, result)
     }
   }
@@ -1749,16 +1757,16 @@ module Ruby {
   /** A class representing `until_modifier` nodes. */
   class UntilModifier extends @ruby_until_modifier, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "UntilModifier" }
+    final override string getAPrimaryQlClass() { result = "UntilModifier" }
 
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_until_modifier_def(this, result, _) }
+    final UnderscoreStatement getBody() { ruby_until_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_until_modifier_def(this, _, result) }
+    final UnderscoreExpression getCondition() { ruby_until_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_until_modifier_def(this, result, _) or ruby_until_modifier_def(this, _, result)
     }
   }
@@ -1766,28 +1774,28 @@ module Ruby {
   /** A class representing `variable_reference_pattern` nodes. */
   class VariableReferencePattern extends @ruby_variable_reference_pattern, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "VariableReferencePattern" }
+    final override string getAPrimaryQlClass() { result = "VariableReferencePattern" }
 
     /** Gets the node corresponding to the field `name`. */
-    AstNode getName() { ruby_variable_reference_pattern_def(this, result) }
+    final AstNode getName() { ruby_variable_reference_pattern_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_variable_reference_pattern_def(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_variable_reference_pattern_def(this, result) }
   }
 
   /** A class representing `when` nodes. */
   class When extends @ruby_when, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "When" }
+    final override string getAPrimaryQlClass() { result = "When" }
 
     /** Gets the node corresponding to the field `body`. */
-    Then getBody() { ruby_when_body(this, result) }
+    final Then getBody() { ruby_when_body(this, result) }
 
     /** Gets the node corresponding to the field `pattern`. */
-    Pattern getPattern(int i) { ruby_when_pattern(this, i, result) }
+    final Pattern getPattern(int i) { ruby_when_pattern(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_when_body(this, result) or ruby_when_pattern(this, _, result)
     }
   }
@@ -1795,16 +1803,16 @@ module Ruby {
   /** A class representing `while` nodes. */
   class While extends @ruby_while, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "While" }
+    final override string getAPrimaryQlClass() { result = "While" }
 
     /** Gets the node corresponding to the field `body`. */
-    Do getBody() { ruby_while_def(this, result, _) }
+    final Do getBody() { ruby_while_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreStatement getCondition() { ruby_while_def(this, _, result) }
+    final UnderscoreStatement getCondition() { ruby_while_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_while_def(this, result, _) or ruby_while_def(this, _, result)
     }
   }
@@ -1812,16 +1820,16 @@ module Ruby {
   /** A class representing `while_modifier` nodes. */
   class WhileModifier extends @ruby_while_modifier, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "WhileModifier" }
+    final override string getAPrimaryQlClass() { result = "WhileModifier" }
 
     /** Gets the node corresponding to the field `body`. */
-    UnderscoreStatement getBody() { ruby_while_modifier_def(this, result, _) }
+    final UnderscoreStatement getBody() { ruby_while_modifier_def(this, result, _) }
 
     /** Gets the node corresponding to the field `condition`. */
-    UnderscoreExpression getCondition() { ruby_while_modifier_def(this, _, result) }
+    final UnderscoreExpression getCondition() { ruby_while_modifier_def(this, _, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() {
+    final override AstNode getAFieldOrChild() {
       ruby_while_modifier_def(this, result, _) or ruby_while_modifier_def(this, _, result)
     }
   }
@@ -1829,13 +1837,13 @@ module Ruby {
   /** A class representing `yield` nodes. */
   class Yield extends @ruby_yield, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Yield" }
+    final override string getAPrimaryQlClass() { result = "Yield" }
 
     /** Gets the child of this node. */
-    ArgumentList getChild() { ruby_yield_child(this, result) }
+    final ArgumentList getChild() { ruby_yield_child(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { ruby_yield_child(this, result) }
+    final override AstNode getAFieldOrChild() { ruby_yield_child(this, result) }
   }
 }
 
@@ -1846,13 +1854,13 @@ module Erb {
     string toString() { result = this.getAPrimaryQlClass() }
 
     /** Gets the location of this element. */
-    L::Location getLocation() { erb_ast_node_info(this, _, _, result) }
+    final L::Location getLocation() { erb_ast_node_info(this, _, _, result) }
 
     /** Gets the parent of this element. */
-    AstNode getParent() { erb_ast_node_info(this, result, _, _) }
+    final AstNode getParent() { erb_ast_node_info(this, result, _, _) }
 
     /** Gets the index of this node among the children of its parent. */
-    int getParentIndex() { erb_ast_node_info(this, _, result, _) }
+    final int getParentIndex() { erb_ast_node_info(this, _, result, _) }
 
     /** Gets a field or child node of this node. */
     AstNode getAFieldOrChild() { none() }
@@ -1867,10 +1875,10 @@ module Erb {
   /** A token. */
   class Token extends @erb_token, AstNode {
     /** Gets the value of this token. */
-    string getValue() { erb_tokeninfo(this, _, result) }
+    final string getValue() { erb_tokeninfo(this, _, result) }
 
     /** Gets a string representation of this element. */
-    override string toString() { result = this.getValue() }
+    final override string toString() { result = this.getValue() }
 
     /** Gets the name of the primary QL class for this element. */
     override string getAPrimaryQlClass() { result = "Token" }
@@ -1879,84 +1887,84 @@ module Erb {
   /** A reserved word. */
   class ReservedWord extends @erb_reserved_word, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "ReservedWord" }
+    final override string getAPrimaryQlClass() { result = "ReservedWord" }
   }
 
   /** A class representing `code` tokens. */
   class Code extends @erb_token_code, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Code" }
+    final override string getAPrimaryQlClass() { result = "Code" }
   }
 
   /** A class representing `comment` tokens. */
   class Comment extends @erb_token_comment, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Comment" }
+    final override string getAPrimaryQlClass() { result = "Comment" }
   }
 
   /** A class representing `comment_directive` nodes. */
   class CommentDirective extends @erb_comment_directive, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "CommentDirective" }
+    final override string getAPrimaryQlClass() { result = "CommentDirective" }
 
     /** Gets the child of this node. */
-    Comment getChild() { erb_comment_directive_def(this, result) }
+    final Comment getChild() { erb_comment_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_comment_directive_def(this, result) }
+    final override AstNode getAFieldOrChild() { erb_comment_directive_def(this, result) }
   }
 
   /** A class representing `content` tokens. */
   class Content extends @erb_token_content, Token {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Content" }
+    final override string getAPrimaryQlClass() { result = "Content" }
   }
 
   /** A class representing `directive` nodes. */
   class Directive extends @erb_directive, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Directive" }
+    final override string getAPrimaryQlClass() { result = "Directive" }
 
     /** Gets the child of this node. */
-    Code getChild() { erb_directive_def(this, result) }
+    final Code getChild() { erb_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_directive_def(this, result) }
+    final override AstNode getAFieldOrChild() { erb_directive_def(this, result) }
   }
 
   /** A class representing `graphql_directive` nodes. */
   class GraphqlDirective extends @erb_graphql_directive, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "GraphqlDirective" }
+    final override string getAPrimaryQlClass() { result = "GraphqlDirective" }
 
     /** Gets the child of this node. */
-    Code getChild() { erb_graphql_directive_def(this, result) }
+    final Code getChild() { erb_graphql_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_graphql_directive_def(this, result) }
+    final override AstNode getAFieldOrChild() { erb_graphql_directive_def(this, result) }
   }
 
   /** A class representing `output_directive` nodes. */
   class OutputDirective extends @erb_output_directive, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "OutputDirective" }
+    final override string getAPrimaryQlClass() { result = "OutputDirective" }
 
     /** Gets the child of this node. */
-    Code getChild() { erb_output_directive_def(this, result) }
+    final Code getChild() { erb_output_directive_def(this, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_output_directive_def(this, result) }
+    final override AstNode getAFieldOrChild() { erb_output_directive_def(this, result) }
   }
 
   /** A class representing `template` nodes. */
   class Template extends @erb_template, AstNode {
     /** Gets the name of the primary QL class for this element. */
-    override string getAPrimaryQlClass() { result = "Template" }
+    final override string getAPrimaryQlClass() { result = "Template" }
 
     /** Gets the `i`th child of this node. */
-    AstNode getChild(int i) { erb_template_child(this, i, result) }
+    final AstNode getChild(int i) { erb_template_child(this, i, result) }
 
     /** Gets a field or child node of this node. */
-    override AstNode getAFieldOrChild() { erb_template_child(this, _, result) }
+    final override AstNode getAFieldOrChild() { erb_template_child(this, _, result) }
   }
 }

--- a/ruby/ql/lib/ruby.dbscheme
+++ b/ruby/ql/lib/ruby.dbscheme
@@ -81,8 +81,7 @@ case @diagnostic.severity of
 ruby_alias_def(
   unique int id: @ruby_alias,
   int alias: @ruby_underscore_method_name ref,
-  int name: @ruby_underscore_method_name ref,
-  int loc: @location ref
+  int name: @ruby_underscore_method_name ref
 );
 
 #keyset[ruby_alternative_pattern, index]
@@ -93,8 +92,7 @@ ruby_alternative_pattern_alternatives(
 );
 
 ruby_alternative_pattern_def(
-  unique int id: @ruby_alternative_pattern,
-  int loc: @location ref
+  unique int id: @ruby_alternative_pattern
 );
 
 @ruby_argument_list_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
@@ -107,8 +105,7 @@ ruby_argument_list_child(
 );
 
 ruby_argument_list_def(
-  unique int id: @ruby_argument_list,
-  int loc: @location ref
+  unique int id: @ruby_argument_list
 );
 
 @ruby_array_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
@@ -121,8 +118,7 @@ ruby_array_child(
 );
 
 ruby_array_def(
-  unique int id: @ruby_array,
-  int loc: @location ref
+  unique int id: @ruby_array
 );
 
 ruby_array_pattern_class(
@@ -140,15 +136,13 @@ ruby_array_pattern_child(
 );
 
 ruby_array_pattern_def(
-  unique int id: @ruby_array_pattern,
-  int loc: @location ref
+  unique int id: @ruby_array_pattern
 );
 
 ruby_as_pattern_def(
   unique int id: @ruby_as_pattern,
   int name: @ruby_token_identifier ref,
-  int value: @ruby_underscore_pattern_expr ref,
-  int loc: @location ref
+  int value: @ruby_underscore_pattern_expr ref
 );
 
 @ruby_assignment_left_type = @ruby_left_assignment_list | @ruby_underscore_lhs
@@ -158,8 +152,7 @@ ruby_as_pattern_def(
 ruby_assignment_def(
   unique int id: @ruby_assignment,
   int left: @ruby_assignment_left_type ref,
-  int right: @ruby_assignment_right_type ref,
-  int loc: @location ref
+  int right: @ruby_assignment_right_type ref
 );
 
 @ruby_bare_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
@@ -172,8 +165,7 @@ ruby_bare_string_child(
 );
 
 ruby_bare_string_def(
-  unique int id: @ruby_bare_string,
-  int loc: @location ref
+  unique int id: @ruby_bare_string
 );
 
 @ruby_bare_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
@@ -186,8 +178,7 @@ ruby_bare_symbol_child(
 );
 
 ruby_bare_symbol_def(
-  unique int id: @ruby_bare_symbol,
-  int loc: @location ref
+  unique int id: @ruby_bare_symbol
 );
 
 @ruby_begin_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
@@ -200,8 +191,7 @@ ruby_begin_child(
 );
 
 ruby_begin_def(
-  unique int id: @ruby_begin,
-  int loc: @location ref
+  unique int id: @ruby_begin
 );
 
 @ruby_begin_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -214,8 +204,7 @@ ruby_begin_block_child(
 );
 
 ruby_begin_block_def(
-  unique int id: @ruby_begin_block,
-  int loc: @location ref
+  unique int id: @ruby_begin_block
 );
 
 case @ruby_binary.operator of
@@ -251,8 +240,7 @@ ruby_binary_def(
   unique int id: @ruby_binary,
   int left: @ruby_underscore_expression ref,
   int operator: int ref,
-  int right: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int right: @ruby_underscore_expression ref
 );
 
 ruby_block_parameters(
@@ -270,8 +258,7 @@ ruby_block_child(
 );
 
 ruby_block_def(
-  unique int id: @ruby_block,
-  int loc: @location ref
+  unique int id: @ruby_block
 );
 
 ruby_block_argument_child(
@@ -280,8 +267,7 @@ ruby_block_argument_child(
 );
 
 ruby_block_argument_def(
-  unique int id: @ruby_block_argument,
-  int loc: @location ref
+  unique int id: @ruby_block_argument
 );
 
 ruby_block_parameter_name(
@@ -290,8 +276,7 @@ ruby_block_parameter_name(
 );
 
 ruby_block_parameter_def(
-  unique int id: @ruby_block_parameter,
-  int loc: @location ref
+  unique int id: @ruby_block_parameter
 );
 
 @ruby_block_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
@@ -304,8 +289,7 @@ ruby_block_parameters_child(
 );
 
 ruby_block_parameters_def(
-  unique int id: @ruby_block_parameters,
-  int loc: @location ref
+  unique int id: @ruby_block_parameters
 );
 
 ruby_break_child(
@@ -314,8 +298,7 @@ ruby_break_child(
 );
 
 ruby_break_def(
-  unique int id: @ruby_break,
-  int loc: @location ref
+  unique int id: @ruby_break
 );
 
 ruby_call_arguments(
@@ -341,8 +324,7 @@ ruby_call_receiver(
 
 ruby_call_def(
   unique int id: @ruby_call,
-  int method: @ruby_call_method_type ref,
-  int loc: @location ref
+  int method: @ruby_call_method_type ref
 );
 
 ruby_case_value(
@@ -360,8 +342,7 @@ ruby_case_child(
 );
 
 ruby_case_def(
-  unique int id: @ruby_case__,
-  int loc: @location ref
+  unique int id: @ruby_case__
 );
 
 #keyset[ruby_case_match, index]
@@ -378,8 +359,7 @@ ruby_case_match_else(
 
 ruby_case_match_def(
   unique int id: @ruby_case_match,
-  int value: @ruby_underscore_statement ref,
-  int loc: @location ref
+  int value: @ruby_underscore_statement ref
 );
 
 #keyset[ruby_chained_string, index]
@@ -390,8 +370,7 @@ ruby_chained_string_child(
 );
 
 ruby_chained_string_def(
-  unique int id: @ruby_chained_string,
-  int loc: @location ref
+  unique int id: @ruby_chained_string
 );
 
 @ruby_class_name_type = @ruby_scope_resolution | @ruby_token_constant
@@ -412,16 +391,14 @@ ruby_class_child(
 
 ruby_class_def(
   unique int id: @ruby_class,
-  int name: @ruby_class_name_type ref,
-  int loc: @location ref
+  int name: @ruby_class_name_type ref
 );
 
 ruby_conditional_def(
   unique int id: @ruby_conditional,
   int alternative: @ruby_underscore_arg ref,
   int condition: @ruby_underscore_arg ref,
-  int consequence: @ruby_underscore_arg ref,
-  int loc: @location ref
+  int consequence: @ruby_underscore_arg ref
 );
 
 @ruby_delimited_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
@@ -434,8 +411,7 @@ ruby_delimited_symbol_child(
 );
 
 ruby_delimited_symbol_def(
-  unique int id: @ruby_delimited_symbol,
-  int loc: @location ref
+  unique int id: @ruby_delimited_symbol
 );
 
 @ruby_destructured_left_assignment_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
@@ -448,8 +424,7 @@ ruby_destructured_left_assignment_child(
 );
 
 ruby_destructured_left_assignment_def(
-  unique int id: @ruby_destructured_left_assignment,
-  int loc: @location ref
+  unique int id: @ruby_destructured_left_assignment
 );
 
 @ruby_destructured_parameter_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
@@ -462,8 +437,7 @@ ruby_destructured_parameter_child(
 );
 
 ruby_destructured_parameter_def(
-  unique int id: @ruby_destructured_parameter,
-  int loc: @location ref
+  unique int id: @ruby_destructured_parameter
 );
 
 @ruby_do_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -476,8 +450,7 @@ ruby_do_child(
 );
 
 ruby_do_def(
-  unique int id: @ruby_do,
-  int loc: @location ref
+  unique int id: @ruby_do
 );
 
 ruby_do_block_parameters(
@@ -495,8 +468,7 @@ ruby_do_block_child(
 );
 
 ruby_do_block_def(
-  unique int id: @ruby_do_block,
-  int loc: @location ref
+  unique int id: @ruby_do_block
 );
 
 @ruby_element_reference_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
@@ -510,8 +482,7 @@ ruby_element_reference_child(
 
 ruby_element_reference_def(
   unique int id: @ruby_element_reference,
-  int object: @ruby_underscore_primary ref,
-  int loc: @location ref
+  int object: @ruby_underscore_primary ref
 );
 
 @ruby_else_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -524,8 +495,7 @@ ruby_else_child(
 );
 
 ruby_else_def(
-  unique int id: @ruby_else,
-  int loc: @location ref
+  unique int id: @ruby_else
 );
 
 @ruby_elsif_alternative_type = @ruby_else | @ruby_elsif
@@ -542,8 +512,7 @@ ruby_elsif_consequence(
 
 ruby_elsif_def(
   unique int id: @ruby_elsif,
-  int condition: @ruby_underscore_statement ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_statement ref
 );
 
 @ruby_end_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -556,8 +525,7 @@ ruby_end_block_child(
 );
 
 ruby_end_block_def(
-  unique int id: @ruby_end_block,
-  int loc: @location ref
+  unique int id: @ruby_end_block
 );
 
 @ruby_ensure_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -570,14 +538,12 @@ ruby_ensure_child(
 );
 
 ruby_ensure_def(
-  unique int id: @ruby_ensure,
-  int loc: @location ref
+  unique int id: @ruby_ensure
 );
 
 ruby_exception_variable_def(
   unique int id: @ruby_exception_variable,
-  int child: @ruby_underscore_lhs ref,
-  int loc: @location ref
+  int child: @ruby_underscore_lhs ref
 );
 
 @ruby_exceptions_child_type = @ruby_splat_argument | @ruby_underscore_arg
@@ -590,14 +556,12 @@ ruby_exceptions_child(
 );
 
 ruby_exceptions_def(
-  unique int id: @ruby_exceptions,
-  int loc: @location ref
+  unique int id: @ruby_exceptions
 );
 
 ruby_expression_reference_pattern_def(
   unique int id: @ruby_expression_reference_pattern,
-  int value: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int value: @ruby_underscore_expression ref
 );
 
 ruby_find_pattern_class(
@@ -615,8 +579,7 @@ ruby_find_pattern_child(
 );
 
 ruby_find_pattern_def(
-  unique int id: @ruby_find_pattern,
-  int loc: @location ref
+  unique int id: @ruby_find_pattern
 );
 
 @ruby_for_pattern_type = @ruby_left_assignment_list | @ruby_underscore_lhs
@@ -625,8 +588,7 @@ ruby_for_def(
   unique int id: @ruby_for,
   int body: @ruby_do ref,
   int pattern: @ruby_for_pattern_type ref,
-  int value: @ruby_in ref,
-  int loc: @location ref
+  int value: @ruby_in ref
 );
 
 @ruby_hash_child_type = @ruby_hash_splat_argument | @ruby_pair
@@ -639,8 +601,7 @@ ruby_hash_child(
 );
 
 ruby_hash_def(
-  unique int id: @ruby_hash,
-  int loc: @location ref
+  unique int id: @ruby_hash
 );
 
 ruby_hash_pattern_class(
@@ -658,14 +619,12 @@ ruby_hash_pattern_child(
 );
 
 ruby_hash_pattern_def(
-  unique int id: @ruby_hash_pattern,
-  int loc: @location ref
+  unique int id: @ruby_hash_pattern
 );
 
 ruby_hash_splat_argument_def(
   unique int id: @ruby_hash_splat_argument,
-  int child: @ruby_underscore_arg ref,
-  int loc: @location ref
+  int child: @ruby_underscore_arg ref
 );
 
 ruby_hash_splat_parameter_name(
@@ -674,8 +633,7 @@ ruby_hash_splat_parameter_name(
 );
 
 ruby_hash_splat_parameter_def(
-  unique int id: @ruby_hash_splat_parameter,
-  int loc: @location ref
+  unique int id: @ruby_hash_splat_parameter
 );
 
 @ruby_heredoc_body_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_heredoc_content | @ruby_token_heredoc_end
@@ -688,8 +646,7 @@ ruby_heredoc_body_child(
 );
 
 ruby_heredoc_body_def(
-  unique int id: @ruby_heredoc_body,
-  int loc: @location ref
+  unique int id: @ruby_heredoc_body
 );
 
 @ruby_if_alternative_type = @ruby_else | @ruby_elsif
@@ -706,27 +663,23 @@ ruby_if_consequence(
 
 ruby_if_def(
   unique int id: @ruby_if,
-  int condition: @ruby_underscore_statement ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_statement ref
 );
 
 ruby_if_guard_def(
   unique int id: @ruby_if_guard,
-  int condition: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_expression ref
 );
 
 ruby_if_modifier_def(
   unique int id: @ruby_if_modifier,
   int body: @ruby_underscore_statement ref,
-  int condition: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_expression ref
 );
 
 ruby_in_def(
   unique int id: @ruby_in,
-  int child: @ruby_underscore_arg ref,
-  int loc: @location ref
+  int child: @ruby_underscore_arg ref
 );
 
 ruby_in_clause_body(
@@ -743,8 +696,7 @@ ruby_in_clause_guard(
 
 ruby_in_clause_def(
   unique int id: @ruby_in_clause,
-  int pattern: @ruby_underscore_pattern_top_expr_body ref,
-  int loc: @location ref
+  int pattern: @ruby_underscore_pattern_top_expr_body ref
 );
 
 @ruby_interpolation_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -757,8 +709,7 @@ ruby_interpolation_child(
 );
 
 ruby_interpolation_def(
-  unique int id: @ruby_interpolation,
-  int loc: @location ref
+  unique int id: @ruby_interpolation
 );
 
 ruby_keyword_parameter_value(
@@ -768,8 +719,7 @@ ruby_keyword_parameter_value(
 
 ruby_keyword_parameter_def(
   unique int id: @ruby_keyword_parameter,
-  int name: @ruby_token_identifier ref,
-  int loc: @location ref
+  int name: @ruby_token_identifier ref
 );
 
 @ruby_keyword_pattern_key_type = @ruby_string__ | @ruby_token_hash_key_symbol
@@ -781,8 +731,7 @@ ruby_keyword_pattern_value(
 
 ruby_keyword_pattern_def(
   unique int id: @ruby_keyword_pattern,
-  int key__: @ruby_keyword_pattern_key_type ref,
-  int loc: @location ref
+  int key__: @ruby_keyword_pattern_key_type ref
 );
 
 @ruby_lambda_body_type = @ruby_block | @ruby_do_block
@@ -794,8 +743,7 @@ ruby_lambda_parameters(
 
 ruby_lambda_def(
   unique int id: @ruby_lambda,
-  int body: @ruby_lambda_body_type ref,
-  int loc: @location ref
+  int body: @ruby_lambda_body_type ref
 );
 
 @ruby_lambda_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
@@ -808,8 +756,7 @@ ruby_lambda_parameters_child(
 );
 
 ruby_lambda_parameters_def(
-  unique int id: @ruby_lambda_parameters,
-  int loc: @location ref
+  unique int id: @ruby_lambda_parameters
 );
 
 @ruby_left_assignment_list_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
@@ -822,8 +769,7 @@ ruby_left_assignment_list_child(
 );
 
 ruby_left_assignment_list_def(
-  unique int id: @ruby_left_assignment_list,
-  int loc: @location ref
+  unique int id: @ruby_left_assignment_list
 );
 
 ruby_method_parameters(
@@ -842,8 +788,7 @@ ruby_method_child(
 
 ruby_method_def(
   unique int id: @ruby_method,
-  int name: @ruby_underscore_method_name ref,
-  int loc: @location ref
+  int name: @ruby_underscore_method_name ref
 );
 
 @ruby_method_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
@@ -856,8 +801,7 @@ ruby_method_parameters_child(
 );
 
 ruby_method_parameters_def(
-  unique int id: @ruby_method_parameters,
-  int loc: @location ref
+  unique int id: @ruby_method_parameters
 );
 
 @ruby_module_name_type = @ruby_scope_resolution | @ruby_token_constant
@@ -873,8 +817,7 @@ ruby_module_child(
 
 ruby_module_def(
   unique int id: @ruby_module,
-  int name: @ruby_module_name_type ref,
-  int loc: @location ref
+  int name: @ruby_module_name_type ref
 );
 
 ruby_next_child(
@@ -883,8 +826,7 @@ ruby_next_child(
 );
 
 ruby_next_def(
-  unique int id: @ruby_next,
-  int loc: @location ref
+  unique int id: @ruby_next
 );
 
 case @ruby_operator_assignment.operator of
@@ -908,15 +850,13 @@ ruby_operator_assignment_def(
   unique int id: @ruby_operator_assignment,
   int left: @ruby_underscore_lhs ref,
   int operator: int ref,
-  int right: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int right: @ruby_underscore_expression ref
 );
 
 ruby_optional_parameter_def(
   unique int id: @ruby_optional_parameter,
   int name: @ruby_token_identifier ref,
-  int value: @ruby_underscore_arg ref,
-  int loc: @location ref
+  int value: @ruby_underscore_arg ref
 );
 
 @ruby_pair_key_type = @ruby_string__ | @ruby_token_hash_key_symbol | @ruby_underscore_arg
@@ -928,14 +868,12 @@ ruby_pair_value(
 
 ruby_pair_def(
   unique int id: @ruby_pair,
-  int key__: @ruby_pair_key_type ref,
-  int loc: @location ref
+  int key__: @ruby_pair_key_type ref
 );
 
 ruby_parenthesized_pattern_def(
   unique int id: @ruby_parenthesized_pattern,
-  int child: @ruby_underscore_pattern_expr ref,
-  int loc: @location ref
+  int child: @ruby_underscore_pattern_expr ref
 );
 
 @ruby_parenthesized_statements_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -948,16 +886,14 @@ ruby_parenthesized_statements_child(
 );
 
 ruby_parenthesized_statements_def(
-  unique int id: @ruby_parenthesized_statements,
-  int loc: @location ref
+  unique int id: @ruby_parenthesized_statements
 );
 
 @ruby_pattern_child_type = @ruby_splat_argument | @ruby_underscore_arg
 
 ruby_pattern_def(
   unique int id: @ruby_pattern,
-  int child: @ruby_pattern_child_type ref,
-  int loc: @location ref
+  int child: @ruby_pattern_child_type ref
 );
 
 @ruby_program_child_type = @ruby_token_empty_statement | @ruby_token_uninterpreted | @ruby_underscore_statement
@@ -970,8 +906,7 @@ ruby_program_child(
 );
 
 ruby_program_def(
-  unique int id: @ruby_program,
-  int loc: @location ref
+  unique int id: @ruby_program
 );
 
 @ruby_range_begin_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
@@ -996,16 +931,14 @@ case @ruby_range.operator of
 
 ruby_range_def(
   unique int id: @ruby_range,
-  int operator: int ref,
-  int loc: @location ref
+  int operator: int ref
 );
 
 @ruby_rational_child_type = @ruby_token_float | @ruby_token_integer
 
 ruby_rational_def(
   unique int id: @ruby_rational,
-  int child: @ruby_rational_child_type ref,
-  int loc: @location ref
+  int child: @ruby_rational_child_type ref
 );
 
 ruby_redo_child(
@@ -1014,8 +947,7 @@ ruby_redo_child(
 );
 
 ruby_redo_def(
-  unique int id: @ruby_redo,
-  int loc: @location ref
+  unique int id: @ruby_redo
 );
 
 @ruby_regex_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
@@ -1028,8 +960,7 @@ ruby_regex_child(
 );
 
 ruby_regex_def(
-  unique int id: @ruby_regex,
-  int loc: @location ref
+  unique int id: @ruby_regex
 );
 
 ruby_rescue_body(
@@ -1048,8 +979,7 @@ ruby_rescue_variable(
 );
 
 ruby_rescue_def(
-  unique int id: @ruby_rescue,
-  int loc: @location ref
+  unique int id: @ruby_rescue
 );
 
 @ruby_rescue_modifier_body_type = @ruby_underscore_arg | @ruby_underscore_statement
@@ -1057,8 +987,7 @@ ruby_rescue_def(
 ruby_rescue_modifier_def(
   unique int id: @ruby_rescue_modifier,
   int body: @ruby_rescue_modifier_body_type ref,
-  int handler: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int handler: @ruby_underscore_expression ref
 );
 
 ruby_rest_assignment_child(
@@ -1067,8 +996,7 @@ ruby_rest_assignment_child(
 );
 
 ruby_rest_assignment_def(
-  unique int id: @ruby_rest_assignment,
-  int loc: @location ref
+  unique int id: @ruby_rest_assignment
 );
 
 ruby_retry_child(
@@ -1077,8 +1005,7 @@ ruby_retry_child(
 );
 
 ruby_retry_def(
-  unique int id: @ruby_retry,
-  int loc: @location ref
+  unique int id: @ruby_retry
 );
 
 ruby_return_child(
@@ -1087,8 +1014,7 @@ ruby_return_child(
 );
 
 ruby_return_def(
-  unique int id: @ruby_return,
-  int loc: @location ref
+  unique int id: @ruby_return
 );
 
 @ruby_right_assignment_list_child_type = @ruby_splat_argument | @ruby_underscore_arg
@@ -1101,8 +1027,7 @@ ruby_right_assignment_list_child(
 );
 
 ruby_right_assignment_list_def(
-  unique int id: @ruby_right_assignment_list,
-  int loc: @location ref
+  unique int id: @ruby_right_assignment_list
 );
 
 @ruby_scope_resolution_name_type = @ruby_token_constant | @ruby_token_identifier
@@ -1116,14 +1041,12 @@ ruby_scope_resolution_scope(
 
 ruby_scope_resolution_def(
   unique int id: @ruby_scope_resolution,
-  int name: @ruby_scope_resolution_name_type ref,
-  int loc: @location ref
+  int name: @ruby_scope_resolution_name_type ref
 );
 
 ruby_setter_def(
   unique int id: @ruby_setter,
-  int name: @ruby_token_identifier ref,
-  int loc: @location ref
+  int name: @ruby_token_identifier ref
 );
 
 @ruby_singleton_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
@@ -1137,8 +1060,7 @@ ruby_singleton_class_child(
 
 ruby_singleton_class_def(
   unique int id: @ruby_singleton_class,
-  int value: @ruby_underscore_arg ref,
-  int loc: @location ref
+  int value: @ruby_underscore_arg ref
 );
 
 @ruby_singleton_method_object_type = @ruby_underscore_arg | @ruby_underscore_variable
@@ -1160,14 +1082,12 @@ ruby_singleton_method_child(
 ruby_singleton_method_def(
   unique int id: @ruby_singleton_method,
   int name: @ruby_underscore_method_name ref,
-  int object: @ruby_singleton_method_object_type ref,
-  int loc: @location ref
+  int object: @ruby_singleton_method_object_type ref
 );
 
 ruby_splat_argument_def(
   unique int id: @ruby_splat_argument,
-  int child: @ruby_underscore_arg ref,
-  int loc: @location ref
+  int child: @ruby_underscore_arg ref
 );
 
 ruby_splat_parameter_name(
@@ -1176,8 +1096,7 @@ ruby_splat_parameter_name(
 );
 
 ruby_splat_parameter_def(
-  unique int id: @ruby_splat_parameter,
-  int loc: @location ref
+  unique int id: @ruby_splat_parameter
 );
 
 @ruby_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
@@ -1190,8 +1109,7 @@ ruby_string_child(
 );
 
 ruby_string_def(
-  unique int id: @ruby_string__,
-  int loc: @location ref
+  unique int id: @ruby_string__
 );
 
 #keyset[ruby_string_array, index]
@@ -1202,8 +1120,7 @@ ruby_string_array_child(
 );
 
 ruby_string_array_def(
-  unique int id: @ruby_string_array,
-  int loc: @location ref
+  unique int id: @ruby_string_array
 );
 
 @ruby_subshell_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
@@ -1216,14 +1133,12 @@ ruby_subshell_child(
 );
 
 ruby_subshell_def(
-  unique int id: @ruby_subshell,
-  int loc: @location ref
+  unique int id: @ruby_subshell
 );
 
 ruby_superclass_def(
   unique int id: @ruby_superclass,
-  int child: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int child: @ruby_underscore_expression ref
 );
 
 #keyset[ruby_symbol_array, index]
@@ -1234,8 +1149,7 @@ ruby_symbol_array_child(
 );
 
 ruby_symbol_array_def(
-  unique int id: @ruby_symbol_array,
-  int loc: @location ref
+  unique int id: @ruby_symbol_array
 );
 
 @ruby_then_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
@@ -1248,8 +1162,7 @@ ruby_then_child(
 );
 
 ruby_then_def(
-  unique int id: @ruby_then,
-  int loc: @location ref
+  unique int id: @ruby_then
 );
 
 @ruby_unary_operand_type = @ruby_parenthesized_statements | @ruby_underscore_expression | @ruby_underscore_simple_numeric
@@ -1267,8 +1180,7 @@ case @ruby_unary.operator of
 ruby_unary_def(
   unique int id: @ruby_unary,
   int operand: @ruby_unary_operand_type ref,
-  int operator: int ref,
-  int loc: @location ref
+  int operator: int ref
 );
 
 #keyset[ruby_undef, index]
@@ -1279,8 +1191,7 @@ ruby_undef_child(
 );
 
 ruby_undef_def(
-  unique int id: @ruby_undef,
-  int loc: @location ref
+  unique int id: @ruby_undef
 );
 
 @ruby_unless_alternative_type = @ruby_else | @ruby_elsif
@@ -1297,43 +1208,37 @@ ruby_unless_consequence(
 
 ruby_unless_def(
   unique int id: @ruby_unless,
-  int condition: @ruby_underscore_statement ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_statement ref
 );
 
 ruby_unless_guard_def(
   unique int id: @ruby_unless_guard,
-  int condition: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_expression ref
 );
 
 ruby_unless_modifier_def(
   unique int id: @ruby_unless_modifier,
   int body: @ruby_underscore_statement ref,
-  int condition: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_expression ref
 );
 
 ruby_until_def(
   unique int id: @ruby_until,
   int body: @ruby_do ref,
-  int condition: @ruby_underscore_statement ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_statement ref
 );
 
 ruby_until_modifier_def(
   unique int id: @ruby_until_modifier,
   int body: @ruby_underscore_statement ref,
-  int condition: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_expression ref
 );
 
 @ruby_variable_reference_pattern_name_type = @ruby_token_identifier | @ruby_underscore_nonlocal_variable
 
 ruby_variable_reference_pattern_def(
   unique int id: @ruby_variable_reference_pattern,
-  int name: @ruby_variable_reference_pattern_name_type ref,
-  int loc: @location ref
+  int name: @ruby_variable_reference_pattern_name_type ref
 );
 
 ruby_when_body(
@@ -1349,22 +1254,19 @@ ruby_when_pattern(
 );
 
 ruby_when_def(
-  unique int id: @ruby_when,
-  int loc: @location ref
+  unique int id: @ruby_when
 );
 
 ruby_while_def(
   unique int id: @ruby_while,
   int body: @ruby_do ref,
-  int condition: @ruby_underscore_statement ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_statement ref
 );
 
 ruby_while_modifier_def(
   unique int id: @ruby_while_modifier,
   int body: @ruby_underscore_statement ref,
-  int condition: @ruby_underscore_expression ref,
-  int loc: @location ref
+  int condition: @ruby_underscore_expression ref
 );
 
 ruby_yield_child(
@@ -1373,15 +1275,13 @@ ruby_yield_child(
 );
 
 ruby_yield_def(
-  unique int id: @ruby_yield,
-  int loc: @location ref
+  unique int id: @ruby_yield
 );
 
 ruby_tokeninfo(
   unique int id: @ruby_token,
   int kind: int ref,
-  string value: string ref,
-  int loc: @location ref
+  string value: string ref
 );
 
 case @ruby_token.kind of
@@ -1425,34 +1325,31 @@ case @ruby_token.kind of
 @ruby_ast_node_parent = @file | @ruby_ast_node
 
 #keyset[parent, parent_index]
-ruby_ast_node_parent(
-  int child: @ruby_ast_node ref,
+ruby_ast_node_info(
+  int node: @ruby_ast_node ref,
   int parent: @ruby_ast_node_parent ref,
-  int parent_index: int ref
+  int parent_index: int ref,
+  int loc: @location ref
 );
 
 erb_comment_directive_def(
   unique int id: @erb_comment_directive,
-  int child: @erb_token_comment ref,
-  int loc: @location ref
+  int child: @erb_token_comment ref
 );
 
 erb_directive_def(
   unique int id: @erb_directive,
-  int child: @erb_token_code ref,
-  int loc: @location ref
+  int child: @erb_token_code ref
 );
 
 erb_graphql_directive_def(
   unique int id: @erb_graphql_directive,
-  int child: @erb_token_code ref,
-  int loc: @location ref
+  int child: @erb_token_code ref
 );
 
 erb_output_directive_def(
   unique int id: @erb_output_directive,
-  int child: @erb_token_code ref,
-  int loc: @location ref
+  int child: @erb_token_code ref
 );
 
 @erb_template_child_type = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_token_content
@@ -1465,15 +1362,13 @@ erb_template_child(
 );
 
 erb_template_def(
-  unique int id: @erb_template,
-  int loc: @location ref
+  unique int id: @erb_template
 );
 
 erb_tokeninfo(
   unique int id: @erb_token,
   int kind: int ref,
-  string value: string ref,
-  int loc: @location ref
+  string value: string ref
 );
 
 case @erb_token.kind of
@@ -1489,9 +1384,10 @@ case @erb_token.kind of
 @erb_ast_node_parent = @erb_ast_node | @file
 
 #keyset[parent, parent_index]
-erb_ast_node_parent(
-  int child: @erb_ast_node ref,
+erb_ast_node_info(
+  int node: @erb_ast_node ref,
   int parent: @erb_ast_node_parent ref,
-  int parent_index: int ref
+  int parent_index: int ref,
+  int loc: @location ref
 );
 

--- a/ruby/ql/lib/ruby.dbscheme.stats
+++ b/ruby/ql/lib/ruby.dbscheme.stats
@@ -21,7 +21,7 @@
         </e>
         <e>
             <k>@erb_directive</k>
-            <v>1457</v>
+            <v>1449</v>
         </e>
         <e>
             <k>@erb_graphql_directive</k>
@@ -29,19 +29,19 @@
         </e>
         <e>
             <k>@erb_output_directive</k>
-            <v>3918</v>
+            <v>3895</v>
         </e>
         <e>
             <k>@erb_reserved_word</k>
-            <v>10751</v>
+            <v>10689</v>
         </e>
         <e>
             <k>@erb_template</k>
-            <v>1561</v>
+            <v>1562</v>
         </e>
         <e>
             <k>@erb_token_code</k>
-            <v>5375</v>
+            <v>5344</v>
         </e>
         <e>
             <k>@erb_token_comment</k>
@@ -49,23 +49,23 @@
         </e>
         <e>
             <k>@erb_token_content</k>
-            <v>3839</v>
+            <v>3816</v>
         </e>
         <e>
             <k>@file</k>
-            <v>16884</v>
+            <v>16948</v>
         </e>
         <e>
             <k>@folder</k>
-            <v>4781</v>
+            <v>4774</v>
         </e>
         <e>
             <k>@location_default</k>
-            <v>8498016</v>
+            <v>8504708</v>
         </e>
         <e>
             <k>@ruby_alias</k>
-            <v>1252</v>
+            <v>1256</v>
         </e>
         <e>
             <k>@ruby_alternative_pattern</k>
@@ -73,11 +73,11 @@
         </e>
         <e>
             <k>@ruby_argument_list</k>
-            <v>662809</v>
+            <v>663118</v>
         </e>
         <e>
             <k>@ruby_array</k>
-            <v>245435</v>
+            <v>245466</v>
         </e>
         <e>
             <k>@ruby_array_pattern</k>
@@ -89,19 +89,19 @@
         </e>
         <e>
             <k>@ruby_assignment</k>
-            <v>130489</v>
+            <v>130604</v>
         </e>
         <e>
             <k>@ruby_bare_string</k>
-            <v>11471</v>
+            <v>11474</v>
         </e>
         <e>
             <k>@ruby_bare_symbol</k>
-            <v>2149</v>
+            <v>2137</v>
         </e>
         <e>
             <k>@ruby_begin</k>
-            <v>2528</v>
+            <v>2533</v>
         </e>
         <e>
             <k>@ruby_begin_block</k>
@@ -109,19 +109,19 @@
         </e>
         <e>
             <k>@ruby_binary_ampersand</k>
-            <v>473</v>
+            <v>474</v>
         </e>
         <e>
             <k>@ruby_binary_ampersandampersand</k>
-            <v>8867</v>
+            <v>8822</v>
         </e>
         <e>
             <k>@ruby_binary_and</k>
-            <v>1349</v>
+            <v>1355</v>
         </e>
         <e>
             <k>@ruby_binary_bangequal</k>
-            <v>1594</v>
+            <v>1585</v>
         </e>
         <e>
             <k>@ruby_binary_bangtilde</k>
@@ -129,11 +129,11 @@
         </e>
         <e>
             <k>@ruby_binary_caret</k>
-            <v>146</v>
+            <v>155</v>
         </e>
         <e>
             <k>@ruby_binary_equalequal</k>
-            <v>31014</v>
+            <v>31084</v>
         </e>
         <e>
             <k>@ruby_binary_equalequalequal</k>
@@ -141,15 +141,15 @@
         </e>
         <e>
             <k>@ruby_binary_equaltilde</k>
-            <v>1821</v>
+            <v>1822</v>
         </e>
         <e>
             <k>@ruby_binary_langle</k>
-            <v>1347</v>
+            <v>1343</v>
         </e>
         <e>
             <k>@ruby_binary_langleequal</k>
-            <v>367</v>
+            <v>369</v>
         </e>
         <e>
             <k>@ruby_binary_langleequalrangle</k>
@@ -157,11 +157,11 @@
         </e>
         <e>
             <k>@ruby_binary_langlelangle</k>
-            <v>10476</v>
+            <v>10484</v>
         </e>
         <e>
             <k>@ruby_binary_minus</k>
-            <v>2876</v>
+            <v>2883</v>
         </e>
         <e>
             <k>@ruby_binary_or</k>
@@ -169,23 +169,23 @@
         </e>
         <e>
             <k>@ruby_binary_percent</k>
-            <v>1011</v>
+            <v>1014</v>
         </e>
         <e>
             <k>@ruby_binary_pipe</k>
-            <v>973</v>
+            <v>981</v>
         </e>
         <e>
             <k>@ruby_binary_pipepipe</k>
-            <v>8132</v>
+            <v>8088</v>
         </e>
         <e>
             <k>@ruby_binary_plus</k>
-            <v>6091</v>
+            <v>6102</v>
         </e>
         <e>
             <k>@ruby_binary_rangle</k>
-            <v>2442</v>
+            <v>2431</v>
         </e>
         <e>
             <k>@ruby_binary_rangleequal</k>
@@ -193,35 +193,35 @@
         </e>
         <e>
             <k>@ruby_binary_ranglerangle</k>
-            <v>216</v>
+            <v>230</v>
         </e>
         <e>
             <k>@ruby_binary_slash</k>
-            <v>1246</v>
+            <v>1248</v>
         </e>
         <e>
             <k>@ruby_binary_star</k>
-            <v>3113</v>
+            <v>3119</v>
         </e>
         <e>
             <k>@ruby_binary_starstar</k>
-            <v>1274</v>
+            <v>1291</v>
         </e>
         <e>
             <k>@ruby_block</k>
-            <v>96877</v>
+            <v>96904</v>
         </e>
         <e>
             <k>@ruby_block_argument</k>
-            <v>6041</v>
+            <v>6048</v>
         </e>
         <e>
             <k>@ruby_block_parameter</k>
-            <v>2411</v>
+            <v>2410</v>
         </e>
         <e>
             <k>@ruby_block_parameters</k>
-            <v>23488</v>
+            <v>23501</v>
         </e>
         <e>
             <k>@ruby_break</k>
@@ -229,11 +229,11 @@
         </e>
         <e>
             <k>@ruby_call</k>
-            <v>960515</v>
+            <v>961220</v>
         </e>
         <e>
             <k>@ruby_case__</k>
-            <v>1215</v>
+            <v>1219</v>
         </e>
         <e>
             <k>@ruby_case_match</k>
@@ -245,15 +245,15 @@
         </e>
         <e>
             <k>@ruby_class</k>
-            <v>16747</v>
+            <v>16778</v>
         </e>
         <e>
             <k>@ruby_conditional</k>
-            <v>3573</v>
+            <v>3556</v>
         </e>
         <e>
             <k>@ruby_delimited_symbol</k>
-            <v>1215</v>
+            <v>1216</v>
         </e>
         <e>
             <k>@ruby_destructured_left_assignment</k>
@@ -265,23 +265,23 @@
         </e>
         <e>
             <k>@ruby_do</k>
-            <v>1616</v>
+            <v>1621</v>
         </e>
         <e>
             <k>@ruby_do_block</k>
-            <v>136477</v>
+            <v>136559</v>
         </e>
         <e>
             <k>@ruby_element_reference</k>
-            <v>82480</v>
+            <v>82281</v>
         </e>
         <e>
             <k>@ruby_else</k>
-            <v>6947</v>
+            <v>6946</v>
         </e>
         <e>
             <k>@ruby_elsif</k>
-            <v>1610</v>
+            <v>1606</v>
         </e>
         <e>
             <k>@ruby_end_block</k>
@@ -289,15 +289,15 @@
         </e>
         <e>
             <k>@ruby_ensure</k>
-            <v>3765</v>
+            <v>3786</v>
         </e>
         <e>
             <k>@ruby_exception_variable</k>
-            <v>1027</v>
+            <v>1021</v>
         </e>
         <e>
             <k>@ruby_exceptions</k>
-            <v>1638</v>
+            <v>1641</v>
         </e>
         <e>
             <k>@ruby_expression_reference_pattern</k>
@@ -313,7 +313,7 @@
         </e>
         <e>
             <k>@ruby_hash</k>
-            <v>39289</v>
+            <v>39344</v>
         </e>
         <e>
             <k>@ruby_hash_pattern</k>
@@ -321,19 +321,19 @@
         </e>
         <e>
             <k>@ruby_hash_splat_argument</k>
-            <v>1812</v>
+            <v>1813</v>
         </e>
         <e>
             <k>@ruby_hash_splat_parameter</k>
-            <v>1350</v>
+            <v>1351</v>
         </e>
         <e>
             <k>@ruby_heredoc_body</k>
-            <v>5568</v>
+            <v>5577</v>
         </e>
         <e>
             <k>@ruby_if</k>
-            <v>18579</v>
+            <v>18504</v>
         </e>
         <e>
             <k>@ruby_if_guard</k>
@@ -341,7 +341,7 @@
         </e>
         <e>
             <k>@ruby_if_modifier</k>
-            <v>13834</v>
+            <v>13763</v>
         </e>
         <e>
             <k>@ruby_in</k>
@@ -353,11 +353,11 @@
         </e>
         <e>
             <k>@ruby_interpolation</k>
-            <v>38591</v>
+            <v>38383</v>
         </e>
         <e>
             <k>@ruby_keyword_parameter</k>
-            <v>3774</v>
+            <v>3777</v>
         </e>
         <e>
             <k>@ruby_keyword_pattern</k>
@@ -365,31 +365,31 @@
         </e>
         <e>
             <k>@ruby_lambda</k>
-            <v>7473</v>
+            <v>7499</v>
         </e>
         <e>
             <k>@ruby_lambda_parameters</k>
-            <v>1649</v>
+            <v>1659</v>
         </e>
         <e>
             <k>@ruby_left_assignment_list</k>
-            <v>2886</v>
+            <v>2887</v>
         </e>
         <e>
             <k>@ruby_method</k>
-            <v>98554</v>
+            <v>98643</v>
         </e>
         <e>
             <k>@ruby_method_parameters</k>
-            <v>28984</v>
+            <v>28992</v>
         </e>
         <e>
             <k>@ruby_module</k>
-            <v>21083</v>
+            <v>21140</v>
         </e>
         <e>
             <k>@ruby_next</k>
-            <v>2082</v>
+            <v>2070</v>
         </e>
         <e>
             <k>@ruby_operator_assignment_ampersandampersandequal</k>
@@ -409,7 +409,7 @@
         </e>
         <e>
             <k>@ruby_operator_assignment_minusequal</k>
-            <v>293</v>
+            <v>294</v>
         </e>
         <e>
             <k>@ruby_operator_assignment_percentequal</k>
@@ -421,11 +421,11 @@
         </e>
         <e>
             <k>@ruby_operator_assignment_pipepipeequal</k>
-            <v>4656</v>
+            <v>4638</v>
         </e>
         <e>
             <k>@ruby_operator_assignment_plusequal</k>
-            <v>1643</v>
+            <v>1752</v>
         </e>
         <e>
             <k>@ruby_operator_assignment_ranglerangleequal</k>
@@ -445,11 +445,11 @@
         </e>
         <e>
             <k>@ruby_optional_parameter</k>
-            <v>6519</v>
+            <v>6527</v>
         </e>
         <e>
             <k>@ruby_pair</k>
-            <v>234896</v>
+            <v>235172</v>
         </e>
         <e>
             <k>@ruby_parenthesized_pattern</k>
@@ -457,23 +457,23 @@
         </e>
         <e>
             <k>@ruby_parenthesized_statements</k>
-            <v>10064</v>
+            <v>10153</v>
         </e>
         <e>
             <k>@ruby_pattern</k>
-            <v>3869</v>
+            <v>3878</v>
         </e>
         <e>
             <k>@ruby_program</k>
-            <v>16871</v>
+            <v>16935</v>
         </e>
         <e>
             <k>@ruby_range_dotdot</k>
-            <v>2747</v>
+            <v>2750</v>
         </e>
         <e>
             <k>@ruby_range_dotdotdot</k>
-            <v>1539</v>
+            <v>1544</v>
         </e>
         <e>
             <k>@ruby_rational</k>
@@ -485,19 +485,19 @@
         </e>
         <e>
             <k>@ruby_regex</k>
-            <v>12819</v>
+            <v>12828</v>
         </e>
         <e>
             <k>@ruby_rescue</k>
-            <v>2094</v>
+            <v>2085</v>
         </e>
         <e>
             <k>@ruby_rescue_modifier</k>
-            <v>554</v>
+            <v>551</v>
         </e>
         <e>
             <k>@ruby_reserved_word</k>
-            <v>3651119</v>
+            <v>3653831</v>
         </e>
         <e>
             <k>@ruby_rest_assignment</k>
@@ -509,19 +509,19 @@
         </e>
         <e>
             <k>@ruby_return</k>
-            <v>8544</v>
+            <v>8521</v>
         </e>
         <e>
             <k>@ruby_right_assignment_list</k>
-            <v>1372</v>
+            <v>1376</v>
         </e>
         <e>
             <k>@ruby_scope_resolution</k>
-            <v>80121</v>
+            <v>80201</v>
         </e>
         <e>
             <k>@ruby_setter</k>
-            <v>594</v>
+            <v>598</v>
         </e>
         <e>
             <k>@ruby_singleton_class</k>
@@ -529,23 +529,23 @@
         </e>
         <e>
             <k>@ruby_singleton_method</k>
-            <v>6598</v>
+            <v>6563</v>
         </e>
         <e>
             <k>@ruby_splat_argument</k>
-            <v>3176</v>
+            <v>3179</v>
         </e>
         <e>
             <k>@ruby_splat_parameter</k>
-            <v>2930</v>
+            <v>2936</v>
         </e>
         <e>
             <k>@ruby_string__</k>
-            <v>474389</v>
+            <v>474637</v>
         </e>
         <e>
             <k>@ruby_string_array</k>
-            <v>3861</v>
+            <v>3868</v>
         </e>
         <e>
             <k>@ruby_subshell</k>
@@ -553,15 +553,15 @@
         </e>
         <e>
             <k>@ruby_superclass</k>
-            <v>13244</v>
+            <v>13262</v>
         </e>
         <e>
             <k>@ruby_symbol_array</k>
-            <v>460</v>
+            <v>457</v>
         </e>
         <e>
             <k>@ruby_then</k>
-            <v>24696</v>
+            <v>24592</v>
         </e>
         <e>
             <k>@ruby_token_character</k>
@@ -569,11 +569,11 @@
         </e>
         <e>
             <k>@ruby_token_class_variable</k>
-            <v>777</v>
+            <v>776</v>
         </e>
         <e>
             <k>@ruby_token_comment</k>
-            <v>179703</v>
+            <v>179885</v>
         </e>
         <e>
             <k>@ruby_token_complex</k>
@@ -581,7 +581,7 @@
         </e>
         <e>
             <k>@ruby_token_constant</k>
-            <v>284485</v>
+            <v>284770</v>
         </e>
         <e>
             <k>@ruby_token_empty_statement</k>
@@ -593,11 +593,11 @@
         </e>
         <e>
             <k>@ruby_token_escape_sequence</k>
-            <v>75406</v>
+            <v>75435</v>
         </e>
         <e>
             <k>@ruby_token_false</k>
-            <v>16981</v>
+            <v>16937</v>
         </e>
         <e>
             <k>@ruby_token_file</k>
@@ -605,23 +605,23 @@
         </e>
         <e>
             <k>@ruby_token_float</k>
-            <v>7813</v>
+            <v>7814</v>
         </e>
         <e>
             <k>@ruby_token_forward_argument</k>
-            <v>62</v>
+            <v>66</v>
         </e>
         <e>
             <k>@ruby_token_forward_parameter</k>
-            <v>72</v>
+            <v>75</v>
         </e>
         <e>
             <k>@ruby_token_global_variable</k>
-            <v>7077</v>
+            <v>7078</v>
         </e>
         <e>
             <k>@ruby_token_hash_key_symbol</k>
-            <v>228236</v>
+            <v>228521</v>
         </e>
         <e>
             <k>@ruby_token_hash_splat_nil</k>
@@ -629,27 +629,27 @@
         </e>
         <e>
             <k>@ruby_token_heredoc_beginning</k>
-            <v>5594</v>
+            <v>5603</v>
         </e>
         <e>
             <k>@ruby_token_heredoc_content</k>
-            <v>12465</v>
+            <v>12423</v>
         </e>
         <e>
             <k>@ruby_token_heredoc_end</k>
-            <v>5568</v>
+            <v>5577</v>
         </e>
         <e>
             <k>@ruby_token_identifier</k>
-            <v>1487594</v>
+            <v>1482144</v>
         </e>
         <e>
             <k>@ruby_token_instance_variable</k>
-            <v>81567</v>
+            <v>81594</v>
         </e>
         <e>
             <k>@ruby_token_integer</k>
-            <v>298219</v>
+            <v>298439</v>
         </e>
         <e>
             <k>@ruby_token_line</k>
@@ -657,31 +657,31 @@
         </e>
         <e>
             <k>@ruby_token_nil</k>
-            <v>17872</v>
+            <v>17874</v>
         </e>
         <e>
             <k>@ruby_token_operator</k>
-            <v>781</v>
+            <v>782</v>
         </e>
         <e>
             <k>@ruby_token_self</k>
-            <v>13127</v>
+            <v>13136</v>
         </e>
         <e>
             <k>@ruby_token_simple_symbol</k>
-            <v>249151</v>
+            <v>249753</v>
         </e>
         <e>
             <k>@ruby_token_string_content</k>
-            <v>488732</v>
+            <v>488998</v>
         </e>
         <e>
             <k>@ruby_token_super</k>
-            <v>4999</v>
+            <v>5009</v>
         </e>
         <e>
             <k>@ruby_token_true</k>
-            <v>23199</v>
+            <v>23064</v>
         </e>
         <e>
             <k>@ruby_token_uninterpreted</k>
@@ -689,7 +689,7 @@
         </e>
         <e>
             <k>@ruby_unary_bang</k>
-            <v>5754</v>
+            <v>5738</v>
         </e>
         <e>
             <k>@ruby_unary_definedquestion</k>
@@ -697,7 +697,7 @@
         </e>
         <e>
             <k>@ruby_unary_minus</k>
-            <v>8493</v>
+            <v>8570</v>
         </e>
         <e>
             <k>@ruby_unary_not</k>
@@ -705,7 +705,7 @@
         </e>
         <e>
             <k>@ruby_unary_plus</k>
-            <v>1388</v>
+            <v>1389</v>
         </e>
         <e>
             <k>@ruby_unary_tilde</k>
@@ -725,7 +725,7 @@
         </e>
         <e>
             <k>@ruby_unless_modifier</k>
-            <v>4363</v>
+            <v>4341</v>
         </e>
         <e>
             <k>@ruby_until</k>
@@ -741,11 +741,11 @@
         </e>
         <e>
             <k>@ruby_when</k>
-            <v>3220</v>
+            <v>3229</v>
         </e>
         <e>
             <k>@ruby_while</k>
-            <v>1339</v>
+            <v>1344</v>
         </e>
         <e>
             <k>@ruby_while_modifier</k>
@@ -753,20 +753,20 @@
         </e>
         <e>
             <k>@ruby_yield</k>
-            <v>2402</v>
+            <v>2406</v>
         </e>
         </typesizes>
   <stats><relation>
             <name>containerparent</name>
-            <cardinality>21640</cardinality>
+            <cardinality>21696</cardinality>
             <columnsizes>
                 <e>
                     <k>parent</k>
-                    <v>4781</v>
+                    <v>4774</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>21640</v>
+                    <v>21696</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -780,22 +780,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2138</v>
+                                    <v>2134</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>920</v>
+                                    <v>905</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>427</v>
+                                    <v>439</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>298</v>
+                                    <v>297</v>
                                 </b>
                                 <b>
                                     <a>5</a>
@@ -809,8 +809,8 @@
                                 </b>
                                 <b>
                                     <a>13</a>
-                                    <b>117</b>
-                                    <v>233</v>
+                                    <b>120</b>
+                                    <v>232</v>
                                 </b>
                             </bs>
                         </hist>
@@ -826,7 +826,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>21640</v>
+                                    <v>21696</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1372,25 +1372,29 @@
             </dependencies>
         </relation>
         <relation>
-            <name>erb_ast_node_parent</name>
-            <cardinality>25772</cardinality>
+            <name>erb_ast_node_info</name>
+            <cardinality>25623</cardinality>
             <columnsizes>
                 <e>
-                    <k>child</k>
-                    <v>25772</v>
+                    <k>node</k>
+                    <v>25623</v>
                 </e>
                 <e>
                     <k>parent</k>
-                    <v>6235</v>
+                    <v>6199</v>
                 </e>
                 <e>
                     <k>parent_index</k>
-                    <v>759</v>
+                    <v>754</v>
+                </e>
+                <e>
+                    <k>loc</k>
+                    <v>25620</v>
                 </e>
             </columnsizes>
             <dependencies>
                 <dep>
-                    <src>child</src>
+                    <src>node</src>
                     <trg>parent</trg>
                     <val>
                         <hist>
@@ -1399,14 +1403,14 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>25772</v>
+                                    <v>25623</v>
                                 </b>
                             </bs>
                         </hist>
                     </val>
                 </dep>
                 <dep>
-                    <src>child</src>
+                    <src>node</src>
                     <trg>parent_index</trg>
                     <val>
                         <hist>
@@ -1415,7 +1419,23 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>25772</v>
+                                    <v>25623</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>node</src>
+                    <trg>loc</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>25623</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1423,7 +1443,7 @@
                 </dep>
                 <dep>
                     <src>parent</src>
-                    <trg>child</trg>
+                    <trg>node</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -1431,17 +1451,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>3</b>
-                                    <v>457</v>
+                                    <v>454</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>5519</v>
+                                    <v>5487</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>250</b>
-                                    <v>259</v>
+                                    <v>257</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1457,17 +1477,43 @@
                                 <b>
                                     <a>1</a>
                                     <b>3</b>
-                                    <v>457</v>
+                                    <v>454</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>5519</v>
+                                    <v>5487</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>250</b>
-                                    <v>259</v>
+                                    <v>257</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>parent</src>
+                    <trg>loc</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>3</b>
+                                    <v>454</v>
+                                </b>
+                                <b>
+                                    <a>3</a>
+                                    <b>4</b>
+                                    <v>5487</v>
+                                </b>
+                                <b>
+                                    <a>4</a>
+                                    <b>250</b>
+                                    <v>257</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1475,7 +1521,7 @@
                 </dep>
                 <dep>
                     <src>parent_index</src>
-                    <trg>child</trg>
+                    <trg>node</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -1483,7 +1529,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>161</v>
+                                    <v>160</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -1503,7 +1549,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>73</v>
+                                    <v>72</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -1544,7 +1590,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>161</v>
+                                    <v>160</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -1564,7 +1610,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>73</v>
+                                    <v>72</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -1590,6 +1636,125 @@
                                     <a>48</a>
                                     <b>2046</b>
                                     <v>48</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>parent_index</src>
+                    <trg>loc</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>160</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>3</b>
+                                    <v>115</v>
+                                </b>
+                                <b>
+                                    <a>3</a>
+                                    <b>4</b>
+                                    <v>97</v>
+                                </b>
+                                <b>
+                                    <a>4</a>
+                                    <b>5</b>
+                                    <v>21</v>
+                                </b>
+                                <b>
+                                    <a>5</a>
+                                    <b>6</b>
+                                    <v>72</v>
+                                </b>
+                                <b>
+                                    <a>6</a>
+                                    <b>8</b>
+                                    <v>60</v>
+                                </b>
+                                <b>
+                                    <a>8</a>
+                                    <b>13</b>
+                                    <v>60</v>
+                                </b>
+                                <b>
+                                    <a>14</a>
+                                    <b>24</b>
+                                    <v>60</v>
+                                </b>
+                                <b>
+                                    <a>24</a>
+                                    <b>45</b>
+                                    <v>57</v>
+                                </b>
+                                <b>
+                                    <a>48</a>
+                                    <b>2045</b>
+                                    <v>48</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>loc</src>
+                    <trg>node</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>25617</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>3</b>
+                                    <v>3</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>loc</src>
+                    <trg>parent</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>25617</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>3</b>
+                                    <v>3</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>loc</src>
+                    <trg>parent_index</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>25620</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1609,10 +1774,6 @@
                     <k>child</k>
                     <v>40</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>40</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -1632,72 +1793,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>40</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>child</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>40</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>40</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>40</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -1715,19 +1812,15 @@
         </relation>
         <relation>
             <name>erb_directive_def</name>
-            <cardinality>1457</cardinality>
+            <cardinality>1449</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1457</v>
+                    <v>1449</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1457</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1457</v>
+                    <v>1449</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -1741,23 +1834,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1457</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1457</v>
+                                    <v>1449</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1773,55 +1850,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1457</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1457</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1457</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1457</v>
+                                    <v>1449</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1841,10 +1870,6 @@
                     <k>child</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -1864,54 +1889,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>child</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -1923,19 +1902,15 @@
         </relation>
         <relation>
             <name>erb_output_directive_def</name>
-            <cardinality>3918</cardinality>
+            <cardinality>3895</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3918</v>
+                    <v>3895</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>3918</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3918</v>
+                    <v>3895</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -1949,23 +1924,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3918</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3918</v>
+                                    <v>3895</v>
                                 </b>
                             </bs>
                         </hist>
@@ -1981,55 +1940,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3918</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3918</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3918</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3918</v>
+                                    <v>3895</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2039,19 +1950,19 @@
         </relation>
         <relation>
             <name>erb_template_child</name>
-            <cardinality>9214</cardinality>
+            <cardinality>9161</cardinality>
             <columnsizes>
                 <e>
                     <k>erb_template</k>
-                    <v>429</v>
+                    <v>427</v>
                 </e>
                 <e>
                     <k>index</k>
-                    <v>759</v>
+                    <v>754</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>9214</v>
+                    <v>9161</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -2070,7 +1981,7 @@
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>143</v>
+                                    <v>142</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -2131,7 +2042,7 @@
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>143</v>
+                                    <v>142</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -2187,7 +2098,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>161</v>
+                                    <v>160</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -2207,7 +2118,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>73</v>
+                                    <v>72</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -2248,7 +2159,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>161</v>
+                                    <v>160</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -2268,7 +2179,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>73</v>
+                                    <v>72</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -2309,7 +2220,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>9214</v>
+                                    <v>9161</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2325,7 +2236,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>9214</v>
+                                    <v>9161</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2335,59 +2246,22 @@
         </relation>
         <relation>
             <name>erb_template_def</name>
-            <cardinality>1561</cardinality>
+            <cardinality>1562</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1561</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1561</v>
+                    <v>1562</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1561</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1561</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>erb_tokeninfo</name>
-            <cardinality>19966</cardinality>
+            <cardinality>19851</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>19966</v>
+                    <v>19851</v>
                 </e>
                 <e>
                     <k>kind</k>
@@ -2395,11 +2269,7 @@
                 </e>
                 <e>
                     <k>value</k>
-                    <v>5909</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>19966</v>
+                    <v>5875</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -2413,7 +2283,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>19966</v>
+                                    <v>19851</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2429,23 +2299,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>19966</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>19966</v>
+                                    <v>19851</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2504,32 +2358,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>kind</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1259</a>
-                                    <b>1260</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>1763</a>
-                                    <b>1764</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>3526</a>
-                                    <b>3527</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>value</src>
                     <trg>id</trg>
                     <val>
@@ -2539,17 +2367,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4717</v>
+                                    <v>4689</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>695</v>
+                                    <v>691</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>20</b>
-                                    <v>448</v>
+                                    <v>445</v>
                                 </b>
                                 <b>
                                     <a>20</a>
@@ -2570,86 +2398,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5909</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4717</v>
-                                </b>
-                                <b>
-                                    <a>2</a>
-                                    <b>3</b>
-                                    <v>695</v>
-                                </b>
-                                <b>
-                                    <a>3</a>
-                                    <b>20</b>
-                                    <v>448</v>
-                                </b>
-                                <b>
-                                    <a>20</a>
-                                    <b>1697</b>
-                                    <v>48</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>19966</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>kind</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>19966</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>19966</v>
+                                    <v>5875</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2659,15 +2408,15 @@
         </relation>
         <relation>
             <name>files</name>
-            <cardinality>16884</cardinality>
+            <cardinality>16948</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>16884</v>
+                    <v>16948</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>16884</v>
+                    <v>16948</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -2681,7 +2430,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>16884</v>
+                                    <v>16948</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2697,7 +2446,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>16884</v>
+                                    <v>16948</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2707,15 +2456,15 @@
         </relation>
         <relation>
             <name>folders</name>
-            <cardinality>4781</cardinality>
+            <cardinality>4774</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>4781</v>
+                    <v>4774</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>4781</v>
+                    <v>4774</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -2729,7 +2478,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4781</v>
+                                    <v>4774</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2745,7 +2494,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4781</v>
+                                    <v>4774</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2755,31 +2504,31 @@
         </relation>
         <relation>
             <name>locations_default</name>
-            <cardinality>8498016</cardinality>
+            <cardinality>8504708</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>8498016</v>
+                    <v>8504708</v>
                 </e>
                 <e>
                     <k>file</k>
-                    <v>16884</v>
+                    <v>16948</v>
                 </e>
                 <e>
                     <k>start_line</k>
-                    <v>30555</v>
+                    <v>30559</v>
                 </e>
                 <e>
                     <k>start_column</k>
-                    <v>5053</v>
+                    <v>5045</v>
                 </e>
                 <e>
                     <k>end_line</k>
-                    <v>30555</v>
+                    <v>30559</v>
                 </e>
                 <e>
                     <k>end_column</k>
-                    <v>5118</v>
+                    <v>5110</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -2793,7 +2542,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8498016</v>
+                                    <v>8504708</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2809,7 +2558,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8498016</v>
+                                    <v>8504708</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2825,7 +2574,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8498016</v>
+                                    <v>8504708</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2841,7 +2590,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8498016</v>
+                                    <v>8504708</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2857,7 +2606,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8498016</v>
+                                    <v>8504708</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2873,72 +2622,72 @@
                                 <b>
                                     <a>1</a>
                                     <b>34</b>
-                                    <v>1399</v>
+                                    <v>1397</v>
                                 </b>
                                 <b>
                                     <a>34</a>
                                     <b>52</b>
-                                    <v>1282</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>52</a>
                                     <b>73</b>
-                                    <v>1321</v>
+                                    <v>1345</v>
                                 </b>
                                 <b>
                                     <a>73</a>
                                     <b>94</b>
-                                    <v>1321</v>
+                                    <v>1319</v>
                                 </b>
                                 <b>
                                     <a>94</a>
-                                    <b>128</b>
-                                    <v>1282</v>
+                                    <b>127</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>128</a>
-                                    <b>169</b>
-                                    <v>1269</v>
+                                    <a>127</a>
+                                    <b>168</b>
+                                    <v>1293</v>
                                 </b>
                                 <b>
-                                    <a>169</a>
+                                    <a>168</a>
                                     <b>215</b>
-                                    <v>1282</v>
+                                    <v>1306</v>
                                 </b>
                                 <b>
                                     <a>215</a>
-                                    <b>268</b>
-                                    <v>1282</v>
+                                    <b>269</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>268</a>
-                                    <b>347</b>
-                                    <v>1269</v>
+                                    <a>269</a>
+                                    <b>350</b>
+                                    <v>1293</v>
                                 </b>
                                 <b>
-                                    <a>348</a>
-                                    <b>465</b>
-                                    <v>1269</v>
+                                    <a>350</a>
+                                    <b>471</b>
+                                    <v>1293</v>
                                 </b>
                                 <b>
-                                    <a>468</a>
-                                    <b>701</b>
-                                    <v>1269</v>
+                                    <a>474</a>
+                                    <b>717</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>704</a>
-                                    <b>1328</b>
-                                    <v>1269</v>
+                                    <a>718</a>
+                                    <b>1367</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>1330</a>
-                                    <b>7896</b>
-                                    <v>1269</v>
+                                    <a>1390</a>
+                                    <b>15687</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>8172</a>
-                                    <b>22773</b>
-                                    <v>90</v>
+                                    <a>22816</a>
+                                    <b>22817</b>
+                                    <v>12</v>
                                 </b>
                             </bs>
                         </hist>
@@ -2954,67 +2703,67 @@
                                 <b>
                                     <a>1</a>
                                     <b>8</b>
-                                    <v>1516</v>
+                                    <v>1500</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>11</b>
-                                    <v>1321</v>
+                                    <v>1371</v>
                                 </b>
                                 <b>
                                     <a>11</a>
                                     <b>14</b>
-                                    <v>1490</v>
+                                    <v>1487</v>
                                 </b>
                                 <b>
                                     <a>14</a>
                                     <b>17</b>
-                                    <v>1399</v>
+                                    <v>1423</v>
                                 </b>
                                 <b>
                                     <a>17</a>
                                     <b>21</b>
-                                    <v>1425</v>
+                                    <v>1436</v>
                                 </b>
                                 <b>
                                     <a>21</a>
                                     <b>26</b>
-                                    <v>1399</v>
+                                    <v>1371</v>
                                 </b>
                                 <b>
                                     <a>26</a>
                                     <b>32</b>
-                                    <v>1334</v>
+                                    <v>1345</v>
                                 </b>
                                 <b>
                                     <a>32</a>
                                     <b>39</b>
-                                    <v>1386</v>
+                                    <v>1397</v>
                                 </b>
                                 <b>
                                     <a>39</a>
-                                    <b>50</b>
-                                    <v>1269</v>
+                                    <b>51</b>
+                                    <v>1384</v>
                                 </b>
                                 <b>
-                                    <a>50</a>
-                                    <b>70</b>
-                                    <v>1269</v>
+                                    <a>51</a>
+                                    <b>75</b>
+                                    <v>1293</v>
                                 </b>
                                 <b>
-                                    <a>70</a>
-                                    <b>117</b>
-                                    <v>1269</v>
+                                    <a>75</a>
+                                    <b>125</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>119</a>
-                                    <b>261</b>
-                                    <v>1269</v>
+                                    <a>125</a>
+                                    <b>313</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>261</a>
-                                    <b>2333</b>
-                                    <v>531</v>
+                                    <a>323</a>
+                                    <b>2337</b>
+                                    <v>375</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3030,67 +2779,67 @@
                                 <b>
                                     <a>1</a>
                                     <b>16</b>
-                                    <v>1282</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>16</a>
                                     <b>25</b>
-                                    <v>1399</v>
+                                    <v>1410</v>
                                 </b>
                                 <b>
                                     <a>25</a>
                                     <b>32</b>
-                                    <v>1360</v>
+                                    <v>1358</v>
                                 </b>
                                 <b>
                                     <a>32</a>
                                     <b>41</b>
-                                    <v>1347</v>
+                                    <v>1358</v>
                                 </b>
                                 <b>
                                     <a>41</a>
                                     <b>47</b>
-                                    <v>1477</v>
+                                    <v>1500</v>
                                 </b>
                                 <b>
                                     <a>47</a>
                                     <b>54</b>
-                                    <v>1503</v>
+                                    <v>1526</v>
                                 </b>
                                 <b>
                                     <a>54</a>
                                     <b>62</b>
-                                    <v>1334</v>
+                                    <v>1332</v>
                                 </b>
                                 <b>
                                     <a>62</a>
                                     <b>68</b>
-                                    <v>1295</v>
+                                    <v>1293</v>
                                 </b>
                                 <b>
                                     <a>68</a>
                                     <b>76</b>
-                                    <v>1373</v>
+                                    <v>1371</v>
                                 </b>
                                 <b>
                                     <a>76</a>
                                     <b>85</b>
-                                    <v>1282</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>85</a>
                                     <b>97</b>
-                                    <v>1282</v>
+                                    <v>1293</v>
                                 </b>
                                 <b>
                                     <a>97</a>
                                     <b>119</b>
-                                    <v>1295</v>
+                                    <v>1293</v>
                                 </b>
                                 <b>
                                     <a>119</a>
                                     <b>357</b>
-                                    <v>647</v>
+                                    <v>646</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3106,67 +2855,67 @@
                                 <b>
                                     <a>1</a>
                                     <b>8</b>
-                                    <v>1477</v>
+                                    <v>1461</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>11</b>
-                                    <v>1347</v>
+                                    <v>1397</v>
                                 </b>
                                 <b>
                                     <a>11</a>
                                     <b>14</b>
-                                    <v>1490</v>
+                                    <v>1487</v>
                                 </b>
                                 <b>
                                     <a>14</a>
                                     <b>17</b>
-                                    <v>1386</v>
+                                    <v>1410</v>
                                 </b>
                                 <b>
                                     <a>17</a>
                                     <b>21</b>
-                                    <v>1451</v>
+                                    <v>1461</v>
                                 </b>
                                 <b>
                                     <a>21</a>
                                     <b>26</b>
-                                    <v>1399</v>
+                                    <v>1371</v>
                                 </b>
                                 <b>
                                     <a>26</a>
                                     <b>32</b>
-                                    <v>1334</v>
+                                    <v>1345</v>
                                 </b>
                                 <b>
                                     <a>32</a>
                                     <b>39</b>
-                                    <v>1386</v>
+                                    <v>1397</v>
                                 </b>
                                 <b>
                                     <a>39</a>
-                                    <b>50</b>
-                                    <v>1269</v>
+                                    <b>51</b>
+                                    <v>1384</v>
                                 </b>
                                 <b>
-                                    <a>50</a>
-                                    <b>70</b>
-                                    <v>1269</v>
+                                    <a>51</a>
+                                    <b>75</b>
+                                    <v>1293</v>
                                 </b>
                                 <b>
-                                    <a>70</a>
-                                    <b>117</b>
-                                    <v>1269</v>
+                                    <a>75</a>
+                                    <b>125</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>119</a>
-                                    <b>261</b>
-                                    <v>1269</v>
+                                    <a>125</a>
+                                    <b>313</b>
+                                    <v>1280</v>
                                 </b>
                                 <b>
-                                    <a>261</a>
-                                    <b>2333</b>
-                                    <v>531</v>
+                                    <a>323</a>
+                                    <b>2337</b>
+                                    <v>375</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3182,67 +2931,67 @@
                                 <b>
                                     <a>1</a>
                                     <b>20</b>
-                                    <v>1308</v>
+                                    <v>1306</v>
                                 </b>
                                 <b>
                                     <a>20</a>
                                     <b>28</b>
-                                    <v>1269</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>28</a>
                                     <b>36</b>
-                                    <v>1360</v>
+                                    <v>1371</v>
                                 </b>
                                 <b>
                                     <a>36</a>
                                     <b>45</b>
-                                    <v>1347</v>
+                                    <v>1358</v>
                                 </b>
                                 <b>
                                     <a>45</a>
                                     <b>50</b>
-                                    <v>1308</v>
+                                    <v>1306</v>
                                 </b>
                                 <b>
                                     <a>50</a>
                                     <b>57</b>
-                                    <v>1347</v>
+                                    <v>1345</v>
                                 </b>
                                 <b>
                                     <a>57</a>
                                     <b>64</b>
-                                    <v>1347</v>
+                                    <v>1371</v>
                                 </b>
                                 <b>
                                     <a>64</a>
                                     <b>71</b>
-                                    <v>1282</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>71</a>
                                     <b>78</b>
-                                    <v>1386</v>
+                                    <v>1397</v>
                                 </b>
                                 <b>
                                     <a>78</a>
                                     <b>87</b>
-                                    <v>1386</v>
+                                    <v>1384</v>
                                 </b>
                                 <b>
                                     <a>87</a>
                                     <b>98</b>
-                                    <v>1269</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>98</a>
                                     <b>116</b>
-                                    <v>1282</v>
+                                    <v>1293</v>
                                 </b>
                                 <b>
                                     <a>116</a>
                                     <b>367</b>
-                                    <v>984</v>
+                                    <v>970</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3258,67 +3007,72 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1516</v>
+                                    <v>1513</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>5</b>
-                                    <v>1762</v>
+                                    <v>1759</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>3537</v>
+                                    <v>3532</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>10</b>
-                                    <v>2449</v>
+                                    <v>2445</v>
                                 </b>
                                 <b>
                                     <a>10</a>
-                                    <b>17</b>
-                                    <v>2747</v>
+                                    <b>16</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>17</a>
-                                    <b>24</b>
-                                    <v>2436</v>
+                                    <a>16</a>
+                                    <b>21</b>
+                                    <v>2419</v>
                                 </b>
                                 <b>
-                                    <a>24</a>
-                                    <b>41</b>
-                                    <v>2293</v>
+                                    <a>21</a>
+                                    <b>37</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>41</a>
-                                    <b>79</b>
-                                    <v>2306</v>
+                                    <a>37</a>
+                                    <b>70</b>
+                                    <v>2315</v>
                                 </b>
                                 <b>
-                                    <a>79</a>
-                                    <b>119</b>
-                                    <v>2319</v>
+                                    <a>70</a>
+                                    <b>113</b>
+                                    <v>2328</v>
                                 </b>
                                 <b>
-                                    <a>119</a>
-                                    <b>176</b>
-                                    <v>2319</v>
+                                    <a>113</a>
+                                    <b>163</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>176</a>
-                                    <b>287</b>
-                                    <v>2319</v>
+                                    <a>163</a>
+                                    <b>256</b>
+                                    <v>2315</v>
                                 </b>
                                 <b>
-                                    <a>287</a>
-                                    <b>850</b>
-                                    <v>2293</v>
+                                    <a>257</a>
+                                    <b>673</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>850</a>
-                                    <b>9912</b>
-                                    <v>2254</v>
+                                    <a>678</a>
+                                    <b>4748</b>
+                                    <v>2302</v>
+                                </b>
+                                <b>
+                                    <a>4761</a>
+                                    <b>9964</b>
+                                    <v>349</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3334,47 +3088,47 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>10664</v>
+                                    <v>10699</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>4781</v>
+                                    <v>4787</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>6</b>
-                                    <v>2267</v>
+                                    <v>2328</v>
                                 </b>
                                 <b>
                                     <a>6</a>
-                                    <b>9</b>
-                                    <v>2371</v>
+                                    <b>10</b>
+                                    <v>2729</v>
                                 </b>
                                 <b>
-                                    <a>9</a>
+                                    <a>10</a>
                                     <b>15</b>
-                                    <v>2773</v>
+                                    <v>2393</v>
                                 </b>
                                 <b>
                                     <a>15</a>
-                                    <b>23</b>
-                                    <v>2371</v>
+                                    <b>24</b>
+                                    <v>2445</v>
                                 </b>
                                 <b>
-                                    <a>23</a>
-                                    <b>59</b>
-                                    <v>2332</v>
+                                    <a>24</a>
+                                    <b>64</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>59</a>
-                                    <b>309</b>
-                                    <v>2293</v>
+                                    <a>64</a>
+                                    <b>378</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>312</a>
-                                    <b>1303</b>
-                                    <v>699</v>
+                                    <a>393</a>
+                                    <b>1310</b>
+                                    <v>569</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3390,72 +3144,72 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1516</v>
+                                    <v>1513</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1580</v>
+                                    <v>1578</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2552</v>
+                                    <v>2548</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>6</b>
-                                    <v>2449</v>
+                                    <v>2445</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>8</b>
-                                    <v>1580</v>
+                                    <v>1578</v>
                                 </b>
                                 <b>
                                     <a>8</a>
-                                    <b>13</b>
-                                    <v>2708</v>
+                                    <b>12</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>13</a>
-                                    <b>17</b>
-                                    <v>2371</v>
+                                    <a>12</a>
+                                    <b>16</b>
+                                    <v>2535</v>
                                 </b>
                                 <b>
-                                    <a>17</a>
-                                    <b>27</b>
-                                    <v>2332</v>
+                                    <a>16</a>
+                                    <b>26</b>
+                                    <v>2406</v>
                                 </b>
                                 <b>
-                                    <a>27</a>
-                                    <b>42</b>
-                                    <v>2436</v>
+                                    <a>26</a>
+                                    <b>41</b>
+                                    <v>2406</v>
                                 </b>
                                 <b>
-                                    <a>42</a>
-                                    <b>56</b>
-                                    <v>2475</v>
+                                    <a>41</a>
+                                    <b>54</b>
+                                    <v>2380</v>
                                 </b>
                                 <b>
-                                    <a>56</a>
-                                    <b>69</b>
-                                    <v>2397</v>
+                                    <a>54</a>
+                                    <b>68</b>
+                                    <v>2458</v>
                                 </b>
                                 <b>
-                                    <a>69</a>
-                                    <b>87</b>
-                                    <v>2332</v>
+                                    <a>68</a>
+                                    <b>85</b>
+                                    <v>2419</v>
                                 </b>
                                 <b>
-                                    <a>87</a>
-                                    <b>113</b>
-                                    <v>2384</v>
+                                    <a>85</a>
+                                    <b>111</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>113</a>
+                                    <a>111</a>
                                     <b>203</b>
-                                    <v>1438</v>
+                                    <v>1617</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3471,42 +3225,42 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>12621</v>
+                                    <v>12588</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>6479</v>
+                                    <v>6675</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2604</v>
+                                    <v>2225</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>1555</v>
+                                    <v>1746</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>7</b>
-                                    <v>2332</v>
+                                    <v>2419</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>12</b>
-                                    <v>2526</v>
+                                    <v>2419</v>
                                 </b>
                                 <b>
                                     <a>12</a>
-                                    <b>43</b>
-                                    <v>2293</v>
+                                    <b>34</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>43</a>
+                                    <a>40</a>
                                     <b>240</b>
-                                    <v>142</v>
+                                    <v>181</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3522,67 +3276,67 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1516</v>
+                                    <v>1513</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>4</b>
-                                    <v>1762</v>
+                                    <v>1759</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>3641</v>
+                                    <v>3635</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>2643</v>
+                                    <v>2652</v>
                                 </b>
                                 <b>
                                     <a>8</a>
-                                    <b>13</b>
-                                    <v>2721</v>
+                                    <b>12</b>
+                                    <v>2225</v>
                                 </b>
                                 <b>
-                                    <a>13</a>
-                                    <b>17</b>
-                                    <v>2358</v>
+                                    <a>12</a>
+                                    <b>16</b>
+                                    <v>2561</v>
                                 </b>
                                 <b>
-                                    <a>17</a>
-                                    <b>28</b>
-                                    <v>2384</v>
+                                    <a>16</a>
+                                    <b>26</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>28</a>
-                                    <b>44</b>
-                                    <v>2410</v>
+                                    <a>26</a>
+                                    <b>41</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>44</a>
-                                    <b>58</b>
-                                    <v>2449</v>
+                                    <a>41</a>
+                                    <b>56</b>
+                                    <v>2471</v>
                                 </b>
                                 <b>
-                                    <a>58</a>
-                                    <b>72</b>
-                                    <v>2462</v>
+                                    <a>56</a>
+                                    <b>70</b>
+                                    <v>2406</v>
                                 </b>
                                 <b>
-                                    <a>72</a>
-                                    <b>89</b>
-                                    <v>2293</v>
+                                    <a>70</a>
+                                    <b>86</b>
+                                    <v>2354</v>
                                 </b>
                                 <b>
-                                    <a>89</a>
-                                    <b>115</b>
-                                    <v>2332</v>
+                                    <a>86</a>
+                                    <b>110</b>
+                                    <v>2341</v>
                                 </b>
                                 <b>
-                                    <a>115</a>
+                                    <a>110</a>
                                     <b>203</b>
-                                    <v>1580</v>
+                                    <v>1901</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3598,32 +3352,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>440</v>
+                                    <v>439</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>622</v>
+                                    <v>621</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>272</v>
+                                    <v>271</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>246</v>
+                                    <v>245</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>9</b>
-                                    <v>466</v>
+                                    <v>465</v>
                                 </b>
                                 <b>
                                     <a>9</a>
@@ -3637,32 +3391,32 @@
                                 </b>
                                 <b>
                                     <a>45</a>
-                                    <b>172</b>
+                                    <b>173</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>179</a>
-                                    <b>770</b>
+                                    <b>773</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>787</a>
-                                    <b>2916</b>
+                                    <a>795</a>
+                                    <b>2929</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>2930</a>
-                                    <b>8152</b>
+                                    <a>2936</a>
+                                    <b>8174</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>8209</a>
-                                    <b>26030</b>
+                                    <a>8240</a>
+                                    <b>26107</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>33912</a>
-                                    <b>35229</b>
+                                    <a>33980</a>
+                                    <b>35323</b>
                                     <v>25</v>
                                 </b>
                             </bs>
@@ -3679,17 +3433,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1503</v>
+                                    <v>1500</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>544</v>
+                                    <v>543</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>427</v>
+                                    <v>426</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -3698,33 +3452,33 @@
                                 </b>
                                 <b>
                                     <a>10</a>
-                                    <b>38</b>
+                                    <b>39</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>38</a>
+                                    <a>39</a>
                                     <b>139</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>145</a>
+                                    <a>146</a>
                                     <b>387</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>399</a>
-                                    <b>742</b>
+                                    <b>749</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>762</a>
-                                    <b>957</b>
+                                    <a>765</a>
+                                    <b>964</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>960</a>
-                                    <b>1303</b>
-                                    <v>246</v>
+                                    <a>964</a>
+                                    <b>1310</b>
+                                    <v>245</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3740,12 +3494,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>544</v>
+                                    <v>543</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>673</v>
+                                    <v>672</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -3760,7 +3514,7 @@
                                 <b>
                                     <a>6</a>
                                     <b>9</b>
-                                    <v>466</v>
+                                    <v>465</v>
                                 </b>
                                 <b>
                                     <a>9</a>
@@ -3769,33 +3523,33 @@
                                 </b>
                                 <b>
                                     <a>19</a>
-                                    <b>64</b>
+                                    <b>63</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>66</a>
-                                    <b>181</b>
+                                    <b>183</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>182</a>
-                                    <b>383</b>
+                                    <a>183</a>
+                                    <b>380</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>392</a>
-                                    <b>732</b>
+                                    <b>736</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>745</a>
+                                    <a>750</a>
                                     <b>1013</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>1020</a>
-                                    <b>1378</b>
-                                    <v>298</v>
+                                    <a>1028</a>
+                                    <b>1385</b>
+                                    <v>297</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3811,12 +3565,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>544</v>
+                                    <v>543</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>673</v>
+                                    <v>672</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -3831,7 +3585,7 @@
                                 <b>
                                     <a>6</a>
                                     <b>9</b>
-                                    <v>466</v>
+                                    <v>465</v>
                                 </b>
                                 <b>
                                     <a>9</a>
@@ -3840,33 +3594,33 @@
                                 </b>
                                 <b>
                                     <a>19</a>
-                                    <b>65</b>
+                                    <b>64</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>66</a>
-                                    <b>182</b>
+                                    <b>184</b>
+                                    <v>401</v>
+                                </b>
+                                <b>
+                                    <a>205</a>
+                                    <b>400</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>183</a>
-                                    <b>387</b>
+                                    <a>431</a>
+                                    <b>752</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>399</a>
-                                    <b>749</b>
+                                    <a>761</a>
+                                    <b>1038</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>753</a>
-                                    <b>1032</b>
-                                    <v>388</v>
-                                </b>
-                                <b>
-                                    <a>1040</a>
-                                    <b>1382</b>
-                                    <v>298</v>
+                                    <a>1048</a>
+                                    <b>1390</b>
+                                    <v>284</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3882,17 +3636,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1282</v>
+                                    <v>1280</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>725</v>
+                                    <v>724</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>440</v>
+                                    <v>439</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -3902,7 +3656,7 @@
                                 <b>
                                     <a>6</a>
                                     <b>16</b>
-                                    <v>401</v>
+                                    <v>388</v>
                                 </b>
                                 <b>
                                     <a>16</a>
@@ -3910,24 +3664,24 @@
                                     <v>401</v>
                                 </b>
                                 <b>
-                                    <a>40</a>
-                                    <b>68</b>
-                                    <v>401</v>
-                                </b>
-                                <b>
-                                    <a>68</a>
-                                    <b>106</b>
-                                    <v>401</v>
-                                </b>
-                                <b>
-                                    <a>106</a>
-                                    <b>129</b>
+                                    <a>37</a>
+                                    <b>67</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>129</a>
+                                    <a>67</a>
+                                    <b>103</b>
+                                    <v>388</v>
+                                </b>
+                                <b>
+                                    <a>103</a>
+                                    <b>126</b>
+                                    <v>388</v>
+                                </b>
+                                <b>
+                                    <a>126</a>
                                     <b>177</b>
-                                    <v>194</v>
+                                    <v>232</v>
                                 </b>
                             </bs>
                         </hist>
@@ -3943,72 +3697,72 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>311</v>
+                                    <v>310</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>3524</v>
+                                    <v>3519</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>6</b>
-                                    <v>2643</v>
+                                    <v>2639</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>9</b>
-                                    <v>2397</v>
+                                    <v>2393</v>
                                 </b>
                                 <b>
                                     <a>9</a>
                                     <b>14</b>
-                                    <v>2319</v>
+                                    <v>2380</v>
                                 </b>
                                 <b>
                                     <a>14</a>
                                     <b>21</b>
-                                    <v>2475</v>
+                                    <v>2497</v>
                                 </b>
                                 <b>
                                     <a>21</a>
                                     <b>34</b>
-                                    <v>2358</v>
+                                    <v>2328</v>
                                 </b>
                                 <b>
                                     <a>34</a>
-                                    <b>64</b>
-                                    <v>2332</v>
+                                    <b>66</b>
+                                    <v>2341</v>
                                 </b>
                                 <b>
-                                    <a>65</a>
-                                    <b>108</b>
-                                    <v>2345</v>
+                                    <a>66</a>
+                                    <b>107</b>
+                                    <v>2315</v>
                                 </b>
                                 <b>
-                                    <a>108</a>
-                                    <b>157</b>
-                                    <v>2306</v>
+                                    <a>107</a>
+                                    <b>158</b>
+                                    <v>2328</v>
                                 </b>
                                 <b>
-                                    <a>157</a>
-                                    <b>235</b>
-                                    <v>2332</v>
+                                    <a>158</a>
+                                    <b>243</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>235</a>
-                                    <b>566</b>
-                                    <v>2293</v>
+                                    <a>243</a>
+                                    <b>574</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>573</a>
-                                    <b>2877</b>
-                                    <v>2293</v>
+                                    <a>580</a>
+                                    <b>2918</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>2878</a>
-                                    <b>9800</b>
-                                    <v>622</v>
+                                    <a>2988</a>
+                                    <b>9852</b>
+                                    <v>595</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4024,47 +3778,47 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>10664</v>
+                                    <v>10699</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>4781</v>
+                                    <v>4787</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>6</b>
-                                    <v>2267</v>
+                                    <v>2328</v>
                                 </b>
                                 <b>
                                     <a>6</a>
-                                    <b>9</b>
-                                    <v>2371</v>
+                                    <b>10</b>
+                                    <v>2729</v>
                                 </b>
                                 <b>
-                                    <a>9</a>
+                                    <a>10</a>
                                     <b>15</b>
-                                    <v>2773</v>
+                                    <v>2393</v>
                                 </b>
                                 <b>
                                     <a>15</a>
-                                    <b>23</b>
-                                    <v>2371</v>
+                                    <b>24</b>
+                                    <v>2445</v>
                                 </b>
                                 <b>
-                                    <a>23</a>
-                                    <b>59</b>
-                                    <v>2332</v>
+                                    <a>24</a>
+                                    <b>64</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>59</a>
-                                    <b>309</b>
-                                    <v>2293</v>
+                                    <a>64</a>
+                                    <b>378</b>
+                                    <v>2302</v>
                                 </b>
                                 <b>
-                                    <a>312</a>
-                                    <b>1287</b>
-                                    <v>699</v>
+                                    <a>393</a>
+                                    <b>1294</b>
+                                    <v>569</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4080,42 +3834,42 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>12349</v>
+                                    <v>12510</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>6453</v>
+                                    <v>6287</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2488</v>
+                                    <v>2458</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>1710</v>
+                                    <v>1668</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>7</b>
-                                    <v>2345</v>
+                                    <v>2341</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>12</b>
-                                    <v>2384</v>
+                                    <v>2471</v>
                                 </b>
                                 <b>
                                     <a>12</a>
                                     <b>27</b>
-                                    <v>2423</v>
+                                    <v>2406</v>
                                 </b>
                                 <b>
                                     <a>27</a>
                                     <b>35</b>
-                                    <v>401</v>
+                                    <v>414</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4131,67 +3885,67 @@
                                 <b>
                                     <a>1</a>
                                     <b>3</b>
-                                    <v>1516</v>
+                                    <v>1513</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>3680</v>
+                                    <v>3674</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>6</b>
-                                    <v>2721</v>
+                                    <v>2716</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>8</b>
-                                    <v>1645</v>
+                                    <v>1643</v>
                                 </b>
                                 <b>
                                     <a>8</a>
-                                    <b>13</b>
-                                    <v>2747</v>
+                                    <b>12</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>13</a>
-                                    <b>17</b>
-                                    <v>2345</v>
+                                    <a>12</a>
+                                    <b>16</b>
+                                    <v>2406</v>
                                 </b>
                                 <b>
-                                    <a>17</a>
-                                    <b>28</b>
-                                    <v>2423</v>
+                                    <a>16</a>
+                                    <b>26</b>
+                                    <v>2484</v>
                                 </b>
                                 <b>
-                                    <a>28</a>
-                                    <b>43</b>
-                                    <v>2410</v>
+                                    <a>26</a>
+                                    <b>41</b>
+                                    <v>2341</v>
                                 </b>
                                 <b>
-                                    <a>43</a>
-                                    <b>57</b>
-                                    <v>2423</v>
+                                    <a>41</a>
+                                    <b>54</b>
+                                    <v>2419</v>
                                 </b>
                                 <b>
-                                    <a>57</a>
-                                    <b>70</b>
-                                    <v>2488</v>
+                                    <a>54</a>
+                                    <b>68</b>
+                                    <v>2419</v>
                                 </b>
                                 <b>
-                                    <a>70</a>
-                                    <b>88</b>
-                                    <v>2397</v>
+                                    <a>68</a>
+                                    <b>84</b>
+                                    <v>2393</v>
                                 </b>
                                 <b>
-                                    <a>88</a>
-                                    <b>113</b>
-                                    <v>2319</v>
+                                    <a>84</a>
+                                    <b>108</b>
+                                    <v>2393</v>
                                 </b>
                                 <b>
-                                    <a>113</a>
+                                    <a>108</a>
                                     <b>200</b>
-                                    <v>1438</v>
+                                    <v>1785</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4207,72 +3961,72 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1503</v>
+                                    <v>1500</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1619</v>
+                                    <v>1617</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2552</v>
+                                    <v>2548</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>6</b>
-                                    <v>2410</v>
+                                    <v>2406</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>8</b>
-                                    <v>1632</v>
+                                    <v>1643</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>13</b>
-                                    <v>2643</v>
+                                    <v>2768</v>
                                 </b>
                                 <b>
                                     <a>13</a>
-                                    <b>17</b>
-                                    <v>2319</v>
+                                    <b>18</b>
+                                    <v>2574</v>
                                 </b>
                                 <b>
-                                    <a>17</a>
-                                    <b>28</b>
-                                    <v>2410</v>
+                                    <a>18</a>
+                                    <b>30</b>
+                                    <v>2341</v>
                                 </b>
                                 <b>
-                                    <a>28</a>
-                                    <b>44</b>
-                                    <v>2371</v>
+                                    <a>30</a>
+                                    <b>45</b>
+                                    <v>2471</v>
                                 </b>
                                 <b>
-                                    <a>44</a>
-                                    <b>57</b>
-                                    <v>2319</v>
+                                    <a>45</a>
+                                    <b>60</b>
+                                    <v>2484</v>
                                 </b>
                                 <b>
-                                    <a>57</a>
-                                    <b>71</b>
-                                    <v>2384</v>
+                                    <a>60</a>
+                                    <b>75</b>
+                                    <v>2354</v>
                                 </b>
                                 <b>
-                                    <a>71</a>
-                                    <b>88</b>
-                                    <v>2345</v>
+                                    <a>75</a>
+                                    <b>94</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>88</a>
-                                    <b>112</b>
-                                    <v>2319</v>
+                                    <a>94</a>
+                                    <b>121</b>
+                                    <v>2367</v>
                                 </b>
                                 <b>
-                                    <a>112</a>
+                                    <a>121</a>
                                     <b>202</b>
-                                    <v>1723</v>
+                                    <v>1112</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4293,7 +4047,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>479</v>
+                                    <v>478</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -4308,7 +4062,7 @@
                                 <b>
                                     <a>6</a>
                                     <b>8</b>
-                                    <v>466</v>
+                                    <v>465</v>
                                 </b>
                                 <b>
                                     <a>8</a>
@@ -4332,27 +4086,27 @@
                                 </b>
                                 <b>
                                     <a>268</a>
-                                    <b>1069</b>
+                                    <b>1065</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>1103</a>
-                                    <b>3365</b>
+                                    <a>1106</a>
+                                    <b>3376</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>3701</a>
-                                    <b>8037</b>
+                                    <a>3708</a>
+                                    <b>8055</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>8101</a>
-                                    <b>10359</b>
+                                    <a>8112</a>
+                                    <b>10395</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>10464</a>
-                                    <b>18202</b>
+                                    <a>10483</a>
+                                    <b>18241</b>
                                     <v>116</v>
                                 </b>
                             </bs>
@@ -4369,17 +4123,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1438</v>
+                                    <v>1436</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>609</v>
+                                    <v>608</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>427</v>
+                                    <v>426</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -4388,33 +4142,33 @@
                                 </b>
                                 <b>
                                     <a>9</a>
-                                    <b>41</b>
+                                    <b>40</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>41</a>
-                                    <b>124</b>
+                                    <b>121</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>142</a>
-                                    <b>407</b>
+                                    <a>143</a>
+                                    <b>410</b>
+                                    <v>401</v>
+                                </b>
+                                <b>
+                                    <a>419</a>
+                                    <b>772</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>409</a>
-                                    <b>757</b>
+                                    <a>794</a>
+                                    <b>1007</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>765</a>
-                                    <b>990</b>
-                                    <v>388</v>
-                                </b>
-                                <b>
-                                    <a>1002</a>
-                                    <b>1270</b>
-                                    <v>298</v>
+                                    <a>1008</a>
+                                    <b>1277</b>
+                                    <v>284</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4430,17 +4184,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>518</v>
+                                    <v>517</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>673</v>
+                                    <v>672</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>298</v>
+                                    <v>297</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -4450,47 +4204,47 @@
                                 <b>
                                     <a>6</a>
                                     <b>9</b>
-                                    <v>453</v>
+                                    <v>452</v>
                                 </b>
                                 <b>
                                     <a>9</a>
                                     <b>16</b>
-                                    <v>401</v>
+                                    <v>414</v>
                                 </b>
                                 <b>
                                     <a>16</a>
-                                    <b>37</b>
+                                    <b>38</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>37</a>
-                                    <b>133</b>
+                                    <a>39</a>
+                                    <b>136</b>
+                                    <v>401</v>
+                                </b>
+                                <b>
+                                    <a>139</a>
+                                    <b>357</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>134</a>
-                                    <b>320</b>
+                                    <a>359</a>
+                                    <b>676</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>346</a>
-                                    <b>633</b>
+                                    <a>687</a>
+                                    <b>1018</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>650</a>
-                                    <b>996</b>
+                                    <a>1020</a>
+                                    <b>1286</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>1009</a>
-                                    <b>1240</b>
-                                    <v>388</v>
-                                </b>
-                                <b>
-                                    <a>1273</a>
-                                    <b>1383</b>
-                                    <v>38</v>
+                                    <a>1386</a>
+                                    <b>1387</b>
+                                    <v>12</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4506,17 +4260,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>894</v>
+                                    <v>892</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>311</v>
+                                    <v>310</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>505</v>
+                                    <v>504</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -4526,7 +4280,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>440</v>
+                                    <v>439</v>
                                 </b>
                                 <b>
                                     <a>8</a>
@@ -4540,28 +4294,28 @@
                                 </b>
                                 <b>
                                     <a>33</a>
-                                    <b>50</b>
+                                    <b>49</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>50</a>
+                                    <a>49</a>
                                     <b>64</b>
                                     <v>388</v>
                                 </b>
                                 <b>
                                     <a>64</a>
                                     <b>81</b>
-                                    <v>401</v>
+                                    <v>388</v>
                                 </b>
                                 <b>
                                     <a>81</a>
                                     <b>94</b>
-                                    <v>401</v>
+                                    <v>414</v>
                                 </b>
                                 <b>
                                     <a>94</a>
-                                    <b>110</b>
-                                    <v>259</v>
+                                    <b>112</b>
+                                    <v>258</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4577,17 +4331,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>518</v>
+                                    <v>517</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>673</v>
+                                    <v>672</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>298</v>
+                                    <v>297</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -4597,47 +4351,47 @@
                                 <b>
                                     <a>6</a>
                                     <b>9</b>
-                                    <v>453</v>
+                                    <v>452</v>
                                 </b>
                                 <b>
                                     <a>9</a>
                                     <b>16</b>
-                                    <v>401</v>
+                                    <v>414</v>
                                 </b>
                                 <b>
                                     <a>16</a>
-                                    <b>37</b>
+                                    <b>38</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>37</a>
-                                    <b>134</b>
+                                    <a>38</a>
+                                    <b>137</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>135</a>
-                                    <b>318</b>
+                                    <a>139</a>
+                                    <b>346</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>345</a>
-                                    <b>629</b>
+                                    <a>354</a>
+                                    <b>637</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>632</a>
-                                    <b>981</b>
+                                    <a>641</a>
+                                    <b>995</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>994</a>
-                                    <b>1220</b>
+                                    <a>997</a>
+                                    <b>1231</b>
                                     <v>388</v>
                                 </b>
                                 <b>
-                                    <a>1234</a>
-                                    <b>1378</b>
-                                    <v>38</v>
+                                    <a>1283</a>
+                                    <b>1382</b>
+                                    <v>25</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4647,23 +4401,19 @@
         </relation>
         <relation>
             <name>ruby_alias_def</name>
-            <cardinality>1252</cardinality>
+            <cardinality>1256</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1252</v>
+                    <v>1256</v>
                 </e>
                 <e>
                     <k>alias</k>
-                    <v>1252</v>
+                    <v>1256</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>1252</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1252</v>
+                    <v>1256</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -4677,7 +4427,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1252</v>
+                                    <v>1256</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4693,23 +4443,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1252</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1252</v>
+                                    <v>1256</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4725,7 +4459,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1252</v>
+                                    <v>1256</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4741,23 +4475,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1252</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>alias</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1252</v>
+                                    <v>1256</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4773,7 +4491,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1252</v>
+                                    <v>1256</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4789,71 +4507,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1252</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1252</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1252</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>alias</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1252</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1252</v>
+                                    <v>1256</v>
                                 </b>
                             </bs>
                         </hist>
@@ -4961,55 +4615,24 @@
                     <k>id</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_argument_list_child</name>
-            <cardinality>822184</cardinality>
+            <cardinality>822785</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_argument_list</k>
-                    <v>662550</v>
+                    <v>662859</v>
                 </e>
                 <e>
                     <k>index</k>
-                    <v>427</v>
+                    <v>426</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>822184</v>
+                    <v>822785</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -5023,17 +4646,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>561124</v>
+                                    <v>561206</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>64260</v>
+                                    <v>64469</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>34</b>
-                                    <v>37164</v>
+                                    <v>37183</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5049,17 +4672,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>561124</v>
+                                    <v>561206</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>64260</v>
+                                    <v>64469</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>34</b>
-                                    <v>37164</v>
+                                    <v>37183</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5103,18 +4726,18 @@
                                     <v>38</v>
                                 </b>
                                 <b>
-                                    <a>55</a>
+                                    <a>56</a>
                                     <b>375</b>
                                     <v>38</v>
                                 </b>
                                 <b>
-                                    <a>899</a>
-                                    <b>7828</b>
+                                    <a>903</a>
+                                    <b>7858</b>
                                     <v>38</v>
                                 </b>
                                 <b>
-                                    <a>51129</a>
-                                    <b>51130</b>
+                                    <a>51234</a>
+                                    <b>51235</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -5159,18 +4782,18 @@
                                     <v>38</v>
                                 </b>
                                 <b>
-                                    <a>55</a>
+                                    <a>56</a>
                                     <b>375</b>
                                     <v>38</v>
                                 </b>
                                 <b>
-                                    <a>899</a>
-                                    <b>7828</b>
+                                    <a>903</a>
+                                    <b>7858</b>
                                     <v>38</v>
                                 </b>
                                 <b>
-                                    <a>51129</a>
-                                    <b>51130</b>
+                                    <a>51234</a>
+                                    <b>51235</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -5187,7 +4810,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>822184</v>
+                                    <v>822785</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5203,7 +4826,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>822184</v>
+                                    <v>822785</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5213,59 +4836,22 @@
         </relation>
         <relation>
             <name>ruby_argument_list_def</name>
-            <cardinality>662809</cardinality>
+            <cardinality>663118</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>662809</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>662809</v>
+                    <v>663118</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>662809</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>662809</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_array_child</name>
-            <cardinality>698821</cardinality>
+            <cardinality>698871</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_array</k>
-                    <v>237298</v>
+                    <v>237321</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -5273,7 +4859,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>698821</v>
+                    <v>698871</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -5287,17 +4873,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>11984</v>
+                                    <v>11990</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>211993</v>
+                                    <v>212002</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>63361</b>
-                                    <v>13321</v>
+                                    <v>13329</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5313,17 +4899,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>11984</v>
+                                    <v>11990</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>211993</v>
+                                    <v>212002</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>63361</b>
-                                    <v>13321</v>
+                                    <v>13329</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5363,7 +4949,7 @@
                                 </b>
                                 <b>
                                     <a>11</a>
-                                    <b>237299</b>
+                                    <b>237322</b>
                                     <v>1294</v>
                                 </b>
                             </bs>
@@ -5404,7 +4990,7 @@
                                 </b>
                                 <b>
                                     <a>11</a>
-                                    <b>237299</b>
+                                    <b>237322</b>
                                     <v>1294</v>
                                 </b>
                             </bs>
@@ -5421,7 +5007,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>698821</v>
+                                    <v>698871</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5437,7 +5023,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>698821</v>
+                                    <v>698871</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5447,51 +5033,14 @@
         </relation>
         <relation>
             <name>ruby_array_def</name>
-            <cardinality>245435</cardinality>
+            <cardinality>245466</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>245435</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>245435</v>
+                    <v>245466</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>245435</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>245435</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_array_pattern_child</name>
@@ -5641,39 +5190,8 @@
                     <k>id</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_as_pattern_def</name>
@@ -5691,10 +5209,6 @@
                     <k>value</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -5730,22 +5244,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>name</src>
                     <trg>id</trg>
                     <val>
@@ -5766,16 +5264,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>value</src>
                     <trg>id</trg>
                     <val>
@@ -5788,46 +5276,6 @@
                 <dep>
                     <src>value</src>
                     <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -5839,23 +5287,19 @@
         </relation>
         <relation>
             <name>ruby_assignment_def</name>
-            <cardinality>130489</cardinality>
+            <cardinality>130604</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>130489</v>
+                    <v>130604</v>
                 </e>
                 <e>
                     <k>left</k>
-                    <v>130489</v>
+                    <v>130604</v>
                 </e>
                 <e>
                     <k>right</k>
-                    <v>130489</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>130489</v>
+                    <v>130604</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -5869,7 +5313,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>130489</v>
+                                    <v>130604</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5885,23 +5329,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>130489</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>130489</v>
+                                    <v>130604</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5917,7 +5345,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>130489</v>
+                                    <v>130604</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5933,23 +5361,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>130489</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>left</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>130489</v>
+                                    <v>130604</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5965,7 +5377,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>130489</v>
+                                    <v>130604</v>
                                 </b>
                             </bs>
                         </hist>
@@ -5981,71 +5393,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>130489</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>right</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>130489</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>130489</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>left</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>130489</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>right</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>130489</v>
+                                    <v>130604</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6054,25 +5402,29 @@
             </dependencies>
         </relation>
         <relation>
-            <name>ruby_ast_node_parent</name>
-            <cardinality>8768380</cardinality>
+            <name>ruby_ast_node_info</name>
+            <cardinality>8775135</cardinality>
             <columnsizes>
                 <e>
-                    <k>child</k>
-                    <v>8768380</v>
+                    <k>node</k>
+                    <v>8775135</v>
                 </e>
                 <e>
                     <k>parent</k>
-                    <v>2868031</v>
+                    <v>2870167</v>
                 </e>
                 <e>
                     <k>parent_index</k>
-                    <v>2786</v>
+                    <v>2781</v>
+                </e>
+                <e>
+                    <k>loc</k>
+                    <v>8492468</v>
                 </e>
             </columnsizes>
             <dependencies>
                 <dep>
-                    <src>child</src>
+                    <src>node</src>
                     <trg>parent</trg>
                     <val>
                         <hist>
@@ -6081,14 +5433,14 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8768380</v>
+                                    <v>8775135</v>
                                 </b>
                             </bs>
                         </hist>
                     </val>
                 </dep>
                 <dep>
-                    <src>child</src>
+                    <src>node</src>
                     <trg>parent_index</trg>
                     <val>
                         <hist>
@@ -6097,15 +5449,15 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>8768380</v>
+                                    <v>8775135</v>
                                 </b>
                             </bs>
                         </hist>
                     </val>
                 </dep>
                 <dep>
-                    <src>parent</src>
-                    <trg>child</trg>
+                    <src>node</src>
+                    <trg>loc</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -6113,27 +5465,43 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>312660</v>
+                                    <v>8775135</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>parent</src>
+                    <trg>node</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>312864</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>392561</v>
+                                    <v>393001</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1605403</v>
+                                    <v>1606523</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>344615</v>
+                                    <v>344781</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>216</b>
-                                    <v>212789</v>
+                                    <v>212996</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6149,27 +5517,63 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>312660</v>
+                                    <v>312864</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>392561</v>
+                                    <v>393001</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1605403</v>
+                                    <v>1606523</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>344615</v>
+                                    <v>344781</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>216</b>
-                                    <v>212789</v>
+                                    <v>212996</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>parent</src>
+                    <trg>loc</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>312864</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>3</b>
+                                    <v>393001</v>
+                                </b>
+                                <b>
+                                    <a>3</a>
+                                    <b>4</b>
+                                    <v>1606523</v>
+                                </b>
+                                <b>
+                                    <a>4</a>
+                                    <b>5</b>
+                                    <v>344781</v>
+                                </b>
+                                <b>
+                                    <a>5</a>
+                                    <b>216</b>
+                                    <v>212996</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6177,7 +5581,7 @@
                 </dep>
                 <dep>
                     <src>parent_index</src>
-                    <trg>child</trg>
+                    <trg>node</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -6190,7 +5594,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>246</v>
+                                    <v>245</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -6200,41 +5604,41 @@
                                 <b>
                                     <a>4</a>
                                     <b>6</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>7</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>10</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>10</a>
                                     <b>22</b>
-                                    <v>246</v>
+                                    <v>245</v>
                                 </b>
                                 <b>
                                     <a>22</a>
                                     <b>50</b>
-                                    <v>220</v>
+                                    <v>219</v>
                                 </b>
                                 <b>
                                     <a>50</a>
                                     <b>129</b>
-                                    <v>220</v>
+                                    <v>219</v>
                                 </b>
                                 <b>
                                     <a>132</a>
-                                    <b>946</b>
-                                    <v>220</v>
+                                    <b>949</b>
+                                    <v>219</v>
                                 </b>
                                 <b>
-                                    <a>1418</a>
-                                    <b>221327</b>
+                                    <a>1419</a>
+                                    <b>221843</b>
                                     <v>142</v>
                                 </b>
                             </bs>
@@ -6256,7 +5660,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>246</v>
+                                    <v>245</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -6266,42 +5670,171 @@
                                 <b>
                                     <a>4</a>
                                     <b>6</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>7</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>10</b>
-                                    <v>233</v>
+                                    <v>232</v>
                                 </b>
                                 <b>
                                     <a>10</a>
                                     <b>22</b>
-                                    <v>246</v>
+                                    <v>245</v>
                                 </b>
                                 <b>
                                     <a>22</a>
                                     <b>50</b>
-                                    <v>220</v>
+                                    <v>219</v>
                                 </b>
                                 <b>
                                     <a>50</a>
                                     <b>129</b>
-                                    <v>220</v>
+                                    <v>219</v>
                                 </b>
                                 <b>
                                     <a>132</a>
-                                    <b>946</b>
-                                    <v>220</v>
+                                    <b>949</b>
+                                    <v>219</v>
                                 </b>
                                 <b>
-                                    <a>1418</a>
-                                    <b>221327</b>
+                                    <a>1419</a>
+                                    <b>221843</b>
                                     <v>142</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>parent_index</src>
+                    <trg>loc</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>401</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>3</b>
+                                    <v>245</v>
+                                </b>
+                                <b>
+                                    <a>3</a>
+                                    <b>4</b>
+                                    <v>388</v>
+                                </b>
+                                <b>
+                                    <a>4</a>
+                                    <b>6</b>
+                                    <v>232</v>
+                                </b>
+                                <b>
+                                    <a>6</a>
+                                    <b>7</b>
+                                    <v>232</v>
+                                </b>
+                                <b>
+                                    <a>7</a>
+                                    <b>10</b>
+                                    <v>232</v>
+                                </b>
+                                <b>
+                                    <a>10</a>
+                                    <b>22</b>
+                                    <v>245</v>
+                                </b>
+                                <b>
+                                    <a>22</a>
+                                    <b>50</b>
+                                    <v>219</v>
+                                </b>
+                                <b>
+                                    <a>50</a>
+                                    <b>129</b>
+                                    <v>219</v>
+                                </b>
+                                <b>
+                                    <a>132</a>
+                                    <b>949</b>
+                                    <v>219</v>
+                                </b>
+                                <b>
+                                    <a>1419</a>
+                                    <b>221660</b>
+                                    <v>142</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>loc</src>
+                    <trg>node</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>8209814</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>4</b>
+                                    <v>282654</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>loc</src>
+                    <trg>parent</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>8209814</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>4</b>
+                                    <v>282654</v>
+                                </b>
+                            </bs>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>loc</src>
+                    <trg>parent_index</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs>
+                                <b>
+                                    <a>1</a>
+                                    <b>2</b>
+                                    <v>8212169</v>
+                                </b>
+                                <b>
+                                    <a>2</a>
+                                    <b>3</b>
+                                    <v>280299</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6311,11 +5844,11 @@
         </relation>
         <relation>
             <name>ruby_bare_string_child</name>
-            <cardinality>14920</cardinality>
+            <cardinality>14923</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_bare_string</k>
-                    <v>11471</v>
+                    <v>11474</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -6323,7 +5856,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>14920</v>
+                    <v>14923</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -6337,7 +5870,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>11143</v>
+                                    <v>11146</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -6358,7 +5891,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>11143</v>
+                                    <v>11146</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -6393,7 +5926,7 @@
                                 </b>
                                 <b>
                                     <a>4</a>
-                                    <b>11472</b>
+                                    <b>11475</b>
                                     <v>19</v>
                                 </b>
                             </bs>
@@ -6424,7 +5957,7 @@
                                 </b>
                                 <b>
                                     <a>4</a>
-                                    <b>11472</b>
+                                    <b>11475</b>
                                     <v>19</v>
                                 </b>
                             </bs>
@@ -6441,7 +5974,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>14920</v>
+                                    <v>14923</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6457,7 +5990,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>14920</v>
+                                    <v>14923</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6467,59 +6000,22 @@
         </relation>
         <relation>
             <name>ruby_bare_string_def</name>
-            <cardinality>11471</cardinality>
+            <cardinality>11474</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>11471</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>11471</v>
+                    <v>11474</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>11471</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>11471</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_bare_symbol_child</name>
-            <cardinality>2149</cardinality>
+            <cardinality>2137</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_bare_symbol</k>
-                    <v>2149</v>
+                    <v>2137</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -6527,7 +6023,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>2149</v>
+                    <v>2137</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -6541,7 +6037,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2149</v>
+                                    <v>2137</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6557,7 +6053,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2149</v>
+                                    <v>2137</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6605,7 +6101,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2149</v>
+                                    <v>2137</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6621,7 +6117,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2149</v>
+                                    <v>2137</v>
                                 </b>
                             </bs>
                         </hist>
@@ -6631,51 +6127,14 @@
         </relation>
         <relation>
             <name>ruby_bare_symbol_def</name>
-            <cardinality>2149</cardinality>
+            <cardinality>2137</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2149</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2149</v>
+                    <v>2137</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2149</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2149</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_begin_block_child</name>
@@ -6901,53 +6360,16 @@
                     <k>id</k>
                     <v>11</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>11</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>11</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>11</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_begin_child</name>
-            <cardinality>7542</cardinality>
+            <cardinality>7555</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_begin</k>
-                    <v>2528</v>
+                    <v>2533</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -6955,7 +6377,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>7542</v>
+                    <v>7555</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -6974,7 +6396,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1321</v>
+                                    <v>1325</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -6989,7 +6411,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>230</v>
+                                    <v>231</v>
                                 </b>
                                 <b>
                                     <a>8</a>
@@ -7015,7 +6437,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1321</v>
+                                    <v>1325</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -7030,7 +6452,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>230</v>
+                                    <v>231</v>
                                 </b>
                                 <b>
                                     <a>8</a>
@@ -7094,13 +6516,13 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>314</a>
-                                    <b>1044</b>
+                                    <a>315</a>
+                                    <b>1045</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>2364</a>
-                                    <b>2529</b>
+                                    <a>2369</a>
+                                    <b>2534</b>
                                     <v>2</v>
                                 </b>
                             </bs>
@@ -7160,13 +6582,13 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>314</a>
-                                    <b>1044</b>
+                                    <a>315</a>
+                                    <b>1045</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>2364</a>
-                                    <b>2529</b>
+                                    <a>2369</a>
+                                    <b>2534</b>
                                     <v>2</v>
                                 </b>
                             </bs>
@@ -7183,7 +6605,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>7542</v>
+                                    <v>7555</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7199,7 +6621,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>7542</v>
+                                    <v>7555</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7209,63 +6631,26 @@
         </relation>
         <relation>
             <name>ruby_begin_def</name>
-            <cardinality>2528</cardinality>
+            <cardinality>2533</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2528</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2528</v>
+                    <v>2533</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2528</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2528</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_binary_def</name>
-            <cardinality>67775</cardinality>
+            <cardinality>67989</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>67775</v>
+                    <v>67989</v>
                 </e>
                 <e>
                     <k>left</k>
-                    <v>67775</v>
+                    <v>67989</v>
                 </e>
                 <e>
                     <k>operator</k>
@@ -7273,11 +6658,7 @@
                 </e>
                 <e>
                     <k>right</k>
-                    <v>67775</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>67775</v>
+                    <v>67989</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -7291,7 +6672,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7307,7 +6688,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7323,23 +6704,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7355,7 +6720,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7371,7 +6736,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7387,23 +6752,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>left</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7417,17 +6766,17 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>146</a>
+                                    <a>155</a>
                                     <b>178</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>216</a>
-                                    <b>368</b>
+                                    <a>230</a>
+                                    <b>370</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>473</a>
+                                    <a>474</a>
                                     <b>557</b>
                                     <v>2</v>
                                 </b>
@@ -7438,47 +6787,47 @@
                                 </b>
                                 <b>
                                     <a>749</a>
-                                    <b>805</b>
+                                    <b>808</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>942</a>
-                                    <b>974</b>
+                                    <a>950</a>
+                                    <b>982</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>992</a>
-                                    <b>1012</b>
+                                    <a>996</a>
+                                    <b>1015</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1246</a>
-                                    <b>1275</b>
+                                    <a>1248</a>
+                                    <b>1292</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1349</a>
-                                    <b>1618</b>
+                                    <a>1355</a>
+                                    <b>1621</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1821</a>
-                                    <b>1973</b>
+                                    <a>1822</a>
+                                    <b>1978</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>2876</a>
-                                    <b>3114</b>
+                                    <a>2883</a>
+                                    <b>3120</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>6091</a>
-                                    <b>6721</b>
+                                    <a>6102</a>
+                                    <b>6755</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>31014</a>
-                                    <b>31015</b>
+                                    <a>31084</a>
+                                    <b>31085</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -7493,17 +6842,17 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>146</a>
+                                    <a>155</a>
                                     <b>178</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>216</a>
-                                    <b>368</b>
+                                    <a>230</a>
+                                    <b>370</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>473</a>
+                                    <a>474</a>
                                     <b>557</b>
                                     <v>2</v>
                                 </b>
@@ -7514,47 +6863,47 @@
                                 </b>
                                 <b>
                                     <a>749</a>
-                                    <b>805</b>
+                                    <b>808</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>942</a>
-                                    <b>974</b>
+                                    <a>950</a>
+                                    <b>982</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>992</a>
-                                    <b>1012</b>
+                                    <a>996</a>
+                                    <b>1015</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1246</a>
-                                    <b>1275</b>
+                                    <a>1248</a>
+                                    <b>1292</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1349</a>
-                                    <b>1618</b>
+                                    <a>1355</a>
+                                    <b>1621</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1821</a>
-                                    <b>1973</b>
+                                    <a>1822</a>
+                                    <b>1978</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>2876</a>
-                                    <b>3114</b>
+                                    <a>2883</a>
+                                    <b>3120</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>6091</a>
-                                    <b>6721</b>
+                                    <a>6102</a>
+                                    <b>6755</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>31014</a>
-                                    <b>31015</b>
+                                    <a>31084</a>
+                                    <b>31085</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -7569,17 +6918,17 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>146</a>
+                                    <a>155</a>
                                     <b>178</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>216</a>
-                                    <b>368</b>
+                                    <a>230</a>
+                                    <b>370</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>473</a>
+                                    <a>474</a>
                                     <b>557</b>
                                     <v>2</v>
                                 </b>
@@ -7590,123 +6939,47 @@
                                 </b>
                                 <b>
                                     <a>749</a>
-                                    <b>805</b>
+                                    <b>808</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>942</a>
-                                    <b>974</b>
+                                    <a>950</a>
+                                    <b>982</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>992</a>
-                                    <b>1012</b>
+                                    <a>996</a>
+                                    <b>1015</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1246</a>
-                                    <b>1275</b>
+                                    <a>1248</a>
+                                    <b>1292</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1349</a>
-                                    <b>1618</b>
+                                    <a>1355</a>
+                                    <b>1621</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>1821</a>
-                                    <b>1973</b>
+                                    <a>1822</a>
+                                    <b>1978</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>2876</a>
-                                    <b>3114</b>
+                                    <a>2883</a>
+                                    <b>3120</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>6091</a>
-                                    <b>6721</b>
+                                    <a>6102</a>
+                                    <b>6755</b>
                                     <v>2</v>
                                 </b>
                                 <b>
-                                    <a>31014</a>
-                                    <b>31015</b>
-                                    <v>1</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>operator</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>146</a>
-                                    <b>178</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>216</a>
-                                    <b>368</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>473</a>
-                                    <b>557</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>603</a>
-                                    <b>674</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>749</a>
-                                    <b>805</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>942</a>
-                                    <b>974</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>992</a>
-                                    <b>1012</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>1246</a>
-                                    <b>1275</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>1349</a>
-                                    <b>1618</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>1821</a>
-                                    <b>1973</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>2876</a>
-                                    <b>3114</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>6091</a>
-                                    <b>6721</b>
-                                    <v>2</v>
-                                </b>
-                                <b>
-                                    <a>31014</a>
-                                    <b>31015</b>
+                                    <a>31084</a>
+                                    <b>31085</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -7723,7 +6996,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7739,7 +7012,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7755,87 +7028,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>right</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>left</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>operator</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>right</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>67775</v>
+                                    <v>67989</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7845,15 +7038,15 @@
         </relation>
         <relation>
             <name>ruby_block_argument_child</name>
-            <cardinality>6041</cardinality>
+            <cardinality>6048</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_block_argument</k>
-                    <v>6041</v>
+                    <v>6048</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>6041</v>
+                    <v>6048</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -7867,7 +7060,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6041</v>
+                                    <v>6048</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7883,7 +7076,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6041</v>
+                                    <v>6048</v>
                                 </b>
                             </bs>
                         </hist>
@@ -7893,59 +7086,22 @@
         </relation>
         <relation>
             <name>ruby_block_argument_def</name>
-            <cardinality>6041</cardinality>
+            <cardinality>6048</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>6041</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>6041</v>
+                    <v>6048</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6041</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6041</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_block_child</name>
-            <cardinality>96721</cardinality>
+            <cardinality>96749</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_block</k>
-                    <v>96578</v>
+                    <v>96607</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -7953,7 +7109,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>96721</v>
+                    <v>96749</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -7967,7 +7123,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>96488</v>
+                                    <v>96516</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -7988,7 +7144,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>96488</v>
+                                    <v>96516</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -8017,8 +7173,8 @@
                                     <v>12</v>
                                 </b>
                                 <b>
-                                    <a>7453</a>
-                                    <b>7454</b>
+                                    <a>7467</a>
+                                    <b>7468</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -8043,8 +7199,8 @@
                                     <v>12</v>
                                 </b>
                                 <b>
-                                    <a>7453</a>
-                                    <b>7454</b>
+                                    <a>7467</a>
+                                    <b>7468</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -8061,7 +7217,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>96721</v>
+                                    <v>96749</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8077,7 +7233,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>96721</v>
+                                    <v>96749</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8087,111 +7243,37 @@
         </relation>
         <relation>
             <name>ruby_block_def</name>
-            <cardinality>96877</cardinality>
+            <cardinality>96904</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>96877</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>96877</v>
+                    <v>96904</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>96877</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>96877</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_block_parameter_def</name>
-            <cardinality>2411</cardinality>
+            <cardinality>2410</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2411</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2411</v>
+                    <v>2410</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2411</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2411</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_block_parameter_name</name>
-            <cardinality>2411</cardinality>
+            <cardinality>2410</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_block_parameter</k>
-                    <v>2411</v>
+                    <v>2410</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>2411</v>
+                    <v>2410</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8205,7 +7287,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2411</v>
+                                    <v>2410</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8221,7 +7303,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2411</v>
+                                    <v>2410</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8231,15 +7313,15 @@
         </relation>
         <relation>
             <name>ruby_block_parameters</name>
-            <cardinality>10437</cardinality>
+            <cardinality>10443</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_block</k>
-                    <v>10437</v>
+                    <v>10443</v>
                 </e>
                 <e>
                     <k>parameters</k>
-                    <v>10437</v>
+                    <v>10443</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8253,7 +7335,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>10437</v>
+                                    <v>10443</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8269,7 +7351,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>10437</v>
+                                    <v>10443</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8279,11 +7361,11 @@
         </relation>
         <relation>
             <name>ruby_block_parameters_child</name>
-            <cardinality>27347</cardinality>
+            <cardinality>27363</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_block_parameters</k>
-                    <v>23488</v>
+                    <v>23501</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -8291,7 +7373,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>27347</v>
+                    <v>27363</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8305,12 +7387,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>20110</v>
+                                    <v>20121</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>3028</v>
+                                    <v>3030</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -8331,12 +7413,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>20110</v>
+                                    <v>20121</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>3028</v>
+                                    <v>3030</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -8375,8 +7457,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>7461</a>
-                                    <b>7462</b>
+                                    <a>7460</a>
+                                    <b>7461</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -8411,8 +7493,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>7461</a>
-                                    <b>7462</b>
+                                    <a>7460</a>
+                                    <b>7461</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -8429,7 +7511,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>27347</v>
+                                    <v>27363</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8445,7 +7527,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>27347</v>
+                                    <v>27363</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8455,51 +7537,14 @@
         </relation>
         <relation>
             <name>ruby_block_parameters_def</name>
-            <cardinality>23488</cardinality>
+            <cardinality>23501</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>23488</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>23488</v>
+                    <v>23501</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>23488</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>23488</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_break_child</name>
@@ -8557,57 +7602,20 @@
                     <k>id</k>
                     <v>3343</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>3343</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3343</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3343</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_call_arguments</name>
-            <cardinality>659777</cardinality>
+            <cardinality>660078</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_call</k>
-                    <v>659777</v>
+                    <v>660078</v>
                 </e>
                 <e>
                     <k>arguments</k>
-                    <v>659777</v>
+                    <v>660078</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8621,7 +7629,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>659777</v>
+                                    <v>660078</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8637,7 +7645,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>659777</v>
+                                    <v>660078</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8647,15 +7655,15 @@
         </relation>
         <relation>
             <name>ruby_call_block</name>
-            <cardinality>230853</cardinality>
+            <cardinality>230967</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_call</k>
-                    <v>230853</v>
+                    <v>230967</v>
                 </e>
                 <e>
                     <k>block</k>
-                    <v>230853</v>
+                    <v>230967</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8669,7 +7677,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>230853</v>
+                                    <v>230967</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8685,7 +7693,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>230853</v>
+                                    <v>230967</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8695,19 +7703,15 @@
         </relation>
         <relation>
             <name>ruby_call_def</name>
-            <cardinality>960515</cardinality>
+            <cardinality>961220</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>960515</v>
+                    <v>961220</v>
                 </e>
                 <e>
                     <k>method</k>
-                    <v>960515</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>960515</v>
+                    <v>961220</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8721,23 +7725,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>960515</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>960515</v>
+                                    <v>961220</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8753,55 +7741,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>960515</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>method</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>960515</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>960515</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>method</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>960515</v>
+                                    <v>961220</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8811,15 +7751,15 @@
         </relation>
         <relation>
             <name>ruby_call_receiver</name>
-            <cardinality>540910</cardinality>
+            <cardinality>538536</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_call</k>
-                    <v>540910</v>
+                    <v>538536</v>
                 </e>
                 <e>
                     <k>receiver</k>
-                    <v>540910</v>
+                    <v>538536</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8833,7 +7773,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>540910</v>
+                                    <v>538536</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8849,7 +7789,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>540910</v>
+                                    <v>538536</v>
                                 </b>
                             </bs>
                         </hist>
@@ -8859,11 +7799,11 @@
         </relation>
         <relation>
             <name>ruby_case_child</name>
-            <cardinality>4114</cardinality>
+            <cardinality>4123</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_case__</k>
-                    <v>1215</v>
+                    <v>1219</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -8871,7 +7811,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>4114</v>
+                    <v>4123</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -8890,7 +7830,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>321</v>
+                                    <v>324</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -8931,7 +7871,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>321</v>
+                                    <v>324</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -9000,8 +7940,8 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>374</a>
-                                    <b>387</b>
+                                    <a>375</a>
+                                    <b>388</b>
                                     <v>6</v>
                                 </b>
                             </bs>
@@ -9051,8 +7991,8 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>374</a>
-                                    <b>387</b>
+                                    <a>375</a>
+                                    <b>388</b>
                                     <v>6</v>
                                 </b>
                             </bs>
@@ -9069,7 +8009,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4114</v>
+                                    <v>4123</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9085,7 +8025,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4114</v>
+                                    <v>4123</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9095,51 +8035,14 @@
         </relation>
         <relation>
             <name>ruby_case_def</name>
-            <cardinality>1215</cardinality>
+            <cardinality>1219</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1215</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1215</v>
+                    <v>1219</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1215</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1215</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_case_match_clauses</name>
@@ -9269,10 +8172,6 @@
                     <k>value</k>
                     <v>2</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>2</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -9292,72 +8191,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>value</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -9423,15 +8258,15 @@
         </relation>
         <relation>
             <name>ruby_case_value</name>
-            <cardinality>1174</cardinality>
+            <cardinality>1178</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_case__</k>
-                    <v>1174</v>
+                    <v>1178</v>
                 </e>
                 <e>
                     <k>value</k>
-                    <v>1174</v>
+                    <v>1178</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -9445,7 +8280,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1174</v>
+                                    <v>1178</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9461,7 +8296,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1174</v>
+                                    <v>1178</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9471,7 +8306,7 @@
         </relation>
         <relation>
             <name>ruby_chained_string_child</name>
-            <cardinality>3377</cardinality>
+            <cardinality>3380</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_chained_string</k>
@@ -9483,7 +8318,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>3377</v>
+                    <v>3380</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -9512,7 +8347,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>125</v>
+                                    <v>126</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -9522,7 +8357,7 @@
                                 <b>
                                     <a>8</a>
                                     <b>13</b>
-                                    <v>62</v>
+                                    <v>63</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9553,7 +8388,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>125</v>
+                                    <v>126</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -9563,7 +8398,7 @@
                                 <b>
                                     <a>8</a>
                                     <b>13</b>
-                                    <v>62</v>
+                                    <v>63</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9711,7 +8546,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3377</v>
+                                    <v>3380</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9727,7 +8562,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3377</v>
+                                    <v>3380</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9743,53 +8578,16 @@
                     <k>id</k>
                     <v>894</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>894</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>894</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>894</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_class_child</name>
-            <cardinality>131471</cardinality>
+            <cardinality>131549</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_class</k>
-                    <v>15095</v>
+                    <v>15128</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -9797,7 +8595,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>131471</v>
+                    <v>131549</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -9811,32 +8609,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3248</v>
+                                    <v>3260</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>2351</v>
+                                    <v>2362</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1561</v>
+                                    <v>1559</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>1237</v>
+                                    <v>1250</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>963</v>
+                                    <v>957</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>7</b>
-                                    <v>834</v>
+                                    <v>831</v>
                                 </b>
                                 <b>
                                     <a>7</a>
@@ -9846,22 +8644,22 @@
                                 <b>
                                     <a>9</a>
                                     <b>13</b>
-                                    <v>1265</v>
+                                    <v>1269</v>
                                 </b>
                                 <b>
                                     <a>13</a>
                                     <b>21</b>
-                                    <v>1180</v>
+                                    <v>1184</v>
                                 </b>
                                 <b>
                                     <a>21</a>
-                                    <b>75</b>
-                                    <v>1133</v>
+                                    <b>76</b>
+                                    <v>1137</v>
                                 </b>
                                 <b>
-                                    <a>75</a>
+                                    <a>77</a>
                                     <b>333</b>
-                                    <v>192</v>
+                                    <v>185</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9877,32 +8675,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3248</v>
+                                    <v>3260</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>2351</v>
+                                    <v>2362</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1561</v>
+                                    <v>1559</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>1237</v>
+                                    <v>1250</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>963</v>
+                                    <v>957</v>
                                 </b>
                                 <b>
                                     <a>6</a>
                                     <b>7</b>
-                                    <v>834</v>
+                                    <v>831</v>
                                 </b>
                                 <b>
                                     <a>7</a>
@@ -9912,22 +8710,22 @@
                                 <b>
                                     <a>9</a>
                                     <b>13</b>
-                                    <v>1265</v>
+                                    <v>1269</v>
                                 </b>
                                 <b>
                                     <a>13</a>
                                     <b>21</b>
-                                    <v>1180</v>
+                                    <v>1184</v>
                                 </b>
                                 <b>
                                     <a>21</a>
-                                    <b>75</b>
-                                    <v>1133</v>
+                                    <b>76</b>
+                                    <v>1137</v>
                                 </b>
                                 <b>
-                                    <a>75</a>
+                                    <a>77</a>
                                     <b>333</b>
-                                    <v>192</v>
+                                    <v>185</v>
                                 </b>
                             </bs>
                         </hist>
@@ -9968,7 +8766,7 @@
                                 <b>
                                     <a>7</a>
                                     <b>9</b>
-                                    <v>84</v>
+                                    <v>85</v>
                                 </b>
                                 <b>
                                     <a>9</a>
@@ -9977,13 +8775,13 @@
                                 </b>
                                 <b>
                                     <a>12</a>
-                                    <b>19</b>
-                                    <v>78</v>
+                                    <b>20</b>
+                                    <v>85</v>
                                 </b>
                                 <b>
-                                    <a>19</a>
+                                    <a>20</a>
                                     <b>30</b>
-                                    <v>84</v>
+                                    <v>78</v>
                                 </b>
                                 <b>
                                     <a>31</a>
@@ -9997,17 +8795,17 @@
                                 </b>
                                 <b>
                                     <a>90</a>
-                                    <b>209</b>
+                                    <b>208</b>
                                     <v>78</v>
                                 </b>
                                 <b>
-                                    <a>215</a>
-                                    <b>1199</b>
+                                    <a>214</a>
+                                    <b>1200</b>
                                     <v>78</v>
                                 </b>
                                 <b>
-                                    <a>1371</a>
-                                    <b>4796</b>
+                                    <a>1372</a>
+                                    <b>4803</b>
                                     <v>25</v>
                                 </b>
                             </bs>
@@ -10049,7 +8847,7 @@
                                 <b>
                                     <a>7</a>
                                     <b>9</b>
-                                    <v>84</v>
+                                    <v>85</v>
                                 </b>
                                 <b>
                                     <a>9</a>
@@ -10058,13 +8856,13 @@
                                 </b>
                                 <b>
                                     <a>12</a>
-                                    <b>19</b>
-                                    <v>78</v>
+                                    <b>20</b>
+                                    <v>85</v>
                                 </b>
                                 <b>
-                                    <a>19</a>
+                                    <a>20</a>
                                     <b>30</b>
-                                    <v>84</v>
+                                    <v>78</v>
                                 </b>
                                 <b>
                                     <a>31</a>
@@ -10078,17 +8876,17 @@
                                 </b>
                                 <b>
                                     <a>90</a>
-                                    <b>209</b>
+                                    <b>208</b>
                                     <v>78</v>
                                 </b>
                                 <b>
-                                    <a>215</a>
-                                    <b>1199</b>
+                                    <a>214</a>
+                                    <b>1200</b>
                                     <v>78</v>
                                 </b>
                                 <b>
-                                    <a>1371</a>
-                                    <b>4796</b>
+                                    <a>1372</a>
+                                    <b>4803</b>
                                     <v>25</v>
                                 </b>
                             </bs>
@@ -10105,7 +8903,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>131471</v>
+                                    <v>131549</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10121,7 +8919,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>131471</v>
+                                    <v>131549</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10131,19 +8929,15 @@
         </relation>
         <relation>
             <name>ruby_class_def</name>
-            <cardinality>16747</cardinality>
+            <cardinality>16778</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>16747</v>
+                    <v>16778</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>16747</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>16747</v>
+                    <v>16778</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -10157,23 +8951,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>16747</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>16747</v>
+                                    <v>16778</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10189,55 +8967,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>16747</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>16747</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>16747</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>16747</v>
+                                    <v>16778</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10247,15 +8977,15 @@
         </relation>
         <relation>
             <name>ruby_class_superclass</name>
-            <cardinality>13244</cardinality>
+            <cardinality>13262</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_class</k>
-                    <v>13244</v>
+                    <v>13262</v>
                 </e>
                 <e>
                     <k>superclass</k>
-                    <v>13244</v>
+                    <v>13262</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -10269,7 +8999,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13244</v>
+                                    <v>13262</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10285,7 +9015,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13244</v>
+                                    <v>13262</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10295,27 +9025,23 @@
         </relation>
         <relation>
             <name>ruby_conditional_def</name>
-            <cardinality>3573</cardinality>
+            <cardinality>3556</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3573</v>
+                    <v>3556</v>
                 </e>
                 <e>
                     <k>alternative</k>
-                    <v>3573</v>
+                    <v>3556</v>
                 </e>
                 <e>
                     <k>condition</k>
-                    <v>3573</v>
+                    <v>3556</v>
                 </e>
                 <e>
                     <k>consequence</k>
-                    <v>3573</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3573</v>
+                    <v>3556</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -10329,7 +9055,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10345,7 +9071,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10361,23 +9087,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10393,7 +9103,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10409,7 +9119,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10425,23 +9135,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>alternative</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10457,7 +9151,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10473,7 +9167,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10489,23 +9183,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10521,7 +9199,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10537,7 +9215,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10553,87 +9231,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>consequence</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>alternative</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>consequence</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3573</v>
+                                    <v>3556</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10643,11 +9241,11 @@
         </relation>
         <relation>
             <name>ruby_delimited_symbol_child</name>
-            <cardinality>1677</cardinality>
+            <cardinality>1679</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_delimited_symbol</k>
-                    <v>1215</v>
+                    <v>1216</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -10655,7 +9253,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1677</v>
+                    <v>1679</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -10823,7 +9421,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1677</v>
+                                    <v>1679</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10839,7 +9437,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1677</v>
+                                    <v>1679</v>
                                 </b>
                             </bs>
                         </hist>
@@ -10849,51 +9447,14 @@
         </relation>
         <relation>
             <name>ruby_delimited_symbol_def</name>
-            <cardinality>1215</cardinality>
+            <cardinality>1216</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1215</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1215</v>
+                    <v>1216</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1215</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1215</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_destructured_left_assignment_child</name>
@@ -11079,45 +9640,8 @@
                     <k>id</k>
                     <v>108</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>108</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>108</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>108</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_destructured_parameter_child</name>
@@ -11293,61 +9817,24 @@
                     <k>id</k>
                     <v>198</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>198</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>198</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>198</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_do_block_child</name>
-            <cardinality>392432</cardinality>
+            <cardinality>392587</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_do_block</k>
-                    <v>136322</v>
+                    <v>136404</v>
                 </e>
                 <e>
                     <k>index</k>
-                    <v>933</v>
+                    <v>931</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>392432</v>
+                    <v>392587</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -11361,32 +9848,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>47622</v>
+                                    <v>47663</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>36490</v>
+                                    <v>36523</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>21497</v>
+                                    <v>21515</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>10379</v>
+                                    <v>10389</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>7</b>
-                                    <v>10561</v>
+                                    <v>10518</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>73</b>
-                                    <v>9770</v>
+                                    <v>9793</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11402,32 +9889,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>47622</v>
+                                    <v>47663</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>36490</v>
+                                    <v>36523</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>21497</v>
+                                    <v>21515</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>10379</v>
+                                    <v>10389</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>7</b>
-                                    <v>10561</v>
+                                    <v>10518</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>73</b>
-                                    <v>9770</v>
+                                    <v>9793</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11448,7 +9935,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>220</v>
+                                    <v>219</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -11487,17 +9974,17 @@
                                 </b>
                                 <b>
                                     <a>174</a>
-                                    <b>589</b>
+                                    <b>592</b>
                                     <v>77</v>
                                 </b>
                                 <b>
-                                    <a>754</a>
-                                    <b>6846</b>
+                                    <a>757</a>
+                                    <b>6860</b>
                                     <v>77</v>
                                 </b>
                                 <b>
-                                    <a>10520</a>
-                                    <b>10521</b>
+                                    <a>10543</a>
+                                    <b>10544</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -11519,7 +10006,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>220</v>
+                                    <v>219</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -11558,17 +10045,17 @@
                                 </b>
                                 <b>
                                     <a>174</a>
-                                    <b>589</b>
+                                    <b>592</b>
                                     <v>77</v>
                                 </b>
                                 <b>
-                                    <a>754</a>
-                                    <b>6846</b>
+                                    <a>757</a>
+                                    <b>6860</b>
                                     <v>77</v>
                                 </b>
                                 <b>
-                                    <a>10520</a>
-                                    <b>10521</b>
+                                    <a>10543</a>
+                                    <b>10544</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -11585,7 +10072,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>392432</v>
+                                    <v>392587</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11601,7 +10088,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>392432</v>
+                                    <v>392587</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11611,63 +10098,26 @@
         </relation>
         <relation>
             <name>ruby_do_block_def</name>
-            <cardinality>136477</cardinality>
+            <cardinality>136559</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>136477</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>136477</v>
+                    <v>136559</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>136477</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>136477</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_do_block_parameters</name>
-            <cardinality>15047</cardinality>
+            <cardinality>15052</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_do_block</k>
-                    <v>15047</v>
+                    <v>15052</v>
                 </e>
                 <e>
                     <k>parameters</k>
-                    <v>15047</v>
+                    <v>15052</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -11681,7 +10131,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>15047</v>
+                                    <v>15052</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11697,7 +10147,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>15047</v>
+                                    <v>15052</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11707,11 +10157,11 @@
         </relation>
         <relation>
             <name>ruby_do_child</name>
-            <cardinality>9201</cardinality>
+            <cardinality>9209</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_do</k>
-                    <v>1593</v>
+                    <v>1598</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -11719,7 +10169,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>9201</v>
+                    <v>9209</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -11733,12 +10183,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>325</v>
+                                    <v>329</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>273</v>
+                                    <v>274</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -11748,12 +10198,12 @@
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>78</v>
+                                    <v>77</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>7</b>
-                                    <v>104</v>
+                                    <v>105</v>
                                 </b>
                                 <b>
                                     <a>7</a>
@@ -11794,12 +10244,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>325</v>
+                                    <v>329</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>273</v>
+                                    <v>274</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -11809,12 +10259,12 @@
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>78</v>
+                                    <v>77</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>7</b>
-                                    <v>104</v>
+                                    <v>105</v>
                                 </b>
                                 <b>
                                     <a>7</a>
@@ -11879,7 +10329,7 @@
                                 </b>
                                 <b>
                                     <a>112</a>
-                                    <b>1594</b>
+                                    <b>1599</b>
                                     <v>15</v>
                                 </b>
                             </bs>
@@ -11920,7 +10370,7 @@
                                 </b>
                                 <b>
                                     <a>112</a>
-                                    <b>1594</b>
+                                    <b>1599</b>
                                     <v>15</v>
                                 </b>
                             </bs>
@@ -11937,7 +10387,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>9201</v>
+                                    <v>9209</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11953,7 +10403,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>9201</v>
+                                    <v>9209</v>
                                 </b>
                             </bs>
                         </hist>
@@ -11963,59 +10413,22 @@
         </relation>
         <relation>
             <name>ruby_do_def</name>
-            <cardinality>1616</cardinality>
+            <cardinality>1621</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1616</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1616</v>
+                    <v>1621</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1616</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1616</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_element_reference_child</name>
-            <cardinality>82641</cardinality>
+            <cardinality>82444</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_element_reference</k>
-                    <v>82474</v>
+                    <v>82275</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -12023,7 +10436,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>82641</v>
+                    <v>82444</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -12037,12 +10450,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>82306</v>
+                                    <v>82105</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>167</v>
+                                    <v>169</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12058,12 +10471,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>82306</v>
+                                    <v>82105</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>167</v>
+                                    <v>169</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12077,13 +10490,13 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>55</a>
-                                    <b>56</b>
+                                    <a>56</a>
+                                    <b>57</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>27047</a>
-                                    <b>27048</b>
+                                    <a>27139</a>
+                                    <b>27140</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -12098,13 +10511,13 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>55</a>
-                                    <b>56</b>
+                                    <a>56</a>
+                                    <b>57</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>27047</a>
-                                    <b>27048</b>
+                                    <a>27139</a>
+                                    <b>27140</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -12121,7 +10534,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>82641</v>
+                                    <v>82444</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12137,7 +10550,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>82641</v>
+                                    <v>82444</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12147,19 +10560,15 @@
         </relation>
         <relation>
             <name>ruby_element_reference_def</name>
-            <cardinality>82480</cardinality>
+            <cardinality>82281</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>82480</v>
+                    <v>82281</v>
                 </e>
                 <e>
                     <k>object</k>
-                    <v>82480</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>82480</v>
+                    <v>82281</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -12173,23 +10582,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>82480</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>82480</v>
+                                    <v>82281</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12205,55 +10598,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>82480</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>object</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>82480</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>82480</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>object</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>82480</v>
+                                    <v>82281</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12267,7 +10612,7 @@
             <columnsizes>
                 <e>
                     <k>ruby_else</k>
-                    <v>6938</v>
+                    <v>6937</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -12289,7 +10634,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5849</v>
+                                    <v>5847</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -12299,7 +10644,7 @@
                                 <b>
                                     <a>3</a>
                                     <b>12</b>
-                                    <v>402</v>
+                                    <v>403</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12315,7 +10660,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5849</v>
+                                    <v>5847</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -12325,7 +10670,7 @@
                                 <b>
                                     <a>3</a>
                                     <b>12</b>
-                                    <v>402</v>
+                                    <v>403</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12389,8 +10734,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>2204</a>
-                                    <b>2205</b>
+                                    <a>2202</a>
+                                    <b>2203</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -12455,8 +10800,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>2204</a>
-                                    <b>2205</b>
+                                    <a>2202</a>
+                                    <b>2203</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -12499,63 +10844,26 @@
         </relation>
         <relation>
             <name>ruby_else_def</name>
-            <cardinality>6947</cardinality>
+            <cardinality>6946</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>6947</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>6947</v>
+                    <v>6946</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6947</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6947</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_elsif_alternative</name>
-            <cardinality>899</cardinality>
+            <cardinality>897</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_elsif</k>
-                    <v>899</v>
+                    <v>897</v>
                 </e>
                 <e>
                     <k>alternative</k>
-                    <v>899</v>
+                    <v>897</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -12569,7 +10877,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>899</v>
+                                    <v>897</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12585,7 +10893,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>899</v>
+                                    <v>897</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12595,15 +10903,15 @@
         </relation>
         <relation>
             <name>ruby_elsif_consequence</name>
-            <cardinality>1606</cardinality>
+            <cardinality>1603</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_elsif</k>
-                    <v>1606</v>
+                    <v>1603</v>
                 </e>
                 <e>
                     <k>consequence</k>
-                    <v>1606</v>
+                    <v>1603</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -12617,7 +10925,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1606</v>
+                                    <v>1603</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12633,7 +10941,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1606</v>
+                                    <v>1603</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12643,19 +10951,15 @@
         </relation>
         <relation>
             <name>ruby_elsif_def</name>
-            <cardinality>1610</cardinality>
+            <cardinality>1606</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1610</v>
+                    <v>1606</v>
                 </e>
                 <e>
                     <k>condition</k>
-                    <v>1610</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1610</v>
+                    <v>1606</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -12669,23 +10973,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1610</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1610</v>
+                                    <v>1606</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12701,55 +10989,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1610</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1610</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1610</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1610</v>
+                                    <v>1606</v>
                                 </b>
                             </bs>
                         </hist>
@@ -12941,53 +11181,16 @@
                     <k>id</k>
                     <v>11</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>11</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>11</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>11</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_ensure_child</name>
-            <cardinality>5059</cardinality>
+            <cardinality>5078</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_ensure</k>
-                    <v>3765</v>
+                    <v>3786</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -12995,7 +11198,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>5059</v>
+                    <v>5078</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -13009,17 +11212,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2937</v>
+                                    <v>2958</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>532</v>
+                                    <v>535</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>9</b>
-                                    <v>289</v>
+                                    <v>286</v>
                                 </b>
                                 <b>
                                     <a>16</a>
@@ -13040,17 +11243,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2937</v>
+                                    <v>2958</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>532</v>
+                                    <v>535</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>9</b>
-                                    <v>289</v>
+                                    <v>286</v>
                                 </b>
                                 <b>
                                     <a>16</a>
@@ -13089,8 +11292,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>94</a>
-                                    <b>95</b>
+                                    <a>93</a>
+                                    <b>94</b>
                                     <v>3</v>
                                 </b>
                                 <b>
@@ -13099,8 +11302,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1196</a>
-                                    <b>1197</b>
+                                    <a>1202</a>
+                                    <b>1203</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -13135,8 +11338,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>94</a>
-                                    <b>95</b>
+                                    <a>93</a>
+                                    <b>94</b>
                                     <v>3</v>
                                 </b>
                                 <b>
@@ -13145,8 +11348,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1196</a>
-                                    <b>1197</b>
+                                    <a>1202</a>
+                                    <b>1203</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -13163,7 +11366,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5059</v>
+                                    <v>5078</v>
                                 </b>
                             </bs>
                         </hist>
@@ -13179,7 +11382,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5059</v>
+                                    <v>5078</v>
                                 </b>
                             </bs>
                         </hist>
@@ -13189,67 +11392,26 @@
         </relation>
         <relation>
             <name>ruby_ensure_def</name>
-            <cardinality>3765</cardinality>
+            <cardinality>3786</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3765</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3765</v>
+                    <v>3786</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3765</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3765</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_exception_variable_def</name>
-            <cardinality>1027</cardinality>
+            <cardinality>1021</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1027</v>
+                    <v>1021</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1027</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1027</v>
+                    <v>1021</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -13263,23 +11425,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1027</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1027</v>
+                                    <v>1021</v>
                                 </b>
                             </bs>
                         </hist>
@@ -13295,55 +11441,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1027</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1027</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1027</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1027</v>
+                                    <v>1021</v>
                                 </b>
                             </bs>
                         </hist>
@@ -13353,11 +11451,11 @@
         </relation>
         <relation>
             <name>ruby_exceptions_child</name>
-            <cardinality>1849</cardinality>
+            <cardinality>1852</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_exceptions</k>
-                    <v>1638</v>
+                    <v>1641</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -13365,7 +11463,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1849</v>
+                    <v>1852</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -13379,7 +11477,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1495</v>
+                                    <v>1498</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -13405,7 +11503,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1495</v>
+                                    <v>1498</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -13464,8 +11562,8 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>1638</a>
-                                    <b>1639</b>
+                                    <a>1641</a>
+                                    <b>1642</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -13515,8 +11613,8 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>1638</a>
-                                    <b>1639</b>
+                                    <a>1641</a>
+                                    <b>1642</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -13533,7 +11631,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1849</v>
+                                    <v>1852</v>
                                 </b>
                             </bs>
                         </hist>
@@ -13549,7 +11647,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1849</v>
+                                    <v>1852</v>
                                 </b>
                             </bs>
                         </hist>
@@ -13559,51 +11657,14 @@
         </relation>
         <relation>
             <name>ruby_exceptions_def</name>
-            <cardinality>1638</cardinality>
+            <cardinality>1641</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1638</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1638</v>
+                    <v>1641</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1638</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1638</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_expression_reference_pattern_def</name>
@@ -13617,10 +11678,6 @@
                     <k>value</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -13640,54 +11697,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>value</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -13845,39 +11856,8 @@
                     <k>id</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_for_def</name>
@@ -13899,10 +11879,6 @@
                     <k>value</k>
                     <v>163</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>163</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -13954,22 +11930,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>body</src>
                     <trg>id</trg>
                     <val>
@@ -14004,22 +11964,6 @@
                 <dep>
                     <src>body</src>
                     <trg>value</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -14082,22 +12026,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>pattern</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>value</src>
                     <trg>id</trg>
                     <val>
@@ -14132,86 +12060,6 @@
                 <dep>
                     <src>value</src>
                     <trg>pattern</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>pattern</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -14229,19 +12077,19 @@
         </relation>
         <relation>
             <name>ruby_hash_child</name>
-            <cardinality>88609</cardinality>
+            <cardinality>88753</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_hash</k>
-                    <v>35622</v>
+                    <v>35630</v>
                 </e>
                 <e>
                     <k>index</k>
-                    <v>1386</v>
+                    <v>1384</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>88609</v>
+                    <v>88753</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -14255,27 +12103,27 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>14733</v>
+                                    <v>14762</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>9913</v>
+                                    <v>9897</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>3965</v>
+                                    <v>3971</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>4146</v>
+                                    <v>4140</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>19</b>
-                                    <v>2682</v>
+                                    <v>2678</v>
                                 </b>
                                 <b>
                                     <a>19</a>
@@ -14296,27 +12144,27 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>14733</v>
+                                    <v>14762</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>9913</v>
+                                    <v>9897</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>3965</v>
+                                    <v>3971</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>4146</v>
+                                    <v>4140</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>19</b>
-                                    <v>2682</v>
+                                    <v>2678</v>
                                 </b>
                                 <b>
                                     <a>19</a>
@@ -14337,26 +12185,26 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>920</v>
+                                    <v>918</v>
                                 </b>
                                 <b>
                                     <a>3</a>
-                                    <b>4</b>
+                                    <b>5</b>
                                     <v>116</v>
                                 </b>
                                 <b>
-                                    <a>4</a>
+                                    <a>5</a>
                                     <b>15</b>
                                     <v>116</v>
                                 </b>
                                 <b>
                                     <a>15</a>
-                                    <b>56</b>
+                                    <b>58</b>
                                     <v>116</v>
                                 </b>
                                 <b>
-                                    <a>66</a>
-                                    <b>2750</b>
+                                    <a>71</a>
+                                    <b>2755</b>
                                     <v>116</v>
                                 </b>
                             </bs>
@@ -14373,26 +12221,26 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>920</v>
+                                    <v>918</v>
                                 </b>
                                 <b>
                                     <a>3</a>
-                                    <b>4</b>
+                                    <b>5</b>
                                     <v>116</v>
                                 </b>
                                 <b>
-                                    <a>4</a>
+                                    <a>5</a>
                                     <b>15</b>
                                     <v>116</v>
                                 </b>
                                 <b>
                                     <a>15</a>
-                                    <b>56</b>
+                                    <b>58</b>
                                     <v>116</v>
                                 </b>
                                 <b>
-                                    <a>66</a>
-                                    <b>2750</b>
+                                    <a>71</a>
+                                    <b>2755</b>
                                     <v>116</v>
                                 </b>
                             </bs>
@@ -14409,7 +12257,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>88609</v>
+                                    <v>88753</v>
                                 </b>
                             </bs>
                         </hist>
@@ -14425,7 +12273,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>88609</v>
+                                    <v>88753</v>
                                 </b>
                             </bs>
                         </hist>
@@ -14435,51 +12283,14 @@
         </relation>
         <relation>
             <name>ruby_hash_def</name>
-            <cardinality>39289</cardinality>
+            <cardinality>39344</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>39289</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>39289</v>
+                    <v>39344</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>39289</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>39289</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_hash_pattern_child</name>
@@ -14629,55 +12440,20 @@
                     <k>id</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_hash_splat_argument_def</name>
-            <cardinality>1812</cardinality>
+            <cardinality>1813</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1812</v>
+                    <v>1813</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1812</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1812</v>
+                    <v>1813</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -14691,23 +12467,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1812</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1812</v>
+                                    <v>1813</v>
                                 </b>
                             </bs>
                         </hist>
@@ -14723,55 +12483,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1812</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1812</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1812</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1812</v>
+                                    <v>1813</v>
                                 </b>
                             </bs>
                         </hist>
@@ -14781,51 +12493,14 @@
         </relation>
         <relation>
             <name>ruby_hash_splat_parameter_def</name>
-            <cardinality>1350</cardinality>
+            <cardinality>1351</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1350</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1350</v>
+                    <v>1351</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1350</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1350</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_hash_splat_parameter_name</name>
@@ -14877,19 +12552,19 @@
         </relation>
         <relation>
             <name>ruby_heredoc_body_child</name>
-            <cardinality>25171</cardinality>
+            <cardinality>25086</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_heredoc_body</k>
-                    <v>5339</v>
+                    <v>5332</v>
                 </e>
                 <e>
                     <k>index</k>
-                    <v>219</v>
+                    <v>218</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>25171</v>
+                    <v>25086</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -14903,12 +12578,12 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>2902</v>
+                                    <v>2907</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>683</v>
+                                    <v>682</v>
                                 </b>
                                 <b>
                                     <a>5</a>
@@ -14918,22 +12593,22 @@
                                 <b>
                                     <a>6</a>
                                     <b>7</b>
-                                    <v>792</v>
+                                    <v>788</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>9</b>
-                                    <v>341</v>
+                                    <v>339</v>
                                 </b>
                                 <b>
                                     <a>10</a>
                                     <b>15</b>
-                                    <v>423</v>
+                                    <v>421</v>
                                 </b>
                                 <b>
                                     <a>16</a>
                                     <b>73</b>
-                                    <v>192</v>
+                                    <v>190</v>
                                 </b>
                             </bs>
                         </hist>
@@ -14949,12 +12624,12 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>2902</v>
+                                    <v>2907</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>683</v>
+                                    <v>682</v>
                                 </b>
                                 <b>
                                     <a>5</a>
@@ -14964,22 +12639,22 @@
                                 <b>
                                     <a>6</a>
                                     <b>7</b>
-                                    <v>792</v>
+                                    <v>788</v>
                                 </b>
                                 <b>
                                     <a>7</a>
                                     <b>9</b>
-                                    <v>341</v>
+                                    <v>339</v>
                                 </b>
                                 <b>
                                     <a>10</a>
                                     <b>15</b>
-                                    <v>423</v>
+                                    <v>421</v>
                                 </b>
                                 <b>
                                     <a>16</a>
                                     <b>73</b>
-                                    <v>192</v>
+                                    <v>190</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15023,7 +12698,7 @@
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>14</a>
+                                    <a>15</a>
                                     <b>25</b>
                                     <v>18</v>
                                 </b>
@@ -15039,12 +12714,12 @@
                                 </b>
                                 <b>
                                     <a>309</a>
-                                    <b>800</b>
+                                    <b>801</b>
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>1751</a>
-                                    <b>1752</b>
+                                    <a>1759</a>
+                                    <b>1760</b>
                                     <v>6</v>
                                 </b>
                             </bs>
@@ -15089,7 +12764,7 @@
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>14</a>
+                                    <a>15</a>
                                     <b>25</b>
                                     <v>18</v>
                                 </b>
@@ -15105,12 +12780,12 @@
                                 </b>
                                 <b>
                                     <a>309</a>
-                                    <b>800</b>
+                                    <b>801</b>
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>1751</a>
-                                    <b>1752</b>
+                                    <a>1759</a>
+                                    <b>1760</b>
                                     <v>6</v>
                                 </b>
                             </bs>
@@ -15127,7 +12802,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>25171</v>
+                                    <v>25086</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15143,7 +12818,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>25171</v>
+                                    <v>25086</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15153,63 +12828,26 @@
         </relation>
         <relation>
             <name>ruby_heredoc_body_def</name>
-            <cardinality>5568</cardinality>
+            <cardinality>5577</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>5568</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>5568</v>
+                    <v>5577</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>5568</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>5568</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_if_alternative</name>
-            <cardinality>6463</cardinality>
+            <cardinality>6461</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_if</k>
-                    <v>6463</v>
+                    <v>6461</v>
                 </e>
                 <e>
                     <k>alternative</k>
-                    <v>6463</v>
+                    <v>6461</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -15223,7 +12861,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6463</v>
+                                    <v>6461</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15239,7 +12877,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6463</v>
+                                    <v>6461</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15249,15 +12887,15 @@
         </relation>
         <relation>
             <name>ruby_if_consequence</name>
-            <cardinality>18518</cardinality>
+            <cardinality>18444</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_if</k>
-                    <v>18518</v>
+                    <v>18444</v>
                 </e>
                 <e>
                     <k>consequence</k>
-                    <v>18518</v>
+                    <v>18444</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -15271,7 +12909,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>18518</v>
+                                    <v>18444</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15287,7 +12925,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>18518</v>
+                                    <v>18444</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15297,19 +12935,15 @@
         </relation>
         <relation>
             <name>ruby_if_def</name>
-            <cardinality>18579</cardinality>
+            <cardinality>18504</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>18579</v>
+                    <v>18504</v>
                 </e>
                 <e>
                     <k>condition</k>
-                    <v>18579</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>18579</v>
+                    <v>18504</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -15323,23 +12957,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>18579</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>18579</v>
+                                    <v>18504</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15355,55 +12973,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>18579</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>18579</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>18579</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>18579</v>
+                                    <v>18504</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15423,10 +12993,6 @@
                     <k>condition</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -15446,54 +13012,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>condition</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -15505,23 +13025,19 @@
         </relation>
         <relation>
             <name>ruby_if_modifier_def</name>
-            <cardinality>13834</cardinality>
+            <cardinality>13763</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>13834</v>
+                    <v>13763</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>13834</v>
+                    <v>13763</v>
                 </e>
                 <e>
                     <k>condition</k>
-                    <v>13834</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>13834</v>
+                    <v>13763</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -15535,7 +13051,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13834</v>
+                                    <v>13763</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15551,23 +13067,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13834</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13834</v>
+                                    <v>13763</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15583,7 +13083,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13834</v>
+                                    <v>13763</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15599,23 +13099,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13834</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13834</v>
+                                    <v>13763</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15631,7 +13115,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13834</v>
+                                    <v>13763</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15647,71 +13131,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13834</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13834</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13834</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13834</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13834</v>
+                                    <v>13763</v>
                                 </b>
                             </bs>
                         </hist>
@@ -15779,10 +13199,6 @@
                     <k>pattern</k>
                     <v>2</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>2</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -15802,72 +13218,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>pattern</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>pattern</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>pattern</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -15943,10 +13295,6 @@
                     <k>child</k>
                     <v>163</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>163</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -15966,72 +13314,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>child</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>163</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -16049,11 +13333,11 @@
         </relation>
         <relation>
             <name>ruby_interpolation_child</name>
-            <cardinality>38591</cardinality>
+            <cardinality>38383</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_interpolation</k>
-                    <v>38591</v>
+                    <v>38383</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -16061,7 +13345,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>38591</v>
+                    <v>38383</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16075,7 +13359,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>38591</v>
+                                    <v>38383</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16091,7 +13375,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>38591</v>
+                                    <v>38383</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16105,8 +13389,8 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>12656</a>
-                                    <b>12657</b>
+                                    <a>12661</a>
+                                    <b>12662</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -16121,8 +13405,8 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>12656</a>
-                                    <b>12657</b>
+                                    <a>12661</a>
+                                    <b>12662</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -16139,7 +13423,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>38591</v>
+                                    <v>38383</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16155,7 +13439,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>38591</v>
+                                    <v>38383</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16165,67 +13449,26 @@
         </relation>
         <relation>
             <name>ruby_interpolation_def</name>
-            <cardinality>38591</cardinality>
+            <cardinality>38383</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>38591</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>38591</v>
+                    <v>38383</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>38591</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>38591</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_keyword_parameter_def</name>
-            <cardinality>3774</cardinality>
+            <cardinality>3777</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3774</v>
+                    <v>3777</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>3774</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3774</v>
+                    <v>3777</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16239,23 +13482,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3774</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3774</v>
+                                    <v>3777</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16271,55 +13498,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3774</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3774</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3774</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3774</v>
+                                    <v>3777</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16329,15 +13508,15 @@
         </relation>
         <relation>
             <name>ruby_keyword_parameter_value</name>
-            <cardinality>2830</cardinality>
+            <cardinality>2832</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_keyword_parameter</k>
-                    <v>2830</v>
+                    <v>2832</v>
                 </e>
                 <e>
                     <k>value</k>
-                    <v>2830</v>
+                    <v>2832</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16351,7 +13530,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2830</v>
+                                    <v>2832</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16367,7 +13546,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2830</v>
+                                    <v>2832</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16387,10 +13566,6 @@
                     <k>key__</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -16410,54 +13585,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>key__</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>key__</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>key__</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -16517,19 +13646,15 @@
         </relation>
         <relation>
             <name>ruby_lambda_def</name>
-            <cardinality>7473</cardinality>
+            <cardinality>7499</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>7473</v>
+                    <v>7499</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>7473</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>7473</v>
+                    <v>7499</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16543,23 +13668,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>7473</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>7473</v>
+                                    <v>7499</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16575,55 +13684,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>7473</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>7473</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>7473</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>7473</v>
+                                    <v>7499</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16633,15 +13694,15 @@
         </relation>
         <relation>
             <name>ruby_lambda_parameters</name>
-            <cardinality>1649</cardinality>
+            <cardinality>1659</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_lambda</k>
-                    <v>1649</v>
+                    <v>1659</v>
                 </e>
                 <e>
                     <k>parameters</k>
-                    <v>1649</v>
+                    <v>1659</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16655,7 +13716,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1649</v>
+                                    <v>1659</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16671,7 +13732,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1649</v>
+                                    <v>1659</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16681,11 +13742,11 @@
         </relation>
         <relation>
             <name>ruby_lambda_parameters_child</name>
-            <cardinality>1888</cardinality>
+            <cardinality>1898</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_lambda_parameters</k>
-                    <v>1640</v>
+                    <v>1650</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -16693,7 +13754,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1888</v>
+                    <v>1898</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16707,7 +13768,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1459</v>
+                                    <v>1469</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -16733,7 +13794,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1459</v>
+                                    <v>1469</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -16787,8 +13848,8 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>1640</a>
-                                    <b>1641</b>
+                                    <a>1650</a>
+                                    <b>1651</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -16833,8 +13894,8 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>1640</a>
-                                    <b>1641</b>
+                                    <a>1650</a>
+                                    <b>1651</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -16851,7 +13912,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1888</v>
+                                    <v>1898</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16867,7 +13928,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1888</v>
+                                    <v>1898</v>
                                 </b>
                             </bs>
                         </hist>
@@ -16877,59 +13938,22 @@
         </relation>
         <relation>
             <name>ruby_lambda_parameters_def</name>
-            <cardinality>1649</cardinality>
+            <cardinality>1659</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1649</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1649</v>
+                    <v>1659</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1649</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1649</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_left_assignment_list_child</name>
-            <cardinality>6388</cardinality>
+            <cardinality>6390</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_left_assignment_list</k>
-                    <v>2886</v>
+                    <v>2887</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -16937,7 +13961,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>6388</v>
+                    <v>6390</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -16956,7 +13980,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1872</v>
+                                    <v>1873</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -16987,7 +14011,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1872</v>
+                                    <v>1873</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -17061,13 +14085,13 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>2527</a>
-                                    <b>2528</b>
+                                    <a>2528</a>
+                                    <b>2529</b>
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>2886</a>
-                                    <b>2887</b>
+                                    <a>2887</a>
+                                    <b>2888</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -17132,13 +14156,13 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>2527</a>
-                                    <b>2528</b>
+                                    <a>2528</a>
+                                    <b>2529</b>
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>2886</a>
-                                    <b>2887</b>
+                                    <a>2887</a>
+                                    <b>2888</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -17155,7 +14179,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6388</v>
+                                    <v>6390</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17171,7 +14195,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6388</v>
+                                    <v>6390</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17181,59 +14205,22 @@
         </relation>
         <relation>
             <name>ruby_left_assignment_list_def</name>
-            <cardinality>2886</cardinality>
+            <cardinality>2887</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2886</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2886</v>
+                    <v>2887</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2886</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2886</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_method_child</name>
-            <cardinality>265153</cardinality>
+            <cardinality>265363</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_method</k>
-                    <v>97528</v>
+                    <v>97610</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -17241,7 +14228,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>265153</v>
+                    <v>265363</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -17255,22 +14242,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>43837</v>
+                                    <v>43881</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>17950</v>
+                                    <v>17963</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>12749</v>
+                                    <v>12762</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>7823</v>
+                                    <v>7819</v>
                                 </b>
                                 <b>
                                     <a>5</a>
@@ -17280,7 +14267,7 @@
                                 <b>
                                     <a>7</a>
                                     <b>77</b>
-                                    <v>7051</v>
+                                    <v>7069</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17296,22 +14283,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>43837</v>
+                                    <v>43881</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>17950</v>
+                                    <v>17963</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>12749</v>
+                                    <v>12762</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>7823</v>
+                                    <v>7819</v>
                                 </b>
                                 <b>
                                     <a>5</a>
@@ -17321,7 +14308,7 @@
                                 <b>
                                     <a>7</a>
                                     <b>77</b>
-                                    <v>7051</v>
+                                    <v>7069</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17380,18 +14367,18 @@
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>150</a>
-                                    <b>408</b>
+                                    <a>151</a>
+                                    <b>407</b>
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>520</a>
-                                    <b>2241</b>
+                                    <a>521</a>
+                                    <b>2245</b>
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>3248</a>
-                                    <b>30981</b>
+                                    <a>3247</a>
+                                    <b>30985</b>
                                     <v>18</v>
                                 </b>
                             </bs>
@@ -17451,18 +14438,18 @@
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>150</a>
-                                    <b>408</b>
+                                    <a>151</a>
+                                    <b>407</b>
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>520</a>
-                                    <b>2241</b>
+                                    <a>521</a>
+                                    <b>2245</b>
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>3248</a>
-                                    <b>30981</b>
+                                    <a>3247</a>
+                                    <b>30985</b>
                                     <v>18</v>
                                 </b>
                             </bs>
@@ -17479,7 +14466,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>265153</v>
+                                    <v>265363</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17495,7 +14482,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>265153</v>
+                                    <v>265363</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17505,19 +14492,15 @@
         </relation>
         <relation>
             <name>ruby_method_def</name>
-            <cardinality>98554</cardinality>
+            <cardinality>98643</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>98554</v>
+                    <v>98643</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>98554</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>98554</v>
+                    <v>98643</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -17531,23 +14514,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>98554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>98554</v>
+                                    <v>98643</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17563,55 +14530,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>98554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>98554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>98554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>98554</v>
+                                    <v>98643</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17621,15 +14540,15 @@
         </relation>
         <relation>
             <name>ruby_method_parameters</name>
-            <cardinality>27316</cardinality>
+            <cardinality>27323</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_method</k>
-                    <v>27316</v>
+                    <v>27323</v>
                 </e>
                 <e>
                     <k>parameters</k>
-                    <v>27316</v>
+                    <v>27323</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -17643,7 +14562,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>27316</v>
+                                    <v>27323</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17659,7 +14578,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>27316</v>
+                                    <v>27323</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17669,11 +14588,11 @@
         </relation>
         <relation>
             <name>ruby_method_parameters_child</name>
-            <cardinality>47656</cardinality>
+            <cardinality>47661</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_method_parameters</k>
-                    <v>28770</v>
+                    <v>28778</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -17681,7 +14600,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>47656</v>
+                    <v>47661</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -17695,22 +14614,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>17317</v>
+                                    <v>17326</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>7058</v>
+                                    <v>7059</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2745</v>
+                                    <v>2740</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>12</b>
-                                    <v>1649</v>
+                                    <v>1650</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17726,22 +14645,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>17317</v>
+                                    <v>17326</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>7058</v>
+                                    <v>7059</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2745</v>
+                                    <v>2740</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>12</b>
-                                    <v>1649</v>
+                                    <v>1650</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17795,18 +14714,18 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1396</a>
-                                    <b>1397</b>
+                                    <a>1394</a>
+                                    <b>1395</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>3638</a>
-                                    <b>3639</b>
+                                    <a>3635</a>
+                                    <b>3636</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>9139</a>
-                                    <b>9140</b>
+                                    <a>9135</a>
+                                    <b>9136</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -17861,18 +14780,18 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1396</a>
-                                    <b>1397</b>
+                                    <a>1394</a>
+                                    <b>1395</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>3638</a>
-                                    <b>3639</b>
+                                    <a>3635</a>
+                                    <b>3636</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>9139</a>
-                                    <b>9140</b>
+                                    <a>9135</a>
+                                    <b>9136</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -17889,7 +14808,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>47656</v>
+                                    <v>47661</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17905,7 +14824,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>47656</v>
+                                    <v>47661</v>
                                 </b>
                             </bs>
                         </hist>
@@ -17915,59 +14834,22 @@
         </relation>
         <relation>
             <name>ruby_method_parameters_def</name>
-            <cardinality>28984</cardinality>
+            <cardinality>28992</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>28984</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>28984</v>
+                    <v>28992</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>28984</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>28984</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_module_child</name>
-            <cardinality>31103</cardinality>
+            <cardinality>31229</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_module</k>
-                    <v>10530</v>
+                    <v>10544</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -17975,7 +14857,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>31103</v>
+                    <v>31229</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -17989,22 +14871,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>7457</v>
+                                    <v>7466</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>884</v>
+                                    <v>885</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>5</b>
-                                    <v>764</v>
+                                    <v>762</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>11</b>
-                                    <v>846</v>
+                                    <v>853</v>
                                 </b>
                                 <b>
                                     <a>11</a>
@@ -18025,22 +14907,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>7457</v>
+                                    <v>7466</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>884</v>
+                                    <v>885</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>5</b>
-                                    <v>764</v>
+                                    <v>762</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>11</b>
-                                    <v>846</v>
+                                    <v>853</v>
                                 </b>
                                 <b>
                                     <a>11</a>
@@ -18095,27 +14977,27 @@
                                 </b>
                                 <b>
                                     <a>16</a>
-                                    <b>24</b>
+                                    <b>25</b>
                                     <v>34</v>
                                 </b>
                                 <b>
-                                    <a>27</a>
-                                    <b>45</b>
+                                    <a>28</a>
+                                    <b>46</b>
                                     <v>31</v>
                                 </b>
                                 <b>
-                                    <a>50</a>
-                                    <b>107</b>
+                                    <a>51</a>
+                                    <b>108</b>
                                     <v>31</v>
                                 </b>
                                 <b>
-                                    <a>122</a>
+                                    <a>123</a>
                                     <b>374</b>
                                     <v>31</v>
                                 </b>
                                 <b>
-                                    <a>452</a>
-                                    <b>3346</b>
+                                    <a>454</a>
+                                    <b>3348</b>
                                     <v>15</v>
                                 </b>
                             </bs>
@@ -18166,27 +15048,27 @@
                                 </b>
                                 <b>
                                     <a>16</a>
-                                    <b>24</b>
+                                    <b>25</b>
                                     <v>34</v>
                                 </b>
                                 <b>
-                                    <a>27</a>
-                                    <b>45</b>
+                                    <a>28</a>
+                                    <b>46</b>
                                     <v>31</v>
                                 </b>
                                 <b>
-                                    <a>50</a>
-                                    <b>107</b>
+                                    <a>51</a>
+                                    <b>108</b>
                                     <v>31</v>
                                 </b>
                                 <b>
-                                    <a>122</a>
+                                    <a>123</a>
                                     <b>374</b>
                                     <v>31</v>
                                 </b>
                                 <b>
-                                    <a>452</a>
-                                    <b>3346</b>
+                                    <a>454</a>
+                                    <b>3348</b>
                                     <v>15</v>
                                 </b>
                             </bs>
@@ -18203,7 +15085,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>31103</v>
+                                    <v>31229</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18219,7 +15101,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>31103</v>
+                                    <v>31229</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18229,19 +15111,15 @@
         </relation>
         <relation>
             <name>ruby_module_def</name>
-            <cardinality>21083</cardinality>
+            <cardinality>21140</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>21083</v>
+                    <v>21140</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>21083</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>21083</v>
+                    <v>21140</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -18255,23 +15133,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>21083</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>21083</v>
+                                    <v>21140</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18287,55 +15149,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>21083</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>21083</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>21083</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>21083</v>
+                                    <v>21140</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18345,15 +15159,15 @@
         </relation>
         <relation>
             <name>ruby_next_child</name>
-            <cardinality>238</cardinality>
+            <cardinality>240</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_next</k>
-                    <v>238</v>
+                    <v>240</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>238</v>
+                    <v>240</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -18367,7 +15181,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>238</v>
+                                    <v>240</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18383,7 +15197,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>238</v>
+                                    <v>240</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18393,63 +15207,26 @@
         </relation>
         <relation>
             <name>ruby_next_def</name>
-            <cardinality>2082</cardinality>
+            <cardinality>2070</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2082</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2082</v>
+                    <v>2070</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2082</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2082</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_operator_assignment_def</name>
-            <cardinality>6540</cardinality>
+            <cardinality>6618</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>6540</v>
+                    <v>6618</v>
                 </e>
                 <e>
                     <k>left</k>
-                    <v>6540</v>
+                    <v>6618</v>
                 </e>
                 <e>
                     <k>operator</k>
@@ -18457,11 +15234,7 @@
                 </e>
                 <e>
                     <k>right</k>
-                    <v>6540</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>6540</v>
+                    <v>6618</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -18475,7 +15248,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18491,7 +15264,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18507,23 +15280,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18539,7 +15296,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18555,7 +15312,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18571,23 +15328,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>left</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18616,18 +15357,18 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>64</a>
-                                    <b>65</b>
+                                    <a>60</a>
+                                    <b>61</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>539</a>
-                                    <b>540</b>
+                                    <a>578</a>
+                                    <b>579</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1527</a>
-                                    <b>1528</b>
+                                    <a>1530</a>
+                                    <b>1531</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -18657,18 +15398,18 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>64</a>
-                                    <b>65</b>
+                                    <a>60</a>
+                                    <b>61</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>539</a>
-                                    <b>540</b>
+                                    <a>578</a>
+                                    <b>579</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1527</a>
-                                    <b>1528</b>
+                                    <a>1530</a>
+                                    <b>1531</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -18698,59 +15439,18 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>64</a>
-                                    <b>65</b>
+                                    <a>60</a>
+                                    <b>61</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>539</a>
-                                    <b>540</b>
+                                    <a>578</a>
+                                    <b>579</b>
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1527</a>
-                                    <b>1528</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>operator</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>5</a>
-                                    <b>6</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>9</a>
-                                    <b>10</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>64</a>
-                                    <b>65</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>539</a>
-                                    <b>540</b>
-                                    <v>3</v>
-                                </b>
-                                <b>
-                                    <a>1527</a>
-                                    <b>1528</b>
+                                    <a>1530</a>
+                                    <b>1531</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -18767,7 +15467,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18783,7 +15483,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18799,87 +15499,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>right</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>left</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>operator</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>right</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6540</v>
+                                    <v>6618</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18889,23 +15509,19 @@
         </relation>
         <relation>
             <name>ruby_optional_parameter_def</name>
-            <cardinality>6519</cardinality>
+            <cardinality>6527</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>6519</v>
+                    <v>6527</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>6519</v>
+                    <v>6527</v>
                 </e>
                 <e>
                     <k>value</k>
-                    <v>6519</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>6519</v>
+                    <v>6527</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -18919,7 +15535,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6519</v>
+                                    <v>6527</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18935,23 +15551,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6519</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6519</v>
+                                    <v>6527</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18967,7 +15567,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6519</v>
+                                    <v>6527</v>
                                 </b>
                             </bs>
                         </hist>
@@ -18983,23 +15583,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6519</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6519</v>
+                                    <v>6527</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19015,7 +15599,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6519</v>
+                                    <v>6527</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19031,71 +15615,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6519</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6519</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6519</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6519</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6519</v>
+                                    <v>6527</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19105,19 +15625,15 @@
         </relation>
         <relation>
             <name>ruby_pair_def</name>
-            <cardinality>234896</cardinality>
+            <cardinality>235172</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>234896</v>
+                    <v>235172</v>
                 </e>
                 <e>
                     <k>key__</k>
-                    <v>234896</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>234896</v>
+                    <v>235172</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -19131,23 +15647,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>234896</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>234896</v>
+                                    <v>235172</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19163,55 +15663,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>234896</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>key__</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>234896</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>234896</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>key__</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>234896</v>
+                                    <v>235172</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19221,15 +15673,15 @@
         </relation>
         <relation>
             <name>ruby_pair_value</name>
-            <cardinality>234896</cardinality>
+            <cardinality>235172</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_pair</k>
-                    <v>234896</v>
+                    <v>235172</v>
                 </e>
                 <e>
                     <k>value</k>
-                    <v>234896</v>
+                    <v>235172</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -19243,7 +15695,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>234896</v>
+                                    <v>235172</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19259,7 +15711,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>234896</v>
+                                    <v>235172</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19279,10 +15731,6 @@
                     <k>child</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -19302,54 +15750,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>child</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -19361,11 +15763,11 @@
         </relation>
         <relation>
             <name>ruby_parenthesized_statements_child</name>
-            <cardinality>10089</cardinality>
+            <cardinality>10178</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_parenthesized_statements</k>
-                    <v>10025</v>
+                    <v>10114</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -19373,7 +15775,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>10089</v>
+                    <v>10178</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -19387,7 +15789,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>9969</v>
+                                    <v>10058</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -19408,7 +15810,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>9969</v>
+                                    <v>10058</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -19442,8 +15844,8 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>10025</a>
-                                    <b>10026</b>
+                                    <a>10114</a>
+                                    <b>10115</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -19473,8 +15875,8 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>10025</a>
-                                    <b>10026</b>
+                                    <a>10114</a>
+                                    <b>10115</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -19491,7 +15893,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>10089</v>
+                                    <v>10178</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19507,7 +15909,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>10089</v>
+                                    <v>10178</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19517,67 +15919,26 @@
         </relation>
         <relation>
             <name>ruby_parenthesized_statements_def</name>
-            <cardinality>10064</cardinality>
+            <cardinality>10153</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>10064</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>10064</v>
+                    <v>10153</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>10064</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>10064</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_pattern_def</name>
-            <cardinality>3869</cardinality>
+            <cardinality>3878</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3869</v>
+                    <v>3878</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>3869</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3869</v>
+                    <v>3878</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -19591,23 +15952,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3869</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3869</v>
+                                    <v>3878</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19623,55 +15968,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3869</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3869</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3869</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3869</v>
+                                    <v>3878</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19681,11 +15978,11 @@
         </relation>
         <relation>
             <name>ruby_program_child</name>
-            <cardinality>33077</cardinality>
+            <cardinality>33094</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_program</k>
-                    <v>10448</v>
+                    <v>10452</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -19693,7 +15990,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>33077</v>
+                    <v>33094</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -19707,32 +16004,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3862</v>
+                                    <v>3865</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>2524</v>
+                                    <v>2526</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1652</v>
+                                    <v>1650</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>777</v>
+                                    <v>778</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>919</v>
+                                    <v>916</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>77</b>
-                                    <v>711</v>
+                                    <v>715</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19748,32 +16045,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3862</v>
+                                    <v>3865</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>2524</v>
+                                    <v>2526</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1652</v>
+                                    <v>1650</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>777</v>
+                                    <v>778</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>919</v>
+                                    <v>916</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>77</b>
-                                    <v>711</v>
+                                    <v>715</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19822,7 +16119,7 @@
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>66</a>
+                                    <a>67</a>
                                     <b>138</b>
                                     <v>18</v>
                                 </b>
@@ -19833,7 +16130,7 @@
                                 </b>
                                 <b>
                                     <a>765</a>
-                                    <b>3320</b>
+                                    <b>3319</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -19883,7 +16180,7 @@
                                     <v>18</v>
                                 </b>
                                 <b>
-                                    <a>66</a>
+                                    <a>67</a>
                                     <b>138</b>
                                     <v>18</v>
                                 </b>
@@ -19894,7 +16191,7 @@
                                 </b>
                                 <b>
                                     <a>765</a>
-                                    <b>3320</b>
+                                    <b>3319</b>
                                     <v>12</v>
                                 </b>
                             </bs>
@@ -19911,7 +16208,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>33077</v>
+                                    <v>33094</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19927,7 +16224,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>33077</v>
+                                    <v>33094</v>
                                 </b>
                             </bs>
                         </hist>
@@ -19937,63 +16234,26 @@
         </relation>
         <relation>
             <name>ruby_program_def</name>
-            <cardinality>16871</cardinality>
+            <cardinality>16935</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>16871</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>16871</v>
+                    <v>16935</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>16871</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>16871</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_range_begin</name>
-            <cardinality>4233</cardinality>
+            <cardinality>4241</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_range</k>
-                    <v>4233</v>
+                    <v>4241</v>
                 </e>
                 <e>
                     <k>begin</k>
-                    <v>4233</v>
+                    <v>4241</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20007,7 +16267,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4233</v>
+                                    <v>4241</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20023,7 +16283,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4233</v>
+                                    <v>4241</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20033,19 +16293,15 @@
         </relation>
         <relation>
             <name>ruby_range_def</name>
-            <cardinality>4286</cardinality>
+            <cardinality>4294</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>4286</v>
+                    <v>4294</v>
                 </e>
                 <e>
                     <k>operator</k>
                     <v>2</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>4286</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20059,23 +16315,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4286</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4286</v>
+                                    <v>4294</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20089,67 +16329,14 @@
                             <budget>12</budget>
                             <bs>
                                 <b>
-                                    <a>1539</a>
-                                    <b>1540</b>
+                                    <a>1544</a>
+                                    <b>1545</b>
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>2747</a>
-                                    <b>2748</b>
+                                    <a>2750</a>
+                                    <b>2751</b>
                                     <v>1</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>operator</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1539</a>
-                                    <b>1540</b>
-                                    <v>1</v>
-                                </b>
-                                <b>
-                                    <a>2747</a>
-                                    <b>2748</b>
-                                    <v>1</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4286</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>operator</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4286</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20159,15 +16346,15 @@
         </relation>
         <relation>
             <name>ruby_range_end</name>
-            <cardinality>3665</cardinality>
+            <cardinality>3671</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_range</k>
-                    <v>3665</v>
+                    <v>3671</v>
                 </e>
                 <e>
                     <k>end</k>
-                    <v>3665</v>
+                    <v>3671</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20181,7 +16368,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3665</v>
+                                    <v>3671</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20197,7 +16384,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3665</v>
+                                    <v>3671</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20217,10 +16404,6 @@
                     <k>child</k>
                     <v>123</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>123</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -20240,72 +16423,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>123</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>child</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>123</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>123</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>123</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -20377,53 +16496,16 @@
                     <k>id</k>
                     <v>33</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>33</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>33</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>33</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_regex_child</name>
-            <cardinality>42820</cardinality>
+            <cardinality>42882</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_regex</k>
-                    <v>12803</v>
+                    <v>12812</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -20431,7 +16513,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>42820</v>
+                    <v>42882</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20445,17 +16527,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6573</v>
+                                    <v>6577</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>720</v>
+                                    <v>721</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1687</v>
+                                    <v>1688</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -20465,7 +16547,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>1089</v>
+                                    <v>1086</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -20475,7 +16557,7 @@
                                 <b>
                                     <a>8</a>
                                     <b>16</b>
-                                    <v>1019</v>
+                                    <v>1023</v>
                                 </b>
                                 <b>
                                     <a>16</a>
@@ -20496,17 +16578,17 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6573</v>
+                                    <v>6577</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>720</v>
+                                    <v>721</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>1687</v>
+                                    <v>1688</v>
                                 </b>
                                 <b>
                                     <a>4</a>
@@ -20516,7 +16598,7 @@
                                 <b>
                                     <a>5</a>
                                     <b>6</b>
-                                    <v>1089</v>
+                                    <v>1086</v>
                                 </b>
                                 <b>
                                     <a>6</a>
@@ -20526,7 +16608,7 @@
                                 <b>
                                     <a>8</a>
                                     <b>16</b>
-                                    <v>1019</v>
+                                    <v>1023</v>
                                 </b>
                                 <b>
                                     <a>16</a>
@@ -20596,22 +16678,22 @@
                                 </b>
                                 <b>
                                     <a>54</a>
-                                    <b>94</b>
+                                    <b>95</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>105</a>
-                                    <b>164</b>
+                                    <a>106</a>
+                                    <b>165</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>226</a>
-                                    <b>335</b>
+                                    <a>227</a>
+                                    <b>336</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>397</a>
-                                    <b>710</b>
+                                    <a>398</a>
+                                    <b>711</b>
                                     <v>9</v>
                                 </b>
                                 <b>
@@ -20687,22 +16769,22 @@
                                 </b>
                                 <b>
                                     <a>54</a>
-                                    <b>94</b>
+                                    <b>95</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>105</a>
-                                    <b>164</b>
+                                    <a>106</a>
+                                    <b>165</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>226</a>
-                                    <b>335</b>
+                                    <a>227</a>
+                                    <b>336</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>397</a>
-                                    <b>710</b>
+                                    <a>398</a>
+                                    <b>711</b>
                                     <v>9</v>
                                 </b>
                                 <b>
@@ -20729,7 +16811,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>42820</v>
+                                    <v>42882</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20745,7 +16827,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>42820</v>
+                                    <v>42882</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20755,63 +16837,26 @@
         </relation>
         <relation>
             <name>ruby_regex_def</name>
-            <cardinality>12819</cardinality>
+            <cardinality>12828</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>12819</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>12819</v>
+                    <v>12828</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12819</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12819</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_rescue_body</name>
-            <cardinality>1802</cardinality>
+            <cardinality>1794</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_rescue</k>
-                    <v>1802</v>
+                    <v>1794</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>1802</v>
+                    <v>1794</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20825,7 +16870,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1802</v>
+                                    <v>1794</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20841,7 +16886,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1802</v>
+                                    <v>1794</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20851,63 +16896,26 @@
         </relation>
         <relation>
             <name>ruby_rescue_def</name>
-            <cardinality>2094</cardinality>
+            <cardinality>2085</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2094</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2094</v>
+                    <v>2085</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2094</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2094</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_rescue_exceptions</name>
-            <cardinality>1638</cardinality>
+            <cardinality>1641</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_rescue</k>
-                    <v>1638</v>
+                    <v>1641</v>
                 </e>
                 <e>
                     <k>exceptions</k>
-                    <v>1638</v>
+                    <v>1641</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20921,7 +16929,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1638</v>
+                                    <v>1641</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20937,7 +16945,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1638</v>
+                                    <v>1641</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20947,23 +16955,19 @@
         </relation>
         <relation>
             <name>ruby_rescue_modifier_def</name>
-            <cardinality>554</cardinality>
+            <cardinality>551</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>554</v>
+                    <v>551</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>554</v>
+                    <v>551</v>
                 </e>
                 <e>
                     <k>handler</k>
-                    <v>554</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>554</v>
+                    <v>551</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -20977,7 +16981,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>554</v>
+                                    <v>551</v>
                                 </b>
                             </bs>
                         </hist>
@@ -20993,23 +16997,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>554</v>
+                                    <v>551</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21025,7 +17013,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>554</v>
+                                    <v>551</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21041,23 +17029,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>554</v>
+                                    <v>551</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21073,7 +17045,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>554</v>
+                                    <v>551</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21089,71 +17061,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>handler</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>554</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>handler</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>554</v>
+                                    <v>551</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21163,15 +17071,15 @@
         </relation>
         <relation>
             <name>ruby_rescue_variable</name>
-            <cardinality>1027</cardinality>
+            <cardinality>1021</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_rescue</k>
-                    <v>1027</v>
+                    <v>1021</v>
                 </e>
                 <e>
                     <k>variable</k>
-                    <v>1027</v>
+                    <v>1021</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -21185,7 +17093,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1027</v>
+                                    <v>1021</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21201,7 +17109,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1027</v>
+                                    <v>1021</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21265,45 +17173,8 @@
                     <k>id</k>
                     <v>398</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>398</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>398</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>398</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_retry_child</name>
@@ -21361,57 +17232,20 @@
                     <k>id</k>
                     <v>56</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>56</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>56</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>56</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_return_child</name>
-            <cardinality>5369</cardinality>
+            <cardinality>5359</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_return</k>
-                    <v>5369</v>
+                    <v>5359</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>5369</v>
+                    <v>5359</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -21425,7 +17259,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5369</v>
+                                    <v>5359</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21441,7 +17275,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5369</v>
+                                    <v>5359</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21451,59 +17285,22 @@
         </relation>
         <relation>
             <name>ruby_return_def</name>
-            <cardinality>8544</cardinality>
+            <cardinality>8521</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>8544</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>8544</v>
+                    <v>8521</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>8544</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>8544</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_right_assignment_list_child</name>
-            <cardinality>2924</cardinality>
+            <cardinality>2932</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_right_assignment_list</k>
-                    <v>1372</v>
+                    <v>1376</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -21511,7 +17308,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>2924</v>
+                    <v>2932</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -21525,7 +17322,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1230</v>
+                                    <v>1234</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -21551,7 +17348,7 @@
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1230</v>
+                                    <v>1234</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -21590,8 +17387,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>436</a>
-                                    <b>437</b>
+                                    <a>437</a>
+                                    <b>438</b>
                                     <v>6</v>
                                 </b>
                             </bs>
@@ -21621,8 +17418,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>436</a>
-                                    <b>437</b>
+                                    <a>437</a>
+                                    <b>438</b>
                                     <v>6</v>
                                 </b>
                             </bs>
@@ -21639,7 +17436,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2924</v>
+                                    <v>2932</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21655,7 +17452,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2924</v>
+                                    <v>2932</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21665,67 +17462,26 @@
         </relation>
         <relation>
             <name>ruby_right_assignment_list_def</name>
-            <cardinality>1372</cardinality>
+            <cardinality>1376</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1372</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1372</v>
+                    <v>1376</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1372</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1372</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_scope_resolution_def</name>
-            <cardinality>80121</cardinality>
+            <cardinality>80201</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>80121</v>
+                    <v>80201</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>80121</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>80121</v>
+                    <v>80201</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -21739,23 +17495,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>80121</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>80121</v>
+                                    <v>80201</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21771,55 +17511,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>80121</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>80121</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>80121</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>80121</v>
+                                    <v>80201</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21829,15 +17521,15 @@
         </relation>
         <relation>
             <name>ruby_scope_resolution_scope</name>
-            <cardinality>78359</cardinality>
+            <cardinality>78442</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_scope_resolution</k>
-                    <v>78359</v>
+                    <v>78442</v>
                 </e>
                 <e>
                     <k>scope</k>
-                    <v>78359</v>
+                    <v>78442</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -21851,7 +17543,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>78359</v>
+                                    <v>78442</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21867,7 +17559,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>78359</v>
+                                    <v>78442</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21877,19 +17569,15 @@
         </relation>
         <relation>
             <name>ruby_setter_def</name>
-            <cardinality>594</cardinality>
+            <cardinality>598</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>594</v>
+                    <v>598</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>594</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>594</v>
+                    <v>598</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -21903,23 +17591,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>594</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>594</v>
+                                    <v>598</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21935,55 +17607,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>594</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>594</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>594</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>594</v>
+                                    <v>598</v>
                                 </b>
                             </bs>
                         </hist>
@@ -21993,7 +17617,7 @@
         </relation>
         <relation>
             <name>ruby_singleton_class_child</name>
-            <cardinality>2424</cardinality>
+            <cardinality>2422</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_singleton_class</k>
@@ -22005,7 +17629,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>2424</v>
+                    <v>2422</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -22159,7 +17783,7 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>21</a>
+                                    <a>20</a>
                                     <b>24</b>
                                     <v>6</v>
                                 </b>
@@ -22225,7 +17849,7 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>21</a>
+                                    <a>20</a>
                                     <b>24</b>
                                     <v>6</v>
                                 </b>
@@ -22263,7 +17887,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2424</v>
+                                    <v>2422</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22279,7 +17903,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2424</v>
+                                    <v>2422</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22299,10 +17923,6 @@
                     <k>value</k>
                     <v>626</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>626</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -22322,72 +17942,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>626</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>value</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>626</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>626</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>626</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -22405,19 +17961,19 @@
         </relation>
         <relation>
             <name>ruby_singleton_method_child</name>
-            <cardinality>16091</cardinality>
+            <cardinality>16000</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_singleton_method</k>
-                    <v>6598</v>
+                    <v>6563</v>
                 </e>
                 <e>
                     <k>index</k>
-                    <v>85</v>
+                    <v>84</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>16091</v>
+                    <v>16000</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -22431,32 +17987,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3732</v>
+                                    <v>3713</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>991</v>
+                                    <v>985</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>591</v>
+                                    <v>588</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>405</v>
+                                    <v>403</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>521</v>
+                                    <v>518</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>29</b>
-                                    <v>356</v>
+                                    <v>354</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22472,32 +18028,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3732</v>
+                                    <v>3713</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>991</v>
+                                    <v>985</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>591</v>
+                                    <v>588</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>5</b>
-                                    <v>405</v>
+                                    <v>403</v>
                                 </b>
                                 <b>
                                     <a>5</a>
                                     <b>8</b>
-                                    <v>521</v>
+                                    <v>518</v>
                                 </b>
                                 <b>
                                     <a>8</a>
                                     <b>29</b>
-                                    <v>356</v>
+                                    <v>354</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22576,8 +18132,8 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>2164</a>
-                                    <b>2165</b>
+                                    <a>2165</a>
+                                    <b>2166</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -22657,8 +18213,8 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>2164</a>
-                                    <b>2165</b>
+                                    <a>2165</a>
+                                    <b>2166</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -22675,7 +18231,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>16091</v>
+                                    <v>16000</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22691,7 +18247,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>16091</v>
+                                    <v>16000</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22701,23 +18257,19 @@
         </relation>
         <relation>
             <name>ruby_singleton_method_def</name>
-            <cardinality>6598</cardinality>
+            <cardinality>6563</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>6598</v>
+                    <v>6563</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>6598</v>
+                    <v>6563</v>
                 </e>
                 <e>
                     <k>object</k>
-                    <v>6598</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>6598</v>
+                    <v>6563</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -22731,7 +18283,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6598</v>
+                                    <v>6563</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22747,23 +18299,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6598</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6598</v>
+                                    <v>6563</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22779,7 +18315,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6598</v>
+                                    <v>6563</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22795,23 +18331,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6598</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6598</v>
+                                    <v>6563</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22827,7 +18347,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6598</v>
+                                    <v>6563</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22843,71 +18363,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>6598</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>object</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6598</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6598</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6598</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>object</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>6598</v>
+                                    <v>6563</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22917,15 +18373,15 @@
         </relation>
         <relation>
             <name>ruby_singleton_method_parameters</name>
-            <cardinality>4159</cardinality>
+            <cardinality>4135</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_singleton_method</k>
-                    <v>4159</v>
+                    <v>4135</v>
                 </e>
                 <e>
                     <k>parameters</k>
-                    <v>4159</v>
+                    <v>4135</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -22939,7 +18395,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4159</v>
+                                    <v>4135</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22955,7 +18411,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4159</v>
+                                    <v>4135</v>
                                 </b>
                             </bs>
                         </hist>
@@ -22965,19 +18421,15 @@
         </relation>
         <relation>
             <name>ruby_splat_argument_def</name>
-            <cardinality>3176</cardinality>
+            <cardinality>3179</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3176</v>
+                    <v>3179</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>3176</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3176</v>
+                    <v>3179</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -22991,23 +18443,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3176</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3176</v>
+                                    <v>3179</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23023,55 +18459,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3176</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3176</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3176</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3176</v>
+                                    <v>3179</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23081,63 +18469,26 @@
         </relation>
         <relation>
             <name>ruby_splat_parameter_def</name>
-            <cardinality>2930</cardinality>
+            <cardinality>2936</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2930</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2930</v>
+                    <v>2936</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2930</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2930</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_splat_parameter_name</name>
-            <cardinality>2364</cardinality>
+            <cardinality>2369</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_splat_parameter</k>
-                    <v>2364</v>
+                    <v>2369</v>
                 </e>
                 <e>
                     <k>name</k>
-                    <v>2364</v>
+                    <v>2369</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -23151,7 +18502,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2364</v>
+                                    <v>2369</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23167,7 +18518,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2364</v>
+                                    <v>2369</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23177,11 +18528,11 @@
         </relation>
         <relation>
             <name>ruby_string_array_child</name>
-            <cardinality>11471</cardinality>
+            <cardinality>11474</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_string_array</k>
-                    <v>3714</v>
+                    <v>3716</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -23189,7 +18540,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>11471</v>
+                    <v>11474</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -23203,12 +18554,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1204</v>
+                                    <v>1205</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1225</v>
+                                    <v>1226</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -23244,12 +18595,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1204</v>
+                                    <v>1205</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>1225</v>
+                                    <v>1226</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -23299,7 +18650,7 @@
                                 </b>
                                 <b>
                                     <a>706</a>
-                                    <b>3715</b>
+                                    <b>3717</b>
                                     <v>4</v>
                                 </b>
                             </bs>
@@ -23330,7 +18681,7 @@
                                 </b>
                                 <b>
                                     <a>706</a>
-                                    <b>3715</b>
+                                    <b>3717</b>
                                     <v>4</v>
                                 </b>
                             </bs>
@@ -23347,7 +18698,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>11471</v>
+                                    <v>11474</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23363,7 +18714,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>11471</v>
+                                    <v>11474</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23373,59 +18724,22 @@
         </relation>
         <relation>
             <name>ruby_string_array_def</name>
-            <cardinality>3861</cardinality>
+            <cardinality>3868</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3861</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3861</v>
+                    <v>3868</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3861</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3861</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_string_child</name>
-            <cardinality>534856</cardinality>
+            <cardinality>535162</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_string__</k>
-                    <v>467197</v>
+                    <v>467438</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -23433,7 +18747,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>534856</v>
+                    <v>535162</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -23447,12 +18761,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>440697</v>
+                                    <v>440917</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>282</b>
-                                    <v>26500</v>
+                                    <v>26521</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23468,12 +18782,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>440697</v>
+                                    <v>440917</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>282</b>
-                                    <v>26500</v>
+                                    <v>26521</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23513,7 +18827,7 @@
                                 </b>
                                 <b>
                                     <a>102</a>
-                                    <b>467198</b>
+                                    <b>467439</b>
                                     <v>22</v>
                                 </b>
                             </bs>
@@ -23554,7 +18868,7 @@
                                 </b>
                                 <b>
                                     <a>102</a>
-                                    <b>467198</b>
+                                    <b>467439</b>
                                     <v>22</v>
                                 </b>
                             </bs>
@@ -23571,7 +18885,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>534856</v>
+                                    <v>535162</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23587,7 +18901,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>534856</v>
+                                    <v>535162</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23597,51 +18911,14 @@
         </relation>
         <relation>
             <name>ruby_string_def</name>
-            <cardinality>474389</cardinality>
+            <cardinality>474637</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>474389</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>474389</v>
+                    <v>474637</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>474389</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>474389</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_subshell_child</name>
@@ -23867,61 +19144,20 @@
                     <k>id</k>
                     <v>409</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>409</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>409</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>409</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_superclass_def</name>
-            <cardinality>13244</cardinality>
+            <cardinality>13262</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>13244</v>
+                    <v>13262</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>13244</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>13244</v>
+                    <v>13262</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -23935,23 +19171,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13244</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13244</v>
+                                    <v>13262</v>
                                 </b>
                             </bs>
                         </hist>
@@ -23967,55 +19187,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>13244</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>child</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13244</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13244</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>child</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>13244</v>
+                                    <v>13262</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24025,11 +19197,11 @@
         </relation>
         <relation>
             <name>ruby_symbol_array_child</name>
-            <cardinality>2149</cardinality>
+            <cardinality>2137</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_symbol_array</k>
-                    <v>460</v>
+                    <v>457</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -24037,7 +19209,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>2149</v>
+                    <v>2137</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -24051,12 +19223,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>176</v>
+                                    <v>175</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>94</v>
+                                    <v>93</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -24102,12 +19274,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>176</v>
+                                    <v>175</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>94</v>
+                                    <v>93</v>
                                 </b>
                                 <b>
                                     <a>3</a>
@@ -24275,7 +19447,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2149</v>
+                                    <v>2137</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24291,7 +19463,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2149</v>
+                                    <v>2137</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24301,59 +19473,22 @@
         </relation>
         <relation>
             <name>ruby_symbol_array_def</name>
-            <cardinality>460</cardinality>
+            <cardinality>457</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>460</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>460</v>
+                    <v>457</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>460</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>460</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_then_child</name>
-            <cardinality>41699</cardinality>
+            <cardinality>41524</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_then</k>
-                    <v>24696</v>
+                    <v>24592</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -24361,7 +19496,7 @@
                 </e>
                 <e>
                     <k>child</k>
-                    <v>41699</v>
+                    <v>41524</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -24375,22 +19510,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>15414</v>
+                                    <v>15349</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>5564</v>
+                                    <v>5541</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2043</v>
+                                    <v>2031</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>36</b>
-                                    <v>1674</v>
+                                    <v>1670</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24406,22 +19541,22 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>15414</v>
+                                    <v>15349</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>5564</v>
+                                    <v>5541</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>2043</v>
+                                    <v>2031</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>36</b>
-                                    <v>1674</v>
+                                    <v>1670</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24460,18 +19595,18 @@
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>43</a>
+                                    <a>42</a>
                                     <b>92</b>
                                     <v>9</v>
                                 </b>
                                 <b>
                                     <a>157</a>
-                                    <b>550</b>
+                                    <b>552</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>1219</a>
-                                    <b>8100</b>
+                                    <a>1221</a>
+                                    <b>8113</b>
                                     <v>9</v>
                                 </b>
                             </bs>
@@ -24511,18 +19646,18 @@
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>43</a>
+                                    <a>42</a>
                                     <b>92</b>
                                     <v>9</v>
                                 </b>
                                 <b>
                                     <a>157</a>
-                                    <b>550</b>
+                                    <b>552</b>
                                     <v>9</v>
                                 </b>
                                 <b>
-                                    <a>1219</a>
-                                    <b>8100</b>
+                                    <a>1221</a>
+                                    <b>8113</b>
                                     <v>9</v>
                                 </b>
                             </bs>
@@ -24539,7 +19674,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>41699</v>
+                                    <v>41524</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24555,7 +19690,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>41699</v>
+                                    <v>41524</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24565,71 +19700,30 @@
         </relation>
         <relation>
             <name>ruby_then_def</name>
-            <cardinality>24696</cardinality>
+            <cardinality>24592</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>24696</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>24696</v>
+                    <v>24592</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>24696</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>24696</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_tokeninfo</name>
-            <cardinality>5917338</cardinality>
+            <cardinality>5922021</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>5917338</v>
+                    <v>5922021</v>
                 </e>
                 <e>
                     <k>kind</k>
-                    <v>70</v>
+                    <v>69</v>
                 </e>
                 <e>
                     <k>value</k>
-                    <v>266245</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>5917234</v>
+                    <v>270444</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -24643,7 +19737,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5917338</v>
+                                    <v>5922021</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24659,23 +19753,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>5917338</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>5917338</v>
+                                    <v>5922021</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24694,58 +19772,58 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>147</a>
+                                    <a>149</a>
                                     <b>216</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>425</a>
-                                    <b>1589</b>
+                                    <a>426</a>
+                                    <b>1594</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>1751</a>
-                                    <b>1752</b>
+                                    <a>1759</a>
+                                    <b>1760</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>3964</a>
-                                    <b>4089</b>
+                                    <a>3972</a>
+                                    <b>4099</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>4142</a>
-                                    <b>5570</b>
+                                    <a>4151</a>
+                                    <b>5588</b>
                                     <v>6</v>
                                 </b>
                                 <b>
                                     <a>7608</a>
-                                    <b>9490</b>
+                                    <b>9506</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>13402</a>
-                                    <b>17010</b>
+                                    <a>13384</a>
+                                    <b>17043</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>23453</a>
-                                    <b>53376</b>
+                                    <a>24845</a>
+                                    <b>53463</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>54170</a>
-                                    <b>77525</b>
+                                    <a>54287</a>
+                                    <b>77797</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>92096</a>
-                                    <b>487850</b>
+                                    <a>93626</a>
+                                    <b>488897</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>1080911</a>
-                                    <b>1080912</b>
+                                    <a>1089226</a>
+                                    <b>1089227</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -24766,7 +19844,7 @@
                                 </b>
                                 <b>
                                     <a>5</a>
-                                    <b>25</b>
+                                    <b>26</b>
                                     <v>6</v>
                                 </b>
                                 <b>
@@ -24775,7 +19853,7 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>65</a>
+                                    <a>66</a>
                                     <b>121</b>
                                     <v>6</v>
                                 </b>
@@ -24785,99 +19863,28 @@
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>558</a>
-                                    <b>1746</b>
+                                    <a>1472</a>
+                                    <b>1747</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>3008</a>
-                                    <b>3682</b>
+                                    <a>3017</a>
+                                    <b>3685</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>4511</a>
-                                    <b>7577</b>
+                                    <a>4567</a>
+                                    <b>7583</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>9950</a>
-                                    <b>18387</b>
+                                    <a>9961</a>
+                                    <b>18415</b>
                                     <v>6</v>
                                 </b>
                                 <b>
-                                    <a>42832</a>
-                                    <b>42833</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>kind</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>35</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>147</a>
-                                    <b>216</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>425</a>
-                                    <b>1589</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>1751</a>
-                                    <b>1752</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>3964</a>
-                                    <b>4089</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>4142</a>
-                                    <b>5570</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>7608</a>
-                                    <b>9490</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>13402</a>
-                                    <b>17010</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>23453</a>
-                                    <b>53376</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>54170</a>
-                                    <b>77525</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>92096</a>
-                                    <b>487850</b>
-                                    <v>6</v>
-                                </b>
-                                <b>
-                                    <a>1080911</a>
-                                    <b>1080912</b>
+                                    <a>43711</a>
+                                    <b>43712</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -24894,32 +19901,32 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>157453</v>
+                                    <v>160511</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>3</b>
-                                    <v>38936</v>
+                                    <v>39768</v>
                                 </b>
                                 <b>
                                     <a>3</a>
                                     <b>4</b>
-                                    <v>18744</v>
+                                    <v>19017</v>
                                 </b>
                                 <b>
                                     <a>4</a>
                                     <b>7</b>
-                                    <v>22360</v>
+                                    <v>22464</v>
                                 </b>
                                 <b>
                                     <a>7</a>
-                                    <b>26</b>
-                                    <v>20152</v>
+                                    <b>27</b>
+                                    <v>20427</v>
                                 </b>
                                 <b>
-                                    <a>26</a>
-                                    <b>178646</b>
-                                    <v>8599</v>
+                                    <a>27</a>
+                                    <b>178897</b>
+                                    <v>8255</v>
                                 </b>
                             </bs>
                         </hist>
@@ -24935,111 +19942,12 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>252768</v>
+                                    <v>257002</v>
                                 </b>
                                 <b>
                                     <a>2</a>
                                     <b>5</b>
-                                    <v>13477</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>value</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>157456</v>
-                                </b>
-                                <b>
-                                    <a>2</a>
-                                    <b>3</b>
-                                    <v>38933</v>
-                                </b>
-                                <b>
-                                    <a>3</a>
-                                    <b>4</b>
-                                    <v>18744</v>
-                                </b>
-                                <b>
-                                    <a>4</a>
-                                    <b>7</b>
-                                    <v>22360</v>
-                                </b>
-                                <b>
-                                    <a>7</a>
-                                    <b>26</b>
-                                    <v>20152</v>
-                                </b>
-                                <b>
-                                    <a>26</a>
-                                    <b>178646</b>
-                                    <v>8599</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>5917130</v>
-                                </b>
-                                <b>
-                                    <a>2</a>
-                                    <b>3</b>
-                                    <v>103</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>kind</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>5917130</v>
-                                </b>
-                                <b>
-                                    <a>2</a>
-                                    <b>3</b>
-                                    <v>103</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>value</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>5917234</v>
+                                    <v>13442</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25049,23 +19957,19 @@
         </relation>
         <relation>
             <name>ruby_unary_def</name>
-            <cardinality>12433</cardinality>
+            <cardinality>12512</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>12433</v>
+                    <v>12512</v>
                 </e>
                 <e>
                     <k>operand</k>
-                    <v>12433</v>
+                    <v>12512</v>
                 </e>
                 <e>
                     <k>operator</k>
                     <v>6</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>12433</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -25079,7 +19983,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>12433</v>
+                                    <v>12512</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25095,23 +19999,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>12433</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12433</v>
+                                    <v>12512</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25127,7 +20015,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>12433</v>
+                                    <v>12512</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25143,23 +20031,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>12433</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>operand</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12433</v>
+                                    <v>12512</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25193,13 +20065,13 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>1745</a>
-                                    <b>1746</b>
+                                    <a>1747</a>
+                                    <b>1748</b>
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>8493</a>
-                                    <b>8494</b>
+                                    <a>8570</a>
+                                    <b>8571</b>
                                     <v>1</v>
                                 </b>
                             </bs>
@@ -25234,103 +20106,14 @@
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>1745</a>
-                                    <b>1746</b>
+                                    <a>1747</a>
+                                    <b>1748</b>
                                     <v>1</v>
                                 </b>
                                 <b>
-                                    <a>8493</a>
-                                    <b>8494</b>
+                                    <a>8570</a>
+                                    <b>8571</b>
                                     <v>1</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>operator</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>88</a>
-                                    <b>89</b>
-                                    <v>1</v>
-                                </b>
-                                <b>
-                                    <a>237</a>
-                                    <b>238</b>
-                                    <v>1</v>
-                                </b>
-                                <b>
-                                    <a>559</a>
-                                    <b>560</b>
-                                    <v>1</v>
-                                </b>
-                                <b>
-                                    <a>1311</a>
-                                    <b>1312</b>
-                                    <v>1</v>
-                                </b>
-                                <b>
-                                    <a>1745</a>
-                                    <b>1746</b>
-                                    <v>1</v>
-                                </b>
-                                <b>
-                                    <a>8493</a>
-                                    <b>8494</b>
-                                    <v>1</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12433</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>operand</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12433</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>operator</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>12433</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25482,45 +20265,8 @@
                     <k>id</k>
                     <v>180</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>180</v>
-                </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>180</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>180</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_unless_alternative</name>
@@ -25630,10 +20376,6 @@
                     <k>condition</k>
                     <v>2568</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>2568</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -25653,72 +20395,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2568</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>condition</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2568</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2568</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2568</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -25746,10 +20424,6 @@
                     <k>condition</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -25769,54 +20443,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>condition</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -25828,23 +20456,19 @@
         </relation>
         <relation>
             <name>ruby_unless_modifier_def</name>
-            <cardinality>4363</cardinality>
+            <cardinality>4341</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>4363</v>
+                    <v>4341</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>4363</v>
+                    <v>4341</v>
                 </e>
                 <e>
                     <k>condition</k>
-                    <v>4363</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>4363</v>
+                    <v>4341</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -25858,7 +20482,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4363</v>
+                                    <v>4341</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25874,23 +20498,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4363</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4363</v>
+                                    <v>4341</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25906,7 +20514,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4363</v>
+                                    <v>4341</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25922,23 +20530,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4363</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4363</v>
+                                    <v>4341</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25954,7 +20546,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4363</v>
+                                    <v>4341</v>
                                 </b>
                             </bs>
                         </hist>
@@ -25970,71 +20562,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>4363</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4363</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4363</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4363</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>4363</v>
+                                    <v>4341</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26058,10 +20586,6 @@
                     <k>condition</k>
                     <v>114</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>114</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -26097,22 +20621,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>114</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>body</src>
                     <trg>id</trg>
                     <val>
@@ -26145,22 +20653,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>114</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>condition</src>
                     <trg>id</trg>
                     <val>
@@ -26179,70 +20671,6 @@
                 <dep>
                     <src>condition</src>
                     <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>114</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>114</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>114</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>114</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -26274,10 +20702,6 @@
                     <k>condition</k>
                     <v>218</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>218</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -26313,22 +20737,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>218</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>body</src>
                     <trg>id</trg>
                     <val>
@@ -26361,22 +20769,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>218</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>condition</src>
                     <trg>id</trg>
                     <val>
@@ -26395,70 +20787,6 @@
                 <dep>
                     <src>condition</src>
                     <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>218</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>218</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>218</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>218</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -26486,10 +20814,6 @@
                     <k>name</k>
                     <v>0</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>0</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -26509,54 +20833,8 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>name</src>
                     <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>name</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs/>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>name</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -26568,15 +20846,15 @@
         </relation>
         <relation>
             <name>ruby_when_body</name>
-            <cardinality>3185</cardinality>
+            <cardinality>3194</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_when</k>
-                    <v>3185</v>
+                    <v>3194</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>3185</v>
+                    <v>3194</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -26590,7 +20868,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3185</v>
+                                    <v>3194</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26606,7 +20884,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3185</v>
+                                    <v>3194</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26616,59 +20894,22 @@
         </relation>
         <relation>
             <name>ruby_when_def</name>
-            <cardinality>3220</cardinality>
+            <cardinality>3229</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>3220</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>3220</v>
+                    <v>3229</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3220</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>3220</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>ruby_when_pattern</name>
-            <cardinality>3869</cardinality>
+            <cardinality>3878</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_when</k>
-                    <v>3220</v>
+                    <v>3229</v>
                 </e>
                 <e>
                     <k>index</k>
@@ -26676,7 +20917,7 @@
                 </e>
                 <e>
                     <k>pattern</k>
-                    <v>3869</v>
+                    <v>3878</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -26690,7 +20931,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2814</v>
+                                    <v>2822</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -26716,7 +20957,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>2814</v>
+                                    <v>2822</v>
                                 </b>
                                 <b>
                                     <a>2</a>
@@ -26775,8 +21016,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1023</a>
-                                    <b>1024</b>
+                                    <a>1025</a>
+                                    <b>1026</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -26826,8 +21067,8 @@
                                     <v>3</v>
                                 </b>
                                 <b>
-                                    <a>1023</a>
-                                    <b>1024</b>
+                                    <a>1025</a>
+                                    <b>1026</b>
                                     <v>3</v>
                                 </b>
                             </bs>
@@ -26844,7 +21085,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3869</v>
+                                    <v>3878</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26860,7 +21101,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>3869</v>
+                                    <v>3878</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26870,23 +21111,19 @@
         </relation>
         <relation>
             <name>ruby_while_def</name>
-            <cardinality>1339</cardinality>
+            <cardinality>1344</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>1339</v>
+                    <v>1344</v>
                 </e>
                 <e>
                     <k>body</k>
-                    <v>1339</v>
+                    <v>1344</v>
                 </e>
                 <e>
                     <k>condition</k>
-                    <v>1339</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>1339</v>
+                    <v>1344</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -26900,7 +21137,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1339</v>
+                                    <v>1344</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26916,23 +21153,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1339</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1339</v>
+                                    <v>1344</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26948,7 +21169,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1339</v>
+                                    <v>1344</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26964,23 +21185,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1339</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1339</v>
+                                    <v>1344</v>
                                 </b>
                             </bs>
                         </hist>
@@ -26996,7 +21201,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1339</v>
+                                    <v>1344</v>
                                 </b>
                             </bs>
                         </hist>
@@ -27012,71 +21217,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1339</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1339</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1339</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1339</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>1339</v>
+                                    <v>1344</v>
                                 </b>
                             </bs>
                         </hist>
@@ -27100,10 +21241,6 @@
                     <k>condition</k>
                     <v>184</v>
                 </e>
-                <e>
-                    <k>loc</k>
-                    <v>184</v>
-                </e>
             </columnsizes>
             <dependencies>
                 <dep>
@@ -27139,22 +21276,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>184</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>body</src>
                     <trg>id</trg>
                     <val>
@@ -27187,22 +21308,6 @@
                     </val>
                 </dep>
                 <dep>
-                    <src>body</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>184</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
                     <src>condition</src>
                     <trg>id</trg>
                     <val>
@@ -27221,70 +21326,6 @@
                 <dep>
                     <src>condition</src>
                     <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>184</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>condition</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>184</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>184</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>body</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>184</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>condition</trg>
                     <val>
                         <hist>
                             <budget>12</budget>
@@ -27302,15 +21343,15 @@
         </relation>
         <relation>
             <name>ruby_yield_child</name>
-            <cardinality>1114</cardinality>
+            <cardinality>1115</cardinality>
             <columnsizes>
                 <e>
                     <k>ruby_yield</k>
-                    <v>1114</v>
+                    <v>1115</v>
                 </e>
                 <e>
                     <k>child</k>
-                    <v>1114</v>
+                    <v>1115</v>
                 </e>
             </columnsizes>
             <dependencies>
@@ -27324,7 +21365,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1114</v>
+                                    <v>1115</v>
                                 </b>
                             </bs>
                         </hist>
@@ -27340,7 +21381,7 @@
                                 <b>
                                     <a>1</a>
                                     <b>2</b>
-                                    <v>1114</v>
+                                    <v>1115</v>
                                 </b>
                             </bs>
                         </hist>
@@ -27350,51 +21391,14 @@
         </relation>
         <relation>
             <name>ruby_yield_def</name>
-            <cardinality>2402</cardinality>
+            <cardinality>2406</cardinality>
             <columnsizes>
                 <e>
                     <k>id</k>
-                    <v>2402</v>
-                </e>
-                <e>
-                    <k>loc</k>
-                    <v>2402</v>
+                    <v>2406</v>
                 </e>
             </columnsizes>
-            <dependencies>
-                <dep>
-                    <src>id</src>
-                    <trg>loc</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2402</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-                <dep>
-                    <src>loc</src>
-                    <trg>id</trg>
-                    <val>
-                        <hist>
-                            <budget>12</budget>
-                            <bs>
-                                <b>
-                                    <a>1</a>
-                                    <b>2</b>
-                                    <v>2402</v>
-                                </b>
-                            </bs>
-                        </hist>
-                    </val>
-                </dep>
-            </dependencies>
+            <dependencies/>
         </relation>
         <relation>
             <name>sourceLocationPrefix</name>

--- a/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/erb_ast_node_info.ql
+++ b/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/erb_ast_node_info.ql
@@ -1,0 +1,26 @@
+class Location extends @location {
+  string toString() { none() }
+}
+
+class ErbAstNodeParent extends @erb_ast_node_parent {
+  string toString() { none() }
+}
+
+class ErbAstNode extends @erb_ast_node {
+  string toString() { none() }
+
+  ErbAstNodeParent getParent(int index) { erb_ast_node_parent(this, result, index) }
+
+  Location getLocation() {
+    erb_tokeninfo(this, _, _, result) or
+    erb_comment_directive_def(this, _, result) or
+    erb_directive_def(this, _, result) or
+    erb_graphql_directive_def(this, _, result) or
+    erb_output_directive_def(this, _, result) or
+    erb_template_def(this, result)
+  }
+}
+
+from ErbAstNode node, ErbAstNodeParent parent, int index, Location loc
+where parent = node.getParent(index) and loc = node.getLocation()
+select node, parent, index, loc

--- a/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/old.dbscheme
+++ b/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/old.dbscheme
@@ -1,0 +1,1497 @@
+// CodeQL database schema for Ruby
+// Automatically generated from the tree-sitter grammar; do not edit
+
+@location = @location_default
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int start_line: int ref,
+  int start_column: int ref,
+  int end_line: int ref,
+  int end_column: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+sourceLocationPrefix(
+  string prefix: string ref
+);
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+
+@ruby_underscore_arg = @ruby_assignment | @ruby_binary | @ruby_conditional | @ruby_operator_assignment | @ruby_range | @ruby_unary | @ruby_underscore_primary
+
+@ruby_underscore_expression = @ruby_assignment | @ruby_binary | @ruby_break | @ruby_call | @ruby_next | @ruby_operator_assignment | @ruby_return | @ruby_unary | @ruby_underscore_arg | @ruby_yield
+
+@ruby_underscore_lhs = @ruby_call | @ruby_element_reference | @ruby_scope_resolution | @ruby_token_false | @ruby_token_nil | @ruby_token_true | @ruby_underscore_variable
+
+@ruby_underscore_method_name = @ruby_delimited_symbol | @ruby_setter | @ruby_token_constant | @ruby_token_identifier | @ruby_token_operator | @ruby_token_simple_symbol | @ruby_underscore_nonlocal_variable
+
+@ruby_underscore_nonlocal_variable = @ruby_token_class_variable | @ruby_token_global_variable | @ruby_token_instance_variable
+
+@ruby_underscore_pattern_constant = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_underscore_pattern_expr = @ruby_alternative_pattern | @ruby_as_pattern | @ruby_underscore_pattern_expr_basic
+
+@ruby_underscore_pattern_expr_basic = @ruby_array_pattern | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_parenthesized_pattern | @ruby_range | @ruby_token_identifier | @ruby_underscore_pattern_constant | @ruby_underscore_pattern_primitive | @ruby_variable_reference_pattern
+
+@ruby_underscore_pattern_primitive = @ruby_delimited_symbol | @ruby_lambda | @ruby_regex | @ruby_string__ | @ruby_string_array | @ruby_symbol_array | @ruby_token_encoding | @ruby_token_false | @ruby_token_file | @ruby_token_line | @ruby_token_nil | @ruby_token_self | @ruby_token_simple_symbol | @ruby_token_true | @ruby_unary | @ruby_underscore_simple_numeric
+
+@ruby_underscore_pattern_top_expr_body = @ruby_array_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_underscore_pattern_expr
+
+@ruby_underscore_primary = @ruby_array | @ruby_begin | @ruby_break | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_delimited_symbol | @ruby_for | @ruby_hash | @ruby_if | @ruby_lambda | @ruby_method | @ruby_module | @ruby_next | @ruby_parenthesized_statements | @ruby_redo | @ruby_regex | @ruby_retry | @ruby_return | @ruby_singleton_class | @ruby_singleton_method | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_symbol_array | @ruby_token_character | @ruby_token_heredoc_beginning | @ruby_token_simple_symbol | @ruby_unary | @ruby_underscore_lhs | @ruby_underscore_simple_numeric | @ruby_unless | @ruby_until | @ruby_while | @ruby_yield
+
+@ruby_underscore_simple_numeric = @ruby_rational | @ruby_token_complex | @ruby_token_float | @ruby_token_integer
+
+@ruby_underscore_statement = @ruby_alias | @ruby_begin_block | @ruby_end_block | @ruby_if_modifier | @ruby_rescue_modifier | @ruby_undef | @ruby_underscore_expression | @ruby_unless_modifier | @ruby_until_modifier | @ruby_while_modifier
+
+@ruby_underscore_variable = @ruby_token_constant | @ruby_token_identifier | @ruby_token_self | @ruby_token_super | @ruby_underscore_nonlocal_variable
+
+ruby_alias_def(
+  unique int id: @ruby_alias,
+  int alias: @ruby_underscore_method_name ref,
+  int name: @ruby_underscore_method_name ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_alternative_pattern, index]
+ruby_alternative_pattern_alternatives(
+  int ruby_alternative_pattern: @ruby_alternative_pattern ref,
+  int index: int ref,
+  unique int alternatives: @ruby_underscore_pattern_expr_basic ref
+);
+
+ruby_alternative_pattern_def(
+  unique int id: @ruby_alternative_pattern,
+  int loc: @location ref
+);
+
+@ruby_argument_list_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_argument_list, index]
+ruby_argument_list_child(
+  int ruby_argument_list: @ruby_argument_list ref,
+  int index: int ref,
+  unique int child: @ruby_argument_list_child_type ref
+);
+
+ruby_argument_list_def(
+  unique int id: @ruby_argument_list,
+  int loc: @location ref
+);
+
+@ruby_array_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_array, index]
+ruby_array_child(
+  int ruby_array: @ruby_array ref,
+  int index: int ref,
+  unique int child: @ruby_array_child_type ref
+);
+
+ruby_array_def(
+  unique int id: @ruby_array,
+  int loc: @location ref
+);
+
+ruby_array_pattern_class(
+  unique int ruby_array_pattern: @ruby_array_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_array_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_array_pattern, index]
+ruby_array_pattern_child(
+  int ruby_array_pattern: @ruby_array_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_array_pattern_child_type ref
+);
+
+ruby_array_pattern_def(
+  unique int id: @ruby_array_pattern,
+  int loc: @location ref
+);
+
+ruby_as_pattern_def(
+  unique int id: @ruby_as_pattern,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_pattern_expr ref,
+  int loc: @location ref
+);
+
+@ruby_assignment_left_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+@ruby_assignment_right_type = @ruby_right_assignment_list | @ruby_splat_argument | @ruby_underscore_expression
+
+ruby_assignment_def(
+  unique int id: @ruby_assignment,
+  int left: @ruby_assignment_left_type ref,
+  int right: @ruby_assignment_right_type ref,
+  int loc: @location ref
+);
+
+@ruby_bare_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_string, index]
+ruby_bare_string_child(
+  int ruby_bare_string: @ruby_bare_string ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string_child_type ref
+);
+
+ruby_bare_string_def(
+  unique int id: @ruby_bare_string,
+  int loc: @location ref
+);
+
+@ruby_bare_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_symbol, index]
+ruby_bare_symbol_child(
+  int ruby_bare_symbol: @ruby_bare_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol_child_type ref
+);
+
+ruby_bare_symbol_def(
+  unique int id: @ruby_bare_symbol,
+  int loc: @location ref
+);
+
+@ruby_begin_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin, index]
+ruby_begin_child(
+  int ruby_begin: @ruby_begin ref,
+  int index: int ref,
+  unique int child: @ruby_begin_child_type ref
+);
+
+ruby_begin_def(
+  unique int id: @ruby_begin,
+  int loc: @location ref
+);
+
+@ruby_begin_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin_block, index]
+ruby_begin_block_child(
+  int ruby_begin_block: @ruby_begin_block ref,
+  int index: int ref,
+  unique int child: @ruby_begin_block_child_type ref
+);
+
+ruby_begin_block_def(
+  unique int id: @ruby_begin_block,
+  int loc: @location ref
+);
+
+case @ruby_binary.operator of
+  0 = @ruby_binary_bangequal
+| 1 = @ruby_binary_bangtilde
+| 2 = @ruby_binary_percent
+| 3 = @ruby_binary_ampersand
+| 4 = @ruby_binary_ampersandampersand
+| 5 = @ruby_binary_star
+| 6 = @ruby_binary_starstar
+| 7 = @ruby_binary_plus
+| 8 = @ruby_binary_minus
+| 9 = @ruby_binary_slash
+| 10 = @ruby_binary_langle
+| 11 = @ruby_binary_langlelangle
+| 12 = @ruby_binary_langleequal
+| 13 = @ruby_binary_langleequalrangle
+| 14 = @ruby_binary_equalequal
+| 15 = @ruby_binary_equalequalequal
+| 16 = @ruby_binary_equaltilde
+| 17 = @ruby_binary_rangle
+| 18 = @ruby_binary_rangleequal
+| 19 = @ruby_binary_ranglerangle
+| 20 = @ruby_binary_caret
+| 21 = @ruby_binary_and
+| 22 = @ruby_binary_or
+| 23 = @ruby_binary_pipe
+| 24 = @ruby_binary_pipepipe
+;
+
+
+ruby_binary_def(
+  unique int id: @ruby_binary,
+  int left: @ruby_underscore_expression ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_block_parameters(
+  unique int ruby_block: @ruby_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_block, index]
+ruby_block_child(
+  int ruby_block: @ruby_block ref,
+  int index: int ref,
+  unique int child: @ruby_block_child_type ref
+);
+
+ruby_block_def(
+  unique int id: @ruby_block,
+  int loc: @location ref
+);
+
+ruby_block_argument_child(
+  unique int ruby_block_argument: @ruby_block_argument ref,
+  unique int child: @ruby_underscore_arg ref
+);
+
+ruby_block_argument_def(
+  unique int id: @ruby_block_argument,
+  int loc: @location ref
+);
+
+ruby_block_parameter_name(
+  unique int ruby_block_parameter: @ruby_block_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_block_parameter_def(
+  unique int id: @ruby_block_parameter,
+  int loc: @location ref
+);
+
+@ruby_block_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_block_parameters, index]
+ruby_block_parameters_child(
+  int ruby_block_parameters: @ruby_block_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_block_parameters_child_type ref
+);
+
+ruby_block_parameters_def(
+  unique int id: @ruby_block_parameters,
+  int loc: @location ref
+);
+
+ruby_break_child(
+  unique int ruby_break: @ruby_break ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_break_def(
+  unique int id: @ruby_break,
+  int loc: @location ref
+);
+
+ruby_call_arguments(
+  unique int ruby_call: @ruby_call ref,
+  unique int arguments: @ruby_argument_list ref
+);
+
+@ruby_call_block_type = @ruby_block | @ruby_do_block
+
+ruby_call_block(
+  unique int ruby_call: @ruby_call ref,
+  unique int block: @ruby_call_block_type ref
+);
+
+@ruby_call_method_type = @ruby_argument_list | @ruby_scope_resolution | @ruby_token_operator | @ruby_underscore_variable
+
+@ruby_call_receiver_type = @ruby_call | @ruby_underscore_primary
+
+ruby_call_receiver(
+  unique int ruby_call: @ruby_call ref,
+  unique int receiver: @ruby_call_receiver_type ref
+);
+
+ruby_call_def(
+  unique int id: @ruby_call,
+  int method: @ruby_call_method_type ref,
+  int loc: @location ref
+);
+
+ruby_case_value(
+  unique int ruby_case__: @ruby_case__ ref,
+  unique int value: @ruby_underscore_statement ref
+);
+
+@ruby_case_child_type = @ruby_else | @ruby_when
+
+#keyset[ruby_case__, index]
+ruby_case_child(
+  int ruby_case__: @ruby_case__ ref,
+  int index: int ref,
+  unique int child: @ruby_case_child_type ref
+);
+
+ruby_case_def(
+  unique int id: @ruby_case__,
+  int loc: @location ref
+);
+
+#keyset[ruby_case_match, index]
+ruby_case_match_clauses(
+  int ruby_case_match: @ruby_case_match ref,
+  int index: int ref,
+  unique int clauses: @ruby_in_clause ref
+);
+
+ruby_case_match_else(
+  unique int ruby_case_match: @ruby_case_match ref,
+  unique int else: @ruby_else ref
+);
+
+ruby_case_match_def(
+  unique int id: @ruby_case_match,
+  int value: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_chained_string, index]
+ruby_chained_string_child(
+  int ruby_chained_string: @ruby_chained_string ref,
+  int index: int ref,
+  unique int child: @ruby_string__ ref
+);
+
+ruby_chained_string_def(
+  unique int id: @ruby_chained_string,
+  int loc: @location ref
+);
+
+@ruby_class_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+ruby_class_superclass(
+  unique int ruby_class: @ruby_class ref,
+  unique int superclass: @ruby_superclass ref
+);
+
+@ruby_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_class, index]
+ruby_class_child(
+  int ruby_class: @ruby_class ref,
+  int index: int ref,
+  unique int child: @ruby_class_child_type ref
+);
+
+ruby_class_def(
+  unique int id: @ruby_class,
+  int name: @ruby_class_name_type ref,
+  int loc: @location ref
+);
+
+ruby_conditional_def(
+  unique int id: @ruby_conditional,
+  int alternative: @ruby_underscore_arg ref,
+  int condition: @ruby_underscore_arg ref,
+  int consequence: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+@ruby_delimited_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_delimited_symbol, index]
+ruby_delimited_symbol_child(
+  int ruby_delimited_symbol: @ruby_delimited_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_delimited_symbol_child_type ref
+);
+
+ruby_delimited_symbol_def(
+  unique int id: @ruby_delimited_symbol,
+  int loc: @location ref
+);
+
+@ruby_destructured_left_assignment_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_destructured_left_assignment, index]
+ruby_destructured_left_assignment_child(
+  int ruby_destructured_left_assignment: @ruby_destructured_left_assignment ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_left_assignment_child_type ref
+);
+
+ruby_destructured_left_assignment_def(
+  unique int id: @ruby_destructured_left_assignment,
+  int loc: @location ref
+);
+
+@ruby_destructured_parameter_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_destructured_parameter, index]
+ruby_destructured_parameter_child(
+  int ruby_destructured_parameter: @ruby_destructured_parameter ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_parameter_child_type ref
+);
+
+ruby_destructured_parameter_def(
+  unique int id: @ruby_destructured_parameter,
+  int loc: @location ref
+);
+
+@ruby_do_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do, index]
+ruby_do_child(
+  int ruby_do: @ruby_do ref,
+  int index: int ref,
+  unique int child: @ruby_do_child_type ref
+);
+
+ruby_do_def(
+  unique int id: @ruby_do,
+  int loc: @location ref
+);
+
+ruby_do_block_parameters(
+  unique int ruby_do_block: @ruby_do_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_do_block_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do_block, index]
+ruby_do_block_child(
+  int ruby_do_block: @ruby_do_block ref,
+  int index: int ref,
+  unique int child: @ruby_do_block_child_type ref
+);
+
+ruby_do_block_def(
+  unique int id: @ruby_do_block,
+  int loc: @location ref
+);
+
+@ruby_element_reference_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_element_reference, index]
+ruby_element_reference_child(
+  int ruby_element_reference: @ruby_element_reference ref,
+  int index: int ref,
+  unique int child: @ruby_element_reference_child_type ref
+);
+
+ruby_element_reference_def(
+  unique int id: @ruby_element_reference,
+  int object: @ruby_underscore_primary ref,
+  int loc: @location ref
+);
+
+@ruby_else_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_else, index]
+ruby_else_child(
+  int ruby_else: @ruby_else ref,
+  int index: int ref,
+  unique int child: @ruby_else_child_type ref
+);
+
+ruby_else_def(
+  unique int id: @ruby_else,
+  int loc: @location ref
+);
+
+@ruby_elsif_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_elsif_alternative(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int alternative: @ruby_elsif_alternative_type ref
+);
+
+ruby_elsif_consequence(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_elsif_def(
+  unique int id: @ruby_elsif,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+@ruby_end_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_end_block, index]
+ruby_end_block_child(
+  int ruby_end_block: @ruby_end_block ref,
+  int index: int ref,
+  unique int child: @ruby_end_block_child_type ref
+);
+
+ruby_end_block_def(
+  unique int id: @ruby_end_block,
+  int loc: @location ref
+);
+
+@ruby_ensure_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_ensure, index]
+ruby_ensure_child(
+  int ruby_ensure: @ruby_ensure ref,
+  int index: int ref,
+  unique int child: @ruby_ensure_child_type ref
+);
+
+ruby_ensure_def(
+  unique int id: @ruby_ensure,
+  int loc: @location ref
+);
+
+ruby_exception_variable_def(
+  unique int id: @ruby_exception_variable,
+  int child: @ruby_underscore_lhs ref,
+  int loc: @location ref
+);
+
+@ruby_exceptions_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_exceptions, index]
+ruby_exceptions_child(
+  int ruby_exceptions: @ruby_exceptions ref,
+  int index: int ref,
+  unique int child: @ruby_exceptions_child_type ref
+);
+
+ruby_exceptions_def(
+  unique int id: @ruby_exceptions,
+  int loc: @location ref
+);
+
+ruby_expression_reference_pattern_def(
+  unique int id: @ruby_expression_reference_pattern,
+  int value: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_find_pattern_class(
+  unique int ruby_find_pattern: @ruby_find_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_find_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_find_pattern, index]
+ruby_find_pattern_child(
+  int ruby_find_pattern: @ruby_find_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_find_pattern_child_type ref
+);
+
+ruby_find_pattern_def(
+  unique int id: @ruby_find_pattern,
+  int loc: @location ref
+);
+
+@ruby_for_pattern_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+ruby_for_def(
+  unique int id: @ruby_for,
+  int body: @ruby_do ref,
+  int pattern: @ruby_for_pattern_type ref,
+  int value: @ruby_in ref,
+  int loc: @location ref
+);
+
+@ruby_hash_child_type = @ruby_hash_splat_argument | @ruby_pair
+
+#keyset[ruby_hash, index]
+ruby_hash_child(
+  int ruby_hash: @ruby_hash ref,
+  int index: int ref,
+  unique int child: @ruby_hash_child_type ref
+);
+
+ruby_hash_def(
+  unique int id: @ruby_hash,
+  int loc: @location ref
+);
+
+ruby_hash_pattern_class(
+  unique int ruby_hash_pattern: @ruby_hash_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_hash_pattern_child_type = @ruby_hash_splat_parameter | @ruby_keyword_pattern | @ruby_token_hash_splat_nil
+
+#keyset[ruby_hash_pattern, index]
+ruby_hash_pattern_child(
+  int ruby_hash_pattern: @ruby_hash_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_hash_pattern_child_type ref
+);
+
+ruby_hash_pattern_def(
+  unique int id: @ruby_hash_pattern,
+  int loc: @location ref
+);
+
+ruby_hash_splat_argument_def(
+  unique int id: @ruby_hash_splat_argument,
+  int child: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+ruby_hash_splat_parameter_name(
+  unique int ruby_hash_splat_parameter: @ruby_hash_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_hash_splat_parameter_def(
+  unique int id: @ruby_hash_splat_parameter,
+  int loc: @location ref
+);
+
+@ruby_heredoc_body_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_heredoc_content | @ruby_token_heredoc_end
+
+#keyset[ruby_heredoc_body, index]
+ruby_heredoc_body_child(
+  int ruby_heredoc_body: @ruby_heredoc_body ref,
+  int index: int ref,
+  unique int child: @ruby_heredoc_body_child_type ref
+);
+
+ruby_heredoc_body_def(
+  unique int id: @ruby_heredoc_body,
+  int loc: @location ref
+);
+
+@ruby_if_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_if_alternative(
+  unique int ruby_if: @ruby_if ref,
+  unique int alternative: @ruby_if_alternative_type ref
+);
+
+ruby_if_consequence(
+  unique int ruby_if: @ruby_if ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_if_def(
+  unique int id: @ruby_if,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_if_guard_def(
+  unique int id: @ruby_if_guard,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_if_modifier_def(
+  unique int id: @ruby_if_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_in_def(
+  unique int id: @ruby_in,
+  int child: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+ruby_in_clause_body(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int body: @ruby_then ref
+);
+
+@ruby_in_clause_guard_type = @ruby_if_guard | @ruby_unless_guard
+
+ruby_in_clause_guard(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int guard: @ruby_in_clause_guard_type ref
+);
+
+ruby_in_clause_def(
+  unique int id: @ruby_in_clause,
+  int pattern: @ruby_underscore_pattern_top_expr_body ref,
+  int loc: @location ref
+);
+
+@ruby_interpolation_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_interpolation, index]
+ruby_interpolation_child(
+  int ruby_interpolation: @ruby_interpolation ref,
+  int index: int ref,
+  unique int child: @ruby_interpolation_child_type ref
+);
+
+ruby_interpolation_def(
+  unique int id: @ruby_interpolation,
+  int loc: @location ref
+);
+
+ruby_keyword_parameter_value(
+  unique int ruby_keyword_parameter: @ruby_keyword_parameter ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_keyword_parameter_def(
+  unique int id: @ruby_keyword_parameter,
+  int name: @ruby_token_identifier ref,
+  int loc: @location ref
+);
+
+@ruby_keyword_pattern_key_type = @ruby_string__ | @ruby_token_hash_key_symbol
+
+ruby_keyword_pattern_value(
+  unique int ruby_keyword_pattern: @ruby_keyword_pattern ref,
+  unique int value: @ruby_underscore_pattern_expr ref
+);
+
+ruby_keyword_pattern_def(
+  unique int id: @ruby_keyword_pattern,
+  int key__: @ruby_keyword_pattern_key_type ref,
+  int loc: @location ref
+);
+
+@ruby_lambda_body_type = @ruby_block | @ruby_do_block
+
+ruby_lambda_parameters(
+  unique int ruby_lambda: @ruby_lambda ref,
+  unique int parameters: @ruby_lambda_parameters ref
+);
+
+ruby_lambda_def(
+  unique int id: @ruby_lambda,
+  int body: @ruby_lambda_body_type ref,
+  int loc: @location ref
+);
+
+@ruby_lambda_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_lambda_parameters, index]
+ruby_lambda_parameters_child(
+  int ruby_lambda_parameters: @ruby_lambda_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_lambda_parameters_child_type ref
+);
+
+ruby_lambda_parameters_def(
+  unique int id: @ruby_lambda_parameters,
+  int loc: @location ref
+);
+
+@ruby_left_assignment_list_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_left_assignment_list, index]
+ruby_left_assignment_list_child(
+  int ruby_left_assignment_list: @ruby_left_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_left_assignment_list_child_type ref
+);
+
+ruby_left_assignment_list_def(
+  unique int id: @ruby_left_assignment_list,
+  int loc: @location ref
+);
+
+ruby_method_parameters(
+  unique int ruby_method: @ruby_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_method, index]
+ruby_method_child(
+  int ruby_method: @ruby_method ref,
+  int index: int ref,
+  unique int child: @ruby_method_child_type ref
+);
+
+ruby_method_def(
+  unique int id: @ruby_method,
+  int name: @ruby_underscore_method_name ref,
+  int loc: @location ref
+);
+
+@ruby_method_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_method_parameters, index]
+ruby_method_parameters_child(
+  int ruby_method_parameters: @ruby_method_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_method_parameters_child_type ref
+);
+
+ruby_method_parameters_def(
+  unique int id: @ruby_method_parameters,
+  int loc: @location ref
+);
+
+@ruby_module_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_module_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_module, index]
+ruby_module_child(
+  int ruby_module: @ruby_module ref,
+  int index: int ref,
+  unique int child: @ruby_module_child_type ref
+);
+
+ruby_module_def(
+  unique int id: @ruby_module,
+  int name: @ruby_module_name_type ref,
+  int loc: @location ref
+);
+
+ruby_next_child(
+  unique int ruby_next: @ruby_next ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_next_def(
+  unique int id: @ruby_next,
+  int loc: @location ref
+);
+
+case @ruby_operator_assignment.operator of
+  0 = @ruby_operator_assignment_percentequal
+| 1 = @ruby_operator_assignment_ampersandampersandequal
+| 2 = @ruby_operator_assignment_ampersandequal
+| 3 = @ruby_operator_assignment_starstarequal
+| 4 = @ruby_operator_assignment_starequal
+| 5 = @ruby_operator_assignment_plusequal
+| 6 = @ruby_operator_assignment_minusequal
+| 7 = @ruby_operator_assignment_slashequal
+| 8 = @ruby_operator_assignment_langlelangleequal
+| 9 = @ruby_operator_assignment_ranglerangleequal
+| 10 = @ruby_operator_assignment_caretequal
+| 11 = @ruby_operator_assignment_pipeequal
+| 12 = @ruby_operator_assignment_pipepipeequal
+;
+
+
+ruby_operator_assignment_def(
+  unique int id: @ruby_operator_assignment,
+  int left: @ruby_underscore_lhs ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_optional_parameter_def(
+  unique int id: @ruby_optional_parameter,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+@ruby_pair_key_type = @ruby_string__ | @ruby_token_hash_key_symbol | @ruby_underscore_arg
+
+ruby_pair_value(
+  unique int ruby_pair: @ruby_pair ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_pair_def(
+  unique int id: @ruby_pair,
+  int key__: @ruby_pair_key_type ref,
+  int loc: @location ref
+);
+
+ruby_parenthesized_pattern_def(
+  unique int id: @ruby_parenthesized_pattern,
+  int child: @ruby_underscore_pattern_expr ref,
+  int loc: @location ref
+);
+
+@ruby_parenthesized_statements_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_parenthesized_statements, index]
+ruby_parenthesized_statements_child(
+  int ruby_parenthesized_statements: @ruby_parenthesized_statements ref,
+  int index: int ref,
+  unique int child: @ruby_parenthesized_statements_child_type ref
+);
+
+ruby_parenthesized_statements_def(
+  unique int id: @ruby_parenthesized_statements,
+  int loc: @location ref
+);
+
+@ruby_pattern_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+ruby_pattern_def(
+  unique int id: @ruby_pattern,
+  int child: @ruby_pattern_child_type ref,
+  int loc: @location ref
+);
+
+@ruby_program_child_type = @ruby_token_empty_statement | @ruby_token_uninterpreted | @ruby_underscore_statement
+
+#keyset[ruby_program, index]
+ruby_program_child(
+  int ruby_program: @ruby_program ref,
+  int index: int ref,
+  unique int child: @ruby_program_child_type ref
+);
+
+ruby_program_def(
+  unique int id: @ruby_program,
+  int loc: @location ref
+);
+
+@ruby_range_begin_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_begin(
+  unique int ruby_range: @ruby_range ref,
+  unique int begin: @ruby_range_begin_type ref
+);
+
+@ruby_range_end_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_end(
+  unique int ruby_range: @ruby_range ref,
+  unique int end: @ruby_range_end_type ref
+);
+
+case @ruby_range.operator of
+  0 = @ruby_range_dotdot
+| 1 = @ruby_range_dotdotdot
+;
+
+
+ruby_range_def(
+  unique int id: @ruby_range,
+  int operator: int ref,
+  int loc: @location ref
+);
+
+@ruby_rational_child_type = @ruby_token_float | @ruby_token_integer
+
+ruby_rational_def(
+  unique int id: @ruby_rational,
+  int child: @ruby_rational_child_type ref,
+  int loc: @location ref
+);
+
+ruby_redo_child(
+  unique int ruby_redo: @ruby_redo ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_redo_def(
+  unique int id: @ruby_redo,
+  int loc: @location ref
+);
+
+@ruby_regex_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_regex, index]
+ruby_regex_child(
+  int ruby_regex: @ruby_regex ref,
+  int index: int ref,
+  unique int child: @ruby_regex_child_type ref
+);
+
+ruby_regex_def(
+  unique int id: @ruby_regex,
+  int loc: @location ref
+);
+
+ruby_rescue_body(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int body: @ruby_then ref
+);
+
+ruby_rescue_exceptions(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int exceptions: @ruby_exceptions ref
+);
+
+ruby_rescue_variable(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int variable: @ruby_exception_variable ref
+);
+
+ruby_rescue_def(
+  unique int id: @ruby_rescue,
+  int loc: @location ref
+);
+
+@ruby_rescue_modifier_body_type = @ruby_underscore_arg | @ruby_underscore_statement
+
+ruby_rescue_modifier_def(
+  unique int id: @ruby_rescue_modifier,
+  int body: @ruby_rescue_modifier_body_type ref,
+  int handler: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_rest_assignment_child(
+  unique int ruby_rest_assignment: @ruby_rest_assignment ref,
+  unique int child: @ruby_underscore_lhs ref
+);
+
+ruby_rest_assignment_def(
+  unique int id: @ruby_rest_assignment,
+  int loc: @location ref
+);
+
+ruby_retry_child(
+  unique int ruby_retry: @ruby_retry ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_retry_def(
+  unique int id: @ruby_retry,
+  int loc: @location ref
+);
+
+ruby_return_child(
+  unique int ruby_return: @ruby_return ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_return_def(
+  unique int id: @ruby_return,
+  int loc: @location ref
+);
+
+@ruby_right_assignment_list_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_right_assignment_list, index]
+ruby_right_assignment_list_child(
+  int ruby_right_assignment_list: @ruby_right_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_right_assignment_list_child_type ref
+);
+
+ruby_right_assignment_list_def(
+  unique int id: @ruby_right_assignment_list,
+  int loc: @location ref
+);
+
+@ruby_scope_resolution_name_type = @ruby_token_constant | @ruby_token_identifier
+
+@ruby_scope_resolution_scope_type = @ruby_underscore_pattern_constant | @ruby_underscore_primary
+
+ruby_scope_resolution_scope(
+  unique int ruby_scope_resolution: @ruby_scope_resolution ref,
+  unique int scope: @ruby_scope_resolution_scope_type ref
+);
+
+ruby_scope_resolution_def(
+  unique int id: @ruby_scope_resolution,
+  int name: @ruby_scope_resolution_name_type ref,
+  int loc: @location ref
+);
+
+ruby_setter_def(
+  unique int id: @ruby_setter,
+  int name: @ruby_token_identifier ref,
+  int loc: @location ref
+);
+
+@ruby_singleton_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_singleton_class, index]
+ruby_singleton_class_child(
+  int ruby_singleton_class: @ruby_singleton_class ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_class_child_type ref
+);
+
+ruby_singleton_class_def(
+  unique int id: @ruby_singleton_class,
+  int value: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+@ruby_singleton_method_object_type = @ruby_underscore_arg | @ruby_underscore_variable
+
+ruby_singleton_method_parameters(
+  unique int ruby_singleton_method: @ruby_singleton_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_singleton_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_singleton_method, index]
+ruby_singleton_method_child(
+  int ruby_singleton_method: @ruby_singleton_method ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_method_child_type ref
+);
+
+ruby_singleton_method_def(
+  unique int id: @ruby_singleton_method,
+  int name: @ruby_underscore_method_name ref,
+  int object: @ruby_singleton_method_object_type ref,
+  int loc: @location ref
+);
+
+ruby_splat_argument_def(
+  unique int id: @ruby_splat_argument,
+  int child: @ruby_underscore_arg ref,
+  int loc: @location ref
+);
+
+ruby_splat_parameter_name(
+  unique int ruby_splat_parameter: @ruby_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_splat_parameter_def(
+  unique int id: @ruby_splat_parameter,
+  int loc: @location ref
+);
+
+@ruby_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_string__, index]
+ruby_string_child(
+  int ruby_string__: @ruby_string__ ref,
+  int index: int ref,
+  unique int child: @ruby_string_child_type ref
+);
+
+ruby_string_def(
+  unique int id: @ruby_string__,
+  int loc: @location ref
+);
+
+#keyset[ruby_string_array, index]
+ruby_string_array_child(
+  int ruby_string_array: @ruby_string_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string ref
+);
+
+ruby_string_array_def(
+  unique int id: @ruby_string_array,
+  int loc: @location ref
+);
+
+@ruby_subshell_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_subshell, index]
+ruby_subshell_child(
+  int ruby_subshell: @ruby_subshell ref,
+  int index: int ref,
+  unique int child: @ruby_subshell_child_type ref
+);
+
+ruby_subshell_def(
+  unique int id: @ruby_subshell,
+  int loc: @location ref
+);
+
+ruby_superclass_def(
+  unique int id: @ruby_superclass,
+  int child: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_symbol_array, index]
+ruby_symbol_array_child(
+  int ruby_symbol_array: @ruby_symbol_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol ref
+);
+
+ruby_symbol_array_def(
+  unique int id: @ruby_symbol_array,
+  int loc: @location ref
+);
+
+@ruby_then_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_then, index]
+ruby_then_child(
+  int ruby_then: @ruby_then ref,
+  int index: int ref,
+  unique int child: @ruby_then_child_type ref
+);
+
+ruby_then_def(
+  unique int id: @ruby_then,
+  int loc: @location ref
+);
+
+@ruby_unary_operand_type = @ruby_parenthesized_statements | @ruby_underscore_expression | @ruby_underscore_simple_numeric
+
+case @ruby_unary.operator of
+  0 = @ruby_unary_bang
+| 1 = @ruby_unary_plus
+| 2 = @ruby_unary_minus
+| 3 = @ruby_unary_definedquestion
+| 4 = @ruby_unary_not
+| 5 = @ruby_unary_tilde
+;
+
+
+ruby_unary_def(
+  unique int id: @ruby_unary,
+  int operand: @ruby_unary_operand_type ref,
+  int operator: int ref,
+  int loc: @location ref
+);
+
+#keyset[ruby_undef, index]
+ruby_undef_child(
+  int ruby_undef: @ruby_undef ref,
+  int index: int ref,
+  unique int child: @ruby_underscore_method_name ref
+);
+
+ruby_undef_def(
+  unique int id: @ruby_undef,
+  int loc: @location ref
+);
+
+@ruby_unless_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_unless_alternative(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int alternative: @ruby_unless_alternative_type ref
+);
+
+ruby_unless_consequence(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_unless_def(
+  unique int id: @ruby_unless,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_unless_guard_def(
+  unique int id: @ruby_unless_guard,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_unless_modifier_def(
+  unique int id: @ruby_unless_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_until_def(
+  unique int id: @ruby_until,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_until_modifier_def(
+  unique int id: @ruby_until_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+@ruby_variable_reference_pattern_name_type = @ruby_token_identifier | @ruby_underscore_nonlocal_variable
+
+ruby_variable_reference_pattern_def(
+  unique int id: @ruby_variable_reference_pattern,
+  int name: @ruby_variable_reference_pattern_name_type ref,
+  int loc: @location ref
+);
+
+ruby_when_body(
+  unique int ruby_when: @ruby_when ref,
+  unique int body: @ruby_then ref
+);
+
+#keyset[ruby_when, index]
+ruby_when_pattern(
+  int ruby_when: @ruby_when ref,
+  int index: int ref,
+  unique int pattern: @ruby_pattern ref
+);
+
+ruby_when_def(
+  unique int id: @ruby_when,
+  int loc: @location ref
+);
+
+ruby_while_def(
+  unique int id: @ruby_while,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref,
+  int loc: @location ref
+);
+
+ruby_while_modifier_def(
+  unique int id: @ruby_while_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref,
+  int loc: @location ref
+);
+
+ruby_yield_child(
+  unique int ruby_yield: @ruby_yield ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_yield_def(
+  unique int id: @ruby_yield,
+  int loc: @location ref
+);
+
+ruby_tokeninfo(
+  unique int id: @ruby_token,
+  int kind: int ref,
+  string value: string ref,
+  int loc: @location ref
+);
+
+case @ruby_token.kind of
+  0 = @ruby_reserved_word
+| 1 = @ruby_token_character
+| 2 = @ruby_token_class_variable
+| 3 = @ruby_token_comment
+| 4 = @ruby_token_complex
+| 5 = @ruby_token_constant
+| 6 = @ruby_token_empty_statement
+| 7 = @ruby_token_encoding
+| 8 = @ruby_token_escape_sequence
+| 9 = @ruby_token_false
+| 10 = @ruby_token_file
+| 11 = @ruby_token_float
+| 12 = @ruby_token_forward_argument
+| 13 = @ruby_token_forward_parameter
+| 14 = @ruby_token_global_variable
+| 15 = @ruby_token_hash_key_symbol
+| 16 = @ruby_token_hash_splat_nil
+| 17 = @ruby_token_heredoc_beginning
+| 18 = @ruby_token_heredoc_content
+| 19 = @ruby_token_heredoc_end
+| 20 = @ruby_token_identifier
+| 21 = @ruby_token_instance_variable
+| 22 = @ruby_token_integer
+| 23 = @ruby_token_line
+| 24 = @ruby_token_nil
+| 25 = @ruby_token_operator
+| 26 = @ruby_token_self
+| 27 = @ruby_token_simple_symbol
+| 28 = @ruby_token_string_content
+| 29 = @ruby_token_super
+| 30 = @ruby_token_true
+| 31 = @ruby_token_uninterpreted
+;
+
+
+@ruby_ast_node = @ruby_alias | @ruby_alternative_pattern | @ruby_argument_list | @ruby_array | @ruby_array_pattern | @ruby_as_pattern | @ruby_assignment | @ruby_bare_string | @ruby_bare_symbol | @ruby_begin | @ruby_begin_block | @ruby_binary | @ruby_block | @ruby_block_argument | @ruby_block_parameter | @ruby_block_parameters | @ruby_break | @ruby_call | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_conditional | @ruby_delimited_symbol | @ruby_destructured_left_assignment | @ruby_destructured_parameter | @ruby_do | @ruby_do_block | @ruby_element_reference | @ruby_else | @ruby_elsif | @ruby_end_block | @ruby_ensure | @ruby_exception_variable | @ruby_exceptions | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_for | @ruby_hash | @ruby_hash_pattern | @ruby_hash_splat_argument | @ruby_hash_splat_parameter | @ruby_heredoc_body | @ruby_if | @ruby_if_guard | @ruby_if_modifier | @ruby_in | @ruby_in_clause | @ruby_interpolation | @ruby_keyword_parameter | @ruby_keyword_pattern | @ruby_lambda | @ruby_lambda_parameters | @ruby_left_assignment_list | @ruby_method | @ruby_method_parameters | @ruby_module | @ruby_next | @ruby_operator_assignment | @ruby_optional_parameter | @ruby_pair | @ruby_parenthesized_pattern | @ruby_parenthesized_statements | @ruby_pattern | @ruby_program | @ruby_range | @ruby_rational | @ruby_redo | @ruby_regex | @ruby_rescue | @ruby_rescue_modifier | @ruby_rest_assignment | @ruby_retry | @ruby_return | @ruby_right_assignment_list | @ruby_scope_resolution | @ruby_setter | @ruby_singleton_class | @ruby_singleton_method | @ruby_splat_argument | @ruby_splat_parameter | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_superclass | @ruby_symbol_array | @ruby_then | @ruby_token | @ruby_unary | @ruby_undef | @ruby_unless | @ruby_unless_guard | @ruby_unless_modifier | @ruby_until | @ruby_until_modifier | @ruby_variable_reference_pattern | @ruby_when | @ruby_while | @ruby_while_modifier | @ruby_yield
+
+@ruby_ast_node_parent = @file | @ruby_ast_node
+
+#keyset[parent, parent_index]
+ruby_ast_node_parent(
+  int child: @ruby_ast_node ref,
+  int parent: @ruby_ast_node_parent ref,
+  int parent_index: int ref
+);
+
+erb_comment_directive_def(
+  unique int id: @erb_comment_directive,
+  int child: @erb_token_comment ref,
+  int loc: @location ref
+);
+
+erb_directive_def(
+  unique int id: @erb_directive,
+  int child: @erb_token_code ref,
+  int loc: @location ref
+);
+
+erb_graphql_directive_def(
+  unique int id: @erb_graphql_directive,
+  int child: @erb_token_code ref,
+  int loc: @location ref
+);
+
+erb_output_directive_def(
+  unique int id: @erb_output_directive,
+  int child: @erb_token_code ref,
+  int loc: @location ref
+);
+
+@erb_template_child_type = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_token_content
+
+#keyset[erb_template, index]
+erb_template_child(
+  int erb_template: @erb_template ref,
+  int index: int ref,
+  unique int child: @erb_template_child_type ref
+);
+
+erb_template_def(
+  unique int id: @erb_template,
+  int loc: @location ref
+);
+
+erb_tokeninfo(
+  unique int id: @erb_token,
+  int kind: int ref,
+  string value: string ref,
+  int loc: @location ref
+);
+
+case @erb_token.kind of
+  0 = @erb_reserved_word
+| 1 = @erb_token_code
+| 2 = @erb_token_comment
+| 3 = @erb_token_content
+;
+
+
+@erb_ast_node = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_template | @erb_token
+
+@erb_ast_node_parent = @erb_ast_node | @file
+
+#keyset[parent, parent_index]
+erb_ast_node_parent(
+  int child: @erb_ast_node ref,
+  int parent: @erb_ast_node_parent ref,
+  int parent_index: int ref
+);
+

--- a/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/ruby.dbscheme
+++ b/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/ruby.dbscheme
@@ -1,0 +1,1393 @@
+// CodeQL database schema for Ruby
+// Automatically generated from the tree-sitter grammar; do not edit
+
+@location = @location_default
+
+locations_default(
+  unique int id: @location_default,
+  int file: @file ref,
+  int start_line: int ref,
+  int start_column: int ref,
+  int end_line: int ref,
+  int end_column: int ref
+);
+
+files(
+  unique int id: @file,
+  string name: string ref
+);
+
+folders(
+  unique int id: @folder,
+  string name: string ref
+);
+
+@container = @file | @folder
+
+containerparent(
+  int parent: @container ref,
+  unique int child: @container ref
+);
+
+sourceLocationPrefix(
+  string prefix: string ref
+);
+
+diagnostics(
+  unique int id: @diagnostic,
+  int severity: int ref,
+  string error_tag: string ref,
+  string error_message: string ref,
+  string full_error_message: string ref,
+  int location: @location_default ref
+);
+
+case @diagnostic.severity of
+  10 = @diagnostic_debug
+| 20 = @diagnostic_info
+| 30 = @diagnostic_warning
+| 40 = @diagnostic_error
+;
+
+
+@ruby_underscore_arg = @ruby_assignment | @ruby_binary | @ruby_conditional | @ruby_operator_assignment | @ruby_range | @ruby_unary | @ruby_underscore_primary
+
+@ruby_underscore_expression = @ruby_assignment | @ruby_binary | @ruby_break | @ruby_call | @ruby_next | @ruby_operator_assignment | @ruby_return | @ruby_unary | @ruby_underscore_arg | @ruby_yield
+
+@ruby_underscore_lhs = @ruby_call | @ruby_element_reference | @ruby_scope_resolution | @ruby_token_false | @ruby_token_nil | @ruby_token_true | @ruby_underscore_variable
+
+@ruby_underscore_method_name = @ruby_delimited_symbol | @ruby_setter | @ruby_token_constant | @ruby_token_identifier | @ruby_token_operator | @ruby_token_simple_symbol | @ruby_underscore_nonlocal_variable
+
+@ruby_underscore_nonlocal_variable = @ruby_token_class_variable | @ruby_token_global_variable | @ruby_token_instance_variable
+
+@ruby_underscore_pattern_constant = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_underscore_pattern_expr = @ruby_alternative_pattern | @ruby_as_pattern | @ruby_underscore_pattern_expr_basic
+
+@ruby_underscore_pattern_expr_basic = @ruby_array_pattern | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_parenthesized_pattern | @ruby_range | @ruby_token_identifier | @ruby_underscore_pattern_constant | @ruby_underscore_pattern_primitive | @ruby_variable_reference_pattern
+
+@ruby_underscore_pattern_primitive = @ruby_delimited_symbol | @ruby_lambda | @ruby_regex | @ruby_string__ | @ruby_string_array | @ruby_symbol_array | @ruby_token_encoding | @ruby_token_false | @ruby_token_file | @ruby_token_line | @ruby_token_nil | @ruby_token_self | @ruby_token_simple_symbol | @ruby_token_true | @ruby_unary | @ruby_underscore_simple_numeric
+
+@ruby_underscore_pattern_top_expr_body = @ruby_array_pattern | @ruby_find_pattern | @ruby_hash_pattern | @ruby_underscore_pattern_expr
+
+@ruby_underscore_primary = @ruby_array | @ruby_begin | @ruby_break | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_delimited_symbol | @ruby_for | @ruby_hash | @ruby_if | @ruby_lambda | @ruby_method | @ruby_module | @ruby_next | @ruby_parenthesized_statements | @ruby_redo | @ruby_regex | @ruby_retry | @ruby_return | @ruby_singleton_class | @ruby_singleton_method | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_symbol_array | @ruby_token_character | @ruby_token_heredoc_beginning | @ruby_token_simple_symbol | @ruby_unary | @ruby_underscore_lhs | @ruby_underscore_simple_numeric | @ruby_unless | @ruby_until | @ruby_while | @ruby_yield
+
+@ruby_underscore_simple_numeric = @ruby_rational | @ruby_token_complex | @ruby_token_float | @ruby_token_integer
+
+@ruby_underscore_statement = @ruby_alias | @ruby_begin_block | @ruby_end_block | @ruby_if_modifier | @ruby_rescue_modifier | @ruby_undef | @ruby_underscore_expression | @ruby_unless_modifier | @ruby_until_modifier | @ruby_while_modifier
+
+@ruby_underscore_variable = @ruby_token_constant | @ruby_token_identifier | @ruby_token_self | @ruby_token_super | @ruby_underscore_nonlocal_variable
+
+ruby_alias_def(
+  unique int id: @ruby_alias,
+  int alias: @ruby_underscore_method_name ref,
+  int name: @ruby_underscore_method_name ref
+);
+
+#keyset[ruby_alternative_pattern, index]
+ruby_alternative_pattern_alternatives(
+  int ruby_alternative_pattern: @ruby_alternative_pattern ref,
+  int index: int ref,
+  unique int alternatives: @ruby_underscore_pattern_expr_basic ref
+);
+
+ruby_alternative_pattern_def(
+  unique int id: @ruby_alternative_pattern
+);
+
+@ruby_argument_list_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_argument_list, index]
+ruby_argument_list_child(
+  int ruby_argument_list: @ruby_argument_list ref,
+  int index: int ref,
+  unique int child: @ruby_argument_list_child_type ref
+);
+
+ruby_argument_list_def(
+  unique int id: @ruby_argument_list
+);
+
+@ruby_array_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_array, index]
+ruby_array_child(
+  int ruby_array: @ruby_array ref,
+  int index: int ref,
+  unique int child: @ruby_array_child_type ref
+);
+
+ruby_array_def(
+  unique int id: @ruby_array
+);
+
+ruby_array_pattern_class(
+  unique int ruby_array_pattern: @ruby_array_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_array_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_array_pattern, index]
+ruby_array_pattern_child(
+  int ruby_array_pattern: @ruby_array_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_array_pattern_child_type ref
+);
+
+ruby_array_pattern_def(
+  unique int id: @ruby_array_pattern
+);
+
+ruby_as_pattern_def(
+  unique int id: @ruby_as_pattern,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_pattern_expr ref
+);
+
+@ruby_assignment_left_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+@ruby_assignment_right_type = @ruby_right_assignment_list | @ruby_splat_argument | @ruby_underscore_expression
+
+ruby_assignment_def(
+  unique int id: @ruby_assignment,
+  int left: @ruby_assignment_left_type ref,
+  int right: @ruby_assignment_right_type ref
+);
+
+@ruby_bare_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_string, index]
+ruby_bare_string_child(
+  int ruby_bare_string: @ruby_bare_string ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string_child_type ref
+);
+
+ruby_bare_string_def(
+  unique int id: @ruby_bare_string
+);
+
+@ruby_bare_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_bare_symbol, index]
+ruby_bare_symbol_child(
+  int ruby_bare_symbol: @ruby_bare_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol_child_type ref
+);
+
+ruby_bare_symbol_def(
+  unique int id: @ruby_bare_symbol
+);
+
+@ruby_begin_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin, index]
+ruby_begin_child(
+  int ruby_begin: @ruby_begin ref,
+  int index: int ref,
+  unique int child: @ruby_begin_child_type ref
+);
+
+ruby_begin_def(
+  unique int id: @ruby_begin
+);
+
+@ruby_begin_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_begin_block, index]
+ruby_begin_block_child(
+  int ruby_begin_block: @ruby_begin_block ref,
+  int index: int ref,
+  unique int child: @ruby_begin_block_child_type ref
+);
+
+ruby_begin_block_def(
+  unique int id: @ruby_begin_block
+);
+
+case @ruby_binary.operator of
+  0 = @ruby_binary_bangequal
+| 1 = @ruby_binary_bangtilde
+| 2 = @ruby_binary_percent
+| 3 = @ruby_binary_ampersand
+| 4 = @ruby_binary_ampersandampersand
+| 5 = @ruby_binary_star
+| 6 = @ruby_binary_starstar
+| 7 = @ruby_binary_plus
+| 8 = @ruby_binary_minus
+| 9 = @ruby_binary_slash
+| 10 = @ruby_binary_langle
+| 11 = @ruby_binary_langlelangle
+| 12 = @ruby_binary_langleequal
+| 13 = @ruby_binary_langleequalrangle
+| 14 = @ruby_binary_equalequal
+| 15 = @ruby_binary_equalequalequal
+| 16 = @ruby_binary_equaltilde
+| 17 = @ruby_binary_rangle
+| 18 = @ruby_binary_rangleequal
+| 19 = @ruby_binary_ranglerangle
+| 20 = @ruby_binary_caret
+| 21 = @ruby_binary_and
+| 22 = @ruby_binary_or
+| 23 = @ruby_binary_pipe
+| 24 = @ruby_binary_pipepipe
+;
+
+
+ruby_binary_def(
+  unique int id: @ruby_binary,
+  int left: @ruby_underscore_expression ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref
+);
+
+ruby_block_parameters(
+  unique int ruby_block: @ruby_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_block, index]
+ruby_block_child(
+  int ruby_block: @ruby_block ref,
+  int index: int ref,
+  unique int child: @ruby_block_child_type ref
+);
+
+ruby_block_def(
+  unique int id: @ruby_block
+);
+
+ruby_block_argument_child(
+  unique int ruby_block_argument: @ruby_block_argument ref,
+  unique int child: @ruby_underscore_arg ref
+);
+
+ruby_block_argument_def(
+  unique int id: @ruby_block_argument
+);
+
+ruby_block_parameter_name(
+  unique int ruby_block_parameter: @ruby_block_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_block_parameter_def(
+  unique int id: @ruby_block_parameter
+);
+
+@ruby_block_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_block_parameters, index]
+ruby_block_parameters_child(
+  int ruby_block_parameters: @ruby_block_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_block_parameters_child_type ref
+);
+
+ruby_block_parameters_def(
+  unique int id: @ruby_block_parameters
+);
+
+ruby_break_child(
+  unique int ruby_break: @ruby_break ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_break_def(
+  unique int id: @ruby_break
+);
+
+ruby_call_arguments(
+  unique int ruby_call: @ruby_call ref,
+  unique int arguments: @ruby_argument_list ref
+);
+
+@ruby_call_block_type = @ruby_block | @ruby_do_block
+
+ruby_call_block(
+  unique int ruby_call: @ruby_call ref,
+  unique int block: @ruby_call_block_type ref
+);
+
+@ruby_call_method_type = @ruby_argument_list | @ruby_scope_resolution | @ruby_token_operator | @ruby_underscore_variable
+
+@ruby_call_receiver_type = @ruby_call | @ruby_underscore_primary
+
+ruby_call_receiver(
+  unique int ruby_call: @ruby_call ref,
+  unique int receiver: @ruby_call_receiver_type ref
+);
+
+ruby_call_def(
+  unique int id: @ruby_call,
+  int method: @ruby_call_method_type ref
+);
+
+ruby_case_value(
+  unique int ruby_case__: @ruby_case__ ref,
+  unique int value: @ruby_underscore_statement ref
+);
+
+@ruby_case_child_type = @ruby_else | @ruby_when
+
+#keyset[ruby_case__, index]
+ruby_case_child(
+  int ruby_case__: @ruby_case__ ref,
+  int index: int ref,
+  unique int child: @ruby_case_child_type ref
+);
+
+ruby_case_def(
+  unique int id: @ruby_case__
+);
+
+#keyset[ruby_case_match, index]
+ruby_case_match_clauses(
+  int ruby_case_match: @ruby_case_match ref,
+  int index: int ref,
+  unique int clauses: @ruby_in_clause ref
+);
+
+ruby_case_match_else(
+  unique int ruby_case_match: @ruby_case_match ref,
+  unique int else: @ruby_else ref
+);
+
+ruby_case_match_def(
+  unique int id: @ruby_case_match,
+  int value: @ruby_underscore_statement ref
+);
+
+#keyset[ruby_chained_string, index]
+ruby_chained_string_child(
+  int ruby_chained_string: @ruby_chained_string ref,
+  int index: int ref,
+  unique int child: @ruby_string__ ref
+);
+
+ruby_chained_string_def(
+  unique int id: @ruby_chained_string
+);
+
+@ruby_class_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+ruby_class_superclass(
+  unique int ruby_class: @ruby_class ref,
+  unique int superclass: @ruby_superclass ref
+);
+
+@ruby_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_class, index]
+ruby_class_child(
+  int ruby_class: @ruby_class ref,
+  int index: int ref,
+  unique int child: @ruby_class_child_type ref
+);
+
+ruby_class_def(
+  unique int id: @ruby_class,
+  int name: @ruby_class_name_type ref
+);
+
+ruby_conditional_def(
+  unique int id: @ruby_conditional,
+  int alternative: @ruby_underscore_arg ref,
+  int condition: @ruby_underscore_arg ref,
+  int consequence: @ruby_underscore_arg ref
+);
+
+@ruby_delimited_symbol_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_delimited_symbol, index]
+ruby_delimited_symbol_child(
+  int ruby_delimited_symbol: @ruby_delimited_symbol ref,
+  int index: int ref,
+  unique int child: @ruby_delimited_symbol_child_type ref
+);
+
+ruby_delimited_symbol_def(
+  unique int id: @ruby_delimited_symbol
+);
+
+@ruby_destructured_left_assignment_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_destructured_left_assignment, index]
+ruby_destructured_left_assignment_child(
+  int ruby_destructured_left_assignment: @ruby_destructured_left_assignment ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_left_assignment_child_type ref
+);
+
+ruby_destructured_left_assignment_def(
+  unique int id: @ruby_destructured_left_assignment
+);
+
+@ruby_destructured_parameter_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_destructured_parameter, index]
+ruby_destructured_parameter_child(
+  int ruby_destructured_parameter: @ruby_destructured_parameter ref,
+  int index: int ref,
+  unique int child: @ruby_destructured_parameter_child_type ref
+);
+
+ruby_destructured_parameter_def(
+  unique int id: @ruby_destructured_parameter
+);
+
+@ruby_do_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do, index]
+ruby_do_child(
+  int ruby_do: @ruby_do ref,
+  int index: int ref,
+  unique int child: @ruby_do_child_type ref
+);
+
+ruby_do_def(
+  unique int id: @ruby_do
+);
+
+ruby_do_block_parameters(
+  unique int ruby_do_block: @ruby_do_block ref,
+  unique int parameters: @ruby_block_parameters ref
+);
+
+@ruby_do_block_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_do_block, index]
+ruby_do_block_child(
+  int ruby_do_block: @ruby_do_block ref,
+  int index: int ref,
+  unique int child: @ruby_do_block_child_type ref
+);
+
+ruby_do_block_def(
+  unique int id: @ruby_do_block
+);
+
+@ruby_element_reference_child_type = @ruby_block_argument | @ruby_hash_splat_argument | @ruby_pair | @ruby_splat_argument | @ruby_token_forward_argument | @ruby_underscore_expression
+
+#keyset[ruby_element_reference, index]
+ruby_element_reference_child(
+  int ruby_element_reference: @ruby_element_reference ref,
+  int index: int ref,
+  unique int child: @ruby_element_reference_child_type ref
+);
+
+ruby_element_reference_def(
+  unique int id: @ruby_element_reference,
+  int object: @ruby_underscore_primary ref
+);
+
+@ruby_else_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_else, index]
+ruby_else_child(
+  int ruby_else: @ruby_else ref,
+  int index: int ref,
+  unique int child: @ruby_else_child_type ref
+);
+
+ruby_else_def(
+  unique int id: @ruby_else
+);
+
+@ruby_elsif_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_elsif_alternative(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int alternative: @ruby_elsif_alternative_type ref
+);
+
+ruby_elsif_consequence(
+  unique int ruby_elsif: @ruby_elsif ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_elsif_def(
+  unique int id: @ruby_elsif,
+  int condition: @ruby_underscore_statement ref
+);
+
+@ruby_end_block_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_end_block, index]
+ruby_end_block_child(
+  int ruby_end_block: @ruby_end_block ref,
+  int index: int ref,
+  unique int child: @ruby_end_block_child_type ref
+);
+
+ruby_end_block_def(
+  unique int id: @ruby_end_block
+);
+
+@ruby_ensure_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_ensure, index]
+ruby_ensure_child(
+  int ruby_ensure: @ruby_ensure ref,
+  int index: int ref,
+  unique int child: @ruby_ensure_child_type ref
+);
+
+ruby_ensure_def(
+  unique int id: @ruby_ensure
+);
+
+ruby_exception_variable_def(
+  unique int id: @ruby_exception_variable,
+  int child: @ruby_underscore_lhs ref
+);
+
+@ruby_exceptions_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_exceptions, index]
+ruby_exceptions_child(
+  int ruby_exceptions: @ruby_exceptions ref,
+  int index: int ref,
+  unique int child: @ruby_exceptions_child_type ref
+);
+
+ruby_exceptions_def(
+  unique int id: @ruby_exceptions
+);
+
+ruby_expression_reference_pattern_def(
+  unique int id: @ruby_expression_reference_pattern,
+  int value: @ruby_underscore_expression ref
+);
+
+ruby_find_pattern_class(
+  unique int ruby_find_pattern: @ruby_find_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_find_pattern_child_type = @ruby_splat_parameter | @ruby_underscore_pattern_expr
+
+#keyset[ruby_find_pattern, index]
+ruby_find_pattern_child(
+  int ruby_find_pattern: @ruby_find_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_find_pattern_child_type ref
+);
+
+ruby_find_pattern_def(
+  unique int id: @ruby_find_pattern
+);
+
+@ruby_for_pattern_type = @ruby_left_assignment_list | @ruby_underscore_lhs
+
+ruby_for_def(
+  unique int id: @ruby_for,
+  int body: @ruby_do ref,
+  int pattern: @ruby_for_pattern_type ref,
+  int value: @ruby_in ref
+);
+
+@ruby_hash_child_type = @ruby_hash_splat_argument | @ruby_pair
+
+#keyset[ruby_hash, index]
+ruby_hash_child(
+  int ruby_hash: @ruby_hash ref,
+  int index: int ref,
+  unique int child: @ruby_hash_child_type ref
+);
+
+ruby_hash_def(
+  unique int id: @ruby_hash
+);
+
+ruby_hash_pattern_class(
+  unique int ruby_hash_pattern: @ruby_hash_pattern ref,
+  unique int class: @ruby_underscore_pattern_constant ref
+);
+
+@ruby_hash_pattern_child_type = @ruby_hash_splat_parameter | @ruby_keyword_pattern | @ruby_token_hash_splat_nil
+
+#keyset[ruby_hash_pattern, index]
+ruby_hash_pattern_child(
+  int ruby_hash_pattern: @ruby_hash_pattern ref,
+  int index: int ref,
+  unique int child: @ruby_hash_pattern_child_type ref
+);
+
+ruby_hash_pattern_def(
+  unique int id: @ruby_hash_pattern
+);
+
+ruby_hash_splat_argument_def(
+  unique int id: @ruby_hash_splat_argument,
+  int child: @ruby_underscore_arg ref
+);
+
+ruby_hash_splat_parameter_name(
+  unique int ruby_hash_splat_parameter: @ruby_hash_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_hash_splat_parameter_def(
+  unique int id: @ruby_hash_splat_parameter
+);
+
+@ruby_heredoc_body_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_heredoc_content | @ruby_token_heredoc_end
+
+#keyset[ruby_heredoc_body, index]
+ruby_heredoc_body_child(
+  int ruby_heredoc_body: @ruby_heredoc_body ref,
+  int index: int ref,
+  unique int child: @ruby_heredoc_body_child_type ref
+);
+
+ruby_heredoc_body_def(
+  unique int id: @ruby_heredoc_body
+);
+
+@ruby_if_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_if_alternative(
+  unique int ruby_if: @ruby_if ref,
+  unique int alternative: @ruby_if_alternative_type ref
+);
+
+ruby_if_consequence(
+  unique int ruby_if: @ruby_if ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_if_def(
+  unique int id: @ruby_if,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_if_guard_def(
+  unique int id: @ruby_if_guard,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_if_modifier_def(
+  unique int id: @ruby_if_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_in_def(
+  unique int id: @ruby_in,
+  int child: @ruby_underscore_arg ref
+);
+
+ruby_in_clause_body(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int body: @ruby_then ref
+);
+
+@ruby_in_clause_guard_type = @ruby_if_guard | @ruby_unless_guard
+
+ruby_in_clause_guard(
+  unique int ruby_in_clause: @ruby_in_clause ref,
+  unique int guard: @ruby_in_clause_guard_type ref
+);
+
+ruby_in_clause_def(
+  unique int id: @ruby_in_clause,
+  int pattern: @ruby_underscore_pattern_top_expr_body ref
+);
+
+@ruby_interpolation_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_interpolation, index]
+ruby_interpolation_child(
+  int ruby_interpolation: @ruby_interpolation ref,
+  int index: int ref,
+  unique int child: @ruby_interpolation_child_type ref
+);
+
+ruby_interpolation_def(
+  unique int id: @ruby_interpolation
+);
+
+ruby_keyword_parameter_value(
+  unique int ruby_keyword_parameter: @ruby_keyword_parameter ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_keyword_parameter_def(
+  unique int id: @ruby_keyword_parameter,
+  int name: @ruby_token_identifier ref
+);
+
+@ruby_keyword_pattern_key_type = @ruby_string__ | @ruby_token_hash_key_symbol
+
+ruby_keyword_pattern_value(
+  unique int ruby_keyword_pattern: @ruby_keyword_pattern ref,
+  unique int value: @ruby_underscore_pattern_expr ref
+);
+
+ruby_keyword_pattern_def(
+  unique int id: @ruby_keyword_pattern,
+  int key__: @ruby_keyword_pattern_key_type ref
+);
+
+@ruby_lambda_body_type = @ruby_block | @ruby_do_block
+
+ruby_lambda_parameters(
+  unique int ruby_lambda: @ruby_lambda ref,
+  unique int parameters: @ruby_lambda_parameters ref
+);
+
+ruby_lambda_def(
+  unique int id: @ruby_lambda,
+  int body: @ruby_lambda_body_type ref
+);
+
+@ruby_lambda_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_lambda_parameters, index]
+ruby_lambda_parameters_child(
+  int ruby_lambda_parameters: @ruby_lambda_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_lambda_parameters_child_type ref
+);
+
+ruby_lambda_parameters_def(
+  unique int id: @ruby_lambda_parameters
+);
+
+@ruby_left_assignment_list_child_type = @ruby_destructured_left_assignment | @ruby_rest_assignment | @ruby_underscore_lhs
+
+#keyset[ruby_left_assignment_list, index]
+ruby_left_assignment_list_child(
+  int ruby_left_assignment_list: @ruby_left_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_left_assignment_list_child_type ref
+);
+
+ruby_left_assignment_list_def(
+  unique int id: @ruby_left_assignment_list
+);
+
+ruby_method_parameters(
+  unique int ruby_method: @ruby_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_method, index]
+ruby_method_child(
+  int ruby_method: @ruby_method ref,
+  int index: int ref,
+  unique int child: @ruby_method_child_type ref
+);
+
+ruby_method_def(
+  unique int id: @ruby_method,
+  int name: @ruby_underscore_method_name ref
+);
+
+@ruby_method_parameters_child_type = @ruby_block_parameter | @ruby_destructured_parameter | @ruby_hash_splat_parameter | @ruby_keyword_parameter | @ruby_optional_parameter | @ruby_splat_parameter | @ruby_token_forward_parameter | @ruby_token_hash_splat_nil | @ruby_token_identifier
+
+#keyset[ruby_method_parameters, index]
+ruby_method_parameters_child(
+  int ruby_method_parameters: @ruby_method_parameters ref,
+  int index: int ref,
+  unique int child: @ruby_method_parameters_child_type ref
+);
+
+ruby_method_parameters_def(
+  unique int id: @ruby_method_parameters
+);
+
+@ruby_module_name_type = @ruby_scope_resolution | @ruby_token_constant
+
+@ruby_module_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_module, index]
+ruby_module_child(
+  int ruby_module: @ruby_module ref,
+  int index: int ref,
+  unique int child: @ruby_module_child_type ref
+);
+
+ruby_module_def(
+  unique int id: @ruby_module,
+  int name: @ruby_module_name_type ref
+);
+
+ruby_next_child(
+  unique int ruby_next: @ruby_next ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_next_def(
+  unique int id: @ruby_next
+);
+
+case @ruby_operator_assignment.operator of
+  0 = @ruby_operator_assignment_percentequal
+| 1 = @ruby_operator_assignment_ampersandampersandequal
+| 2 = @ruby_operator_assignment_ampersandequal
+| 3 = @ruby_operator_assignment_starstarequal
+| 4 = @ruby_operator_assignment_starequal
+| 5 = @ruby_operator_assignment_plusequal
+| 6 = @ruby_operator_assignment_minusequal
+| 7 = @ruby_operator_assignment_slashequal
+| 8 = @ruby_operator_assignment_langlelangleequal
+| 9 = @ruby_operator_assignment_ranglerangleequal
+| 10 = @ruby_operator_assignment_caretequal
+| 11 = @ruby_operator_assignment_pipeequal
+| 12 = @ruby_operator_assignment_pipepipeequal
+;
+
+
+ruby_operator_assignment_def(
+  unique int id: @ruby_operator_assignment,
+  int left: @ruby_underscore_lhs ref,
+  int operator: int ref,
+  int right: @ruby_underscore_expression ref
+);
+
+ruby_optional_parameter_def(
+  unique int id: @ruby_optional_parameter,
+  int name: @ruby_token_identifier ref,
+  int value: @ruby_underscore_arg ref
+);
+
+@ruby_pair_key_type = @ruby_string__ | @ruby_token_hash_key_symbol | @ruby_underscore_arg
+
+ruby_pair_value(
+  unique int ruby_pair: @ruby_pair ref,
+  unique int value: @ruby_underscore_arg ref
+);
+
+ruby_pair_def(
+  unique int id: @ruby_pair,
+  int key__: @ruby_pair_key_type ref
+);
+
+ruby_parenthesized_pattern_def(
+  unique int id: @ruby_parenthesized_pattern,
+  int child: @ruby_underscore_pattern_expr ref
+);
+
+@ruby_parenthesized_statements_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_parenthesized_statements, index]
+ruby_parenthesized_statements_child(
+  int ruby_parenthesized_statements: @ruby_parenthesized_statements ref,
+  int index: int ref,
+  unique int child: @ruby_parenthesized_statements_child_type ref
+);
+
+ruby_parenthesized_statements_def(
+  unique int id: @ruby_parenthesized_statements
+);
+
+@ruby_pattern_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+ruby_pattern_def(
+  unique int id: @ruby_pattern,
+  int child: @ruby_pattern_child_type ref
+);
+
+@ruby_program_child_type = @ruby_token_empty_statement | @ruby_token_uninterpreted | @ruby_underscore_statement
+
+#keyset[ruby_program, index]
+ruby_program_child(
+  int ruby_program: @ruby_program ref,
+  int index: int ref,
+  unique int child: @ruby_program_child_type ref
+);
+
+ruby_program_def(
+  unique int id: @ruby_program
+);
+
+@ruby_range_begin_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_begin(
+  unique int ruby_range: @ruby_range ref,
+  unique int begin: @ruby_range_begin_type ref
+);
+
+@ruby_range_end_type = @ruby_underscore_arg | @ruby_underscore_pattern_primitive
+
+ruby_range_end(
+  unique int ruby_range: @ruby_range ref,
+  unique int end: @ruby_range_end_type ref
+);
+
+case @ruby_range.operator of
+  0 = @ruby_range_dotdot
+| 1 = @ruby_range_dotdotdot
+;
+
+
+ruby_range_def(
+  unique int id: @ruby_range,
+  int operator: int ref
+);
+
+@ruby_rational_child_type = @ruby_token_float | @ruby_token_integer
+
+ruby_rational_def(
+  unique int id: @ruby_rational,
+  int child: @ruby_rational_child_type ref
+);
+
+ruby_redo_child(
+  unique int ruby_redo: @ruby_redo ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_redo_def(
+  unique int id: @ruby_redo
+);
+
+@ruby_regex_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_regex, index]
+ruby_regex_child(
+  int ruby_regex: @ruby_regex ref,
+  int index: int ref,
+  unique int child: @ruby_regex_child_type ref
+);
+
+ruby_regex_def(
+  unique int id: @ruby_regex
+);
+
+ruby_rescue_body(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int body: @ruby_then ref
+);
+
+ruby_rescue_exceptions(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int exceptions: @ruby_exceptions ref
+);
+
+ruby_rescue_variable(
+  unique int ruby_rescue: @ruby_rescue ref,
+  unique int variable: @ruby_exception_variable ref
+);
+
+ruby_rescue_def(
+  unique int id: @ruby_rescue
+);
+
+@ruby_rescue_modifier_body_type = @ruby_underscore_arg | @ruby_underscore_statement
+
+ruby_rescue_modifier_def(
+  unique int id: @ruby_rescue_modifier,
+  int body: @ruby_rescue_modifier_body_type ref,
+  int handler: @ruby_underscore_expression ref
+);
+
+ruby_rest_assignment_child(
+  unique int ruby_rest_assignment: @ruby_rest_assignment ref,
+  unique int child: @ruby_underscore_lhs ref
+);
+
+ruby_rest_assignment_def(
+  unique int id: @ruby_rest_assignment
+);
+
+ruby_retry_child(
+  unique int ruby_retry: @ruby_retry ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_retry_def(
+  unique int id: @ruby_retry
+);
+
+ruby_return_child(
+  unique int ruby_return: @ruby_return ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_return_def(
+  unique int id: @ruby_return
+);
+
+@ruby_right_assignment_list_child_type = @ruby_splat_argument | @ruby_underscore_arg
+
+#keyset[ruby_right_assignment_list, index]
+ruby_right_assignment_list_child(
+  int ruby_right_assignment_list: @ruby_right_assignment_list ref,
+  int index: int ref,
+  unique int child: @ruby_right_assignment_list_child_type ref
+);
+
+ruby_right_assignment_list_def(
+  unique int id: @ruby_right_assignment_list
+);
+
+@ruby_scope_resolution_name_type = @ruby_token_constant | @ruby_token_identifier
+
+@ruby_scope_resolution_scope_type = @ruby_underscore_pattern_constant | @ruby_underscore_primary
+
+ruby_scope_resolution_scope(
+  unique int ruby_scope_resolution: @ruby_scope_resolution ref,
+  unique int scope: @ruby_scope_resolution_scope_type ref
+);
+
+ruby_scope_resolution_def(
+  unique int id: @ruby_scope_resolution,
+  int name: @ruby_scope_resolution_name_type ref
+);
+
+ruby_setter_def(
+  unique int id: @ruby_setter,
+  int name: @ruby_token_identifier ref
+);
+
+@ruby_singleton_class_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_singleton_class, index]
+ruby_singleton_class_child(
+  int ruby_singleton_class: @ruby_singleton_class ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_class_child_type ref
+);
+
+ruby_singleton_class_def(
+  unique int id: @ruby_singleton_class,
+  int value: @ruby_underscore_arg ref
+);
+
+@ruby_singleton_method_object_type = @ruby_underscore_arg | @ruby_underscore_variable
+
+ruby_singleton_method_parameters(
+  unique int ruby_singleton_method: @ruby_singleton_method ref,
+  unique int parameters: @ruby_method_parameters ref
+);
+
+@ruby_singleton_method_child_type = @ruby_else | @ruby_ensure | @ruby_rescue | @ruby_token_empty_statement | @ruby_underscore_arg | @ruby_underscore_statement
+
+#keyset[ruby_singleton_method, index]
+ruby_singleton_method_child(
+  int ruby_singleton_method: @ruby_singleton_method ref,
+  int index: int ref,
+  unique int child: @ruby_singleton_method_child_type ref
+);
+
+ruby_singleton_method_def(
+  unique int id: @ruby_singleton_method,
+  int name: @ruby_underscore_method_name ref,
+  int object: @ruby_singleton_method_object_type ref
+);
+
+ruby_splat_argument_def(
+  unique int id: @ruby_splat_argument,
+  int child: @ruby_underscore_arg ref
+);
+
+ruby_splat_parameter_name(
+  unique int ruby_splat_parameter: @ruby_splat_parameter ref,
+  unique int name: @ruby_token_identifier ref
+);
+
+ruby_splat_parameter_def(
+  unique int id: @ruby_splat_parameter
+);
+
+@ruby_string_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_string__, index]
+ruby_string_child(
+  int ruby_string__: @ruby_string__ ref,
+  int index: int ref,
+  unique int child: @ruby_string_child_type ref
+);
+
+ruby_string_def(
+  unique int id: @ruby_string__
+);
+
+#keyset[ruby_string_array, index]
+ruby_string_array_child(
+  int ruby_string_array: @ruby_string_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_string ref
+);
+
+ruby_string_array_def(
+  unique int id: @ruby_string_array
+);
+
+@ruby_subshell_child_type = @ruby_interpolation | @ruby_token_escape_sequence | @ruby_token_string_content
+
+#keyset[ruby_subshell, index]
+ruby_subshell_child(
+  int ruby_subshell: @ruby_subshell ref,
+  int index: int ref,
+  unique int child: @ruby_subshell_child_type ref
+);
+
+ruby_subshell_def(
+  unique int id: @ruby_subshell
+);
+
+ruby_superclass_def(
+  unique int id: @ruby_superclass,
+  int child: @ruby_underscore_expression ref
+);
+
+#keyset[ruby_symbol_array, index]
+ruby_symbol_array_child(
+  int ruby_symbol_array: @ruby_symbol_array ref,
+  int index: int ref,
+  unique int child: @ruby_bare_symbol ref
+);
+
+ruby_symbol_array_def(
+  unique int id: @ruby_symbol_array
+);
+
+@ruby_then_child_type = @ruby_token_empty_statement | @ruby_underscore_statement
+
+#keyset[ruby_then, index]
+ruby_then_child(
+  int ruby_then: @ruby_then ref,
+  int index: int ref,
+  unique int child: @ruby_then_child_type ref
+);
+
+ruby_then_def(
+  unique int id: @ruby_then
+);
+
+@ruby_unary_operand_type = @ruby_parenthesized_statements | @ruby_underscore_expression | @ruby_underscore_simple_numeric
+
+case @ruby_unary.operator of
+  0 = @ruby_unary_bang
+| 1 = @ruby_unary_plus
+| 2 = @ruby_unary_minus
+| 3 = @ruby_unary_definedquestion
+| 4 = @ruby_unary_not
+| 5 = @ruby_unary_tilde
+;
+
+
+ruby_unary_def(
+  unique int id: @ruby_unary,
+  int operand: @ruby_unary_operand_type ref,
+  int operator: int ref
+);
+
+#keyset[ruby_undef, index]
+ruby_undef_child(
+  int ruby_undef: @ruby_undef ref,
+  int index: int ref,
+  unique int child: @ruby_underscore_method_name ref
+);
+
+ruby_undef_def(
+  unique int id: @ruby_undef
+);
+
+@ruby_unless_alternative_type = @ruby_else | @ruby_elsif
+
+ruby_unless_alternative(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int alternative: @ruby_unless_alternative_type ref
+);
+
+ruby_unless_consequence(
+  unique int ruby_unless: @ruby_unless ref,
+  unique int consequence: @ruby_then ref
+);
+
+ruby_unless_def(
+  unique int id: @ruby_unless,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_unless_guard_def(
+  unique int id: @ruby_unless_guard,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_unless_modifier_def(
+  unique int id: @ruby_unless_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_until_def(
+  unique int id: @ruby_until,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_until_modifier_def(
+  unique int id: @ruby_until_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+@ruby_variable_reference_pattern_name_type = @ruby_token_identifier | @ruby_underscore_nonlocal_variable
+
+ruby_variable_reference_pattern_def(
+  unique int id: @ruby_variable_reference_pattern,
+  int name: @ruby_variable_reference_pattern_name_type ref
+);
+
+ruby_when_body(
+  unique int ruby_when: @ruby_when ref,
+  unique int body: @ruby_then ref
+);
+
+#keyset[ruby_when, index]
+ruby_when_pattern(
+  int ruby_when: @ruby_when ref,
+  int index: int ref,
+  unique int pattern: @ruby_pattern ref
+);
+
+ruby_when_def(
+  unique int id: @ruby_when
+);
+
+ruby_while_def(
+  unique int id: @ruby_while,
+  int body: @ruby_do ref,
+  int condition: @ruby_underscore_statement ref
+);
+
+ruby_while_modifier_def(
+  unique int id: @ruby_while_modifier,
+  int body: @ruby_underscore_statement ref,
+  int condition: @ruby_underscore_expression ref
+);
+
+ruby_yield_child(
+  unique int ruby_yield: @ruby_yield ref,
+  unique int child: @ruby_argument_list ref
+);
+
+ruby_yield_def(
+  unique int id: @ruby_yield
+);
+
+ruby_tokeninfo(
+  unique int id: @ruby_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @ruby_token.kind of
+  0 = @ruby_reserved_word
+| 1 = @ruby_token_character
+| 2 = @ruby_token_class_variable
+| 3 = @ruby_token_comment
+| 4 = @ruby_token_complex
+| 5 = @ruby_token_constant
+| 6 = @ruby_token_empty_statement
+| 7 = @ruby_token_encoding
+| 8 = @ruby_token_escape_sequence
+| 9 = @ruby_token_false
+| 10 = @ruby_token_file
+| 11 = @ruby_token_float
+| 12 = @ruby_token_forward_argument
+| 13 = @ruby_token_forward_parameter
+| 14 = @ruby_token_global_variable
+| 15 = @ruby_token_hash_key_symbol
+| 16 = @ruby_token_hash_splat_nil
+| 17 = @ruby_token_heredoc_beginning
+| 18 = @ruby_token_heredoc_content
+| 19 = @ruby_token_heredoc_end
+| 20 = @ruby_token_identifier
+| 21 = @ruby_token_instance_variable
+| 22 = @ruby_token_integer
+| 23 = @ruby_token_line
+| 24 = @ruby_token_nil
+| 25 = @ruby_token_operator
+| 26 = @ruby_token_self
+| 27 = @ruby_token_simple_symbol
+| 28 = @ruby_token_string_content
+| 29 = @ruby_token_super
+| 30 = @ruby_token_true
+| 31 = @ruby_token_uninterpreted
+;
+
+
+@ruby_ast_node = @ruby_alias | @ruby_alternative_pattern | @ruby_argument_list | @ruby_array | @ruby_array_pattern | @ruby_as_pattern | @ruby_assignment | @ruby_bare_string | @ruby_bare_symbol | @ruby_begin | @ruby_begin_block | @ruby_binary | @ruby_block | @ruby_block_argument | @ruby_block_parameter | @ruby_block_parameters | @ruby_break | @ruby_call | @ruby_case__ | @ruby_case_match | @ruby_chained_string | @ruby_class | @ruby_conditional | @ruby_delimited_symbol | @ruby_destructured_left_assignment | @ruby_destructured_parameter | @ruby_do | @ruby_do_block | @ruby_element_reference | @ruby_else | @ruby_elsif | @ruby_end_block | @ruby_ensure | @ruby_exception_variable | @ruby_exceptions | @ruby_expression_reference_pattern | @ruby_find_pattern | @ruby_for | @ruby_hash | @ruby_hash_pattern | @ruby_hash_splat_argument | @ruby_hash_splat_parameter | @ruby_heredoc_body | @ruby_if | @ruby_if_guard | @ruby_if_modifier | @ruby_in | @ruby_in_clause | @ruby_interpolation | @ruby_keyword_parameter | @ruby_keyword_pattern | @ruby_lambda | @ruby_lambda_parameters | @ruby_left_assignment_list | @ruby_method | @ruby_method_parameters | @ruby_module | @ruby_next | @ruby_operator_assignment | @ruby_optional_parameter | @ruby_pair | @ruby_parenthesized_pattern | @ruby_parenthesized_statements | @ruby_pattern | @ruby_program | @ruby_range | @ruby_rational | @ruby_redo | @ruby_regex | @ruby_rescue | @ruby_rescue_modifier | @ruby_rest_assignment | @ruby_retry | @ruby_return | @ruby_right_assignment_list | @ruby_scope_resolution | @ruby_setter | @ruby_singleton_class | @ruby_singleton_method | @ruby_splat_argument | @ruby_splat_parameter | @ruby_string__ | @ruby_string_array | @ruby_subshell | @ruby_superclass | @ruby_symbol_array | @ruby_then | @ruby_token | @ruby_unary | @ruby_undef | @ruby_unless | @ruby_unless_guard | @ruby_unless_modifier | @ruby_until | @ruby_until_modifier | @ruby_variable_reference_pattern | @ruby_when | @ruby_while | @ruby_while_modifier | @ruby_yield
+
+@ruby_ast_node_parent = @file | @ruby_ast_node
+
+#keyset[parent, parent_index]
+ruby_ast_node_info(
+  int node: @ruby_ast_node ref,
+  int parent: @ruby_ast_node_parent ref,
+  int parent_index: int ref,
+  int loc: @location ref
+);
+
+erb_comment_directive_def(
+  unique int id: @erb_comment_directive,
+  int child: @erb_token_comment ref
+);
+
+erb_directive_def(
+  unique int id: @erb_directive,
+  int child: @erb_token_code ref
+);
+
+erb_graphql_directive_def(
+  unique int id: @erb_graphql_directive,
+  int child: @erb_token_code ref
+);
+
+erb_output_directive_def(
+  unique int id: @erb_output_directive,
+  int child: @erb_token_code ref
+);
+
+@erb_template_child_type = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_token_content
+
+#keyset[erb_template, index]
+erb_template_child(
+  int erb_template: @erb_template ref,
+  int index: int ref,
+  unique int child: @erb_template_child_type ref
+);
+
+erb_template_def(
+  unique int id: @erb_template
+);
+
+erb_tokeninfo(
+  unique int id: @erb_token,
+  int kind: int ref,
+  string value: string ref
+);
+
+case @erb_token.kind of
+  0 = @erb_reserved_word
+| 1 = @erb_token_code
+| 2 = @erb_token_comment
+| 3 = @erb_token_content
+;
+
+
+@erb_ast_node = @erb_comment_directive | @erb_directive | @erb_graphql_directive | @erb_output_directive | @erb_template | @erb_token
+
+@erb_ast_node_parent = @erb_ast_node | @file
+
+#keyset[parent, parent_index]
+erb_ast_node_info(
+  int node: @erb_ast_node ref,
+  int parent: @erb_ast_node_parent ref,
+  int parent_index: int ref,
+  int loc: @location ref
+);
+

--- a/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/ruby_ast_node_info.ql
+++ b/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/ruby_ast_node_info.ql
@@ -1,0 +1,120 @@
+class Location extends @location {
+  string toString() { none() }
+}
+
+class RubyAstNodeParent extends @ruby_ast_node_parent {
+  string toString() { none() }
+}
+
+class RubyAstNode extends @ruby_ast_node {
+  string toString() { none() }
+
+  RubyAstNodeParent getParent(int index) { ruby_ast_node_parent(this, result, index) }
+
+  Location getLocation() {
+    ruby_tokeninfo(this, _, _, result) or
+    ruby_alias_def(this, _, _, result) or
+    ruby_alternative_pattern_def(this, result) or
+    ruby_argument_list_def(this, result) or
+    ruby_array_def(this, result) or
+    ruby_array_pattern_def(this, result) or
+    ruby_as_pattern_def(this, _, _, result) or
+    ruby_assignment_def(this, _, _, result) or
+    ruby_bare_string_def(this, result) or
+    ruby_bare_symbol_def(this, result) or
+    ruby_begin_def(this, result) or
+    ruby_begin_block_def(this, result) or
+    ruby_binary_def(this, _, _, _, result) or
+    ruby_block_def(this, result) or
+    ruby_block_argument_def(this, result) or
+    ruby_block_parameter_def(this, result) or
+    ruby_block_parameters_def(this, result) or
+    ruby_break_def(this, result) or
+    ruby_call_def(this, _, result) or
+    ruby_case_def(this, result) or
+    ruby_case_match_def(this, _, result) or
+    ruby_chained_string_def(this, result) or
+    ruby_class_def(this, _, result) or
+    ruby_conditional_def(this, _, _, _, result) or
+    ruby_delimited_symbol_def(this, result) or
+    ruby_destructured_left_assignment_def(this, result) or
+    ruby_destructured_parameter_def(this, result) or
+    ruby_do_def(this, result) or
+    ruby_do_block_def(this, result) or
+    ruby_element_reference_def(this, _, result) or
+    ruby_else_def(this, result) or
+    ruby_elsif_def(this, _, result) or
+    ruby_end_block_def(this, result) or
+    ruby_ensure_def(this, result) or
+    ruby_exception_variable_def(this, _, result) or
+    ruby_exceptions_def(this, result) or
+    ruby_expression_reference_pattern_def(this, _, result) or
+    ruby_find_pattern_def(this, result) or
+    ruby_for_def(this, _, _, _, result) or
+    ruby_hash_def(this, result) or
+    ruby_hash_pattern_def(this, result) or
+    ruby_hash_splat_argument_def(this, _, result) or
+    ruby_hash_splat_parameter_def(this, result) or
+    ruby_heredoc_body_def(this, result) or
+    ruby_if_def(this, _, result) or
+    ruby_if_guard_def(this, _, result) or
+    ruby_if_modifier_def(this, _, _, result) or
+    ruby_in_def(this, _, result) or
+    ruby_in_clause_def(this, _, result) or
+    ruby_interpolation_def(this, result) or
+    ruby_keyword_parameter_def(this, _, result) or
+    ruby_keyword_pattern_def(this, _, result) or
+    ruby_lambda_def(this, _, result) or
+    ruby_lambda_parameters_def(this, result) or
+    ruby_left_assignment_list_def(this, result) or
+    ruby_method_def(this, _, result) or
+    ruby_method_parameters_def(this, result) or
+    ruby_module_def(this, _, result) or
+    ruby_next_def(this, result) or
+    ruby_operator_assignment_def(this, _, _, _, result) or
+    ruby_optional_parameter_def(this, _, _, result) or
+    ruby_pair_def(this, _, result) or
+    ruby_parenthesized_pattern_def(this, _, result) or
+    ruby_parenthesized_statements_def(this, result) or
+    ruby_pattern_def(this, _, result) or
+    ruby_program_def(this, result) or
+    ruby_range_def(this, _, result) or
+    ruby_rational_def(this, _, result) or
+    ruby_redo_def(this, result) or
+    ruby_regex_def(this, result) or
+    ruby_rescue_def(this, result) or
+    ruby_rescue_modifier_def(this, _, _, result) or
+    ruby_rest_assignment_def(this, result) or
+    ruby_retry_def(this, result) or
+    ruby_return_def(this, result) or
+    ruby_right_assignment_list_def(this, result) or
+    ruby_scope_resolution_def(this, _, result) or
+    ruby_setter_def(this, _, result) or
+    ruby_singleton_class_def(this, _, result) or
+    ruby_singleton_method_def(this, _, _, result) or
+    ruby_splat_argument_def(this, _, result) or
+    ruby_splat_parameter_def(this, result) or
+    ruby_string_def(this, result) or
+    ruby_string_array_def(this, result) or
+    ruby_subshell_def(this, result) or
+    ruby_superclass_def(this, _, result) or
+    ruby_symbol_array_def(this, result) or
+    ruby_then_def(this, result) or
+    ruby_unary_def(this, _, _, result) or
+    ruby_undef_def(this, result) or
+    ruby_unless_def(this, _, result) or
+    ruby_unless_guard_def(this, _, result) or
+    ruby_unless_modifier_def(this, _, _, result) or
+    ruby_until_def(this, _, _, result) or
+    ruby_until_modifier_def(this, _, _, result) or
+    ruby_variable_reference_pattern_def(this, _, result) or
+    ruby_when_def(this, result) or
+    ruby_while_def(this, _, _, result) or
+    ruby_while_modifier_def(this, _, _, result) or
+    ruby_yield_def(this, result)
+  }
+}
+
+from RubyAstNode node, RubyAstNodeParent parent, int index, Location loc
+where parent = node.getParent(index) and loc = node.getLocation()
+select node, parent, index, loc

--- a/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/upgrade.properties
+++ b/ruby/ql/lib/upgrades/24d81950f3ab7e67e14553e1a5111a04e8ae8445/upgrade.properties
@@ -1,0 +1,116 @@
+description: Move location columns to a single table
+compatibility: full
+erb_ast_node_info.rel:    run erb_ast_node_info.qlo
+ruby_ast_node_info.rel:   run ruby_ast_node_info.qlo
+
+erb_ast_node_parent.rel:  delete
+ruby_ast_node_parent.rel: delete
+
+erb_tokeninfo.rel:        reorder erb_tokeninfo.rel                     (int id, int kind, string value, int loc) id kind value
+ruby_tokeninfo.rel:       reorder ruby_tokeninfo.rel                    (int id, int kind, string value, int loc) id kind value
+
+erb_comment_directive_def.rel:   reorder erb_comment_directive_def.rel  (int id, int child, int loc) id child
+erb_directive_def.rel:           reorder erb_directive_def.rel          (int id, int child, int loc) id child
+erb_graphql_directive_def.rel:   reorder erb_graphql_directive_def.rel  (int id, int child, int loc) id child
+erb_output_directive_def.rel:    reorder erb_output_directive_def.rel   (int id, int child, int loc) id child
+erb_template_def.rel:            reorder erb_template_def.rel           (int id, int loc) id
+
+ruby_alias_def.rel:                          reorder ruby_alias_def.rel                         (int id, int alias, int name, int loc) id alias name
+ruby_alternative_pattern_def.rel:            reorder ruby_alternative_pattern_def.rel           (int id, int loc) id
+ruby_argument_list_def.rel:                  reorder ruby_argument_list_def.rel                 (int id, int loc) id
+ruby_array_def.rel:                          reorder ruby_array_def.rel                         (int id, int loc) id
+ruby_array_pattern_def.rel:                  reorder ruby_array_pattern_def.rel                 (int id, int loc) id
+ruby_as_pattern_def.rel:                     reorder ruby_as_pattern_def.rel                    (int id, int name, int value, int loc) id name value
+ruby_assignment_def.rel:                     reorder ruby_assignment_def.rel                    (int id, int left, int right, int loc) id left right
+ruby_bare_string_def.rel:                    reorder ruby_bare_string_def.rel                   (int id, int loc) id
+ruby_bare_symbol_def.rel:                    reorder ruby_bare_symbol_def.rel                   (int id, int loc) id
+ruby_begin_def.rel:                          reorder ruby_begin_def.rel                         (int id, int loc) id
+ruby_begin_block_def.rel:                    reorder ruby_begin_block_def.rel                   (int id, int loc) id
+ruby_binary_def.rel:                         reorder ruby_binary_def.rel                        (int id, int left, int operator, int right, int loc) id left operator right
+ruby_block_def.rel:                          reorder ruby_block_def.rel                         (int id, int loc) id
+ruby_block_argument_def.rel:                 reorder ruby_block_argument_def.rel                (int id, int loc) id
+ruby_block_parameter_def.rel:                reorder ruby_block_parameter_def.rel               (int id, int loc) id
+ruby_block_parameters_def.rel:               reorder ruby_block_parameters_def.rel              (int id, int loc) id
+ruby_break_def.rel:                          reorder ruby_break_def.rel                         (int id, int loc) id
+ruby_call_def.rel:                           reorder ruby_call_def.rel                          (int id, int method, int loc) id method
+ruby_case_def.rel:                           reorder ruby_case_def.rel                          (int id, int loc) id
+ruby_case_match_def.rel:                     reorder ruby_case_match_def.rel                    (int id, int value, int loc) id value
+ruby_chained_string_def.rel:                 reorder ruby_chained_string_def.rel                (int id, int loc) id
+ruby_class_def.rel:                          reorder ruby_class_def.rel                         (int id, int name, int loc) id name
+ruby_conditional_def.rel:                    reorder ruby_conditional_def.rel                   (int id, int alternative, int condition, int consequence, int loc) id alternative condition consequence
+ruby_delimited_symbol_def.rel:               reorder ruby_delimited_symbol_def.rel              (int id, int loc) id
+ruby_destructured_left_assignment_def.rel:   reorder ruby_destructured_left_assignment_def.rel  (int id, int loc) id
+ruby_destructured_parameter_def.rel:         reorder ruby_destructured_parameter_def.rel        (int id, int loc) id
+ruby_do_def.rel:                             reorder ruby_do_def.rel                            (int id, int loc) id
+ruby_do_block_def.rel:                       reorder ruby_do_block_def.rel                      (int id, int loc) id
+ruby_element_reference_def.rel:              reorder ruby_element_reference_def.rel             (int id, int object, int loc) id object
+ruby_else_def.rel:                           reorder ruby_else_def.rel                          (int id, int loc) id
+ruby_elsif_def.rel:                          reorder ruby_elsif_def.rel                         (int id, int condition, int loc) id condition
+ruby_end_block_def.rel:                      reorder ruby_end_block_def.rel                     (int id, int loc) id
+ruby_ensure_def.rel:                         reorder ruby_ensure_def.rel                        (int id, int loc) id
+ruby_exception_variable_def.rel:             reorder ruby_exception_variable_def.rel            (int id, int child, int loc) id child
+ruby_exceptions_def.rel:                     reorder ruby_exceptions_def.rel                    (int id, int loc) id
+ruby_expression_reference_pattern_def.rel:   reorder ruby_expression_reference_pattern_def.rel  (int id, int value, int loc) id value
+ruby_find_pattern_def.rel:                   reorder ruby_find_pattern_def.rel                  (int id, int loc) id
+ruby_for_def.rel:                            reorder ruby_for_def.rel                           (int id, int body, int pattern, int value, int loc) id body pattern value
+ruby_hash_def.rel:                           reorder ruby_hash_def.rel                          (int id, int loc) id
+ruby_hash_pattern_def.rel:                   reorder ruby_hash_pattern_def.rel                  (int id, int loc) id
+ruby_hash_splat_argument_def.rel:            reorder ruby_hash_splat_argument_def.rel           (int id, int child, int loc) id child
+ruby_hash_splat_parameter_def.rel:           reorder ruby_hash_splat_parameter_def.rel          (int id, int loc) id
+ruby_heredoc_body_def.rel:                   reorder ruby_heredoc_body_def.rel                  (int id, int loc) id
+ruby_if_def.rel:                             reorder ruby_if_def.rel                            (int id, int condition, int loc) id condition
+ruby_if_guard_def.rel:                       reorder ruby_if_guard_def.rel                      (int id, int condition, int loc) id condition
+ruby_if_modifier_def.rel:                    reorder ruby_if_modifier_def.rel                   (int id, int body, int condition, int loc) id body condition
+ruby_in_def.rel:                             reorder ruby_in_def.rel                            (int id, int child, int loc) id child
+ruby_in_clause_def.rel:                      reorder ruby_in_clause_def.rel                     (int id, int pattern, int loc) id pattern
+ruby_interpolation_def.rel:                  reorder ruby_interpolation_def.rel                 (int id, int loc) id
+ruby_keyword_parameter_def.rel:              reorder ruby_keyword_parameter_def.rel             (int id, int name, int loc) id name
+ruby_keyword_pattern_def.rel:                reorder ruby_keyword_pattern_def.rel               (int id, int key__, int loc) id key__
+ruby_lambda_def.rel:                         reorder ruby_lambda_def.rel                        (int id, int body, int loc) id body
+ruby_lambda_parameters_def.rel:              reorder ruby_lambda_parameters_def.rel             (int id, int loc) id
+ruby_left_assignment_list_def.rel:           reorder ruby_left_assignment_list_def.rel          (int id, int loc) id
+ruby_method_def.rel:                         reorder ruby_method_def.rel                        (int id, int name, int loc) id name
+ruby_method_parameters_def.rel:              reorder ruby_method_parameters_def.rel             (int id, int loc) id
+ruby_module_def.rel:                         reorder ruby_module_def.rel                        (int id, int name, int loc) id name
+ruby_next_def.rel:                           reorder ruby_next_def.rel                          (int id, int loc) id
+ruby_operator_assignment_def.rel:            reorder ruby_operator_assignment_def.rel           (int id, int left, int operator, int right, int loc) id left operator right
+ruby_optional_parameter_def.rel:             reorder ruby_optional_parameter_def.rel            (int id, int name, int value, int loc) id name value
+ruby_pair_def.rel:                           reorder ruby_pair_def.rel                          (int id, int key__, int loc) id key__
+ruby_parenthesized_pattern_def.rel:          reorder ruby_parenthesized_pattern_def.rel         (int id, int child, int loc) id child
+ruby_parenthesized_statements_def.rel:       reorder ruby_parenthesized_statements_def.rel      (int id, int loc) id
+ruby_pattern_def.rel:                        reorder ruby_pattern_def.rel                       (int id, int child, int loc) id child
+ruby_program_def.rel:                        reorder ruby_program_def.rel                       (int id, int loc) id
+ruby_range_def.rel:                          reorder ruby_range_def.rel                         (int id, int operator, int loc) id operator
+ruby_rational_def.rel:                       reorder ruby_rational_def.rel                      (int id, int child, int loc) id child
+ruby_redo_def.rel:                           reorder ruby_redo_def.rel                          (int id, int loc) id
+ruby_regex_def.rel:                          reorder ruby_regex_def.rel                         (int id, int loc) id
+ruby_rescue_def.rel:                         reorder ruby_rescue_def.rel                        (int id, int loc) id
+ruby_rescue_modifier_def.rel:                reorder ruby_rescue_modifier_def.rel               (int id, int body, int handler, int loc) id body handler
+ruby_rest_assignment_def.rel:                reorder ruby_rest_assignment_def.rel               (int id, int loc) id
+ruby_retry_def.rel:                          reorder ruby_retry_def.rel                         (int id, int loc) id
+ruby_return_def.rel:                         reorder ruby_return_def.rel                        (int id, int loc) id
+ruby_right_assignment_list_def.rel:          reorder ruby_right_assignment_list_def.rel         (int id, int loc) id
+ruby_scope_resolution_def.rel:               reorder ruby_scope_resolution_def.rel              (int id, int name, int loc) id name
+ruby_setter_def.rel:                         reorder ruby_setter_def.rel                        (int id, int name, int loc) id name
+ruby_singleton_class_def.rel:                reorder ruby_singleton_class_def.rel               (int id, int value, int loc) id value
+ruby_singleton_method_def.rel:               reorder ruby_singleton_method_def.rel              (int id, int name, int object, int loc) id name object
+ruby_splat_argument_def.rel:                 reorder ruby_splat_argument_def.rel                (int id, int child, int loc) id child
+ruby_splat_parameter_def.rel:                reorder ruby_splat_parameter_def.rel               (int id, int loc) id
+ruby_string_def.rel:                         reorder ruby_string_def.rel                        (int id, int loc) id
+ruby_string_array_def.rel:                   reorder ruby_string_array_def.rel                  (int id, int loc) id
+ruby_subshell_def.rel:                       reorder ruby_subshell_def.rel                      (int id, int loc) id
+ruby_superclass_def.rel:                     reorder ruby_superclass_def.rel                    (int id, int child, int loc) id child
+ruby_symbol_array_def.rel:                   reorder ruby_symbol_array_def.rel                  (int id, int loc) id
+ruby_then_def.rel:                           reorder ruby_then_def.rel                          (int id, int loc) id
+ruby_unary_def.rel:                          reorder ruby_unary_def.rel                         (int id, int operand, int operator, int loc) id operand operator
+ruby_undef_def.rel:                          reorder ruby_undef_def.rel                         (int id, int loc) id
+ruby_unless_def.rel:                         reorder ruby_unless_def.rel                        (int id, int condition, int loc) id condition
+ruby_unless_guard_def.rel:                   reorder ruby_unless_guard_def.rel                  (int id, int condition, int loc) id condition
+ruby_unless_modifier_def.rel:                reorder ruby_unless_modifier_def.rel               (int id, int body, int condition, int loc) id body condition
+ruby_until_def.rel:                          reorder ruby_until_def.rel                         (int id, int body, int condition, int loc) id body condition
+ruby_until_modifier_def.rel:                 reorder ruby_until_modifier_def.rel                (int id, int body, int condition, int loc) id body condition
+ruby_variable_reference_pattern_def.rel:     reorder ruby_variable_reference_pattern_def.rel    (int id, int name, int loc) id name
+ruby_when_def.rel:                           reorder ruby_when_def.rel                          (int id, int loc) id
+ruby_while_def.rel:                          reorder ruby_while_def.rel                         (int id, int body, int condition, int loc) id body condition
+ruby_while_modifier_def.rel:                 reorder ruby_while_modifier_def.rel                (int id, int body, int condition, int loc) id body condition
+ruby_yield_def.rel:                          reorder ruby_yield_def.rel                         (int id, int loc) id


### PR DESCRIPTION
This should make `getLocation()` on generated nodes faster.

I generated the upgrade/downgrade scripts with some quick hacks to the generator program, and only hand-edited the results for formatting. That means reviewers should feel confident that, for the upgrades/downgrades, they only need to check:
- `{ruby,erb}_ast_node_parent` <-> `{ruby,erb}_ast_node_info` upgrades/downgrades.
- `{ruby,erb}_tokeninfo` modifications
- and just a small sample of the `*_def` table modifications.

I tested them by:
1. Running all the qltests with `--search-path=main-extractor-pack:ql` so that they would use an extractor from `main` and upgrade the dbs on the fly.
2. Building a large Ruby database with an extractor from `main`, upgrading it, then downgrading it, and checking that all the relations in the original and downgraded databases were byte-for-byte identical.