### PR TITLE
JS: cache RegExpCreationNode::getAReference

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -1650,5 +1650,9 @@ class RegExpCreationNode extends DataFlow::SourceNode {
   }
 
   /** Gets a data flow node referring to this regular expression. */
-  DataFlow::SourceNode getAReference() { result = this.getAReference(DataFlow::TypeTracker::end()) }
+  cached
+  DataFlow::SourceNode getAReference() {
+    Stages::FlowSteps::ref() and
+    result = this.getAReference(DataFlow::TypeTracker::end())
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/CachedStages.qll
@@ -238,6 +238,8 @@ module Stages {
       AccessPath::DominatingPaths::hasDominatingWrite(_)
       or
       DataFlow::SharedFlowStep::step(_, _)
+      or
+      exists(any(DataFlow::RegExpCreationNode e).getAReference())
     }
   }
 


### PR DESCRIPTION
[Evaluation shows a decent speedup](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/cacheReg__nightly__security-extend/reports#analysis-time-per-source-compact-always-interesting), mostly for big benchmarks.  

[And the db-size is almost completely unaffected](https://github.com/github/codeql-dca-main/blob/data/erik-krogh/cacheReg__nightly__security-extend/reports/db-sizes/entire-db.afterNormalCleanup.txt). 