### PR TITLE
Java: CWE-200 Query to detect insecure WebResourceResponse implementation

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
@@ -55,15 +55,13 @@ private class FetchUrlStep extends AdditionalValueStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(
       // webview.loadUrl(url) -> webview.setWebViewClient(new WebViewClient() { shouldInterceptRequest(view, url) });
-      WebViewLoadUrlMethod lm, ShouldInterceptRequestMethod im, SetWebViewClientMethodAccess sma
+      MethodAccess lma, ShouldInterceptRequestMethod im, SetWebViewClientMethodAccess sma
     |
       sma.getArgument(0).getType() = im.getDeclaringType().getASupertype*() and
-      exists(MethodAccess lma |
-        lma.getMethod() = lm and
-        lma.getQualifier().getType() = sma.getQualifier().getType() and
-        pred.asExpr() = lma.getArgument(0) and
-        succ.asParameter() = im.getParameter(1)
-      )
+      lma.getMethod() instanceof WebViewLoadUrlMethod and
+      lma.getQualifier().getType() = sma.getQualifier().getType() and
+      pred.asExpr() = lma.getArgument(0) and
+      succ.asParameter() = im.getParameter(1)
     )
   }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
@@ -1,7 +1,10 @@
 /** Provides Android methods relating to web resource response. */
 
 import java
-import semmle.code.java.dataflow.FlowSources
+private import semmle.code.java.dataflow.DataFlow
+private import semmle.code.java.dataflow.ExternalFlow
+private import semmle.code.java.dataflow.FlowSteps
+private import semmle.code.java.frameworks.android.WebView
 
 /**
  * The Android class `android.webkit.WebResourceRequest` for handling web requests.

--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
@@ -21,8 +21,7 @@ class WebResourceResponse extends RefType {
 class ShouldInterceptRequestMethod extends Method {
   ShouldInterceptRequestMethod() {
     this.hasName("shouldInterceptRequest") and
-    this.getDeclaringType().getASupertype*() instanceof TypeWebViewClient and
-    this.getReturnType() instanceof WebResourceResponse
+    this.getDeclaringType().getASupertype*() instanceof TypeWebViewClient
   }
 }
 
@@ -30,12 +29,11 @@ class ShouldInterceptRequestMethod extends Method {
 class SetWebViewClientMethodAccess extends MethodAccess {
   SetWebViewClientMethodAccess() {
     this.getMethod().hasName("setWebViewClient") and
-    this.getMethod().getDeclaringType().getASupertype*() instanceof TypeWebView and
-    this.getMethod().getParameterType(0) instanceof TypeWebViewClient
+    this.getMethod().getDeclaringType().getASupertype*() instanceof TypeWebView
   }
 }
 
-/** A sink representing a constructor call of `WebResourceResponse` in Android `WebViewClient`. */
+/** A sink representing the data argument of a call to the constructor of `WebResourceResponse`. */
 class WebResourceResponseSink extends DataFlow::Node {
   WebResourceResponseSink() {
     exists(ConstructorCall cc |
@@ -50,7 +48,8 @@ class WebResourceResponseSink extends DataFlow::Node {
 }
 
 /**
- * Value step from a fetching url call of `WebView` to `WebViewClient`.
+ * A value step from the URL argument of `WebView::loadUrl` to the URL parameter of
+ * `WebViewClient::shouldInterceptRequest`.
  */
 private class FetchUrlStep extends AdditionalValueStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
@@ -63,20 +62,20 @@ private class FetchUrlStep extends AdditionalValueStep {
         lma.getMethod() = lm and
         lma.getQualifier().getType() = sma.getQualifier().getType() and
         pred.asExpr() = lma.getArgument(0) and
-        succ.asExpr() = im.getParameter(1).getAnAccess()
+        succ.asParameter() = im.getParameter(1)
       )
     )
   }
 }
 
 /** Value/taint steps relating to url loading and file reading in an Android application. */
