### PR TITLE
C#: ExternalAPI implementation for Telemetry.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -964,6 +964,9 @@ class ArgumentNode extends Node instanceof ArgumentNodeImpl {
   final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
     super.argumentOf(call, pos)
   }
+
+  /** Gets the call in which this node is an argument. */
+  DataFlowCall getCall() { this.argumentOf(result, _) }
 }
 
 abstract private class ArgumentNodeImpl extends Node {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2038,19 +2038,20 @@ abstract class SyntheticField extends string {
  */
 predicate containerContent(DataFlow::Content c) { c instanceof DataFlow::ElementContent }
 
+/** Gets the string representation of the parameters of `c`. */
+string parameterQualifiedTypeNamesToString(DataFlowCallable c) {
+  result =
+    concat(Parameter p, int i |
+      p = c.getParameter(i)
+    |
+      p.getType().getQualifiedName(), "," order by i
+    )
+}
+
 /**
  * A module containing predicates related to generating models as data.
  */
 module Csv {
-  private string parameterQualifiedTypeNamesToString(DataFlowCallable c) {
-    result =
-      concat(Parameter p, int i |
-        p = c.getParameter(i)
-      |
-        p.getType().getQualifiedName(), "," order by i
-      )
-  }
-
   /** Holds if the summary should apply for all overrides of `c`. */
   predicate isBaseCallableOrPrototype(DataFlowCallable c) {
     c.getDeclaringType() instanceof Interface

--- a/csharp/ql/src/Telemetry/ExternalAPI.qll
+++ b/csharp/ql/src/Telemetry/ExternalAPI.qll
@@ -1,0 +1,99 @@
+/** Provides classes and predicates related to handling APIs from external libraries. */
+
+private import csharp
+private import semmle.code.csharp.dataflow.DataFlow
+private import semmle.code.csharp.dataflow.ExternalFlow
+private import semmle.code.csharp.dataflow.FlowSummary
+private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
+private import semmle.code.csharp.dataflow.TaintTracking
+private import semmle.code.csharp.dataflow.internal.TaintTrackingPrivate
+private import semmle.code.csharp.security.dataflow.flowsources.Remote
+
+/**
+ * An external API from either the C# Standard Library or a 3rd party library.
+ */
+class ExternalAPI extends Callable {
+  ExternalAPI() { this.fromLibrary() }
+
+  /** Holds if this API is not worth supporting */
+  predicate isUninteresting() { this.isTestLibrary() or this.isParameterlessConstructor() }
+
+  /** Holds if this API is is a constructor without parameters */
+  private predicate isParameterlessConstructor() {
+    this instanceof Constructor and this.getNumberOfParameters() = 0
+  }
+
+  /** Holds if this API is part of a common testing library or framework */
+  private predicate isTestLibrary() { this.getDeclaringType() instanceof TestLibrary }
+
+  /**
+   * Gets the unbound type, name and parameter types of this API.
+   */
+  private string getSignature() {
+    result =
+      this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
+        this.parameterTypesToString() + ")"
+  }
+
+  /**
+   * Gets the namespace of this API.
+   */
+  private string getNamespace() { result = this.getDeclaringType().getNamespace().toString() }
+
+  /**
+   * Gets the assembly file name containing this API.
+   */
+  private string getAssembly() { result = this.getFile().getBaseName() }
+
+  /**
+   * Gets the assembly file name and namespace of this API.
+   */
+  string getInfoPrefix() { result = this.getAssembly() + "#" + this.getNamespace() }
+
+  /**
+   * Gets the assembly file name, namespace and signature of this API.
+   */
+  string getInfo() { result = getInfoPrefix() + "#" + getSignature() }
+
+  /** Gets a node that is an input to a call to this API. */
+  private DataFlow::Node getAnInput() {
+    exists(Call call | call.getTarget().getUnboundDeclaration() = this |
+      result.asExpr() = call.getAnArgument()
+    )
+    or
+    result.(ArgumentNode).getCall().getEnclosingCallable() = this
+  }
+
+  /** Gets a node that is an output from a call to this API. */
+  private DataFlow::Node getAnOutput() {
+    exists(Call call | call.getTarget().getUnboundDeclaration() = this | result.asExpr() = call)
+    or
+    result.(PostUpdateNode).getPreUpdateNode().(ArgumentNode).getCall().getEnclosingCallable() =
+      this
+  }
+
+  /** Holds if this API has a supported summary. */
+  private predicate hasSummary() {
+    this.getUnboundDeclaration() = any(SummarizedCallable sc) or
+    defaultAdditionalTaintStep(this.getAnInput(), _)
+  }
+
+  /** Holds if this API is a known source. */
+  predicate isSource() {
+    this.getAnOutput() instanceof RemoteFlowSource or sourceNode(this.getAnOutput(), _)
+  }
+
+  /** Holds if this API is a known sink. */
+  predicate isSink() { sinkNode(this.getAnInput(), _) }
+
+  /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
+  predicate isSupported() { this.hasSummary() or this.isSource() or this.isSink() }
+}
+
+private class TestLibrary extends RefType {
+  TestLibrary() {
+    this.getNamespace()
+        .getName()
+        .matches(["NUnit.Framework%", "Microsoft.VisualStudio.TestTools.UnitTesting%"])
+  }
+}

--- a/csharp/ql/src/Telemetry/ExternalAPI.qll
+++ b/csharp/ql/src/Telemetry/ExternalAPI.qll
@@ -73,7 +73,7 @@ class ExternalAPI extends Callable {
   }
 
   /** Holds if this API has a supported summary. */
-  private predicate hasSummary() {
+  predicate hasSummary() {
     this.getUnboundDeclaration() = any(SummarizedCallable sc) or
     defaultAdditionalTaintStep(this.getAnInput(), _)
   }

--- a/csharp/ql/src/Telemetry/ExternalAPI.qll
+++ b/csharp/ql/src/Telemetry/ExternalAPI.qll
@@ -94,6 +94,6 @@ private class TestLibrary extends RefType {
   TestLibrary() {
     this.getNamespace()
         .getName()
-        .matches(["NUnit.Framework%", "Microsoft.VisualStudio.TestTools.UnitTesting%"])
+        .matches(["NUnit.Framework%", "Xunit%", "Microsoft.VisualStudio.TestTools.UnitTesting%"])
   }
 }

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -5,6 +5,7 @@ private import semmle.code.csharp.dataflow.DataFlow
 private import semmle.code.csharp.dataflow.ExternalFlow
 private import semmle.code.csharp.dataflow.FlowSummary
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
+private import semmle.code.csharp.dataflow.internal.DataFlowDispatch as DataFlowDispatch
 private import semmle.code.csharp.dataflow.TaintTracking
 private import semmle.code.csharp.dataflow.internal.TaintTrackingPrivate
 private import semmle.code.csharp.security.dataflow.flowsources.Remote
@@ -23,7 +24,7 @@ class TestLibrary extends RefType {
 /**
  * An external API from either the C# Standard Library or a 3rd party library.
  */
-class ExternalApi extends Callable {
+class ExternalApi extends DataFlowDispatch::DataFlowCallable {
   ExternalApi() { this.fromLibrary() }
 
   /**
@@ -32,13 +33,13 @@ class ExternalApi extends Callable {
   private string getSignature() {
     result =
       this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
-        this.parameterTypesToString() + ")"
+        parameterQualifiedTypeNamesToString(this) + ")"
   }
 
   /**
    * Gets the namespace of this API.
    */
-  private string getNamespace() { result = this.getDeclaringType().getNamespace().toString() }
+  private string getNamespace() { this.getDeclaringType().hasQualifiedName(result, _) }
 
   /**
    * Gets the assembly file name containing this API.
@@ -74,7 +75,7 @@ class ExternalApi extends Callable {
 
   /** Holds if this API has a supported summary. */
   predicate hasSummary() {
-    this.getUnboundDeclaration() = any(SummarizedCallable sc) or
+    this instanceof SummarizedCallable or
     defaultAdditionalTaintStep(this.getAnInput(), _)
   }
 

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -58,15 +58,18 @@ class ExternalApi extends DataFlowDispatch::DataFlowCallable {
    */
   string getInfo() { result = this.getInfoPrefix() + "#" + this.getSignature() }
 
+  /** Gets a call to this API callable. */
+  DispatchCall getACall() {
+    exists(DataFlowDispatch::NonDelegateDataFlowCall call | call.getDispatchCall() = result |
+      this = result.getADynamicTarget().getUnboundDeclaration()
+      or
+      this = result.getAStaticTarget().getUnboundDeclaration()
+    )
+  }
+
   /** Gets a node that is an input to a call to this API. */
   private ArgumentNode getAnInput() {
-    exists(DispatchCall call |
-      result.getCall().(DataFlowDispatch::NonDelegateDataFlowCall).getDispatchCall() = call
-    |
-      this = call.getADynamicTarget().getUnboundDeclaration()
-      or
-      this = call.getAStaticTarget().getUnboundDeclaration()
-    )
+    result.getCall().(DataFlowDispatch::NonDelegateDataFlowCall).getDispatchCall() = this.getACall()
   }
 
   /** Gets a node that is an output from a call to this API. */
@@ -74,9 +77,7 @@ class ExternalApi extends DataFlowDispatch::DataFlowCallable {
     exists(DataFlowDispatch::NonDelegateDataFlowCall call, DataFlowImplCommon::ReturnKindExt ret |
       result = ret.getAnOutNode(call)
     |
-      this = call.getDispatchCall().getADynamicTarget().getUnboundDeclaration()
-      or
-      this = call.getDispatchCall().getAStaticTarget().getUnboundDeclaration()
+      this.getACall() = call.getDispatchCall()
     )
   }
 

--- a/csharp/ql/src/Telemetry/ExternalApi.qll
+++ b/csharp/ql/src/Telemetry/ExternalApi.qll
@@ -60,11 +60,9 @@ class ExternalApi extends DataFlowDispatch::DataFlowCallable {
 
   /** Gets a call to this API callable. */
   DispatchCall getACall() {
-    exists(DataFlowDispatch::NonDelegateDataFlowCall call | call.getDispatchCall() = result |
-      this = result.getADynamicTarget().getUnboundDeclaration()
-      or
-      this = result.getAStaticTarget().getUnboundDeclaration()
-    )
+    this = result.getADynamicTarget().getUnboundDeclaration()
+    or
+    this = result.getAStaticTarget().getUnboundDeclaration()
   }
 
   /** Gets a node that is an input to a call to this API. */

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -7,12 +7,12 @@
  */
 
 import csharp
-import ExternalAPI
+import ExternalApi
 
 from int usages, string info
 where
   usages =
-    strictcount(Call c, ExternalAPI api |
+    strictcount(Call c, ExternalApi api |
       c.getTarget() = api and
       api.getInfoPrefix() = info and
       not api.isUninteresting()

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -13,7 +13,7 @@ from int usages, string info
 where
   usages =
     strictcount(Call c, ExternalApi api |
-      c.getTarget() = api and
+      c.getTarget().getUnboundDeclaration() = api and
       api.getInfoPrefix() = info and
       not api.isUninteresting()
     )

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -1,0 +1,20 @@
+/**
+ * @name External libraries
+ * @description A list of external libraries used in the code
+ * @kind metric
+ * @tags summary
+ * @id csharp/telemetry/external-libs
+ */
+
+import csharp
+import ExternalAPI
+
+from int usages, string info
+where
+  usages =
+    strictcount(Call c, ExternalAPI api |
+      c.getTarget() = api and
+      api.getInfoPrefix() = info and
+      not api.isUninteresting()
+    )
+select info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -6,14 +6,15 @@
  * @id csharp/telemetry/external-libs
  */
 
-import csharp
-import ExternalApi
+private import csharp
+private import semmle.code.csharp.dispatch.Dispatch
+private import ExternalApi
 
 from int usages, string info
 where
   usages =
-    strictcount(Call c, ExternalApi api |
-      c.getTarget().getUnboundDeclaration() = api and
+    strictcount(DispatchCall c, ExternalApi api |
+      c = api.getACall() and
       api.getInfoPrefix() = info and
       not api.isUninteresting()
     )

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -13,5 +13,5 @@ from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.isSink() and
-  usages = strictcount(Call c | c.getTarget() = api)
+  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -7,9 +7,9 @@
  */
 
 import csharp
-import ExternalAPI
+import ExternalApi
 
-from ExternalAPI api, int usages
+from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.isSink() and

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Supported sinks in external libraries
+ * @description A list of 3rd party APIs detected as sinks. Excludes test and generated code.
+ * @kind metric
+ * @tags summary
+ * @id csharp/telemetry/supported-external-api-sinks
+ */
+
+import csharp
+import ExternalAPI
+
+from ExternalAPI api, int usages
+where
+  not api.isUninteresting() and
+  api.isSink() and
+  usages = strictcount(Call c | c.getTarget() = api)
+select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -1,6 +1,6 @@
 /**
  * @name Supported sinks in external libraries
- * @description A list of 3rd party APIs detected as sinks. Excludes test and generated code.
+ * @description A list of 3rd party APIs detected as sinks. Excludes APIs exposed by test libraries.
  * @kind metric
  * @tags summary
  * @id csharp/telemetry/supported-external-api-sinks

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -6,12 +6,13 @@
  * @id csharp/telemetry/supported-external-api-sinks
  */
 
-import csharp
-import ExternalApi
+private import csharp
+private import semmle.code.csharp.dispatch.Dispatch
+private import ExternalApi
 
 from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.isSink() and
-  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
+  usages = strictcount(DispatchCall c | c = api.getACall())
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -1,6 +1,6 @@
 /**
  * @name Supported sources in external libraries
- * @description A list of 3rd party APIs detected as sources. Excludes test and generated code.
+ * @description A list of 3rd party APIs detected as sources. Excludes APIs exposed by test libraries.
  * @kind metric
  * @tags summary
  * @id csharp/telemetry/supported-external-api-sources

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -7,9 +7,9 @@
  */
 
 import csharp
-import ExternalAPI
+import ExternalApi
 
-from ExternalAPI api, int usages
+from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.isSource() and

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Supported sources in external libraries
+ * @description A list of 3rd party APIs detected as sources. Excludes test and generated code.
+ * @kind metric
+ * @tags summary
+ * @id csharp/telemetry/supported-external-api-sources
+ */
+
+import csharp
+import ExternalAPI
+
+from ExternalAPI api, int usages
+where
+  not api.isUninteresting() and
+  api.isSource() and
+  usages = strictcount(Call c | c.getTarget() = api)
+select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -13,5 +13,5 @@ from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.isSource() and
-  usages = strictcount(Call c | c.getTarget() = api)
+  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -6,12 +6,13 @@
  * @id csharp/telemetry/supported-external-api-sources
  */
 
-import csharp
-import ExternalApi
+private import csharp
+private import semmle.code.csharp.dispatch.Dispatch
+private import ExternalApi
 
 from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.isSource() and
-  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
+  usages = strictcount(DispatchCall c | c = api.getACall())
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Supported flow steps in external libraries
+ * @description A list of 3rd party APIs detected as flow steps. Excludes test and generated code.
+ * @kind metric
+ * @tags summary
+ * @id csharp/telemetry/supported-external-api-taint
+ */
+
+import csharp
+import ExternalAPI
+
+from ExternalAPI api, int usages
+where
+  not api.isUninteresting() and
+  api.hasSummary() and
+  usages = strictcount(Call c | c.getTarget() = api)
+select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -6,12 +6,13 @@
  * @id csharp/telemetry/supported-external-api-taint
  */
 
-import csharp
-import ExternalApi
+private import csharp
+private import semmle.code.csharp.dispatch.Dispatch
+private import ExternalApi
 
 from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.hasSummary() and
-  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
+  usages = strictcount(DispatchCall c | c = api.getACall())
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -13,5 +13,5 @@ from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.hasSummary() and
-  usages = strictcount(Call c | c.getTarget() = api)
+  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -7,9 +7,9 @@
  */
 
 import csharp
-import ExternalAPI
+import ExternalApi
 
-from ExternalAPI api, int usages
+from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   api.hasSummary() and

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -1,6 +1,6 @@
 /**
  * @name Supported flow steps in external libraries
- * @description A list of 3rd party APIs detected as flow steps. Excludes test and generated code.
+ * @description A list of 3rd party APIs detected as flow steps. Excludes APIs exposed by test libraries.
  * @kind metric
  * @tags summary
  * @id csharp/telemetry/supported-external-api-taint

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -7,9 +7,9 @@
  */
 
 import csharp
-import ExternalAPI
+import ExternalApi
 
-from ExternalAPI api, int usages
+from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   not api.isSupported() and

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Usage of unsupported APIs coming from external libraries
+ * @description A list of 3rd party APIs used in the codebase. Excludes test and generated code.
+ * @kind metric
+ * @tags summary
+ * @id csharp/telemetry/unsupported-external-api
+ */
+
+import csharp
+import ExternalAPI
+
+from ExternalAPI api, int usages
+where
+  not api.isUninteresting() and
+  not api.isSupported() and
+  usages = strictcount(Call c | c.getTarget() = api)
+select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -13,5 +13,5 @@ from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   not api.isSupported() and
-  usages = strictcount(Call c | c.getTarget() = api)
+  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -1,6 +1,6 @@
 /**
  * @name Usage of unsupported APIs coming from external libraries
- * @description A list of 3rd party APIs used in the codebase. Excludes test and generated code.
+ * @description A list of 3rd party APIs used in the codebase. Excludes APIs exposed by test libraries.
  * @kind metric
  * @tags summary
  * @id csharp/telemetry/unsupported-external-api

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -6,12 +6,13 @@
  * @id csharp/telemetry/unsupported-external-api
  */
 
-import csharp
-import ExternalApi
+private import csharp
+private import semmle.code.csharp.dispatch.Dispatch
+private import ExternalApi
 
 from ExternalApi api, int usages
 where
   not api.isUninteresting() and
   not api.isSupported() and
-  usages = strictcount(Call c | c.getTarget().getUnboundDeclaration() = api)
+  usages = strictcount(DispatchCall c | c = api.getACall())
 select api.getInfo() as info, usages order by usages desc

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.cs
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+public class LibraryUsage
+{
+    public void M1()
+    {
+        var l = new List<object>(); // Uninteresting parameterless constructor
+        var o = new object(); // Uninteresting parameterless constructor
+        l.Add(o); // Has flow summary
+        l.Add(o); // Has flow summary
+    }
+
+    public void M2()
+    {
+        var d0 = new DateTime(); // Uninteresting parameterless constructor
+        var next0 = d0.AddYears(30); // Has no flow summary
+
+        var d1 = new DateTime(2000, 1, 1); // Interesting constructor
+        var next1 = next0.AddDays(3); // Has no flow summary
+        var next2 = next1.AddYears(5); // Has no flow summary
+    }
+
+    public void M3()
+    {
+        var guid1 = Guid.Parse("{12345678-1234-1234-1234-123456789012}"); // Has no flow summary
+    }
+}

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.expected
@@ -1,0 +1,2 @@
+| System.Private.CoreLib.dll#System | 5 |
+| System.Private.CoreLib.dll#System.Collections.Generic | 2 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.qlref
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/ExternalLibraryUsage.qlref
@@ -1,0 +1,1 @@
+Telemetry/ExternalLibraryUsage.ql

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
@@ -1,0 +1,1 @@
+| System.Private.CoreLib.dll#System.Collections.Generic#List<>.Add(object) | 2 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.expected
@@ -1,1 +1,1 @@
-| System.Private.CoreLib.dll#System.Collections.Generic#List<>.Add(object) | 2 |
+| System.Private.CoreLib.dll#System.Collections.Generic#List<>.Add(T) | 2 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.qlref
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/SupportedExternalTaint.qlref
@@ -1,0 +1,1 @@
+Telemetry/SupportedExternalTaint.ql

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/UnsupportedExternalAPIs.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/UnsupportedExternalAPIs.expected
@@ -1,4 +1,4 @@
-| System.Private.CoreLib.dll#System#DateTime.AddYears(int) | 2 |
-| System.Private.CoreLib.dll#System#DateTime.AddDays(double) | 1 |
-| System.Private.CoreLib.dll#System#DateTime.DateTime(int, int, int) | 1 |
-| System.Private.CoreLib.dll#System#Guid.Parse(string) | 1 |
+| System.Private.CoreLib.dll#System#DateTime.AddYears(System.Int32) | 2 |
+| System.Private.CoreLib.dll#System#DateTime.AddDays(System.Double) | 1 |
+| System.Private.CoreLib.dll#System#DateTime.DateTime(System.Int32,System.Int32,System.Int32) | 1 |
+| System.Private.CoreLib.dll#System#Guid.Parse(System.String) | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/UnsupportedExternalAPIs.expected
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/UnsupportedExternalAPIs.expected
@@ -1,0 +1,4 @@
+| System.Private.CoreLib.dll#System#DateTime.AddYears(int) | 2 |
+| System.Private.CoreLib.dll#System#DateTime.AddDays(double) | 1 |
+| System.Private.CoreLib.dll#System#DateTime.DateTime(int, int, int) | 1 |
+| System.Private.CoreLib.dll#System#Guid.Parse(string) | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/LibraryUsage/UnsupportedExternalAPIs.qlref
+++ b/csharp/ql/test/query-tests/Telemetry/LibraryUsage/UnsupportedExternalAPIs.qlref
@@ -1,0 +1,1 @@
+Telemetry/UnsupportedExternalAPIs.ql

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.cs
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Web;
+
+public class SupportedExternalSinks
+{
+    public void M1()
+    {
+        var o = new object();
+        var response = new HttpResponse();
+        response.AddHeader("header", "value");
+        response.AppendHeader("header", "value");
+        response.Write(o); // Known sink.
+        response.WriteFile("filename"); // Known sink.
+        response.Write(o); // Known sink.
+    }
+}

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.expected
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.expected
@@ -1,2 +1,2 @@
-| System.Web.cs#System.Web#HttpResponse.Write(object) | 2 |
-| System.Web.cs#System.Web#HttpResponse.WriteFile(string) | 1 |
+| System.Web.cs#System.Web#HttpResponse.Write(System.Object) | 2 |
+| System.Web.cs#System.Web#HttpResponse.WriteFile(System.String) | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.expected
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.expected
@@ -1,0 +1,2 @@
+| System.Web.cs#System.Web#HttpResponse.Write(object) | 2 |
+| System.Web.cs#System.Web#HttpResponse.WriteFile(string) | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.qlref
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/SupportedExternalSinks.qlref
@@ -1,0 +1,1 @@
+Telemetry/SupportedExternalSinks.ql

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/options
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSinks/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: /r:System.Collections.Specialized.dll
+semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Web.cs

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.cs
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.cs
@@ -1,0 +1,12 @@
+using System;
+
+public class SupportExternalSources
+{
+    public void M1()
+    {
+        var l1 = Console.ReadLine(); // Known source.
+        var l2 = Console.ReadLine(); // Known source.
+        Console.SetError(Console.Out);
+        var x = Console.Read(); // Know source.
+    }
+}

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.expected
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.expected
@@ -1,0 +1,2 @@
+| System.Console.dll#System#Console.ReadLine() | 2 |
+| System.Console.dll#System#Console.Read() | 1 |

--- a/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.qlref
+++ b/csharp/ql/test/query-tests/Telemetry/SupportedExternalSources/SupportedExternalSources.qlref
@@ -1,0 +1,1 @@
+Telemetry/SupportedExternalSources.ql

--- a/java/ql/src/Telemetry/ExternalAPI.qll
+++ b/java/ql/src/Telemetry/ExternalAPI.qll
@@ -2,7 +2,6 @@
 
 private import java
 private import semmle.code.java.dataflow.DataFlow
-private import semmle.code.java.dataflow.DataFlow
 private import semmle.code.java.dataflow.ExternalFlow
 private import semmle.code.java.dataflow.FlowSources
 private import semmle.code.java.dataflow.FlowSummary

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -9,21 +9,29 @@ private import semmle.code.java.dataflow.internal.DataFlowPrivate
 private import semmle.code.java.dataflow.TaintTracking
 
 /**
- * An external API from either the Java Standard Library or a 3rd party library.
+ * A test library.
+ */
+private class TestLibrary extends RefType {
+  TestLibrary() {
+    this.getPackage()
+        .getName()
+        .matches([
+            "org.junit%", "junit.%", "org.mockito%", "org.assertj%",
+            "com.github.tomakehurst.wiremock%", "org.hamcrest%", "org.springframework.test.%",
+            "org.springframework.mock.%", "org.springframework.boot.test.%", "reactor.test%",
+            "org.xmlunit%", "org.testcontainers.%", "org.opentest4j%", "org.mockserver%",
+            "org.powermock%", "org.skyscreamer.jsonassert%", "org.rnorth.visibleassertions",
+            "org.openqa.selenium%", "com.gargoylesoftware.htmlunit%",
+            "org.jboss.arquillian.testng%", "org.testng%"
+          ])
+  }
+}
+
+/**
+ * An external API from either the Standard Library or a 3rd party library.
  */
 class ExternalApi extends Callable {
   ExternalApi() { not this.fromSource() }
-
-  /** Holds if this API is not worth supporting */
-  predicate isUninteresting() { this.isTestLibrary() or this.isParameterlessConstructor() }
-
-  /** Holds if this API is is a constructor without parameters */
-  predicate isParameterlessConstructor() {
-    this instanceof Constructor and this.getNumberOfParameters() = 0
-  }
-
-  /** Holds if this API is part of a common testing library or framework */
-  private predicate isTestLibrary() { this.getDeclaringType() instanceof TestLibrary }
 
   /**
    * Gets information about the external API in the form expected by the CSV modeling framework.
@@ -34,15 +42,15 @@ class ExternalApi extends Callable {
         "#" + this.getName() + paramsString(this)
   }
 
+  private string containerAsJar(Container container) {
+    if container instanceof JarFile then result = container.getBaseName() else result = "rt.jar"
+  }
+
   /**
    * Gets the jar file containing this API. Normalizes the Java Runtime to "rt.jar" despite the presence of modules.
    */
   string jarContainer() {
     result = this.containerAsJar(this.getCompilationUnit().getParentContainer*())
-  }
-
-  private string containerAsJar(Container container) {
-    if container instanceof JarFile then result = container.getBaseName() else result = "rt.jar"
   }
 
   /** Gets a node that is an input to a call to this API. */
@@ -67,6 +75,17 @@ class ExternalApi extends Callable {
     TaintTracking::localAdditionalTaintStep(this.getAnInput(), _)
   }
 
+  /** Holds if this API is is a constructor without parameters */
+  private predicate isParameterlessConstructor() {
+    this instanceof Constructor and this.getNumberOfParameters() = 0
+  }
+
+  /** Holds if this API is part of a common testing library or framework */
+  private predicate isTestLibrary() { this.getDeclaringType() instanceof TestLibrary }
+
+  /** Holds if this API is not worth supporting */
+  predicate isUninteresting() { this.isTestLibrary() or this.isParameterlessConstructor() }
+
   /** Holds if this API is a known source. */
   predicate isSource() {
     this.getAnOutput() instanceof RemoteFlowSource or sourceNode(this.getAnOutput(), _)
@@ -77,23 +96,4 @@ class ExternalApi extends Callable {
 
   /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
   predicate isSupported() { this.hasSummary() or this.isSource() or this.isSink() }
-}
-
-/** DEPRECATED: Alias for ExternalApi */
-deprecated class ExternalAPI = ExternalApi;
-
-private class TestLibrary extends RefType {
-  TestLibrary() {
-    this.getPackage()
-        .getName()
-        .matches([
-            "org.junit%", "junit.%", "org.mockito%", "org.assertj%",
-            "com.github.tomakehurst.wiremock%", "org.hamcrest%", "org.springframework.test.%",
-            "org.springframework.mock.%", "org.springframework.boot.test.%", "reactor.test%",
-            "org.xmlunit%", "org.testcontainers.%", "org.opentest4j%", "org.mockserver%",
-            "org.powermock%", "org.skyscreamer.jsonassert%", "org.rnorth.visibleassertions",
-            "org.openqa.selenium%", "com.gargoylesoftware.htmlunit%",
-            "org.jboss.arquillian.testng%", "org.testng%"
-          ])
-  }
 }

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -27,6 +27,10 @@ private class TestLibrary extends RefType {
   }
 }
 
+private string containerAsJar(Container container) {
+  if container instanceof JarFile then result = container.getBaseName() else result = "rt.jar"
+}
+
 /**
  * An external API from either the Standard Library or a 3rd party library.
  */
@@ -42,16 +46,10 @@ class ExternalApi extends Callable {
         "#" + this.getName() + paramsString(this)
   }
 
-  private string containerAsJar(Container container) {
-    if container instanceof JarFile then result = container.getBaseName() else result = "rt.jar"
-  }
-
   /**
    * Gets the jar file containing this API. Normalizes the Java Runtime to "rt.jar" despite the presence of modules.
    */
-  string jarContainer() {
-    result = this.containerAsJar(this.getCompilationUnit().getParentContainer*())
-  }
+  string jarContainer() { result = containerAsJar(this.getCompilationUnit().getParentContainer*()) }
 
   /** Gets a node that is an input to a call to this API. */
   private DataFlow::Node getAnInput() {
@@ -97,3 +95,6 @@ class ExternalApi extends Callable {
   /** Holds if this API is supported by existing CodeQL libraries, that is, it is either a recognized source or sink or has a flow summary. */
   predicate isSupported() { this.hasSummary() or this.isSource() or this.isSink() }
 }
+
+/** DEPRECATED: Alias for ExternalApi */
+deprecated class ExternalAPI = ExternalApi;

--- a/java/ql/src/Telemetry/ExternalApi.qll
+++ b/java/ql/src/Telemetry/ExternalApi.qll
@@ -75,15 +75,15 @@ class ExternalApi extends Callable {
     TaintTracking::localAdditionalTaintStep(this.getAnInput(), _)
   }
 
-  /** Holds if this API is is a constructor without parameters */
+  /** Holds if this API is is a constructor without parameters. */
   private predicate isParameterlessConstructor() {
     this instanceof Constructor and this.getNumberOfParameters() = 0
   }
 
-  /** Holds if this API is part of a common testing library or framework */
+  /** Holds if this API is part of a common testing library or framework. */
   private predicate isTestLibrary() { this.getDeclaringType() instanceof TestLibrary }
 
-  /** Holds if this API is not worth supporting */
+  /** Holds if this API is not worth supporting. */
   predicate isUninteresting() { this.isTestLibrary() or this.isParameterlessConstructor() }
 
   /** Holds if this API is a known source. */

--- a/java/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/java/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -7,7 +7,7 @@
  */
 
 import java
-import ExternalAPI
+import ExternalApi
 
 from int usages, string jarname
 where

--- a/java/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -7,7 +7,7 @@
  */
 
 import java
-import ExternalAPI
+import ExternalApi
 import semmle.code.java.GeneratedFiles
 
 from ExternalApi api, int usages

--- a/java/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSources.ql
@@ -7,7 +7,7 @@
  */
 
 import java
-import ExternalAPI
+import ExternalApi
 import semmle.code.java.GeneratedFiles
 
 from ExternalApi api, int usages

--- a/java/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/java/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -7,7 +7,7 @@
  */
 
 import java
-import ExternalAPI
+import ExternalApi
 import semmle.code.java.GeneratedFiles
 
 from ExternalApi api, int usages

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -7,7 +7,7 @@
  */
 
 import java
-import ExternalAPI
+import ExternalApi
 import semmle.code.java.GeneratedFiles
 
 from ExternalApi api, int usages


### PR DESCRIPTION
In this PR we introduce C# Telemetry queries for
* All usages of libraries (summarised).
* Usages of unsupported APIs (ie. missing flow summaries).
* Usages of supported APIs (ie. flow summaries)
* Usages of known Sources.
* Usages of known Sinks.

The structure implementation is inspired by the corresponding java implementation, but there is only limited re-use of the java implementation itself.
Furthermore, the there are some language specific differences between C# and Java.
Some explicit sharing between C# and Java has been made.

The following concepts has been translated from Java to C# (which is reflected in the C# implementation).
* Java Package -> C# Namespace.
* Java Jar container -> C# Assembly

Other relevant information:
* The *Telemetry* queries have *kind* `metric` and is tagged as `summary`. This means that the queries will be executed as a part of the `csharp-code-scanning.qls` suite (as this suite includes all `metric` queries with the tag `summary`). Also see the discussion here: `https://github.com/github/codeql/pull/7417`.
* The query [meta data](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) for `metric` queries has been extended to allow the result to be of type `string`,`int` (see this [ADR](https://github.com/github/code-scanning/blob/main/docs%2Fadrs%2F0014-metrics-for-external-libraries.md).
* The result message (ie. string results of the query) will be stored in GitHubs datawarehouse in the table `ts_metric_results` and should be accessible via *datadot*.