### PR TITLE
C++/C#: Fix spelling of 'postDominanceFrontier'

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -200,7 +200,7 @@ class IRBlock extends IRBlockBase {
    * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
    */
   pragma[noinline]
-  final IRBlock postPominanceFrontier() {
+  final IRBlock postDominanceFrontier() {
     this.postDominates(result.getASuccessor()) and
     not this.strictlyPostDominates(result)
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -200,7 +200,7 @@ class IRBlock extends IRBlockBase {
    * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
    */
   pragma[noinline]
-  final IRBlock postPominanceFrontier() {
+  final IRBlock postDominanceFrontier() {
     this.postDominates(result.getASuccessor()) and
     not this.strictlyPostDominates(result)
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -200,7 +200,7 @@ class IRBlock extends IRBlockBase {
    * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
    */
   pragma[noinline]
-  final IRBlock postPominanceFrontier() {
+  final IRBlock postDominanceFrontier() {
     this.postDominates(result.getASuccessor()) and
     not this.strictlyPostDominates(result)
   }

--- a/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/IRBlock.qll
@@ -200,7 +200,7 @@ class IRBlock extends IRBlockBase {
    * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
    */
   pragma[noinline]
-  final IRBlock postPominanceFrontier() {
+  final IRBlock postDominanceFrontier() {
     this.postDominates(result.getASuccessor()) and
     not this.strictlyPostDominates(result)
   }

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -200,7 +200,7 @@ class IRBlock extends IRBlockBase {
    * post-dominate block `B`, but block `A` does post-dominate an immediate successor of block `B`.
    */
   pragma[noinline]
-  final IRBlock postPominanceFrontier() {
+  final IRBlock postDominanceFrontier() {
     this.postDominates(result.getASuccessor()) and
     not this.strictlyPostDominates(result)
   }


### PR DESCRIPTION
_No comments necessary..._ 🤫