### PR TITLE
C# Extractor Option for specifying compression.

### DIFF
--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -17,9 +17,15 @@ file_types:
       - .cs
 legacy_qltest_extraction: true
 options:
-  compression:
-    title: The type of compression.
-    description: >
-      A value indicating, which type of compression that should be used for the TRAP archive.
-      Allowed values are 'brotli', 'gzip' or 'none'. The default is 'brotli'.
-    type: string
+  trap:
+    title: Options pertaining to TRAP.
+    type: object
+    properties:
+      compression:
+        title: Controls compression for the TRAP files written by the extractor.
+        description: >
+          This option is only intended for use in debugging the extractor. Accepted
+          values are 'brotli' (the default, to write brotli-compressed TRAP), 'gzip', and 'none'
+          (to write uncompressed TRAP).
+        type: string
+        pattern: "^(none|gzip|brotli)$"

--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -16,3 +16,10 @@ file_types:
     extensions:
       - .cs
 legacy_qltest_extraction: true
+options:
+  compression:
+    title: The type of compression.
+    description: >
+      A value indicating, which type of compression that should be used for the TRAP archive.
+      Allowed values are 'brotli', 'gzip' or 'none'. The default is 'brotli'.
+    type: string

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Options.cs
@@ -46,7 +46,9 @@ namespace Semmle.Extraction.CSharp
             var argsList = new List<string>(arguments);
 
             if (!string.IsNullOrEmpty(extractionOptions))
+            {
                 argsList.AddRange(extractionOptions.Split(' '));
+            }
 
             options.ParseArguments(argsList);
             return options;

--- a/csharp/extractor/Semmle.Extraction.Tests/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Options.cs
@@ -210,19 +210,19 @@ namespace Semmle.Extraction.Tests
         [Fact]
         public void CompressionTests()
         {
-            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", "gzip");
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_TRAP_COMPRESSION", "gzip");
             options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
             Assert.Equal(TrapWriter.CompressionMode.Gzip, options.TrapCompression);
 
-            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", "brotli");
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_TRAP_COMPRESSION", "brotli");
             options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
             Assert.Equal(TrapWriter.CompressionMode.Brotli, options.TrapCompression);
 
-            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", "none");
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_TRAP_COMPRESSION", "none");
             options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
             Assert.Equal(TrapWriter.CompressionMode.None, options.TrapCompression);
 
-            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", null);
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_TRAP_COMPRESSION", null);
             options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
             Assert.Equal(TrapWriter.CompressionMode.Brotli, options.TrapCompression);
         }

--- a/csharp/extractor/Semmle.Extraction.Tests/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/Options.cs
@@ -33,6 +33,7 @@ namespace Semmle.Extraction.Tests
             Assert.False(options.ClrTracer);
             Assert.False(options.PDB);
             Assert.False(options.Fast);
+            Assert.Equal(TrapWriter.CompressionMode.Brotli, options.TrapCompression);
         }
 
         [Fact]
@@ -204,6 +205,26 @@ namespace Semmle.Extraction.Tests
             {
                 File.Delete(file);
             }
+        }
+
+        [Fact]
+        public void CompressionTests()
+        {
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", "gzip");
+            options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
+            Assert.Equal(TrapWriter.CompressionMode.Gzip, options.TrapCompression);
+
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", "brotli");
+            options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
+            Assert.Equal(TrapWriter.CompressionMode.Brotli, options.TrapCompression);
+
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", "none");
+            options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
+            Assert.Equal(TrapWriter.CompressionMode.None, options.TrapCompression);
+
+            Environment.SetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_OPTION_COMPRESSION", null);
+            options = CSharp.Options.CreateWithEnvironment(Array.Empty<string>());
+            Assert.Equal(TrapWriter.CompressionMode.Brotli, options.TrapCompression);
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -67,15 +67,12 @@ namespace Semmle.Extraction
                     Verbosity = (Verbosity)int.Parse(value);
                     return true;
                 case "compression":
-                    try
+                    if (Enum.TryParse<TrapWriter.CompressionMode>(value, true, out var mode))
                     {
-                        TrapCompression = (TrapWriter.CompressionMode)Enum.Parse(typeof(TrapWriter.CompressionMode), value, true);
+                        TrapCompression = mode;
                         return true;
                     }
-                    catch (ArgumentException)
-                    {
-                        return false;
-                    }
+                    return false;
                 default:
                     return false;
             }

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -66,7 +66,7 @@ namespace Semmle.Extraction
                 case "verbosity":
                     Verbosity = (Verbosity)int.Parse(value);
                     return true;
