### PR TITLE
JS: Add a `isNaN` sanitizer, and use it in queries that already had a typeof check

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -1179,6 +1179,17 @@ module TaintTracking {
         parse = isNaN.getArgument(0) and
         operand = parse.getArgument(0).asExpr()
       )
+      or
+      exists(UnaryExpr unary | unary.getOperator() = ["+", "-"] |
+        unary = isNaN.getArgument(0).asExpr() and
+        operand = unary.getOperand()
+      )
+      or
+      exists(BinaryExpr bin | bin.getOperator() = ["+", "-"] |
+        bin = isNaN.getArgument(0).asExpr() and
+        operand = bin.getAnOperand() and
+        bin.getAnOperand() instanceof NumberLiteral
+      )
     )
     or
     isTypeofGuard(guard.asExpr(), operand, "number") and

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -1166,6 +1166,25 @@ module TaintTracking {
     )
   }
 
+  /** Holds if `guard` is a test that checks if `operand` is a number. */
+  predicate isNumberGuard(DataFlow::Node guard, Expr operand, boolean polarity) {
+    exists(DataFlow::CallNode isNaN |
+      isNaN = DataFlow::globalVarRef("isNaN").getACall() and guard = isNaN and polarity = false
+    |
+      operand = isNaN.getArgument(0).asExpr()
+      or
+      exists(DataFlow::CallNode parse |
+        parse = DataFlow::globalVarRef(["parseInt", "parseFloat"]).getACall()
+      |
+        parse = isNaN.getArgument(0) and
+        operand = parse.getArgument(0).asExpr()
+      )
+    )
+    or
+    isTypeofGuard(guard.asExpr(), operand, "number") and
+    polarity = guard.asExpr().(EqualityTest).getPolarity()
+  }
+
   /** DEPRECATED. This class has been renamed to `MembershipTestSanitizer`. */
   deprecated class StringInclusionSanitizer = MembershipTestSanitizer;
 

--- a/javascript/ql/lib/semmle/javascript/security/TaintedObject.qll
+++ b/javascript/ql/lib/semmle/javascript/security/TaintedObject.qll
@@ -110,6 +110,16 @@ module TaintedObject {
     }
   }
 
+  /** A guard that checks whether `x` is a number. */
+  class NumberGuard extends SanitizerGuard instanceof DataFlow::CallNode {
+    Expr x;
+    boolean polarity;
+
+    NumberGuard() { TaintTracking::isNumberGuard(this, x, polarity) }
+
+    override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = polarity }
+  }
+
   /**
    * A sanitizer guard that validates an input against a JSON schema.
    */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentQuery.qll
@@ -122,6 +122,7 @@ class Configuration extends TaintTracking::Configuration {
     guard instanceof InstanceofCheck or
     guard instanceof IsArrayCheck or
     guard instanceof TypeofCheck or
+    guard instanceof NumberGuard or
     guard instanceof EqualityCheck or
     guard instanceof IncludesCheck
   }
@@ -226,6 +227,16 @@ private class TypeofCheck extends TaintTracking::LabeledSanitizerGuardNode, Data
     e = operand and
     label instanceof ObjectPrototype
   }
+}
+
+/** A guard that checks whether `x` is a number. */
+class NumberGuard extends TaintTracking::SanitizerGuardNode instanceof DataFlow::CallNode {
+  Expr x;
+  boolean polarity;
+
+  NumberGuard() { TaintTracking::isNumberGuard(this, x, polarity) }
+
+  override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = polarity }
 }
 
 /** A call to `Array.isArray`, which is false for `Object.prototype`. */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginCustomizations.qll
@@ -153,6 +153,16 @@ module UnsafeJQueryPlugin {
     }
   }
 
+  /** A guard that checks whether `x` is a number. */
+  class NumberGuard extends TaintTracking::SanitizerGuardNode instanceof DataFlow::CallNode {
+    Expr x;
+    boolean polarity;
+
+    NumberGuard() { TaintTracking::isNumberGuard(this, x, polarity) }
+
+    override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = polarity }
+  }
+
   /**
    * The client-provided options object for a jQuery plugin, considered as a source for unsafe jQuery plugins.
    */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeJQueryPluginQuery.qll
