### PR TITLE
C#: Buildless extractor option.

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -399,6 +399,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             actions.GetEnvironmentVariable["LGTM_INDEX_SOLUTION"] = solution;
             actions.GetEnvironmentVariable["LGTM_INDEX_IGNORE_ERRORS"] = ignoreErrors;
             actions.GetEnvironmentVariable["LGTM_INDEX_BUILDLESS"] = buildless;
+            actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_OPTION_BUILDLESS"] = buildless;
             actions.GetEnvironmentVariable["LGTM_INDEX_ALL_SOLUTIONS"] = allSolutions;
             actions.GetEnvironmentVariable["LGTM_INDEX_NUGET_RESTORE"] = nugetRestore;
             actions.GetEnvironmentVariable["ProgramFiles(x86)"] = isWindows ? @"C:\Program Files (x86)" : null;

--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -40,3 +40,4 @@ options:
       and should only be used in cases where it is not possible to build
       the code (for example if it uses inaccessible dependencies).
     type: string
+    pattern: "^(false|true)$"

--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -33,7 +33,10 @@ options:
     title: Whether to use buildless (standalone) extraction.
     description: >
       A value indicating, which type of extraction the autobuilder should perform.
-      If 'yes', then the standalone extractor will be used, otherwise tracing extraction
+      If 'true', then the standalone extractor will be used, otherwise tracing extraction
       will be performed.
-      The default is 'no'.
+      The default is 'false'.
+      Note that buildless extraction will generally yield less accurate analysis results,
+      and should only be used in cases where it is not possible to build
+      the code (for example if it uses inaccessible dependencies).
     type: string

--- a/csharp/codeql-extractor.yml
+++ b/csharp/codeql-extractor.yml
@@ -29,3 +29,11 @@ options:
           (to write uncompressed TRAP).
         type: string
         pattern: "^(none|gzip|brotli)$"
+  buildless:
+    title: Whether to use buildless (standalone) extraction.
+    description: >
+      A value indicating, which type of extraction the autobuilder should perform.
+      If 'yes', then the standalone extractor will be used, otherwise tracing extraction
+      will be performed.
+      The default is 'no'.
+    type: string

--- a/csharp/ql/src/change-notes/2022-02-24-buildless-extractor-option.md
+++ b/csharp/ql/src/change-notes/2022-02-24-buildless-extractor-option.md
@@ -2,3 +2,4 @@
 category: minorAnalysis
 ---
 * The C# extractor now accepts an extractor option `buildless`, which is used to decide what type of extraction that should be performed. If `true` then buildless (standalone) extraction will be performed. Otherwise tracing extraction will be performed (default).
+The option is added via `codeql database create --language=csharp -Obuildless=true ...`.

--- a/csharp/ql/src/change-notes/2022-02-24-buildless-extractor-option.md
+++ b/csharp/ql/src/change-notes/2022-02-24-buildless-extractor-option.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The C# extractor now accepts an extractor option `buildless`, which is used to decide what type of extraction that should be performed. If `yes` then buildless (standalone) extraction will be performed. Otherwise tracing extraction will be performed (default).
+* The C# extractor now accepts an extractor option `buildless`, which is used to decide what type of extraction that should be performed. If `true` then buildless (standalone) extraction will be performed. Otherwise tracing extraction will be performed (default).

--- a/csharp/ql/src/change-notes/2022-02-24-buildless-extractor-option.md
+++ b/csharp/ql/src/change-notes/2022-02-24-buildless-extractor-option.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The C# extractor now accepts an extractor option `buildless`, which is used to decide what type of extraction that should be performed. If `yes` then buildless (standalone) extraction will be performed. Otherwise tracing extraction will be performed (default).


### PR DESCRIPTION
In this PR we introduce a new C# extractor option, which indicates, whether a tracing or buildless (standalone) extraction should be performed, when using the autobuilder.

Closes https://github.com/github/codeql-csharp-team/issues/205

```bash
codeql database create --language=csharp -Obuildless=true db
codeql database create --language=csharp --extractor-option=buildless=true db
```