-                case "compression":
+                case "trap_compression":
                     if (Enum.TryParse<TrapWriter.CompressionMode>(value, true, out var mode))
                     {
                         TrapCompression = mode;

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -54,7 +54,7 @@ namespace Semmle.Extraction
         /// <summary>
         /// The compression algorithm used for trap files.
         /// </summary>
-        public TrapWriter.CompressionMode TrapCompression { get; set; } = TrapWriter.CompressionMode.Brotli;
+        public TrapWriter.CompressionMode TrapCompression { get; private set; } = TrapWriter.CompressionMode.Brotli;
 
         public virtual bool HandleOption(string key, string value)
         {

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -1,3 +1,4 @@
+using System;
 using Semmle.Util.Logging;
 using Semmle.Util;
 
@@ -49,6 +50,7 @@ namespace Semmle.Extraction
         /// </summary>
         public bool QlTest { get; private set; } = false;
 
+
         /// <summary>
         /// The compression algorithm used for trap files.
         /// </summary>
@@ -64,6 +66,16 @@ namespace Semmle.Extraction
                 case "verbosity":
                     Verbosity = (Verbosity)int.Parse(value);
                     return true;
+                case "compression":
+                    try
+                    {
+                        TrapCompression = (TrapWriter.CompressionMode)Enum.Parse(typeof(TrapWriter.CompressionMode), value, true);
+                        return true;
+                    }
+                    catch (ArgumentException)
+                    {
+                        return false;
+                    }
                 default:
                     return false;
             }

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -114,9 +114,6 @@ namespace Semmle.Extraction
                 case "qltest":
                     QlTest = value;
                     return true;
-                case "brotli":
-                    TrapCompression = value ? TrapWriter.CompressionMode.Brotli : TrapWriter.CompressionMode.Gzip;
-                    return true;
                 default:
                     return false;
             }

