### PR TITLE
Python: Fix syntax error in `with` test output

### DIFF
--- a/python/ql/test/3/library-tests/with/test.expected
+++ b/python/ql/test/3/library-tests/with/test.expected
@@ -11,6 +11,4 @@
 | test.py:4:5:4:17 | CtxManager3() |
 | test.py:4:5:4:29 | With |
 | test.py:4:22:4:29 | example3 |
-| test.py:4:31:4:30 |  |
-| test.py:4:31:4:30 | With |
 | test.py:6:5:6:8 | Pass |


### PR DESCRIPTION
Depends on an internal PR. The two lines in question were caused by
the insertion of an extra node due to the failure to parse a trailing
comma corrcetly.