### PR TITLE
Ruby: Fix off-by-one error in `getGroupName`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/ParseRegExp.qll
@@ -488,7 +488,7 @@ abstract class RegExp extends AST::StringlikeLiteral {
     this.group(start, end) and
     exists(int nameEnd |
       this.namedGroupStart(start, nameEnd) and
-      result = this.getText().substring(start + 4, nameEnd - 1)
+      result = this.getText().substring(start + 3, nameEnd - 1)
     )
   }
 

--- a/ruby/ql/test/library-tests/regexp/regexp.expected
+++ b/ruby/ql/test/library-tests/regexp/regexp.expected
@@ -1,7 +1,7 @@
 groupName
-| regexp.rb:52:2:52:11 | (?<id>\\w+) | d |
-| regexp.rb:53:2:53:12 | (?'foo'fo+) | oo |
-| regexp.rb:57:2:57:11 | (?<qux>q+) | ux |
+| regexp.rb:52:2:52:11 | (?<id>\\w+) | id |
+| regexp.rb:53:2:53:12 | (?'foo'fo+) | foo |
+| regexp.rb:57:2:57:11 | (?<qux>q+) | qux |
 groupNumber
 | regexp.rb:46:2:46:6 | (foo) | 1 |
 | regexp.rb:47:4:47:8 | (o\|b) | 1 |

--- a/ruby/ql/test/library-tests/regexp/regexp.expected
+++ b/ruby/ql/test/library-tests/regexp/regexp.expected
@@ -1,0 +1,13 @@
+groupName
+| regexp.rb:52:2:52:11 | (?<id>\\w+) | d |
+| regexp.rb:53:2:53:12 | (?'foo'fo+) | oo |
+| regexp.rb:57:2:57:11 | (?<qux>q+) | ux |
+groupNumber
+| regexp.rb:46:2:46:6 | (foo) | 1 |
+| regexp.rb:47:4:47:8 | (o\|b) | 1 |
+| regexp.rb:48:2:48:9 | (a\|b\|cd) | 1 |
+| regexp.rb:49:2:49:7 | (?::+) | 1 |
+| regexp.rb:52:2:52:11 | (?<id>\\w+) | 1 |
+| regexp.rb:53:2:53:12 | (?'foo'fo+) | 1 |
+| regexp.rb:56:2:56:5 | (a+) | 1 |
+| regexp.rb:57:2:57:11 | (?<qux>q+) | 1 |

--- a/ruby/ql/test/library-tests/regexp/regexp.ql
+++ b/ruby/ql/test/library-tests/regexp/regexp.ql
@@ -1,0 +1,5 @@
+import codeql.ruby.security.performance.RegExpTreeView
+
+query predicate groupName(RegExpGroup g, string name) { name = g.getName() }
+
+query predicate groupNumber(RegExpGroup g, int number) { number = g.getNumber() }


### PR DESCRIPTION
cc @yoff and @joefarebrother for Python and Java.