### PR TITLE
Fix 0.0.9 change note to match concatenated change log

### DIFF
--- a/csharp/ql/lib/change-notes/released/0.0.9.md
+++ b/csharp/ql/lib/change-notes/released/0.0.9.md
@@ -2,9 +2,9 @@
 
 ### Major Analysis Improvements
 
-Added support for C# 10 lambda improvements
-* Explicit return types on lambda expressions.
-* Lambda expression can be tagged with method and return value attributes.
+* Added support for C# 10 lambda improvements
+  * Explicit return types on lambda expressions.
+  * Lambda expression can be tagged with method and return value attributes.
 * Added support for C# 10 [Extended property patterns](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#extended-property-patterns).
 * Return value attributes are extracted.
 * The QL `Attribute` class now has subclasses for each kind of attribute.


### PR DESCRIPTION
This formatting change was already applied in the concatenated change log for release 2.8.1 in https://github.com/github/codeql/pull/7975/commits/c5d917eb72d9eb93af12577496e87a26d5c06852.