### PR TITLE
C++: Factor must-flow predicates out of two queries

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
@@ -1,0 +1,265 @@
+/**
+ * This file provides a library for inter-procedural must-flow data flow analysis.
+ * Unlike `DataFlow.qll`, the analysis provided by this file checks whether data _must_ flow
+ * from a source to a _sink_.
+ */
+
+private import cpp
+import semmle.code.cpp.ir.dataflow.DataFlow
+private import semmle.code.cpp.ir.IR
+
+/**
+ * A configuration of a data flow analysis that performs must-flow analysis. This is different
+ * from `DataFlow.qll` which performs may-flow analysis (i.e., it finds paths where the source _may_
+ * flow to the sink).
+ *
+ * Like in `DataFlow.qll`, each use of the `MustFlow.qll` library must define its own unique extension
+ * of this abstract class. To create a configuration, extend this class with a subclass whose
+ * characteristic predicate is a unique singleton string and override `isSource`, `isSink` (and
+ * `isAdditionalFlowStep` if additional steps are required).
+ */
+abstract class MustFlowConfiguration extends string {
+  bindingset[this]
+  MustFlowConfiguration() { any() }
+
+  /**
+   * Holds if `source` is a relevant data flow source.
+   */
+  abstract predicate isSource(DataFlow::Node source);
+
+  /**
+   * Holds if `sink` is a relevant data flow sink.
+   */
+  abstract predicate isSink(DataFlow::Node sink);
+
+  /**
+   * Holds if the additional flow step from `node1` to `node2` must be taken
+   * into account in the analysis.
+   */
+  predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
+
+  /**
+   * Holds if data must flow from `source` to `sink` for this configuration.
+   *
+   * The corresponding paths are generated from the end-points and the graph
+   * included in the module `PathGraph`.
+   */
+  final predicate hasFlowPath(MustFlowPathNode source, MustFlowPathSink sink) {
+    this.isSource(source.getNode()) and
+    source.getASuccessor+() = sink
+  }
+}
+
+/** Holds if `node` flows from a source. */
+pragma[nomagic]
+private predicate flowsFromSource(DataFlow::Node node, MustFlowConfiguration config) {
+  config.isSource(node)
+  or
+  exists(DataFlow::Node mid |
+    step(mid, node, config) and
+    flowsFromSource(mid, pragma[only_bind_into](config))
+  )
+}
+
+/** Holds if `instr` flows to a sink. */
+pragma[nomagic]
+private predicate flowsToSink(DataFlow::Node node, MustFlowConfiguration config) {
+  flowsFromSource(node, pragma[only_bind_into](config)) and
+  (
+    config.isSink(node)
+    or
+    exists(DataFlow::Node mid |
+      step(node, mid, config) and
+      flowsToSink(mid, pragma[only_bind_into](config))
+    )
+  )
+}
+
+cached
+private module Cached {
+  /** Holds if `p` is the `n`'th parameter of the non-virtual function `f`. */
+  private predicate parameterOf(Parameter p, Function f, int n) {
+    not f.isVirtual() and f.getParameter(n) = p
+  }
+
+  /**
+   * Holds if `instr` is the `n`'th argument to a call to the non-virtual function `f`, and
+   * `init` is the corresponding initiazation instruction that receives the value of `instr` in `f`.
+   */
+  private predicate flowIntoParameter(
+    Function f, int n, CallInstruction call, Instruction instr, InitializeParameterInstruction init
+  ) {
+    not f.isVirtual() and
+    call.getPositionalArgument(n) = instr and
+    f = call.getStaticCallTarget() and
+    getEnclosingNonVirtualFunctionInitializeParameter(init, f) and
+    init.getParameter().getIndex() = pragma[only_bind_into](pragma[only_bind_out](n))
+  }
+
+  /**
+   * Holds if `instr` is an argument to a call to the function `f`, and `init` is the
+   * corresponding initialization instruction that receives the value of `instr` in `f`.
+   */
+  pragma[noinline]
+  private predicate getPositionalArgumentInitParam(
+    CallInstruction call, Instruction instr, InitializeParameterInstruction init, Function f
+  ) {
+    exists(int n |
+      parameterOf(_, f, n) and
+      flowIntoParameter(f, pragma[only_bind_into](pragma[only_bind_out](n)), call, instr, init)
+    )
+  }
+
+  /**
+   * Holds if `instr` is the qualifier to a call to the non-virtual function `f`, and
+   * `init` is the corresponding initiazation instruction that receives the value of
+   * `instr` in `f`.
+   */
+  pragma[noinline]
+  private predicate getThisArgumentInitParam(
+    CallInstruction call, Instruction instr, InitializeParameterInstruction init, Function f
+  ) {
+    not f.isVirtual() and
+    call.getStaticCallTarget() = f and
+    getEnclosingNonVirtualFunctionInitializeParameter(init, f) and
+    call.getThisArgument() = instr and
+    init.getIRVariable() instanceof IRThisVariable
+  }
+
+  /** Holds if `f` is the enclosing non-virtual function of `init`. */
+  private predicate getEnclosingNonVirtualFunctionInitializeParameter(
+    InitializeParameterInstruction init, Function f
+  ) {
+    not f.isVirtual() and
+    init.getEnclosingFunction() = f
+  }
+
+  /** Holds if `f` is the enclosing non-virtual function of `init`. */
+  private predicate getEnclosingNonVirtualFunctionInitializeIndirection(
+    InitializeIndirectionInstruction init, Function f
+  ) {
+    not f.isVirtual() and
+    init.getEnclosingFunction() = f
+  }
+
+  /**
+   * Holds if `instr` is an argument (or argument indirection) to a call, and
+   * `succ` is the corresponding initialization instruction in the call target.
+   */
+  private predicate flowThroughCallable(Instruction argument, Instruction parameter) {
+    // Flow from an argument to a parameter
+    exists(CallInstruction call, InitializeParameterInstruction init | init = parameter |
+      getPositionalArgumentInitParam(call, argument, init, call.getStaticCallTarget())
+      or
+      getThisArgumentInitParam(call, argument, init, call.getStaticCallTarget())
+    )
+    or
+    // Flow from argument indirection to parameter indirection
+    exists(
+      CallInstruction call, ReadSideEffectInstruction read, InitializeIndirectionInstruction init
+    |
+      init = parameter and
+      read.getPrimaryInstruction() = call and
+      getEnclosingNonVirtualFunctionInitializeIndirection(init, call.getStaticCallTarget())
+    |
+      exists(int n |
+        read.getSideEffectOperand().getAnyDef() = argument and
+        read.getIndex() = pragma[only_bind_into](n) and
+        init.getParameter().getIndex() = pragma[only_bind_into](n)
+      )
+      or
+      call.getThisArgument() = argument and
+      init.getIRVariable() instanceof IRThisVariable
+    )
+  }
+
+  private predicate instructionToOperandStep(Instruction instr, Operand operand) {
+    operand.getDef() = instr
+  }
+
+  private predicate operandToInstructionStep(Operand operand, Instruction instr) {
+    instr.(CopyInstruction).getSourceValueOperand() = operand
+    or
+    instr.(ConvertInstruction).getUnaryOperand() = operand
+    or
+    instr.(CheckedConvertOrNullInstruction).getUnaryOperand() = operand
+    or
+    instr.(InheritanceConversionInstruction).getUnaryOperand() = operand
+    or
+    instr.(ChiInstruction).getTotalOperand() = operand
+  }
+
+  cached
+  predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+    instructionToOperandStep(nodeFrom.asInstruction(), nodeTo.asOperand())
+    or
+    flowThroughCallable(nodeFrom.asInstruction(), nodeTo.asInstruction())
+    or
+    operandToInstructionStep(nodeFrom.asOperand(), nodeTo.asInstruction())
+  }
+}
+
+/** Holds if `nodeFrom` flows to `nodeTo`. */
+private predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo, MustFlowConfiguration config) {
+  exists(config) and
+  Cached::step(nodeFrom, nodeTo)
+  or
+  config.isAdditionalFlowStep(nodeFrom, nodeTo)
+}
+
+private newtype TLocalPathNode =
+  MkLocalPathNode(DataFlow::Node n, MustFlowConfiguration config) {
+    flowsToSink(n, config) and
+    (
+      config.isSource(n)
+      or
+      exists(MustFlowPathNode mid | step(mid.getNode(), n, config))
+    )
+  }
+
+/** A `Node` that is in a path from a source to a sink. */
+class MustFlowPathNode extends TLocalPathNode {
+  DataFlow::Node n;
+
+  MustFlowPathNode() { this = MkLocalPathNode(n, _) }
+
+  /** Gets the underlying node. */
+  DataFlow::Node getNode() { result = n }
+
+  /** Gets a textual representation of this node. */
+  string toString() { result = n.toString() }
+
+  /** Gets the location of this element. */
+  Location getLocation() { result = n.getLocation() }
+
+  /** Gets a successor node, if any. */
+  MustFlowPathNode getASuccessor() {
+    step(this.getNode(), result.getNode(), this.getConfiguration())
+  }
+
+  /** Gets the associated configuration. */
+  MustFlowConfiguration getConfiguration() { this = MkLocalPathNode(_, result) }
+}
+
+private class MustFlowPathSink extends MustFlowPathNode {
+  MustFlowPathSink() { this.getConfiguration().isSink(this.getNode()) }
+}
+
+/**
+ * Provides the query predicates needed to include a graph in a path-problem query.
+ */
+module PathGraph {
+  private predicate reach(MustFlowPathNode n) {
+    n instanceof MustFlowPathSink or reach(n.getASuccessor())
+  }
+
+  /** Holds if `(a,b)` is an edge in the graph of data flow path explanations. */
+  query predicate edges(MustFlowPathNode a, MustFlowPathNode b) {
+    a.getASuccessor() = b and reach(b)
+  }
+
+  /** Holds if `n` is a node in the graph of data flow path explanations. */
+  query predicate nodes(MustFlowPathNode n, string key, string val) {
+    reach(n) and key = "semmle.label" and val = n.toString()
+  }
+}

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
@@ -177,6 +177,11 @@ private module Cached {
     operand.getDef() = instr
   }
 
