### PR TITLE
Ruby: Add `OrmWriteAccess` concept to model writes to a DB using an ORM

### DIFF
--- a/ruby/ql/lib/change-notes/2022-02-28-orm-write-access.md
+++ b/ruby/ql/lib/change-notes/2022-02-28-orm-write-access.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added `OrmWriteAccess` concept to model data written to a database using an object-relational mapping (ORM) library.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -626,6 +626,37 @@ module OrmInstantiation {
 }
 
 /**
+ * A data-flow node that may represent a write to the database in an ORM system.
+ *
+ * Extend this class to refine existing API models. If you want to model new APIs,
+ * extend `OrmWriteAccess::Range` instead.
+ */
+class OrmWriteAccess extends DataFlow::Node instanceof OrmWriteAccess::Range {
+  /**
+   * Gets the name of a field that is assigned to `value` by this write.
+   */
+  string getFieldNameAssignedTo(DataFlow::Node value) {
+    result = super.getFieldNameAssignedTo(value)
+  }
+}
+
+/** Provides a class for modeling new ORM write access APIs. */
+module OrmWriteAccess {
+  /**
+   * A data-flow node that may represent a write to the database in an ORM system.
+   *
+   * Extend this class to model new APIs. If you want to refine existing API models,
+   * extend `OrmWriteAccess` instead.
+   */
+  abstract class Range extends DataFlow::Node {
+    /**
+     * Gets the name of a field that is assigned to `value` by this write.
+     */
+    abstract string getFieldNameAssignedTo(DataFlow::Node value);
+  }
+}
+
+/**
  * A data-flow node that may set or unset Cross-site request forgery protection.
  *
  * Extend this class to refine existing API models. If you want to model new APIs,

--- a/ruby/ql/test/library-tests/frameworks/ActionController.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActionController.expected
@@ -7,6 +7,7 @@ actionControllerControllerClasses
 | app/controllers/photos_controller.rb:1:1:4:3 | PhotosController |
 | app/controllers/posts_controller.rb:1:1:10:3 | PostsController |
 | app/controllers/users/notifications_controller.rb:2:3:5:5 | NotificationsController |
+| app/controllers/users/users_controller.rb:2:3:33:5 | UsersController |
 actionControllerActionMethods
 | ActiveRecordInjection.rb:32:3:57:5 | some_request_handler |
 | ActiveRecordInjection.rb:61:3:69:5 | some_other_request_handler |
@@ -22,6 +23,8 @@ actionControllerActionMethods
 | app/controllers/posts_controller.rb:5:3:6:5 | show |
 | app/controllers/posts_controller.rb:8:3:9:5 | upvote |
 | app/controllers/users/notifications_controller.rb:3:5:4:7 | mark_as_read |
+| app/controllers/users/users_controller.rb:3:5:28:7 | create_or_modify |
+| app/controllers/users/users_controller.rb:30:5:32:7 | get_uid |
 paramsCalls
 | ActiveRecordInjection.rb:35:30:35:35 | call to params |
 | ActiveRecordInjection.rb:39:29:39:34 | call to params |

--- a/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
@@ -2,6 +2,8 @@ activeRecordModelClasses
 | ActiveRecordInjection.rb:1:1:3:3 | UserGroup |
 | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:19:1:25:3 | Admin |
+| app/models/application_record.rb:1:1:3:3 | ApplicationRecord |
+| app/models/user.rb:1:1:2:3 | User |
 activeRecordSqlExecutionRanges
 | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" |
 | ActiveRecordInjection.rb:23:16:23:24 | condition |
@@ -33,6 +35,18 @@ activeRecordModelClassMethodCalls
 | ActiveRecordInjection.rb:85:5:85:33 | call to find_by |
 | ActiveRecordInjection.rb:88:5:88:34 | call to find |
 | ActiveRecordInjection.rb:94:5:94:45 | call to delete_by |
+| app/controllers/users/users_controller.rb:5:7:5:44 | call to create! |
+| app/controllers/users/users_controller.rb:6:7:6:29 | call to create |
+| app/controllers/users/users_controller.rb:7:7:7:31 | call to insert |
+| app/controllers/users/users_controller.rb:10:7:10:32 | call to update |
+| app/controllers/users/users_controller.rb:11:7:11:73 | call to update! |
+| app/controllers/users/users_controller.rb:14:7:14:66 | call to insert_all |
+| app/controllers/users/users_controller.rb:16:14:16:25 | call to find |
+| app/controllers/users/users_controller.rb:31:7:31:15 | call to last |
+| app/controllers/users/users_controller.rb:31:7:31:18 | call to id |
+| app/controllers/users/users_controller.rb:31:7:31:22 | ... + ... |
+| app/models/application_record.rb:2:3:2:21 | call to abstract_class |
+| app/models/application_record.rb:2:3:2:21 | call to abstract_class= |
 potentiallyUnsafeSqlExecutingMethodCall
 | ActiveRecordInjection.rb:10:5:10:68 | call to find |
 | ActiveRecordInjection.rb:23:5:23:25 | call to destroy_by |
@@ -49,5 +63,12 @@ activeRecordModelInstantiations
 | ActiveRecordInjection.rb:15:5:15:40 | call to find_by | ActiveRecordInjection.rb:1:1:3:3 | UserGroup |
 | ActiveRecordInjection.rb:23:5:23:25 | self | ActiveRecordInjection.rb:19:1:25:3 | Admin |
 | ActiveRecordInjection.rb:80:7:80:40 | call to find_by | ActiveRecordInjection.rb:5:1:17:3 | User |
+| ActiveRecordInjection.rb:80:7:80:40 | call to find_by | app/models/user.rb:1:1:2:3 | User |
 | ActiveRecordInjection.rb:85:5:85:33 | call to find_by | ActiveRecordInjection.rb:5:1:17:3 | User |
+| ActiveRecordInjection.rb:85:5:85:33 | call to find_by | app/models/user.rb:1:1:2:3 | User |
 | ActiveRecordInjection.rb:88:5:88:34 | call to find | ActiveRecordInjection.rb:5:1:17:3 | User |
+| ActiveRecordInjection.rb:88:5:88:34 | call to find | app/models/user.rb:1:1:2:3 | User |
+| app/controllers/users/users_controller.rb:16:14:16:25 | call to find | ActiveRecordInjection.rb:5:1:17:3 | User |
+| app/controllers/users/users_controller.rb:16:14:16:25 | call to find | app/models/user.rb:1:1:2:3 | User |
+| app/controllers/users/users_controller.rb:31:7:31:15 | call to last | ActiveRecordInjection.rb:5:1:17:3 | User |
+| app/controllers/users/users_controller.rb:31:7:31:15 | call to last | app/models/user.rb:1:1:2:3 | User |

--- a/ruby/ql/test/library-tests/frameworks/Orm.expected
+++ b/ruby/ql/test/library-tests/frameworks/Orm.expected
@@ -1,0 +1,16 @@
+| app/controllers/users/users_controller.rb:5:7:5:44 | call to create! | name | app/controllers/users/users_controller.rb:5:26:5:29 | "U1" |
+| app/controllers/users/users_controller.rb:5:7:5:44 | call to create! | uid | app/controllers/users/users_controller.rb:5:37:5:43 | call to get_uid |
+| app/controllers/users/users_controller.rb:6:7:6:29 | call to create | name | app/controllers/users/users_controller.rb:6:25:6:28 | "U2" |
+| app/controllers/users/users_controller.rb:7:7:7:31 | call to insert | name | app/controllers/users/users_controller.rb:7:26:7:29 | "U3" |
+| app/controllers/users/users_controller.rb:10:7:10:32 | call to update | name | app/controllers/users/users_controller.rb:10:28:10:31 | "U4" |
+| app/controllers/users/users_controller.rb:11:7:11:73 | call to update! | name | app/controllers/users/users_controller.rb:11:39:11:42 | "U5" |
+| app/controllers/users/users_controller.rb:11:7:11:73 | call to update! | name | app/controllers/users/users_controller.rb:11:53:11:56 | "U6" |
+| app/controllers/users/users_controller.rb:11:7:11:73 | call to update! | name | app/controllers/users/users_controller.rb:11:67:11:70 | "U7" |
+| app/controllers/users/users_controller.rb:14:7:14:66 | call to insert_all | name | app/controllers/users/users_controller.rb:14:31:14:34 | "U8" |
+| app/controllers/users/users_controller.rb:14:7:14:66 | call to insert_all | name | app/controllers/users/users_controller.rb:14:45:14:48 | "U9" |
+| app/controllers/users/users_controller.rb:14:7:14:66 | call to insert_all | name | app/controllers/users/users_controller.rb:14:59:14:63 | "U10" |
+| app/controllers/users/users_controller.rb:19:7:19:30 | call to update | name | app/controllers/users/users_controller.rb:19:25:19:29 | "U11" |
+| app/controllers/users/users_controller.rb:20:7:20:57 | call to update_attributes | name | app/controllers/users/users_controller.rb:20:37:20:41 | "U12" |
+| app/controllers/users/users_controller.rb:20:7:20:57 | call to update_attributes | uid | app/controllers/users/users_controller.rb:20:49:20:55 | call to get_uid |
+| app/controllers/users/users_controller.rb:23:7:23:42 | call to update_attribute | name | app/controllers/users/users_controller.rb:23:37:23:41 | "U13" |
+| app/controllers/users/users_controller.rb:26:7:26:15 | call to name= | name | app/controllers/users/users_controller.rb:26:19:26:23 | "U14" |

--- a/ruby/ql/test/library-tests/frameworks/Orm.ql
+++ b/ruby/ql/test/library-tests/frameworks/Orm.ql
@@ -1,0 +1,6 @@
+import codeql.ruby.DataFlow
+import codeql.ruby.Concepts
+
+query predicate ormFieldWrites(OrmWriteAccess acc, string fieldName, DataFlow::Node value) {
+  fieldName = acc.getFieldNameAssignedTo(value)
+}

--- a/ruby/ql/test/library-tests/frameworks/app/controllers/users/users_controller.rb
+++ b/ruby/ql/test/library-tests/frameworks/app/controllers/users/users_controller.rb
@@ -1,0 +1,34 @@
+module Users
+  class UsersController < ApplicationController
+    def create_or_modify
+      # CreateLikeCall
+      User.create!(name: "U1", uid: get_uid)
+      User.create(name: "U2")
+      User.insert({name: "U3"})
+
+      # UpdateLikeClassMethodCall
+      User.update(4, name: "U4")
+      User.update!([5, 6, 7], [{name: "U5"}, {name: "U6"}, {name: "U7"}])
+
+      # InsertAllLikeCall
+      User.insert_all([{name: "U8"}, {name: "U9"}, {name: "U10"}])
+
+      user = User.find(5)
+
+      # UpdateLikeInstanceMethodCall
+      user.update(name: "U11")
+      user.update_attributes({name: "U12", uid: get_uid})
+
+      # UpdateAttributeCall
+      user.update_attribute("name", "U13")
+
+      # AssignAttributeCall
+      user.name = "U14"
+      user.save
+    end
+
+    def get_uid
+      User.last.id + 1
+    end
+  end
+end

--- a/ruby/ql/test/library-tests/frameworks/app/models/application_record.rb
+++ b/ruby/ql/test/library-tests/frameworks/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/ruby/ql/test/library-tests/frameworks/app/models/user.rb
+++ b/ruby/ql/test/library-tests/frameworks/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end


### PR DESCRIPTION
This in particular applies to `ActiveRecord::Persistence` methods - in particular those that include a field name and value as part of the method call. This notably doesn't include `save` or `destroy` and similar methods.

The immediate intention for this change is to support a plaintext storage query including database sinks.

The main limitation of the modelling here is that it assumes that these methods are called with literal arguments - e.g. `new_name = "foo"; user.update({name: new_name})` would be picked up since the argument is a hash literal, but `new_attrs = {name: "foo"}; user.update(new_attrs)` would not as the argument is a variable read.

On a separate note, assignments such as `user.name = "foo"`, where `user` is an `ActiveRecord` model object, are included as DB writes here. This is not strictly true, as the write only occurs if the object is subsequently persisted (e.g. with a `save` call). It seemed worth pretending that these were in fact writes to avoid cases where the flow from the assignment to the actual write may be too complex for us to track, in which case we would miss potential writes. The tradeoff of FPs where there is an assignment without a subsequent write seems worthwhile to me since this seems like it would be an uncommon thing to do, but I may not have considered all use cases.

See https://apidock.com/rails/v6.1.3.1/ActiveRecord/Persistence/ and https://apidock.com/rails/v6.1.3.1/ActiveRecord/Persistence/ClassMethods/ for reference.