### PR TITLE
Ruby: parse more string literals as regular expressions

### DIFF
--- a/.github/workflows/ruby-qltest.yml
+++ b/.github/workflows/ruby-qltest.yml
@@ -63,6 +63,7 @@ jobs:
   qltest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         slice: ["1/2", "2/2"]
     steps:

--- a/ruby/ql/lib/change-notes/2022-02-28-regex-string-literals.md
+++ b/ruby/ql/lib/change-notes/2022-02-28-regex-string-literals.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `Regex` class now an abstract class that extends `StringlikeLiteral` with implementations for `RegExpLiteral` and string literals that 'flow' into functions that are known to interpret string arguments as regular expressions such `Regex.new` and `String.match`.

--- a/ruby/ql/lib/change-notes/2022-02-28-regex-string-literals.md
+++ b/ruby/ql/lib/change-notes/2022-02-28-regex-string-literals.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `Regex` class now an abstract class that extends `StringlikeLiteral` with implementations for `RegExpLiteral` and string literals that 'flow' into functions that are known to interpret string arguments as regular expressions such `Regex.new` and `String.match`.
+* The `Regex` class is now an abstract class that extends `StringlikeLiteral` with implementations for `RegExpLiteral` and string literals that 'flow' into functions that are known to interpret string arguments as regular expressions such as `Regex.new` and `String.match`.

