### PR TITLE
QL: Streamline qlpacks

### DIFF
--- a/ql/ql/consistency-queries/qlpack.yml
+++ b/ql/ql/consistency-queries/qlpack.yml
@@ -1,5 +1,5 @@
 name: codeql/ql-consistency-queries
 groups: [ql, test, consistency-queries]
 dependencies:
-  codeql-ql: "*"
+  codeql/ql: "*"
 extractor: ql

--- a/ql/ql/examples/qlpack.yml
+++ b/ql/ql/examples/qlpack.yml
@@ -1,3 +1,4 @@
-name: codeql-ql-examples
-version: 0.0.0
-libraryPathDependencies: codeql-ql
+name: codeql/ql-examples
+groups: [ql, examples]
+dependencies:
+    codeql/ql: "*"

--- a/ql/ql/src/qlpack.yml
+++ b/ql/ql/src/qlpack.yml
@@ -1,5 +1,6 @@
-name: codeql-ql
+name: codeql/ql
 version: 0.0.0
+groups: [ql, queries]
 dbscheme: ql.dbscheme
 suites: codeql-suites
 defaultSuiteFile: codeql-suites/ql-code-scanning.qls

--- a/ql/ql/test/qlpack.yml
+++ b/ql/ql/test/qlpack.yml
@@ -1,7 +1,7 @@
-name: codeql-ql-tests
-version: 0.0.0
-libraryPathDependencies:
-  - codeql-ql
-  - codeql-ql-examples
+name: codeql/ql-tests
+groups: [ql, test]
+dependencies:
+    codeql/ql: "*"
+    codeql/ql-examples: "*"
 extractor: ql
 tests: .


### PR DESCRIPTION
So they follow the same format as the other languages.

`git grep codeql-ql` in the ql/ subfolder does not yield any results now.