### PR TITLE
Shared: use shared access path syntax to parse arguments in CSV rows

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/AccessPathSyntax.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/AccessPathSyntax.qll
@@ -6,12 +6,110 @@
  * (which does not use the shared data flow libraries).
  */
 
+/**
+ * Convenience-predicate for extracting two capture groups at once.
+ */
+bindingset[input, regexp]
+private predicate regexpCaptureTwo(string input, string regexp, string capture1, string capture2) {
+  capture1 = input.regexpCapture(regexp, 1) and
+  capture2 = input.regexpCapture(regexp, 2)
+}
+
 /** Companion module to the `AccessPath` class. */
 module AccessPath {
   /** A string that should be parsed as an access path. */
   abstract class Range extends string {
     bindingset[this]
     Range() { any() }
+  }
+
+  /**
+   * Parses an integer constant `n` or interval `n1..n2` (inclusive) and gets the value
+   * of the constant or any value contained in the interval.
+   */
+  bindingset[arg]
+  int parseInt(string arg) {
+    result = arg.toInt()
+    or
+    // Match "n1..n2"
+    exists(string lo, string hi |
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.(-?\\d+)", lo, hi) and
+      result = [lo.toInt() .. hi.toInt()]
+    )
+  }
+
+  /**
+   * Parses a lower-bounded interval `n..` and gets the lower bound.
+   */
+  bindingset[arg]
+  private int parseLowerBound(string arg) {
+    result = arg.regexpCapture("(-?\\d+)\\.\\.", 1).toInt()
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that explicitly
+   * references the arity, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  private int parseIntWithExplicitArity(string arg, int arity) {
+    result >= 0 and // do not allow N-1 to resolve to a negative index
+    exists(string lo |
+      // N-x
+      lo = arg.regexpCapture("N-(\\d+)", 1) and
+      result = arity - lo.toInt()
+      or
+      // N-x..
+      lo = arg.regexpCapture("N-(\\d+)\\.\\.", 1) and
+      result = [arity - lo.toInt(), arity - 1]
+    )
+    or
+    exists(string lo, string hi |
+      // x..N-y
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [lo.toInt() .. arity - hi.toInt()]
+      or
+      // N-x..Ny
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. arity - hi.toInt()] and
+      result >= 0
+      or
+      // N-x..y
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. hi.toInt()] and
+      result >= 0
+    )
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) and gets any
+   * of the integers contained within (of which there may be infinitely many).
+   *
+   * Has no result for arguments involving an explicit arity, such as `N-1`.
+   */
+  bindingset[arg, result]
+  int parseIntUnbounded(string arg) {
+    result = parseInt(arg)
+    or
+    result >= parseLowerBound(arg)
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that
+   * may reference the arity of a call, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  int parseIntWithArity(string arg, int arity) {
+    result = parseInt(arg)
+    or
+    result in [parseLowerBound(arg) .. arity - 1]
+    or
+    result = parseIntWithExplicitArity(arg, arity)
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/AccessPathSyntax.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/AccessPathSyntax.qll
@@ -71,7 +71,7 @@ module AccessPath {
       regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [lo.toInt() .. arity - hi.toInt()]
       or
-      // N-x..Ny
+      // N-x..N-y
       regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [arity - lo.toInt() .. arity - hi.toInt()] and
       result >= 0

--- a/java/ql/lib/semmle/code/java/dataflow/internal/AccessPathSyntax.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/AccessPathSyntax.qll
@@ -6,12 +6,110 @@
  * (which does not use the shared data flow libraries).
  */
 
+/**
+ * Convenience-predicate for extracting two capture groups at once.
+ */
+bindingset[input, regexp]
+private predicate regexpCaptureTwo(string input, string regexp, string capture1, string capture2) {
+  capture1 = input.regexpCapture(regexp, 1) and
+  capture2 = input.regexpCapture(regexp, 2)
+}
+
 /** Companion module to the `AccessPath` class. */
 module AccessPath {
   /** A string that should be parsed as an access path. */
   abstract class Range extends string {
     bindingset[this]
     Range() { any() }
+  }
+
+  /**
+   * Parses an integer constant `n` or interval `n1..n2` (inclusive) and gets the value
+   * of the constant or any value contained in the interval.
+   */
+  bindingset[arg]
+  int parseInt(string arg) {
+    result = arg.toInt()
+    or
+    // Match "n1..n2"
+    exists(string lo, string hi |
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.(-?\\d+)", lo, hi) and
+      result = [lo.toInt() .. hi.toInt()]
+    )
+  }
+
+  /**
+   * Parses a lower-bounded interval `n..` and gets the lower bound.
+   */
+  bindingset[arg]
+  private int parseLowerBound(string arg) {
+    result = arg.regexpCapture("(-?\\d+)\\.\\.", 1).toInt()
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that explicitly
+   * references the arity, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  private int parseIntWithExplicitArity(string arg, int arity) {
+    result >= 0 and // do not allow N-1 to resolve to a negative index
+    exists(string lo |
+      // N-x
+      lo = arg.regexpCapture("N-(\\d+)", 1) and
+      result = arity - lo.toInt()
+      or
+      // N-x..
+      lo = arg.regexpCapture("N-(\\d+)\\.\\.", 1) and
+      result = [arity - lo.toInt(), arity - 1]
+    )
+    or
+    exists(string lo, string hi |
+      // x..N-y
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [lo.toInt() .. arity - hi.toInt()]
+      or
+      // N-x..Ny
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. arity - hi.toInt()] and
+      result >= 0
+      or
+      // N-x..y
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. hi.toInt()] and
+      result >= 0
+    )
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) and gets any
+   * of the integers contained within (of which there may be infinitely many).
+   *
+   * Has no result for arguments involving an explicit arity, such as `N-1`.
+   */
+  bindingset[arg, result]
+  int parseIntUnbounded(string arg) {
+    result = parseInt(arg)
+    or
+    result >= parseLowerBound(arg)
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that
+   * may reference the arity of a call, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  int parseIntWithArity(string arg, int arity) {
+    result = parseInt(arg)
+    or
+    result in [parseLowerBound(arg) .. arity - 1]
+    or
+    result = parseIntWithExplicitArity(arg, arity)
   }
 }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/AccessPathSyntax.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/AccessPathSyntax.qll
@@ -71,7 +71,7 @@ module AccessPath {
       regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [lo.toInt() .. arity - hi.toInt()]
       or
-      // N-x..Ny
+      // N-x..N-y
       regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [arity - lo.toInt() .. arity - hi.toInt()] and
       result >= 0

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -200,21 +200,10 @@ predicate interpretInputSpecific(string c, InterpretNode mid, InterpretNode n) {
   )
 }
 
-bindingset[s]
-private int parsePosition(string s) {
-  result = s.regexpCapture("([-0-9]+)", 1).toInt()
-  or
-  exists(int n1, int n2 |
-    s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 1).toInt() = n1 and
-    s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 2).toInt() = n2 and
-    result in [n1 .. n2]
-  )
-}
-
 /** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
 bindingset[s]
-ArgumentPosition parseParamBody(string s) { result = parsePosition(s) }
+ArgumentPosition parseParamBody(string s) { result = AccessPath::parseInt(s) }
 
 /** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
 bindingset[s]
-ParameterPosition parseArgBody(string s) { result = parsePosition(s) }
+ParameterPosition parseArgBody(string s) { result = AccessPath::parseInt(s) }

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/AccessPathSyntax.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/AccessPathSyntax.qll
@@ -6,12 +6,110 @@
  * (which does not use the shared data flow libraries).
  */
 
+/**
+ * Convenience-predicate for extracting two capture groups at once.
+ */
+bindingset[input, regexp]
+private predicate regexpCaptureTwo(string input, string regexp, string capture1, string capture2) {
+  capture1 = input.regexpCapture(regexp, 1) and
+  capture2 = input.regexpCapture(regexp, 2)
+}
+
 /** Companion module to the `AccessPath` class. */
 module AccessPath {
   /** A string that should be parsed as an access path. */
   abstract class Range extends string {
     bindingset[this]
     Range() { any() }
+  }
+
+  /**
+   * Parses an integer constant `n` or interval `n1..n2` (inclusive) and gets the value
+   * of the constant or any value contained in the interval.
+   */
+  bindingset[arg]
+  int parseInt(string arg) {
+    result = arg.toInt()
+    or
+    // Match "n1..n2"
+    exists(string lo, string hi |
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.(-?\\d+)", lo, hi) and
+      result = [lo.toInt() .. hi.toInt()]
+    )
+  }
+
+  /**
+   * Parses a lower-bounded interval `n..` and gets the lower bound.
+   */
+  bindingset[arg]
+  private int parseLowerBound(string arg) {
+    result = arg.regexpCapture("(-?\\d+)\\.\\.", 1).toInt()
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that explicitly
+   * references the arity, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  private int parseIntWithExplicitArity(string arg, int arity) {
+    result >= 0 and // do not allow N-1 to resolve to a negative index
+    exists(string lo |
+      // N-x
+      lo = arg.regexpCapture("N-(\\d+)", 1) and
+      result = arity - lo.toInt()
+      or
+      // N-x..
+      lo = arg.regexpCapture("N-(\\d+)\\.\\.", 1) and
+      result = [arity - lo.toInt(), arity - 1]
+    )
+    or
+    exists(string lo, string hi |
+      // x..N-y
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [lo.toInt() .. arity - hi.toInt()]
+      or
+      // N-x..Ny
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. arity - hi.toInt()] and
+      result >= 0
+      or
+      // N-x..y
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. hi.toInt()] and
+      result >= 0
+    )
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) and gets any
+   * of the integers contained within (of which there may be infinitely many).
+   *
+   * Has no result for arguments involving an explicit arity, such as `N-1`.
+   */
+  bindingset[arg, result]
+  int parseIntUnbounded(string arg) {
+    result = parseInt(arg)
+    or
+    result >= parseLowerBound(arg)
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that
+   * may reference the arity of a call, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  int parseIntWithArity(string arg, int arity) {
+    result = parseInt(arg)
+    or
+    result in [parseLowerBound(arg) .. arity - 1]
+    or
+    result = parseIntWithExplicitArity(arg, arity)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/AccessPathSyntax.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/AccessPathSyntax.qll
@@ -71,7 +71,7 @@ module AccessPath {
       regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [lo.toInt() .. arity - hi.toInt()]
       or
-      // N-x..Ny
+      // N-x..N-y
       regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [arity - lo.toInt() .. arity - hi.toInt()] and
       result >= 0

--- a/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/FlowSummary.qll
@@ -32,12 +32,18 @@ module SummaryComponent {
   /** Gets a summary component that represents an element in an array at an unknown index. */
   SummaryComponent arrayElementUnknown() { result = SC::content(TUnknownArrayElementContent()) }
 
-  /** Gets a summary component that represents an element in an array at a known index. */
+  /**
+   * Gets a summary component that represents an element in an array at a known index.
+   *
+   * Has no result for negative indices. Wrap-around interpretation of negative indices should be
+   * handled by the caller, if modeling a function that has such behavior.
+   */
   bindingset[i]
   SummaryComponent arrayElementKnown(int i) {
     result = SC::content(TKnownArrayElementContent(i))
     or
     // `i` may be out of range
+    i >= 0 and
     not exists(TKnownArrayElementContent(i)) and
     result = arrayElementUnknown()
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/AccessPathSyntax.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/AccessPathSyntax.qll
@@ -6,12 +6,110 @@
  * (which does not use the shared data flow libraries).
  */
 
+/**
+ * Convenience-predicate for extracting two capture groups at once.
+ */
+bindingset[input, regexp]
+private predicate regexpCaptureTwo(string input, string regexp, string capture1, string capture2) {
+  capture1 = input.regexpCapture(regexp, 1) and
+  capture2 = input.regexpCapture(regexp, 2)
+}
+
 /** Companion module to the `AccessPath` class. */
 module AccessPath {
   /** A string that should be parsed as an access path. */
   abstract class Range extends string {
     bindingset[this]
     Range() { any() }
+  }
+
+  /**
+   * Parses an integer constant `n` or interval `n1..n2` (inclusive) and gets the value
+   * of the constant or any value contained in the interval.
+   */
+  bindingset[arg]
+  int parseInt(string arg) {
+    result = arg.toInt()
+    or
+    // Match "n1..n2"
+    exists(string lo, string hi |
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.(-?\\d+)", lo, hi) and
+      result = [lo.toInt() .. hi.toInt()]
+    )
+  }
+
+  /**
+   * Parses a lower-bounded interval `n..` and gets the lower bound.
+   */
+  bindingset[arg]
+  private int parseLowerBound(string arg) {
+    result = arg.regexpCapture("(-?\\d+)\\.\\.", 1).toInt()
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that explicitly
+   * references the arity, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  private int parseIntWithExplicitArity(string arg, int arity) {
+    result >= 0 and // do not allow N-1 to resolve to a negative index
+    exists(string lo |
+      // N-x
+      lo = arg.regexpCapture("N-(\\d+)", 1) and
+      result = arity - lo.toInt()
+      or
+      // N-x..
+      lo = arg.regexpCapture("N-(\\d+)\\.\\.", 1) and
+      result = [arity - lo.toInt(), arity - 1]
+    )
+    or
+    exists(string lo, string hi |
+      // x..N-y
+      regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [lo.toInt() .. arity - hi.toInt()]
+      or
+      // N-x..Ny
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. arity - hi.toInt()] and
+      result >= 0
+      or
+      // N-x..y
+      regexpCaptureTwo(arg, "N-(\\d+)\\.\\.(\\d+)", lo, hi) and
+      result = [arity - lo.toInt() .. hi.toInt()] and
+      result >= 0
+    )
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) and gets any
+   * of the integers contained within (of which there may be infinitely many).
+   *
+   * Has no result for arguments involving an explicit arity, such as `N-1`.
+   */
+  bindingset[arg, result]
+  int parseIntUnbounded(string arg) {
+    result = parseInt(arg)
+    or
+    result >= parseLowerBound(arg)
+  }
+
+  /**
+   * Parses an integer constant or interval (bounded or unbounded) that
+   * may reference the arity of a call, such as `N-1` or `N-3..N-1`.
+   *
+   * Note that expressions of form `N-x` will never resolve to a negative index,
+   * even if `N` is zero (it will have no result in that case).
+   */
+  bindingset[arg, arity]
+  int parseIntWithArity(string arg, int arity) {
+    result = parseInt(arg)
+    or
+    result in [parseLowerBound(arg) .. arity - 1]
+    or
+    result = parseIntWithExplicitArity(arg, arity)
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/AccessPathSyntax.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/AccessPathSyntax.qll
@@ -71,7 +71,7 @@ module AccessPath {
       regexpCaptureTwo(arg, "(-?\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [lo.toInt() .. arity - hi.toInt()]
       or
-      // N-x..Ny
+      // N-x..N-y
       regexpCaptureTwo(arg, "N-(\\d+)\\.\\.N-(\\d+)", lo, hi) and
       result = [arity - lo.toInt() .. arity - hi.toInt()] and
       result >= 0

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -59,7 +59,7 @@ predicate summaryElement(DataFlowCallable c, string input, string output, string
  * is currently restricted to `"BlockArgument"`.
  */
 bindingset[c]
-SummaryComponent interpretComponentSpecific(string c) {
+SummaryComponent interpretComponentSpecific(AccessPathToken c) {
   c = "Receiver" and
   result = FlowSummary::SummaryComponent::receiver()
   or
@@ -76,14 +76,9 @@ SummaryComponent interpretComponentSpecific(string c) {
   result = FlowSummary::SummaryComponent::arrayElementUnknown()
   or
   exists(int i |
-    c.regexpCapture("ArrayElement\\[([0-9]+)\\]", 1).toInt() = i and
+    c.getName() = "ArrayElement" and
+    i = AccessPath::parseInt(c.getAnArgument()) and
     result = FlowSummary::SummaryComponent::arrayElementKnown(i)
-  )
-  or
-  exists(int i1, int i2 |
-    c.regexpCapture("ArrayElement\\[([-0-9]+)\\.\\.([0-9]+)\\]", 1).toInt() = i1 and
-    c.regexpCapture("ArrayElement\\[([-0-9]+)\\.\\.([0-9]+)\\]", 2).toInt() = i2 and
-    result = FlowSummary::SummaryComponent::arrayElementKnown([i1 .. i2])
   )
 }
 
@@ -172,25 +167,14 @@ module ParsePositions {
     )
   }
 
-  bindingset[s]
-  private int parsePosition(string s) {
-    result = s.regexpCapture("([-0-9]+)", 1).toInt()
-    or
-    exists(int n1, int n2 |
-      s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 1).toInt() = n1 and
-      s.regexpCapture("([-0-9]+)\\.\\.([0-9]+)", 2).toInt() = n2 and
-      result in [n1 .. n2]
-    )
-  }
-
   predicate isParsedParameterPosition(string c, int i) {
     isParamBody(c) and
-    i = parsePosition(c)
+    i = AccessPath::parseInt(c)
   }
 
   predicate isParsedArgumentPosition(string c, int i) {
     isArgBody(c) and
-    i = parsePosition(c)
+    i = AccessPath::parseInt(c)
   }
 }
 


### PR DESCRIPTION
Previously it was up to each language to parse the numeric arguments in an access path token, such as `Argument[1..3]`. This has lead to some duplication and inconsistency, with plenty of `regexpCapture` calls doing similar things.

This PR places some common parsing primitives into the `AccessPathSyntax.qll` file and uses those where possible.

Note that for the _identifying_ access path (in dynamic languages), the syntax `Argument[N-1]` means the last argument of a call, and `Argument[N-2]` the second-last, etc. For the time being at least, this syntax is specific to the identifying access path and therefore to dynamic languages, but I still think the shared `AccessPathSyntax.qll` file is the best place for this code to live. The predicate for parsing it, `parseIntWithExplicitArity`, can only be invoked with a known arity, and the call-site arity is not generally known when interpreting an input/output spec (for static langauges, it should be known to the author writing the spec, so there is no need to use the `N-1` syntax). I'm mentioning this here in case you're wondering why this code appears to be unused for your language.

Also replaces a few `regexpCapture` calls for extracting a field name from a token such as `Field[x]`. The qualified name of a field can contain commas (at least for C#), so to avoid splitting it, we extract it with `getArgumentList()` rather than `getAnArgument()`.