### PR TITLE
JS: recognize more startswith sanitizers for path-injection queries

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -513,12 +513,23 @@ module TaintedPath {
 
     override predicate blocks(boolean outcome, Expr e) {
       member = "relative" and
-      e = pathCall.getArgument(1).asExpr() and
+      e = maybeGetJoinArg(pathCall.getArgument(1)).asExpr() and
       outcome = startsWith.getPolarity().booleanNot()
       or
       not member = "relative" and
-      e = pathCall.getArgument(0).asExpr() and
+      e = maybeGetJoinArg(pathCall.getArgument(0)).asExpr() and
       outcome = startsWith.getPolarity()
+    }
+
+    bindingset[e]
+    private DataFlow::Node maybeGetJoinArg(DataFlow::Node e) {
+      exists(DataFlow::CallNode call |
+        call = NodeJSLib::Path::moduleMember("join").getACall() and e = call
+      |
+        result = call.getLastArgument()
+      )
+      or
+      result = e
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -513,16 +513,21 @@ module TaintedPath {
 
     override predicate blocks(boolean outcome, Expr e) {
       member = "relative" and
-      e = maybeGetJoinArg(pathCall.getArgument(1)).asExpr() and
+      e = maybeGetPathSuffix(pathCall.getArgument(1)).asExpr() and
       outcome = startsWith.getPolarity().booleanNot()
       or
       not member = "relative" and
-      e = maybeGetJoinArg(pathCall.getArgument(0)).asExpr() and
+      e = maybeGetPathSuffix(pathCall.getArgument(0)).asExpr() and
       outcome = startsWith.getPolarity()
     }
 
+    /**
+     * Gets the last argument to the given `path.join()` call,
+     * or the node itself if it is not a join call.
+     * Is used to get the suffix of the path.
+     */
     bindingset[e]
-    private DataFlow::Node maybeGetJoinArg(DataFlow::Node e) {
+    private DataFlow::Node maybeGetPathSuffix(DataFlow::Node e) {
       exists(DataFlow::CallNode call |
         call = NodeJSLib::Path::moduleMember("join").getACall() and e = call
       |

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -513,11 +513,11 @@ module TaintedPath {
 
     override predicate blocks(boolean outcome, Expr e) {
       member = "relative" and
-      e = maybeGetPathSuffix(pathCall.getArgument(1)).asExpr() and
+      e = this.maybeGetPathSuffix(pathCall.getArgument(1)).asExpr() and
       outcome = startsWith.getPolarity().booleanNot()
       or
       not member = "relative" and
-      e = maybeGetPathSuffix(pathCall.getArgument(0)).asExpr() and
+      e = this.maybeGetPathSuffix(pathCall.getArgument(0)).asExpr() and
       outcome = startsWith.getPolarity()
     }
 

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
@@ -45,18 +45,18 @@ nodes
 | ZipSlipBad.js:23:28:23:35 | fileName |
 | ZipSlipBad.js:23:28:23:35 | fileName |
 | ZipSlipBad.js:23:28:23:35 | fileName |
-| ZipSlipBad.js:29:14:29:17 | name |
-| ZipSlipBad.js:29:14:29:17 | name |
-| ZipSlipBad.js:29:14:29:17 | name |
-| ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name |
-| ZipSlipBad.js:33:16:33:19 | name |
-| ZipSlipBad.js:33:16:33:19 | name |
-| ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name |
+| ZipSlipBad.js:30:14:30:17 | name |
+| ZipSlipBad.js:30:14:30:17 | name |
+| ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name |
+| ZipSlipBad.js:34:16:34:19 | name |
+| ZipSlipBad.js:34:16:34:19 | name |
+| ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:35:26:35:29 | name |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
 | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path |
@@ -103,20 +103,20 @@ edges
 | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:22:11:22:31 | fileName |
 | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:22:11:22:31 | fileName |
 | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:22:11:22:31 | fileName |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
-| ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
+| ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
@@ -133,6 +133,6 @@ edges
 | ZipSlipBad.js:8:37:8:44 | fileName | ZipSlipBad.js:7:22:7:31 | entry.path | ZipSlipBad.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:7:22:7:31 | entry.path | item path |
 | ZipSlipBad.js:16:30:16:37 | fileName | ZipSlipBad.js:15:22:15:31 | entry.path | ZipSlipBad.js:16:30:16:37 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:15:22:15:31 | entry.path | item path |
 | ZipSlipBad.js:23:28:23:35 | fileName | ZipSlipBad.js:22:22:22:31 | entry.path | ZipSlipBad.js:23:28:23:35 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:22:22:22:31 | entry.path | item path |
-| ZipSlipBad.js:30:26:30:29 | name | ZipSlipBad.js:29:14:29:17 | name | ZipSlipBad.js:30:26:30:29 | name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:29:14:29:17 | name | item path |
-| ZipSlipBad.js:34:26:34:29 | name | ZipSlipBad.js:33:16:33:19 | name | ZipSlipBad.js:34:26:34:29 | name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:33:16:33:19 | name | item path |
+| ZipSlipBad.js:31:26:31:29 | name | ZipSlipBad.js:30:14:30:17 | name | ZipSlipBad.js:31:26:31:29 | name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:30:14:30:17 | name | item path |
+| ZipSlipBad.js:35:26:35:29 | name | ZipSlipBad.js:34:16:34:19 | name | ZipSlipBad.js:35:26:35:29 | name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:34:16:34:19 | name | item path |
 | ZipSlipBadUnzipper.js:8:37:8:44 | fileName | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | ZipSlipBadUnzipper.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | item path |

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlipBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlipBad.js
@@ -25,6 +25,7 @@ fs.createReadStream('archive.zip')
 
 const JSZip = require('jszip');
 const zip = new JSZip();
+const path = require('path');
 function doZipSlip() {
   for (const name in zip.files) {
     fs.createWriteStream(name);
@@ -33,4 +34,22 @@ function doZipSlip() {
   zip.forEach((name, file) => {
     fs.createWriteStream(name);
   });
+
+  const extractTo = path.resolve("/some/path/to/extract/to");
+  var files = [];
+
+  for (var name in zip.files) {
+    var entry = zip.files[name];
+
+    var targetPath = path.resolve(
+      path.join(extractTo, name)
+    );
+    if (!targetPath.startsWith(extractTo)) {
+      throw new Error("Entry is outside the extraction path");
+    }
+    files.push(name);
+  }
+  for (const file of files) {
+    fs.createWriteStream(path.join(extractTo, file)); // OK
+  }
 }


### PR DESCRIPTION
Gets a TN for CVE-2021-23484 

[An evaluation seems clean](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-7876-ca5f91e__nightly__CustomSuite/reports).  