--- a/csharp/extractor/Semmle.Util/CommandLineOptions.cs
+++ b/csharp/extractor/Semmle.Util/CommandLineOptions.cs
@@ -47,10 +47,10 @@ namespace Semmle.Util
         {
             var extractorOptions = new List<string>();
 
-            var compressionMode = GetExtractorOption("compression");
-            if (!string.IsNullOrEmpty(compressionMode))
+            var trapCompression = GetExtractorOption("trap_compression");
+            if (!string.IsNullOrEmpty(trapCompression))
             {
-                extractorOptions.Add($"--compression:{compressionMode}");
+                extractorOptions.Add($"--trap_compression:{trapCompression}");
             }
 
             return extractorOptions;

--- a/csharp/extractor/Semmle.Util/CommandLineOptions.cs
+++ b/csharp/extractor/Semmle.Util/CommandLineOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Semmle.Util
@@ -39,8 +40,26 @@ namespace Semmle.Util
 
     public static class OptionsExtensions
     {
-        public static void ParseArguments(this ICommandLineOptions options, IReadOnlyList<string> arguments)
+        private static string? GetExtractorOption(string name) =>
+            Environment.GetEnvironmentVariable($"CODEQL_EXTRACTOR_CSHARP_OPTION_{name.ToUpper()}");
+
+        private static List<string> GetExtractorOptions()
         {
+            var extractorOptions = new List<string>();
+
+            var compressionMode = GetExtractorOption("compression");
+            if (!string.IsNullOrEmpty(compressionMode))
+            {
+                extractorOptions.Add($"--compression:{compressionMode}");
+            }
+
+            return extractorOptions;
+        }
+
+        public static void ParseArguments(this ICommandLineOptions options, IReadOnlyList<string> providedArguments)
+        {
+            var arguments = GetExtractorOptions();
+            arguments.AddRange(providedArguments);
             for (var i = 0; i < arguments.Count; ++i)
             {
                 var arg = arguments[i];

--- a/csharp/ql/src/change-notes/2022-02-23-extractor-option-compression.md
+++ b/csharp/ql/src/change-notes/2022-02-23-extractor-option-compression.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* The C# extractor now accepts an extractor option `compression`, which is used to decide the compression format for TRAP files. The legal options are `brotli` (default), `gzip` or `none`.
+* The C# extractor no longer accepts `--no-brotli` or `--brotli` flags to switch between `gzip` and `brotli` as compression method for TRAP files.

--- a/csharp/ql/src/change-notes/2022-02-23-extractor-option-compression.md
+++ b/csharp/ql/src/change-notes/2022-02-23-extractor-option-compression.md
@@ -1,5 +1,5 @@
 ---
 category: minorAnalysis
 ---
-* The C# extractor now accepts an extractor option `compression`, which is used to decide the compression format for TRAP files. The legal options are `brotli` (default), `gzip` or `none`.
+* The C# extractor now accepts an extractor option `trap.compression`, which is used to decide the compression format for TRAP files. The legal options are `brotli` (default), `gzip` or `none`.
 * The C# extractor no longer accepts `--no-brotli` or `--brotli` flags to switch between `gzip` and `brotli` as compression method for TRAP files.

--- a/csharp/ql/src/change-notes/2022-02-23-extractor-option-compression.md
+++ b/csharp/ql/src/change-notes/2022-02-23-extractor-option-compression.md
@@ -1,5 +1,5 @@
 ---
 category: minorAnalysis
 ---
-* The C# extractor now accepts an extractor option `trap.compression`, which is used to decide the compression format for TRAP files. The legal options are `brotli` (default), `gzip` or `none`.
-* The C# extractor no longer accepts `--no-brotli` or `--brotli` flags to switch between `gzip` and `brotli` as compression method for TRAP files.
+* The C# extractor now accepts an extractor option `trap.compression`, which is used to decide the compression format for TRAP files. The legal values are `brotli` (default), `gzip` or `none`.
+The option is added via `codeql database create --language=csharp -Otrap.compression=value ...`.


### PR DESCRIPTION
- [x] Investigate (and fix) why multiple compressed files are stored (gz is now always included). It turns it this was because, I was extracting the extractor itself and put the database in the extractor directory, combined with re-using the same directly for stored the database (some dangling processes of previous extraction runs could mess up the output)
- [x] Make a release note (old option for specifying "brotli" will be removed.
- [x] Investigate if existing documentation for the C# extractor should be updated (this should not be the case, as the extractor option is self documented in the yaml file)
- [x] Investigate (and fix) whether a change is needed in the semmle-code repo as well. This doesn't appear to the case.
- [x] Run DCA. There are no negative effects on database build times with these changes

<img width="1138" alt="Screenshot 2022-02-24 at 08 39 04" src="https://user-images.githubusercontent.com/6472811/155479818-fdca8226-ce99-46b9-a9c8-9e661a834541.png">


Example on, how to use the new option
```bash
codeql database create --language=csharp --keep-trap --extractor-option=trap.compression=gzip mytest.db
codeql database create --language=csharp --keep-trap --extractor-option=trap.compression=none -c="dotnet build /t:rebuild mytest_out/mytest.csproj /p:UseSharedCompilation=false" mytest.db
```