### PR TITLE
QLSpeciifcation: Add documentation for expression pragmas 

### DIFF
--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -1308,7 +1308,7 @@ The values of an ``any`` expression are those values of the expression for which
 The abbreviated cases for an ``any`` expression are interpreted in the same way as for an aggregation.
 
 Expression Pragma
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 Expression pragmas can be used to guide optimisation.
 

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -1310,20 +1310,20 @@ The abbreviated cases for an ``any`` expression are interpreted in the same way 
 Expression Pragma
 ~~~~~~~~~~~~~~~~~
 
-Expression pragmas can be used to guide optimisation.
+Expression pragmas can be used to guide optimization.
 
 ::
    expression_pragma ::= "pragma" "[" expression_pragma_type "]" "(" expr ")"
 
    expression_pragma_type ::= "only_bind_out" | "only_bind_into"
 
-The values of an expression pragma are the values of the expression.
+The values of an expression pragma are the values of the contained expression.
 
-The type `only_bind_out` hints that uses the result of the expression pragma should not be used to guide the evaluation of the result of the contained expression.
+The type `only_bind_out` hints that uses of the result of the expression pragma should not be used to guide the evaluation of the result of the contained expression.
 When checking to see that all values are bound the compiler does not assume that if the result of the expression pragma is bound then the result of the contained 
 expression is bound.
 
-The type `only_bind_into` hints that uses the result of expression pragma should not be used to guide the evaluation of the result of the expression pragma.
+The type `only_bind_into` hints that uses of the contained expression should not be used to guide the evaluation of the result of the expression pragma.
 When checking to see that all values are bound the compiler does not assume that if the result of the contained expression is bound then the result of the 
 expression pragma is bound.
 

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -1530,9 +1530,10 @@ A range check has the following syntax:
 
 ::
 
-   inrange ::= expr "in" range
+   inrange ::= expr "in" (range | setliteral)
 
-The formula is equivalent to ``expr "=" range``.
+
+The formula is equivalent to ``expr "=" range`` or ``expr "=" setliteral``.
 
 Calls
 ~~~~~
@@ -2131,7 +2132,7 @@ The complete grammar for QL is as follows:
 
    instanceof ::= expr "instanceof" type
 
-   inrange ::= expr "in" range
+   inrange ::= expr "in" (range | setliteral)
 
    call ::= predicateRef (closure)? "(" (exprs)? ")"
         |   primary "." predicateName (closure)? "(" (exprs)? ")"

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -1001,6 +1001,7 @@ There are several kinds of expressions:
            |   postfix_cast
            |   callwithresults
            |   aggregation
+           |   expression_pragma
            |   any
            |   range
            |   setliteral
@@ -1305,6 +1306,26 @@ The ``any`` expression is a special kind of quantified expression.
 The values of an ``any`` expression are those values of the expression for which the formula matches.
 
 The abbreviated cases for an ``any`` expression are interpreted in the same way as for an aggregation.
+
+Expression Pragma
+~~~~~~~~~~~~~~~~
+
+Expression pragmas can be used to guide optimisation.
+
+::
+   expression_pragma ::= "pragma" "[" expression_pragma_type "]" "(" expr ")"
+
+   expression_pragma_type ::= "only_bind_out" | "only_bind_into"
+
+The values of an expression pragma are the values of the expression.
+
+The type `only_bind_out` hints that uses the result of the expression pragma should not be used to guide the evaluation of the result of the contained expression.
+When checking to see that all values are bound the compiler does not assume that if the result of the expression pragma is bound then the result of the contained 
+expression is bound.
+
+The type `only_bind_into` hints that uses the result of expression pragma should not be used to guide the evaluation of the result of the expression pragma.
+When checking to see that all values are bound the compiler does not assume that if the result of the contained expression is bound then the result of the 
+expression pragma is bound.
 
 Ranges
 ~~~~~~
@@ -2131,6 +2152,7 @@ The complete grammar for QL is as follows:
            |   postfix_cast
            |   callwithresults
            |   aggregation
+           |   expression_pragma
            |   any
            |   range
            |   setliteral
@@ -2162,6 +2184,10 @@ The complete grammar for QL is as follows:
                |   aggid ("[" expr "]")? "(" as_exprs ("order" "by" aggorderbys)? ")"
                |   "unique" "(" var_decls "|" (formula)? ("|" as_exprs)? ")"
  
+   expression_pragma ::= "pragma" "[" expression_pragma_type "]" "(" expr ")"
+
+   expression_pragma_type ::= "only_bind_out" | "only_bind_into"
+
    aggid ::= "avg" | "concat" | "count" | "max" | "min" | "rank" | "strictconcat" | "strictcount" | "strictsum" | "sum"
 
    aggorderbys ::= aggorderby ("," aggorderby)*

--- a/docs/codeql/ql-language-reference/ql-language-specification.rst
+++ b/docs/codeql/ql-language-reference/ql-language-specification.rst
@@ -998,10 +998,13 @@ There are several kinds of expressions:
            |   literal
            |   variable
            |   super_expr
-           |   callwithresult
            |   postfix_cast
+           |   callwithresults
            |   aggregation
            |   any
+           |   range
+           |   setliteral
+
 
 Parenthesized expressions
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The main part of this PR is adding documentation for expression pragmas. The semantics are simple but I gave a vague explanation of what the actual cases do.

I also drive-by fixed a couple of minor issues in the grammar:

- Cases missing from the local fragment for primary (but not from the dull description). Also the order differed for the cases that did exist.
- `in` not allowing set literals.

