### PR TITLE
JS: Fix ATM timeout on NodeJS

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -120,13 +120,17 @@ predicate isBaseAdditionalFlowStep(
 }
 
 /**
+ * Gets a value that is (transitively) written to `query`, where `query` is a NoSQL sink.
+ *
  * This predicate allows us to propagate data flow through property writes and array constructors
  * within a query object, enabling the security query to pick up NoSQL injection vulnerabilities
  * involving more complex queries.
  */
 DataFlow::Node getASubexpressionWithinQuery(DataFlow::Node query) {
+  any(NosqlInjectionATMConfig cfg).isEffectiveSink(query) and
   exists(DataFlow::SourceNode receiver |
-    receiver.flowsTo(getASubexpressionWithinQuery*(query.getALocalSource())) and
+    receiver = [getASubexpressionWithinQuery(query), query].getALocalSource()
+  |
     result =
       [receiver.getAPropertyWrite().getRhs(), receiver.(DataFlow::ArrayCreationNode).getAnElement()]
   )

--- a/javascript/ql/lib/semmle/javascript/frameworks/Testing.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Testing.qll
@@ -39,12 +39,14 @@ class BDDTest extends Test, @call_expr {
 }
 
 /**
- * Gets the test file for `f` with stem extension `stemExt`.
+ * Gets the test file for `f` with stem extension `stemExt`, where `stemExt` is "test" or "spec".
  * That is, a file named file named `<base>.<stemExt>.<ext>` in the
  * same directory as `f` which is named `<base>.<ext>`.
  */
-bindingset[stemExt]
+pragma[noinline]
 File getTestFile(File f, string stemExt) {
+  stemExt = ["test", "spec"] and
+  result.getBaseName().regexpMatch(".*\\.(test|spec)\\..*") and
   result = f.getParentContainer().getFile(f.getStem() + "." + stemExt + "." + f.getExtension())
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Testing.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Testing.qll
@@ -40,7 +40,7 @@ class BDDTest extends Test, @call_expr {
 
 /**
  * Gets the test file for `f` with stem extension `stemExt`, where `stemExt` is "test" or "spec".
- * That is, a file named file named `<base>.<stemExt>.<ext>` in the
+ * That is, a file named `<base>.<stemExt>.<ext>` in the
  * same directory as `f` which is named `<base>.<ext>`.
  */
 pragma[noinline]


### PR DESCRIPTION
[Evaluation](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/atmPerf__nightly__atm/reports).   

There is no baseline in the evaluation as the baseline was a timeout.    
The `nodejs/node` benchmark now finished in ~10 minutes instead of timing out. 

[Evaluation with a baseline](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-8297-dfc74d7__nightly__atm/reports).  

--- 

The change in `getTestFile` prevents an InverseAppend on all file names by limiting the set of feasible files early.  
This saves ~40s pr. query on `nodejs/node`.  

--- 

There were many problems with the `getASubexpressionWithinQuery` predicate.  
- It was a recursive predicate, but each step of the recursion computed the transitive closure of the recursion.  
  So it searched the entire tree in every step of the recursion, instead of just considering the previous layer.  
  The fix is to more explicitly represent the base-case and the recursive-case, and make sure that the recursive step only considers the previous layer instead of the transitive closure. 
- The base case of the recursion was extremely broad. 
  In the base case there was effectively no limit on the values that `query` could have, which meant that the predicate computed the cartesian product between nodes that a `SourceNode` flows to and all writes to that `SourceNode`.  
  Magic sets can in some cases fix this, but the recursive nature of the predicate prevents magic sets from fixing this performance problem.  
  The fix is to limit the values of `query` by adding some context: `any(NosqlInjectionATMConfig cfg).isEffectiveSink(query)`.  
- The predicate effectively used `getALocalSource` multiple times, but only a single use was needed.   
  Replacing `query.getALocalSource()` with just `query` in the recursive call allows a much simpler recursion where the value of `query` doesn't change. (And that allows for the fix in the previous bullet-point).   
  `SourceNode::flowTo` is the dual of `Node::getALocalSource`, and having both of those close to each other is very suspicious.   
  The fixed predicate only has a single call to `getALocalSource`.  
- The QLDoc didn't explain what was computed by the predicate, which made the initial investigation tricky.   
  The QLDoc for a predicate with a result should start with `Gets `.   