### PR TITLE
QL: add ql-for-ql query for detecting bad predicate qldoc

### DIFF
--- a/javascript/ql/examples/queries/dataflow/StoredXss/StoredXssTypeTracking.ql
+++ b/javascript/ql/examples/queries/dataflow/StoredXss/StoredXssTypeTracking.ql
@@ -13,7 +13,7 @@ import semmle.javascript.security.dataflow.StoredXssQuery
 import DataFlow::PathGraph
 
 /**
- * An instance of `mysql.createConnection()`, tracked globally.
+ * Gets an instance of `mysql.createConnection()`, tracked globally.
  */
 DataFlow::SourceNode mysqlConnection(DataFlow::TypeTracker t) {
   t.start() and
@@ -23,7 +23,7 @@ DataFlow::SourceNode mysqlConnection(DataFlow::TypeTracker t) {
 }
 
 /**
- * An instance of `mysql.createConnection()`, tracked globally.
+ * Gets an instance of `mysql.createConnection()`, tracked globally.
  */
 DataFlow::SourceNode mysqlConnection() { result = mysqlConnection(DataFlow::TypeTracker::end()) }
 

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/FunctionBodyFeatures.qll
@@ -134,7 +134,7 @@ int getNumCharsInFunction(Function f) {
 }
 
 /**
- * The maximum number of characters a feature can be.
+ * Gets the maximum number of characters a feature can be.
  * The evaluator string limit is 5395415 characters. We choose a limit lower than this.
  */
 private int getMaxChars() { result = 1000000 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractMisclassifiedEndpointFeatures.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractMisclassifiedEndpointFeatures.ql
@@ -12,7 +12,7 @@ import experimental.adaptivethreatmodeling.EndpointFeatures as EndpointFeatures
 import experimental.adaptivethreatmodeling.EndpointTypes
 import semmle.javascript.security.dataflow.NosqlInjectionCustomizations
 
-/** The positive endpoint type for which you wish to find misclassified examples. */
+/** Gets the positive endpoint type for which you wish to find misclassified examples. */
 EndpointType getEndpointType() { result instanceof NosqlInjectionSinkType }
 
 /** Get a positive endpoint. This will be run through the classifier to determine whether it is misclassified. */

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -16,7 +16,7 @@ module ArrayTaintTracking {
   }
 
   /**
-   * A taint propagating data flow edge from `pred` to `succ` caused by a call `call` to a builtin array functions.
+   * Holds if there is a taint propagating data flow edge from `pred` to `succ` caused by a call `call` to a builtin array functions.
    */
   predicate arrayFunctionTaintStep(DataFlow::Node pred, DataFlow::Node succ, DataFlow::CallNode call) {
     // `array.map(function (elt, i, ary) { ... })`: if `array` is tainted, then so are
@@ -357,7 +357,7 @@ private module ArrayLibraries {
   }
 
   /**
-   * A call to a library that copies the elements of an array into another array.
+   * Gets a call to a library that copies the elements of an array into another array.
    * E.g. `array-union` that creates a union of multiple arrays, or `array-uniq` that creates an array with unique elements.
    */
   DataFlow::CallNode arrayCopyCall(DataFlow::Node array) {

--- a/javascript/ql/lib/semmle/javascript/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/DOM.qll
@@ -300,7 +300,7 @@ module DOM {
     }
 
     /**
-     * A data flow node that might refer to some form.
+     * Gets a data flow node that might refer to some form.
      * Either by a read like `document.forms[0]`, or a property read from `document` with some constant property-name.
      * E.g. if `<form name="foobar">..</form>` exists, then `document.foobar` refers to that form.
      */

--- a/javascript/ql/lib/semmle/javascript/JsonSchema.qll
+++ b/javascript/ql/lib/semmle/javascript/JsonSchema.qll
@@ -56,7 +56,7 @@ module JsonSchema {
 
   /** Provides a model of the `ajv` library. */
   module Ajv {
-    /** A method on `Ajv` that returns `this`. */
+    /** Gets a method on `Ajv` that returns `this`. */
     private string chainedMethod() {
       result =
         ["addSchema", "addMetaSchema", "removeSchema", "addFormat", "addKeyword", "removeKeyword"]
@@ -141,7 +141,7 @@ module JsonSchema {
 
   /** Provides a model for working with the [`joi`](https://npmjs.org/package/joi) library. */
   module Joi {
-    /** A schema created using `joi.object()` or other schemas that might refer an object schema. */
+    /** Gets a schema created using `joi.object()` or other schemas that might refer an object schema. */
     private API::Node objectSchema() {
       // A call that creates a schema that might be an object schema.
       result =

--- a/javascript/ql/lib/semmle/javascript/SSA.qll
+++ b/javascript/ql/lib/semmle/javascript/SSA.qll
@@ -503,7 +503,7 @@ class SsaExplicitDefinition extends SsaDefinition, TExplicitDef {
   /** This SSA definition corresponds to the definition of `v` at `def`. */
   predicate defines(VarDef d, SsaSourceVariable v) { this = TExplicitDef(_, _, d, v) }
 
-  /** The variable definition wrapped by this SSA definition. */
+  /** Gets the variable definition wrapped by this SSA definition. */
   VarDef getDef() { this = TExplicitDef(_, _, result, _) }
 
   /** Gets the basic block to which this definition belongs. */

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -787,16 +787,16 @@ class MemberKind extends string {
 }
 
 module MemberKind {
-  /** The kind of a method, such as `m() {}` */
+  /** Gets the kind of a method, such as `m() {}` */
   MemberKind method() { result = "method" }
 
-  /** The kind of a getter accessor, such as `get f() {}`. */
+  /** Gets the kind of a getter accessor, such as `get f() {}`. */
   MemberKind getter() { result = "getter" }
 
-  /** The kind of a setter accessor, such as `set f() {}`. */
+  /** Gets the kind of a setter accessor, such as `set f() {}`. */
   MemberKind setter() { result = "setter" }
 
-  /** The `getter` and `setter` kinds. */
+  /** Gets the `getter` and `setter` kinds. */
   MemberKind accessor() { result = getter() or result = setter() }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -804,13 +804,13 @@ module TaintTracking {
   }
 
   /**
-   * A pseudo-property a `URL` that stores a value that can be obtained
+   * Gets a pseudo-property a `URL` that stores a value that can be obtained
    * with a `get` or `getAll` call to the `searchParams` property.
    */
   private string hiddenUrlPseudoProperty() { result = "$hiddenSearchPararms" }
 
   /**
-   * A pseudo-property on a `URLSearchParams` that can be obtained
+   * Gets a pseudo-property on a `URLSearchParams` that can be obtained
    * with a `get` or `getAll` call.
    */
   private string getableUrlPseudoProperty() { result = "$gettableSearchPararms" }

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -480,7 +480,7 @@ private module CachedSteps {
   }
 
   /**
-   * A step from `pred` to `succ` through a call to an identity function.
+   * Holds if there is a step from `pred` to `succ` through a call to an identity function.
    */
   cached
   predicate identityFunctionStep(DataFlow::Node pred, DataFlow::CallNode succ) {

--- a/javascript/ql/lib/semmle/javascript/dependencies/Dependencies.qll
+++ b/javascript/ql/lib/semmle/javascript/dependencies/Dependencies.qll
@@ -21,7 +21,7 @@ abstract class Dependency extends Locatable {
   abstract predicate info(string id, string v);
 
   /**
-   * A use of this dependency, which is of the given `kind`.
+   * Gets a use of this dependency, which is of the given `kind`.
    *
    * Currently, the only supported kinds are `"import"` and `"use"`.
    */

--- a/javascript/ql/lib/semmle/javascript/frameworks/Bundling.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Bundling.qll
@@ -99,7 +99,7 @@ private predicate isBrowserifyDependencyMap(ObjectExpr deps) {
 }
 
 /**
- * A function that looks like a bundled module created
+ * Holds if `m` is a function that looks like a bundled module created
  * by Webpack.
  *
  * Parameters must be named either `module` or `exports`,

--- a/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Cheerio.qll
@@ -6,14 +6,14 @@ import javascript
 private import semmle.javascript.security.dataflow.Xss as Xss
 
 module Cheerio {
-  /** A reference to the `cheerio` function, possibly with a loaded DOM. */
+  /** Gets a reference to the `cheerio` function, possibly with a loaded DOM. */
   private API::Node cheerioApi() {
     result = API::moduleImport("cheerio")
     or
     result = cheerioApi().getMember(["load", "parseHTML"]).getReturn()
   }
 
-  /** A reference to the `cheerio` function, possibly with a loaded DOM. */
+  /** Gets a reference to the `cheerio` function, possibly with a loaded DOM. */
   DataFlow::SourceNode cheerioRef() { result = cheerioApi().getAUse() }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -807,7 +807,7 @@ module ClientRequest {
    */
   private module ApolloClient {
     /**
-     * A function from `apollo-client` that accepts an options object that may contain a `uri` property.
+     * Gets a function from `apollo-client` that accepts an options object that may contain a `uri` property.
      */
     API::Node apolloUriCallee() {
       result = API::moduleImport("apollo-link-http").getMember(["HttpLink", "createHttpLink"])

--- a/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
@@ -51,12 +51,12 @@ module CookieWrites {
   }
 
   /**
-   * The flag that indicates that a cookie is secure.
+   * Gets the flag that indicates that a cookie is secure.
    */
   string secure() { result = "secure" }
 
   /**
-   * The flag that indicates that a cookie is HttpOnly.
+   * Gets the flag that indicates that a cookie is HttpOnly.
    */
   string httpOnly() { result = "httpOnly" }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Immutable.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Immutable.qll
@@ -22,7 +22,7 @@ private module Immutable {
   }
 
   /**
-   * An import of the `Immutable` library.
+   * Gets an import of the `Immutable` library.
    */
   API::Node immutableImport() {
     result = API::moduleImport("immutable")
@@ -31,7 +31,7 @@ private module Immutable {
   }
 
   /**
-   * An instance of any immutable collection.
+   * Gets an instance of any immutable collection.
    *
    * This predicate keeps track of which values in the program are Immutable collections.
    */

--- a/javascript/ql/lib/semmle/javascript/frameworks/LdapJS.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LdapJS.qll
@@ -36,10 +36,10 @@ module LdapJS {
 
   /** A creation of an LDAPjs filter, or object containing a filter, that doesn't sanitizes the input. */
   abstract class TaintPreservingLdapFilterStep extends DataFlow::Node {
-    /** The input that creates (part of) an LDAPjs filter. */
+    /** Gets the input that creates (part of) an LDAPjs filter. */
     abstract DataFlow::Node getInput();
 
-    /** The resulting LDAPjs filter. */
+    /** Gets the resulting LDAPjs filter. */
     abstract DataFlow::Node getOutput();
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Markdown.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Markdown.qll
@@ -80,7 +80,7 @@ module Markdown {
    */
   private module Unified {
     /**
-     * The creation of a parser from `unified`.
+     * Gets a parser from `unified`.
      * The `remark` module is a shorthand that initializes `unified` with a markdown parser.
      */
     DataFlow::CallNode unified() {
@@ -152,7 +152,7 @@ module Markdown {
    */
   private module MarkdownIt {
     /**
-     * The creation of a parser from `markdown-it`.
+     * Gets a creation of a parser from `markdown-it`.
      */
     private API::Node markdownIt() {
       exists(API::InvokeNode call |

--- a/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
@@ -8,7 +8,7 @@ private module Micro {
   private import DataFlow
 
   /**
-   * A node that should be interpreted as a route handler, to use as starting
+   * Gets a node that should be interpreted as a route handler, to use as starting
    * point for back-tracking.
    */
   Node microRouteHandlerSink() {

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -493,7 +493,7 @@ module NodeJSLib {
    */
   module FS {
     /**
-     * A member `member` from module `fs` or its drop-in replacements `graceful-fs`, `fs-extra`, `original-fs`.
+     * Gets a member `member` from module `fs` or its drop-in replacements `graceful-fs`, `fs-extra`, `original-fs`.
      */
     DataFlow::SourceNode moduleMember(string member) {
       result = fsModule(DataFlow::TypeTracker::end()).getAPropertyRead(member)

--- a/javascript/ql/lib/semmle/javascript/frameworks/Puppeteer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Puppeteer.qll
@@ -9,12 +9,12 @@ import javascript
  */
 module Puppeteer {
   /**
-   * A reference to a module import of puppeteer.
+   * Gets a reference to a module import of puppeteer.
    */
   private API::Node puppeteer() { result = API::moduleImport(["puppeteer", "puppeteer-core"]) }
 
   /**
-   * A reference to a `Browser` from puppeteer.
+   * Gets a reference to a `Browser` from puppeteer.
    */
   private API::Node browser() {
     result = API::Node::ofType("puppeteer", "Browser")
@@ -25,7 +25,7 @@ module Puppeteer {
   }
 
   /**
-   * A reference to a `Page` from puppeteer.
+   * Gets a reference to a `Page` from puppeteer.
    */
   API::Node page() {
     result = API::Node::ofType("puppeteer", "Page")
@@ -38,7 +38,7 @@ module Puppeteer {
   }
 
   /**
-   * A reference to a `Target` from puppeteer.
+   * Gets a reference to a `Target` from puppeteer.
    */
   private API::Node target() {
     result = API::Node::ofType("puppeteer", "Target")
@@ -51,7 +51,7 @@ module Puppeteer {
   }
 
   /**
-   * A reference to a `BrowserContext` from puppeteer.
+   * Gets a reference to a `BrowserContext` from puppeteer.
    */
   private API::Node context() {
     result = API::Node::ofType("puppeteer", "BrowserContext")

--- a/javascript/ql/lib/semmle/javascript/frameworks/Redux.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Redux.qll
@@ -27,7 +27,7 @@ module Redux {
       importer.getADependenciesObject("").getADependency(dependency.getPackageName(), _)
     }
 
-    /** A package that can be considered an entry point for a Redux app. */
+    /** Gets a package that can be considered an entry point for a Redux app. */
     private PackageJSON entryPointPackage() {
       result = getPackageJson(any(StoreCreation c).getFile())
       or

--- a/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
@@ -376,7 +376,7 @@ private module Sqlite {
     result = API::Node::ofType("sqlite3", "Database")
   }
 
-  /** A call to a query method on a Sqlite database instance that returns the same instance. */
+  /** Gets a call to a query method on a Sqlite database instance that returns the same instance. */
   private API::Node getAChainingQueryCall() {
     result = database().getMember(["all", "each", "exec", "get", "run"]).getReturn()
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Vue.qll
@@ -43,7 +43,7 @@ module Vue {
    */
   DataFlow::SourceNode vue() { result = vueLibrary().getAnImmediateUse() }
 
-  /** An API node referring to a component or `Vue`. */
+  /** Gets an API node referring to a component or `Vue`. */
   private API::Node component() {
     result = vueLibrary()
     or
@@ -683,7 +683,7 @@ module Vue {
     }
   }
 
-  /** An API node referring to a `RouteConfig` being passed to `vue-router`. */
+  /** Gets an API node referring to a `RouteConfig` being passed to `vue-router`. */
   private API::Node routeConfig() {
     result = API::moduleImport("vue-router").getParameter(0).getMember("routes").getAMember()
     or

--- a/javascript/ql/lib/semmle/javascript/frameworks/Vuex.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Vuex.qll
@@ -376,7 +376,7 @@ module Vuex {
       importer.getADependenciesObject("").getADependency(dependency.getPackageName(), _)
     }
 
-    /** A package that can be considered an entry point for a Vuex app. */
+    /** Gets a package that can be considered an entry point for a Vuex app. */
     private PackageJSON entryPointPackage() {
       result = getPackageJson(storeRef().getAnImmediateUse().getFile())
       or

--- a/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
@@ -60,7 +60,7 @@ module XML {
     }
 
     /**
-     * A document from the `libxmljs` library.
+     * Gets a document from the `libxmljs` library.
      * The API is based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/libxmljs/index.d.ts
      */
     private API::Node doc() {
@@ -74,7 +74,7 @@ module XML {
     }
 
     /**
-     * An `Element` from the `libxmljs` library.
+     * Gets an `Element` from the `libxmljs` library.
      */
     private API::Node element() {
       result = doc().getMember(["child", "get", "node", "root"]).getReturn()
@@ -91,7 +91,7 @@ module XML {
     }
 
     /**
-     * An `Attr` from the `libxmljs` library.
+     * Gets an `Attr` from the `libxmljs` library.
      */
     private API::Node attr() {
       result = element().getMember("attr").getReturn()

--- a/javascript/ql/lib/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/jQuery.qll
@@ -525,7 +525,7 @@ module JQuery {
     }
   }
 
-  /** A source of jQuery objects from the AST-based `JQueryObject` class. */
+  /** Gets a source of jQuery objects from the AST-based `JQueryObject` class. */
   private DataFlow::SourceNode legacyObjectSource() {
     result = any(JQueryObjectInternal e).flow().getALocalSource()
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
@@ -83,7 +83,7 @@ module IndirectCommandInjection {
   }
 
   /**
-   * A command line parsing step from `pred` to `succ`.
+   * Holds if there is a command line parsing step from `pred` to `succ`.
    * E.g: `var succ = require("minimist")(pred)`.
    */
   predicate argsParseStep(DataFlow::Node pred, DataFlow::Node succ) {
@@ -97,7 +97,7 @@ module IndirectCommandInjection {
   }
 
   /**
-   * A Command instance from the `commander` library.
+   * Gets a Command instance from the `commander` library.
    */
   private API::Node commander() {
     result = API::moduleImport("commander")

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PrototypePollutingAssignmentCustomizations.qll
@@ -25,7 +25,7 @@ module PrototypePollutingAssignment {
    */
   abstract class Sink extends DataFlow::Node {
     /**
-     * The flow label relevant for this sink.
+     * Gets the flow label relevant for this sink.
      *
      * Use the `taint` label for untrusted property names, and the `ObjectPrototype` label for
      * object mutations.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -136,7 +136,7 @@ module XssThroughDom {
    */
   module Forms {
     /**
-     * A reference to an import of `Formik`.
+     * Gets a reference to an import of `Formik`.
      */
     private DataFlow::SourceNode formik() {
       result = DataFlow::moduleImport("formik")

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -30,7 +30,7 @@ predicate isRouteHandlerUsingCookies(Routing::RouteHandler handler) {
 }
 
 /**
- * Checks if `route` is preceded by the cookie middleware `cookie`.
+ * Holds if `route` is preceded by the cookie middleware `cookie`.
  *
  * A router handler following after cookie parsing is assumed to depend on
  * cookies, and thus require CSRF protection.
@@ -135,7 +135,7 @@ API::CallNode passportAuthenticateCall() {
 }
 
 /**
- * A call of form `passport.authenticate(..., { session: false })`, implying that the incoming
+ * Gets a call of form `passport.authenticate(..., { session: false })`, implying that the incoming
  * request must carry its credentials rather than relying on cookies.
  *
  * In principle such routes should not be preceded by a cookie-parsing middleware, but to

--- a/javascript/ql/src/Security/CWE-730/ServerCrash.ql
+++ b/javascript/ql/src/Security/CWE-730/ServerCrash.ql
@@ -172,7 +172,7 @@ query predicate edges(ASTNode pred, ASTNode succ) {
 }
 
 /**
- * A node in the `edge/2` relation above.
+ * Holds if `node` is in the `edge/2` relation above.
  */
 query predicate nodes(ASTNode node) {
   edges(node, _) or

--- a/javascript/ql/src/printAst.ql
+++ b/javascript/ql/src/printAst.ql
@@ -12,7 +12,7 @@ import semmle.javascript.PrintAst
 import definitions
 
 /**
- * The source file to generate an AST from.
+ * Gets the source file to generate an AST from.
  */
 external string selectedSourceFile();
 

--- a/ql/ql/src/queries/style/docs/PredicateDocs.ql
+++ b/ql/ql/src/queries/style/docs/PredicateDocs.ql
@@ -17,6 +17,7 @@ string docLines(Predicate pred) {
 
 from Predicate pred, string message
 where
+  not pred.isPrivate() and
   // only considering qldocs that look like a class-doc, to avoid reporting way too much.
   docLines(pred).matches(["A", "An", "The"] + " %") and // looks like a class doc.
   not pred instanceof NewTypeBranch and // <- these are actually kinda class-like.

--- a/ql/ql/src/queries/style/docs/PredicateDocs.ql
+++ b/ql/ql/src/queries/style/docs/PredicateDocs.ql
@@ -24,13 +24,25 @@ where
     exists(pred.getReturnTypeExpr()) and
     not docLines(pred)
         .matches([
-            ["Gets", "Get", "Holds", "Create", "Creates"] + " %", "INTERNAL%", "DEPRECATED%",
+            "Gets %", //
+            "Get %", //
+            "Holds %", // <- predicates without a result can sometimes still use 'Holds'.
+            "Create %", //
+            "Creates %", //
+            "INTERNAL%", //
+            "DEPRECATED%", //
             "EXPERIMENTAL%"
-          ]) and // <- predicates without a result can sometimes still use 'Holds'.
+          ]) and
     message = "The QLDoc for a predicate with a result should start with 'Gets'."
     or
     not exists(pred.getReturnTypeExpr()) and
-    not docLines(pred).matches(["Holds ", "INTERNAL", "DEPRECATED", "EXPERIMENTAL"] + "%") and
+    not docLines(pred)
+        .matches([
+            "Holds %", //
+            "INTERNAL%", //
+            "DEPRECATED%", //
+            "EXPERIMENTAL%" //
+          ]) and
     message = "The QLDoc for a predicate without a result should start with 'Holds'."
   )
 select pred.getQLDoc(), message

--- a/ql/ql/src/queries/style/docs/PredicateDocs.ql
+++ b/ql/ql/src/queries/style/docs/PredicateDocs.ql
@@ -30,7 +30,7 @@ where
     message = "The QLDoc for a predicate with a result should start with 'Gets'."
     or
     not exists(pred.getReturnTypeExpr()) and
-    not docLines(pred).matches(["Holds" + " %", "INTERNAL%", "DEPRECATED%", "EXPERIMENTAL%"]) and
+    not docLines(pred).matches(["Holds ", "INTERNAL", "DEPRECATED", "EXPERIMENTAL"] + "%") and
     message = "The QLDoc for a predicate without a result should start with 'Holds'."
   )
 select pred.getQLDoc(), message

--- a/ql/ql/src/queries/style/docs/PredicateDocs.ql
+++ b/ql/ql/src/queries/style/docs/PredicateDocs.ql
@@ -1,0 +1,36 @@
+/**
+ * @name Predicate QLDoc style.
+ * @description The QLDoc for a predicate should start with "Gets" or "Holds".
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/pred-doc-style
+ * @tags maintainability
+ * @precision very-high
+ */
+
+import ql
+
+string docLines(Predicate pred) {
+  result =
+    pred.getQLDoc().getContents().replaceAll("/**", "").replaceAll("*", "").splitAt("\n").trim()
+}
+
+from Predicate pred, string message
+where
+  // only considering qldocs that look like a class-doc, to avoid reporting way too much.
+  docLines(pred).matches(["A", "An", "The"] + " %") and // looks like a class doc.
+  not pred instanceof NewTypeBranch and // <- these are actually kinda class-like.
+  (
+    exists(pred.getReturnTypeExpr()) and
+    not docLines(pred)
+        .matches([
+            ["Gets", "Get", "Holds", "Create", "Creates"] + " %", "INTERNAL%", "DEPRECATED%",
+            "EXPERIMENTAL%"
+          ]) and // <- predicates without a result can sometimes still use 'Holds'.
+    message = "The QLDoc for a predicate with a result should start with 'Gets'."
+    or
+    not exists(pred.getReturnTypeExpr()) and
+    not docLines(pred).matches(["Holds" + " %", "INTERNAL%", "DEPRECATED%", "EXPERIMENTAL%"]) and
+    message = "The QLDoc for a predicate without a result should start with 'Holds'."
+  )
+select pred.getQLDoc(), message


### PR DESCRIPTION
Inspired by some qldoc from https://github.com/github/codeql/pull/8014 

[Here is the style guide](https://github.com/github/codeql/blob/main/docs/qldoc-style-guide.md#qldoc-for-predicates). 

And drive-by fix most of the instances I found throughout JS. 