### PR TITLE
Ruby: add meta-queries for measuring sources, sinks, and call edges

### DIFF
--- a/ruby/ql/src/queries/meta/CallGraph.ql
+++ b/ruby/ql/src/queries/meta/CallGraph.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Call graph
+ * @description An edge in the call graph.
+ * @kind problem
+ * @problem.severity recommendation
+ * @id rb/meta/call-graph
+ * @tags meta
+ * @precision very-low
+ */
+
+import codeql.ruby.AST
+
+from Call invoke, Callable f
+where invoke.getATarget() = f
+select invoke, "Call to $@", f, f.toString()

--- a/ruby/ql/src/queries/meta/TaintSinks.ql
+++ b/ruby/ql/src/queries/meta/TaintSinks.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Taint sinks
+ * @description Sinks that are sensitive to untrusted data.
+ * @kind problem
+ * @problem.severity recommendation
+ * @id rb/meta/taint-sinks
+ * @tags meta
+ * @precision very-low
+ */
+
+import internal.TaintMetrics
+
+from string kind
+select relevantTaintSink(kind), kind + " sink"

--- a/ruby/ql/src/queries/meta/TaintSources.ql
+++ b/ruby/ql/src/queries/meta/TaintSources.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Taint sources
+ * @description Sources of untrusted input.
+ * @kind problem
+ * @problem.severity recommendation
+ * @id rb/meta/taint-sources
+ * @tags meta
+ * @precision very-low
+ */
+
+import internal.TaintMetrics
+
+from string kind
+select relevantTaintSource(kind), kind

--- a/ruby/ql/src/queries/meta/internal/TaintMetrics.qll
+++ b/ruby/ql/src/queries/meta/internal/TaintMetrics.qll
@@ -1,0 +1,38 @@
+private import codeql.files.FileSystem
+private import codeql.ruby.DataFlow
+private import codeql.ruby.dataflow.RemoteFlowSources
+private import codeql.ruby.security.CodeInjectionCustomizations
+private import codeql.ruby.security.CommandInjectionCustomizations
+private import codeql.ruby.security.XSS
+private import codeql.ruby.security.PathInjectionCustomizations
+private import codeql.ruby.security.ServerSideRequestForgeryCustomizations
+private import codeql.ruby.security.UnsafeDeserializationCustomizations
+private import codeql.ruby.security.UrlRedirectCustomizations
+
+class RelevantFile extends File {
+  RelevantFile() { not getRelativePath().regexpMatch(".*/test(case)?s?/.*") }
+}
+
+RemoteFlowSource relevantTaintSource(string kind) {
+  result.getLocation().getFile() instanceof RelevantFile and
+  kind = result.getSourceType()
+}
+
+DataFlow::Node relevantTaintSink(string kind) {
+  result.getLocation().getFile() instanceof RelevantFile and
+  (
+    kind = "CodeInjection" and result instanceof CodeInjection::Sink
+    or
+    kind = "CommandInjection" and result instanceof CommandInjection::Sink
+    or
+    kind = "XSS" and result instanceof ReflectedXSS::Sink
+    or
+    kind = "PathInjection" and result instanceof PathInjection::Sink
+    or
+    kind = "ServerSideRequestForgery" and result instanceof ServerSideRequestForgery::Sink
+    or
+    kind = "UnsafeDeserialization" and result instanceof UnsafeDeserialization::Sink
+    or
+    kind = "UrlRedirect" and result instanceof UrlRedirect::Sink
+  )
+}


### PR DESCRIPTION
Adds three meta-queries for measuring the number of taint sources, sinks, and call edges.

The idea is to include these in a DCA evaluation (as meta-queries) so it's possible to see the impact of your changes at a more fine-grained level. Often, a change generates no new alerts, but produces sources or sinks that give an indication of its impact. The idea was initially discussed in [this issue](https://github.com/github/codeql-javascript-team/issues/191). As for JS, I didn't include logging-related sinks as they tend to dominate too much compared to their security-relevance.

As an example, [this diff](https://github.com/github/codeql-dca-main/blob/data/asgerf/meta-queries__Differences__smoke-test/reports/alert-meta-comparison.md) is comparing `main` to some earlier version from about a week ago, showing plenty of new sinks.