### PR TITLE
[Java]: Improving ZipSlip query

### DIFF
--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
@@ -41,9 +41,9 @@ Prefix checking can be done with <code>String.startsWith(..)</code>, but it is b
 </recommendation>
 <example>
 
-<p>In this example, a file path taken from a zip archive item entry is combined with a
+<p>In this example, a file path taken from a zip and Jar archive item entry is combined with a
 destination directory. The result is used as the destination file path without verifying that
-the result is within the destination directory. If provided with a zip file containing an archive
+the result is within the destination directory. If provided with a zip or Jar file containing an archive
 path like <code>..\sneaky-file</code>, then this file would be written outside the destination
 directory.</p>
 

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.ql
@@ -27,7 +27,11 @@ class ArchiveEntryNameMethod extends Method {
   ArchiveEntryNameMethod() {
     exists(RefType archiveEntry |
       archiveEntry.hasQualifiedName("java.util.zip", "ZipEntry") or
-      archiveEntry.hasQualifiedName("org.apache.commons.compress.archivers", "ArchiveEntry")
+      archiveEntry.hasQualifiedName("org.apache.commons.compress.archivers", "ArchiveEntry") or 
+      archiveEntry.hasQualifiedName("java.util.jar", "JarEntry") or
+      archiveEntry.hasQualifiedName("org.apache.commons.compress.archivers.zip", "ZipArchiveEntry") or
+      archiveEntry.hasQualifiedName("org.apache.tools.zip", "ZipEntry") or
+      archiveEntry.hasQualifiedName("org.apache.commons.compress.archivers.tar", "TarArchiveEntry")
     |
       this.getDeclaringType().getASupertype*() = archiveEntry and
       this.hasName("getName")

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlipBad.java
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlipBad.java
@@ -3,3 +3,12 @@ void writeZipEntry(ZipEntry entry, File destinationDir) {
     FileOutputStream fos = new FileOutputStream(file); // BAD
     // ... write entry to fos ...
 }
+
+
+
+void writeJarEntry(JarEntry entry, File destinationDir) {
+    File file = new File(destinationDir, entry.getName());
+    FileOutputStream fos = new FileOutputStream(file); // BAD
+    // ... write entry to fos ...
+}
+  

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlipGood.java
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlipGood.java
@@ -5,3 +5,15 @@ void writeZipEntry(ZipEntry entry, File destinationDir) {
     FileOutputStream fos = new FileOutputStream(file); // OK
     // ... write entry to fos ...
 }
+
+
+
+
+void writeJarEntry(JarEntry entry, File destinationDir) {
+    File file = new File(destinationDir, entry.getName());
+    if (!file.toPath().normalize().startsWith(destinationDir.toPath()))
+        throw new Exception("Bad Jar entry");
+    FileOutputStream fos = new FileOutputStream(file); // OK
+    // ... write entry to fos ...
+}
+  


### PR DESCRIPTION
Zip Slip is a widespread critical archive extraction vulnerability, allowing attackers to write arbitrary files on the system, typically resulting in remote command execution, in this PR i try to improve the zipslip query.