### PR TITLE
C#: Use Brotli instead of Gzip

### DIFF
--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -52,7 +52,7 @@ namespace Semmle.Extraction
         /// <summary>
         /// The compression algorithm used for trap files.
         /// </summary>
-        public TrapWriter.CompressionMode TrapCompression { get; set; } = TrapWriter.CompressionMode.Gzip;
+        public TrapWriter.CompressionMode TrapCompression { get; set; } = TrapWriter.CompressionMode.Brotli;
 
         public virtual bool HandleOption(string key, string value)
         {


### PR DESCRIPTION
#### Trap size, per source
   
| source                                        | `a` targets | `b` targets | a\_m  | b\_m  | diff   | relative | weight |
| --------------------------------------------- | ----------- | ----------- | ----- | ----- | ------ | -------- | ------ |
| mcintyre321\_\_OneOf                          | 1           | 1           | 185.1 | 143.6 | -41.47 | -0.224   | ✔      |
| DeafLight\_\_SilentLux.AutoFixture.Moq.Xunit2 | 1           | 1           | 83.75 | 67.86 | -15.89 | -0.19    | ✔      |
| microsoft\_\_fhir-codegen                     | 1           | 1           | 341.9 | 283.4 | -58.49 | -0.171   | ✔      |
| JetBrains\_\_resharper-rider-plugin           | 1           | 1           | 726.9 | 615.7 | -111.2 | -0.153   | ✔      |
| OrchardCMS\_\_OrchardCore                     | 1           | 1           | 413.9 | 351.7 | -62.16 | -0.15    | ✔      |
| rapPayne\_\_WebGoat.Net                       | 1           | 1           | 72.59 | 62.21 | -10.37 | -0.143   | ✔      |
| DynamoDS\_\_Dynamo                            | 1           | 1           | 115.5 | 100.3 | -15.21 | -0.132   | ✔      |
| dotnet\_\_runtime                             | 1           | 1           | 1120  | 973.5 | -147   | -0.131   | ✔      |
| dotnet\_\_roslyn                              | 1           | 1           | 1954  | 1703  | -251   | -0.128   | ✔      |
| dotnet\_\_efcore                              | 1           | 1           | 904.9 | 791   | -113.9 | -0.126   | ✔      |
| PowerShell\_\_PowerShell                      | 1           | 1           | 235.7 | 207.7 | -28.06 | -0.119   | ✔      |
| urfnet\_\_URF.Core                            | 1           | 1           | 117   | 103.5 | -13.52 | -0.115   | ✔      |
| mono\_\_mono                                  | 1           | 1           | 1557  | 1388  | -168.6 | -0.108   | ✔      |