### PR TITLE
CI: add QLdoc test

### DIFF
--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -1,4 +1,4 @@
-name: "Check QLdoc"
+name: "Check QLdoc coverage"
 
 on:
   pull_request:

--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check QLdoc
+      - name: Check QLdoc coverage
         shell: bash
         run: |
           EXIT_CODE=0

--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -33,15 +33,15 @@ jobs:
           changed_lib_packs="$(git diff --name-only --diff-filter=ACMRT HEAD^ HEAD | { grep -o '^[a-z]*/ql/lib' || true; } | sort -u)"
           for pack_dir in ${changed_lib_packs}; do
             lang="${pack_dir%/ql/lib}"
-            gh codeql generate library-doc-coverage --output="${{ runner.temp }}/${lang}-current.txt" --dir="${pack_dir}"
+            gh codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-current.txt" --dir="${pack_dir}"
           done
           git checkout HEAD^
           for pack_dir in ${changed_lib_packs}; do
             lang="${pack_dir%/ql/lib}"
-            gh codeql generate library-doc-coverage --output="${{ runner.temp }}/${lang}-baseline.txt" --dir="${pack_dir}"
-            awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${{ runner.temp }}/${lang}-current.txt" | sort -u > "${{ runner.temp }}/current-undocumented.txt"
-            awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${{ runner.temp }}/${lang}-baseline.txt" | sort -u > "${{ runner.temp }}/baseline-undocumented.txt"
-            UNDOCUMENTED="$(grep -f <(comm -13 "${{ runner.temp }}/baseline-undocumented.txt" "${{ runner.temp }}/current-undocumented.txt") "${{ runner.temp }}/${lang}-current.txt" || true)"
+            gh codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-baseline.txt" --dir="${pack_dir}"
+            awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${RUNNER_TEMP}/${lang}-current.txt" | sort -u > "${RUNNER_TEMP}/current-undocumented.txt"
+            awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${RUNNER_TEMP}/${lang}-baseline.txt" | sort -u > "${RUNNER_TEMP}/baseline-undocumented.txt"
+            UNDOCUMENTED="$(grep -f <(comm -13 "${RUNNER_TEMP}/baseline-undocumented.txt" "${RUNNER_TEMP}/current-undocumented.txt") "${RUNNER_TEMP}/${lang}-current.txt" || true)"
             if [ -n "$UNDOCUMENTED" ]; then
               echo "$UNDOCUMENTED" | awk -F, '{gsub(/"/,""); print "::warning file='"${pack_dir}"'/"$1",line="$2"::Missing QLdoc for "$5, $3 }'
               EXIT_CODE=1

--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -1,0 +1,50 @@
+name: "Check QLdoc"
+
+on:
+  pull_request:
+    paths:
+      - "*/ql/lib/**"
+      - .github/workflows/check-qldoc.yml
+    branches:
+      - main
+      - "rc/*"
+
+jobs:
+  qldoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install CodeQL
+        run: |
+          gh extension install github/gh-codeql
+          gh codeql set-channel nightly
+          gh codeql version
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Check QLdoc
+        shell: bash
+        run: |
+          EXIT_CODE=0
+          changed_lib_packs="$(git diff --name-only --diff-filter=ACMRT HEAD^ HEAD | { grep -o '^[a-z]*/ql/lib' || true; } | sort -u)"
+          for pack_dir in ${changed_lib_packs}; do
+            lang="${pack_dir%/ql/lib}"
+            gh codeql generate library-doc-coverage --output="${{ runner.temp }}/${lang}-current.txt" --dir="${pack_dir}"
+          done
+          git checkout HEAD^
+          for pack_dir in ${changed_lib_packs}; do
+            lang="${pack_dir%/ql/lib}"
+            gh codeql generate library-doc-coverage --output="${{ runner.temp }}/${lang}-baseline.txt" --dir="${pack_dir}"
+            awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${{ runner.temp }}/${lang}-current.txt" | sort -u > "${{ runner.temp }}/current-undocumented.txt"
+            awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${{ runner.temp }}/${lang}-baseline.txt" | sort -u > "${{ runner.temp }}/baseline-undocumented.txt"
+            UNDOCUMENTED="$(grep -f <(comm -13 "${{ runner.temp }}/baseline-undocumented.txt" "${{ runner.temp }}/current-undocumented.txt") "${{ runner.temp }}/${lang}-current.txt" || true)"
+            if [ -n "$UNDOCUMENTED" ]; then
+              echo "$UNDOCUMENTED" | awk -F, '{gsub(/"/,""); print "::warning file='"${pack_dir}"'/"$1",line="$2"::Missing QLdoc for "$5, $3 }'
+              EXIT_CODE=1
+            fi
+          done
+          exit "${EXIT_CODE}"


### PR DESCRIPTION
This pull request adds a CI check based on the new `codeql generate library-doc-coverage` command. It is very similar to the   internal test we have, except that it is *much* faster (30s vs 10m),  and adds check annotations to the files. In addition the test output is available to external contributors.

Below some links for an example run:
* [Summary](https://github.com/github/codeql/actions/runs/1951059124)
* [Annotation](https://github.com/github/codeql/pull/8367/files#annotation_2932028736)
* [Log](https://github.com/github/codeql/runs/5463433141?check_suite_focus=true)

@adityasharad @alexet 