-private class LoadUrlSource extends SummaryModelCsv {
+private class LoadUrlSummaries extends SummaryModelCsv {
   override predicate row(string row) {
     row =
       [
         "java.io;FileInputStream;true;FileInputStream;;;Argument[0];Argument[-1];taint",
-        "android.net;Uri;false;getPath;;;Argument[0];ReturnValue;value",
-        "android.webkit;WebResourceRequest;false;getUrl;;;Argument[-1];ReturnValue;value"
+        "android.net;Uri;false;getPath;;;Argument[0];ReturnValue;taint",
+        "android.webkit;WebResourceRequest;false;getUrl;;;Argument[-1];ReturnValue;taint"
       ]
   }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
@@ -20,7 +20,7 @@ class WebResourceResponse extends RefType {
   WebResourceResponse() { this.hasQualifiedName("android.webkit", "WebResourceResponse") }
 }
 
-/** The `shouldInterceptRequest` method of Android's `WebViewClient` class. */
+/** The `shouldInterceptRequest` method of a class implementing `WebViewClient`. */
 class ShouldInterceptRequestMethod extends Method {
   ShouldInterceptRequestMethod() {
     this.hasName("shouldInterceptRequest") and
@@ -28,7 +28,7 @@ class ShouldInterceptRequestMethod extends Method {
   }
 }
 
-/** A method call to `setWebViewClient` of `WebView`. */
+/** A method call to `WebView.setWebViewClient`. */
 class SetWebViewClientMethodAccess extends MethodAccess {
   SetWebViewClientMethodAccess() {
     this.getMethod().hasName("setWebViewClient") and
@@ -75,7 +75,6 @@ private class LoadUrlSummaries extends SummaryModelCsv {
     row =
       [
         "java.io;FileInputStream;true;FileInputStream;;;Argument[0];Argument[-1];taint",
-        "android.net;Uri;false;getPath;;;Argument[0];ReturnValue;taint",
         "android.webkit;WebResourceRequest;false;getUrl;;;Argument[-1];ReturnValue;taint"
       ]
   }

--- a/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/AndroidWebResourceResponse.qll
@@ -1,0 +1,82 @@
+/** Provides Android methods relating to web resource response. */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+
+/**
+ * The Android class `android.webkit.WebResourceRequest` for handling web requests.
+ */
+class WebResourceRequest extends RefType {
+  WebResourceRequest() { this.hasQualifiedName("android.webkit", "WebResourceRequest") }
+}
+
+/**
+ * The Android class `android.webkit.WebResourceResponse` for rendering web responses.
+ */
+class WebResourceResponse extends RefType {
+  WebResourceResponse() { this.hasQualifiedName("android.webkit", "WebResourceResponse") }
+}
+
+/** The `shouldInterceptRequest` method of Android's `WebViewClient` class. */
+class ShouldInterceptRequestMethod extends Method {
+  ShouldInterceptRequestMethod() {
+    this.hasName("shouldInterceptRequest") and
+    this.getDeclaringType().getASupertype*() instanceof TypeWebViewClient and
+    this.getReturnType() instanceof WebResourceResponse
+  }
+}
+
+/** A method call to `setWebViewClient` of `WebView`. */
+class SetWebViewClientMethodAccess extends MethodAccess {
+  SetWebViewClientMethodAccess() {
+    this.getMethod().hasName("setWebViewClient") and
+    this.getMethod().getDeclaringType().getASupertype*() instanceof TypeWebView and
+    this.getMethod().getParameterType(0) instanceof TypeWebViewClient
+  }
+}
+
+/** A sink representing a constructor call of `WebResourceResponse` in Android `WebViewClient`. */
+class WebResourceResponseSink extends DataFlow::Node {
+  WebResourceResponseSink() {
+    exists(ConstructorCall cc |
+      cc.getConstructedType() instanceof WebResourceResponse and
+      (
+        this.asExpr() = cc.getArgument(2) and cc.getNumArgument() = 3 // WebResourceResponse(String mimeType, String encoding, InputStream data)
+        or
+        this.asExpr() = cc.getArgument(5) and cc.getNumArgument() = 6 // WebResourceResponse(String mimeType, String encoding, int statusCode, String reasonPhrase, Map<String, String> responseHeaders, InputStream data)
+      )
+    )
+  }
+}
+
+/**
+ * Value step from a fetching url call of `WebView` to `WebViewClient`.
+ */
+private class FetchUrlStep extends AdditionalValueStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(
+      // webview.loadUrl(url) -> webview.setWebViewClient(new WebViewClient() { shouldInterceptRequest(view, url) });
+      WebViewLoadUrlMethod lm, ShouldInterceptRequestMethod im, SetWebViewClientMethodAccess sma
+    |
+      sma.getArgument(0).getType() = im.getDeclaringType().getASupertype*() and
+      exists(MethodAccess lma |
+        lma.getMethod() = lm and
+        lma.getQualifier().getType() = sma.getQualifier().getType() and
+        pred.asExpr() = lma.getArgument(0) and
+        succ.asExpr() = im.getParameter(1).getAnAccess()
+      )
+    )
+  }
+}
+
+/** Value/taint steps relating to url loading and file reading in an Android application. */
+private class LoadUrlSource extends SummaryModelCsv {
+  override predicate row(string row) {
+    row =
+      [
+        "java.io;FileInputStream;true;FileInputStream;;;Argument[0];Argument[-1];taint",
+        "android.net;Uri;false;getPath;;;Argument[0];ReturnValue;value",
+        "android.webkit;WebResourceRequest;false;getUrl;;;Argument[-1];ReturnValue;value"
+      ]
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.java
@@ -1,0 +1,17 @@
+// BAD: no URI validation
+Uri uri = Uri.parse(url);
+FileInputStream inputStream = new FileInputStream(uri.getPath());
+String mimeType = getMimeTypeFromPath(uri.getPath());
+return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+
+
+// GOOD: check for a trusted prefix, ensuring path traversal is not used to erase that prefix:
+// (alternatively use `WebViewAssetsLoader`)
+if (uri.getPath().startsWith("/local_cache/") && !uri.getPath().contains("..")) {
+    File cacheFile = new File(getCacheDir(), uri.getLastPathSegment());
+    FileInputStream inputStream = new FileInputStream(cacheFile);
+    String mimeType = getMimeTypeFromPath(uri.getPath());
+    return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+}
+
+return assetLoader.shouldInterceptRequest(request.getUrl());

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.qhelp
@@ -3,28 +3,28 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>Android provides a <code>WebResourceResponse</code> API, which is a <code>WebView</code> class that
-allows an Android application to behave as a web server by handling requests of popular protocols such
-as <code>http(s)</code>, <code>file</code>, as well as <code>javascript</code>; and returning a response
-(including status code, content type, content encoding, headers and the response body). Improper
-implementation with insufficient input validation can lead to leaking of sensitive configuration file
-or user data because requests could refer to paths intended to be application-private.
+<p>Android provides a <code>WebResourceResponse</code> class, which allows an Android application to behave
+as a web server by handling requests of popular protocols such as <code>http(s)</code>, <code>file</code>,
+as well as <code>javascript</code>; and returning a response (including status code, content type, content
+encoding, headers and the response body). Improper implementation with insufficient input validation can lead
+to leakage of sensitive configuration files or user data because requests could refer to paths intended to be
+application-private.
 </p>
 </overview>
 
 <recommendation>
 <p>
-Unsanitized user provided url must not be used to serve a response directly. When handling a request,
-always validate that the file path is not the receiver's protected directory. Alternatively the Android
-API <code>WebViewAssetLoader</code> can be used, which safely processes data from resources, assets or
-a predefined directory.
+Unsanitized user-provided URLs must not be used to serve a response directly. When handling a request,
+always validate that the requested file path is not in the receiver's protected directory. Alternatively
+the Android class <code>WebViewAssetLoader</code> can be used, which safely processes data from resources,
+assets or a predefined directory.
 </p>
 </recommendation>
 
 <example>
 <p>
-The following examples show a bad situation and two good situations respectively. In the bad situation, a
-response is served without path validation. In the good situation, a response is either served with path
+The following examples show a bad scenario and two good scenarios respectively. In the bad scenario, a
+response is served without path validation. In the good scenario, a response is either served with path
 validation or through the safe <code>WebViewAssetLoader</code> implementation.
 </p>
 <sample src="InsecureWebResourceResponse.java" />
@@ -32,7 +32,7 @@ validation or through the safe <code>WebViewAssetLoader</code> implementation.
 
 <references>
 <li>
-Google:
+Oversecured:
 <a href="https://blog.oversecured.com/Android-Exploring-vulnerabilities-in-WebResourceResponse/">Android: Exploring vulnerabilities in WebResourceResponse</a>.
 </li>
 <li>

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.qhelp
@@ -5,7 +5,7 @@
 <overview>
 <p>Android provides a <code>WebResourceResponse</code> class, which allows an Android application to behave
 as a web server by handling requests of popular protocols such as <code>http(s)</code>, <code>file</code>,
-as well as <code>javascript</code>; and returning a response (including status code, content type, content
+as well as <code>javascript</code> and returning a response (including status code, content type, content
 encoding, headers and the response body). Improper implementation with insufficient input validation can lead
 to leakage of sensitive configuration files or user data because requests could refer to paths intended to be
 application-private.

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.qhelp
@@ -1,0 +1,43 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Android provides a <code>WebResourceResponse</code> API, which is a <code>WebView</code> class that
+allows an Android application to behave as a web server by handling requests of popular protocols such
+as <code>http(s)</code>, <code>file</code>, as well as <code>javascript</code>; and returning a response
+(including status code, content type, content encoding, headers and the response body). Improper
+implementation with insufficient input validation can lead to leaking of sensitive configuration file
+or user data because requests could refer to paths intended to be application-private.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Unsanitized user provided url must not be used to serve a response directly. When handling a request,
+always validate that the file path is not the receiver's protected directory. Alternatively the Android
+API <code>WebViewAssetLoader</code> can be used, which safely processes data from resources, assets or
+a predefined directory.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following examples show a bad situation and two good situations respectively. In the bad situation, a
+response is served without path validation. In the good situation, a response is either served with path
+validation or through the safe <code>WebViewAssetLoader</code> implementation.
+</p>
+<sample src="InsecureWebResourceResponse.java" />
+</example>
+
+<references>
+<li>
+Google:
+<a href="https://blog.oversecured.com/Android-Exploring-vulnerabilities-in-WebResourceResponse/">Android: Exploring vulnerabilities in WebResourceResponse</a>.
+</li>
+<li>
+CVE:
+<a href="https://cordova.apache.org/announcements/2014/08/04/android-351.html">CVE-2014-3502: Cordova apps can potentially leak data to other apps via URL loading</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
@@ -1,7 +1,7 @@
 /**
  * @name Insecure Android WebView Resource Response
- * @description Insecure implementation of Android WebResourceResponse intercepts malicious app requests
- *              and return arbitrary sensitive content.
+ * @description An insecure implementation of Android `WebResourceResponse` may lead to leakage of arbitrary
+ *               sensitive content.
  * @kind path-problem
  * @id java/insecure-webview-resource-response
  * @problem.severity error
@@ -29,5 +29,5 @@ class InsecureWebResourceResponseConfig extends TaintTracking::Configuration {
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, InsecureWebResourceResponseConfig conf
 where conf.hasFlowPath(source, sink)
-select sink.getNode(), source, sink, "Leaking arbitrary content in Android from $@.", source.getNode(),
-  "this user input"
+select sink.getNode(), source, sink, "Leaking arbitrary content in Android from $@.",
+  source.getNode(), "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql
@@ -1,0 +1,33 @@
+/**
+ * @name Insecure Android WebView Resource Response
+ * @description Insecure implementation of Android WebResourceResponse intercepts malicious app requests
+ *              and return arbitrary sensitive content.
+ * @kind path-problem
+ * @id java/insecure-webview-resource-response
+ * @problem.severity error
+ * @tags security
+ *       external/cwe/cwe-200
+ */
+
+import java
+import semmle.code.java.controlflow.Guards
+import experimental.semmle.code.java.PathSanitizer
+import AndroidWebResourceResponse
+import DataFlow::PathGraph
+
+class InsecureWebResourceResponseConfig extends TaintTracking::Configuration {
+  InsecureWebResourceResponseConfig() { this = "InsecureWebResourceResponseConfig" }
+
+  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof WebResourceResponseSink }
+
+  override predicate isSanitizerGuard(DataFlow::BarrierGuard guard) {
+    guard instanceof PathTraversalBarrierGuard
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, InsecureWebResourceResponseConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Leaking arbitrary content in Android from $@.", source.getNode(),
+  "this user input"

--- a/java/ql/src/experimental/semmle/code/java/PathSanitizer.qll
+++ b/java/ql/src/experimental/semmle/code/java/PathSanitizer.qll
@@ -21,13 +21,12 @@ private class ExactStringPathMatchGuard extends PathTraversalBarrierGuard instan
 }
 
 /**
- * Returns the qualifier of a method call if it's a variable access, or the qualifier of the qualifier if
- * the qualifier itself is a method call to `getPath`, which helps to reduce FPs by handling scenarios
- * such as `!uri.getPath().contains("..")`.
+ * Returns the qualifier of a method call if it's a variable access, or the qualifier of the qualifier
+ * if the qualifier itself is a method call, which helps to reduce FPs by handling scenarios such as
+ * `!uri.getPath().contains("..")`.
  */
 private Expr getRealQualifier(Expr e) {
-  e.(MethodAccess).getMethod().hasQualifiedName("android.net", "Uri", "getPath") and
-  result = e.(MethodAccess).getQualifier()
+  result = getRealQualifier(e.(MethodAccess).getQualifier())
   or
   result = e.(VarAccess)
 }

--- a/java/ql/src/experimental/semmle/code/java/PathSanitizer.qll
+++ b/java/ql/src/experimental/semmle/code/java/PathSanitizer.qll
@@ -21,12 +21,12 @@ private class ExactStringPathMatchGuard extends PathTraversalBarrierGuard instan
 }
 
 /**
- * Returns the qualifier of a method call if it's a variable access, or the qualifier of the qualifier
- * if the qualifier itself is a method call, which helps to reduce FPs by handling scenarios such as
- * `!uri.getPath().contains("..")`.
+ * Given input `e` = `v.method1(...).method2(...)...`, returns `v` where `v` is a `VarAccess`.
+ *
+ * This is used to look through field accessors such as `uri.getPath()`.
  */
-private Expr getRealQualifier(Expr e) {
-  result = getRealQualifier(e.(MethodAccess).getQualifier())
+private Expr getUnderlyingVarAccess(Expr e) {
+  result = getUnderlyingVarAccess(e.(MethodAccess).getQualifier())
   or
   result = e.(VarAccess)
 }
@@ -37,7 +37,7 @@ private class AllowListGuard extends Guard instanceof MethodAccess {
     not isDisallowedWord(super.getAnArgument())
   }
 
-  Expr getCheckedExpr() { result = getRealQualifier(super.getQualifier()) }
+  Expr getCheckedExpr() { result = getUnderlyingVarAccess(super.getQualifier()) }
 }
 
 /**
@@ -84,7 +84,7 @@ private class BlockListGuard extends Guard instanceof MethodAccess {
     isDisallowedWord(super.getAnArgument())
   }
 
-  Expr getCheckedExpr() { result = getRealQualifier(super.getQualifier()) }
+  Expr getCheckedExpr() { result = getUnderlyingVarAccess(super.getQualifier()) }
 }
 
 /**
@@ -155,7 +155,7 @@ class PathTraversalGuard extends Guard instanceof MethodAccess {
     super.getAnArgument().(CompileTimeConstantExpr).getStringValue() = ".."
   }
 
-  Expr getCheckedExpr() { result = getRealQualifier(super.getQualifier()) }
+  Expr getCheckedExpr() { result = getUnderlyingVarAccess(super.getQualifier()) }
 }
 
 /** A complementary sanitizer that protects against path traversal using path normalization. */

--- a/java/ql/test/experimental/query-tests/security/CWE-200/AndroidManifest.xml
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.app"
+    android:installLocation="auto"
+    android:versionCode="1"
+    android:versionName="0.1" >
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme" >
+        <activity
+            android:name=".InsecureWebResourceResponse"
+            android:icon="@drawable/ic_launcher"
+			android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <activity android:name=".InsecureWebViewActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.expected
@@ -17,17 +17,19 @@ edges
 | InsecureWebResourceResponse.java:42:25:42:32 | inputUrl : Object | InsecureWebResourceResponse.java:188:34:188:43 | url : Object |
 | InsecureWebResourceResponse.java:44:26:44:33 | inputUrl : Object | InsecureWebResourceResponse.java:217:35:217:44 | url : Object |
 | InsecureWebResourceResponse.java:59:34:59:43 | url : Object | InsecureWebResourceResponse.java:75:20:75:22 | url : Object |
+| InsecureWebResourceResponse.java:63:77:63:86 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
 | InsecureWebResourceResponse.java:65:31:65:44 | parse(...) : Uri | InsecureWebResourceResponse.java:66:71:66:73 | uri : Uri |
 | InsecureWebResourceResponse.java:65:41:65:43 | url : Object | InsecureWebResourceResponse.java:65:31:65:44 | parse(...) : Uri |
 | InsecureWebResourceResponse.java:66:51:66:84 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:68:71:68:81 | inputStream |
 | InsecureWebResourceResponse.java:66:71:66:73 | uri : Uri | InsecureWebResourceResponse.java:66:71:66:83 | getPath(...) : String |
 | InsecureWebResourceResponse.java:66:71:66:83 | getPath(...) : String | InsecureWebResourceResponse.java:66:51:66:84 | new FileInputStream(...) : FileInputStream |
-| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:80:34:80:43 | url : Object | InsecureWebResourceResponse.java:101:20:101:22 | url : Object |
+| InsecureWebResourceResponse.java:84:77:84:86 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
 | InsecureWebResourceResponse.java:86:31:86:44 | parse(...) : Uri | InsecureWebResourceResponse.java:88:66:88:68 | uri : Uri |
 | InsecureWebResourceResponse.java:86:41:86:43 | url : Object | InsecureWebResourceResponse.java:86:31:86:44 | parse(...) : Uri |
 | InsecureWebResourceResponse.java:88:42:88:90 | new File(...) : File | InsecureWebResourceResponse.java:89:75:89:83 | cacheFile : File |
@@ -35,12 +37,13 @@ edges
 | InsecureWebResourceResponse.java:88:66:88:89 | getLastPathSegment(...) : String | InsecureWebResourceResponse.java:88:42:88:90 | new File(...) : File |
 | InsecureWebResourceResponse.java:89:55:89:84 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:91:75:91:85 | inputStream |
 | InsecureWebResourceResponse.java:89:75:89:83 | cacheFile : File | InsecureWebResourceResponse.java:89:55:89:84 | new FileInputStream(...) : FileInputStream |
-| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:106:34:106:43 | url : Object | InsecureWebResourceResponse.java:127:20:127:22 | url : Object |
+| InsecureWebResourceResponse.java:110:77:110:86 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
 | InsecureWebResourceResponse.java:112:31:112:44 | parse(...) : Uri | InsecureWebResourceResponse.java:113:35:113:37 | uri : Uri |
 | InsecureWebResourceResponse.java:112:41:112:43 | url : Object | InsecureWebResourceResponse.java:112:31:112:44 | parse(...) : Uri |
 | InsecureWebResourceResponse.java:113:35:113:37 | uri : Uri | InsecureWebResourceResponse.java:113:35:113:47 | getPath(...) : String |
@@ -49,48 +52,50 @@ edges
 | InsecureWebResourceResponse.java:115:55:115:108 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:117:75:117:85 | inputStream |
 | InsecureWebResourceResponse.java:115:75:115:78 | path : String | InsecureWebResourceResponse.java:115:75:115:107 | substring(...) : String |
 | InsecureWebResourceResponse.java:115:75:115:107 | substring(...) : String | InsecureWebResourceResponse.java:115:55:115:108 | new FileInputStream(...) : FileInputStream |
-| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:131:36:131:45 | url : Object | InsecureWebResourceResponse.java:152:20:152:22 | url : Object |
-| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:156:35:156:44 | url : Object | InsecureWebResourceResponse.java:177:20:177:22 | url : Object |
-| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:181:34:181:43 | url : Object | InsecureWebResourceResponse.java:184:20:184:22 | url : Object |
-| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:188:34:188:43 | url : Object | InsecureWebResourceResponse.java:209:20:209:22 | url : Object |
-| InsecureWebResourceResponse.java:194:31:194:37 | request : Object | InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Object |
-| InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Object | InsecureWebResourceResponse.java:196:66:196:68 | uri : Object |
+| InsecureWebResourceResponse.java:192:77:192:102 | request : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:194:31:194:37 | request : Object | InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Uri |
+| InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Uri | InsecureWebResourceResponse.java:196:66:196:68 | uri : Uri |
 | InsecureWebResourceResponse.java:196:42:196:90 | new File(...) : File | InsecureWebResourceResponse.java:197:75:197:83 | cacheFile : File |
-| InsecureWebResourceResponse.java:196:66:196:68 | uri : Object | InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String |
+| InsecureWebResourceResponse.java:196:66:196:68 | uri : Uri | InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String |
 | InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String | InsecureWebResourceResponse.java:196:42:196:90 | new File(...) : File |
 | InsecureWebResourceResponse.java:197:55:197:84 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:199:75:199:85 | inputStream |
 | InsecureWebResourceResponse.java:197:75:197:83 | cacheFile : File | InsecureWebResourceResponse.java:197:55:197:84 | new FileInputStream(...) : FileInputStream |
-| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
 | InsecureWebResourceResponse.java:217:35:217:44 | url : Object | InsecureWebResourceResponse.java:226:20:226:22 | url : Object |
-| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
-| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
-| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
-| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
-| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:63:77:63:86 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:84:77:84:86 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:110:77:110:86 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:192:77:192:102 | request : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:232:69:232:78 | url : Object |
+| InsecureWebResourceResponse.java:232:69:232:78 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
 | InsecureWebResourceResponse.java:234:23:234:36 | parse(...) : Uri | InsecureWebResourceResponse.java:235:63:235:65 | uri : Uri |
 | InsecureWebResourceResponse.java:234:33:234:35 | url : Object | InsecureWebResourceResponse.java:234:23:234:36 | parse(...) : Uri |
 | InsecureWebResourceResponse.java:235:43:235:76 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:237:63:237:73 | inputStream |
@@ -100,7 +105,8 @@ edges
 | InsecureWebViewActivity.java:27:27:27:64 | getStringExtra(...) : Object | InsecureWebViewActivity.java:28:20:28:27 | inputUrl : Object |
 | InsecureWebViewActivity.java:28:20:28:27 | inputUrl : Object | InsecureWebViewActivity.java:42:28:42:37 | url : Object |
 | InsecureWebViewActivity.java:42:28:42:37 | url : Object | InsecureWebViewActivity.java:43:25:43:27 | url : Object |
-| InsecureWebViewActivity.java:43:25:43:27 | url : Object | InsecureWebViewActivity.java:55:41:55:43 | url : Object |
+| InsecureWebViewActivity.java:43:25:43:27 | url : Object | InsecureWebViewActivity.java:53:77:53:86 | url : Object |
+| InsecureWebViewActivity.java:53:77:53:86 | url : Object | InsecureWebViewActivity.java:55:41:55:43 | url : Object |
 | InsecureWebViewActivity.java:55:31:55:44 | parse(...) : Uri | InsecureWebViewActivity.java:56:71:56:73 | uri : Uri |
 | InsecureWebViewActivity.java:55:41:55:43 | url : Object | InsecureWebViewActivity.java:55:31:55:44 | parse(...) : Uri |
 | InsecureWebViewActivity.java:56:51:56:84 | new FileInputStream(...) : FileInputStream | InsecureWebViewActivity.java:58:71:58:81 | inputStream |
@@ -118,6 +124,7 @@ nodes
 | InsecureWebResourceResponse.java:42:25:42:32 | inputUrl : Object | semmle.label | inputUrl : Object |
 | InsecureWebResourceResponse.java:44:26:44:33 | inputUrl : Object | semmle.label | inputUrl : Object |
 | InsecureWebResourceResponse.java:59:34:59:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:63:77:63:86 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:65:31:65:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
 | InsecureWebResourceResponse.java:65:41:65:43 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:66:51:66:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
@@ -126,6 +133,7 @@ nodes
 | InsecureWebResourceResponse.java:68:71:68:81 | inputStream | semmle.label | inputStream |
 | InsecureWebResourceResponse.java:75:20:75:22 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:80:34:80:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:84:77:84:86 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:86:31:86:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
 | InsecureWebResourceResponse.java:86:41:86:43 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:88:42:88:90 | new File(...) : File | semmle.label | new File(...) : File |
@@ -136,6 +144,7 @@ nodes
 | InsecureWebResourceResponse.java:91:75:91:85 | inputStream | semmle.label | inputStream |
 | InsecureWebResourceResponse.java:101:20:101:22 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:106:34:106:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:110:77:110:86 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:112:31:112:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
 | InsecureWebResourceResponse.java:112:41:112:43 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:113:35:113:37 | uri : Uri | semmle.label | uri : Uri |
@@ -153,10 +162,11 @@ nodes
 | InsecureWebResourceResponse.java:181:34:181:43 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:184:20:184:22 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:188:34:188:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:192:77:192:102 | request : Object | semmle.label | request : Object |
 | InsecureWebResourceResponse.java:194:31:194:37 | request : Object | semmle.label | request : Object |
-| InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Object | semmle.label | getUrl(...) : Object |
+| InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Uri | semmle.label | getUrl(...) : Uri |
 | InsecureWebResourceResponse.java:196:42:196:90 | new File(...) : File | semmle.label | new File(...) : File |
-| InsecureWebResourceResponse.java:196:66:196:68 | uri : Object | semmle.label | uri : Object |
+| InsecureWebResourceResponse.java:196:66:196:68 | uri : Uri | semmle.label | uri : Uri |
 | InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String | semmle.label | getLastPathSegment(...) : String |
 | InsecureWebResourceResponse.java:197:55:197:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
 | InsecureWebResourceResponse.java:197:75:197:83 | cacheFile : File | semmle.label | cacheFile : File |
@@ -164,6 +174,7 @@ nodes
 | InsecureWebResourceResponse.java:209:20:209:22 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:217:35:217:44 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:226:20:226:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:232:69:232:78 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:234:23:234:36 | parse(...) : Uri | semmle.label | parse(...) : Uri |
 | InsecureWebResourceResponse.java:234:33:234:35 | url : Object | semmle.label | url : Object |
 | InsecureWebResourceResponse.java:235:43:235:76 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
@@ -175,6 +186,7 @@ nodes
 | InsecureWebViewActivity.java:28:20:28:27 | inputUrl : Object | semmle.label | inputUrl : Object |
 | InsecureWebViewActivity.java:42:28:42:37 | url : Object | semmle.label | url : Object |
 | InsecureWebViewActivity.java:43:25:43:27 | url : Object | semmle.label | url : Object |
+| InsecureWebViewActivity.java:53:77:53:86 | url : Object | semmle.label | url : Object |
 | InsecureWebViewActivity.java:55:31:55:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
 | InsecureWebViewActivity.java:55:41:55:43 | url : Object | semmle.label | url : Object |
 | InsecureWebViewActivity.java:56:51:56:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |

--- a/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.expected
@@ -1,0 +1,191 @@
+edges
+| InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:30:25:30:32 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:32:25:32:32 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:34:25:34:32 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:36:26:36:33 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:38:26:38:33 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:40:25:40:32 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:42:25:42:32 | inputUrl : Object |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | InsecureWebResourceResponse.java:44:26:44:33 | inputUrl : Object |
+| InsecureWebResourceResponse.java:30:25:30:32 | inputUrl : Object | InsecureWebResourceResponse.java:59:34:59:43 | url : Object |
+| InsecureWebResourceResponse.java:32:25:32:32 | inputUrl : Object | InsecureWebResourceResponse.java:80:34:80:43 | url : Object |
+| InsecureWebResourceResponse.java:34:25:34:32 | inputUrl : Object | InsecureWebResourceResponse.java:106:34:106:43 | url : Object |
+| InsecureWebResourceResponse.java:36:26:36:33 | inputUrl : Object | InsecureWebResourceResponse.java:131:36:131:45 | url : Object |
+| InsecureWebResourceResponse.java:38:26:38:33 | inputUrl : Object | InsecureWebResourceResponse.java:156:35:156:44 | url : Object |
+| InsecureWebResourceResponse.java:40:25:40:32 | inputUrl : Object | InsecureWebResourceResponse.java:181:34:181:43 | url : Object |
+| InsecureWebResourceResponse.java:42:25:42:32 | inputUrl : Object | InsecureWebResourceResponse.java:188:34:188:43 | url : Object |
+| InsecureWebResourceResponse.java:44:26:44:33 | inputUrl : Object | InsecureWebResourceResponse.java:217:35:217:44 | url : Object |
+| InsecureWebResourceResponse.java:59:34:59:43 | url : Object | InsecureWebResourceResponse.java:75:20:75:22 | url : Object |
+| InsecureWebResourceResponse.java:65:31:65:44 | parse(...) : Uri | InsecureWebResourceResponse.java:66:71:66:73 | uri : Uri |
+| InsecureWebResourceResponse.java:65:41:65:43 | url : Object | InsecureWebResourceResponse.java:65:31:65:44 | parse(...) : Uri |
+| InsecureWebResourceResponse.java:66:51:66:84 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:68:71:68:81 | inputStream |
+| InsecureWebResourceResponse.java:66:71:66:73 | uri : Uri | InsecureWebResourceResponse.java:66:71:66:83 | getPath(...) : String |
+| InsecureWebResourceResponse.java:66:71:66:83 | getPath(...) : String | InsecureWebResourceResponse.java:66:51:66:84 | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:80:34:80:43 | url : Object | InsecureWebResourceResponse.java:101:20:101:22 | url : Object |
+| InsecureWebResourceResponse.java:86:31:86:44 | parse(...) : Uri | InsecureWebResourceResponse.java:88:66:88:68 | uri : Uri |
+| InsecureWebResourceResponse.java:86:41:86:43 | url : Object | InsecureWebResourceResponse.java:86:31:86:44 | parse(...) : Uri |
+| InsecureWebResourceResponse.java:88:42:88:90 | new File(...) : File | InsecureWebResourceResponse.java:89:75:89:83 | cacheFile : File |
+| InsecureWebResourceResponse.java:88:66:88:68 | uri : Uri | InsecureWebResourceResponse.java:88:66:88:89 | getLastPathSegment(...) : String |
+| InsecureWebResourceResponse.java:88:66:88:89 | getLastPathSegment(...) : String | InsecureWebResourceResponse.java:88:42:88:90 | new File(...) : File |
+| InsecureWebResourceResponse.java:89:55:89:84 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:91:75:91:85 | inputStream |
+| InsecureWebResourceResponse.java:89:75:89:83 | cacheFile : File | InsecureWebResourceResponse.java:89:55:89:84 | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:106:34:106:43 | url : Object | InsecureWebResourceResponse.java:127:20:127:22 | url : Object |
+| InsecureWebResourceResponse.java:112:31:112:44 | parse(...) : Uri | InsecureWebResourceResponse.java:113:35:113:37 | uri : Uri |
+| InsecureWebResourceResponse.java:112:41:112:43 | url : Object | InsecureWebResourceResponse.java:112:31:112:44 | parse(...) : Uri |
+| InsecureWebResourceResponse.java:113:35:113:37 | uri : Uri | InsecureWebResourceResponse.java:113:35:113:47 | getPath(...) : String |
+| InsecureWebResourceResponse.java:113:35:113:47 | getPath(...) : String | InsecureWebResourceResponse.java:113:35:113:60 | substring(...) : String |
+| InsecureWebResourceResponse.java:113:35:113:60 | substring(...) : String | InsecureWebResourceResponse.java:115:75:115:78 | path : String |
+| InsecureWebResourceResponse.java:115:55:115:108 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:117:75:117:85 | inputStream |
+| InsecureWebResourceResponse.java:115:75:115:78 | path : String | InsecureWebResourceResponse.java:115:75:115:107 | substring(...) : String |
+| InsecureWebResourceResponse.java:115:75:115:107 | substring(...) : String | InsecureWebResourceResponse.java:115:55:115:108 | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:131:36:131:45 | url : Object | InsecureWebResourceResponse.java:152:20:152:22 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:156:35:156:44 | url : Object | InsecureWebResourceResponse.java:177:20:177:22 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:181:34:181:43 | url : Object | InsecureWebResourceResponse.java:184:20:184:22 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:188:34:188:43 | url : Object | InsecureWebResourceResponse.java:209:20:209:22 | url : Object |
+| InsecureWebResourceResponse.java:194:31:194:37 | request : Object | InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Object |
+| InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Object | InsecureWebResourceResponse.java:196:66:196:68 | uri : Object |
+| InsecureWebResourceResponse.java:196:42:196:90 | new File(...) : File | InsecureWebResourceResponse.java:197:75:197:83 | cacheFile : File |
+| InsecureWebResourceResponse.java:196:66:196:68 | uri : Object | InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String |
+| InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String | InsecureWebResourceResponse.java:196:42:196:90 | new File(...) : File |
+| InsecureWebResourceResponse.java:197:55:197:84 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:199:75:199:85 | inputStream |
+| InsecureWebResourceResponse.java:197:75:197:83 | cacheFile : File | InsecureWebResourceResponse.java:197:55:197:84 | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:217:35:217:44 | url : Object | InsecureWebResourceResponse.java:226:20:226:22 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:65:41:65:43 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:86:41:86:43 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:112:41:112:43 | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:194:31:194:37 | request : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | InsecureWebResourceResponse.java:234:33:234:35 | url : Object |
+| InsecureWebResourceResponse.java:234:23:234:36 | parse(...) : Uri | InsecureWebResourceResponse.java:235:63:235:65 | uri : Uri |
+| InsecureWebResourceResponse.java:234:33:234:35 | url : Object | InsecureWebResourceResponse.java:234:23:234:36 | parse(...) : Uri |
+| InsecureWebResourceResponse.java:235:43:235:76 | new FileInputStream(...) : FileInputStream | InsecureWebResourceResponse.java:237:63:237:73 | inputStream |
+| InsecureWebResourceResponse.java:235:63:235:65 | uri : Uri | InsecureWebResourceResponse.java:235:63:235:75 | getPath(...) : String |
+| InsecureWebResourceResponse.java:235:63:235:75 | getPath(...) : String | InsecureWebResourceResponse.java:235:43:235:76 | new FileInputStream(...) : FileInputStream |
+| InsecureWebViewActivity.java:27:27:27:37 | getIntent(...) : Intent | InsecureWebViewActivity.java:27:27:27:64 | getStringExtra(...) : Object |
+| InsecureWebViewActivity.java:27:27:27:64 | getStringExtra(...) : Object | InsecureWebViewActivity.java:28:20:28:27 | inputUrl : Object |
+| InsecureWebViewActivity.java:28:20:28:27 | inputUrl : Object | InsecureWebViewActivity.java:42:28:42:37 | url : Object |
+| InsecureWebViewActivity.java:42:28:42:37 | url : Object | InsecureWebViewActivity.java:43:25:43:27 | url : Object |
+| InsecureWebViewActivity.java:43:25:43:27 | url : Object | InsecureWebViewActivity.java:55:41:55:43 | url : Object |
+| InsecureWebViewActivity.java:55:31:55:44 | parse(...) : Uri | InsecureWebViewActivity.java:56:71:56:73 | uri : Uri |
+| InsecureWebViewActivity.java:55:41:55:43 | url : Object | InsecureWebViewActivity.java:55:31:55:44 | parse(...) : Uri |
+| InsecureWebViewActivity.java:56:51:56:84 | new FileInputStream(...) : FileInputStream | InsecureWebViewActivity.java:58:71:58:81 | inputStream |
+| InsecureWebViewActivity.java:56:71:56:73 | uri : Uri | InsecureWebViewActivity.java:56:71:56:83 | getPath(...) : String |
+| InsecureWebViewActivity.java:56:71:56:83 | getPath(...) : String | InsecureWebViewActivity.java:56:51:56:84 | new FileInputStream(...) : FileInputStream |
+nodes
+| InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | semmle.label | getIntent(...) : Intent |
+| InsecureWebResourceResponse.java:28:27:28:64 | getStringExtra(...) : Object | semmle.label | getStringExtra(...) : Object |
+| InsecureWebResourceResponse.java:30:25:30:32 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:32:25:32:32 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:34:25:34:32 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:36:26:36:33 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:38:26:38:33 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:40:25:40:32 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:42:25:42:32 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:44:26:44:33 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebResourceResponse.java:59:34:59:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:65:31:65:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
+| InsecureWebResourceResponse.java:65:41:65:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:66:51:66:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:66:71:66:73 | uri : Uri | semmle.label | uri : Uri |
+| InsecureWebResourceResponse.java:66:71:66:83 | getPath(...) : String | semmle.label | getPath(...) : String |
+| InsecureWebResourceResponse.java:68:71:68:81 | inputStream | semmle.label | inputStream |
+| InsecureWebResourceResponse.java:75:20:75:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:80:34:80:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:86:31:86:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
+| InsecureWebResourceResponse.java:86:41:86:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:88:42:88:90 | new File(...) : File | semmle.label | new File(...) : File |
+| InsecureWebResourceResponse.java:88:66:88:68 | uri : Uri | semmle.label | uri : Uri |
+| InsecureWebResourceResponse.java:88:66:88:89 | getLastPathSegment(...) : String | semmle.label | getLastPathSegment(...) : String |
+| InsecureWebResourceResponse.java:89:55:89:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:89:75:89:83 | cacheFile : File | semmle.label | cacheFile : File |
+| InsecureWebResourceResponse.java:91:75:91:85 | inputStream | semmle.label | inputStream |
+| InsecureWebResourceResponse.java:101:20:101:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:106:34:106:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:112:31:112:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
+| InsecureWebResourceResponse.java:112:41:112:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:113:35:113:37 | uri : Uri | semmle.label | uri : Uri |
+| InsecureWebResourceResponse.java:113:35:113:47 | getPath(...) : String | semmle.label | getPath(...) : String |
+| InsecureWebResourceResponse.java:113:35:113:60 | substring(...) : String | semmle.label | substring(...) : String |
+| InsecureWebResourceResponse.java:115:55:115:108 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:115:75:115:78 | path : String | semmle.label | path : String |
+| InsecureWebResourceResponse.java:115:75:115:107 | substring(...) : String | semmle.label | substring(...) : String |
+| InsecureWebResourceResponse.java:117:75:117:85 | inputStream | semmle.label | inputStream |
+| InsecureWebResourceResponse.java:127:20:127:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:131:36:131:45 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:152:20:152:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:156:35:156:44 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:177:20:177:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:181:34:181:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:184:20:184:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:188:34:188:43 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:194:31:194:37 | request : Object | semmle.label | request : Object |
+| InsecureWebResourceResponse.java:194:31:194:46 | getUrl(...) : Object | semmle.label | getUrl(...) : Object |
+| InsecureWebResourceResponse.java:196:42:196:90 | new File(...) : File | semmle.label | new File(...) : File |
+| InsecureWebResourceResponse.java:196:66:196:68 | uri : Object | semmle.label | uri : Object |
+| InsecureWebResourceResponse.java:196:66:196:89 | getLastPathSegment(...) : String | semmle.label | getLastPathSegment(...) : String |
+| InsecureWebResourceResponse.java:197:55:197:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:197:75:197:83 | cacheFile : File | semmle.label | cacheFile : File |
+| InsecureWebResourceResponse.java:199:75:199:85 | inputStream | semmle.label | inputStream |
+| InsecureWebResourceResponse.java:209:20:209:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:217:35:217:44 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:226:20:226:22 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:234:23:234:36 | parse(...) : Uri | semmle.label | parse(...) : Uri |
+| InsecureWebResourceResponse.java:234:33:234:35 | url : Object | semmle.label | url : Object |
+| InsecureWebResourceResponse.java:235:43:235:76 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
+| InsecureWebResourceResponse.java:235:63:235:65 | uri : Uri | semmle.label | uri : Uri |
+| InsecureWebResourceResponse.java:235:63:235:75 | getPath(...) : String | semmle.label | getPath(...) : String |
+| InsecureWebResourceResponse.java:237:63:237:73 | inputStream | semmle.label | inputStream |
+| InsecureWebViewActivity.java:27:27:27:37 | getIntent(...) : Intent | semmle.label | getIntent(...) : Intent |
+| InsecureWebViewActivity.java:27:27:27:64 | getStringExtra(...) : Object | semmle.label | getStringExtra(...) : Object |
+| InsecureWebViewActivity.java:28:20:28:27 | inputUrl : Object | semmle.label | inputUrl : Object |
+| InsecureWebViewActivity.java:42:28:42:37 | url : Object | semmle.label | url : Object |
+| InsecureWebViewActivity.java:43:25:43:27 | url : Object | semmle.label | url : Object |
+| InsecureWebViewActivity.java:55:31:55:44 | parse(...) : Uri | semmle.label | parse(...) : Uri |
+| InsecureWebViewActivity.java:55:41:55:43 | url : Object | semmle.label | url : Object |
+| InsecureWebViewActivity.java:56:51:56:84 | new FileInputStream(...) : FileInputStream | semmle.label | new FileInputStream(...) : FileInputStream |
+| InsecureWebViewActivity.java:56:71:56:73 | uri : Uri | semmle.label | uri : Uri |
+| InsecureWebViewActivity.java:56:71:56:83 | getPath(...) : String | semmle.label | getPath(...) : String |
+| InsecureWebViewActivity.java:58:71:58:81 | inputStream | semmle.label | inputStream |
+subpaths
+#select
+| InsecureWebResourceResponse.java:68:71:68:81 | inputStream | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | InsecureWebResourceResponse.java:68:71:68:81 | inputStream | Leaking arbitrary content in Android from $@. | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) | this user input |
+| InsecureWebResourceResponse.java:91:75:91:85 | inputStream | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | InsecureWebResourceResponse.java:91:75:91:85 | inputStream | Leaking arbitrary content in Android from $@. | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) | this user input |
+| InsecureWebResourceResponse.java:117:75:117:85 | inputStream | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | InsecureWebResourceResponse.java:117:75:117:85 | inputStream | Leaking arbitrary content in Android from $@. | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) | this user input |
+| InsecureWebResourceResponse.java:199:75:199:85 | inputStream | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | InsecureWebResourceResponse.java:199:75:199:85 | inputStream | Leaking arbitrary content in Android from $@. | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) | this user input |
+| InsecureWebResourceResponse.java:237:63:237:73 | inputStream | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) : Intent | InsecureWebResourceResponse.java:237:63:237:73 | inputStream | Leaking arbitrary content in Android from $@. | InsecureWebResourceResponse.java:28:27:28:37 | getIntent(...) | this user input |
+| InsecureWebViewActivity.java:58:71:58:81 | inputStream | InsecureWebViewActivity.java:27:27:27:37 | getIntent(...) : Intent | InsecureWebViewActivity.java:58:71:58:81 | inputStream | Leaking arbitrary content in Android from $@. | InsecureWebViewActivity.java:27:27:27:37 | getIntent(...) | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.java
@@ -1,0 +1,242 @@
+package com.example.app;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Locale;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import android.webkit.MimeTypeMap;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import androidx.webkit.WebViewAssetLoader;
+import androidx.webkit.WebViewAssetLoader.AssetsPathHandler;
+import android.webkit.WebViewClient;
+import android.webkit.WebResourceResponse;
+
+/** Insecure activity with its subclassed webviewclient implementation. */
+public class InsecureWebResourceResponse extends Activity {
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(-1);
+
+        String inputUrl = getIntent().getStringExtra("inputUrl");
+
+        getBadResponse1(inputUrl);
+
+        getBadResponse2(inputUrl);
+
+        getBadResponse3(inputUrl);
+
+        getGoodResponse4(inputUrl);
+
+        getGoodResponse5(inputUrl);
+
+        getBadResponse6(inputUrl);
+
+        getBadResponse7(inputUrl);
+
+        getGoodResponse8(inputUrl);
+    }
+
+    public static String getMimeTypeFromPath(String path) {
+        String extension = path;
+        int lastDot = extension.lastIndexOf('.');
+        if (lastDot != -1) {
+            extension = extension.substring(lastDot + 1);
+        }
+
+        extension = extension.toLowerCase(Locale.getDefault());
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+    }
+
+    // BAD: Return file of input path in annonyous WebViewClient without validation
+    private void getBadResponse1(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                try {
+                    Uri uri = Uri.parse(url);
+                    FileInputStream inputStream = new FileInputStream(uri.getPath());
+                    String mimeType = getMimeTypeFromPath(uri.getPath());
+                    return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+
+    // BAD: Return file of input path in annonyous WebViewClient with insufficient validation
+    // A malicious input such as https://any.domain/local_cache/..%2Fshared_prefs/auth.xml can bypass the validation
+    private void getBadResponse2(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                try {
+                    Uri uri = Uri.parse(url);
+                    if (uri.getPath().startsWith("/local_cache/")) {
+                        File cacheFile = new File(getCacheDir(), uri.getLastPathSegment());
+                        FileInputStream inputStream = new FileInputStream(cacheFile);
+                        String mimeType = getMimeTypeFromPath(uri.getPath());
+                        return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                    } else {
+                        return new WebResourceResponse("text/plain", "UTF-8", null);
+                    }
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+
+    // BAD: Return file of input path in annonyous WebViewClient with insufficient validation
+    // A malicious input such as https://any.domain/files/..%2Fshared_prefs/auth.xml can bypass the validation
+    private void getBadResponse3(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                try {
+                    Uri uri = Uri.parse(url);
+                    String path = uri.getPath().substring(1);
+                    if (path.startsWith("files/")) {
+                        FileInputStream inputStream = new FileInputStream(path.substring("files/".length()));
+                        String mimeType = getMimeTypeFromPath(uri.getPath());
+                        return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                    } else {
+                        return new WebResourceResponse("text/plain", "UTF-8", null);
+                    }
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+
+    // GOOD: Return file of input path in annonyous WebViewClient with sufficient validation
+     private void getGoodResponse4(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                try {
+                    Uri uri = Uri.parse(url);
+                    if (uri.getPath().startsWith("/local_cache/") && !uri.getPath().contains("..")) {
+                        File cacheFile = new File(getCacheDir(), uri.getLastPathSegment());
+                        FileInputStream inputStream = new FileInputStream(cacheFile);
+                        String mimeType = getMimeTypeFromPath(uri.getPath());
+                        return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                    } else {
+                        return new WebResourceResponse("text/plain", "UTF-8", null);
+                    }
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+
+    // GOOD: Return file of input path in annonyous WebViewClient with sufficient validation
+    private void getGoodResponse5(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                try {
+                    Uri uri = Uri.parse(url);
+                    String path = uri.getPath().substring(1);
+                    if (path.startsWith("files/")  && !path.contains("..")) {
+                        FileInputStream inputStream = new FileInputStream(path.substring("files/".length()));
+                        String mimeType = getMimeTypeFromPath(uri.getPath());
+                        return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                    } else {
+                        return new WebResourceResponse("text/plain", "UTF-8", null);
+                    }
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+
+    // BAD: Return file of input path in standalone WebViewClient without validation
+    private void getBadResponse6(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new VulnerableWebViewClient());
+        wv.loadUrl(url);
+    }
+
+    // BAD: Return file of input path in annonyous WebViewClient with insufficient validation using WebResourceRequest object
+    private void getBadResponse7(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+                try {
+                    Uri uri = request.getUrl();
+                    if (uri.getPath().startsWith("/local_cache/")) {
+                        File cacheFile = new File(getCacheDir(), uri.getLastPathSegment());
+                        FileInputStream inputStream = new FileInputStream(cacheFile);
+                        String mimeType = getMimeTypeFromPath(uri.getPath());
+                        return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                    } else {
+                        return new WebResourceResponse("text/plain", "UTF-8", null);
+                    }
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+
+    final WebViewAssetLoader assetLoader = new WebViewAssetLoader.Builder()
+            .addPathHandler("/assets/", new AssetsPathHandler(this))
+            .build();
+   
+    // GOOD: Return file of input path in annonyous WebViewClient with WebViewAssetLoader
+    private void getGoodResponse8(String url) {
+        WebView wv = (WebView) findViewById(-1);
+        wv.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+                return assetLoader.shouldInterceptRequest(request.getUrl());
+            }
+        });
+
+        wv.loadUrl(url);
+    }
+}
+
+class VulnerableWebViewClient extends WebViewClient {
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+        try {
+            Uri uri = Uri.parse(url);
+            FileInputStream inputStream = new FileInputStream(uri.getPath());
+            String mimeType = InsecureWebResourceResponse.getMimeTypeFromPath(uri.getPath());
+            return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+        } catch (IOException ie) {
+            return new WebResourceResponse("text/plain", "UTF-8", null);
+        }
+    }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebResourceResponse.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-200/InsecureWebResourceResponse.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebViewActivity.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-200/InsecureWebViewActivity.java
@@ -1,0 +1,65 @@
+package com.example.app;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Locale;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import android.webkit.MimeTypeMap;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.webkit.WebResourceResponse;
+
+/** Insecure WebView activity with its subclassed webview implementation. */
+public class InsecureWebViewActivity extends Activity {
+    VulnerableWebView webview;
+
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(-1);
+        webview = (VulnerableWebView) findViewById(-1);
+
+        String inputUrl = getIntent().getStringExtra("inputUrl");
+        loadWebUrl(inputUrl);
+    }
+
+    public static String getMimeTypeFromPath(String path) {
+        String extension = path;
+        int lastDot = extension.lastIndexOf('.');
+        if (lastDot != -1) {
+            extension = extension.substring(lastDot + 1);
+        }
+
+        extension = extension.toLowerCase(Locale.getDefault());
+        return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+    }
+
+    public void loadWebUrl(String url) {
+        webview.loadUrl(url);
+    }
+}
+
+class VulnerableWebView extends WebView {
+    public VulnerableWebView(Context context) {
+        super(context);
+
+        this.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+                try {
+                    Uri uri = Uri.parse(url);
+                    FileInputStream inputStream = new FileInputStream(uri.getPath());
+                    String mimeType = InsecureWebViewActivity.getMimeTypeFromPath(uri.getPath());
+                    return new WebResourceResponse(mimeType, "UTF-8", inputStream);
+                } catch (IOException ie) {
+                    return new WebResourceResponse("text/plain", "UTF-8", null);
+                }
+            }
+        });
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/webkit/MimeTypeMap.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/webkit/MimeTypeMap.java
@@ -1,0 +1,51 @@
+package android.webkit;
+
+public class MimeTypeMap {
+    /**
+     * Returns the file extension or an empty string iff there is no
+     * extension. This method is a convenience method for obtaining the
+     * extension of a url and has undefined results for other Strings.
+     * @param url
+     * @return The file extension of the given url.
+     */
+    public static String getFileExtensionFromUrl(String url) {
+        return null;
+    }
+
+    /**
+     * Return the MIME type for the given extension.
+     * @param extension A file extension without the leading '.'
+     * @return The MIME type for the given extension or null iff there is none.
+     */
+    public String getMimeTypeFromExtension(String extension) {
+        return null;
+    }
+
+    /**
+     * Return true if the given extension has a registered MIME type.
+     * @param extension A file extension without the leading '.'
+     * @return True iff there is an extension entry in the map.
+     */
+    public boolean hasExtension(String extension) {
+        return false;
+    }
+
+    /**
+     * Return the registered extension for the given MIME type. Note that some
+     * MIME types map to multiple extensions. This call will return the most
+     * common extension for the given MIME type.
+     * @param mimeType A MIME type (i.e. text/plain)
+     * @return The extension for the given MIME type or null iff there is none.
+     */
+    public String getExtensionFromMimeType(String mimeType) {
+        return null;
+    }
+
+    /**
+     * Get the singleton instance of MimeTypeMap.
+     * @return The singleton instance of the MIME-type map.
+     */
+    public static MimeTypeMap getSingleton() {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/androidx/webkit/WebViewAssetLoader.java
+++ b/java/ql/test/stubs/google-android-9.0.0/androidx/webkit/WebViewAssetLoader.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.webkit;
+
+import android.content.Context;
+import android.net.Uri;
+import android.webkit.WebResourceResponse;
+import java.io.File;
+
+/**
+ * Helper class to load local files including application's static assets and resources using
+ * http(s):// URLs inside a {@link android.webkit.WebView} class.
+ * Loading local files using web-like URLs instead of {@code "file://"} is desirable as it is
+ * compatible with the Same-Origin policy.
+ *
+ * <p>
+ * For more context about application's assets and resources and how to normally access them please
+ * refer to <a href="https://developer.android.com/guide/topics/resources/providing-resources">
+ * Android Developer Docs: App resources overview</a>.
+ *
+ * <p class='note'>
+ * This class is expected to be used within
+ * {@link android.webkit.WebViewClient#shouldInterceptRequest}, which is invoked on a different
+ * thread than application's main thread. Although instances are themselves thread-safe (and may be
+ * safely constructed on the application's main thread), exercise caution when accessing private
+ * data or the view system.
+ * <p>
+ * Using http(s):// URLs to access local resources may conflict with a real website. This means
+ * that local files should only be hosted on domains your organization owns (at paths reserved
+ * for this purpose) or the default domain reserved for this: {@code appassets.androidplatform.net}.
+ * <p>
+ * A typical usage would be like:
+ * <pre class="prettyprint">
+ * final WebViewAssetLoader assetLoader = new WebViewAssetLoader.Builder()
+ *          .addPathHandler("/assets/", new AssetsPathHandler(this))
+ *          .build();
+ *
+ * webView.setWebViewClient(new WebViewClientCompat() {
+ *     {@literal @}Override
+ *     {@literal @}RequiresApi(21)
+ *     public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+ *         return assetLoader.shouldInterceptRequest(request.getUrl());
+ *     }
+ *
+ *     {@literal @}Override
+ *     {@literal @}SuppressWarnings("deprecation") // for API < 21
+ *     public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
+ *         return assetLoader.shouldInterceptRequest(Uri.parse(url));
+ *     }
+ * });
+ *
+ * WebSettings webViewSettings = webView.getSettings();
+ * // Setting this off for security. Off by default for SDK versions >= 16.
+ * webViewSettings.setAllowFileAccessFromFileURLs(false);
+ * // Off by default, deprecated for SDK versions >= 30.
+ * webViewSettings.setAllowUniversalAccessFromFileURLs(false);
+ * // Keeping these off is less critical but still a good idea, especially if your app is not
+ * // using file:// or content:// URLs.
+ * webViewSettings.setAllowFileAccess(false);
+ * webViewSettings.setAllowContentAccess(false);
+ *
+ * // Assets are hosted under http(s)://appassets.androidplatform.net/assets/... .
+ * // If the application's assets are in the "main/assets" folder this will read the file
+ * // from "main/assets/www/index.html" and load it as if it were hosted on:
+ * // https://appassets.androidplatform.net/assets/www/index.html
+ * webview.loadUrl("https://appassets.androidplatform.net/assets/www/index.html");
+ * </pre>
+ */
+public final class WebViewAssetLoader {
+
+    /**
+     * A handler that produces responses for a registered path.
+     *
+     * <p>
+     * Implement this interface to handle other use-cases according to your app's needs.
+     * <p>
+     * Methods of this handler will be invoked on a background thread and care must be taken to
+     * correctly synchronize access to any shared state.
+     * <p>
+     * On Android KitKat and above these methods may be called on more than one thread. This thread
+     * may be different than the thread on which the shouldInterceptRequest method was invoked.
+     * This means that on Android KitKat and above it is possible to block in this method without
+     * blocking other resources from loading. The number of threads used to parallelize loading
+     * is an internal implementation detail of the WebView and may change between updates which
+     * means that the amount of time spent blocking in this method should be kept to an absolute
+     * minimum.
+     */
+    public interface PathHandler {
+        /**
+         * Handles the requested URL by returning the appropriate response.
+         * <p>
+         * Returning a {@code null} value means that the handler decided not to handle this path.
+         * In this case, {@link WebViewAssetLoader} will try the next handler registered on this
+         * path or pass to WebView that will fall back to network to try to resolve the URL.
+         * <p>
+         * However, if the handler wants to save unnecessary processing either by another handler or
+         * by falling back to network, in cases like a file cannot be found, it may return a
+         * {@code new WebResourceResponse(null, null, null)} which is received as an
+         * HTTP response with status code {@code 404} and no body.
+         *
+         * @param path the suffix path to be handled.
+         * @return {@link WebResourceResponse} for the requested path or {@code null} if it can't
+         *                                     handle this path.
+         */
+        WebResourceResponse handle(String path);
+    }
+
+    /**
+     * Handler class to open a file from assets directory in the application APK.
+     */
+    public static final class AssetsPathHandler implements PathHandler {
+        /**
+         * @param context {@link Context} used to resolve assets.
+         */
+        public AssetsPathHandler(Context context) {
+        }
+
+        /**
+         * Opens the requested file from the application's assets directory.
+         * <p>
+         * The matched prefix path used shouldn't be a prefix of a real web path. Thus, if the
+         * requested file cannot be found a {@link WebResourceResponse} object with a {@code null}
+         * {@link InputStream} will be returned instead of {@code null}. This saves the time of
+         * falling back to network and trying to resolve a path that doesn't exist. A
+         * {@link WebResourceResponse} with {@code null} {@link InputStream} will be received as an
+         * HTTP response with status code {@code 404} and no body.
+         * <p class="note">
+         * The MIME type for the file will be determined from the file's extension using
+         * {@link java.net.URLConnection#guessContentTypeFromName}. Developers should ensure that
+         * asset files are named using standard file extensions. If the file does not have a
+         * recognised extension, {@code "text/plain"} will be used by default.
+         *
+         * @param path the suffix path to be handled.
+         * @return {@link WebResourceResponse} for the requested file.
+         */
+        @Override
+        public WebResourceResponse handle(String path) {
+            return null;
+        }
+    }
+
+    /**
+     * Handler class to open a file from resources directory in the application APK.
+     */
+    public static final class ResourcesPathHandler implements PathHandler {
+        /**
+         * @param context {@link Context} used to resolve resources.
+         */
+        public ResourcesPathHandler(Context context) {
+        }
+
+        /**
+         * Opens the requested file from application's resources directory.
+         * <p>
+         * The matched prefix path used shouldn't be a prefix of a real web path. Thus, if the
+         * requested file cannot be found a {@link WebResourceResponse} object with a {@code null}
+         * {@link InputStream} will be returned instead of {@code null}. This saves the time of
+         * falling back to network and trying to resolve a path that doesn't exist. A
+         * {@link WebResourceResponse} with {@code null} {@link InputStream} will be received as an
+         * HTTP response with status code {@code 404} and no body.
+         * <p class="note">
+         * The MIME type for the file will be determined from the file's extension using
+         * {@link java.net.URLConnection#guessContentTypeFromName}. Developers should ensure that
+         * resource files are named using standard file extensions. If the file does not have a
+         * recognised extension, {@code "text/plain"} will be used by default.
+         *
+         * @param path the suffix path to be handled.
+         * @return {@link WebResourceResponse} for the requested file.
+         */
+        @Override
+        public WebResourceResponse handle(String path) {
+            return null;
+        }
+    }
+
+    /**
+     * Handler class to open files from application internal storage.
+     * For more information about android storage please refer to
+     * <a href="https://developer.android.com/guide/topics/data/data-storage">Android Developers
+     * Docs: Data and file storage overview</a>.
+     * <p class="note">
+     * To avoid leaking user or app data to the web, make sure to choose {@code directory}
+     * carefully, and assume any file under this directory could be accessed by any web page subject
+     * to same-origin rules.
+     * <p>
+     * A typical usage would be like:
+     * <pre class="prettyprint">
+     * File publicDir = new File(context.getFilesDir(), "public");
+     * // Host "files/public/" in app's data directory under:
+     * // http://appassets.androidplatform.net/public/...
+     * WebViewAssetLoader assetLoader = new WebViewAssetLoader.Builder()
+     *          .addPathHandler("/public/", new InternalStoragePathHandler(context, publicDir))
+     *          .build();
+     * </pre>
+     */
+    public static final class InternalStoragePathHandler implements PathHandler {
+        /**
+         * Forbidden subdirectories of {@link Context#getDataDir} that cannot be exposed by this
+         * handler. They are forbidden as they often contain sensitive information.
+         * <p class="note">
+         * Note: Any future addition to this list will be considered breaking changes to the API.
+         */
+
+         /**
+         * Creates PathHandler for app's internal storage.
+         * The directory to be exposed must be inside either the application's internal data
+         * directory {@link Context#getDataDir} or cache directory {@link Context#getCacheDir}.
+         * External storage is not supported for security reasons, as other apps with
+         * {@link android.Manifest.permission#WRITE_EXTERNAL_STORAGE} may be able to modify the
+         * files.
+         * <p>
+         * Exposing the entire data or cache directory is not permitted, to avoid accidentally
+         * exposing sensitive application files to the web. Certain existing subdirectories of
+         * {@link Context#getDataDir} are also not permitted as they are often sensitive.
+         * These files are ({@code "app_webview/"}, {@code "databases/"}, {@code "lib/"},
+         * {@code "shared_prefs/"} and {@code "code_cache/"}).
+         * <p>
+         * The application should typically use a dedicated subdirectory for the files it intends to
+         * expose and keep them separate from other files.
+         *
+         * @param context {@link Context} that is used to access app's internal storage.
+         * @param directory the absolute path of the exposed app internal storage directory from
+         *                  which files can be loaded.
+         * @throws IllegalArgumentException if the directory is not allowed.
+         */
+        public InternalStoragePathHandler(Context context, File directory) {
+        }
+
+        /**
+         * Opens the requested file from the exposed data directory.
+         * <p>
+         * The matched prefix path used shouldn't be a prefix of a real web path. Thus, if the
+         * requested file cannot be found or is outside the mounted directory a
+         * {@link WebResourceResponse} object with a {@code null} {@link InputStream} will be
+         * returned instead of {@code null}. This saves the time of falling back to network and
+         * trying to resolve a path that doesn't exist. A {@link WebResourceResponse} with
+         * {@code null} {@link InputStream} will be received as an HTTP response with status code
+         * {@code 404} and no body.
+         * <p class="note">
+         * The MIME type for the file will be determined from the file's extension using
+         * {@link java.net.URLConnection#guessContentTypeFromName}. Developers should ensure that
+         * files are named using standard file extensions. If the file does not have a
+         * recognised extension, {@code "text/plain"} will be used by default.
+         *
+         * @param path the suffix path to be handled.
+         * @return {@link WebResourceResponse} for the requested file.
+         */
+        @Override
+        public WebResourceResponse handle(String path) {
+            return null;
+        }
+    }
+
+    /**
+     * A builder class for constructing {@link WebViewAssetLoader} objects.
+     */
+    public static final class Builder {
+        /**
+         * Set the domain under which app assets can be accessed.
+         * The default domain is {@code "appassets.androidplatform.net"}
+         *
+         * @param domain the domain on which app assets should be hosted.
+         * @return {@link Builder} object.
+         */
+        public Builder setDomain(String domain) {
+            return null;
+        }
+
+        /**
+         * Allow using the HTTP scheme in addition to HTTPS.
+         * The default is to not allow HTTP.
+         *
+         * @return {@link Builder} object.
+         */
+        public Builder setHttpAllowed(boolean httpAllowed) {
+            return null;
+        }
+
+        /**
+         * Register a {@link PathHandler} for a specific path.
+         * <p>
+         * The path should start and end with a {@code "/"} and it shouldn't collide with a real web
+         * path.
+         *
+         * <p>{@code WebViewAssetLoader} will try {@code PathHandlers} in the order they're
+         * registered, and will use whichever is the first to return a non-{@code null} {@link
+         * WebResourceResponse}.
+         *
+         * @param path the prefix path where this handler should be register.
+         * @param handler {@link PathHandler} that handles requests for this path.
+         * @return {@link Builder} object.
+         * @throws IllegalArgumentException if the path is invalid.
+         */
+        public Builder addPathHandler(String path, PathHandler handler) {
+            return null;
+        }
+
+        /**
+         * Build and return a {@link WebViewAssetLoader} object.
+         *
+         * @return immutable {@link WebViewAssetLoader} object.
+         */
+        public WebViewAssetLoader build() {
+            return null;
+        }
+    }
+
+    /**
+     * Attempt to resolve the {@code url} to an application resource or asset, and return
+     * a {@link WebResourceResponse} for the content.
+     * <p>
+     * This method should be invoked from within
+     * {@link android.webkit.WebViewClient#shouldInterceptRequest(android.webkit.WebView, String)}.
+     *
+     * @param url the URL to process.
+     * @return {@link WebResourceResponse} if the request URL matches a registered URL,
+     *         {@code null} otherwise.
+     */
+    public WebResourceResponse shouldInterceptRequest(Uri url) {
+        return null;
+    }
+}


### PR DESCRIPTION
Android provides a <code>WebResourceResponse</code> API, which is a <code>WebView</code> class that allows an Android application to behave as a web server by handling requests of popular protocols such as <code>http(s)</code>, <code>file</code>, as well as <code>javascript</code>; and returning a response (including status code, content type, content encoding, headers and the response body). Improper implementation with insufficient input validation can lead to leaking of sensitive configuration file or user data because requests could refer to paths intended to be application-private.

It's a common vulnerability with Android applications that an implementation doesn't handle path validation correctly therefore sensitive app data can be leaked. The query detects insecure implementation and provides recommendation on the correct implementation.

Please consider to merge the PR. Thanks. 