### PR TITLE
Fix MaD workflows to be more resilient to missing files

### DIFF
--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -56,15 +56,15 @@ jobs:
         echo "Running generator on merge"
         PATH="$PATH:codeql-cli/codeql" python merge/misc/scripts/library-coverage/generate-report.py ci merge merge
         mkdir out_merge
-        cp framework-coverage-*.csv out_merge/
-        cp framework-coverage-*.rst out_merge/
+        mv framework-coverage-*.csv out_merge/
+        mv framework-coverage-*.rst out_merge/
     - name: Generate CSV files on base commit of the PR
       run: |
         echo "Running generator on base"
         PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci base base
         mkdir out_base
-        cp framework-coverage-*.csv out_base/
-        cp framework-coverage-*.rst out_base/
+        mv framework-coverage-*.csv out_base/
+        mv framework-coverage-*.rst out_base/
     - name: Generate diff of coverage reports
       run: |
         python base/misc/scripts/library-coverage/compare-folders.py out_base out_merge comparison.md

--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Generate CSV files on merge commit of the PR
       run: |
         echo "Running generator on merge"
-        PATH="$PATH:codeql-cli/codeql" python merge/misc/scripts/library-coverage/generate-report.py ci merge merge
+        PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci merge merge
         mkdir out_merge
         mv framework-coverage-*.csv out_merge/
         mv framework-coverage-*.rst out_merge/

--- a/misc/scripts/library-coverage/compare.py
+++ b/misc/scripts/library-coverage/compare.py
@@ -37,17 +37,26 @@ def compare_folders(folder1, folder2, output_file):
         # check if files exist in both folder1 and folder 2
         if not utils.check_file_exists(f"{folder1}/{generated_output_rst}"):
             expected_files += f"- {generated_output_rst} doesn't exist in folder {folder1}\n"
+            utils.subprocess_check_output(
+                ["touch", f"{folder1}/{generated_output_rst}"])
         if not utils.check_file_exists(f"{folder2}/{generated_output_rst}"):
             expected_files += f"- {generated_output_rst} doesn't exist in folder {folder2}\n"
+            utils.subprocess_check_output(
+                ["touch", f"{folder2}/{generated_output_rst}"])
         if not utils.check_file_exists(f"{folder1}/{generated_output_csv}"):
             expected_files += f"- {generated_output_csv} doesn't exist in folder {folder1}\n"
+            utils.subprocess_check_output(
+                ["touch", f"{folder1}/{generated_output_csv}"])
         if not utils.check_file_exists(f"{folder2}/{generated_output_csv}"):
             expected_files += f"- {generated_output_csv} doesn't exist in folder {folder2}\n"
+            utils.subprocess_check_output(
+                ["touch", f"{folder2}/{generated_output_csv}"])
+
+        return_md += f"\n### {lang}\n\n"
 
         if expected_files != "":
             print("Expected files are missing", file=sys.stderr)
-            return_md += f"\n### {lang}\n\n#### Expected files are missing for {lang}\n{expected_files}\n"
-            continue
+            return_md += f"#### Expected files are missing for {lang}\n{expected_files}\n\n"
 
         # compare contents of files
         cmp1 = compare_files(
@@ -57,7 +66,7 @@ def compare_folders(folder1, folder2, output_file):
 
         if cmp1 != "" or cmp2 != "":
             print("Generated file contents are not matching", file=sys.stderr)
-            return_md += f"\n### {lang}\n\n#### Generated file changes for {lang}\n\n"
+            return_md += f"#### Generated file changes for {lang}\n\n"
             if cmp1 != "":
                 return_md += f"- Changes to {generated_output_rst}:\n```diff\n{cmp1}```\n\n"
             if cmp2 != "":


### PR DESCRIPTION
I'm experimenting with adding JS to the MaD coverage reports: https://github.com/github/codeql/pull/8290. I found that the current scripts are not handling gracefully if no coverage is generated for a language in either the `merge` or `base` comparison cases.

This PR is fixing the following issues:
- Generated files are not copied, but moved, so that they are not left in place for the second (`base`) coverage generation.
- Missing report files are reported, but then are considered as empty files for diff generation.
- Uses python scripts from the `base` SHA.