+  /**
+   * Holds if data flows from `operand` to `instr`.
+   *
+   * This predicate ignores flow through `PhiInstruction`s to create a 'must flow' relation.
+   */
   private predicate operandToInstructionStep(Operand operand, Instruction instr) {
     instr.(CopyInstruction).getSourceValueOperand() = operand
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
@@ -112,7 +112,7 @@ private module Cached {
 
   /**
    * Holds if `instr` is the qualifier to a call to the non-virtual function `f`, and
-   * `init` is the corresponding initiazation instruction that receives the value of
+   * `init` is the corresponding initialization instruction that receives the value of
    * `instr` in `f`.
    */
   pragma[noinline]

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
@@ -61,7 +61,7 @@ private predicate flowsFromSource(DataFlow::Node node, MustFlowConfiguration con
   )
 }
 
-/** Holds if `instr` flows to a sink. */
+/** Holds if `node` flows to a sink. */
 pragma[nomagic]
 private predicate flowsToSink(DataFlow::Node node, MustFlowConfiguration config) {
   flowsFromSource(node, pragma[only_bind_into](config)) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/MustFlow.qll
@@ -84,7 +84,7 @@ private module Cached {
 
   /**
    * Holds if `instr` is the `n`'th argument to a call to the non-virtual function `f`, and
-   * `init` is the corresponding initiazation instruction that receives the value of `instr` in `f`.
+   * `init` is the corresponding initialization instruction that receives the value of `instr` in `f`.
    */
   private predicate flowIntoParameter(
     Function f, int n, CallInstruction call, Instruction instr, InitializeParameterInstruction init

--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -18,157 +18,70 @@ import cpp
 // recomputing the IR.
 private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.ir.IR
-import semmle.code.cpp.ir.dataflow.DataFlow::DataFlow
+import semmle.code.cpp.ir.dataflow.MustFlow
+import PathGraph
 
 /** Holds if `f` has a name that we intrepret as evidence of intentionally returning the value of the stack pointer. */
 predicate intentionallyReturnsStackPointer(Function f) {
   f.getName().toLowerCase().matches(["%stack%", "%sp%"])
 }
 
-/**
- * Holds if `source` is a node that represents the use of a stack variable
- */
-predicate isSource(Node source) {
-  exists(VariableAddressInstruction var, Function func |
-    var = source.asInstruction() and
-    func = var.getEnclosingFunction() and
-    var.getASTVariable() instanceof StackVariable and
-    // Pointer-to-member types aren't properly handled in the dbscheme.
-    not var.getResultType() instanceof PointerToMemberType and
-    // Rule out FPs caused by extraction errors.
-    not any(ErrorExpr e).getEnclosingFunction() = func and
-    not intentionallyReturnsStackPointer(func)
-  )
-}
+class ReturnStackAllocatedMemoryConfig extends MustFlowConfiguration {
+  ReturnStackAllocatedMemoryConfig() { this = "ReturnStackAllocatedMemoryConfig" }
 
-/**
- * Holds if `sink` is a node that represents the `StoreInstruction` that is subsequently used in
- * a `ReturnValueInstruction`. We use the `StoreInstruction` instead of the instruction that defines the
- * `ReturnValueInstruction`'s source value oprand because the former has better location information.
- */
-predicate isSink(Node sink) {
-  exists(StoreInstruction store |
-    store.getDestinationAddress().(VariableAddressInstruction).getIRVariable() instanceof
-      IRReturnVariable and
-    sink.asOperand() = store.getSourceValueOperand()
-  )
-}
-
-/** Holds if `node1` _must_ flow to `node2`. */
-predicate step(Node node1, Node node2) {
-  instructionToOperandStep(node1.asInstruction(), node2.asOperand())
-  or
-  operandToInstructionStep(node1.asOperand(), node2.asInstruction())
-}
-
-predicate instructionToOperandStep(Instruction instr, Operand operand) { operand.getDef() = instr }
-
-/**
- * Holds if `operand` flows to the result of `instr`.
- *
- * This predicate ignores flow through `PhiInstruction`s to create a 'must flow' relation. It also
- * intentionally conflates addresses of fields and their object, and pointer offsets with their
- * base pointer as this allows us to detect cases where an object's address flows to a return statement
- * via a field. For example:
- *
- * ```cpp
- * struct S { int x, y };
- * int* test() {
- *   S s;
- *   return &s.x; // BAD: &s.x is an address of a variable on the stack.
- * }
- * ```
- */
-predicate operandToInstructionStep(Operand operand, Instruction instr) {
-  instr.(CopyInstruction).getSourceValueOperand() = operand
-  or
-  instr.(ConvertInstruction).getUnaryOperand() = operand
-  or
-  instr.(CheckedConvertOrNullInstruction).getUnaryOperand() = operand
-  or
-  instr.(InheritanceConversionInstruction).getUnaryOperand() = operand
-  or
-  instr.(FieldAddressInstruction).getObjectAddressOperand() = operand
-  or
-  instr.(PointerOffsetInstruction).getLeftOperand() = operand
-}
-
-/** Holds if a source node flows to `n`. */
-predicate branchlessLocalFlow0(Node n) {
-  isSource(n)
-  or
-  exists(Node mid |
-    branchlessLocalFlow0(mid) and
-    step(mid, n)
-  )
-}
-
-/** Holds if `n` is reachable through some source node, and `n` also eventually reaches a sink. */
-predicate branchlessLocalFlow1(Node n) {
-  branchlessLocalFlow0(n) and
-  (
-    isSink(n)
-    or
-    exists(Node mid |
-      branchlessLocalFlow1(mid) and
-      step(n, mid)
-    )
-  )
-}
-
-newtype TLocalPathNode =
-  TLocalPathNodeMid(Node n) {
-    branchlessLocalFlow1(n) and
-    (
-      isSource(n) or
-      exists(LocalPathNodeMid mid | step(mid.getNode(), n))
+  override predicate isSource(DataFlow::Node source) {
+    // Holds if `source` is a node that represents the use of a stack variable
+    exists(VariableAddressInstruction var, Function func |
+      var = source.asInstruction() and
+      func = var.getEnclosingFunction() and
+      var.getASTVariable() instanceof StackVariable and
+      // Pointer-to-member types aren't properly handled in the dbscheme.
+      not var.getResultType() instanceof PointerToMemberType and
+      // Rule out FPs caused by extraction errors.
+      not any(ErrorExpr e).getEnclosingFunction() = func and
+      not intentionallyReturnsStackPointer(func)
     )
   }
 
-abstract class LocalPathNode extends TLocalPathNode {
-  Node n;
+  override predicate isSink(DataFlow::Node sink) {
+    // Holds if `sink` is a node that represents the `StoreInstruction` that is subsequently used in
+    // a `ReturnValueInstruction`.
+    // We use the `StoreInstruction` instead of the instruction that defines the
+    // `ReturnValueInstruction`'s source value oprand because the former has better location information.
+    exists(StoreInstruction store |
+      store.getDestinationAddress().(VariableAddressInstruction).getIRVariable() instanceof
+        IRReturnVariable and
+      sink.asOperand() = store.getSourceValueOperand()
+    )
+  }
 
-  /** Gets the underlying node. */
-  Node getNode() { result = n }
-
-  /** Gets a textual representation of this node. */
-  string toString() { result = n.toString() }
-
-  /** Gets the location of this element. */
-  Location getLocation() { result = n.getLocation() }
-
-  /** Gets a successor `LocalPathNode`, if any. */
-  LocalPathNode getASuccessor() { step(this.getNode(), result.getNode()) }
+  /**
+   * This configuration intentionally conflates addresses of fields and their object, and pointer offsets
+   * with their base pointer as this allows us to detect cases where an object's address flows to a
+   * return statement via a field. For example:
+   *
+   * ```cpp
+   * struct S { int x, y };
+   * int* test() {
+   *   S s;
+   *   return &s.x; // BAD: &s.x is an address of a variable on the stack.
+   * }
+   */
+  override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
+    node2.asInstruction().(FieldAddressInstruction).getObjectAddressOperand() = node1.asOperand()
+    or
+    node2.asInstruction().(PointerOffsetInstruction).getLeftOperand() = node1.asOperand()
+  }
 }
 
-class LocalPathNodeMid extends LocalPathNode, TLocalPathNodeMid {
-  LocalPathNodeMid() { this = TLocalPathNodeMid(n) }
-}
-
-class LocalPathNodeSink extends LocalPathNodeMid {
-  LocalPathNodeSink() { isSink(this.getNode()) }
-}
-
-/**
- * Holds if `source` is a source node, `sink` is a sink node, and there's flow
- * from `source` to `sink` using `step` relation.
- */
-predicate hasFlow(LocalPathNode source, LocalPathNodeSink sink) {
-  isSource(source.getNode()) and
-  source.getASuccessor+() = sink
-}
-
-predicate reach(LocalPathNode n) { n instanceof LocalPathNodeSink or reach(n.getASuccessor()) }
-
-query predicate edges(LocalPathNode a, LocalPathNode b) { a.getASuccessor() = b and reach(b) }
-
-query predicate nodes(LocalPathNode n, string key, string val) {
-  reach(n) and key = "semmle.label" and val = n.toString()
-}
-
-from LocalPathNode source, LocalPathNodeSink sink, VariableAddressInstruction var
+from
+  MustFlowPathNode source, MustFlowPathNode sink, VariableAddressInstruction var,
+  ReturnStackAllocatedMemoryConfig conf
 where
-  hasFlow(source, sink) and
-  source.getNode().asInstruction() = var
+  conf.hasFlowPath(source, sink) and
+  source.getNode().asInstruction() = var and
+  // Only raise an alert if we're returning from the _same_ callable as the on that
+  // declared the stack variable.
+  var.getEnclosingFunction() = sink.getNode().getEnclosingCallable()
 select sink.getNode(), source, sink, "May return stack-allocated memory from $@.", var.getAST(),
   var.getAST().toString()

--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -66,6 +66,7 @@ class ReturnStackAllocatedMemoryConfig extends MustFlowConfiguration {
    *   S s;
    *   return &s.x; // BAD: &s.x is an address of a variable on the stack.
    * }
+   * ```
    */
   override predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     node2.asInstruction().(FieldAddressInstruction).getObjectAddressOperand() = node1.asOperand()

--- a/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
+++ b/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
@@ -17,167 +17,45 @@
 import cpp
 // We don't actually use the global value numbering library in this query, but without it we end up
 // recomputing the IR.
-private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
-private import semmle.code.cpp.ir.IR
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+import semmle.code.cpp.ir.IR
+import semmle.code.cpp.ir.dataflow.MustFlow
+import PathGraph
 
-bindingset[n, result]
-int unbind(int n) { result >= n and result <= n }
+class UnsafeUseOfThisConfig extends MustFlowConfiguration {
+  UnsafeUseOfThisConfig() { this = "UnsafeUseOfThisConfig" }
 
-/** Holds if `p` is the `n`'th parameter of the non-virtual function `f`. */
-predicate parameterOf(Parameter p, Function f, int n) {
-  not f.isVirtual() and f.getParameter(n) = p
-}
+  override predicate isSource(DataFlow::Node source) { isSource(source, _, _) }
 
-/**
- * Holds if `instr` is the `n`'th argument to a call to the non-virtual function `f`, and
- * `init` is the corresponding initiazation instruction that receives the value of `instr` in `f`.
- */
-predicate flowIntoParameter(
-  CallInstruction call, Instruction instr, Function f, int n, InitializeParameterInstruction init
-) {
-  not f.isVirtual() and
-  call.getPositionalArgument(n) = instr and
-  f = call.getStaticCallTarget() and
-  getEnclosingNonVirtualFunctionInitializeParameter(init, f) and
-  init.getParameter().getIndex() = unbind(n)
-}
-
-/**
- * Holds if `instr` is an argument to a call to the function `f`, and `init` is the
- * corresponding initialization instruction that receives the value of `instr` in `f`.
- */
-pragma[noinline]
-predicate getPositionalArgumentInitParam(
-  CallInstruction call, Instruction instr, InitializeParameterInstruction init, Function f
-) {
-  exists(int n |
-    parameterOf(_, f, n) and
-    flowIntoParameter(call, instr, f, unbind(n), init)
-  )
-}
-
-/**
- * Holds if `instr` is the qualifier to a call to the non-virtual function `f`, and
- * `init` is the corresponding initiazation instruction that receives the value of
- * `instr` in `f`.
- */
-pragma[noinline]
-predicate getThisArgumentInitParam(
-  CallInstruction call, Instruction instr, InitializeParameterInstruction init, Function f
-) {
-  not f.isVirtual() and
-  call.getStaticCallTarget() = f and
-  getEnclosingNonVirtualFunctionInitializeParameter(init, f) and
-  call.getThisArgument() = instr and
-  init.getIRVariable() instanceof IRThisVariable
+  override predicate isSink(DataFlow::Node sink) { isSink(sink, _) }
 }
 
 /** Holds if `instr` is a `this` pointer used by the call instruction `call`. */
-predicate isSink(Instruction instr, CallInstruction call) {
+predicate isSink(DataFlow::Node sink, CallInstruction call) {
   exists(PureVirtualFunction func |
     call.getStaticCallTarget() = func and
-    call.getThisArgument() = instr and
+    call.getThisArgument() = sink.asInstruction() and
     // Weed out implicit calls to destructors of a base class
     not func instanceof Destructor
   )
 }
 
 /** Holds if `init` initializes the `this` pointer in class `c`. */
-predicate isSource(InitializeParameterInstruction init, string msg, Class c) {
-  (
-    exists(Constructor func |
-      not func instanceof CopyConstructor and
-      not func instanceof MoveConstructor and
-      func = init.getEnclosingFunction() and
-      msg = "construction"
-    )
-    or
-    init.getEnclosingFunction() instanceof Destructor and msg = "destruction"
-  ) and
-  init.getIRVariable() instanceof IRThisVariable and
-  init.getEnclosingFunction().getDeclaringType() = c
-}
-
-/**
- * Holds if `instr` flows to a sink (which is a use of the value of `instr` as a `this` pointer).
- */
-predicate flowsToSink(Instruction instr, Instruction sink) {
-  flowsFromSource(instr) and
-  (
-    isSink(instr, _) and instr = sink
-    or
-    exists(Instruction mid |
-      successor(instr, mid) and
-      flowsToSink(mid, sink)
-    )
+predicate isSource(DataFlow::Node source, string msg, Class c) {
+  exists(InitializeParameterInstruction init | init = source.asInstruction() |
+    (
+      exists(Constructor func |
+        not func instanceof CopyConstructor and
+        not func instanceof MoveConstructor and
+        func = init.getEnclosingFunction() and
+        msg = "construction"
+      )
+      or
+      init.getEnclosingFunction() instanceof Destructor and msg = "destruction"
+    ) and
+    init.getIRVariable() instanceof IRThisVariable and
+    init.getEnclosingFunction().getDeclaringType() = c
   )
-}
-
-/** Holds if `instr` flows from a source. */
-predicate flowsFromSource(Instruction instr) {
-  isSource(instr, _, _)
-  or
-  exists(Instruction mid |
-    successor(mid, instr) and
-    flowsFromSource(mid)
-  )
-}
-
-/** Holds if `f` is the enclosing non-virtual function of `init`. */
-predicate getEnclosingNonVirtualFunctionInitializeParameter(
-  InitializeParameterInstruction init, Function f
-) {
-  not f.isVirtual() and
-  init.getEnclosingFunction() = f
-}
-
-/** Holds if `f` is the enclosing non-virtual function of `init`. */
-predicate getEnclosingNonVirtualFunctionInitializeIndirection(
-  InitializeIndirectionInstruction init, Function f
-) {
-  not f.isVirtual() and
-  init.getEnclosingFunction() = f
-}
-
-/**
- * Holds if `instr` is an argument (or argument indirection) to a call, and
- * `succ` is the corresponding initialization instruction in the call target.
- */
-predicate flowThroughCallable(Instruction instr, Instruction succ) {
-  // Flow from an argument to a parameter
-  exists(CallInstruction call, InitializeParameterInstruction init | init = succ |
-    getPositionalArgumentInitParam(call, instr, init, call.getStaticCallTarget())
-    or
-    getThisArgumentInitParam(call, instr, init, call.getStaticCallTarget())
-  )
-  or
-  // Flow from argument indirection to parameter indirection
-  exists(
-    CallInstruction call, ReadSideEffectInstruction read, InitializeIndirectionInstruction init
-  |
-    init = succ and
-    read.getPrimaryInstruction() = call and
-    getEnclosingNonVirtualFunctionInitializeIndirection(init, call.getStaticCallTarget())
-  |
-    exists(int n |
-      read.getSideEffectOperand().getAnyDef() = instr and
-      read.getIndex() = n and
-      init.getParameter().getIndex() = unbind(n)
-    )
-    or
-    call.getThisArgument() = instr and
-    init.getIRVariable() instanceof IRThisVariable
-  )
-}
-
-/** Holds if `instr` flows to `succ`. */
-predicate successor(Instruction instr, Instruction succ) {
-  succ.(CopyInstruction).getSourceValue() = instr or
-  succ.(CheckedConvertOrNullInstruction).getUnary() = instr or
-  succ.(ChiInstruction).getTotal() = instr or
-  succ.(ConvertInstruction).getUnary() = instr or
-  succ.(InheritanceConversionInstruction).getUnary() = instr or
-  flowThroughCallable(instr, succ)
 }
 
 /**
@@ -188,22 +66,19 @@ predicate successor(Instruction instr, Instruction succ) {
  * - `msg` is a string describing whether `source` is from a constructor or destructor.
  */
 predicate flows(
-  Instruction source, string msg, Class sourceClass, Instruction sink, CallInstruction call
+  MustFlowPathNode source, string msg, Class sourceClass, MustFlowPathNode sink,
+  CallInstruction call
 ) {
-  isSource(source, msg, sourceClass) and
-  flowsToSink(source, sink) and
-  isSink(sink, call)
+  exists(UnsafeUseOfThisConfig conf |
+    conf.hasFlowPath(source, sink) and
+    isSource(source.getNode(), msg, sourceClass) and
+    isSink(sink.getNode(), call)
+  )
 }
 
-query predicate edges(Instruction a, Instruction b) { successor(a, b) and flowsToSink(b, _) }
-
-query predicate nodes(Instruction n, string key, string val) {
-  flowsToSink(n, _) and
-  key = "semmle.label" and
-  val = n.toString()
-}
-
-from Instruction source, Instruction sink, CallInstruction call, string msg, Class sourceClass
+from
+  MustFlowPathNode source, MustFlowPathNode sink, CallInstruction call, string msg,
+  Class sourceClass
 where
   flows(source, msg, sourceClass, sink, call) and
   // Only raise an alert if there is no override of the pure virtual function in any base class.

--- a/cpp/ql/test/query-tests/Critical/UnsafeUseOfThis/UnsafeUseOfThis.expected
+++ b/cpp/ql/test/query-tests/Critical/UnsafeUseOfThis/UnsafeUseOfThis.expected
@@ -1,61 +1,103 @@
 edges
-| test.cpp:7:3:7:3 | InitializeParameter: B | test.cpp:8:12:8:15 | Load: this |
-| test.cpp:8:12:8:15 | Load: this | test.cpp:34:16:34:16 | InitializeParameter: x |
-| test.cpp:11:8:11:8 | InitializeParameter: b | test.cpp:12:5:12:5 | Load: b |
-| test.cpp:12:5:12:5 | CopyValue: (reference dereference) | test.cpp:12:5:12:5 | ConvertToNonVirtualBase: (A)... |
-| test.cpp:12:5:12:5 | Load: b | test.cpp:12:5:12:5 | CopyValue: (reference dereference) |
-| test.cpp:15:3:15:4 | InitializeParameter: ~B | test.cpp:16:5:16:5 | Load: this |
-| test.cpp:16:5:16:5 | Load: this | file://:0:0:0:0 | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:21:3:21:3 | InitializeParameter: C | test.cpp:21:13:21:13 | ConvertToNonVirtualBase: call to B |
-| test.cpp:21:3:21:3 | InitializeParameter: C | test.cpp:22:12:22:15 | Load: this |
-| test.cpp:21:3:21:3 | InitializeParameter: C | test.cpp:25:7:25:10 | Load: this |
-| test.cpp:21:13:21:13 | ConvertToNonVirtualBase: call to B | test.cpp:7:3:7:3 | InitializeParameter: B |
-| test.cpp:22:12:22:15 | ConvertToNonVirtualBase: (B *)... | test.cpp:34:16:34:16 | InitializeParameter: x |
-| test.cpp:22:12:22:15 | Load: this | test.cpp:22:12:22:15 | ConvertToNonVirtualBase: (B *)... |
-| test.cpp:25:7:25:10 | ConvertToNonVirtualBase: (B *)... | test.cpp:25:7:25:10 | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:25:7:25:10 | Load: this | test.cpp:25:7:25:10 | ConvertToNonVirtualBase: (B *)... |
-| test.cpp:31:3:31:3 | InitializeParameter: D | test.cpp:31:12:31:15 | Load: this |
-| test.cpp:31:11:31:15 | ConvertToNonVirtualBase: (B)... | test.cpp:31:11:31:15 | CopyValue: (reference to) |
-| test.cpp:31:11:31:15 | CopyValue: (reference to) | test.cpp:11:8:11:8 | InitializeParameter: b |
-| test.cpp:31:11:31:15 | CopyValue: * ... | test.cpp:31:11:31:15 | ConvertToNonVirtualBase: (B)... |
-| test.cpp:31:12:31:15 | Load: this | test.cpp:31:11:31:15 | CopyValue: * ... |
-| test.cpp:34:16:34:16 | InitializeParameter: x | test.cpp:35:3:35:3 | Load: x |
-| test.cpp:35:3:35:3 | Load: x | test.cpp:35:3:35:3 | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:47:3:47:3 | InitializeParameter: F | test.cpp:48:10:48:13 | Load: this |
-| test.cpp:48:10:48:13 | ConvertToNonVirtualBase: (E *)... | test.cpp:48:6:48:13 | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:48:10:48:13 | Load: this | test.cpp:48:10:48:13 | ConvertToNonVirtualBase: (E *)... |
+| test.cpp:7:3:7:3 | this | test.cpp:8:12:8:15 | Load |
+| test.cpp:8:12:8:15 | Load | test.cpp:8:12:8:15 | this |
+| test.cpp:8:12:8:15 | this | test.cpp:34:16:34:16 | x |
+| test.cpp:11:8:11:8 | b | test.cpp:12:5:12:5 | Load |
+| test.cpp:12:5:12:5 | (reference dereference) | test.cpp:12:5:12:5 | Unary |
+| test.cpp:12:5:12:5 | Load | test.cpp:12:5:12:5 | b |
+| test.cpp:12:5:12:5 | Unary | test.cpp:12:5:12:5 | (A)... |
+| test.cpp:12:5:12:5 | Unary | test.cpp:12:5:12:5 | (reference dereference) |
+| test.cpp:12:5:12:5 | b | test.cpp:12:5:12:5 | Unary |
+| test.cpp:15:3:15:4 | this | test.cpp:16:5:16:5 | Load |
+| test.cpp:16:5:16:5 | Load | test.cpp:16:5:16:5 | this |
+| test.cpp:16:5:16:5 | Unary | file://:0:0:0:0 | (A *)... |
+| test.cpp:16:5:16:5 | this | test.cpp:16:5:16:5 | Unary |
+| test.cpp:21:3:21:3 | Unary | test.cpp:21:13:21:13 | ConvertToNonVirtualBase |
+| test.cpp:21:3:21:3 | this | test.cpp:21:3:21:3 | Unary |
+| test.cpp:21:3:21:3 | this | test.cpp:22:12:22:15 | Load |
+| test.cpp:21:3:21:3 | this | test.cpp:25:7:25:10 | Load |
+| test.cpp:21:13:21:13 | ConvertToNonVirtualBase | test.cpp:7:3:7:3 | this |
+| test.cpp:22:12:22:15 | (B *)... | test.cpp:34:16:34:16 | x |
+| test.cpp:22:12:22:15 | Load | test.cpp:22:12:22:15 | this |
+| test.cpp:22:12:22:15 | Unary | test.cpp:22:12:22:15 | (B *)... |
+| test.cpp:22:12:22:15 | this | test.cpp:22:12:22:15 | Unary |
+| test.cpp:25:7:25:10 | (B *)... | test.cpp:25:7:25:10 | Unary |
+| test.cpp:25:7:25:10 | Load | test.cpp:25:7:25:10 | this |
+| test.cpp:25:7:25:10 | Unary | test.cpp:25:7:25:10 | (A *)... |
+| test.cpp:25:7:25:10 | Unary | test.cpp:25:7:25:10 | (B *)... |
+| test.cpp:25:7:25:10 | this | test.cpp:25:7:25:10 | Unary |
+| test.cpp:31:3:31:3 | this | test.cpp:31:12:31:15 | Load |
+| test.cpp:31:11:31:15 | (B)... | test.cpp:31:11:31:15 | Unary |
+| test.cpp:31:11:31:15 | (reference to) | test.cpp:11:8:11:8 | b |
+| test.cpp:31:11:31:15 | * ... | test.cpp:31:11:31:15 | Unary |
+| test.cpp:31:11:31:15 | Unary | test.cpp:31:11:31:15 | (B)... |
+| test.cpp:31:11:31:15 | Unary | test.cpp:31:11:31:15 | (reference to) |
+| test.cpp:31:12:31:15 | Load | test.cpp:31:12:31:15 | this |
+| test.cpp:31:12:31:15 | Unary | test.cpp:31:11:31:15 | * ... |
+| test.cpp:31:12:31:15 | this | test.cpp:31:12:31:15 | Unary |
+| test.cpp:34:16:34:16 | x | test.cpp:35:3:35:3 | Load |
+| test.cpp:35:3:35:3 | Load | test.cpp:35:3:35:3 | x |
+| test.cpp:35:3:35:3 | Unary | test.cpp:35:3:35:3 | (A *)... |
+| test.cpp:35:3:35:3 | x | test.cpp:35:3:35:3 | Unary |
+| test.cpp:47:3:47:3 | this | test.cpp:48:10:48:13 | Load |
+| test.cpp:48:10:48:13 | (E *)... | test.cpp:48:10:48:13 | Unary |
+| test.cpp:48:10:48:13 | Load | test.cpp:48:10:48:13 | this |
+| test.cpp:48:10:48:13 | Unary | test.cpp:48:6:48:13 | (A *)... |
+| test.cpp:48:10:48:13 | Unary | test.cpp:48:10:48:13 | (E *)... |
+| test.cpp:48:10:48:13 | this | test.cpp:48:10:48:13 | Unary |
 nodes
-| file://:0:0:0:0 | ConvertToNonVirtualBase: (A *)... | semmle.label | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:7:3:7:3 | InitializeParameter: B | semmle.label | InitializeParameter: B |
-| test.cpp:8:12:8:15 | Load: this | semmle.label | Load: this |
-| test.cpp:11:8:11:8 | InitializeParameter: b | semmle.label | InitializeParameter: b |
-| test.cpp:12:5:12:5 | ConvertToNonVirtualBase: (A)... | semmle.label | ConvertToNonVirtualBase: (A)... |
-| test.cpp:12:5:12:5 | CopyValue: (reference dereference) | semmle.label | CopyValue: (reference dereference) |
-| test.cpp:12:5:12:5 | Load: b | semmle.label | Load: b |
-| test.cpp:15:3:15:4 | InitializeParameter: ~B | semmle.label | InitializeParameter: ~B |
-| test.cpp:16:5:16:5 | Load: this | semmle.label | Load: this |
-| test.cpp:21:3:21:3 | InitializeParameter: C | semmle.label | InitializeParameter: C |
-| test.cpp:21:13:21:13 | ConvertToNonVirtualBase: call to B | semmle.label | ConvertToNonVirtualBase: call to B |
-| test.cpp:22:12:22:15 | ConvertToNonVirtualBase: (B *)... | semmle.label | ConvertToNonVirtualBase: (B *)... |
-| test.cpp:22:12:22:15 | Load: this | semmle.label | Load: this |
-| test.cpp:25:7:25:10 | ConvertToNonVirtualBase: (A *)... | semmle.label | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:25:7:25:10 | ConvertToNonVirtualBase: (B *)... | semmle.label | ConvertToNonVirtualBase: (B *)... |
-| test.cpp:25:7:25:10 | Load: this | semmle.label | Load: this |
-| test.cpp:31:3:31:3 | InitializeParameter: D | semmle.label | InitializeParameter: D |
-| test.cpp:31:11:31:15 | ConvertToNonVirtualBase: (B)... | semmle.label | ConvertToNonVirtualBase: (B)... |
-| test.cpp:31:11:31:15 | CopyValue: (reference to) | semmle.label | CopyValue: (reference to) |
-| test.cpp:31:11:31:15 | CopyValue: * ... | semmle.label | CopyValue: * ... |
-| test.cpp:31:12:31:15 | Load: this | semmle.label | Load: this |
-| test.cpp:34:16:34:16 | InitializeParameter: x | semmle.label | InitializeParameter: x |
-| test.cpp:35:3:35:3 | ConvertToNonVirtualBase: (A *)... | semmle.label | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:35:3:35:3 | Load: x | semmle.label | Load: x |
-| test.cpp:47:3:47:3 | InitializeParameter: F | semmle.label | InitializeParameter: F |
-| test.cpp:48:6:48:13 | ConvertToNonVirtualBase: (A *)... | semmle.label | ConvertToNonVirtualBase: (A *)... |
-| test.cpp:48:10:48:13 | ConvertToNonVirtualBase: (E *)... | semmle.label | ConvertToNonVirtualBase: (E *)... |
-| test.cpp:48:10:48:13 | Load: this | semmle.label | Load: this |
+| file://:0:0:0:0 | (A *)... | semmle.label | (A *)... |
+| test.cpp:7:3:7:3 | this | semmle.label | this |
+| test.cpp:8:12:8:15 | Load | semmle.label | Load |
+| test.cpp:8:12:8:15 | this | semmle.label | this |
+| test.cpp:11:8:11:8 | b | semmle.label | b |
+| test.cpp:12:5:12:5 | (A)... | semmle.label | (A)... |
+| test.cpp:12:5:12:5 | (reference dereference) | semmle.label | (reference dereference) |
+| test.cpp:12:5:12:5 | Load | semmle.label | Load |
+| test.cpp:12:5:12:5 | Unary | semmle.label | Unary |
+| test.cpp:12:5:12:5 | Unary | semmle.label | Unary |
+| test.cpp:12:5:12:5 | b | semmle.label | b |
+| test.cpp:15:3:15:4 | this | semmle.label | this |
+| test.cpp:16:5:16:5 | Load | semmle.label | Load |
+| test.cpp:16:5:16:5 | Unary | semmle.label | Unary |
+| test.cpp:16:5:16:5 | this | semmle.label | this |
+| test.cpp:21:3:21:3 | Unary | semmle.label | Unary |
+| test.cpp:21:3:21:3 | this | semmle.label | this |
+| test.cpp:21:13:21:13 | ConvertToNonVirtualBase | semmle.label | ConvertToNonVirtualBase |
+| test.cpp:22:12:22:15 | (B *)... | semmle.label | (B *)... |
+| test.cpp:22:12:22:15 | Load | semmle.label | Load |
+| test.cpp:22:12:22:15 | Unary | semmle.label | Unary |
+| test.cpp:22:12:22:15 | this | semmle.label | this |
+| test.cpp:25:7:25:10 | (A *)... | semmle.label | (A *)... |
+| test.cpp:25:7:25:10 | (B *)... | semmle.label | (B *)... |
+| test.cpp:25:7:25:10 | Load | semmle.label | Load |
+| test.cpp:25:7:25:10 | Unary | semmle.label | Unary |
+| test.cpp:25:7:25:10 | Unary | semmle.label | Unary |
+| test.cpp:25:7:25:10 | this | semmle.label | this |
+| test.cpp:31:3:31:3 | this | semmle.label | this |
+| test.cpp:31:11:31:15 | (B)... | semmle.label | (B)... |
+| test.cpp:31:11:31:15 | (reference to) | semmle.label | (reference to) |
+| test.cpp:31:11:31:15 | * ... | semmle.label | * ... |
+| test.cpp:31:11:31:15 | Unary | semmle.label | Unary |
+| test.cpp:31:11:31:15 | Unary | semmle.label | Unary |
+| test.cpp:31:12:31:15 | Load | semmle.label | Load |
+| test.cpp:31:12:31:15 | Unary | semmle.label | Unary |
+| test.cpp:31:12:31:15 | this | semmle.label | this |
+| test.cpp:34:16:34:16 | x | semmle.label | x |
+| test.cpp:35:3:35:3 | (A *)... | semmle.label | (A *)... |
+| test.cpp:35:3:35:3 | Load | semmle.label | Load |
+| test.cpp:35:3:35:3 | Unary | semmle.label | Unary |
+| test.cpp:35:3:35:3 | x | semmle.label | x |
+| test.cpp:47:3:47:3 | this | semmle.label | this |
+| test.cpp:48:6:48:13 | (A *)... | semmle.label | (A *)... |
+| test.cpp:48:10:48:13 | (E *)... | semmle.label | (E *)... |
+| test.cpp:48:10:48:13 | Load | semmle.label | Load |
+| test.cpp:48:10:48:13 | Unary | semmle.label | Unary |
+| test.cpp:48:10:48:13 | Unary | semmle.label | Unary |
+| test.cpp:48:10:48:13 | this | semmle.label | this |
 #select
-| test.cpp:12:7:12:7 | call to f | test.cpp:31:3:31:3 | InitializeParameter: D | test.cpp:12:5:12:5 | ConvertToNonVirtualBase: (A)... | Call to pure virtual function during construction |
-| test.cpp:16:5:16:5 | call to f | test.cpp:15:3:15:4 | InitializeParameter: ~B | file://:0:0:0:0 | ConvertToNonVirtualBase: (A *)... | Call to pure virtual function during destruction |
-| test.cpp:25:13:25:13 | call to f | test.cpp:21:3:21:3 | InitializeParameter: C | test.cpp:25:7:25:10 | ConvertToNonVirtualBase: (A *)... | Call to pure virtual function during construction |
-| test.cpp:35:6:35:6 | call to f | test.cpp:7:3:7:3 | InitializeParameter: B | test.cpp:35:3:35:3 | ConvertToNonVirtualBase: (A *)... | Call to pure virtual function during construction |
-| test.cpp:35:6:35:6 | call to f | test.cpp:21:3:21:3 | InitializeParameter: C | test.cpp:35:3:35:3 | ConvertToNonVirtualBase: (A *)... | Call to pure virtual function during construction |
+| test.cpp:12:7:12:7 | call to f | test.cpp:31:3:31:3 | this | test.cpp:12:5:12:5 | (A)... | Call to pure virtual function during construction |
+| test.cpp:16:5:16:5 | call to f | test.cpp:15:3:15:4 | this | file://:0:0:0:0 | (A *)... | Call to pure virtual function during destruction |
+| test.cpp:25:13:25:13 | call to f | test.cpp:21:3:21:3 | this | test.cpp:25:7:25:10 | (A *)... | Call to pure virtual function during construction |
+| test.cpp:35:6:35:6 | call to f | test.cpp:7:3:7:3 | this | test.cpp:35:3:35:3 | (A *)... | Call to pure virtual function during construction |
+| test.cpp:35:6:35:6 | call to f | test.cpp:21:3:21:3 | this | test.cpp:35:3:35:3 | (A *)... | Call to pure virtual function during construction |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/ReturnStackAllocatedMemory.expected
@@ -100,6 +100,12 @@ edges
 | test.cpp:190:10:190:13 | Unary | test.cpp:190:10:190:13 | (reference dereference) |
 | test.cpp:190:10:190:13 | Unary | test.cpp:190:10:190:13 | (reference to) |
 | test.cpp:190:10:190:13 | pRef | test.cpp:190:10:190:13 | Unary |
+| test.cpp:225:14:225:15 | px | test.cpp:226:10:226:11 | Load |
+| test.cpp:226:10:226:11 | Load | test.cpp:226:10:226:11 | px |
+| test.cpp:226:10:226:11 | px | test.cpp:226:10:226:11 | StoreValue |
+| test.cpp:231:16:231:17 | & ... | test.cpp:225:14:225:15 | px |
+| test.cpp:231:17:231:17 | Unary | test.cpp:231:16:231:17 | & ... |
+| test.cpp:231:17:231:17 | x | test.cpp:231:17:231:17 | Unary |
 nodes
 | test.cpp:17:9:17:11 | & ... | semmle.label | & ... |
 | test.cpp:17:9:17:11 | StoreValue | semmle.label | StoreValue |
@@ -215,6 +221,13 @@ nodes
 | test.cpp:190:10:190:13 | Unary | semmle.label | Unary |
 | test.cpp:190:10:190:13 | Unary | semmle.label | Unary |
 | test.cpp:190:10:190:13 | pRef | semmle.label | pRef |
+| test.cpp:225:14:225:15 | px | semmle.label | px |
+| test.cpp:226:10:226:11 | Load | semmle.label | Load |
+| test.cpp:226:10:226:11 | StoreValue | semmle.label | StoreValue |
+| test.cpp:226:10:226:11 | px | semmle.label | px |
+| test.cpp:231:16:231:17 | & ... | semmle.label | & ... |
+| test.cpp:231:17:231:17 | Unary | semmle.label | Unary |
+| test.cpp:231:17:231:17 | x | semmle.label | x |
 #select
 | test.cpp:17:9:17:11 | StoreValue | test.cpp:17:10:17:11 | mc | test.cpp:17:9:17:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:17:10:17:11 | mc | mc |
 | test.cpp:25:9:25:11 | StoreValue | test.cpp:23:18:23:19 | mc | test.cpp:25:9:25:11 | StoreValue | May return stack-allocated memory from $@. | test.cpp:23:18:23:19 | mc | mc |

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -221,3 +221,12 @@ void* get_sp() {
 	int p;
 	return (void*)&p; // GOOD: The function name makes it sound like the programmer intended to get the value of the stack pointer.
 }
+
+int* id(int* px) {
+  return px; // GOOD
+}
+
+void f() {
+  int x;
+  int* px = id(&x); // GOOD
+}


### PR DESCRIPTION
This PR factors out the common functionality from `cpp/unsafe-use-of-this` and `cpp/return-stack-allocated-memory`. This shouldn't change any behavior[^1], but it should mean that we re-evaluate a _tiny_ little bit less stuff in the Code Scanning suite.

[^1]: Apart from the path explanation for `cpp/unsafe-use-of-this` which is now a lot better as it doesn't just use the `toString` given by the IR.