### PR TITLE
JS: support that the base is not a method-call in getAChainedMethodCall

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -147,7 +147,7 @@ class SourceNode extends DataFlow::Node {
    */
   DataFlow::CallNode getAChainedMethodCall(string methodName) {
     // the direct call to `getAMethodCall` is needed in case the base is not a `DataFlow::CallNode`.
-    result = [getAMethodCall*().getAMethodCall(methodName), getAMethodCall(methodName)]
+    result = [getAMethodCall+().getAMethodCall(methodName), getAMethodCall(methodName)]
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -146,7 +146,8 @@ class SourceNode extends DataFlow::Node {
    * that is, `o.m(...)` or `o[p](...)`.
    */
   DataFlow::CallNode getAChainedMethodCall(string methodName) {
-    result = getAMethodCall*().getAMethodCall(methodName)
+    // the direct call to `getAMethodCall` is needed in case the base is not a `DataFlow::CallNode`.
+    result = [getAMethodCall*().getAMethodCall(methodName), getAMethodCall(methodName)]
   }
 
   /**

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -52,6 +52,11 @@ nodes
 | child_process-test.js:83:19:83:36 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName |
+| child_process-test.js:94:11:94:35 | "ping " ... ms.host |
+| child_process-test.js:94:11:94:35 | "ping " ... ms.host |
+| child_process-test.js:94:21:94:30 | ctx.params |
+| child_process-test.js:94:21:94:30 | ctx.params |
+| child_process-test.js:94:21:94:35 | ctx.params.host |
 | exec-sh2.js:9:17:9:23 | command |
 | exec-sh2.js:10:40:10:46 | command |
 | exec-sh2.js:10:40:10:46 | command |
@@ -229,6 +234,10 @@ edges
 | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:7:32:7:35 | name |
 | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:7:32:7:35 | name |
+| child_process-test.js:94:21:94:30 | ctx.params | child_process-test.js:94:21:94:35 | ctx.params.host |
+| child_process-test.js:94:21:94:30 | ctx.params | child_process-test.js:94:21:94:35 | ctx.params.host |
+| child_process-test.js:94:21:94:35 | ctx.params.host | child_process-test.js:94:11:94:35 | "ping " ... ms.host |
+| child_process-test.js:94:21:94:35 | ctx.params.host | child_process-test.js:94:11:94:35 | "ping " ... ms.host |
 | exec-sh2.js:9:17:9:23 | command | exec-sh2.js:10:40:10:46 | command |
 | exec-sh2.js:9:17:9:23 | command | exec-sh2.js:10:40:10:46 | command |
 | exec-sh2.js:14:9:14:49 | cmd | exec-sh2.js:15:12:15:14 | cmd |
@@ -365,6 +374,7 @@ edges
 | child_process-test.js:67:3:67:21 | cp.spawn(cmd, args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:48:15:48:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:75:29:75:31 | cmd | child_process-test.js:73:25:73:31 | req.url | child_process-test.js:75:29:75:31 | cmd | This command depends on $@. | child_process-test.js:73:25:73:31 | req.url | a user-provided value |
 | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | This command depends on $@. | child_process-test.js:83:19:83:36 | req.query.fileName | a user-provided value |
+| child_process-test.js:94:11:94:35 | "ping " ... ms.host | child_process-test.js:94:21:94:30 | ctx.params | child_process-test.js:94:11:94:35 | "ping " ... ms.host | This command depends on $@. | child_process-test.js:94:21:94:30 | ctx.params | a user-provided value |
 | exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:40:10:46 | command | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
 | exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:19:25:19:31 | req.url | exec-sh.js:15:44:15:50 | command | This command depends on $@. | exec-sh.js:19:25:19:31 | req.url | a user-provided value |
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/child_process-test.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/child_process-test.js
@@ -86,3 +86,10 @@ new webpackDevServer(compiler, {
         });
     }
 });
+
+import Router from "koa-router";
+const router = new Router();
+
+router.get("/ping/:host", async (ctx) => {
+  cp.exec("ping " + ctx.params.host); // NOT OK
+});


### PR DESCRIPTION
Gets a TP for CVE-2021-46704 

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-8380-cebd241__nightly__security-extend/reports).  

--- 

Consider the below. 

```CodeQL
result = DataFlow::moduleImport("foo").getAnInstantiation().getAMethodCall*().getAMethodCall("bar");
```

This will not flag the below: 
```JavaScript
const Foo = require("foo");
const inst = new Foo();
const result = inst.bar();
```

Because `DataFlow::moduleImport("foo").getAnInstantiation().getAMethodCall*()` is restricted to the type `DataFlow::CallNode`, even if we take 0 steps through the transitive closure. 