### PR TITLE
Python: Fix bad `fastTC` in `ASTNode::contains`

### DIFF
--- a/python/ql/lib/semmle/python/AstExtended.qll
+++ b/python/ql/lib/semmle/python/AstExtended.qll
@@ -47,6 +47,7 @@ abstract class AstNode extends AstNode_ {
   AstNode getParentNode() { result.getAChildNode() = this }
 
   /** Whether this contains `inner` syntactically */
+  pragma[inline]
   predicate contains(AstNode inner) { this.getAChildNode+() = inner }
 
   pragma[noinline]

--- a/python/ql/lib/semmle/python/Patterns.qll
+++ b/python/ql/lib/semmle/python/Patterns.qll
@@ -10,7 +10,8 @@ class Pattern extends Pattern_, AstNode {
   override Scope getScope() { result = this.getCase().getScope() }
 
   /** Gets the case statement containing this pattern */
-  Case getCase() { result = this.getParent() or result = this.getParent().(Pattern).getCase() }
+  pragma[nomagic]
+  Case getCase() { result.contains(this) }
 
   override string toString() { result = "Pattern" }
 

--- a/python/ql/lib/semmle/python/Patterns.qll
+++ b/python/ql/lib/semmle/python/Patterns.qll
@@ -10,7 +10,7 @@ class Pattern extends Pattern_, AstNode {
   override Scope getScope() { result = this.getCase().getScope() }
 
   /** Gets the case statement containing this pattern */
-  Case getCase() { result.contains(this) }
+  Case getCase() { result = this.getParent() or result = this.getParent().(Pattern).getCase() }
 
   override string toString() { result = "Pattern" }
 

--- a/python/ql/src/Statements/NestedLoopsSameVariable.ql
+++ b/python/ql/src/Statements/NestedLoopsSameVariable.ql
@@ -21,8 +21,11 @@ predicate variableUsedInNestedLoops(For inner, For outer, Variable v) {
   loop_variable(inner, v) and
   loop_variable(outer, v) and
   /* Ignore cases where there is no use of the variable or the only use is in the inner loop */
-  exists(Name n | n.uses(v) and outer.contains(n) and not inner.contains(n))
+  exists(Name n | n.uses(v) and forLoopContainsName(outer, n) and not forLoopContainsName(inner, n))
 }
+
+pragma[nomagic]
+private predicate forLoopContainsName(For for, Name n) { for.contains(n) }
 
 from For inner, For outer, Variable v
 where variableUsedInNestedLoops(inner, outer, v)

--- a/python/ql/src/Statements/NestedLoopsSameVariableWithReuse.ql
+++ b/python/ql/src/Statements/NestedLoopsSameVariableWithReuse.ql
@@ -19,8 +19,8 @@ predicate loop_variable_ssa(For f, Variable v, SsaVariable s) {
 
 predicate variableUsedInNestedLoops(For inner, For outer, Variable v, Name n) {
   /* Ignore cases where there is no use of the variable or the only use is in the inner loop. */
-  outer.contains(n) and
-  not inner.contains(n) and
+  forLoopContainsName(outer, n) and
+  not forLoopContainsName(inner, n) and
   /* Only treat loops in body as inner loops. Loops in the else clause are ignored. */
   outer.getBody().contains(inner) and
   exists(SsaVariable s |
@@ -29,6 +29,9 @@ predicate variableUsedInNestedLoops(For inner, For outer, Variable v, Name n) {
     s.getAUse().getNode() = n
   )
 }
+
+pragma[nomagic]
+private predicate forLoopContainsName(For for, Name name) { for.contains(name) }
 
 from For inner, For outer, Variable v, Name n
 where variableUsedInNestedLoops(inner, outer, v, n)


### PR DESCRIPTION
Between 2.8.0 and 2.8.1, the performance of `ASTNode::contains` degraded considerably for some queries (and some databases), one such example being the `py/comparison-of-identical-expressions` query.

In 2.8.0, the `contains` relation was inlined into the helper predicates for that query, whereas in 2.8.1, the `contains` relation was evaluated in isolation using a `boundedFastTC`:
```
(4s) Starting to evaluate predicate boundedFastTC(AstExtended::AstNode::getAChildNode_dispred#ff,AstExtended::AstNode#class#f)/2@c4bc3flu = HOP boundedFastTC(3646779,2616172)
(887s)  >>> Relation boundedFastTC(AstExtended::AstNode::getAChildNode_dispred#ff,AstExtended::AstNode#class#f): 12307755 rows using 115 MB
```

I tried rewriting the `contains` predicate to use a manual TC, but this also had poor performance (though still better than `fastTC`). Because `contains` is used in a lot of places, it's inconvenient to manually fix up and magic all of these places, and so I opted to `inline` this predicate instead.