### PR TITLE
Python: Normalise string prefixes

### DIFF
--- a/python/ql/test/3/library-tests/locations/general/Prefix.expected
+++ b/python/ql/test/3/library-tests/locations/general/Prefix.expected
@@ -6,7 +6,7 @@
 | 66 | \nSingle quotes string | ''' |
 | 69 | \nDouble-quotes\nstring | """ |
 | 73 | \nBytes\n | r''' |
-| 77 | \nRaw\nUnicode\n | U""" |
+| 77 | \nRaw\nUnicode\n | u""" |
 | 101 |   | " |
 | 101 | Hello | " |
 | 101 | world | " |


### PR DESCRIPTION
This is the external part of a change to the extractor that normalises the `UBRF` prefix characters to their lower-case parts.

This PR is expected to fail. Please see the internal PR for the successful test run.