### PR TITLE
C++: Promote cpp/non-https-url

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -3,7 +3,7 @@
  * @description Non-HTTPS connections can be intercepted by third parties.
  * @kind path-problem
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @id cpp/non-https-url
  * @tags security
  *       external/cwe/cwe-319

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -12,6 +12,7 @@
 
 import cpp
 import semmle.code.cpp.dataflow.TaintTracking
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import DataFlow::PathGraph
 
 /**
@@ -61,7 +62,7 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
     // block taint starting at `strstr`, which is likely testing an existing URL, rather than constructing an HTTP URL.
     not exists(FunctionCall fc |
       fc.getTarget().getName() = ["strstr", "strcasestr"] and
-      fc.getAnArgument() = src.asExpr()
+      fc.getArgument(1) = globalValueNumber(src.asExpr()).getAnExpr()
     )
   }
 

--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -57,7 +57,12 @@ class HttpStringToUrlOpenConfig extends TaintTracking::Configuration {
 
   override predicate isSource(DataFlow::Node src) {
     // Sources are strings containing an HTTP URL not in a private domain.
-    src.asExpr() instanceof HttpStringLiteral
+    src.asExpr() instanceof HttpStringLiteral and
+    // block taint starting at `strstr`, which is likely testing an existing URL, rather than constructing an HTTP URL.
+    not exists(FunctionCall fc |
+      fc.getTarget().getName() = ["strstr", "strcasestr"] and
+      fc.getAnArgument() = src.asExpr()
+    )
   }
 
   override predicate isSink(DataFlow::Node sink) {

--- a/cpp/ql/src/change-notes/2022-02-24-non-https-url.md
+++ b/cpp/ql/src/change-notes/2022-02-24-non-https-url.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Failure to use HTTPS URLs" (`cpp/non-https-url`) has been improved reducing false positive results, and its precision has been increased to 'high'.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -7,6 +7,8 @@ edges
 | test.cpp:40:11:40:17 | access to array | test.cpp:11:26:11:28 | url |
 | test.cpp:46:18:46:26 | http:// | test.cpp:49:11:49:16 | buffer |
 | test.cpp:49:11:49:16 | buffer | test.cpp:11:26:11:28 | url |
+| test.cpp:81:21:81:29 | http:// | test.cpp:86:11:86:13 | ptr |
+| test.cpp:86:11:86:13 | ptr | test.cpp:11:26:11:28 | url |
 nodes
 | test.cpp:11:26:11:28 | url | semmle.label | url |
 | test.cpp:15:30:15:32 | url | semmle.label | url |
@@ -17,9 +19,12 @@ nodes
 | test.cpp:40:11:40:17 | access to array | semmle.label | access to array |
 | test.cpp:46:18:46:26 | http:// | semmle.label | http:// |
 | test.cpp:49:11:49:16 | buffer | semmle.label | buffer |
+| test.cpp:81:21:81:29 | http:// | semmle.label | http:// |
+| test.cpp:86:11:86:13 | ptr | semmle.label | ptr |
 subpaths
 #select
 | test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:81:21:81:29 | http:// | test.cpp:81:21:81:29 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -7,8 +7,6 @@ edges
 | test.cpp:40:11:40:17 | access to array | test.cpp:11:26:11:28 | url |
 | test.cpp:46:18:46:26 | http:// | test.cpp:49:11:49:16 | buffer |
 | test.cpp:49:11:49:16 | buffer | test.cpp:11:26:11:28 | url |
-| test.cpp:93:28:93:36 | http:// | test.cpp:104:11:104:13 | ptr |
-| test.cpp:104:11:104:13 | ptr | test.cpp:11:26:11:28 | url |
 | test.cpp:110:21:110:40 | http://example.com | test.cpp:121:11:121:13 | ptr |
 | test.cpp:121:11:121:13 | ptr | test.cpp:11:26:11:28 | url |
 nodes
@@ -21,8 +19,6 @@ nodes
 | test.cpp:40:11:40:17 | access to array | semmle.label | access to array |
 | test.cpp:46:18:46:26 | http:// | semmle.label | http:// |
 | test.cpp:49:11:49:16 | buffer | semmle.label | buffer |
-| test.cpp:93:28:93:36 | http:// | semmle.label | http:// |
-| test.cpp:104:11:104:13 | ptr | semmle.label | ptr |
 | test.cpp:110:21:110:40 | http://example.com | semmle.label | http://example.com |
 | test.cpp:121:11:121:13 | ptr | semmle.label | ptr |
 subpaths
@@ -31,5 +27,4 @@ subpaths
 | test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
-| test.cpp:93:28:93:36 | http:// | test.cpp:93:28:93:36 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:110:21:110:40 | http://example.com | test.cpp:110:21:110:40 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -7,8 +7,6 @@ edges
 | test.cpp:40:11:40:17 | access to array | test.cpp:11:26:11:28 | url |
 | test.cpp:46:18:46:26 | http:// | test.cpp:49:11:49:16 | buffer |
 | test.cpp:49:11:49:16 | buffer | test.cpp:11:26:11:28 | url |
-| test.cpp:81:21:81:29 | http:// | test.cpp:86:11:86:13 | ptr |
-| test.cpp:86:11:86:13 | ptr | test.cpp:11:26:11:28 | url |
 nodes
 | test.cpp:11:26:11:28 | url | semmle.label | url |
 | test.cpp:15:30:15:32 | url | semmle.label | url |
@@ -19,12 +17,9 @@ nodes
 | test.cpp:40:11:40:17 | access to array | semmle.label | access to array |
 | test.cpp:46:18:46:26 | http:// | semmle.label | http:// |
 | test.cpp:49:11:49:16 | buffer | semmle.label | buffer |
-| test.cpp:81:21:81:29 | http:// | semmle.label | http:// |
-| test.cpp:86:11:86:13 | ptr | semmle.label | ptr |
 subpaths
 #select
 | test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
-| test.cpp:81:21:81:29 | http:// | test.cpp:81:21:81:29 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/UseOfHttp.expected
@@ -7,6 +7,10 @@ edges
 | test.cpp:40:11:40:17 | access to array | test.cpp:11:26:11:28 | url |
 | test.cpp:46:18:46:26 | http:// | test.cpp:49:11:49:16 | buffer |
 | test.cpp:49:11:49:16 | buffer | test.cpp:11:26:11:28 | url |
+| test.cpp:93:28:93:36 | http:// | test.cpp:104:11:104:13 | ptr |
+| test.cpp:104:11:104:13 | ptr | test.cpp:11:26:11:28 | url |
+| test.cpp:110:21:110:40 | http://example.com | test.cpp:121:11:121:13 | ptr |
+| test.cpp:121:11:121:13 | ptr | test.cpp:11:26:11:28 | url |
 nodes
 | test.cpp:11:26:11:28 | url | semmle.label | url |
 | test.cpp:15:30:15:32 | url | semmle.label | url |
@@ -17,9 +21,15 @@ nodes
 | test.cpp:40:11:40:17 | access to array | semmle.label | access to array |
 | test.cpp:46:18:46:26 | http:// | semmle.label | http:// |
 | test.cpp:49:11:49:16 | buffer | semmle.label | buffer |
+| test.cpp:93:28:93:36 | http:// | semmle.label | http:// |
+| test.cpp:104:11:104:13 | ptr | semmle.label | ptr |
+| test.cpp:110:21:110:40 | http://example.com | semmle.label | http://example.com |
+| test.cpp:121:11:121:13 | ptr | semmle.label | ptr |
 subpaths
 #select
 | test.cpp:28:10:28:29 | http://example.com | test.cpp:28:10:28:29 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:35:23:35:42 | http://example.com | test.cpp:35:23:35:42 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:36:26:36:45 | http://example.com | test.cpp:36:26:36:45 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
 | test.cpp:46:18:46:26 | http:// | test.cpp:46:18:46:26 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:93:28:93:36 | http:// | test.cpp:93:28:93:36 | http:// | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |
+| test.cpp:110:21:110:40 | http://example.com | test.cpp:110:21:110:40 | http://example.com | test.cpp:15:30:15:32 | url | A URL may be constructed with the HTTP protocol. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
@@ -78,7 +78,7 @@ void test3(char *url)
 	ptr = strstr(url, "https://");
 	if (!ptr)
 	{
-		ptr = strstr(url, "http://"); // GOOD (we are not constructing the URL) [FALSE POSITIVE]
+		ptr = strstr(url, "http://"); // GOOD (we are not constructing the URL)
 	}
 
 	if (ptr)

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
@@ -75,10 +75,45 @@ void test3(char *url)
 {
 	char *ptr;
 
-	ptr = strstr(url, "https://");
+	ptr = strstr(url, "https://"); // GOOD (https)
 	if (!ptr)
 	{
 		ptr = strstr(url, "http://"); // GOOD (we are not constructing the URL)
+	}
+
+	if (ptr)
+	{
+		openUrl(ptr);
+	}
+}
+
+void test4(char *url)
+{
+	const char *https_string = "https://"; // GOOD (https)
+	const char *http_string = "http://"; // GOOD (we are not constructing the URL) [FALSE POSITIVE]
+	char *ptr;
+
+	ptr = strstr(url, https_string);
+	if (!ptr)
+	{
+		ptr = strstr(url, http_string);
+	}
+
+	if (ptr)
+	{
+		openUrl(ptr);
+	}
+}
+
+void test5()
+{
+	char *url_string = "http://example.com"; // BAD
+	char *ptr;
+
+	ptr = strstr(url_string, "https://"); // GOOD (https)
+	if (!ptr)
+	{
+		ptr = strstr(url_string, "http://"); // GOOD (we are not constructing the URL here)
 	}
 
 	if (ptr)

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
@@ -58,3 +58,31 @@ void test()
 		openUrl(buffer);
 	}
 }
+
+typedef unsigned long size_t;
+int strncmp(const char *s1, const char *s2, size_t n);
+char* strstr(char* s1, const char* s2);
+
+void test2(const char *url)
+{
+	if (strncmp(url, "http://", 7)) // GOOD (or at least dubious; we are not constructing the URL)
+	{
+		openUrl(url);
+	}
+}
+
+void test3(char *url)
+{
+	char *ptr;
+
+	ptr = strstr(url, "https://");
+	if (!ptr)
+	{
+		ptr = strstr(url, "http://"); // GOOD (we are not constructing the URL) [FALSE POSITIVE]
+	}
+
+	if (ptr)
+	{
+		openUrl(ptr);
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-319/UseOfHttp/test.cpp
@@ -90,7 +90,7 @@ void test3(char *url)
 void test4(char *url)
 {
 	const char *https_string = "https://"; // GOOD (https)
-	const char *http_string = "http://"; // GOOD (we are not constructing the URL) [FALSE POSITIVE]
+	const char *http_string = "http://"; // GOOD (we are not constructing the URL)
 	char *ptr;
 
 	ptr = strstr(url, https_string);


### PR DESCRIPTION
Fix a minor source of (arguable) false positives in `cpp/non-https-url`, then promote it to `@precision high`.  LGTM results for this query have previously shown a low number of false positives.

Here's the query running on some relevant projects: [before](https://lgtm.com/query/7625654925223762953/) and [after](https://lgtm.com/query/7741957734714363773/) the change.