@@ -46,7 +46,8 @@ class Configuration extends TaintTracking::Configuration {
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode node) {
     super.isSanitizerGuard(node) or
     node instanceof IsElementSanitizer or
-    node instanceof PropertyPresenceSanitizer
+    node instanceof PropertyPresenceSanitizer or
+    node instanceof NumberGuard
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
@@ -286,6 +286,29 @@ module UnsafeShellCommandConstruction {
     }
   }
 
+  /**
+   * A guard of the form `isNaN(x)`, which sanitizes `x` in its "else" branch.
+   */
+  class NaNGuard extends TaintTracking::SanitizerGuardNode instanceof DataFlow::CallNode {
+    Expr x;
+
+    NaNGuard() {
+      this = DataFlow::globalVarRef("isNaN").getACall() and
+      (
+        x = this.getArgument(0).asExpr()
+        or
+        exists(DataFlow::CallNode parse |
+          parse = DataFlow::globalVarRef(["parseInt", "parseFloat"]).getACall()
+        |
+          parse = this.getArgument(0) and
+          x = parse.getArgument(0).asExpr()
+        )
+      )
+    }
+
+    override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = false }
+  }
+
   private import semmle.javascript.dataflow.internal.AccessPaths
   private import semmle.javascript.dataflow.InferredTypes
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionCustomizations.qll
@@ -286,27 +286,14 @@ module UnsafeShellCommandConstruction {
     }
   }
 
-  /**
-   * A guard of the form `isNaN(x)`, which sanitizes `x` in its "else" branch.
-   */
-  class NaNGuard extends TaintTracking::SanitizerGuardNode instanceof DataFlow::CallNode {
+  /** A guard that checks whether `x` is a number. */
+  class NumberGuard extends TaintTracking::SanitizerGuardNode instanceof DataFlow::CallNode {
     Expr x;
+    boolean polarity;
 
-    NaNGuard() {
-      this = DataFlow::globalVarRef("isNaN").getACall() and
-      (
-        x = this.getArgument(0).asExpr()
-        or
-        exists(DataFlow::CallNode parse |
-          parse = DataFlow::globalVarRef(["parseInt", "parseFloat"]).getACall()
-        |
-          parse = this.getArgument(0) and
-          x = parse.getArgument(0).asExpr()
-        )
-      )
-    }
+    NumberGuard() { TaintTracking::isNumberGuard(this, x, polarity) }
 
-    override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = false }
+    override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = polarity }
   }
 
   private import semmle.javascript.dataflow.internal.AccessPaths

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionQuery.qll
@@ -25,7 +25,7 @@ class Configuration extends TaintTracking::Configuration {
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
     guard instanceof PathExistsSanitizerGuard or
     guard instanceof TaintTracking::AdHocWhitelistCheckSanitizer or
-    guard instanceof NaNGuard or
+    guard instanceof NumberGuard or
     guard instanceof TypeOfSanitizer
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeShellCommandConstructionQuery.qll
@@ -24,7 +24,9 @@ class Configuration extends TaintTracking::Configuration {
 
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
     guard instanceof PathExistsSanitizerGuard or
-    guard instanceof TaintTracking::AdHocWhitelistCheckSanitizer
+    guard instanceof TaintTracking::AdHocWhitelistCheckSanitizer or
+    guard instanceof NaNGuard or
+    guard instanceof TypeOfSanitizer
   }
 
   // override to require that there is a path without unmatched return steps

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCallCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCallCustomizations.qll
@@ -108,4 +108,14 @@ module UnvalidatedDynamicMethodCall {
       label instanceof MaybeNonFunction
     }
   }
