### PR TITLE
JS: Refactor the XSS / Client-side-url queries 

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/TaintedUrlSuffix.qll
+++ b/javascript/ql/lib/semmle/javascript/security/TaintedUrlSuffix.qll
@@ -26,6 +26,17 @@ module TaintedUrlSuffix {
    */
   FlowLabel label() { result instanceof TaintedUrlSuffixLabel }
 
+  /**
+   * Gets a remote flow source that is a tainted URL query or fragment part.
+   */
+  ClientSideRemoteFlowSource source() {
+    result.getKind().isFragment()
+    or
+    result.getKind().isQuery()
+    or
+    result.getKind().isUrl()
+  }
+
   /** Holds for `pred -> succ` is a step of form `x -> x.p` */
   private predicate isSafeLocationProp(DataFlow::PropRead read) {
     // Ignore properties that refer to the scheme, domain, port, auth, or path.

--- a/javascript/ql/lib/semmle/javascript/security/TaintedUrlSuffix.qll
+++ b/javascript/ql/lib/semmle/javascript/security/TaintedUrlSuffix.qll
@@ -26,13 +26,11 @@ module TaintedUrlSuffix {
    */
   FlowLabel label() { result instanceof TaintedUrlSuffixLabel }
 
-  /**
-   * Gets a remote flow source that is a tainted URL query or fragment part.
-   */
+  /** Gets a remote flow source that is a tainted URL query or fragment part from `window.location`. */
   ClientSideRemoteFlowSource source() {
-    result.getKind().isFragment()
+    result = DOM::locationRef().getAPropertyRead(["search", "hash"])
     or
-    result.getKind().isQuery()
+    result = DOM::locationSource()
     or
     result.getKind().isUrl()
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -174,7 +174,7 @@ module ClientSideUrlRedirect {
     AttributeUrlSink() {
       // e.g. `$("<a>", {href: sink}).appendTo("body")`
       exists(DOM::AttributeDefinition attr |
-        not attr instanceof JSXAttribute and // handled more precisely in `ReactAttributeWriteUrlSink`.
+        not attr instanceof JsxAttribute and // handled more precisely in `ReactAttributeWriteUrlSink`.
         attr.getName() = DOM::getAPropertyNameInterpretedAsJavaScriptUrl()
       |
         this = attr.getValueNode()

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -8,8 +8,6 @@ import javascript
 import semmle.javascript.security.dataflow.RemoteFlowSources
 
 module ClientSideUrlRedirect {
-  private import Xss::DomBasedXss as DomBasedXss
-
   /**
    * A data flow source for unvalidated URL redirect vulnerabilities.
    */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -21,7 +21,7 @@ module ClientSideUrlRedirect {
    */
   abstract class Sink extends DataFlow::Node {
     /** Holds if the sink can execute JavaScript code in the current context. */
-    predicate isXSSSink() {
+    predicate isXssSink() {
       none() // overwritten in subclasses
     }
   }
@@ -128,7 +128,7 @@ module ClientSideUrlRedirect {
       xss = false
     }
 
-    override predicate isXSSSink() { xss = true }
+    override predicate isXssSink() { xss = true }
   }
 
   /**
@@ -184,7 +184,7 @@ module ClientSideUrlRedirect {
       any(DomMethodCallExpr call).interpretsArgumentsAsURL(this.asExpr())
     }
 
-    override predicate isXSSSink() { any() }
+    override predicate isXssSink() { any() }
   }
 
   /**
@@ -199,7 +199,7 @@ module ClientSideUrlRedirect {
       )
     }
 
-    override predicate isXSSSink() { any() }
+    override predicate isXssSink() { any() }
   }
 
   /**
@@ -217,7 +217,7 @@ module ClientSideUrlRedirect {
       )
     }
 
-    override predicate isXSSSink() { any() }
+    override predicate isXssSink() { any() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -94,7 +94,17 @@ class DomMethodCallExpr extends MethodCallExpr {
       name = "createElement" and argPos = 0
       or
       name = "appendChild" and argPos = 0
-      or
+    )
+  }
+
+  /**
+   * Holds if `arg` is an argument that is used as an URL.
+   */
+  predicate interpretsArgumentsAsURL(Expr arg) {
+    exists(int argPos, string name |
+      arg = this.getArgument(argPos) and
+      name = this.getMethodName()
+    |
       (
         name = "setAttribute" and argPos = 1
         or

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -12,4 +12,29 @@ module DomBasedXss {
   class RemoteFlowSourceAsSource extends Source {
     RemoteFlowSourceAsSource() { this instanceof RemoteFlowSource }
   }
+
+  /**
+   * A flow-label representing tainted values where the prefix is attacker controlled.
+   */
+  class PrefixString extends DataFlow::FlowLabel {
+    PrefixString() { this = "PrefixString" }
+  }
+
+  /** Gets the flow-label representing tainted values where the prefix is attacker controlled. */
+  PrefixString prefixLabel() { any() }
+
+  /**
+   * A sanitizer that blocks the `PrefixString` label when the start of the string is being tested as being of a particular prefix.
+   */
+  class PrefixStringSanitizer extends SanitizerGuard instanceof StringOps::StartsWith {
+    override predicate sanitizes(boolean outcome, Expr e) { none() }
+
+    override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
+      super.blocks(outcome, e, label)
+      or
+      e = super.getBaseString().asExpr() and
+      label = prefixLabel() and
+      outcome = super.getPolarity()
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -22,19 +22,4 @@ module DomBasedXss {
 
   /** Gets the flow-label representing tainted values where the prefix is attacker controlled. */
   PrefixString prefixLabel() { any() }
-
-  /**
-   * A sanitizer that blocks the `PrefixString` label when the start of the string is being tested as being of a particular prefix.
-   */
-  class PrefixStringSanitizer extends SanitizerGuard instanceof StringOps::StartsWith {
-    override predicate sanitizes(boolean outcome, Expr e) { none() }
-
-    override predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
-      super.blocks(outcome, e, label)
-      or
-      e = super.getBaseString().asExpr() and
-      label = prefixLabel() and
-      outcome = super.getPolarity()
-    }
-  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
@@ -123,3 +123,14 @@ class Configuration extends TaintTracking::Configuration {
     outlbl = prefixLabel()
   }
 }
+
+/**
+ * A sanitizer that blocks the `PrefixString` label when the start of the string is being tested as being of a particular prefix.
+ */
+class PrefixStringSanitizer extends SanitizerGuard, TaintTracking::LabeledSanitizerGuardNode instanceof StringOps::StartsWith {
+  override predicate sanitizes(boolean outcome, Expr e, DataFlow::FlowLabel label) {
+    e = super.getBaseString().asExpr() and
+    label = prefixLabel() and
+    outcome = super.getPolarity()
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
@@ -8,64 +8,60 @@ private import semmle.javascript.security.TaintedUrlSuffix
 import DomBasedXssCustomizations::DomBasedXss
 
 /**
- * DEPRECATED. Use `HtmlInjectionConfiguration` or `JQueryHtmlOrSelectorInjectionConfiguration`.
- */
-deprecated class Configuration = HtmlInjectionConfiguration;
-
-/**
  * DEPRECATED. Use `Vue::VHtmlSourceWrite` instead.
  */
 deprecated class VHtmlSourceWrite = Vue::VHtmlSourceWrite;
 
+/** DEPRECATED. Use `Configuration`. */
+deprecated class HtmlInjectionConfiguration = Configuration;
+
+/** DEPRECATED. Use `Configuration`. */
+deprecated class JQueryHtmlOrSelectorInjectionConfiguration = Configuration;
+
 /**
- * A taint-tracking configuration for reasoning about XSS.
+ * A sink that is not a URL write or a JQuery selector,
+ * assumed to be a value that is interpreted as HTML.
  */
-class HtmlInjectionConfiguration extends TaintTracking::Configuration {
-  HtmlInjectionConfiguration() { this = "HtmlInjection" }
-
-  override predicate isSource(DataFlow::Node source) { source instanceof Source }
-
-  override predicate isSink(DataFlow::Node sink) {
-    sink instanceof Sink and
-    not sink instanceof JQueryHtmlOrSelectorSink // Handled by JQueryHtmlOrSelectorInjectionConfiguration below
-  }
-
-  override predicate isSanitizer(DataFlow::Node node) {
-    super.isSanitizer(node)
-    or
-    node instanceof Sanitizer
-  }
-
-  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
-    guard instanceof SanitizerGuard
-  }
-
-  override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ) {
-    isOptionallySanitizedEdge(pred, succ)
+class HTMLSink extends DataFlow::Node instanceof Sink {
+  HTMLSink() {
+    not this instanceof WriteURLSink and
+    not this instanceof JQueryHtmlOrSelectorSink
   }
 }
 
 /**
- * A taint-tracking configuration for reasoning about injection into the jQuery `$` function
- * or similar, where the interpretation of the input string depends on its first character.
+ * A taint-tracking configuration for reasoning about XSS.
+ * Both ordinary HTML sinks, URL sinks, and JQuery selector based sinks.
+ * - HTML sinks are sinks for any tainted value
+ * - URL sinks are only sinks when the scheme is user controlled
+ * - JQuery selector sinks are sinks when the tainted value can start with `<`.
  *
- * Values are only considered tainted if they can start with the `<` character.
+ * The above is achieved using three flow labels:
+ * - TaintedUrlSuffix: a URL where the attacker only controls a suffix.
+ * - Taint: a tainted value where the attacker controls part of the value.
+ * - PrefixLabel: a tainted value where the attacker controls the prefix
  */
-class JQueryHtmlOrSelectorInjectionConfiguration extends TaintTracking::Configuration {
-  JQueryHtmlOrSelectorInjectionConfiguration() { this = "JQueryHtmlOrSelectorInjection" }
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "HtmlInjection" }
 
   override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel label) {
-    // Reuse any source not derived from location
     source instanceof Source and
-    not source = [DOM::locationRef(), DOM::locationRef().getAPropertyRead()] and
-    label.isTaint()
+    (label.isTaint() or label = prefixLabel()) and
+    not source = TaintedUrlSuffix::source()
     or
-    source = [DOM::locationSource(), DOM::locationRef().getAPropertyRead(["hash", "search"])] and
+    source = TaintedUrlSuffix::source() and
     label = TaintedUrlSuffix::label()
   }
 
   override predicate isSink(DataFlow::Node sink, DataFlow::FlowLabel label) {
-    sink instanceof JQueryHtmlOrSelectorSink and label.isTaint()
+    sink instanceof HTMLSink and
+    label = [TaintedUrlSuffix::label(), prefixLabel(), DataFlow::FlowLabel::taint()]
+    or
+    sink instanceof JQueryHtmlOrSelectorSink and
+    label = [DataFlow::FlowLabel::taint(), prefixLabel()]
+    or
+    sink instanceof WriteURLSink and
+    label = prefixLabel()
   }
 
   override predicate isSanitizer(DataFlow::Node node) {
@@ -76,6 +72,32 @@ class JQueryHtmlOrSelectorInjectionConfiguration extends TaintTracking::Configur
 
   override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
     guard instanceof SanitizerGuard
+  }
+
+  override predicate isLabeledBarrier(DataFlow::Node node, DataFlow::FlowLabel lbl) {
+    super.isLabeledBarrier(node, lbl)
+    or
+    // copy all taint barriers to the TaintedUrlSuffix/PrefixLabel label. This copies both the ordinary sanitizers and the sanitizer-guards.
+    super.isLabeledBarrier(node, DataFlow::FlowLabel::taint()) and
+    lbl = [TaintedUrlSuffix::label(), prefixLabel()]
+    or
+    // any non-first string-concatenation leaf is a barrier for the prefix label.
+    exists(StringOps::ConcatenationRoot root |
+      node = root.getALeaf() and
+      not node = root.getFirstLeaf() and
+      lbl = prefixLabel()
+    )
+    or
+    // we assume that `.join()` calls have a prefix, and thus block the prefix label.
+    node = any(DataFlow::MethodCallNode call | call.getMethodName() = "join") and
+    lbl = prefixLabel()
+  }
+
+  override predicate isSanitizerEdge(
+    DataFlow::Node pred, DataFlow::Node succ, DataFlow::FlowLabel label
+  ) {
+    isOptionallySanitizedEdge(pred, succ) and
+    label = [DataFlow::FlowLabel::taint(), prefixLabel(), TaintedUrlSuffix::label()]
   }
 
   override predicate isAdditionalFlowStep(
@@ -89,5 +111,15 @@ class JQueryHtmlOrSelectorInjectionConfiguration extends TaintTracking::Configur
       inlbl = TaintedUrlSuffix::label() and
       outlbl.isTaint()
     )
+    or
+    // inherit all ordinary taint steps for prefixLabel
+    inlbl = prefixLabel() and
+    outlbl = prefixLabel() and
+    TaintTracking::sharedTaintStep(src, trg)
+    or
+    // steps out of taintedSuffixlabel to taint-label are also a steps to prefixLabel.
+    TaintedUrlSuffix::step(src, trg, TaintedUrlSuffix::label(), DataFlow::FlowLabel::taint()) and
+    inlbl = TaintedUrlSuffix::label() and
+    outlbl = prefixLabel()
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -253,6 +253,15 @@ module DomBasedXss {
     }
   }
 
+  import ClientSideUrlRedirectCustomizations::ClientSideUrlRedirect as ClientSideUrlRedirect
+
+  /**
+   * A write to a URL which may execute JavaScript code.
+   */
+  class WriteURLSink extends Sink instanceof ClientSideUrlRedirect::Sink {
+    WriteURLSink() { super.isXSSSink() }
+  }
+
   /**
    * An expression whose value is interpreted as HTML or CSS
    * and may be inserted into the DOM.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -347,7 +347,7 @@ module DomBasedXss {
   /**
    * A write to the `template` option of a Vue instance, viewed as an XSS sink.
    */
-  class VueTemplateSink extends DomBasedXss::Sink {
+  class VueTemplateSink extends Sink {
     VueTemplateSink() {
       // Note: don't use Vue::Component#getTemplate as it includes an unwanted getALocalSource() step
       this = any(Vue::Component c).getOption("template")
@@ -358,7 +358,7 @@ module DomBasedXss {
    * The tag name argument to the `createElement` parameter of the
    * `render` method of a Vue instance, viewed as an XSS sink.
    */
-  class VueCreateElementSink extends DomBasedXss::Sink {
+  class VueCreateElementSink extends Sink {
     VueCreateElementSink() {
       exists(Vue::Component c, DataFlow::FunctionNode f |
         f.flowsTo(c.getRender()) and
@@ -370,12 +370,12 @@ module DomBasedXss {
   /**
    * A Vue `v-html` attribute, viewed as an XSS sink.
    */
-  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink { }
+  class VHtmlSink extends Vue::VHtmlAttribute, Sink { }
 
   /**
    * A raw interpolation tag in a template file, viewed as an XSS sink.
    */
-  class TemplateSink extends DomBasedXss::Sink {
+  class TemplateSink extends Sink {
     TemplateSink() {
       exists(Templating::TemplatePlaceholderTag tag |
         tag.isRawInterpolation() and
@@ -388,7 +388,7 @@ module DomBasedXss {
    * A value being piped into the `safe` pipe in a template file,
    * disabling subsequent HTML escaping.
    */
-  class SafePipe extends DomBasedXss::Sink {
+  class SafePipe extends Sink {
     SafePipe() { this = Templating::getAPipeCall("safe").getArgument(0) }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/Xss.qll
@@ -259,7 +259,7 @@ module DomBasedXss {
    * A write to a URL which may execute JavaScript code.
    */
   class WriteURLSink extends Sink instanceof ClientSideUrlRedirect::Sink {
-    WriteURLSink() { super.isXSSSink() }
+    WriteURLSink() { super.isXssSink() }
   }
 
   /**

--- a/javascript/ql/src/Security/CWE-079/Xss.ql
+++ b/javascript/ql/src/Security/CWE-079/Xss.ql
@@ -17,12 +17,7 @@ import semmle.javascript.security.dataflow.DomBasedXssQuery
 import DataFlow::PathGraph
 
 from DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
-where
-  (
-    cfg instanceof HtmlInjectionConfiguration or
-    cfg instanceof JQueryHtmlOrSelectorInjectionConfiguration
-  ) and
-  cfg.hasFlowPath(source, sink)
+where cfg.hasFlowPath(source, sink)
 select sink.getNode(), source, sink,
   sink.getNode().(Sink).getVulnerabilityKind() + " vulnerability due to $@.", source.getNode(),
   "user-provided value"

--- a/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
+++ b/javascript/ql/test/library-tests/frameworks/Templating/Xss.expected
@@ -1,201 +1,335 @@
 nodes
 | app.js:8:18:8:34 | req.query.rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml |
+| app.js:11:26:11:46 | req.que ... tmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp |
 | app.js:14:33:14:64 | req.que ... eralRaw |
 | app.js:14:33:14:64 | req.que ... eralRaw |
+| app.js:14:33:14:64 | req.que ... eralRaw |
+| app.js:16:33:16:64 | req.que ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw |
+| app.js:20:38:20:74 | req.que ... ringRaw |
+| app.js:27:18:27:34 | req.query.rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml |
 | app.js:30:26:30:46 | req.que ... tmlProp |
 | app.js:30:26:30:46 | req.que ... tmlProp |
+| app.js:30:26:30:46 | req.que ... tmlProp |
+| app.js:33:33:33:64 | req.que ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw |
 | app.js:46:18:46:34 | req.query.rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml |
+| app.js:49:26:49:46 | req.que ... tmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp |
 | app.js:52:33:52:64 | req.que ... eralRaw |
 | app.js:52:33:52:64 | req.que ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw |
+| app.js:55:37:55:72 | req.que ... JsonRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw |
 | app.js:66:18:66:34 | req.query.rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA |
 | projectA/src/index.js:6:38:6:53 | req.query.taintA |
 | projectA/src/index.js:6:38:6:53 | req.query.taintA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA |
+| projectA/src/index.js:12:16:12:30 | req.query.sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA |
 | projectA/src/index.js:22:16:22:30 | req.query.sinkA |
 | projectA/src/index.js:22:16:22:30 | req.query.sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA |
+| projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA |
 | projectA/src/index.js:47:16:47:30 | req.query.sinkA |
 | projectA/src/index.js:47:16:47:30 | req.query.sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA |
+| projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB |
 | projectB/src/index.js:6:38:6:53 | req.query.taintB |
 | projectB/src/index.js:6:38:6:53 | req.query.taintB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB |
+| projectB/src/index.js:13:16:13:30 | req.query.sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB |
 | projectB/src/index.js:23:16:23:30 | req.query.sinkB |
 | projectB/src/index.js:23:16:23:30 | req.query.sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB |
+| projectB/src/index.js:38:16:38:30 | req.query.sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB |
 | projectB/src/index.js:43:16:43:30 | req.query.sinkB |
 | projectB/src/index.js:43:16:43:30 | req.query.sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB |
+| projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
+| views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
+| views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
+| views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
+| views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
+| views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
 | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
 | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
 | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
 | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
 | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
 | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
 | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
 | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
 | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
 | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
 | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
 | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
 | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
 | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
 | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
 | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
 | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
 | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
 | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
 | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
 | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
 | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
 | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
 | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
 | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
 | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
+| views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
+| views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 edges
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_include2.ejs:1:5:1:11 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
 | app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
+| app.js:8:18:8:34 | req.query.rawHtml | views/ejs_sinks.ejs:24:44:24:50 | rawHtml |
+| app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
+| app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
 | app.js:11:26:11:46 | req.que ... tmlProp | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp |
 | app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
 | app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:14:33:14:64 | req.que ... eralRaw | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw |
+| app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
+| app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:16:33:16:64 | req.que ... CodeRaw | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
 | app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:20:38:20:74 | req.que ... ringRaw | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:9:13:9:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:10:13:10:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:11:13:11:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:12:13:12:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:13:14:13:20 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
 | app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
+| app.js:27:18:27:34 | req.query.rawHtml | views/hbs_sinks.hbs:15:13:15:19 | rawHtml |
+| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
+| app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | app.js:30:26:30:46 | req.que ... tmlProp | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp |
 | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
 | app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
+| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
+| app.js:33:33:33:64 | req.que ... eralRaw | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
 | app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
+| app.js:35:33:35:64 | req.que ... CodeRaw | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
+| app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | app.js:39:38:39:74 | req.que ... ringRaw | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
 | app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:46:18:46:34 | req.query.rawHtml | views/njk_sinks.njk:4:12:4:18 | rawHtml |
+| app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
+| app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
+| app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
 | app.js:49:26:49:46 | req.que ... tmlProp | views/njk_sinks.njk:7:12:7:29 | object.rawHtmlProp |
@@ -204,103 +338,203 @@ edges
 | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
 | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
 | app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:52:33:52:64 | req.que ... eralRaw | views/njk_sinks.njk:11:46:11:67 | dataInS ... eralRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
+| app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:54:33:54:64 | req.que ... CodeRaw | views/njk_sinks.njk:14:45:14:66 | dataInG ... CodeRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
 | app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| app.js:55:37:55:72 | req.que ... JsonRaw | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
+| app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:59:38:59:74 | req.que ... ringRaw | views/njk_sinks.njk:23:42:23:68 | dataInE ... ringRaw |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_include.ejs:3:9:3:15 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
+| app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | app.js:66:18:66:34 | req.query.rawHtml | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml |
 | projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
 | projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectA/src/index.js:6:38:6:53 | req.query.taintA | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:12:16:12:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:17:16:17:30 | req.query.sinkA | projectA/views/main.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:22:16:22:30 | req.query.sinkA | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:37:16:37:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
+| projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:42:16:42:30 | req.query.sinkA | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA |
 | projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
 | projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/src/index.js:47:16:47:30 | req.query.sinkA | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA |
+| projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:2:5:2:9 | sinkA | projectA/views/main.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectA/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectA/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/index.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/index.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
 | projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/subfolder/other.ejs:2:5:2:9 | sinkA | projectA/views/subfolder/other.ejs:2:1:2:12 | <%- sinkA %> |
+| projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
+| projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectA/views/upward_traversal.ejs:1:5:1:9 | sinkA | projectA/views/upward_traversal.ejs:1:1:1:12 | <%- sinkA %> |
 | projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
 | projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectB/src/index.js:6:38:6:53 | req.query.taintB | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware |
+| projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:13:16:13:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:18:16:18:30 | req.query.sinkB | projectB/views/main.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:23:16:23:30 | req.query.sinkB | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:38:16:38:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
+| projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/src/index.js:43:16:43:30 | req.query.sinkB | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/main.ejs:3:5:3:9 | sinkB | projectB/views/main.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
+| projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/main.ejs:5:5:5:23 | taintedInMiddleware | projectB/views/main.ejs:5:1:5:26 | <%- taintedInMiddleware %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/index.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/index.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
+| projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | projectB/views/subfolder/other.ejs:3:5:3:9 | sinkB | projectB/views/subfolder/other.ejs:3:1:3:12 | <%- sinkB %> |
 | views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
 | views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
+| views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
+| views/angularjs_include.ejs:3:9:3:15 | rawHtml | views/angularjs_include.ejs:3:5:3:18 | <%- rawHtml %> |
+| views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/angularjs_sinks.ejs:4:13:4:19 | rawHtml | views/angularjs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
 | views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
+| views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
+| views/ejs_include1.ejs:1:5:1:7 | foo | views/ejs_include1.ejs:1:1:1:10 | <%- foo %> |
+| views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
+| views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_include2.ejs:1:5:1:11 | rawHtml | views/ejs_include2.ejs:1:1:1:14 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
 | views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/ejs_sinks.ejs:4:13:4:19 | rawHtml | views/ejs_sinks.ejs:4:9:4:22 | <%- rawHtml %> |
+| views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
+| views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:7:13:7:30 | object.rawHtmlProp | views/ejs_sinks.ejs:7:9:7:33 | <%- object.rawHtmlProp %> |
 | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
+| views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
+| views/ejs_sinks.ejs:11:47:11:68 | dataInS ... eralRaw | views/ejs_sinks.ejs:11:43:11:71 | <%- dataInStringLiteralRaw %> |
 | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
 | views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
+| views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
+| views/ejs_sinks.ejs:14:46:14:67 | dataInG ... CodeRaw | views/ejs_sinks.ejs:14:42:14:70 | <%- dataInGeneratedCodeRaw %> |
+| views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
+| views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:22:43:22:69 | dataInE ... ringRaw | views/ejs_sinks.ejs:22:39:22:72 | <%- dataInEventHandlerStringRaw %> |
 | views/ejs_sinks.ejs:24:44:24:50 | rawHtml | views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/ejs_sinks.ejs:24:44:24:50 | rawHtml | views/ejs_include1.ejs:1:5:1:7 | foo |
+| views/hbs_sinks.hbs:9:13:9:19 | rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
+| views/hbs_sinks.hbs:9:13:9:19 | rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:9:13:9:19 | rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:9:13:9:19 | rawHtml | views/hbs_sinks.hbs:9:9:9:23 | {{{ rawHtml }}} |
 | views/hbs_sinks.hbs:10:13:10:19 | rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
 | views/hbs_sinks.hbs:10:13:10:19 | rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:13:10:19 | rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:10:13:10:19 | rawHtml | views/hbs_sinks.hbs:10:9:10:23 | {{{~rawHtml }}} |
+| views/hbs_sinks.hbs:11:13:11:19 | rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
+| views/hbs_sinks.hbs:11:13:11:19 | rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
 | views/hbs_sinks.hbs:11:13:11:19 | rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
 | views/hbs_sinks.hbs:11:13:11:19 | rawHtml | views/hbs_sinks.hbs:11:9:11:23 | {{{ rawHtml~}}} |
 | views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
 | views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:12:13:12:19 | rawHtml | views/hbs_sinks.hbs:12:9:12:23 | {{{~rawHtml~}}} |
+| views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
+| views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:13:14:13:20 | rawHtml | views/hbs_sinks.hbs:13:9:13:25 | {{{~ rawHtml ~}}} |
 | views/hbs_sinks.hbs:15:13:15:19 | rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
 | views/hbs_sinks.hbs:15:13:15:19 | rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:13:15:19 | rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:15:13:15:19 | rawHtml | views/hbs_sinks.hbs:15:9:15:22 | {{& rawHtml }} |
+| views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
+| views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:19:13:19:30 | object.rawHtmlProp | views/hbs_sinks.hbs:19:9:19:34 | {{{ object.rawHtmlProp }}} |
 | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
 | views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:23:47:23:68 | dataInS ... eralRaw | views/hbs_sinks.hbs:23:43:23:72 | {{{ dataInStringLiteralRaw }}} |
+| views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
+| views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:26:46:26:67 | dataInG ... CodeRaw | views/hbs_sinks.hbs:26:42:26:71 | {{{ dataInGeneratedCodeRaw }}} |
 | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
 | views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/hbs_sinks.hbs:34:43:34:69 | dataInE ... ringRaw | views/hbs_sinks.hbs:34:39:34:73 | {{{ dataInEventHandlerStringRaw }}} |
+| views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
+| views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 | views/njk_sinks.njk:15:49:15:74 | dataInG ... JsonRaw | views/njk_sinks.njk:15:49:15:81 | dataInG ...  \| json |
 #select

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -432,26 +432,6 @@ nodes
 | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
-| tst3.js:2:23:2:74 | decodeU ... str(1)) |
-| tst3.js:2:42:2:63 | window. ... .search |
-| tst3.js:2:42:2:63 | window. ... .search |
-| tst3.js:2:42:2:73 | window. ... bstr(1) |
-| tst3.js:4:25:4:28 | data |
-| tst3.js:4:25:4:32 | data.src |
-| tst3.js:4:25:4:32 | data.src |
-| tst3.js:5:26:5:29 | data |
-| tst3.js:5:26:5:31 | data.p |
-| tst3.js:5:26:5:31 | data.p |
-| tst3.js:7:32:7:35 | data |
-| tst3.js:7:32:7:37 | data.p |
-| tst3.js:7:32:7:37 | data.p |
-| tst3.js:9:37:9:40 | data |
-| tst3.js:9:37:9:42 | data.p |
-| tst3.js:9:37:9:42 | data.p |
-| tst3.js:10:38:10:41 | data |
-| tst3.js:10:38:10:43 | data.p |
-| tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -1192,25 +1172,6 @@ edges
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
-| tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
-| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
-| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
-| tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
-| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
-| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
-| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
-| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
-| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
-| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
-| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
-| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
-| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
-| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
@@ -1622,11 +1583,6 @@ edges
 | tooltip.jsx:11:25:11:30 | source | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:11:25:11:30 | source | Cross-site scripting vulnerability due to $@. | tooltip.jsx:6:20:6:30 | window.name | user-provided value |
 | translate.js:9:27:9:50 | searchP ... 'term') | translate.js:6:16:6:39 | documen ... .search | translate.js:9:27:9:50 | searchP ... 'term') | Cross-site scripting vulnerability due to $@. | translate.js:6:16:6:39 | documen ... .search | user-provided value |
 | trusted-types.js:2:71:2:71 | x | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:71:2:71 | x | Cross-site scripting vulnerability due to $@. | trusted-types.js:3:24:3:34 | window.name | user-provided value |
-| tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:63 | window. ... .search | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
-| tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
-| tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
-| tst3.js:9:37:9:42 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:9:37:9:42 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
-| tst3.js:10:38:10:43 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:10:38:10:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
 | tst.js:5:18:5:23 | target | tst.js:2:16:2:39 | documen ... .search | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:58 | documen ... on.href | user-provided value |
 | tst.js:12:5:12:42 | '<div s ...  'px">' | tst.js:2:16:2:39 | documen ... .search | tst.js:12:5:12:42 | '<div s ...  'px">' | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -28,7 +28,6 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
@@ -80,8 +79,6 @@ nodes
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
-| angular2-client.ts:38:44:38:58 | this.router.url |
-| angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
@@ -298,6 +295,7 @@ nodes
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
 | dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -525,41 +523,28 @@ nodes
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
-| string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
@@ -622,8 +607,10 @@ nodes
 | tst.js:5:18:5:23 | target |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
+| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
@@ -1335,6 +1322,8 @@ edges
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
@@ -1552,12 +1541,6 @@ edges
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
@@ -1566,12 +1549,6 @@ edges
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
@@ -1580,12 +1557,6 @@ edges
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
@@ -1655,6 +1626,11 @@ edges
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -432,6 +432,26 @@ nodes
 | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
+| tst3.js:2:23:2:74 | decodeU ... str(1)) |
+| tst3.js:2:42:2:63 | window. ... .search |
+| tst3.js:2:42:2:63 | window. ... .search |
+| tst3.js:2:42:2:73 | window. ... bstr(1) |
+| tst3.js:4:25:4:28 | data |
+| tst3.js:4:25:4:32 | data.src |
+| tst3.js:4:25:4:32 | data.src |
+| tst3.js:5:26:5:29 | data |
+| tst3.js:5:26:5:31 | data.p |
+| tst3.js:5:26:5:31 | data.p |
+| tst3.js:7:32:7:35 | data |
+| tst3.js:7:32:7:37 | data.p |
+| tst3.js:7:32:7:37 | data.p |
+| tst3.js:9:37:9:40 | data |
+| tst3.js:9:37:9:42 | data.p |
+| tst3.js:9:37:9:42 | data.p |
+| tst3.js:10:38:10:41 | data |
+| tst3.js:10:38:10:43 | data.p |
+| tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -732,6 +752,29 @@ nodes
 | tst.js:465:19:465:24 | source |
 | tst.js:467:20:467:25 | source |
 | tst.js:467:20:467:25 | source |
+| tst.js:471:7:471:46 | url |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:473:19:473:21 | url |
+| tst.js:473:19:473:21 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:479:43:479:45 | url |
+| tst.js:481:20:481:45 | ["http: ... ", url] |
+| tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:42:481:44 | url |
+| tst.js:484:22:484:24 | url |
+| tst.js:484:22:484:24 | url |
+| tst.js:486:22:486:24 | url |
+| tst.js:486:22:486:24 | url |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:45 | documen ... .search |
@@ -1172,6 +1215,25 @@ edges
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
+| tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
+| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
+| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
+| tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
+| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
+| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
+| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
+| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
+| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
+| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
+| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
+| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
+| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
+| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
@@ -1426,6 +1488,28 @@ edges
 | tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:479:43:479:45 | url |
+| tst.js:471:7:471:46 | url | tst.js:481:42:481:44 | url |
+| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
+| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:42:481:44 | url | tst.js:481:20:481:45 | ["http: ... ", url] |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
@@ -1583,6 +1667,11 @@ edges
 | tooltip.jsx:11:25:11:30 | source | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:11:25:11:30 | source | Cross-site scripting vulnerability due to $@. | tooltip.jsx:6:20:6:30 | window.name | user-provided value |
 | translate.js:9:27:9:50 | searchP ... 'term') | translate.js:6:16:6:39 | documen ... .search | translate.js:9:27:9:50 | searchP ... 'term') | Cross-site scripting vulnerability due to $@. | translate.js:6:16:6:39 | documen ... .search | user-provided value |
 | trusted-types.js:2:71:2:71 | x | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:71:2:71 | x | Cross-site scripting vulnerability due to $@. | trusted-types.js:3:24:3:34 | window.name | user-provided value |
+| tst3.js:4:25:4:32 | data.src | tst3.js:2:42:2:63 | window. ... .search | tst3.js:4:25:4:32 | data.src | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:5:26:5:31 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:5:26:5:31 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:7:32:7:37 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:7:32:7:37 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:9:37:9:42 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:9:37:9:42 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
+| tst3.js:10:38:10:43 | data.p | tst3.js:2:42:2:63 | window. ... .search | tst3.js:10:38:10:43 | data.p | Cross-site scripting vulnerability due to $@. | tst3.js:2:42:2:63 | window. ... .search | user-provided value |
 | tst.js:5:18:5:23 | target | tst.js:2:16:2:39 | documen ... .search | tst.js:5:18:5:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:18:8:126 | "<OPTIO ... PTION>" | Cross-site scripting vulnerability due to $@. | tst.js:8:37:8:58 | documen ... on.href | user-provided value |
 | tst.js:12:5:12:42 | '<div s ...  'px">' | tst.js:2:16:2:39 | documen ... .search | tst.js:12:5:12:42 | '<div s ...  'px">' | Cross-site scripting vulnerability due to $@. | tst.js:2:16:2:39 | documen ... .search | user-provided value |
@@ -1665,6 +1754,14 @@ edges
 | tst.js:463:21:463:26 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:463:21:463:26 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
 | tst.js:465:19:465:24 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:465:19:465:24 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
 | tst.js:467:20:467:25 | source | tst.js:460:15:460:38 | documen ... .search | tst.js:467:20:467:25 | source | Cross-site scripting vulnerability due to $@. | tst.js:460:15:460:38 | documen ... .search | user-provided value |
+| tst.js:473:19:473:21 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:473:19:473:21 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:474:26:474:28 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:474:26:474:28 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:475:25:475:27 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:475:25:475:27 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:476:20:476:22 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:476:20:476:22 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:479:20:479:45 | "http:/ ... " + url | tst.js:471:13:471:36 | documen ... .search | tst.js:479:20:479:45 | "http:/ ... " + url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:481:20:481:55 | ["http: ... in("/") | tst.js:471:13:471:36 | documen ... .search | tst.js:481:20:481:55 | ["http: ... in("/") | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:484:22:484:24 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:484:22:484:24 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
+| tst.js:486:22:486:24 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:486:22:486:24 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:45 | documen ... .search | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | Cross-site scripting vulnerability due to $@. | various-concat-obfuscations.js:2:16:2:39 | documen ... .search | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -28,6 +28,7 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
@@ -36,15 +37,19 @@ nodes
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams |
 | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
@@ -75,6 +80,8 @@ nodes
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
@@ -291,7 +298,6 @@ nodes
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
 | dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
-| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -519,28 +525,41 @@ nodes
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
+| string-manipulations.js:4:16:4:37 | documen ... on.href |
+| string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
+| string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
@@ -603,10 +622,8 @@ nodes
 | tst.js:5:18:5:23 | target |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
-| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
@@ -1065,6 +1082,9 @@ edges
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
@@ -1315,8 +1335,6 @@ edges
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
-| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
-| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
@@ -1534,6 +1552,12 @@ edges
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
@@ -1542,6 +1566,12 @@ edges
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
@@ -1550,6 +1580,12 @@ edges
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
@@ -1619,11 +1655,6 @@ edges
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -1,18 +1,28 @@
 nodes
 | addEventListener.js:1:43:1:47 | event |
 | addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | {data} |
 | addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
@@ -20,6 +30,8 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
@@ -32,32 +44,41 @@ nodes
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
@@ -92,124 +113,194 @@ nodes
 | classnames.js:15:52:15:62 | window.name |
 | classnames.js:15:52:15:62 | window.name |
 | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | d3.js:4:12:4:22 | window.name |
 | d3.js:4:12:4:22 | window.name |
+| d3.js:4:12:4:22 | window.name |
+| d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
+| d3.js:12:20:12:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
+| d3.js:14:20:14:29 | getTaint() |
+| d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint |
+| dates.js:9:9:9:69 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:63:11:67 | taint |
 | dates.js:11:63:11:67 | taint |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:66:12:70 | taint |
 | dates.js:12:66:12:70 | taint |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:59:13:63 | taint |
 | dates.js:13:59:13:63 | taint |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:62:16:66 | taint |
 | dates.js:16:62:16:66 | taint |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:59:18:63 | taint |
 | dates.js:18:59:18:63 | taint |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint |
+| dates.js:21:61:21:65 | taint |
 | dates.js:30:9:30:69 | taint |
+| dates.js:30:9:30:69 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:77:37:81 | taint |
 | dates.js:37:77:37:81 | taint |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:77:38:81 | taint |
 | dates.js:38:77:38:81 | taint |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:79:39:83 | taint |
 | dates.js:39:79:39:83 | taint |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint |
+| dates.js:40:77:40:81 | taint |
 | dates.js:46:9:46:69 | taint |
+| dates.js:46:9:46:69 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:83:48:87 | taint |
 | dates.js:48:83:48:87 | taint |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:82:49:86 | taint |
 | dates.js:49:82:49:86 | taint |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint |
+| dates.js:50:97:50:101 | taint |
 | dates.js:54:9:54:69 | taint |
+| dates.js:54:9:54:69 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:94:57:98 | taint |
 | dates.js:57:94:57:98 | taint |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:80:59:84 | taint |
 | dates.js:59:80:59:84 | taint |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
+| express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search |
-| jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -242,31 +333,43 @@ nodes
 | jquery.js:21:5:21:8 | hash |
 | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:22:5:22:8 | hash |
+| jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash |
 | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:24:5:24:8 | hash |
+| jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:28:5:28:26 | window. ... .search |
 | jquery.js:28:5:28:26 | window. ... .search |
+| jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash |
 | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:9:55:9:61 | decoded |
 | jwt-server.js:9:55:9:61 | decoded |
 | jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:29 | decoded.foo |
 | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -313,43 +416,67 @@ nodes
 | optionalSanitizer.js:45:41:45:46 | target |
 | optionalSanitizer.js:45:51:45:56 | target |
 | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:8:18:8:24 | tainted |
 | react-native.js:8:18:8:24 | tainted |
+| react-native.js:8:18:8:24 | tainted |
 | react-native.js:9:27:9:33 | tainted |
 | react-native.js:9:27:9:33 | tainted |
+| react-native.js:9:27:9:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name |
 | react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name |
 | react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name |
 | react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -368,6 +495,8 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search |
@@ -380,6 +509,7 @@ nodes
 | stored-xss.js:8:20:8:48 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') |
+| stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href |
@@ -414,22 +544,36 @@ nodes
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
+| translate.js:7:7:7:61 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:47 | target |
 | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:9:27:9:38 | searchParams |
+| translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | trusted-types.js:2:66:2:66 | x |
+| trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
@@ -453,27 +597,38 @@ nodes
 | tst3.js:10:38:10:43 | data.p |
 | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
-| tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search |
-| tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:5:18:5:23 | target |
 | tst.js:5:18:5:23 | target |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target |
+| tst.js:17:7:17:56 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location |
 | tst.js:17:25:17:41 | document.location |
+| tst.js:18:18:18:23 | params |
 | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:47 | target |
 | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:21:18:21:29 | searchParams |
+| tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target |
@@ -491,18 +646,25 @@ nodes
 | tst.js:40:20:40:43 | documen ... .search |
 | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search |
 | tst.js:46:21:46:44 | documen ... .search |
+| tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() |
 | tst.js:60:34:60:34 | s |
@@ -545,11 +707,19 @@ nodes
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:110:18:110:18 | v |
 | tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:136:18:136:18 | v |
+| tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:148:29:148:50 | window. ... .search |
@@ -619,9 +789,12 @@ nodes
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
+| tst.js:259:7:259:17 | window.name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
+| tst.js:260:7:260:10 | name |
+| tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
@@ -629,8 +802,11 @@ nodes
 | tst.js:280:22:280:29 | location |
 | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted |
+| tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name |
 | tst.js:285:19:285:29 | window.name |
+| tst.js:285:19:285:29 | window.name |
+| tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:301:9:301:16 | location |
@@ -648,11 +824,17 @@ nodes
 | tst.js:316:35:316:42 | location |
 | tst.js:327:18:327:34 | document.location |
 | tst.js:327:18:327:34 | document.location |
+| tst.js:331:7:331:43 | params |
+| tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:332:18:332:23 | params |
+| tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target |
@@ -697,9 +879,15 @@ nodes
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:417:18:417:24 | payload |
+| tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:419:7:419:55 | match |
@@ -712,6 +900,10 @@ nodes
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target |
@@ -764,15 +956,6 @@ nodes
 | tst.js:475:25:475:27 | url |
 | tst.js:476:20:476:22 | url |
 | tst.js:476:20:476:22 | url |
-| tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:479:43:479:45 | url |
-| tst.js:481:20:481:45 | ["http: ... ", url] |
-| tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:42:481:44 | url |
-| tst.js:484:22:484:24 | url |
-| tst.js:484:22:484:24 | url |
 | tst.js:486:22:486:24 | url |
 | tst.js:486:22:486:24 | url |
 | typeahead.js:20:13:20:45 | target |
@@ -828,28 +1011,52 @@ nodes
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:3:43:3:49 | tainted |
 | winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 edges
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
+| addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
@@ -867,7 +1074,13 @@ edges
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
@@ -901,6 +1114,10 @@ edges
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
@@ -910,6 +1127,12 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
@@ -918,90 +1141,178 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1009,8 +1320,6 @@ edges
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:7:20:7:26 | tainted | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -1043,14 +1352,21 @@ edges
 | jquery.js:18:14:18:33 | window.location.hash | jquery.js:18:7:18:33 | hash |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
@@ -1058,10 +1374,17 @@ edges
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
 | jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -1113,30 +1436,56 @@ edges
 | optionalSanitizer.js:45:51:45:56 | target | optionalSanitizer.js:45:18:45:56 | sanitiz ...  target |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
+| react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:23:29:23:35 | tainted |
@@ -1145,6 +1494,9 @@ edges
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -1157,6 +1509,8 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -1171,6 +1525,7 @@ edges
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href | stored-xss.js:12:35:12:38 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') | stored-xss.js:10:9:10:44 | href |
+| stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location |
@@ -1201,18 +1556,40 @@ edges
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
+| translate.js:7:7:7:61 | searchParams | translate.js:9:27:9:38 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) | translate.js:7:7:7:61 | searchParams |
 | translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
+| trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
@@ -1240,21 +1617,43 @@ edges
 | tst.js:2:7:2:39 | target | tst.js:20:42:20:47 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
+| tst.js:17:7:17:56 | params | tst.js:18:18:18:23 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams | tst.js:17:7:17:56 | params |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams | tst.js:21:18:21:29 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) | tst.js:20:7:20:61 | searchParams |
 | tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
@@ -1277,16 +1676,30 @@ edges
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
@@ -1311,10 +1724,24 @@ edges
 | tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
@@ -1382,6 +1809,10 @@ edges
 | tst.js:280:22:280:29 | location | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:301:9:301:16 | location | tst.js:302:10:302:10 | e |
@@ -1393,12 +1824,20 @@ edges
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:316:35:316:42 | location | tst.js:316:35:316:42 | location |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:331:7:331:43 | params | tst.js:332:18:332:23 | params |
+| tst.js:331:16:331:43 | getTain ... hParams | tst.js:331:7:331:43 | params |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
@@ -1441,8 +1880,18 @@ edges
 | tst.js:408:19:408:31 | target.taint8 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:419:7:419:55 | match | tst.js:421:20:421:24 | match |
 | tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
@@ -1452,6 +1901,14 @@ edges
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
@@ -1496,20 +1953,11 @@ edges
 | tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
 | tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
 | tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
-| tst.js:471:7:471:46 | url | tst.js:479:43:479:45 | url |
-| tst.js:471:7:471:46 | url | tst.js:481:42:481:44 | url |
-| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
-| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
 | tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
 | tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
-| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:42:481:44 | url | tst.js:481:20:481:45 | ["http: ... ", url] |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:20:13:20:45 | target |
@@ -1560,10 +2008,24 @@ edges
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 #select
 | addEventListener.js:2:20:2:29 | event.data | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
@@ -1758,9 +2220,6 @@ edges
 | tst.js:474:26:474:28 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:474:26:474:28 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | tst.js:475:25:475:27 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:475:25:475:27 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | tst.js:476:20:476:22 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:476:20:476:22 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
-| tst.js:479:20:479:45 | "http:/ ... " + url | tst.js:471:13:471:36 | documen ... .search | tst.js:479:20:479:45 | "http:/ ... " + url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
-| tst.js:481:20:481:55 | ["http: ... in("/") | tst.js:471:13:471:36 | documen ... .search | tst.js:481:20:481:55 | ["http: ... in("/") | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
-| tst.js:484:22:484:24 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:484:22:484:24 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | tst.js:486:22:486:24 | url | tst.js:471:13:471:36 | documen ... .search | tst.js:486:22:486:24 | url | Cross-site scripting vulnerability due to $@. | tst.js:471:13:471:36 | documen ... .search | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:45 | documen ... .search | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:45 | documen ... .search | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -439,6 +439,26 @@ nodes
 | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
+| tst3.js:2:23:2:74 | decodeU ... str(1)) |
+| tst3.js:2:42:2:63 | window. ... .search |
+| tst3.js:2:42:2:63 | window. ... .search |
+| tst3.js:2:42:2:73 | window. ... bstr(1) |
+| tst3.js:4:25:4:28 | data |
+| tst3.js:4:25:4:32 | data.src |
+| tst3.js:4:25:4:32 | data.src |
+| tst3.js:5:26:5:29 | data |
+| tst3.js:5:26:5:31 | data.p |
+| tst3.js:5:26:5:31 | data.p |
+| tst3.js:7:32:7:35 | data |
+| tst3.js:7:32:7:37 | data.p |
+| tst3.js:7:32:7:37 | data.p |
+| tst3.js:9:37:9:40 | data |
+| tst3.js:9:37:9:42 | data.p |
+| tst3.js:9:37:9:42 | data.p |
+| tst3.js:10:38:10:41 | data |
+| tst3.js:10:38:10:43 | data.p |
+| tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -739,6 +759,29 @@ nodes
 | tst.js:465:19:465:24 | source |
 | tst.js:467:20:467:25 | source |
 | tst.js:467:20:467:25 | source |
+| tst.js:471:7:471:46 | url |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:36 | documen ... .search |
+| tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:473:19:473:21 | url |
+| tst.js:473:19:473:21 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:474:26:474:28 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:475:25:475:27 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:476:20:476:22 | url |
+| tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:479:43:479:45 | url |
+| tst.js:481:20:481:45 | ["http: ... ", url] |
+| tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:42:481:44 | url |
+| tst.js:484:22:484:24 | url |
+| tst.js:484:22:484:24 | url |
+| tst.js:486:22:486:24 | url |
+| tst.js:486:22:486:24 | url |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:10:16:10:18 | loc |
@@ -1207,6 +1250,25 @@ edges
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
+| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
+| tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
+| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
+| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
+| tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
+| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
+| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
+| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
+| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
+| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
+| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
+| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
+| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
+| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
+| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |
@@ -1461,6 +1523,28 @@ edges
 | tst.js:460:6:460:38 | source | tst.js:467:20:467:25 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
 | tst.js:460:15:460:38 | documen ... .search | tst.js:460:6:460:38 | source |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:473:19:473:21 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:474:26:474:28 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
+| tst.js:471:7:471:46 | url | tst.js:479:43:479:45 | url |
+| tst.js:471:7:471:46 | url | tst.js:481:42:481:44 | url |
+| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
+| tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
+| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
+| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
+| tst.js:481:42:481:44 | url | tst.js:481:20:481:45 | ["http: ... ", url] |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -28,6 +28,7 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
@@ -36,15 +37,19 @@ nodes
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams |
 | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
+| angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
@@ -75,6 +80,8 @@ nodes
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:38:44:38:58 | this.router.url |
+| angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
@@ -291,7 +298,6 @@ nodes
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
 | dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
-| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -531,28 +537,41 @@ nodes
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
+| string-manipulations.js:4:16:4:37 | documen ... on.href |
+| string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
+| string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
@@ -615,10 +634,8 @@ nodes
 | tst.js:5:18:5:23 | target |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
-| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
@@ -1115,6 +1132,9 @@ edges
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
+| angular2-client.ts:25:44:25:74 | this.ro ... yParams | angular2-client.ts:25:44:25:78 | this.ro ... ams.foo |
 | angular2-client.ts:26:44:26:71 | this.ro ... ragment | angular2-client.ts:26:44:26:71 | this.ro ... ragment |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
@@ -1365,8 +1385,6 @@ edges
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
-| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
-| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
@@ -1596,6 +1614,12 @@ edges
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
+| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
@@ -1604,6 +1628,12 @@ edges
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
+| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
@@ -1612,6 +1642,12 @@ edges
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
+| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
@@ -1681,11 +1717,6 @@ edges
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
-| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
-| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -439,26 +439,6 @@ nodes
 | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
-| tst3.js:2:23:2:74 | decodeU ... str(1)) |
-| tst3.js:2:42:2:63 | window. ... .search |
-| tst3.js:2:42:2:63 | window. ... .search |
-| tst3.js:2:42:2:73 | window. ... bstr(1) |
-| tst3.js:4:25:4:28 | data |
-| tst3.js:4:25:4:32 | data.src |
-| tst3.js:4:25:4:32 | data.src |
-| tst3.js:5:26:5:29 | data |
-| tst3.js:5:26:5:31 | data.p |
-| tst3.js:5:26:5:31 | data.p |
-| tst3.js:7:32:7:35 | data |
-| tst3.js:7:32:7:37 | data.p |
-| tst3.js:7:32:7:37 | data.p |
-| tst3.js:9:37:9:40 | data |
-| tst3.js:9:37:9:42 | data.p |
-| tst3.js:9:37:9:42 | data.p |
-| tst3.js:10:38:10:41 | data |
-| tst3.js:10:38:10:43 | data.p |
-| tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search |
@@ -1227,25 +1207,6 @@ edges
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:5:26:5:29 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:7:32:7:35 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:9:37:9:40 | data |
-| tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:10:38:10:41 | data |
-| tst3.js:2:23:2:74 | decodeU ... str(1)) | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
-| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
-| tst3.js:2:42:2:63 | window. ... .search | tst3.js:2:42:2:73 | window. ... bstr(1) |
-| tst3.js:2:42:2:73 | window. ... bstr(1) | tst3.js:2:23:2:74 | decodeU ... str(1)) |
-| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
-| tst3.js:4:25:4:28 | data | tst3.js:4:25:4:32 | data.src |
-| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
-| tst3.js:5:26:5:29 | data | tst3.js:5:26:5:31 | data.p |
-| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
-| tst3.js:7:32:7:35 | data | tst3.js:7:32:7:37 | data.p |
-| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
-| tst3.js:9:37:9:40 | data | tst3.js:9:37:9:42 | data.p |
-| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
-| tst3.js:10:38:10:41 | data | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:5:18:5:23 | target |
 | tst.js:2:7:2:39 | target | tst.js:12:28:12:33 | target |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -1,18 +1,28 @@
 nodes
 | addEventListener.js:1:43:1:47 | event |
 | addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:1:43:1:47 | event |
+| addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:5:43:5:48 | {data} |
 | addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:43:5:48 | {data} |
+| addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:10:21:10:25 | event |
 | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
@@ -20,6 +30,8 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params |
+| angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:25:44:25:74 | this.ro ... yParams |
@@ -32,32 +44,41 @@ nodes
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
+| angular2-client.ts:27:44:27:82 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:28:44:28:87 | this.ro ... ('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
 | angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:30:46:30:59 | map.get('foo') |
+| angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:33:44:33:74 | this.ro ... 1].path |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
+| angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
 | angular2-client.ts:44:44:44:76 | routeSn ... ('foo') |
@@ -92,124 +113,194 @@ nodes
 | classnames.js:15:52:15:62 | window.name |
 | classnames.js:15:52:15:62 | window.name |
 | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
 | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:29:19:29:54 | e.clipb ... /html') |
+| clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | clipboard.ts:33:19:33:68 | e.origi ... /html') |
 | d3.js:4:12:4:22 | window.name |
 | d3.js:4:12:4:22 | window.name |
+| d3.js:4:12:4:22 | window.name |
+| d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:11:15:11:24 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
 | d3.js:12:20:12:29 | getTaint() |
+| d3.js:12:20:12:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
 | d3.js:14:20:14:29 | getTaint() |
+| d3.js:14:20:14:29 | getTaint() |
+| d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint |
+| dates.js:9:9:9:69 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:55 | window.location.hash |
 | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:42:11:68 | dateFns ...  taint) |
+| dates.js:11:63:11:67 | taint |
 | dates.js:11:63:11:67 | taint |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:42:12:71 | dateFns ...  taint) |
+| dates.js:12:66:12:70 | taint |
 | dates.js:12:66:12:70 | taint |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:42:13:70 | dateFns ... )(time) |
+| dates.js:13:59:13:63 | taint |
 | dates.js:13:59:13:63 | taint |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:42:16:67 | moment( ... (taint) |
+| dates.js:16:62:16:66 | taint |
 | dates.js:16:62:16:66 | taint |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:42:18:64 | datefor ...  taint) |
+| dates.js:18:59:18:63 | taint |
 | dates.js:18:59:18:63 | taint |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint |
+| dates.js:21:61:21:65 | taint |
 | dates.js:30:9:30:69 | taint |
+| dates.js:30:9:30:69 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:55 | window.location.hash |
 | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:42:37:82 | dateFns ...  taint) |
+| dates.js:37:77:37:81 | taint |
 | dates.js:37:77:37:81 | taint |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:42:38:82 | luxon.f ...  taint) |
+| dates.js:38:77:38:81 | taint |
 | dates.js:38:77:38:81 | taint |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:42:39:84 | moment. ...  taint) |
+| dates.js:39:79:39:83 | taint |
 | dates.js:39:79:39:83 | taint |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint |
+| dates.js:40:77:40:81 | taint |
 | dates.js:46:9:46:69 | taint |
+| dates.js:46:9:46:69 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:55 | window.location.hash |
 | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:42:48:88 | DateTim ... (taint) |
+| dates.js:48:83:48:87 | taint |
 | dates.js:48:83:48:87 | taint |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:42:49:87 | new Dat ... (taint) |
+| dates.js:49:82:49:86 | taint |
 | dates.js:49:82:49:86 | taint |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint |
+| dates.js:50:97:50:101 | taint |
 | dates.js:54:9:54:69 | taint |
+| dates.js:54:9:54:69 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:55 | window.location.hash |
 | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:42:57:99 | moment. ... (taint) |
+| dates.js:57:94:57:98 | taint |
 | dates.js:57:94:57:98 | taint |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:42:59:85 | luxon.e ... (taint) |
+| dates.js:59:80:59:84 | taint |
 | dates.js:59:80:59:84 | taint |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | event-handler-receiver.js:2:49:2:61 | location.href |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
 | express.js:7:15:7:33 | req.param("wobble") |
+| express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search |
-| jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:2:17:2:40 | documen ... .search |
 | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -242,38 +333,55 @@ nodes
 | jquery.js:21:5:21:8 | hash |
 | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:22:5:22:8 | hash |
+| jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash |
 | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:24:5:24:8 | hash |
+| jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:28:5:28:26 | window. ... .search |
 | jquery.js:28:5:28:26 | window. ... .search |
+| jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash |
 | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:7:17:7:35 | req.param("wobble") |
 | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:9:16:9:20 | taint |
 | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt.js:4:36:4:39 | data |
 | jwt.js:4:36:4:39 | data |
 | jwt.js:4:36:4:39 | data |
 | jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:19:5:34 | jwt_decode(data) |
 | jwt.js:5:19:5:34 | jwt_decode(data) |
 | jwt.js:5:30:5:33 | data |
+| jwt.js:5:30:5:33 | data |
+| jwt.js:6:14:6:20 | decoded |
 | jwt.js:6:14:6:20 | decoded |
 | jwt.js:6:14:6:20 | decoded |
 | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -320,43 +428,67 @@ nodes
 | optionalSanitizer.js:45:41:45:46 | target |
 | optionalSanitizer.js:45:51:45:56 | target |
 | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:8:18:8:24 | tainted |
 | react-native.js:8:18:8:24 | tainted |
+| react-native.js:8:18:8:24 | tainted |
 | react-native.js:9:27:9:33 | tainted |
 | react-native.js:9:27:9:33 | tainted |
+| react-native.js:9:27:9:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:10:22:10:32 | window.name |
+| react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:9:4:49 | state |
+| react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name |
 | react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:4:38:4:48 | window.name |
+| react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name |
 | react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:10:14:10:24 | window.name |
+| react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name |
 | react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:16:20:16:30 | window.name |
+| react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | react-use-state.js:25:20:25:30 | window.name |
 | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:16:17:16:27 | window.name |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -375,6 +507,8 @@ nodes
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search |
@@ -387,6 +521,7 @@ nodes
 | stored-xss.js:8:20:8:48 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') |
+| stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href |
@@ -421,22 +556,36 @@ nodes
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:6:20:6:30 | window.name |
 | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:11:25:11:30 | source |
 | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search |
 | translate.js:6:16:6:39 | documen ... .search |
+| translate.js:7:7:7:61 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:47 | target |
 | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:9:27:9:38 | searchParams |
+| translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:9:27:9:50 | searchP ... 'term') |
 | trusted-types.js:2:66:2:66 | x |
+| trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
 | trusted-types.js:3:24:3:34 | window.name |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) |
@@ -460,27 +609,38 @@ nodes
 | tst3.js:10:38:10:43 | data.p |
 | tst3.js:10:38:10:43 | data.p |
 | tst.js:2:7:2:39 | target |
-| tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search |
-| tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:2:16:2:39 | documen ... .search |
 | tst.js:5:18:5:23 | target |
 | tst.js:5:18:5:23 | target |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target |
+| tst.js:17:7:17:56 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location |
 | tst.js:17:25:17:41 | document.location |
+| tst.js:18:18:18:23 | params |
 | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:47 | target |
 | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:21:18:21:29 | searchParams |
+| tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target |
@@ -498,18 +658,25 @@ nodes
 | tst.js:40:20:40:43 | documen ... .search |
 | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search |
 | tst.js:46:21:46:44 | documen ... .search |
+| tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:54:21:54:44 | documen ... .search |
 | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:56:21:56:44 | documen ... .search |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() |
 | tst.js:60:34:60:34 | s |
@@ -552,11 +719,19 @@ nodes
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
+| tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:34 | documen ... .search |
 | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:110:18:110:18 | v |
 | tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:110:18:110:18 | v |
+| tst.js:136:18:136:18 | v |
+| tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:136:18:136:18 | v |
 | tst.js:148:29:148:50 | window. ... .search |
@@ -626,9 +801,12 @@ nodes
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
 | tst.js:259:7:259:17 | window.name |
+| tst.js:259:7:259:17 | window.name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
 | tst.js:260:7:260:10 | name |
+| tst.js:260:7:260:10 | name |
+| tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
 | tst.js:264:11:264:21 | window.name |
@@ -636,8 +814,11 @@ nodes
 | tst.js:280:22:280:29 | location |
 | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted |
+| tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name |
 | tst.js:285:19:285:29 | window.name |
+| tst.js:285:19:285:29 | window.name |
+| tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:288:59:288:65 | tainted |
 | tst.js:301:9:301:16 | location |
@@ -655,11 +836,17 @@ nodes
 | tst.js:316:35:316:42 | location |
 | tst.js:327:18:327:34 | document.location |
 | tst.js:327:18:327:34 | document.location |
+| tst.js:331:7:331:43 | params |
+| tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:332:18:332:23 | params |
+| tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:341:20:341:36 | document.location |
 | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target |
@@ -704,9 +891,15 @@ nodes
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
+| tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:36 | window.location.hash |
 | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:417:18:417:24 | payload |
+| tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:417:18:417:24 | payload |
 | tst.js:419:7:419:55 | match |
@@ -719,6 +912,10 @@ nodes
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:37 | window.location.hash |
 | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target |
@@ -771,19 +968,12 @@ nodes
 | tst.js:475:25:475:27 | url |
 | tst.js:476:20:476:22 | url |
 | tst.js:476:20:476:22 | url |
-| tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:479:43:479:45 | url |
-| tst.js:481:20:481:45 | ["http: ... ", url] |
-| tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:42:481:44 | url |
-| tst.js:484:22:484:24 | url |
-| tst.js:484:22:484:24 | url |
 | tst.js:486:22:486:24 | url |
 | tst.js:486:22:486:24 | url |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
+| typeahead.js:9:28:9:30 | loc |
+| typeahead.js:10:16:10:18 | loc |
 | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:20:13:20:45 | target |
@@ -839,46 +1029,84 @@ nodes
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:7:2:53 | tainted |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:40 | documen ... .search |
 | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:3:43:3:49 | tainted |
 | winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:3:43:3:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
+| winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 | winjs.js:4:43:4:49 | tainted |
 | xmlRequest.js:8:13:8:47 | json |
+| xmlRequest.js:8:13:8:47 | json |
+| xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
 | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
 | xmlRequest.js:8:31:8:46 | xhr.responseText |
 | xmlRequest.js:8:31:8:46 | xhr.responseText |
+| xmlRequest.js:8:31:8:46 | xhr.responseText |
+| xmlRequest.js:9:28:9:31 | json |
 | xmlRequest.js:9:28:9:31 | json |
 | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:9:28:9:39 | json.message |
+| xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:20:11:20:48 | resp |
+| xmlRequest.js:20:11:20:48 | resp |
+| xmlRequest.js:20:18:20:48 | await g ... rl }}") |
 | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") |
+| xmlRequest.js:20:24:20:48 | got.get ... rl }}") |
+| xmlRequest.js:21:11:21:38 | json |
 | xmlRequest.js:21:11:21:38 | json |
 | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:21:29:21:32 | resp |
 | xmlRequest.js:21:29:21:32 | resp |
 | xmlRequest.js:21:29:21:37 | resp.body |
+| xmlRequest.js:21:29:21:37 | resp.body |
 | xmlRequest.js:22:24:22:27 | json |
+| xmlRequest.js:22:24:22:27 | json |
+| xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:35 | json.message |
 edges
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
 | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:24 | event |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
+| addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:2:20:2:24 | event | addEventListener.js:2:20:2:29 | event.data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
 | addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | data | addEventListener.js:6:20:6:23 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
+| addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:5:44:5:47 | data |
 | addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
+| addEventListener.js:5:44:5:47 | data | addEventListener.js:5:43:5:48 | data |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
 | addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:10:21:10:25 | event | addEventListener.js:12:24:12:28 | event |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
+| addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | addEventListener.js:12:24:12:28 | event | addEventListener.js:12:24:12:33 | event.data |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
+| angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params | angular2-client.ts:24:44:24:73 | this.ro ... ams.foo |
@@ -896,7 +1124,13 @@ edges
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
+| angular2-client.ts:34:44:34:80 | this.ro ... ameters | angular2-client.ts:34:44:34:82 | this.ro ... eters.x |
 | angular2-client.ts:35:44:35:91 | this.ro ... et('x') | angular2-client.ts:35:44:35:91 | this.ro ... et('x') |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
+| angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
 | angular2-client.ts:36:44:36:89 | this.ro ... .params | angular2-client.ts:36:44:36:91 | this.ro ... arams.x |
@@ -930,6 +1164,10 @@ edges
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
+| clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') | clipboard.ts:24:23:24:58 | e.clipb ... /html') |
@@ -939,6 +1177,12 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:11:15:11:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:12:20:12:29 | getTaint() |
@@ -947,90 +1191,178 @@ edges
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:14:20:14:29 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
+| d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | d3.js:4:12:4:22 | window.name | d3.js:21:15:21:24 | getTaint() |
 | dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:11:63:11:67 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:12:66:12:70 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:13:59:13:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:16:62:16:66 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:18:59:18:63 | taint |
 | dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:9:9:69 | taint | dates.js:21:61:21:65 | taint |
+| dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:17:9:69 | decodeU ... ing(1)) | dates.js:9:9:9:69 | taint |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
 | dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:55 | window.location.hash | dates.js:9:36:9:68 | window. ... ring(1) |
+| dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:9:36:9:68 | window. ... ring(1) | dates.js:9:17:9:69 | decodeU ... ing(1)) |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
 | dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:42:11:68 | dateFns ...  taint) | dates.js:11:31:11:70 | `Time i ... aint)}` |
+| dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:11:63:11:67 | taint | dates.js:11:42:11:68 | dateFns ...  taint) |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
 | dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:42:12:71 | dateFns ...  taint) | dates.js:12:31:12:73 | `Time i ... aint)}` |
+| dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:12:66:12:70 | taint | dates.js:12:42:12:71 | dateFns ...  taint) |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
 | dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:42:13:70 | dateFns ... )(time) | dates.js:13:31:13:72 | `Time i ... time)}` |
+| dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:13:59:13:63 | taint | dates.js:13:42:13:70 | dateFns ... )(time) |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
 | dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:42:16:67 | moment( ... (taint) | dates.js:16:31:16:69 | `Time i ... aint)}` |
+| dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:16:62:16:66 | taint | dates.js:16:42:16:67 | moment( ... (taint) |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
 | dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:42:18:64 | datefor ...  taint) | dates.js:18:31:18:66 | `Time i ... aint)}` |
+| dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:18:59:18:63 | taint | dates.js:18:42:18:64 | datefor ...  taint) |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
 | dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:42:21:66 | dayjs(t ... (taint) | dates.js:21:31:21:68 | `Time i ... aint)}` |
+| dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:21:61:21:65 | taint | dates.js:21:42:21:66 | dayjs(t ... (taint) |
 | dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:37:77:37:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:38:77:38:81 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:39:79:39:83 | taint |
 | dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:9:30:69 | taint | dates.js:40:77:40:81 | taint |
+| dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:17:30:69 | decodeU ... ing(1)) | dates.js:30:9:30:69 | taint |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
 | dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:55 | window.location.hash | dates.js:30:36:30:68 | window. ... ring(1) |
+| dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:30:36:30:68 | window. ... ring(1) | dates.js:30:17:30:69 | decodeU ... ing(1)) |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
 | dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:42:37:82 | dateFns ...  taint) | dates.js:37:31:37:84 | `Time i ... aint)}` |
+| dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:37:77:37:81 | taint | dates.js:37:42:37:82 | dateFns ...  taint) |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
 | dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:42:38:82 | luxon.f ...  taint) | dates.js:38:31:38:84 | `Time i ... aint)}` |
+| dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:38:77:38:81 | taint | dates.js:38:42:38:82 | luxon.f ...  taint) |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
 | dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:42:39:84 | moment. ...  taint) | dates.js:39:31:39:86 | `Time i ... aint)}` |
+| dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:39:79:39:83 | taint | dates.js:39:42:39:84 | moment. ...  taint) |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
 | dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:42:40:82 | dayjs.f ...  taint) | dates.js:40:31:40:84 | `Time i ... aint)}` |
+| dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:40:77:40:81 | taint | dates.js:40:42:40:82 | dayjs.f ...  taint) |
 | dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:48:83:48:87 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:49:82:49:86 | taint |
 | dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:9:46:69 | taint | dates.js:50:97:50:101 | taint |
+| dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:17:46:69 | decodeU ... ing(1)) | dates.js:46:9:46:69 | taint |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
 | dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:55 | window.location.hash | dates.js:46:36:46:68 | window. ... ring(1) |
+| dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:46:36:46:68 | window. ... ring(1) | dates.js:46:17:46:69 | decodeU ... ing(1)) |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
 | dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:42:48:88 | DateTim ... (taint) | dates.js:48:31:48:90 | `Time i ... aint)}` |
+| dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:48:83:48:87 | taint | dates.js:48:42:48:88 | DateTim ... (taint) |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
 | dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:42:49:87 | new Dat ... (taint) | dates.js:49:31:49:89 | `Time i ... aint)}` |
+| dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:49:82:49:86 | taint | dates.js:49:42:49:87 | new Dat ... (taint) |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
 | dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:42:50:102 | DateTim ... (taint) | dates.js:50:31:50:104 | `Time i ... aint)}` |
+| dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:50:97:50:101 | taint | dates.js:50:42:50:102 | DateTim ... (taint) |
 | dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:57:94:57:98 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:59:80:59:84 | taint |
 | dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:9:54:69 | taint | dates.js:61:81:61:85 | taint |
+| dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:17:54:69 | decodeU ... ing(1)) | dates.js:54:9:54:69 | taint |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
 | dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:55 | window.location.hash | dates.js:54:36:54:68 | window. ... ring(1) |
+| dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:54:36:54:68 | window. ... ring(1) | dates.js:54:17:54:69 | decodeU ... ing(1)) |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
 | dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:42:57:99 | moment. ... (taint) | dates.js:57:31:57:101 | `Time i ... aint)}` |
+| dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:57:94:57:98 | taint | dates.js:57:42:57:99 | moment. ... (taint) |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
 | dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:42:59:85 | luxon.e ... (taint) | dates.js:59:31:59:87 | `Time i ... aint)}` |
+| dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:59:80:59:84 | taint | dates.js:59:42:59:85 | luxon.e ... (taint) |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
+| dates.js:61:42:61:86 | dayjs.s ... (taint) | dates.js:61:31:61:88 | `Time i ... aint)}` |
 | dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| dates.js:61:81:61:85 | taint | dates.js:61:42:61:86 | dayjs.s ... (taint) |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
@@ -1038,8 +1370,6 @@ edges
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
-| jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:2:17:2:40 | documen ... .search | jquery.js:2:7:2:40 | tainted |
 | jquery.js:7:20:7:26 | tainted | jquery.js:7:5:7:34 | "<div i ... + "\\">" |
@@ -1072,14 +1402,21 @@ edges
 | jquery.js:18:14:18:33 | window.location.hash | jquery.js:18:7:18:33 | hash |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
 | jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:21:5:21:8 | hash | jquery.js:21:5:21:21 | hash.substring(1) |
+| jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:22:5:22:8 | hash | jquery.js:22:5:22:25 | hash.su ... (1, 10) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
 | jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:23:5:23:8 | hash | jquery.js:23:5:23:18 | hash.substr(1) |
+| jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:24:5:24:8 | hash | jquery.js:24:5:24:17 | hash.slice(1) |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
 | jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:27:5:27:8 | hash | jquery.js:27:5:27:25 | hash.re ... #', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
+| jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
 | jquery.js:28:5:28:26 | window. ... .search | jquery.js:28:5:28:43 | window. ... ?', '') |
@@ -1087,17 +1424,30 @@ edges
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jquery.js:34:13:34:16 | hash | jquery.js:34:5:34:25 | '<b>' + ...  '</b>' |
 | jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:9:7:35 | taint | jwt-server.js:9:16:9:20 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
+| jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:7:17:7:35 | req.param("wobble") | jwt-server.js:7:9:7:35 | taint |
 | jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:16:9:20 | taint | jwt-server.js:9:55:9:61 | decoded |
+| jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:9:55:9:61 | decoded | jwt-server.js:11:19:11:25 | decoded |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
+| jwt-server.js:11:19:11:25 | decoded | jwt-server.js:11:19:11:29 | decoded.foo |
 | jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
 | jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
+| jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
+| jwt.js:4:36:4:39 | data | jwt.js:5:30:5:33 | data |
+| jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
+| jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
 | jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
 | jwt.js:5:9:5:34 | decoded | jwt.js:6:14:6:20 | decoded |
 | jwt.js:5:19:5:34 | jwt_decode(data) | jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:19:5:34 | jwt_decode(data) | jwt.js:5:9:5:34 | decoded |
+| jwt.js:5:30:5:33 | data | jwt.js:5:19:5:34 | jwt_decode(data) |
 | jwt.js:5:30:5:33 | data | jwt.js:5:19:5:34 | jwt_decode(data) |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
 | nodemailer.js:13:50:13:66 | req.query.message | nodemailer.js:13:11:13:69 | `Hi, yo ... sage}.` |
@@ -1148,30 +1498,56 @@ edges
 | optionalSanitizer.js:45:51:45:56 | target | optionalSanitizer.js:45:18:45:56 | sanitiz ...  target |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:8:18:8:24 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:7:7:33 | tainted | react-native.js:9:27:9:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
+| react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") | react-native.js:7:7:7:33 | tainted |
 | react-use-context.js:10:22:10:32 | window.name | react-use-context.js:10:22:10:32 | window.name |
 | react-use-context.js:16:26:16:36 | window.name | react-use-context.js:16:26:16:36 | window.name |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
 | react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:9:4:49 | state | react-use-state.js:5:51:5:55 | state |
+| react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:10:4:14 | state | react-use-state.js:4:9:4:49 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
 | react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:4:38:4:48 | window.name | react-use-state.js:4:10:4:14 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
+| react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:9:9:43 | state | react-use-state.js:11:51:11:55 | state |
 | react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
+| react-use-state.js:9:10:9:14 | state | react-use-state.js:9:9:9:43 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
 | react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:10:14:10:24 | window.name | react-use-state.js:9:10:9:14 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
+| react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:9:15:43 | state | react-use-state.js:17:51:17:55 | state |
 | react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:15:10:15:14 | state | react-use-state.js:15:9:15:43 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
+| react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:15:10:15:14 | state |
 | react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
+| react-use-state.js:21:10:21:14 | state | react-use-state.js:22:14:22:17 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
+| react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:23:29:23:35 | tainted |
@@ -1180,6 +1556,9 @@ edges
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
+| sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' |
@@ -1192,6 +1571,8 @@ edges
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
+| sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') |
 | stored-xss.js:2:39:2:62 | documen ... .search | stored-xss.js:5:20:5:52 | session ... ssion') |
@@ -1206,6 +1587,7 @@ edges
 | stored-xss.js:3:35:3:58 | documen ... .search | stored-xss.js:10:16:10:44 | localSt ... local') |
 | stored-xss.js:10:9:10:44 | href | stored-xss.js:12:35:12:38 | href |
 | stored-xss.js:10:16:10:44 | localSt ... local') | stored-xss.js:10:9:10:44 | href |
+| stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | stored-xss.js:12:35:12:38 | href | stored-xss.js:12:20:12:54 | "<a hre ... ar</a>" |
 | string-manipulations.js:3:16:3:32 | document.location | string-manipulations.js:3:16:3:32 | document.location |
@@ -1236,18 +1618,40 @@ edges
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:10:25:10:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
 | tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:11:6:30 | source | tooltip.jsx:11:25:11:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
+| tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | tooltip.jsx:6:20:6:30 | window.name | tooltip.jsx:6:11:6:30 | source |
 | translate.js:6:7:6:39 | target | translate.js:7:42:7:47 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
 | translate.js:6:16:6:39 | documen ... .search | translate.js:6:7:6:39 | target |
+| translate.js:7:7:7:61 | searchParams | translate.js:9:27:9:38 | searchParams |
+| translate.js:7:22:7:61 | new URL ... ing(1)) | translate.js:7:7:7:61 | searchParams |
 | translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:47 | target | translate.js:7:42:7:60 | target.substring(1) |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:7:22:7:61 | new URL ... ing(1)) |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
 | translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:7:42:7:60 | target.substring(1) | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
+| translate.js:9:27:9:38 | searchParams | translate.js:9:27:9:50 | searchP ... 'term') |
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
 | trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:2:66:2:66 | x | trusted-types.js:2:71:2:71 | x |
+| trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
+| trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | trusted-types.js:3:24:3:34 | window.name | trusted-types.js:2:66:2:66 | x |
 | tst3.js:2:12:2:75 | JSON.pa ... tr(1))) | tst3.js:4:25:4:28 | data |
@@ -1275,21 +1679,43 @@ edges
 | tst.js:2:7:2:39 | target | tst.js:20:42:20:47 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
-| tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |
+| tst.js:17:7:17:56 | params | tst.js:18:18:18:23 | params |
+| tst.js:17:16:17:56 | (new UR ... hParams | tst.js:17:7:17:56 | params |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
+| tst.js:17:25:17:41 | document.location | tst.js:17:16:17:56 | (new UR ... hParams |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
 | tst.js:17:25:17:41 | document.location | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:18:18:18:23 | params | tst.js:18:18:18:35 | params.get('name') |
+| tst.js:20:7:20:61 | searchParams | tst.js:21:18:21:29 | searchParams |
+| tst.js:20:22:20:61 | new URL ... ing(1)) | tst.js:20:7:20:61 | searchParams |
 | tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:47 | target | tst.js:20:42:20:60 | target.substring(1) |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:20:22:20:61 | new URL ... ing(1)) |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:20:42:20:60 | target.substring(1) | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
+| tst.js:21:18:21:29 | searchParams | tst.js:21:18:21:41 | searchP ... 'name') |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:24:14:24:19 | target | tst.js:26:18:26:23 | target |
 | tst.js:28:5:28:28 | documen ... .search | tst.js:24:14:24:19 | target |
@@ -1312,16 +1738,30 @@ edges
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
+| tst.js:46:21:46:44 | documen ... .search | tst.js:46:16:46:45 | wrap(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
 | tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:54:21:54:44 | documen ... .search | tst.js:54:16:54:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
+| tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:56:21:56:44 | documen ... .search | tst.js:56:16:56:45 | chop(do ... search) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
 | tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:21:58:31 | chop(bar()) | tst.js:58:16:58:32 | wrap(chop(bar())) |
+| tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:58:26:58:30 | bar() | tst.js:58:21:58:31 | chop(bar()) |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
 | tst.js:60:34:60:34 | s | tst.js:62:18:62:18 | s |
@@ -1346,10 +1786,24 @@ edges
 | tst.js:102:25:102:48 | documen ... .search | tst.js:102:25:102:48 | documen ... .search |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:110:18:110:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
+| tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:7:107:44 | v | tst.js:136:18:136:18 | v |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
 | tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:34 | documen ... .search | tst.js:107:11:107:44 | documen ... bstr(1) |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
+| tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:107:11:107:44 | documen ... bstr(1) | tst.js:107:7:107:44 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
 | tst.js:148:29:148:50 | window. ... .search | tst.js:151:29:151:29 | v |
@@ -1417,6 +1871,10 @@ edges
 | tst.js:280:22:280:29 | location | tst.js:280:22:280:29 | location |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
 | tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:9:285:29 | tainted | tst.js:288:59:288:65 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
+| tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:285:19:285:29 | window.name | tst.js:285:9:285:29 | tainted |
 | tst.js:301:9:301:16 | location | tst.js:302:10:302:10 | e |
@@ -1428,12 +1886,20 @@ edges
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:310:10:310:10 | e | tst.js:311:20:311:20 | e |
 | tst.js:316:35:316:42 | location | tst.js:316:35:316:42 | location |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
+| tst.js:327:18:327:34 | document.location | tst.js:331:16:331:43 | getTain ... hParams |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:327:18:327:34 | document.location | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:331:7:331:43 | params | tst.js:332:18:332:23 | params |
+| tst.js:331:16:331:43 | getTain ... hParams | tst.js:331:7:331:43 | params |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
+| tst.js:332:18:332:23 | params | tst.js:332:18:332:35 | params.get('name') |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
 | tst.js:341:20:341:36 | document.location | tst.js:343:5:343:17 | getUrl().hash |
+| tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:343:5:343:17 | getUrl().hash | tst.js:343:5:343:30 | getUrl( ... ring(1) |
 | tst.js:348:7:348:39 | target | tst.js:349:12:349:17 | target |
@@ -1476,8 +1942,18 @@ edges
 | tst.js:408:19:408:31 | target.taint8 | tst.js:409:18:409:30 | target.taint8 |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
+| tst.js:416:7:416:46 | payload | tst.js:417:18:417:24 | payload |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
 | tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:36 | window.location.hash | tst.js:416:17:416:46 | window. ... bstr(1) |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
+| tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:416:17:416:46 | window. ... bstr(1) | tst.js:416:7:416:46 | payload |
 | tst.js:419:7:419:55 | match | tst.js:421:20:421:24 | match |
 | tst.js:419:15:419:34 | window.location.hash | tst.js:419:15:419:55 | window. ... (\\w+)/) |
@@ -1487,6 +1963,14 @@ edges
 | tst.js:421:20:421:24 | match | tst.js:421:20:421:27 | match[1] |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
 | tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:37 | window.location.hash | tst.js:424:18:424:48 | window. ... it('#') |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
+| tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:424:18:424:48 | window. ... it('#') | tst.js:424:18:424:51 | window. ... '#')[1] |
 | tst.js:428:7:428:39 | target | tst.js:430:18:430:23 | target |
@@ -1531,20 +2015,14 @@ edges
 | tst.js:471:7:471:46 | url | tst.js:475:25:475:27 | url |
 | tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
 | tst.js:471:7:471:46 | url | tst.js:476:20:476:22 | url |
-| tst.js:471:7:471:46 | url | tst.js:479:43:479:45 | url |
-| tst.js:471:7:471:46 | url | tst.js:481:42:481:44 | url |
-| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
-| tst.js:471:7:471:46 | url | tst.js:484:22:484:24 | url |
 | tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
 | tst.js:471:7:471:46 | url | tst.js:486:22:486:24 | url |
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:36 | documen ... .search | tst.js:471:13:471:46 | documen ... bstr(1) |
 | tst.js:471:13:471:46 | documen ... bstr(1) | tst.js:471:7:471:46 | url |
-| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:479:43:479:45 | url | tst.js:479:20:479:45 | "http:/ ... " + url |
-| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:20:481:45 | ["http: ... ", url] | tst.js:481:20:481:55 | ["http: ... in("/") |
-| tst.js:481:42:481:44 | url | tst.js:481:20:481:45 | ["http: ... ", url] |
+| typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
+| typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
+| typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
@@ -1599,25 +2077,55 @@ edges
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
+| winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) |
 | winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
+| winjs.js:2:17:2:53 | documen ... ring(1) | winjs.js:2:7:2:53 | tainted |
 | xmlRequest.js:8:13:8:47 | json | xmlRequest.js:9:28:9:31 | json |
+| xmlRequest.js:8:13:8:47 | json | xmlRequest.js:9:28:9:31 | json |
+| xmlRequest.js:8:20:8:47 | JSON.pa ... seText) | xmlRequest.js:8:13:8:47 | json |
 | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) | xmlRequest.js:8:13:8:47 | json |
 | xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
 | xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
+| xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
+| xmlRequest.js:8:31:8:46 | xhr.responseText | xmlRequest.js:8:20:8:47 | JSON.pa ... seText) |
+| xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
+| xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:9:28:9:31 | json | xmlRequest.js:9:28:9:39 | json.message |
 | xmlRequest.js:20:11:20:48 | resp | xmlRequest.js:21:29:21:32 | resp |
+| xmlRequest.js:20:11:20:48 | resp | xmlRequest.js:21:29:21:32 | resp |
+| xmlRequest.js:20:18:20:48 | await g ... rl }}") | xmlRequest.js:20:11:20:48 | resp |
 | xmlRequest.js:20:18:20:48 | await g ... rl }}") | xmlRequest.js:20:11:20:48 | resp |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
 | xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
+| xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
+| xmlRequest.js:20:24:20:48 | got.get ... rl }}") | xmlRequest.js:20:18:20:48 | await g ... rl }}") |
+| xmlRequest.js:21:11:21:38 | json | xmlRequest.js:22:24:22:27 | json |
 | xmlRequest.js:21:11:21:38 | json | xmlRequest.js:22:24:22:27 | json |
 | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) | xmlRequest.js:21:11:21:38 | json |
+| xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) | xmlRequest.js:21:11:21:38 | json |
+| xmlRequest.js:21:29:21:32 | resp | xmlRequest.js:21:29:21:37 | resp.body |
 | xmlRequest.js:21:29:21:32 | resp | xmlRequest.js:21:29:21:37 | resp.body |
 | xmlRequest.js:21:29:21:37 | resp.body | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:21:29:21:37 | resp.body | xmlRequest.js:21:18:21:38 | JSON.pa ... p.body) |
+| xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
+| xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
 | xmlRequest.js:22:24:22:27 | json | xmlRequest.js:22:24:22:35 | json.message |
 #select

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -28,7 +28,6 @@ nodes
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
-| angular2-client.ts:22:44:22:71 | \\u0275getDOM ... ().href |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
 | angular2-client.ts:24:44:24:69 | this.ro ... .params |
@@ -80,8 +79,6 @@ nodes
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
 | angular2-client.ts:38:44:38:58 | this.router.url |
-| angular2-client.ts:38:44:38:58 | this.router.url |
-| angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
 | angular2-client.ts:40:45:40:59 | this.router.url |
@@ -298,6 +295,7 @@ nodes
 | dates.js:61:42:61:86 | dayjs.s ... (taint) |
 | dates.js:61:81:61:85 | taint |
 | dates.js:61:81:61:85 | taint |
+| event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href |
@@ -537,41 +535,28 @@ nodes
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
 | string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:4:16:4:37 | documen ... on.href |
-| string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:37 | documen ... on.href |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:37 | documen ... on.href |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:37 | documen ... on.href |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:37 | documen ... on.href |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:9:36:9:57 | documen ... on.href |
-| string-manipulations.js:9:36:9:57 | documen ... on.href |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | string-manipulations.js:10:23:10:44 | documen ... on.href |
 | tooltip.jsx:6:11:6:30 | source |
@@ -634,8 +619,10 @@ nodes
 | tst.js:5:18:5:23 | target |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:58 | documen ... on.href |
 | tst.js:8:37:8:58 | documen ... on.href |
+| tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
 | tst.js:12:5:12:42 | '<div s ...  'px">' |
@@ -1385,6 +1372,8 @@ edges
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
+| event-handler-receiver.js:2:49:2:61 | location.href | event-handler-receiver.js:2:31:2:83 | '<h2><a ... ></h2>' |
 | express.js:7:15:7:33 | req.param("wobble") | express.js:7:15:7:33 | req.param("wobble") |
 | jquery.js:2:7:2:40 | tainted | jquery.js:7:20:7:26 | tainted |
 | jquery.js:2:7:2:40 | tainted | jquery.js:8:28:8:34 | tainted |
@@ -1614,12 +1603,6 @@ edges
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
 | string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:5:16:5:37 | documen ... on.href | string-manipulations.js:5:16:5:47 | documen ... lueOf() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
-| string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
 | string-manipulations.js:6:16:6:37 | documen ... on.href | string-manipulations.js:6:16:6:43 | documen ... f.sup() |
@@ -1628,12 +1611,6 @@ edges
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
 | string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:7:16:7:37 | documen ... on.href | string-manipulations.js:7:16:7:51 | documen ... rCase() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
-| string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
 | string-manipulations.js:8:16:8:37 | documen ... on.href | string-manipulations.js:8:16:8:48 | documen ... mLeft() |
@@ -1642,12 +1619,6 @@ edges
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
 | string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:9:36:9:57 | documen ... on.href | string-manipulations.js:9:16:9:58 | String. ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
-| string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
 | string-manipulations.js:10:23:10:44 | documen ... on.href | string-manipulations.js:10:16:10:45 | String( ... n.href) |
@@ -1717,6 +1688,11 @@ edges
 | tst.js:2:16:2:39 | documen ... .search | tst.js:2:7:2:39 | target |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
 | tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:58 | documen ... on.href | tst.js:8:37:8:114 | documen ... t=")+8) |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
+| tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:8:37:8:114 | documen ... t=")+8) | tst.js:8:18:8:126 | "<OPTIO ... PTION>" |
 | tst.js:12:28:12:33 | target | tst.js:12:5:12:42 | '<div s ...  'px">' |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -466,3 +466,25 @@ function domMethods() {
   let cell = row.insertCell();
   cell.innerHTML = source; // NOT OK
 }
+
+function urlStuff() {
+  var url = document.location.search.substr(1);
+
+  $("<a>", {href: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+  $("#foo").attr("href", url); // NOT OK - but not detected [INCONSISTENCY]
+  $("#foo").attr({href: url}); // NOT OK - but not detected [INCONSISTENCY]
+  $("<img>", {src: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+  $("<a>", {href: win.location.href}).appendTo("body"); // OK
+
+  $("<img>", {src: "http://google.com/" + url}).appendTo("body"); // OK
+
+  $("<img>", {src: ["http://google.com", url].join("/")}).appendTo("body"); // OK
+
+  if (url.startsWith("https://")) {
+    $("<img>", {src: url}).appendTo("body"); // OK
+  } else {
+    $("<img>", {src: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+  }
+
+  window.open(location.hash.substr(1)); // OK - any JavaScript is executed in another context
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -470,20 +470,20 @@ function domMethods() {
 function urlStuff() {
   var url = document.location.search.substr(1);
 
-  $("<a>", {href: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
-  $("#foo").attr("href", url); // NOT OK - but not detected [INCONSISTENCY]
-  $("#foo").attr({href: url}); // NOT OK - but not detected [INCONSISTENCY]
-  $("<img>", {src: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+  $("<a>", {href: url}).appendTo("body"); // NOT OK
+  $("#foo").attr("href", url); // NOT OK
+  $("#foo").attr({href: url}); // NOT OK
+  $("<img>", {src: url}).appendTo("body"); // NOT OK
   $("<a>", {href: win.location.href}).appendTo("body"); // OK
 
-  $("<img>", {src: "http://google.com/" + url}).appendTo("body"); // OK
+  $("<img>", {src: "http://google.com/" + url}).appendTo("body"); // OK - but flagged [INCONSISTENCY]
 
-  $("<img>", {src: ["http://google.com", url].join("/")}).appendTo("body"); // OK
+  $("<img>", {src: ["http://google.com", url].join("/")}).appendTo("body"); // OK - but flagged [INCONSISTENCY]
 
   if (url.startsWith("https://")) {
-    $("<img>", {src: url}).appendTo("body"); // OK
+    $("<img>", {src: url}).appendTo("body"); // OK - but flagged [INCONSISTENCY]
   } else {
-    $("<img>", {src: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+    $("<img>", {src: url}).appendTo("body"); // NOT OK
   }
 
   window.open(location.hash.substr(1)); // OK - any JavaScript is executed in another context

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst.js
@@ -476,12 +476,12 @@ function urlStuff() {
   $("<img>", {src: url}).appendTo("body"); // NOT OK
   $("<a>", {href: win.location.href}).appendTo("body"); // OK
 
-  $("<img>", {src: "http://google.com/" + url}).appendTo("body"); // OK - but flagged [INCONSISTENCY]
+  $("<img>", {src: "http://google.com/" + url}).appendTo("body"); // OK
 
-  $("<img>", {src: ["http://google.com", url].join("/")}).appendTo("body"); // OK - but flagged [INCONSISTENCY]
+  $("<img>", {src: ["http://google.com", url].join("/")}).appendTo("body"); // OK
 
   if (url.startsWith("https://")) {
-    $("<img>", {src: url}).appendTo("body"); // OK - but flagged [INCONSISTENCY]
+    $("<img>", {src: url}).appendTo("body"); // OK
   } else {
     $("<img>", {src: url}).appendTo("body"); // NOT OK
   }

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst3.js
@@ -1,13 +1,13 @@
 var foo = document.getElementById("foo");
 var data = JSON.parse(decodeURIComponent(window.location.search.substr(1)));
 
-foo.setAttribute("src", data.src); // NOT OK - but not detected [INCONSISTENCY]
-foo.setAttribute("HREF", data.p);  // NOT OK - but not detected [INCONSISTENCY]
+foo.setAttribute("src", data.src); // NOT OK
+foo.setAttribute("HREF", data.p);  // NOT OK
 foo.setAttribute("width", data.w); // OK
-foo.setAttribute("xlink:href", data.p) // NOT OK - but not detected [INCONSISTENCY]
+foo.setAttribute("xlink:href", data.p) // NOT OK
 
-foo.setAttributeNS('xlink', 'href', data.p); // NOT OK - but not detected [INCONSISTENCY]
-foo.setAttributeNS('foobar', 'href', data.p); // NOT OK - but not detected [INCONSISTENCY]
+foo.setAttributeNS('xlink', 'href', data.p); // NOT OK
+foo.setAttributeNS('foobar', 'href', data.p); // NOT OK
 foo.setAttributeNS('baz', 'width', data.w); // OK
 
 

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/tst3.js
@@ -1,13 +1,13 @@
 var foo = document.getElementById("foo");
 var data = JSON.parse(decodeURIComponent(window.location.search.substr(1)));
 
-foo.setAttribute("src", data.src); // NOT OK
-foo.setAttribute("HREF", data.p);  // NOT OK
+foo.setAttribute("src", data.src); // NOT OK - but not detected [INCONSISTENCY]
+foo.setAttribute("HREF", data.p);  // NOT OK - but not detected [INCONSISTENCY]
 foo.setAttribute("width", data.w); // OK
-foo.setAttribute("xlink:href", data.p) // NOT OK
+foo.setAttribute("xlink:href", data.p) // NOT OK - but not detected [INCONSISTENCY]
 
-foo.setAttributeNS('xlink', 'href', data.p); // NOT OK
-foo.setAttributeNS('foobar', 'href', data.p); // NOT OK
+foo.setAttributeNS('xlink', 'href', data.p); // NOT OK - but not detected [INCONSISTENCY]
+foo.setAttributeNS('foobar', 'href', data.p); // NOT OK - but not detected [INCONSISTENCY]
 foo.setAttributeNS('baz', 'width', data.w); // OK
 
 

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/ClientSideUrlRedirect.expected
@@ -147,6 +147,18 @@ nodes
 | tst13.js:72:19:72:49 | history ... bstr(1) |
 | tst13.js:74:21:74:27 | payload |
 | tst13.js:74:21:74:27 | payload |
+| tst13.js:78:9:78:48 | url |
+| tst13.js:78:15:78:38 | documen ... .search |
+| tst13.js:78:15:78:38 | documen ... .search |
+| tst13.js:78:15:78:48 | documen ... bstr(1) |
+| tst13.js:80:21:80:23 | url |
+| tst13.js:80:21:80:23 | url |
+| tst13.js:81:28:81:30 | url |
+| tst13.js:81:28:81:30 | url |
+| tst13.js:82:27:82:29 | url |
+| tst13.js:82:27:82:29 | url |
+| tst13.js:83:22:83:24 | url |
+| tst13.js:83:22:83:24 | url |
 | tst.js:2:19:2:69 | /.*redi ... n.href) |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
@@ -339,6 +351,17 @@ edges
 | tst13.js:72:19:72:39 | history ... on.hash | tst13.js:72:19:72:49 | history ... bstr(1) |
 | tst13.js:72:19:72:39 | history ... on.hash | tst13.js:72:19:72:49 | history ... bstr(1) |
 | tst13.js:72:19:72:49 | history ... bstr(1) | tst13.js:72:9:72:49 | payload |
+| tst13.js:78:9:78:48 | url | tst13.js:80:21:80:23 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:80:21:80:23 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:81:28:81:30 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:81:28:81:30 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:82:27:82:29 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:82:27:82:29 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:83:22:83:24 | url |
+| tst13.js:78:9:78:48 | url | tst13.js:83:22:83:24 | url |
+| tst13.js:78:15:78:38 | documen ... .search | tst13.js:78:15:78:48 | documen ... bstr(1) |
+| tst13.js:78:15:78:38 | documen ... .search | tst13.js:78:15:78:48 | documen ... bstr(1) |
+| tst13.js:78:15:78:48 | documen ... bstr(1) | tst13.js:78:9:78:48 | url |
 | tst.js:2:19:2:69 | /.*redi ... n.href) | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
 | tst.js:2:19:2:69 | /.*redi ... n.href) | tst.js:2:19:2:72 | /.*redi ... ref)[1] |
 | tst.js:2:47:2:63 | document.location | tst.js:2:47:2:68 | documen ... on.href |
@@ -433,6 +456,10 @@ edges
 | tst13.js:61:18:61:24 | payload | tst13.js:59:19:59:42 | documen ... .search | tst13.js:61:18:61:24 | payload | Untrusted URL redirection due to $@. | tst13.js:59:19:59:42 | documen ... .search | user-provided value |
 | tst13.js:67:21:67:27 | payload | tst13.js:65:19:65:39 | history ... on.hash | tst13.js:67:21:67:27 | payload | Untrusted URL redirection due to $@. | tst13.js:65:19:65:39 | history ... on.hash | user-provided value |
 | tst13.js:74:21:74:27 | payload | tst13.js:72:19:72:39 | history ... on.hash | tst13.js:74:21:74:27 | payload | Untrusted URL redirection due to $@. | tst13.js:72:19:72:39 | history ... on.hash | user-provided value |
+| tst13.js:80:21:80:23 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:80:21:80:23 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
+| tst13.js:81:28:81:30 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:81:28:81:30 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
+| tst13.js:82:27:82:29 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:82:27:82:29 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
+| tst13.js:83:22:83:24 | url | tst13.js:78:15:78:38 | documen ... .search | tst13.js:83:22:83:24 | url | Untrusted URL redirection due to $@. | tst13.js:78:15:78:38 | documen ... .search | user-provided value |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] | tst.js:2:47:2:63 | document.location | tst.js:2:19:2:72 | /.*redi ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:2:47:2:63 | document.location | user-provided value |
 | tst.js:2:19:2:72 | /.*redi ... ref)[1] | tst.js:2:47:2:68 | documen ... on.href | tst.js:2:19:2:72 | /.*redi ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:2:47:2:68 | documen ... on.href | user-provided value |
 | tst.js:6:20:6:59 | indirec ... ref)[1] | tst.js:6:34:6:50 | document.location | tst.js:6:20:6:59 | indirec ... ref)[1] | Untrusted URL redirection due to $@. | tst.js:6:34:6:50 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/tst13.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/tst13.js
@@ -77,8 +77,8 @@ function quz() {
 function bar() {
     var url = document.location.search.substr(1);
 
-    $("<a>", {href: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
-    $("#foo").attr("href", url); // NOT OK - but not detected [INCONSISTENCY]
-    $("#foo").attr({href: url}); // NOT OK - but not detected [INCONSISTENCY]
-    $("<img>", {src: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+    $("<a>", {href: url}).appendTo("body"); // NOT OK
+    $("#foo").attr("href", url); // NOT OK
+    $("#foo").attr({href: url}); // NOT OK
+    $("<img>", {src: url}).appendTo("body"); // NOT OK
 }

--- a/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/tst13.js
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ClientSideUrlRedirect/tst13.js
@@ -73,3 +73,12 @@ function quz() {
 
     history.replace(payload); // NOT OK
 }
+
+function bar() {
+    var url = document.location.search.substr(1);
+
+    $("<a>", {href: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+    $("#foo").attr("href", url); // NOT OK - but not detected [INCONSISTENCY]
+    $("#foo").attr({href: url}); // NOT OK - but not detected [INCONSISTENCY]
+    $("<img>", {src: url}).appendTo("body"); // NOT OK - but not detected [INCONSISTENCY]
+}


### PR DESCRIPTION
This PR replaces https://github.com/github/codeql/pull/6632 

See [this comment by Asger](https://github.com/github/codeql/pull/6632#discussion_r705269103) for what this PR tries to fix.  

This is a deep fix where flow-labels are used to hopefully correctly model how url sinks can cause XSS.  

There are now 3 flow labels in the XSS query:   
- TaintedUrlSuffix: a URL where the attacker only controls a suffix.
- Taint: a tainted value where the attacker controls part of the value.
- PrefixLabel: a tainted value where the attacker controls the prefix 

--- 

All tests pass on every commit (the expected files are updated on each commit).  
This should help in doing a commit-by-commit review. 

--- 

[An evaluation looks good](https://github.com/github/codeql-dca-main/tree/data/PR-8304-0-javascript/reports) (I think).  
I like the new alerts, and I don't miss the alerts that got removed.    
(I didn't triage the `xss-through-dom` results). 

(Sidenote: If you think a user-controlled `src=".."` attribute on an `<img/>` tag is safe, then checkout SVG parsing in browsers).  

There is a small performance penalty, but I think we can live with that. 