### PR TITLE
Python: Prevent magic/inlining in `getCase`

### DIFF
--- a/python/ql/lib/semmle/python/Patterns.qll
+++ b/python/ql/lib/semmle/python/Patterns.qll
@@ -10,6 +10,7 @@ class Pattern extends Pattern_, AstNode {
   override Scope getScope() { result = this.getCase().getScope() }
 
   /** Gets the case statement containing this pattern */
+  pragma[nomagic]
   Case getCase() { result.contains(this) }
 
   override string toString() { result = "Pattern" }


### PR DESCRIPTION
This is a simplified version of https://github.com/github/codeql/pull/8028 consisting of just the `nomagic` fix.