### PR TITLE
CPP: Fix performance for cpp/cleartext-transmission

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -168,15 +168,11 @@ class NetworkRecv extends NetworkSendRecv {
   override Recv target;
 }
 
-predicate encryptionFunction(Function f)
-{
-  f.getName()
-  .toLowerCase()
-  .regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
+predicate encryptionFunction(Function f) {
+  f.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
 }
 
-predicate encryptionType(UserType t)
-{
+predicate encryptionType(UserType t) {
   t.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -175,7 +175,7 @@ predicate encryptionFunction(Function f)
   .regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
 }
 
-predicate encryptionType(Type t)
+predicate encryptionType(UserType t)
 {
   t.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
 }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -168,10 +168,12 @@ class NetworkRecv extends NetworkSendRecv {
   override Recv target;
 }
 
+pragma[noinline]
 predicate encryptionFunction(Function f) {
   f.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
 }
 
+pragma[noinline]
 predicate encryptionType(UserType t) {
   t.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
 }

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -168,6 +168,18 @@ class NetworkRecv extends NetworkSendRecv {
   override Recv target;
 }
 
+predicate encryptionFunction(Function f)
+{
+  f.getName()
+  .toLowerCase()
+  .regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
+}
+
+predicate encryptionType(Type t)
+{
+  t.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
+}
+
 /**
  * An expression that is an argument or return value from an encryption /
  * decryption call. This is quite inclusive to minimize false positives, for
@@ -177,10 +189,7 @@ class NetworkRecv extends NetworkSendRecv {
 class Encrypted extends Expr {
   Encrypted() {
     exists(FunctionCall fc |
-      fc.getTarget()
-          .getName()
-          .toLowerCase()
-          .regexpMatch(".*(crypt|encode|decode|hash|securezero).*") and
+      encryptionFunction(fc.getTarget()) and
       (
         this = fc or
         this = fc.getAnArgument()
@@ -189,7 +198,7 @@ class Encrypted extends Expr {
     or
     exists(Type t |
       this.getType().refersTo(t) and
-      t.getName().toLowerCase().regexpMatch(".*(crypt|encode|decode|hash|securezero).*")
+      encryptionType(t)
     )
   }
 }


### PR DESCRIPTION
There was a moderate performance explosion on some projects (such as `nlohmann__json`), caused by the `Encrypted` class.  Tested locally, DCA run to follow.