+
+  /** A guard that checks whether `x` is a number. */
+  class NumberGuard extends TaintTracking::SanitizerGuardNode instanceof DataFlow::CallNode {
+    Expr x;
+    boolean polarity;
+
+    NumberGuard() { TaintTracking::isNumberGuard(this, x, polarity) }
+
+    override predicate sanitizes(boolean outcome, Expr e) { e = x and outcome = polarity }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCallQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnvalidatedDynamicMethodCallQuery.qll
@@ -40,6 +40,11 @@ class Configuration extends TaintTracking::Configuration {
 
   override predicate isSanitizer(DataFlow::Node nd) { super.isSanitizer(nd) }
 
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
+    guard instanceof NumberGuard or
+    guard instanceof FunctionCheck
+  }
+
   override predicate isAdditionalFlowStep(
     DataFlow::Node src, DataFlow::Node dst, DataFlow::FlowLabel srclabel,
     DataFlow::FlowLabel dstlabel

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomQuery.qll
@@ -28,6 +28,7 @@ class Configuration extends TaintTracking::Configuration {
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
     guard instanceof TypeTestGuard or
     guard instanceof UnsafeJQuery::PropertyPresenceSanitizer or
+    guard instanceof UnsafeJQuery::NumberGuard or
     guard instanceof DomBasedXss::SanitizerGuard
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -262,6 +262,16 @@ nodes
 | lib/lib.js:513:23:513:26 | name |
 | lib/lib.js:519:23:519:26 | name |
 | lib/lib.js:519:23:519:26 | name |
+| lib/lib.js:525:23:525:26 | name |
+| lib/lib.js:525:23:525:26 | name |
+| lib/lib.js:531:23:531:26 | name |
+| lib/lib.js:531:23:531:26 | name |
+| lib/lib.js:537:23:537:26 | name |
+| lib/lib.js:537:23:537:26 | name |
+| lib/lib.js:543:23:543:26 | name |
+| lib/lib.js:543:23:543:26 | name |
+| lib/lib.js:545:23:545:26 | name |
+| lib/lib.js:545:23:545:26 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -594,6 +604,26 @@ edges
 | lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
 | lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
 | lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:525:23:525:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:525:23:525:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:525:23:525:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:525:23:525:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:531:23:531:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:531:23:531:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:531:23:531:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:531:23:531:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:537:23:537:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:537:23:537:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:537:23:537:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:537:23:537:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:543:23:543:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:543:23:543:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:543:23:543:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:543:23:543:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -689,6 +719,11 @@ edges
 | lib/lib.js:510:10:510:25 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:510:22:510:25 | name | $@ based on $@ is later used in $@. | lib/lib.js:510:10:510:25 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:510:2:510:26 | cp.exec ... + name) | shell command |
 | lib/lib.js:513:11:513:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:513:23:513:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:513:11:513:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:513:3:513:27 | cp.exec ... + name) | shell command |
 | lib/lib.js:519:11:519:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:519:11:519:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:519:3:519:27 | cp.exec ... + name) | shell command |
+| lib/lib.js:525:11:525:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:525:23:525:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:525:11:525:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:525:3:525:27 | cp.exec ... + name) | shell command |
+| lib/lib.js:531:11:531:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:531:23:531:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:531:11:531:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:531:3:531:27 | cp.exec ... + name) | shell command |
+| lib/lib.js:537:11:537:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:537:23:537:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:537:11:537:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:537:3:537:27 | cp.exec ... + name) | shell command |
+| lib/lib.js:543:11:543:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:543:23:543:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:543:11:543:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:543:3:543:27 | cp.exec ... + name) | shell command |
+| lib/lib.js:545:11:545:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:545:11:545:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:545:3:545:27 | cp.exec ... + name) | shell command |
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | $@ based on $@ is later used in $@. | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | String concatenation | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -254,6 +254,14 @@ nodes
 | lib/lib.js:498:45:498:48 | name |
 | lib/lib.js:499:31:499:34 | name |
 | lib/lib.js:499:31:499:34 | name |
+| lib/lib.js:509:39:509:42 | name |
+| lib/lib.js:509:39:509:42 | name |
+| lib/lib.js:510:22:510:25 | name |
+| lib/lib.js:510:22:510:25 | name |
+| lib/lib.js:513:23:513:26 | name |
+| lib/lib.js:513:23:513:26 | name |
+| lib/lib.js:519:23:519:26 | name |
+| lib/lib.js:519:23:519:26 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name |
 | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -574,6 +582,18 @@ edges
 | lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
 | lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
 | lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:510:22:510:25 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:510:22:510:25 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:510:22:510:25 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:510:22:510:25 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:513:23:513:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:513:23:513:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:513:23:513:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:513:23:513:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
+| lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
 | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name |
@@ -666,6 +686,9 @@ edges
 | lib/lib.js:478:27:478:46 | config.installedPath | lib/lib.js:477:33:477:38 | config | lib/lib.js:478:27:478:46 | config.installedPath | $@ based on $@ is later used in $@. | lib/lib.js:478:27:478:46 | config.installedPath | Path concatenation | lib/lib.js:477:33:477:38 | config | library input | lib/lib.js:479:12:479:20 | exec(cmd) | shell command |
 | lib/lib.js:483:13:483:33 | ' my na ...  + name | lib/lib.js:482:40:482:43 | name | lib/lib.js:483:30:483:33 | name | $@ based on $@ is later used in $@. | lib/lib.js:483:13:483:33 | ' my na ...  + name | String concatenation | lib/lib.js:482:40:482:43 | name | library input | lib/lib.js:485:2:485:20 | cp.exec(cmd + args) | shell command |
 | lib/lib.js:499:19:499:34 | "rm -rf " + name | lib/lib.js:498:45:498:48 | name | lib/lib.js:499:31:499:34 | name | $@ based on $@ is later used in $@. | lib/lib.js:499:19:499:34 | "rm -rf " + name | String concatenation | lib/lib.js:498:45:498:48 | name | library input | lib/lib.js:499:3:499:35 | MyThing ... + name) | shell command |
+| lib/lib.js:510:10:510:25 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:510:22:510:25 | name | $@ based on $@ is later used in $@. | lib/lib.js:510:10:510:25 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:510:2:510:26 | cp.exec ... + name) | shell command |
+| lib/lib.js:513:11:513:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:513:23:513:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:513:11:513:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:513:3:513:27 | cp.exec ... + name) | shell command |
+| lib/lib.js:519:11:519:26 | "rm -rf " + name | lib/lib.js:509:39:509:42 | name | lib/lib.js:519:23:519:26 | name | $@ based on $@ is later used in $@. | lib/lib.js:519:11:519:26 | "rm -rf " + name | String concatenation | lib/lib.js:509:39:509:42 | name | library input | lib/lib.js:519:3:519:27 | cp.exec ... + name) | shell command |
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | $@ based on $@ is later used in $@. | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | String concatenation | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -505,3 +505,19 @@ var imp = require('./isImported');
 for (var name in imp){
   module.exports[name] = imp[name];
 }
+
+module.exports.sanitizer4 = function (name) {
+	cp.exec("rm -rf " + name); // NOT OK
+
+	if (isNaN(name)) {
+		cp.exec("rm -rf " + name); // NOT OK
+	} else {
+		cp.exec("rm -rf " + name); // OK
+	}
+
+	if (isNaN(parseInt(name))) {
+		cp.exec("rm -rf " + name); // NOT OK
+	} else {
+		cp.exec("rm -rf " + name); // OK
+	}
+}

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -520,4 +520,28 @@ module.exports.sanitizer4 = function (name) {
 	} else {
 		cp.exec("rm -rf " + name); // OK
 	}
+
+	if (isNaN(+name)) {
+		cp.exec("rm -rf " + name); // NOT OK
+	} else {
+		cp.exec("rm -rf " + name); // OK
+	}
+
+	if (isNaN(parseInt(name, 10))) {
+		cp.exec("rm -rf " + name); // NOT OK
+	} else {
+		cp.exec("rm -rf " + name); // OK
+	}
+
+	if (isNaN(name - 0)) {
+		cp.exec("rm -rf " + name); // NOT OK
+	} else {
+		cp.exec("rm -rf " + name); // OK
+	}
+
+	if (isNaN(name | 0)) { // <- not a sanitizer
+		cp.exec("rm -rf " + name); // NOT OK
+	} else {
+		cp.exec("rm -rf " + name); // NOT OK
+	}
 }


### PR DESCRIPTION
Gets a TN for CVE-2021-45459 

[Evaluation looks clean](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/nanSan__nightly__security-extend/reports) (ignore the backrefs).  

In `UnsafeShellCommandConstructionQuery.qll` and `UnvalidatedDynamicMethodCallQuery.qll` I also added a missing sanitizierGuard to the `isSanitizerGuard` predicate.  