### PR TITLE
JS: Add query that maps queries to sink type

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
@@ -1,0 +1,22 @@
+import experimental.adaptivethreatmodeling.SqlInjectionATM as SqlInjectionATM
+import experimental.adaptivethreatmodeling.NosqlInjectionATM as NosqlInjectionATM
+import experimental.adaptivethreatmodeling.TaintedPathATM as TaintedPathATM
+import experimental.adaptivethreatmodeling.XssATM as XssATM
+import experimental.adaptivethreatmodeling.AdaptiveThreatModeling
+
+from string query, ATMConfig c, EndpointType e
+where
+  (
+    query = "SqlInjectionATM.ql" and
+    c instanceof SqlInjectionATM::SqlInjectionATMConfig
+    or
+    query = "NosqlInjectionATM.ql" and
+    c instanceof NosqlInjectionATM::NosqlInjectionATMConfig
+    or
+    query = "TaintedPathInjectionATM.ql" and
+    c instanceof TaintedPathATM::TaintedPathATMConfig
+    or
+    query = "XssATM.ql" and c instanceof XssATM::DomBasedXssATMConfig
+  ) and
+  e = c.getASinkEndpointType()
+select query, e.toString() as name, e.getEncoding() as encoding

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
@@ -4,19 +4,19 @@ import experimental.adaptivethreatmodeling.TaintedPathATM as TaintedPathATM
 import experimental.adaptivethreatmodeling.XssATM as XssATM
 import experimental.adaptivethreatmodeling.AdaptiveThreatModeling
 
-from string query, ATMConfig c, EndpointType e
+from string queryName, ATMConfig c, EndpointType e
 where
   (
-    query = "SqlInjectionATM.ql" and
+    queryName = "SqlInjectionATM.ql" and
     c instanceof SqlInjectionATM::SqlInjectionATMConfig
     or
-    query = "NosqlInjectionATM.ql" and
+    queryName = "NosqlInjectionATM.ql" and
     c instanceof NosqlInjectionATM::NosqlInjectionATMConfig
     or
-    query = "TaintedPathInjectionATM.ql" and
+    queryName = "TaintedPathInjectionATM.ql" and
     c instanceof TaintedPathATM::TaintedPathATMConfig
     or
-    query = "XssATM.ql" and c instanceof XssATM::DomBasedXssATMConfig
+    queryName = "XssATM.ql" and c instanceof XssATM::DomBasedXssATMConfig
   ) and
   e = c.getASinkEndpointType()
-select query, e.toString() as name, e.getEncoding() as encoding
+select queryName, e.toString() as endpointType

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
@@ -19,4 +19,4 @@ where
     queryName = "XssATM.ql" and c instanceof XssATM::DomBasedXssATMConfig
   ) and
   e = c.getASinkEndpointType()
-select queryName, e.toString() as endpointType
+select queryName, e.getEncoding() as endpointTypeEncoded


### PR DESCRIPTION
This query produces a mapping between the ATM security query and the type of sink used in that query. This query will be used in the endpoint pipeline to produce a CSV file ready for the modelling code to consume.

It is necessary for when we add the "cheap" `Xss` queries that utilise the same `Xss` sinks.