### PR TITLE
JS: convert more type-trackers to API-graphs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
@@ -6,27 +6,15 @@ import javascript
 private import semmle.javascript.security.dataflow.Xss as Xss
 
 module Cheerio {
-  /**
-   * A reference to the `cheerio` function, possibly with a loaded DOM.
-   */
-  private DataFlow::SourceNode cheerioRef(DataFlow::TypeTracker t) {
-    t.start() and
-    (
-      result = DataFlow::moduleImport("cheerio")
-      or
-      exists(string name | result = cheerioRef().getAMemberCall(name) |
-        name = "load" or
-        name = "parseHTML"
-      )
-    )
+  /** A reference to the `cheerio` function, possibly with a loaded DOM. */
+  private API::Node cheerioApi() {
+    result = API::moduleImport("cheerio")
     or
-    exists(DataFlow::TypeTracker t2 | result = cheerioRef(t2).track(t2, t))
+    result = cheerioApi().getMember(["load", "parseHTML"]).getReturn()
   }
 
-  /**
-   * A reference to the `cheerio` function, possibly with a loaded DOM.
-   */
-  DataFlow::SourceNode cheerioRef() { result = cheerioRef(DataFlow::TypeTracker::end()) }
+  /** A reference to the `cheerio` function, possibly with a loaded DOM. */
+  DataFlow::SourceNode cheerioRef() { result = cheerioApi().getAUse() }
 
   /**
    * A creation of `cheerio` object, a collection of virtual DOM elements
@@ -43,9 +31,9 @@ module Cheerio {
 
     private class DefaultRange extends Range {
       DefaultRange() {
-        this = cheerioRef().getACall()
+        this = cheerioApi().getACall()
         or
-        this = cheerioRef().getAMethodCall()
+        this = cheerioApi().getAMember().getACall()
       }
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Electron.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Electron.qll
@@ -56,18 +56,13 @@ module Electron {
     }
   }
 
-  private DataFlow::SourceNode browserObject(DataFlow::TypeTracker t) {
-    t.start() and
-    result instanceof NewBrowserObject
-    or
-    exists(DataFlow::TypeTracker t2 | result = browserObject(t2).track(t2, t))
-  }
+  private API::Node browserObject() { result.getAnImmediateUse() instanceof NewBrowserObject }
 
   /**
    * A data flow node whose value may originate from a browser object instantiation.
    */
   private class BrowserObjectByFlow extends BrowserObject {
-    BrowserObjectByFlow() { browserObject(DataFlow::TypeTracker::end()).flowsTo(this) }
+    BrowserObjectByFlow() { browserObject().getAUse() = this }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Files.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Files.qll
@@ -76,72 +76,47 @@ private class GlobFileNameSource extends FileNameSource {
 
 /**
  * Gets a file name or an array of file names from the `globby` library.
- * The predicate uses type-tracking. However, type-tracking is only used to track a step out of a promise.
  */
-private DataFlow::SourceNode globbyFileNameSource(DataFlow::TypeTracker t) {
-  exists(string moduleName | moduleName = "globby" |
-    // `require('globby').sync(_)`
-    t.start() and
-    result = DataFlow::moduleMember(moduleName, "sync").getACall()
-    or
-    // `files` in `require('globby')(_).then(files => ...)`
-    t.startInPromise() and
-    result = DataFlow::moduleImport(moduleName).getACall()
-  )
+private API::Node globbyFileNameSource() {
+  // `require('globby').sync(_)`
+  result = API::moduleImport("globby").getMember("sync").getReturn()
   or
-  // Tracking out of a promise
-  exists(DataFlow::TypeTracker t2 |
-    result = PromiseTypeTracking::promiseStep(globbyFileNameSource(t2), t, t2)
-  )
+  // `files` in `require('globby')(_).then(files => ...)`
+  result = API::moduleImport("globby").getReturn().getPromised()
 }
 
 /**
  * A file name or an array of file names from the `globby` library.
  */
 private class GlobbyFileNameSource extends FileNameSource {
-  GlobbyFileNameSource() { this = globbyFileNameSource(DataFlow::TypeTracker::end()) }
+  GlobbyFileNameSource() { this = globbyFileNameSource().getAnImmediateUse() }
 }
 
-/**
- * Gets a file name or an array of file names from the `fast-glob` library.
- * The predicate uses type-tracking. However, type-tracking is only used to track a step out of a promise.
- */
-private DataFlow::Node fastGlobFileNameSource(DataFlow::TypeTracker t) {
-  exists(string moduleName | moduleName = "fast-glob" |
-    // `require('fast-glob').sync(_)
-    t.start() and result = DataFlow::moduleMember(moduleName, "sync").getACall()
-    or
-    exists(DataFlow::SourceNode f |
-      f = DataFlow::moduleImport(moduleName)
-      or
-      f = DataFlow::moduleMember(moduleName, "async")
-    |
-      // `files` in `require('fast-glob')(_).then(files => ...)` and
-      // `files` in `require('fast-glob').async(_).then(files => ...)`
-      t.startInPromise() and result = f.getACall()
-    )
-    or
-    // `file` in `require('fast-glob').stream(_).on(_,  file => ...)`
-    t.start() and
-    result =
-      DataFlow::moduleMember(moduleName, "stream")
-          .getACall()
-          .getAMethodCall(EventEmitter::on())
-          .getCallback(1)
-          .getParameter(0)
+/** Gets a file name or an array of file names from the `fast-glob` library. */
+private API::Node fastGlobFileName() {
+  // `require('fast-glob').sync(_)
+  result = API::moduleImport("fast-glob").getMember("sync").getReturn()
+  or
+  exists(API::Node base |
+    base = [API::moduleImport("fast-glob"), API::moduleImport("fast-glob").getMember("async")]
+  |
+    result = base.getReturn().getPromised()
   )
   or
-  // Tracking out of a promise
-  exists(DataFlow::TypeTracker t2 |
-    result = PromiseTypeTracking::promiseStep(fastGlobFileNameSource(t2), t, t2)
-  )
+  result =
+    API::moduleImport("fast-glob")
+        .getMember("stream")
+        .getReturn()
+        .getMember(EventEmitter::on())
+        .getParameter(1)
+        .getParameter(0)
 }
 
 /**
  * A file name or an array of file names from the `fast-glob` library.
  */
 private class FastGlobFileNameSource extends FileNameSource {
-  FastGlobFileNameSource() { this = fastGlobFileNameSource(DataFlow::TypeTracker::end()) }
+  FastGlobFileNameSource() { this = fastGlobFileName().getAnImmediateUse() }
 }
 
 /**
@@ -220,24 +195,17 @@ private class WriteFileAtomic extends FileSystemWriteAccess, DataFlow::CallNode 
 /**
  * A call to the library `recursive-readdir`.
  */
-private class RecursiveReadDir extends FileSystemAccess, FileNameProducer, DataFlow::CallNode {
-  RecursiveReadDir() { this = DataFlow::moduleImport("recursive-readdir").getACall() }
+private class RecursiveReadDir extends FileSystemAccess, FileNameProducer, API::CallNode {
+  RecursiveReadDir() { this = API::moduleImport("recursive-readdir").getACall() }
 
   override DataFlow::Node getAPathArgument() { result = this.getArgument(0) }
 
-  override DataFlow::Node getAFileName() {
-    result = this.trackFileSource(DataFlow::TypeTracker::end())
-  }
+  override DataFlow::Node getAFileName() { result = this.trackFileSource().getAnImmediateUse() }
 
-  private DataFlow::SourceNode trackFileSource(DataFlow::TypeTracker t) {
-    t.start() and result = this.getCallback([1 .. 2]).getParameter(1)
+  private API::Node trackFileSource() {
+    result = this.getParameter([1 .. 2]).getParameter(1)
     or
-    t.startInPromise() and not exists(this.getCallback([1 .. 2])) and result = this
-    or
-    // Tracking out of a promise
-    exists(DataFlow::TypeTracker t2 |
-      result = PromiseTypeTracking::promiseStep(this.trackFileSource(t2), t, t2)
-    )
+    not exists(this.getCallback([1 .. 2])) and result = this.getReturn().getPromised()
   }
 }
 
@@ -248,33 +216,25 @@ private module JSONFile {
   /**
    * A reader for JSON files.
    */
-  class JSONFileReader extends FileSystemReadAccess, DataFlow::CallNode {
+  class JSONFileReader extends FileSystemReadAccess, API::CallNode {
     JSONFileReader() {
-      this =
-        DataFlow::moduleMember("jsonfile", any(string s | s = "readFile" or s = "readFileSync"))
-            .getACall()
+      this = API::moduleImport("jsonfile").getMember(["readFile", "readFileSync"]).getACall()
     }
 
     override DataFlow::Node getAPathArgument() { result = this.getArgument(0) }
 
-    override DataFlow::Node getADataNode() { result = this.trackRead(DataFlow::TypeTracker::end()) }
+    override DataFlow::Node getADataNode() { result = this.trackRead().getAnImmediateUse() }
 
-    private DataFlow::SourceNode trackRead(DataFlow::TypeTracker t) {
+    private API::Node trackRead() {
       this.getCalleeName() = "readFile" and
       (
-        t.start() and result = this.getCallback([1 .. 2]).getParameter(1)
+        result = this.getParameter([1 .. 2]).getParameter(1)
         or
-        t.startInPromise() and not exists(this.getCallback([1 .. 2])) and result = this
+        not exists(this.getCallback([1 .. 2])) and result = this.getReturn().getPromised()
       )
       or
-      t.start() and
       this.getCalleeName() = "readFileSync" and
-      result = this
-      or
-      // Tracking out of a promise
-      exists(DataFlow::TypeTracker t2 |
-        result = PromiseTypeTracking::promiseStep(this.trackRead(t2), t, t2)
-      )
+      result = this.getReturn()
     }
   }
 
@@ -297,26 +257,21 @@ private module JSONFile {
 /**
  * A call to the library `load-json-file`.
  */
-private class LoadJsonFile extends FileSystemReadAccess, DataFlow::CallNode {
+private class LoadJsonFile extends FileSystemReadAccess, API::CallNode {
   LoadJsonFile() {
-    this = DataFlow::moduleImport("load-json-file").getACall()
+    this = API::moduleImport("load-json-file").getACall()
     or
-    this = DataFlow::moduleMember("load-json-file", "sync").getACall()
+    this = API::moduleImport("load-json-file").getMember("sync").getACall()
   }
 
   override DataFlow::Node getAPathArgument() { result = this.getArgument(0) }
 
-  override DataFlow::Node getADataNode() { result = this.trackRead(DataFlow::TypeTracker::end()) }
+  override DataFlow::Node getADataNode() { result = this.trackRead().getAnImmediateUse() }
 
-  private DataFlow::SourceNode trackRead(DataFlow::TypeTracker t) {
-    this.getCalleeName() = "sync" and t.start() and result = this
+  private API::Node trackRead() {
+    this.getCalleeName() = "sync" and result = this.getReturn()
     or
-    not this.getCalleeName() = "sync" and t.startInPromise() and result = this
-    or
-    // Tracking out of a promise
-    exists(DataFlow::TypeTracker t2 |
-      result = PromiseTypeTracking::promiseStep(this.trackRead(t2), t, t2)
-    )
+    not this.getCalleeName() = "sync" and result = this.getReturn().getPromised()
   }
 }
 
@@ -338,38 +293,30 @@ private class WriteJsonFile extends FileSystemWriteAccess, DataFlow::CallNode {
 /**
  * A call to the library `walkdir`.
  */
-private class WalkDir extends FileNameProducer, FileSystemAccess, DataFlow::CallNode {
+private class WalkDir extends FileNameProducer, FileSystemAccess, API::CallNode {
   WalkDir() {
-    this = DataFlow::moduleImport("walkdir").getACall()
+    this = API::moduleImport("walkdir").getACall()
     or
-    this = DataFlow::moduleMember("walkdir", "sync").getACall()
+    this = API::moduleImport("walkdir").getMember("sync").getACall()
     or
-    this = DataFlow::moduleMember("walkdir", "async").getACall()
+    this = API::moduleImport("walkdir").getMember("async").getACall()
   }
 
   override DataFlow::Node getAPathArgument() { result = this.getArgument(0) }
 
-  override DataFlow::Node getAFileName() {
-    result = this.trackFileSource(DataFlow::TypeTracker::end())
-  }
+  override DataFlow::Node getAFileName() { result = this.trackFileSource().getAnImmediateUse() }
 
-  private DataFlow::SourceNode trackFileSource(DataFlow::TypeTracker t) {
-    not this.getCalleeName() = any(string s | s = "sync" or s = "async") and
-    t.start() and
+  private API::Node trackFileSource() {
+    not this.getCalleeName() = ["sync", "async"] and
     (
-      result = this.getCallback(this.getNumArgument() - 1).getParameter(0)
+      result = this.getParameter(this.getNumArgument() - 1).getParameter(0)
       or
-      result = this.getAMethodCall(EventEmitter::on()).getCallback(1).getParameter(0)
+      result = this.getReturn().getMember(EventEmitter::on()).getParameter(1).getParameter(0)
     )
     or
-    t.start() and this.getCalleeName() = "sync" and result = this
+    this.getCalleeName() = "sync" and result = this.getReturn()
     or
-    t.startInPromise() and this.getCalleeName() = "async" and result = this
-    or
-    // Tracking out of a promise
-    exists(DataFlow::TypeTracker t2 |
-      result = PromiseTypeTracking::promiseStep(this.trackFileSource(t2), t, t2)
-    )
+    this.getCalleeName() = "async" and result = this.getReturn().getPromised()
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/SocketIO.qll
@@ -16,11 +16,11 @@ import javascript
  */
 module SocketIO {
   /** Gets a data flow node that creates a new socket.io server. */
-  private DataFlow::SourceNode newServer() {
-    result = DataFlow::moduleImport("socket.io").getAnInvocation()
+  private API::Node newServer() {
+    result = API::moduleImport("socket.io").getReturn()
     or
     // alias for `Server`
-    result = DataFlow::moduleImport("socket.io").getAMemberCall("listen")
+    result = API::moduleImport("socket.io").getMember("listen").getReturn()
   }
 
   /**
@@ -39,7 +39,12 @@ module SocketIO {
 
   /** A socket.io server. */
   class ServerObject extends SocketIOObject {
-    ServerObject() { this = newServer() }
+    API::Node node;
+
+    ServerObject() { node = newServer() and this = node.getAnImmediateUse() }
+
+    /** Gets the Api node for this server. */
+    API::Node asApiNode() { result = node }
 
     /** Gets the default namespace of this server. */
     NamespaceObject getDefaultNamespace() { result = MkNamespace(this, "/") }
@@ -50,17 +55,13 @@ module SocketIO {
     /** Gets the namespace with the given path of this server. */
     NamespaceObject getNamespace(string path) { result = MkNamespace(this, path) }
 
-    /**
-     * Gets a data flow node that may refer to the socket.io server created at `srv`.
-     */
-    private DataFlow::SourceNode server(DataFlow::TypeTracker t) {
-      result = this and t.start()
+    /** Gets a api node that may refer to the socket.io server created at `srv`. */
+    private API::Node server() {
+      result = node
       or
-      exists(DataFlow::TypeTracker t2, DataFlow::SourceNode pred | pred = this.server(t2) |
-        result = pred.track(t2, t)
-        or
+      exists(API::Node pred | pred = server() |
         // invocation of a chainable method
-        exists(DataFlow::MethodCallNode mcn, string m |
+        exists(API::CallNode mcn, string m |
           m = "adapter" or
           m = "attach" or
           m = "bind" or
@@ -72,16 +73,15 @@ module SocketIO {
           m = "set" or
           m = EventEmitter::chainableMethod()
         |
-          mcn = pred.getAMethodCall(m) and
+          mcn = pred.getMember(m).getACall() and
           // exclude getter versions
           exists(mcn.getAnArgument()) and
-          result = mcn and
-          t = t2.continue()
+          result = mcn.getReturn()
         )
       )
     }
 
-    override DataFlow::SourceNode ref() { result = this.server(DataFlow::TypeTracker::end()) }
+    override DataFlow::SourceNode ref() { result = this.server().getAUse() }
 
     /**
      * DEPRECATED. Always returns `this` as a `ServerObject` now represents the origin of a server.
@@ -121,54 +121,49 @@ module SocketIO {
    */
   class NamespaceBase extends SocketIOObject {
     NamespaceObject ns;
+    API::Node node;
 
     NamespaceBase() {
+      this = node.getAnImmediateUse() and
       exists(ServerObject srv |
         // namespace lookup on `srv`
-        this = srv.ref().getAPropertyRead("sockets") and
+        node = srv.asApiNode().getMember("sockets") and
         ns = srv.getDefaultNamespace()
         or
-        exists(DataFlow::MethodCallNode mcn, string path |
-          mcn = srv.ref().getAMethodCall("of") and
+        exists(API::CallNode mcn, string path |
+          mcn = srv.asApiNode().getMember("of").getACall() and
           mcn.getArgument(0).mayHaveStringValue(path) and
-          this = mcn and
+          node = mcn.getReturn() and
           ns = MkNamespace(srv, path)
         )
         or
         // invocation of a method that `srv` forwards to its default namespace
-        this = srv.ref().getAMethodCall(namespaceChainableMethod()) and
+        node = srv.asApiNode().getMember(namespaceChainableMethod()).getReturn() and
         ns = srv.getDefaultNamespace()
       )
     }
+
+    /** Gets the API node for this namespace. */
+    API::Node asApiNode() { result = node }
 
     override NamespaceObject getNamespace() { result = ns }
 
     /**
      * Gets a data flow node that may refer to the socket.io namespace created at `ns`.
      */
-    private DataFlow::SourceNode namespace(DataFlow::TypeTracker t) {
-      t.start() and result = this
+    private API::Node namespace() {
+      result = node
       or
-      exists(DataFlow::SourceNode pred, DataFlow::TypeTracker t2 | pred = this.namespace(t2) |
-        result = pred.track(t2, t)
-        or
+      exists(API::Node pred | pred = this.namespace() |
         // invocation of a chainable method
-        result = pred.getAMethodCall(namespaceChainableMethod()) and
-        t = t2.continue()
+        result = pred.getMember(namespaceChainableMethod()).getReturn()
         or
         // invocation of chainable getter method
-        exists(string m |
-          m = "json" or
-          m = "local" or
-          m = "volatile"
-        |
-          result = pred.getAPropertyRead(m) and
-          t = t2.continue()
-        )
+        result = pred.getMember(["json", "local", "volatile"])
       )
     }
 
-    override DataFlow::SourceNode ref() { result = this.namespace(DataFlow::TypeTracker::end()) }
+    override DataFlow::SourceNode ref() { result = this.namespace().getAUse() }
   }
 
   /** A data flow node that may produce a namespace object. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/TorrentLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/TorrentLibraries.qll
@@ -8,39 +8,37 @@ import javascript
  * Provides classes for working with [parse-torrent](https://github.com/webtorrent/parse-torrent) code.
  */
 module ParseTorrent {
-  private DataFlow::SourceNode mod() { result = DataFlow::moduleImport("parse-torrent") }
+  private API::Node mod() { result = API::moduleImport("parse-torrent") }
 
   /**
    * A torrent that has been parsed into a JavaScript object.
    */
   class ParsedTorrent extends DataFlow::SourceNode {
-    ParsedTorrent() {
-      this = mod().getACall() or
-      this = mod().getAMemberCall("remote").getCallback(1).getParameter(1)
-    }
-  }
+    API::Node node;
 
-  private DataFlow::SourceNode parsedTorrentRef(DataFlow::TypeTracker t) {
-    t.start() and
-    result instanceof ParsedTorrent
-    or
-    exists(DataFlow::TypeTracker t2 | result = parsedTorrentRef(t2).track(t2, t))
+    ParsedTorrent() {
+      (
+        node = mod().getReturn() or
+        node = mod().getMember("remote").getParameter(1).getParameter(1)
+      ) and
+      this = node.getAnImmediateUse()
+    }
+
+    /** Gets the API node for this torrent object. */
+    API::Node asApiNode() { result = node }
   }
 
   /** Gets a data flow node referring to a parsed torrent. */
-  DataFlow::SourceNode parsedTorrentRef() {
-    result = parsedTorrentRef(DataFlow::TypeTracker::end())
-  }
+  DataFlow::SourceNode parsedTorrentRef() { result = any(ParsedTorrent t).asApiNode().getAUse() }
 
   /**
    * An access to user-controlled torrent information.
    */
-  class UserControlledTorrentInfo extends RemoteFlowSource {
+  class UserControlledTorrentInfo extends RemoteFlowSource instanceof DataFlow::PropRead {
     UserControlledTorrentInfo() {
-      exists(DataFlow::SourceNode ref, DataFlow::PropRead read |
-        ref = parsedTorrentRef() and
-        read = ref.getAPropertyRead() and
-        this = read
+      exists(API::Node read |
+        read = any(ParsedTorrent t).asApiNode().getAMember() and
+        this = read.getAnImmediateUse()
       |
         exists(string prop |
           not (
@@ -49,10 +47,10 @@ module ParseTorrent {
             prop = "length"
             // "pieceLength" and "lastPieceLength" are not guaranteed to be numbers as of commit ae3ad15d
           ) and
-          read.getPropertyName() = prop
+          super.getPropertyName() = prop
         )
         or
-        not exists(read.getPropertyName())
+        not exists(super.getPropertyName())
       )
     }
 

--- a/javascript/ql/test/library-tests/frameworks/Cheerio/Cheerio.expected
+++ b/javascript/ql/test/library-tests/frameworks/Cheerio/Cheerio.expected
@@ -2,6 +2,7 @@ test_CheerioRef
 | tst.js:1:1:1:30 | import  ... eerio"; |
 | tst.js:1:8:1:14 | cheerio |
 | tst.js:4:11:4:23 | getTemplate() |
+| tst.js:8:1:10:1 | return of function getTemplate |
 | tst.js:9:10:9:36 | cheerio ... t</b>') |
 test_CheerioObjectCreation
 | tst.js:5:3:5:18 | $.attr('foo', 5) |


### PR DESCRIPTION
I was looking at some of our TypeTrackers and I realized that we had some that could be expressed using API-graphs.  