### PR TITLE
C# Exclude dynamic casts from useless casts check

### DIFF
--- a/csharp/ql/src/Language Abuse/UselessUpcast.ql
+++ b/csharp/ql/src/Language Abuse/UselessUpcast.ql
@@ -207,6 +207,17 @@ class ExplicitUpcast extends ExplicitCast {
   }
 }
 
+// Stop external filepaths from appearing in the results
+class ValueOrRefTypeLocation extends ValueOrRefType {
+  override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
+    exists(string fullPath | super.hasLocationInfo(fullPath, sl, sc, el, ec) |
+      if exists(this.getFile().getRelativePath())
+      then path = fullPath
+      else path = fullPath.regexpReplaceAll(".*/", "<external>/")
+    )
+  }
+}
+
 from ExplicitUpcast u, ValueOrRefType src, ValueOrRefType dest
 where
   src = u.getSourceType() and

--- a/csharp/ql/src/Language Abuse/UselessUpcast.ql
+++ b/csharp/ql/src/Language Abuse/UselessUpcast.ql
@@ -204,17 +204,8 @@ class ExplicitUpcast extends ExplicitCast {
     this = any(LocalVariableDeclAndInitExpr decl | decl.isImplicitlyTyped()).getInitializer()
     or
     exists(LambdaExpr c | c.canReturn(this))
-  }
-}
-
-// Stop external filepaths from appearing in the results
-class ValueOrRefTypeLocation extends ValueOrRefType {
-  override predicate hasLocationInfo(string path, int sl, int sc, int el, int ec) {
-    exists(string fullPath | super.hasLocationInfo(fullPath, sl, sc, el, ec) |
-      if exists(this.getFile().getRelativePath())
-      then path = fullPath
-      else path = fullPath.regexpReplaceAll(".*/", "<external>/")
-    )
+    or
+    dest instanceof DynamicType
   }
 }
 

--- a/csharp/ql/src/change-notes/2022-02-28-useless-upcast.md
+++ b/csharp/ql/src/change-notes/2022-02-28-useless-upcast.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Casts to `dynamic` are excluded from the useless upcasts check (`cs/useless-upcast`).

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.cs
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.cs
@@ -17,8 +17,8 @@ class A : I1, I2
 
 class B : A
 {
-    public static bool operator==(B b1, B b2) { return false; }
-    public static bool operator!=(B b1, B b2) { return true; }
+    public static bool operator ==(B b1, B b2) { return false; }
+    public static bool operator !=(B b1, B b2) { return true; }
     public void M(B b) { }
 }
 
@@ -68,11 +68,11 @@ class Tests
 
         ((I2)a).Foo(); // GOOD: Cast to an interface
 
-        o = a==(A)b; // GOOD: EQExpr
+        o = a == (A)b; // GOOD: EQExpr
 
-        o = b==(B)b; // GOOD: Operator call
+        o = b == (B)b; // GOOD: Operator call
 
-        var act = (Action) (() => { }); // GOOD
+        var act = (Action)(() => { }); // GOOD
 
         var objects = args.Select(arg => (object)arg); // GOOD
 
@@ -126,9 +126,9 @@ static class IExtensions
 
 static class StaticMethods
 {
-   public static void M1(A _) { }
-   public static void M1(B _) { }
-   public static void M2(B _) { }
+    public static void M1(A _) { }
+    public static void M1(B _) { }
+    public static void M2(B _) { }
 }
 
 class Constructors : I2
@@ -160,6 +160,14 @@ class Constructors : I2
         void M(SubSub ss)
         {
             new Sub((Sub)ss); // BAD
+        }
+    }
+
+    class Dynamic
+    {
+        void M(object o)
+        {
+            var s0 = ((dynamic)o).ToString(); // GOOD
         }
     }
 }

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
@@ -6,4 +6,5 @@
 | UselessUpcast.cs:103:16:103:19 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:25:7:25:7 | C | C | UselessUpcast.cs:18:7:18:7 | B | B |
 | UselessUpcast.cs:158:34:158:40 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:156:11:156:16 | SubSub | SubSub | UselessUpcast.cs:151:11:151:13 | Sub | Sub |
 | UselessUpcast.cs:162:21:162:27 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:156:11:156:16 | SubSub | SubSub | UselessUpcast.cs:151:11:151:13 | Sub | Sub |
+| UselessUpcast.cs:170:23:170:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | file://<external>/System.Private.CoreLib.dll:0:0:0:0 | Object | Object | file://<external>/System.Private.CoreLib.dll:0:0:0:0 | dynamic | dynamic |
 | UselessUpcastBad.cs:9:23:9:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcastBad.cs:4:11:4:13 | Sub | Sub | UselessUpcastBad.cs:3:11:3:15 | Super | Super |

--- a/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessUpcast/UselessUpcast.expected
@@ -6,5 +6,4 @@
 | UselessUpcast.cs:103:16:103:19 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:25:7:25:7 | C | C | UselessUpcast.cs:18:7:18:7 | B | B |
 | UselessUpcast.cs:158:34:158:40 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:156:11:156:16 | SubSub | SubSub | UselessUpcast.cs:151:11:151:13 | Sub | Sub |
 | UselessUpcast.cs:162:21:162:27 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcast.cs:156:11:156:16 | SubSub | SubSub | UselessUpcast.cs:151:11:151:13 | Sub | Sub |
-| UselessUpcast.cs:170:23:170:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | file://<external>/System.Private.CoreLib.dll:0:0:0:0 | Object | Object | file://<external>/System.Private.CoreLib.dll:0:0:0:0 | dynamic | dynamic |
 | UselessUpcastBad.cs:9:23:9:32 | (...) ... | There is no need to upcast from $@ to $@ - the conversion can be done implicitly. | UselessUpcastBad.cs:4:11:4:13 | Sub | Sub | UselessUpcastBad.cs:3:11:3:15 | Super | Super |


### PR DESCRIPTION
This PR removes all casts to `dynamic` from the useless upcast check. The issue was reported in https://github.com/github/codeql/issues/8069.