### PR TITLE
JS: Taint analysis for win paths

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -371,7 +371,7 @@ module TaintedPath {
         Path::PathLabel inputLabel, DataFlow::Node inputNode, Path::PathLabel outputLabel,
         DataFlow::Node outputNode
       ) {
-        getInput() = inputNode and
+        this.getInput() = inputNode and
         this = outputNode and
         outputLabel = inputLabel.toNormalized()
       }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -326,8 +326,8 @@ module TaintedPath {
           inputLabel.getPlatform() = Path::platformWin32() and
           // on windows, when one input is absolute, the output may also be
           // absolute, no matter the position. This is due to drive paths:
-          // path.win32.join('foo\\bar', 'D:\\fnord') => absolute ('D:\\test.txt')
-          // path.win32.join('D:\\fnord', 'foo\\bar') => absolute ('D:\\fnord\\foo\\bar')
+          // path.win32.join('bar\\..', 'D:\\fnord') => absolute ('D:\\fnord')
+          // path.win32.join('D:\\fnord', 'bar\\..') => absolute ('D:\\fnord')
           if
             inputLabel.isAbsolute() or
             exists(int n | Path::isDrivePath(this.getArgument(n).getStringValue()))
@@ -580,7 +580,9 @@ module TaintedPath {
       override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
         e = operand.asExpr() and
         exists(Path::PathLabel pathLabel | pathLabel = label |
-          outcome = polarity and pathLabel.isRelative()
+          pathLabel.getPlatform() = Path::platformPosix() and
+          outcome = polarity and
+          pathLabel.isRelative()
           or
           negatable = true and
           outcome = polarity.booleanNot() and

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -6,6 +6,9 @@
 
 import javascript
 
+/**
+ * Provides logic for tracking of tainted paths.
+ */
 module TaintedPath {
   /**
    * A data flow source for tainted-path vulnerabilities.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -47,18 +47,21 @@ module TaintedPath {
       SplitPath() { this = "splitPath" }
     }
 
+    /** Gets the string used for tracking Posix paths. */
     string platformPosix() { result = "posix" }
 
+    /** Gets the string used for tracking Windows paths. */
     string platformWin32() { result = "win32" }
 
+    /** A platform on which we track paths, eg.: `posix`. */
     abstract class Platform extends string {
       Platform() { this = [platformPosix(), platformWin32()] }
 
+      /** Gets the separator used on this platform. */
       abstract string getSep();
-
-      DataFlow::SourceNode getExplicitImport() { result = DataFlow::moduleMember("path", this) }
     }
 
+    /** An instance of `Platform` for tracking paths on Posix systems. */
     class PosixPlatform extends Platform {
       PosixPlatform() { this = platformPosix() }
 
@@ -358,9 +361,9 @@ module TaintedPath {
       }
     }
 
-    // /**
-    //  * A call that normalizes a path.
-    //  */
+    /**
+     * A call that normalizes a path.
+     */
     class NormalizingPathCall extends PathTransformationNode {
       NormalizingPathCall() { this = NodeJSLib::Path::moduleMember("normalize").getACall() }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathQuery.qll
@@ -11,11 +11,11 @@ import javascript
 import TaintedPathCustomizations::TaintedPath
 
 // Materialize flow labels
-private class ConcretePosixPath extends Label::PosixPath {
-  ConcretePosixPath() { this = this }
+private class ConcretePathLabel extends Path::PathLabel {
+  ConcretePathLabel() { this = this }
 }
 
-private class ConcreteSplitPath extends Label::SplitPath {
+private class ConcreteSplitPath extends Path::SplitPath {
   ConcreteSplitPath() { this = this }
 }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ZipSlipCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ZipSlipCustomizations.qll
@@ -14,7 +14,7 @@ module ZipSlip {
    */
   abstract class Source extends DataFlow::Node {
     /** Gets a flow label denoting the type of value for which this is a source. */
-    TaintedPath::Label::PosixPath getAFlowLabel() { result.isRelative() }
+    TaintedPath::Path::PathLabel getAFlowLabel() { result.isRelative() }
   }
 
   /**
@@ -22,7 +22,7 @@ module ZipSlip {
    */
   abstract class Sink extends DataFlow::Node {
     /** Gets a flow label denoting the type of value for which this is a sink. */
-    TaintedPath::Label::PosixPath getAFlowLabel() { any() }
+    TaintedPath::Path::PathLabel getAFlowLabel() { any() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ZipSlipQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ZipSlipQuery.qll
@@ -11,11 +11,11 @@ import javascript
 import ZipSlipCustomizations::ZipSlip
 
 // Materialize flow labels
-private class ConcretePosixPath extends TaintedPath::Label::PosixPath {
+private class ConcretePosixPath extends TaintedPath::Path::PathLabel {
   ConcretePosixPath() { this = this }
 }
 
-private class ConcreteSplitPath extends TaintedPath::Label::SplitPath {
+private class ConcreteSplitPath extends TaintedPath::Path::SplitPath {
   ConcreteSplitPath() { this = this }
 }
 

--- a/javascript/ql/src/Security/CWE-022/TaintedWindowsPath.qhelp
+++ b/javascript/ql/src/Security/CWE-022/TaintedWindowsPath.qhelp
@@ -2,7 +2,6 @@
   "-//Semmle//qhelp//EN"
   "qhelp.dtd">
 <qhelp>
-
   <overview>
     <p>
       Accessing files using paths constructed from user-controlled data can allow an attacker to access
@@ -24,13 +23,29 @@
     <ul>
       <li>Do not allow more than a single "." character.</li>
       <li>Do not allow directory separators such as "/" or "\" (depending on the file system).</li>
-      <li>
-        Do not rely on simply replacing problematic sequences such as "../". For example, after
-        applying this filter to ".../...//", the resulting string would still be "../".
-      </li>
+      <li>Do not rely on simply replacing problematic sequences such as "../". For example, after
+      replacing this in the string ".../...//", the result "../" would be returned.</li>
       <li>Use an allowlist of known good patterns.</li>
     </ul>
+
+    <p>On windows, beware of some pitfalls:</p>
+    <ul>
+      <li>The <code>path</code> library accepts the forward slash as path separator.</li>
+      <li>The <code>path.relative</code> method may return an absolute path, eg.:
+      <code>path.relative("foo", "C:\\baz")</code> returns <code>"C:\\baz"</code>.</li>
+      <li>
+        The <code>path.join</code> method sometimes returns an absolute path, even
+        when the first input is relative, eg.: <code>path.join("foo\\..", "C:\\foo")</code> will
+        return <code>"C:\\foo"</code>, which is absolute.
+      </li>
+      <li>
+        The <code>path.isAbsolute</code> method returns <code>true</code> for some paths
+        that are relative, even if <code>path.resolve</code> treats them as absolute. Eg.:
+        <code>path.isAbsolute("C:../../foo")</code> returns <code>true</code>.
+      </li>
+    </ul>
   </recommendation>
+
 
   <example>
     <p>

--- a/javascript/ql/src/Security/CWE-022/TaintedWindowsPath.ql
+++ b/javascript/ql/src/Security/CWE-022/TaintedWindowsPath.ql
@@ -1,0 +1,33 @@
+/**
+ * @name Uncontrolled data used in path expression (Posix and Win32)
+ * @description Accessing paths influenced by users can allow an attacker to access
+ *              unexpected resources.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.5
+ * @precision high
+ * @id js/path-injection-win32-enabled
+ * @tags security
+ *       external/cwe/cwe-022
+ *       external/cwe/cwe-023
+ *       external/cwe/cwe-036
+ *       external/cwe/cwe-073
+ *       external/cwe/cwe-099
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.TaintedPathQuery
+import semmle.javascript.security.dataflow.TaintedPathCustomizations
+import DataFlow::PathGraph
+import semmle.javascript.frameworks.NodeJSLib
+
+class Win32Platform extends Path::Platform {
+  Win32Platform() { this = Path::platformWin32() }
+
+  override string getSep() { result = "\\" }
+}
+
+from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "This path depends on $@.", source.getNode(),
+  "a user-provided value"

--- a/javascript/ql/src/change-notes/2022-03-04-tainted-windows-paths.md
+++ b/javascript/ql/src/change-notes/2022-03-04-tainted-windows-paths.md
@@ -1,0 +1,8 @@
+---
+category: newQuery
+---
+* Added the query `js/path-injection-win32-enabled` which tracks possible
+  injections of paths. Its behaviour is comparable to the standard query 
+  `js/path-injection`, but it is aware of pitfalls that only apply on
+  windows (eg., that some libraries for working with paths recognize both
+  forward and backward slashes as path separators).

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/express.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/express.js
@@ -5,7 +5,7 @@ let app = express();
 app.use(fileUpload());
 
 app.get("/some/path/1", function (req, res) {
-  req.files.foo.mv(req.query.bar); // NOT OK
+  req.files.foo.mv(req.query.bar);
 });
 
 app.get("/some/path/2", function (req, res) {

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/express.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/express.js
@@ -4,6 +4,16 @@ var express = require("express"),
 let app = express();
 app.use(fileUpload());
 
-app.get("/some/path", function (req, res) {
-  req.files.foo.mv(req.query.bar);
+app.get("/some/path/1", function (req, res) {
+  req.files.foo.mv(req.query.bar); // NOT OK
+});
+
+app.get("/some/path/2", function (req, res) {
+  const p = path.join('.', req.query.filename);
+  if (!p.startsWith('..')) {
+    req.files.foo.mv(p); // OK (but not on windows)
+    res.status(200);
+  } else {
+    res.status(400);
+  }
 });

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/TaintedWindowsPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/TaintedWindowsPath.expected
@@ -23,12 +23,15 @@ nodes
 | express.js:23:9:23:50 | p |
 | express.js:23:9:23:50 | p |
 | express.js:23:9:23:50 | p |
+| express.js:23:9:23:50 | p |
 | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename |
 | express.js:23:32:23:49 | req.query.filename |
 | express.js:23:32:23:49 | req.query.filename |
 | express.js:23:32:23:49 | req.query.filename |
@@ -43,6 +46,27 @@ nodes
 | express.js:27:22:27:22 | p |
 | express.js:27:22:27:22 | p |
 | express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+| express.js:33:9:33:46 | p |
+| express.js:33:9:33:46 | p |
+| express.js:33:9:33:46 | p |
+| express.js:33:9:33:46 | p |
+| express.js:33:9:33:46 | p |
+| express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename |
+| express.js:33:28:33:45 | req.query.filename |
+| express.js:33:28:33:45 | req.query.filename |
+| express.js:33:28:33:45 | req.query.filename |
+| express.js:35:22:35:22 | p |
+| express.js:35:22:35:22 | p |
+| express.js:35:22:35:22 | p |
+| express.js:35:22:35:22 | p |
+| express.js:35:22:35:22 | p |
+| express.js:35:22:35:22 | p |
 edges
 | express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
 | express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
@@ -81,12 +105,15 @@ edges
 | express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
 | express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
 | express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
 | express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
 | express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
 | express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
 | express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
 | express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
 | express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
 | express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
@@ -99,6 +126,34 @@ edges
 | express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
 | express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:9:33:46 | p | express.js:35:22:35:22 | p |
+| express.js:33:13:33:46 | path.jo ... lename) | express.js:33:9:33:46 | p |
+| express.js:33:13:33:46 | path.jo ... lename) | express.js:33:9:33:46 | p |
+| express.js:33:13:33:46 | path.jo ... lename) | express.js:33:9:33:46 | p |
+| express.js:33:13:33:46 | path.jo ... lename) | express.js:33:9:33:46 | p |
+| express.js:33:13:33:46 | path.jo ... lename) | express.js:33:9:33:46 | p |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
+| express.js:33:28:33:45 | req.query.filename | express.js:33:13:33:46 | path.jo ... lename) |
 #select
 | express.js:9:20:9:55 | req.que ... /g, "") | express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") | This path depends on $@. | express.js:9:20:9:32 | req.query.bar | a user-provided value |
 | express.js:27:22:27:22 | p | express.js:23:32:23:49 | req.query.filename | express.js:27:22:27:22 | p | This path depends on $@. | express.js:23:32:23:49 | req.query.filename | a user-provided value |
+| express.js:35:22:35:22 | p | express.js:33:28:33:45 | req.query.filename | express.js:35:22:35:22 | p | This path depends on $@. | express.js:33:28:33:45 | req.query.filename | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/TaintedWindowsPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/TaintedWindowsPath.expected
@@ -1,0 +1,104 @@
+nodes
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:32 | req.query.bar |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:23:9:23:50 | p |
+| express.js:23:9:23:50 | p |
+| express.js:23:9:23:50 | p |
+| express.js:23:9:23:50 | p |
+| express.js:23:9:23:50 | p |
+| express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:23:32:23:49 | req.query.filename |
+| express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+| express.js:27:22:27:22 | p |
+edges
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:9:23:50 | p | express.js:27:22:27:22 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:13:23:50 | path.jo ... lename) | express.js:23:9:23:50 | p |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+| express.js:23:32:23:49 | req.query.filename | express.js:23:13:23:50 | path.jo ... lename) |
+#select
+| express.js:9:20:9:55 | req.que ... /g, "") | express.js:9:20:9:32 | req.query.bar | express.js:9:20:9:55 | req.que ... /g, "") | This path depends on $@. | express.js:9:20:9:32 | req.query.bar | a user-provided value |
+| express.js:27:22:27:22 | p | express.js:23:32:23:49 | req.query.filename | express.js:27:22:27:22 | p | This path depends on $@. | express.js:23:32:23:49 | req.query.filename | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/TaintedWindowsPath.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/TaintedWindowsPath.qlref
@@ -1,0 +1,1 @@
+Security/CWE-022/TaintedWindowsPath.ql

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/express.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedWindowsPath/express.js
@@ -1,0 +1,40 @@
+const express = require("express");
+const fileUpload = require("express-fileupload");
+const path = require("path");
+
+let app = express();
+app.use(fileUpload());
+
+app.get("/some/path/1", function (req, res) {
+  req.files.foo.mv(req.query.bar.replace(/\.\.\//g, "")); // NOT OK, replacing a posix path segment is not safe on win32.
+  res.status(200);
+});
+
+app.get("/some/path/2", function (req, res) {
+  const p = req.query.bar;
+  if (['foo.txt', 'bar.txt'].includes(p)) { // a valid sanitizer, even on windows
+    req.files.foo.mv(p); // OK, because sanitized
+  }
+  res.status(200);
+});
+
+app.get("/some/path/3", function (req, res) {
+  const workdir = "C:\\workdir"
+  const p = path.join(workdir, req.query.filename);
+  if (path.relative(workdir, p).startsWith("..")) {
+    res.status(400);
+  } else {
+    req.files.foo.mv(p); // NOT OK (but would be on unix).
+    res.status(200);
+  }
+});
+
+app.get("/some/path/4", function (req, res) {
+  const p = path.join('.', req.query.filename);
+  if (!p.startsWith('..')) {
+    req.files.foo.mv(p); // NOT OK because p could be C:\\foo.txt - but would be OK on posix
+    res.status(200);
+  } else {
+    res.status(400);
+  }
+});


### PR DESCRIPTION
This contributes support for tracking win32 paths in tainted path queries.

The main difference is, that you can now extend query labels by extending the `Platform` class (as in `TaintedWindowsPaths.ql`) and path will then be tracked using 8 labels, instead of four.

By default, there's the four labels as before:

 1. `normalized-relative-posix-path`
 2. `normalized-absolute-posix-path`
 3. `raw-relative-posix-path`
 4. `raw-absolute-posix-path`

When extending the `Platform` class by a `win32` variant, you'll additionally get:

 5. `normalized-relative-win32-path`
 6. `normalized-absolute-win32-path`
 7. `raw-relative-win32-path`
 8. `raw-absolute-win32-path`.

I also refactored the `isAdditionalTaintStep` predicate that would have — IMHO — become too large after this change by pulling out much of the logic into an abstract class and extensions thereof.

I ran an experiment, and looked at it with @esbena looking over my shoulder. It's not affecting the results of pre-existing queries. The results it finds for the new queries lgtm (I've looked at a subset of results from various projects).
