### PR TITLE
C++: Fix `GVN` performance on more invalid IR

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -106,6 +106,12 @@ private predicate filteredNumberableInstruction(Instruction instr) {
   or
   instr instanceof FieldAddressInstruction and
   count(instr.(FieldAddressInstruction).getField()) != 1
+  or
+  instr instanceof InheritanceConversionInstruction and
+  (
+    count(instr.(InheritanceConversionInstruction).getBaseClass()) != 1 or
+    count(instr.(InheritanceConversionInstruction).getDerivedClass()) != 1
+  )
 }
 
 private predicate variableAddressValueNumber(
@@ -115,8 +121,7 @@ private predicate variableAddressValueNumber(
   // The underlying AST element is used as value-numbering key instead of the
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
-  instr.getIRVariable().getAST() = ast and
-  strictcount(instr.getIRVariable().getAST()) = 1
+  unique( | | instr.getIRVariable().getAST()) = ast
 }
 
 private predicate initializeParameterValueNumber(
@@ -133,8 +138,7 @@ private predicate constantValueNumber(
   ConstantInstruction instr, IRFunction irFunc, IRType type, string value
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  strictcount(instr.getResultIRType()) = 1 and
-  instr.getResultIRType() = type and
+  unique( | | instr.getResultIRType()) = type and
   instr.getValue() = value
 }
 
@@ -152,7 +156,7 @@ private predicate fieldAddressValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getField() = field and
-  strictcount(instr.getField()) = 1 and
+  unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }
 
@@ -195,9 +199,9 @@ private predicate inheritanceConversionValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
-  instr.getBaseClass() = baseClass and
-  instr.getDerivedClass() = derivedClass and
-  tvalueNumber(instr.getUnary()) = operand
+  tvalueNumber(instr.getUnary()) = operand and
+  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
+  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -155,7 +155,6 @@ private predicate fieldAddressValueNumber(
   TValueNumber objectAddress
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getField() = field and
   unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -200,8 +200,8 @@ private predicate inheritanceConversionValueNumber(
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
   tvalueNumber(instr.getUnary()) = operand and
-  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
-  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
+  unique( | | instr.getBaseClass()) = baseClass and
+  unique( | | instr.getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -106,6 +106,12 @@ private predicate filteredNumberableInstruction(Instruction instr) {
   or
   instr instanceof FieldAddressInstruction and
   count(instr.(FieldAddressInstruction).getField()) != 1
+  or
+  instr instanceof InheritanceConversionInstruction and
+  (
+    count(instr.(InheritanceConversionInstruction).getBaseClass()) != 1 or
+    count(instr.(InheritanceConversionInstruction).getDerivedClass()) != 1
+  )
 }
 
 private predicate variableAddressValueNumber(
@@ -115,8 +121,7 @@ private predicate variableAddressValueNumber(
   // The underlying AST element is used as value-numbering key instead of the
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
-  instr.getIRVariable().getAST() = ast and
-  strictcount(instr.getIRVariable().getAST()) = 1
+  unique( | | instr.getIRVariable().getAST()) = ast
 }
 
 private predicate initializeParameterValueNumber(
@@ -133,8 +138,7 @@ private predicate constantValueNumber(
   ConstantInstruction instr, IRFunction irFunc, IRType type, string value
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  strictcount(instr.getResultIRType()) = 1 and
-  instr.getResultIRType() = type and
+  unique( | | instr.getResultIRType()) = type and
   instr.getValue() = value
 }
 
@@ -152,7 +156,7 @@ private predicate fieldAddressValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getField() = field and
-  strictcount(instr.getField()) = 1 and
+  unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }
 
@@ -195,9 +199,9 @@ private predicate inheritanceConversionValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
-  instr.getBaseClass() = baseClass and
-  instr.getDerivedClass() = derivedClass and
-  tvalueNumber(instr.getUnary()) = operand
+  tvalueNumber(instr.getUnary()) = operand and
+  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
+  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -155,7 +155,6 @@ private predicate fieldAddressValueNumber(
   TValueNumber objectAddress
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getField() = field and
   unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -200,8 +200,8 @@ private predicate inheritanceConversionValueNumber(
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
   tvalueNumber(instr.getUnary()) = operand and
-  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
-  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
+  unique( | | instr.getBaseClass()) = baseClass and
+  unique( | | instr.getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -106,6 +106,12 @@ private predicate filteredNumberableInstruction(Instruction instr) {
   or
   instr instanceof FieldAddressInstruction and
   count(instr.(FieldAddressInstruction).getField()) != 1
+  or
+  instr instanceof InheritanceConversionInstruction and
+  (
+    count(instr.(InheritanceConversionInstruction).getBaseClass()) != 1 or
+    count(instr.(InheritanceConversionInstruction).getDerivedClass()) != 1
+  )
 }
 
 private predicate variableAddressValueNumber(
@@ -115,8 +121,7 @@ private predicate variableAddressValueNumber(
   // The underlying AST element is used as value-numbering key instead of the
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
-  instr.getIRVariable().getAST() = ast and
-  strictcount(instr.getIRVariable().getAST()) = 1
+  unique( | | instr.getIRVariable().getAST()) = ast
 }
 
 private predicate initializeParameterValueNumber(
@@ -133,8 +138,7 @@ private predicate constantValueNumber(
   ConstantInstruction instr, IRFunction irFunc, IRType type, string value
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  strictcount(instr.getResultIRType()) = 1 and
-  instr.getResultIRType() = type and
+  unique( | | instr.getResultIRType()) = type and
   instr.getValue() = value
 }
 
@@ -152,7 +156,7 @@ private predicate fieldAddressValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getField() = field and
-  strictcount(instr.getField()) = 1 and
+  unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }
 
@@ -195,9 +199,9 @@ private predicate inheritanceConversionValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
-  instr.getBaseClass() = baseClass and
-  instr.getDerivedClass() = derivedClass and
-  tvalueNumber(instr.getUnary()) = operand
+  tvalueNumber(instr.getUnary()) = operand and
+  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
+  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -155,7 +155,6 @@ private predicate fieldAddressValueNumber(
   TValueNumber objectAddress
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getField() = field and
   unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -200,8 +200,8 @@ private predicate inheritanceConversionValueNumber(
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
   tvalueNumber(instr.getUnary()) = operand and
-  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
-  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
+  unique( | | instr.getBaseClass()) = baseClass and
+  unique( | | instr.getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -106,6 +106,12 @@ private predicate filteredNumberableInstruction(Instruction instr) {
   or
   instr instanceof FieldAddressInstruction and
   count(instr.(FieldAddressInstruction).getField()) != 1
+  or
+  instr instanceof InheritanceConversionInstruction and
+  (
+    count(instr.(InheritanceConversionInstruction).getBaseClass()) != 1 or
+    count(instr.(InheritanceConversionInstruction).getDerivedClass()) != 1
+  )
 }
 
 private predicate variableAddressValueNumber(
@@ -115,8 +121,7 @@ private predicate variableAddressValueNumber(
   // The underlying AST element is used as value-numbering key instead of the
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
-  instr.getIRVariable().getAST() = ast and
-  strictcount(instr.getIRVariable().getAST()) = 1
+  unique( | | instr.getIRVariable().getAST()) = ast
 }
 
 private predicate initializeParameterValueNumber(
@@ -133,8 +138,7 @@ private predicate constantValueNumber(
   ConstantInstruction instr, IRFunction irFunc, IRType type, string value
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  strictcount(instr.getResultIRType()) = 1 and
-  instr.getResultIRType() = type and
+  unique( | | instr.getResultIRType()) = type and
   instr.getValue() = value
 }
 
@@ -152,7 +156,7 @@ private predicate fieldAddressValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getField() = field and
-  strictcount(instr.getField()) = 1 and
+  unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }
 
@@ -195,9 +199,9 @@ private predicate inheritanceConversionValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
-  instr.getBaseClass() = baseClass and
-  instr.getDerivedClass() = derivedClass and
-  tvalueNumber(instr.getUnary()) = operand
+  tvalueNumber(instr.getUnary()) = operand and
+  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
+  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -155,7 +155,6 @@ private predicate fieldAddressValueNumber(
   TValueNumber objectAddress
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getField() = field and
   unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }

--- a/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -200,8 +200,8 @@ private predicate inheritanceConversionValueNumber(
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
   tvalueNumber(instr.getUnary()) = operand and
-  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
-  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
+  unique( | | instr.getBaseClass()) = baseClass and
+  unique( | | instr.getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -106,6 +106,12 @@ private predicate filteredNumberableInstruction(Instruction instr) {
   or
   instr instanceof FieldAddressInstruction and
   count(instr.(FieldAddressInstruction).getField()) != 1
+  or
+  instr instanceof InheritanceConversionInstruction and
+  (
+    count(instr.(InheritanceConversionInstruction).getBaseClass()) != 1 or
+    count(instr.(InheritanceConversionInstruction).getDerivedClass()) != 1
+  )
 }
 
 private predicate variableAddressValueNumber(
@@ -115,8 +121,7 @@ private predicate variableAddressValueNumber(
   // The underlying AST element is used as value-numbering key instead of the
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
-  instr.getIRVariable().getAST() = ast and
-  strictcount(instr.getIRVariable().getAST()) = 1
+  unique( | | instr.getIRVariable().getAST()) = ast
 }
 
 private predicate initializeParameterValueNumber(
@@ -133,8 +138,7 @@ private predicate constantValueNumber(
   ConstantInstruction instr, IRFunction irFunc, IRType type, string value
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  strictcount(instr.getResultIRType()) = 1 and
-  instr.getResultIRType() = type and
+  unique( | | instr.getResultIRType()) = type and
   instr.getValue() = value
 }
 
@@ -152,7 +156,7 @@ private predicate fieldAddressValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getField() = field and
-  strictcount(instr.getField()) = 1 and
+  unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }
 
@@ -195,9 +199,9 @@ private predicate inheritanceConversionValueNumber(
 ) {
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
-  instr.getBaseClass() = baseClass and
-  instr.getDerivedClass() = derivedClass and
-  tvalueNumber(instr.getUnary()) = operand
+  tvalueNumber(instr.getUnary()) = operand and
+  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
+  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -155,7 +155,6 @@ private predicate fieldAddressValueNumber(
   TValueNumber objectAddress
 ) {
   instr.getEnclosingIRFunction() = irFunc and
-  instr.getField() = field and
   unique( | | instr.getField()) = field and
   tvalueNumber(instr.getObjectAddress()) = objectAddress
 }

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -200,8 +200,8 @@ private predicate inheritanceConversionValueNumber(
   instr.getEnclosingIRFunction() = irFunc and
   instr.getOpcode() = opcode and
   tvalueNumber(instr.getUnary()) = operand and
-  unique( | | instr.(InheritanceConversionInstruction).getBaseClass()) = baseClass and
-  unique( | | instr.(InheritanceConversionInstruction).getDerivedClass()) = derivedClass
+  unique( | | instr.getBaseClass()) = baseClass and
+  unique( | | instr.getDerivedClass()) = derivedClass
 }
 
 private predicate loadTotalOverlapValueNumber(


### PR DESCRIPTION
As we've seen in the past, the performance of GVN degrades exponentially when it's run on invalid IR.

In this case, a project had some `InheritanceConversionInstruction`s with 10 base classes and 10 derived classes, which meant that some instructions had 100 value numbers. To make things worse, this could lead to an instruction getting `100^2` value numbers if one invalid `InheritanceConversionInstruction` depended on another invalid `InheritanceConversionInstruction`.

The fix is to exclude `InheritanceConversionInstruction`s with multiple base or derived classes from the GVN loop. This is also how we handle other cases of invalid IR.

While we're at it, I also decided to replace the uses of `strictcount(...) = 1` with `unique( | | ...)`. This code predates the introduction of `unique`, which is why this wasn't done initially.