### PR TITLE
JS: step through parentheses in barrier functions

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -2043,11 +2043,9 @@ private class BarrierGuardFunction extends Function {
         // ad hoc support for conjunctions:
         getALogicalAndParent(guard) = returnExpr and guardOutcome = true
         or
-        // getALogicalAndOperand+(returnExpr) = guard.asExpr() and guardOutcome = true
         // ad hoc support for disjunctions:
         getALogicalOrParent(guard) = returnExpr and guardOutcome = false
       |
-        // getALogicalOrOperand+(returnExpr) = guard.asExpr() and guardOutcome = false
         exists(SsaExplicitDefinition ssa |
           ssa.getDef().getSource() = returnExpr and
           ssa.getVariable().getAUse() = getAReturnedExpr()

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
@@ -88,6 +88,12 @@ nodes
 | lib.js:92:3:92:12 | maybeProto |
 | lib.js:95:3:95:12 | maybeProto |
 | lib.js:95:3:95:12 | maybeProto |
+| lib.js:104:7:104:24 | one |
+| lib.js:104:13:104:24 | arguments[1] |
+| lib.js:104:13:104:24 | arguments[1] |
+| lib.js:108:3:108:10 | obj[one] |
+| lib.js:108:3:108:10 | obj[one] |
+| lib.js:108:7:108:9 | one |
 | tst.js:5:9:5:38 | taint |
 | tst.js:5:17:5:38 | String( ... y.data) |
 | tst.js:5:24:5:37 | req.query.data |
@@ -219,6 +225,11 @@ edges
 | lib.js:91:7:91:28 | maybeProto | lib.js:95:3:95:12 | maybeProto |
 | lib.js:91:20:91:28 | obj[path] | lib.js:91:7:91:28 | maybeProto |
 | lib.js:91:24:91:27 | path | lib.js:91:20:91:28 | obj[path] |
+| lib.js:104:7:104:24 | one | lib.js:108:7:108:9 | one |
+| lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
+| lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
+| lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
+| lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
 | tst.js:5:9:5:38 | taint | tst.js:8:12:8:16 | taint |
 | tst.js:5:9:5:38 | taint | tst.js:9:12:9:16 | taint |
 | tst.js:5:9:5:38 | taint | tst.js:12:25:12:29 | taint |
@@ -272,6 +283,7 @@ edges
 | lib.js:42:3:42:14 | obj[path[0]] | lib.js:40:14:40:20 | args[1] | lib.js:42:3:42:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:40:14:40:20 | args[1] | library input |
 | lib.js:70:13:70:24 | obj[path[0]] | lib.js:59:18:59:18 | s | lib.js:70:13:70:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:59:18:59:18 | s | library input |
 | lib.js:87:10:87:14 | proto | lib.js:83:14:83:25 | arguments[1] | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:25 | arguments[1] | library input |
+| lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:24 | arguments[1] | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:24 | arguments[1] | library input |
 | tst.js:8:5:8:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:8:5:8:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |
 | tst.js:9:5:9:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:9:5:9:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |
 | tst.js:14:5:14:32 | unsafeG ...  taint) | tst.js:5:24:5:37 | req.query.data | tst.js:14:5:14:32 | unsafeG ...  taint) | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/lib.js
@@ -94,3 +94,21 @@ module.exports.fixedProp = function (obj, path, value) {
   var i = 0;
   maybeProto[i + 2] = value; // OK - number properties are OK.
 }
+
+function isPossibilityOfPrototypePollution(key) {
+  return (key === '__proto__' || key === 'constructor');
+}
+
+module.exports.sanWithFcuntion = function() {
+  var obj = arguments[0];
+  var one = arguments[1];
+  var two = arguments[2];
+  var value = arguments[3];
+  
+  obj[one][two] = value; // NOT OK
+
+  if (isPossibilityOfPrototypePollution(one) || isPossibilityOfPrototypePollution(two)) {
+    throw new Error('Prototype pollution is not allowed');
+  }
+  obj[one][two] = value; // OK
+}


### PR DESCRIPTION
Gets a TN for CVE-2020-28503 

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/parenSan__nightly__security-extend__1/reports). (Ignore the backref).