### PR TITLE
JS: Add url-parse.qs as an alias for the querystringify library

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/UriLibraries.qll
@@ -175,7 +175,12 @@ module querystringify {
    * Gets a data flow source node for member `name` of the querystringify library.
    */
   DataFlow::SourceNode querystringifyMember(string name) {
-    result = DataFlow::moduleMember("querystringify", name)
+    result = querystringify().getMember(name).getAnImmediateUse()
+  }
+
+  /** Gets an API node referring to the `querystringify` module. */
+  private API::Node querystringify() {
+    result = [API::moduleImport("querystringify"), API::moduleImport("url-parse").getMember("qs")]
   }
 
   /**
@@ -184,7 +189,7 @@ module querystringify {
   private class Step extends TaintTracking::SharedTaintStep {
     override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call |
-        call = querystringifyMember(["parse", "stringify"]).getACall() and
+        call = querystringify().getMember(["parse", "stringify"]).getACall() and
         pred = call.getAnArgument() and
         succ = call
       )

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
@@ -45,6 +45,7 @@
 | querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
 | querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
 | querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
+| querystringify.js:8:23:8:23 | x | querystringify.js:8:1:8:24 | queryst ... arse(x) |
 | uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
 | uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
 | uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/querystringify.js
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/querystringify.js
@@ -3,3 +3,6 @@ var querystringify = require("querystringify");
 var r = querystringify.parse(x);
 
 r = querystringify.stringify(x);
+
+var querystringify2 = require('url-parse').qs;
+querystringify2.parse(x);

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.expected
@@ -17,6 +17,7 @@ querystring
 querystringify
 | querystringify.js:3:9:3:28 | querystringify.parse |
 | querystringify.js:5:5:5:28 | queryst ... ringify |
+| querystringify.js:8:1:8:21 | queryst ... 2.parse |
 uridashjs
 | uri-js.js:3:9:3:17 | URI.parse |
 | uri-js.js:5:5:5:17 | URI.serialize |
@@ -76,6 +77,7 @@ uriLibraryStep
 | querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
 | querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
 | querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
+| querystringify.js:8:23:8:23 | x | querystringify.js:8:1:8:24 | queryst ... arse(x) |
 | uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
 | uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
 | uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |
@@ -101,4 +103,5 @@ url
 | url.js:5:5:5:14 | url.format |
 | url.js:7:5:7:15 | url.resolve |
 urlParse
+| querystringify.js:7:23:7:42 | require('url-parse') |
 | url-parse.js:1:13:1:32 | require('url-parse') |


### PR DESCRIPTION
The `querystringify` package is re-exported as `qs` from `url-parse`.