### PR TITLE
JS: recognize modules imported by AMD imports as library inputs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/lib/semmle/javascript/PackageExports.qll
@@ -87,6 +87,15 @@ private DataFlow::Node getAValueExportedByPackage() {
     result = getAnExportFromModule(mod)
   )
   or
+  // require("./other-module.js"); inside an AMD module.
+  exists(Module mod, CallExpr call |
+    call = getAValueExportedByPackage().asExpr() and
+    call = any(AmdModuleDefinition e).getARequireCall() and
+    mod = call.getAnArgument().(Import).getImportedModule()
+  |
+    result = getAnExportFromModule(mod)
+  )
+  or
   // module.exports = class Foo {
   //   bar() {} // <- result
   //   static baz() {} // <- result

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -284,6 +284,10 @@ nodes
 | lib/subLib3/my-file.ts:3:28:3:31 | name |
 | lib/subLib3/my-file.ts:4:22:4:25 | name |
 | lib/subLib3/my-file.ts:4:22:4:25 | name |
+| lib/subLib/amdSub.js:3:28:3:31 | name |
+| lib/subLib/amdSub.js:3:28:3:31 | name |
+| lib/subLib/amdSub.js:4:22:4:25 | name |
+| lib/subLib/amdSub.js:4:22:4:25 | name |
 | lib/subLib/index.js:3:28:3:31 | name |
 | lib/subLib/index.js:3:28:3:31 | name |
 | lib/subLib/index.js:4:22:4:25 | name |
@@ -636,6 +640,10 @@ edges
 | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name |
 | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name |
 | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name |
+| lib/subLib/amdSub.js:3:28:3:31 | name | lib/subLib/amdSub.js:4:22:4:25 | name |
+| lib/subLib/amdSub.js:3:28:3:31 | name | lib/subLib/amdSub.js:4:22:4:25 | name |
+| lib/subLib/amdSub.js:3:28:3:31 | name | lib/subLib/amdSub.js:4:22:4:25 | name |
+| lib/subLib/amdSub.js:3:28:3:31 | name | lib/subLib/amdSub.js:4:22:4:25 | name |
 | lib/subLib/index.js:3:28:3:31 | name | lib/subLib/index.js:4:22:4:25 | name |
 | lib/subLib/index.js:3:28:3:31 | name | lib/subLib/index.js:4:22:4:25 | name |
 | lib/subLib/index.js:3:28:3:31 | name | lib/subLib/index.js:4:22:4:25 | name |
@@ -727,5 +735,6 @@ edges
 | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | lib/subLib2/compiled-file.ts:3:26:3:29 | name | lib/subLib2/compiled-file.ts:4:25:4:28 | name | $@ based on $@ is later used in $@. | lib/subLib2/compiled-file.ts:4:13:4:28 | "rm -rf " + name | String concatenation | lib/subLib2/compiled-file.ts:3:26:3:29 | name | library input | lib/subLib2/compiled-file.ts:4:5:4:29 | cp.exec ... + name) | shell command |
 | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | lib/subLib2/special-file.js:3:28:3:31 | name | lib/subLib2/special-file.js:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib2/special-file.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib2/special-file.js:3:28:3:31 | name | library input | lib/subLib2/special-file.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | lib/subLib3/my-file.ts:3:28:3:31 | name | lib/subLib3/my-file.ts:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib3/my-file.ts:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib3/my-file.ts:3:28:3:31 | name | library input | lib/subLib3/my-file.ts:4:2:4:26 | cp.exec ... + name) | shell command |
+| lib/subLib/amdSub.js:4:10:4:25 | "rm -rf " + name | lib/subLib/amdSub.js:3:28:3:31 | name | lib/subLib/amdSub.js:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib/amdSub.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib/amdSub.js:3:28:3:31 | name | library input | lib/subLib/amdSub.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib/index.js:4:10:4:25 | "rm -rf " + name | lib/subLib/index.js:3:28:3:31 | name | lib/subLib/index.js:4:22:4:25 | name | $@ based on $@ is later used in $@. | lib/subLib/index.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/subLib/index.js:3:28:3:31 | name | library input | lib/subLib/index.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | lib/subLib/index.js:7:32:7:35 | name | lib/subLib/index.js:8:22:8:25 | name | $@ based on $@ is later used in $@. | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | String concatenation | lib/subLib/index.js:7:32:7:35 | name | library input | lib/subLib/index.js:8:2:8:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/subLib/amd.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/subLib/amd.js
@@ -1,0 +1,6 @@
+// this file is imported from `index.js`.
+define(function (require) {
+  return {
+    amdSub: require("./amdSub"),
+  };
+});

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/subLib/amdSub.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/subLib/amdSub.js
@@ -1,0 +1,5 @@
+const cp = require("child_process");
+
+module.exports = function (name) {
+	cp.exec("rm -rf " + name); // NOT OK - this function is exported from `amd.js`
+};

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/subLib/index.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/subLib/index.js
@@ -7,3 +7,5 @@ module.exports = function (name) {
 module.exports.foo = function (name) {
 	cp.exec("rm -rf " + name); // NOT OK - this is being called explicitly from child_process-test.js
 };
+
+module.exports.amd = require("./amd.js");


### PR DESCRIPTION
Recognizes the source for CVE-2020-7792 

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-8185-2032126__nightly__CustomSuite/reports). 