--- a/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
@@ -14,7 +14,7 @@ private import codeql.ruby.ApiGraphs
 
 /**
  * A `StringlikeLiteral` containing a regular expression term, that is, either
- * a regular expression literal, a string literal used in a context where
+ * a regular expression literal, or a string literal used in a context where
  * it is parsed as regular expression.
  */
 abstract class RegExp extends AST::StringlikeLiteral {

--- a/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
@@ -7,8 +7,32 @@
 
 private import codeql.ruby.ast.Literal as AST
 private import codeql.Locations
+private import codeql.ruby.DataFlow
+private import codeql.ruby.TaintTracking
+private import codeql.ruby.typetracking.TypeTracker
+private import codeql.ruby.ApiGraphs
 
-class RegExp extends AST::RegExpLiteral {
+/**
+ * A `StringlikeLiteral` containing a regular expression term, that is, either
+ * a regular expression literal, a string literal used in a context where
+ * it is parsed as regular expression.
+ */
+abstract class RegExp extends AST::StringlikeLiteral {
+  /**
+   * Holds if this `RegExp` has the `s` flag for multi-line matching.
+   */
+  predicate isDotAll() { none() }
+
+  /**
+   * Holds if this `RegExp` has the `i` flag for case-insensitive matching.
+   */
+  predicate isIgnoreCase() { none() }
+
+  /**
+   * Gets the flags for this `RegExp`, or the empty string if it has no flags.
+   */
+  string getFlags() { result = "" }
+
   /**
    * Helper predicate for `charSetStart(int start, int end)`.
    *
@@ -933,3 +957,63 @@ class RegExp extends AST::RegExpLiteral {
     this.lastPart(start, end)
   }
 }
+
+private class RegExpLiteralRegExp extends RegExp, AST::RegExpLiteral {
+  override predicate isDotAll() { this.hasMultilineFlag() }
+
+  override predicate isIgnoreCase() { this.hasCaseInsensitiveFlag() }
+
+  override string getFlags() { result = this.getFlagString() }
+}
+
+private class ParsedStringRegExp extends RegExp {
+  private DataFlow::Node parse;
+
+  ParsedStringRegExp() { this = regExpSource(parse).asExpr().getExpr() }
+
+  DataFlow::Node getAParse() { result = parse }
+
+  override predicate isDotAll() { none() }
+
+  override predicate isIgnoreCase() { none() }
+
+  override string getFlags() { none() }
+}
+
+/**
+ * Holds if `source` may be interpreted as a regular expression.
+ */
+cached
+private predicate isInterpretedAsRegExp(DataFlow::Node source) {
+  // The first argument to an invocation of `Regexp.new` or `Regexp.compile`.
+  source = API::getTopLevelMember("Regexp").getAMethodCall(["compile", "new"]).getArgument(0)
+  or
+  // The argument of a call that coerces the argument to a regular expression.
+  exists(DataFlow::CallNode mce |
+    mce.getMethodName() = ["match", "match?"] and
+    source = mce.getArgument(0)
+  )
+}
+
+/**
+ * Gets a node whose value may flow (inter-procedurally) to `re`, where it is interpreted
+ * as a part of a regular expression.
+ */
+private DataFlow::Node regExpSource(DataFlow::Node re, TypeBackTracker t) {
+  t.start() and
+  re = result and
+  isInterpretedAsRegExp(result)
+  or
+  exists(TypeBackTracker t2, DataFlow::Node succ | succ = regExpSource(re, t2) |
+    t2 = t.smallstep(result, succ)
+    or
+    TaintTracking::localTaintStep(result, succ) and
+    t = t2
+  )
+}
+
+/**
+ * Gets a node whose value may flow (inter-procedurally) to `re`, where it is interpreted
+ * as a part of a regular expression.
+ */
+DataFlow::Node regExpSource(DataFlow::Node re) { result = regExpSource(re, TypeBackTracker::end()) }

--- a/ruby/ql/lib/codeql/ruby/security/performance/RegExpTreeView.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/RegExpTreeView.qll
@@ -1,7 +1,6 @@
 private import codeql.ruby.ast.Literal as AST
 private import codeql.Locations
 private import ParseRegExp
-import codeql.Locations
 
 /**
  * Holds if `term` is an ecape class representing e.g. `\d`.
@@ -27,7 +26,7 @@ predicate isEscapeClass(RegExpTerm term, string clazz) {
  * Holds if the regular expression should not be considered.
  */
 predicate isExcluded(RegExpParent parent) {
-  parent.(RegExpTerm).getRegExp().hasFreeSpacingFlag() // exclude free-spacing mode regexes
+  parent.(RegExpTerm).getRegExp().(AST::RegExpLiteral).hasFreeSpacingFlag() // exclude free-spacing mode regexes
 }
 
 /**
@@ -93,11 +92,11 @@ class RegExpLiteral extends TRegExpLiteral, RegExpParent {
 
   override RegExpTerm getChild(int i) { i = 0 and result.getRegExp() = re and result.isRootTerm() }
 
-  predicate isDotAll() { re.hasMultilineFlag() }
+  predicate isDotAll() { re.isDotAll() }
 
-  predicate isIgnoreCase() { re.hasCaseInsensitiveFlag() }
+  predicate isIgnoreCase() { re.isIgnoreCase() }
 
-  string getFlags() { result = re.getFlagString() }
+  string getFlags() { result = re.getFlags() }
 
   override string getAPrimaryQlClass() { result = "RegExpLiteral" }
 }

--- a/ruby/ql/test/query-tests/security/cwe-1333-exponential-redos/ReDoS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-exponential-redos/ReDoS.expected
@@ -20,6 +20,7 @@
 | tst.rb:74:10:74:17 | (b\|a?b)* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'b'. |
 | tst.rb:77:10:77:17 | (a\|aa?)* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | tst.rb:83:10:83:16 | (.\|\\n)* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of '\\n'. |
+| tst.rb:89:21:89:28 | (a\|aa?)* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | tst.rb:95:11:95:24 | ([\\S\\s]\|[^a])* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of '`'. |
 | tst.rb:101:11:101:19 | (.\|[^a])* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of '`'. |
 | tst.rb:107:11:107:19 | (b\|[^a])* | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'b'. |

--- a/ruby/ql/test/query-tests/security/cwe-1333-exponential-redos/tst.rb
+++ b/ruby/ql/test/query-tests/security/cwe-1333-exponential-redos/tst.rb
@@ -85,7 +85,7 @@ bad16 = /(.|\n)*!/m
 # GOOD
 good8 = /([\w.]+)*/
 
-# BAD - we don't yet parse regexps constructed from strings
+# NOT GOOD
 bad17 = Regexp.new '(a|aa?)*b'
 
 # GOOD - not used as regexp


### PR DESCRIPTION
This pull request changes the `Regex` class to be `abstract` and extend `StringlikeLiteral`. This allows adding custom subclasses to parse more string literals as regular expressions if needed. The default subclasses are `RegExpLiteral` and string literals that somehow flow into functions like `Regex.new`, `Regex.compile`, `String.match` and `String.match?`. 