### PR TITLE
JS: preparation for sharing MaD library based on API graphs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/ModelsAsData.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/ModelsAsData.qll
@@ -40,7 +40,7 @@ private class RemoteFlowSourceFromCsv extends RemoteFlowSource {
  */
 private predicate summaryStepNodes(DataFlow::Node pred, DataFlow::Node succ, string kind) {
   exists(API::Node predNode, API::Node succNode |
-    ModelOutput::summaryStep(predNode, succNode, kind) and
+    Specific::summaryStep(predNode, succNode, kind) and
     pred = predNode.getARhs() and
     succ = succNode.getAnImmediateUse()
   )

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/ModelsAsData.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/ModelsAsData.qll
@@ -21,7 +21,8 @@
  */
 
 private import javascript
-private import internal.Shared as Shared
+private import internal.ApiGraphModels as Shared
+private import internal.ApiGraphModelsSpecific as Specific
 import Shared::ModelInput as ModelInput
 import Shared::ModelOutput as ModelOutput
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -275,9 +275,6 @@ API::Node getSuccessorFromNode(API::Node node, AccessPathToken token) {
   token.getName() = ["Argument", "Parameter"] and
   result = node.getParameter(getAnIntFromStringUnbounded(token.getAnArgument()))
   or
-  token.getName() = "Member" and
-  result = node.getMember(token.getAnArgument())
-  or
   token.getName() = "ReturnValue" and
   result = node.getReturn()
   or

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -57,11 +57,12 @@
  */
 
 private import ApiGraphModelsSpecific as Specific
-import AccessPathSyntax
 
 private class Unit = Specific::Unit;
 
 private module API = Specific::API;
+
+private import Specific::AccessPathSyntax
 
 /** Module containing hooks for providing input data to be interpreted as a model. */
 module ModelInput {

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -56,12 +56,12 @@
  * the type is related to the `foo` package but is not intended to match a static type.
  */
 
-private import Impl as Impl
+private import ApiGraphModelsSpecific as Specific
 import AccessPathSyntax
 
-private class Unit = Impl::Unit;
+private class Unit = Specific::Unit;
 
-private module API = Impl::API;
+private module API = Specific::API;
 
 /** Module containing hooks for providing input data to be interpreted as a model. */
 module ModelInput {
@@ -230,7 +230,7 @@ string getAPackageAlias(string package) {
  * Holds if CSV rows involving `package` might be relevant for the analysis of this database.
  */
 private predicate isRelevantPackage(string package) {
-  Impl::isPackageUsed(package)
+  Specific::isPackageUsed(package)
   or
   exists(string other |
     isRelevantPackage(other) and
@@ -282,7 +282,7 @@ private API::Node getSuccessorFromNode(API::Node node, AccessPathToken token) {
   result = node.getReturn()
   or
   // Language-specific tokens
-  result = Impl::getExtraSuccessorFromNode(node, token)
+  result = Specific::getExtraSuccessorFromNode(node, token)
 }
 
 /**
@@ -303,7 +303,7 @@ private API::Node getSuccessorFromInvoke(API::InvokeNode invoke, AccessPathToken
   result = invoke.getReturn()
   or
   // Language-specific tokens
-  result = Impl::getExtraSuccessorFromInvoke(invoke, token)
+  result = Specific::getExtraSuccessorFromInvoke(invoke, token)
 }
 
 /**
@@ -314,7 +314,7 @@ private predicate invocationMatchesCallSiteFilter(API::InvokeNode invoke, Access
   token.getName() = "WithArity" and
   invoke.getNumArgument() = getAnIntFromStringUnbounded(token.getAnArgument())
   or
-  Impl::invocationMatchesExtraCallSiteFilter(invoke, token)
+  Specific::invocationMatchesExtraCallSiteFilter(invoke, token)
 }
 
 /**
@@ -335,7 +335,7 @@ API::Node getNodeFromPath(string package, string type, AccessPath path, int n) {
     )
     or
     // Language-specific cases, such as handling of global variables
-    result = Impl::getExtraNodeFromPath(package, type, path, n)
+    result = Specific::getExtraNodeFromPath(package, type, path, n)
   )
   or
   result = getSuccessorFromNode(getNodeFromPath(package, type, path, n - 1), path.getToken(n - 1))

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -132,3 +132,45 @@ predicate invocationMatchesExtraCallSiteFilter(API::InvokeNode invoke, AccessPat
   invoke instanceof API::CallNode and
   invoke instanceof DataFlow::CallNode // Workaround compiler bug
 }
+
+/**
+ * Holds if `path` is an input or output spec for a summary with the given `base` node.
+ */
+pragma[nomagic]
+private predicate relevantInputOutputPath(API::InvokeNode base, AccessPath path) {
+  ModelOutput::resolvedSummaryBase(base, path, _, _)
+  or
+  ModelOutput::resolvedSummaryBase(base, _, path, _)
+}
+
+/**
+ * Gets the API node for the first `n` tokens of the given input/output path, evaluated relative to `baseNode`.
+ */
+private API::Node getNodeFromInputOutputPath(API::InvokeNode baseNode, AccessPath path, int n) {
+  relevantInputOutputPath(baseNode, path) and
+  (
+    n = 1 and
+    result = getSuccessorFromInvoke(baseNode, path.getToken(0))
+    or
+    result =
+      getSuccessorFromNode(getNodeFromInputOutputPath(baseNode, path, n - 1), path.getToken(n - 1))
+  )
+}
+
+/**
+ * Gets the API node for the given input/output path, evaluated relative to `baseNode`.
+ */
+private API::Node getNodeFromInputOutputPath(API::InvokeNode baseNode, AccessPath path) {
+  result = getNodeFromInputOutputPath(baseNode, path, path.getNumToken())
+}
+
+/**
+ * Holds if a CSV summary contributed the step `pred -> succ` of the given `kind`.
+ */
+predicate summaryStep(API::Node pred, API::Node succ, string kind) {
+  exists(API::InvokeNode base, AccessPath input, AccessPath output |
+    ModelOutput::resolvedSummaryBase(base, input, output, kind) and
+    pred = getNodeFromInputOutputPath(base, input) and
+    succ = getNodeFromInputOutputPath(base, output)
+  )
+}

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -72,6 +72,10 @@ private API::Node getGlobalNode(string globalName) {
 /** Gets a JavaScript-specific interpretation of the `(package, type, path)` tuple after resolving the first `n` access path tokens. */
 bindingset[package, type, path]
 API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int n) {
+  type = "" and
+  n = 0 and
+  result = API::moduleImport(package)
+  or
   // Global variable accesses is via the 'global' package
   exists(AccessPathToken token |
     package = getAPackageAlias("global") and
@@ -180,3 +184,8 @@ predicate summaryStep(API::Node pred, API::Node succ, string kind) {
     succ = getNodeFromInputOutputPath(base, output)
   )
 }
+
+class InvokeNode = API::InvokeNode;
+
+/** Gets an `InvokeNode` corresponding to an invocation of `node`. */
+InvokeNode getAnInvocationOf(API::Node node) { result = node.getAnInvocation() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -1,5 +1,5 @@
 /**
- * Contains the language-specific part of the models-as-data implementation found in `Shared.qll`.
+ * Contains the language-specific part of the models-as-data implementation found in `ApiGraphModels.qll`.
  *
  * It must export the following members:
  * ```codeql
@@ -15,7 +15,7 @@
 
 private import javascript as js
 private import js::DataFlow as DataFlow
-private import Shared
+private import ApiGraphModels
 
 class Unit = js::Unit;
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -21,6 +21,9 @@ class Unit = js::Unit;
 
 module API = js::API;
 
+import semmle.javascript.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
+private import AccessPathSyntax
+
 /**
  * Holds if models describing `package` may be relevant for the analysis of this database.
  */

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -89,6 +89,9 @@ API::Node getExtraNodeFromPath(string package, string type, AccessPath path, int
  */
 bindingset[token]
 API::Node getExtraSuccessorFromNode(API::Node node, AccessPathToken token) {
+  token.getName() = "Member" and
+  result = node.getMember(token.getAnArgument())
+  or
   token.getName() = "Instance" and
   result = node.getInstance()
   or


### PR DESCRIPTION
Some preparation to make the MaD prototype in JavaScript usable from Ruby. Only JS code is actually affected by this PR.

- Renames `{Shared,Impl}.qll` to `ApiGraphModels` and `ApiGraphModelsSpecfic`. The `Specific` suffix matches the convention for files providing language-specific details in the shared data flow library.
- Makes the `API::InvokeNode` type be provided by the language, as not all languages use the term `InvokeNode`.
- Makes the base case of access path resolution be language-specific. That is, the `moduleImport` part is now JS-specific. In Ruby, the base case looks quite different as members of an imported package are just flooded into the local scope where it is imported (or something to that effect), and you can't really see locally which access paths refer to something from the imported package.
- Finally, `Member[x]` is now treated as a language-specific token. Ruby has both `obj.foo` and `obj::foo` and it's a bit ambiguous which of these is a "member". It might still have a token named `Member` but I'm not convinced the implementation can be shared (i.e. the corresponding predicate on an API graph node might be called something different).