### PR TITLE
C++: Use a `TaintTracking::Configuration` in three more queries

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -15,55 +15,89 @@
 
 import cpp
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
-import semmle.code.cpp.security.TaintTracking
-import TaintedWithPath
+import semmle.code.cpp.ir.dataflow.TaintTracking
+import semmle.code.cpp.ir.IR
+import semmle.code.cpp.controlflow.IRGuards
+import semmle.code.cpp.security.FlowSources
+import DataFlow::PathGraph
 
 /**
  * Holds if `alloc` is an allocation, and `tainted` is a child of it that is a
  * taint sink.
  */
-predicate allocSink(Expr alloc, Expr tainted) {
-  isAllocationExpr(alloc) and
-  tainted = alloc.getAChild() and
-  tainted.getUnspecifiedType() instanceof IntegralType
-}
-
-class TaintedAllocationSizeConfiguration extends TaintTrackingConfiguration {
-  override predicate isSink(Element tainted) { allocSink(_, tainted) }
-
-  override predicate isBarrier(Expr e) {
-    super.isBarrier(e)
-    or
-    // There can be two separate reasons for `convertedExprMightOverflow` not holding:
-    // 1. `e` really cannot overflow.
-    // 2. `e` isn't analyzable.
-    // If we didn't rule out case 2 we would place barriers on anything that isn't analyzable.
-    (
-      e instanceof UnaryArithmeticOperation or
-      e instanceof BinaryArithmeticOperation or
-      e instanceof AssignArithmeticOperation
-    ) and
-    not convertedExprMightOverflow(e)
-    or
-    // Subtracting two pointers is either well-defined (and the result will likely be small), or
-    // terribly undefined and dangerous. Here, we assume that the programmer has ensured that the
-    // result is well-defined (i.e., the two pointers point to the same object), and thus the result
-    // will likely be small.
-    e = any(PointerDiffExpr diff).getAnOperand()
-  }
-}
-
-predicate taintedAllocSize(
-  Expr source, Expr alloc, PathNode sourceNode, PathNode sinkNode, string taintCause
-) {
-  isUserInput(source, taintCause) and
-  exists(Expr tainted |
-    allocSink(alloc, tainted) and
-    taintedWithPath(source, tainted, sourceNode, sinkNode)
+predicate allocSink(Expr alloc, DataFlow::Node sink) {
+  exists(Expr e | e = sink.asConvertedExpr() |
+    isAllocationExpr(alloc) and
+    e = alloc.getAChild() and
+    e.getUnspecifiedType() instanceof IntegralType
   )
 }
 
-from Expr source, Expr alloc, PathNode sourceNode, PathNode sinkNode, string taintCause
-where taintedAllocSize(source, alloc, sourceNode, sinkNode, taintCause)
-select alloc, sourceNode, sinkNode, "This allocation size is derived from $@ and might overflow",
-  source, "user input (" + taintCause + ")"
+predicate readsVariable(LoadInstruction load, Variable var) {
+  load.getSourceAddress().(VariableAddressInstruction).getASTVariable() = var
+}
+
+predicate hasUpperBoundsCheck(Variable var) {
+  exists(RelationalOperation oper, VariableAccess access |
+    oper.getAnOperand() = access and
+    access.getTarget() = var and
+    // Comparing to 0 is not an upper bound check
+    not oper.getAnOperand().getValue() = "0"
+  )
+}
+
+predicate nodeIsBarrierEqualityCandidate(DataFlow::Node node, Operand access, Variable checkedVar) {
+  readsVariable(node.asInstruction(), checkedVar) and
+  any(IRGuardCondition guard).ensuresEq(access, _, _, node.asInstruction().getBlock(), true)
+}
+
+predicate isFlowSource(FlowSource source, string sourceType) { sourceType = source.getSourceType() }
+
+class TaintedAllocationSizeConfiguration extends TaintTracking::Configuration {
+  TaintedAllocationSizeConfiguration() { this = "TaintedAllocationSizeConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) { isFlowSource(source, _) }
+
+  override predicate isSink(DataFlow::Node sink) { allocSink(_, sink) }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    exists(Expr e | e = node.asExpr() |
+      // There can be two separate reasons for `convertedExprMightOverflow` not holding:
+      // 1. `e` really cannot overflow.
+      // 2. `e` isn't analyzable.
+      // If we didn't rule out case 2 we would place barriers on anything that isn't analyzable.
+      (
+        e instanceof UnaryArithmeticOperation or
+        e instanceof BinaryArithmeticOperation or
+        e instanceof AssignArithmeticOperation
+      ) and
+      not convertedExprMightOverflow(e)
+      or
+      // Subtracting two pointers is either well-defined (and the result will likely be small), or
+      // terribly undefined and dangerous. Here, we assume that the programmer has ensured that the
+      // result is well-defined (i.e., the two pointers point to the same object), and thus the result
+      // will likely be small.
+      e = any(PointerDiffExpr diff).getAnOperand()
+    )
+    or
+    exists(Variable checkedVar |
+      readsVariable(node.asInstruction(), checkedVar) and
+      hasUpperBoundsCheck(checkedVar)
+    )
+    or
+    exists(Variable checkedVar, Operand access |
+      readsVariable(access.getDef(), checkedVar) and
+      nodeIsBarrierEqualityCandidate(node, access, checkedVar)
+    )
+  }
+}
+
+from
+  Expr alloc, DataFlow::PathNode source, DataFlow::PathNode sink, string taintCause,
+  TaintedAllocationSizeConfiguration conf
+where
+  isFlowSource(source.getNode(), taintCause) and
+  conf.hasFlowPath(source, sink) and
+  allocSink(alloc, sink.getNode())
+select alloc, source, sink, "This allocation size is derived from $@ and might overflow",
+  source.getNode(), "user input (" + taintCause + ")"

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/SAMATE/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/SAMATE/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -1,1 +1,8 @@
-| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:20:52:23 | data | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | inputBuffer | User-provided value |
+edges
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:13:52:24 | access to array |
+nodes
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | semmle.label | fgets output argument |
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:13:52:24 | access to array | semmle.label | access to array |
+subpaths
+#select
+| CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:13:52:24 | access to array | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:52:13:52:24 | access to array | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | CWE122_Heap_Based_Buffer_Overflow__c_CWE129_fgets_01.c:30:19:30:29 | fgets output argument | String read by fgets |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -1,3 +1,26 @@
-| test1.c:18:16:18:16 | i | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | test1.c:8:16:8:19 | argv | User-provided value |
-| test1.c:33:11:33:11 | i | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | test1.c:8:16:8:19 | argv | User-provided value |
-| test1.c:53:15:53:15 | j | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | test1.c:8:16:8:19 | argv | User-provided value |
+edges
+| test1.c:8:16:8:19 | argv | test1.c:9:9:9:9 | i |
+| test1.c:8:16:8:19 | argv | test1.c:11:9:11:9 | i |
+| test1.c:8:16:8:19 | argv | test1.c:13:9:13:9 | i |
+| test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i |
+| test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i |
+| test1.c:13:9:13:9 | i | test1.c:48:16:48:16 | i |
+| test1.c:16:16:16:16 | i | test1.c:18:12:18:17 | access to array |
+| test1.c:32:16:32:16 | i | test1.c:33:3:33:12 | access to array |
+| test1.c:48:16:48:16 | i | test1.c:53:7:53:16 | access to array |
+nodes
+| test1.c:8:16:8:19 | argv | semmle.label | argv |
+| test1.c:9:9:9:9 | i | semmle.label | i |
+| test1.c:11:9:11:9 | i | semmle.label | i |
+| test1.c:13:9:13:9 | i | semmle.label | i |
+| test1.c:16:16:16:16 | i | semmle.label | i |
+| test1.c:18:12:18:17 | access to array | semmle.label | access to array |
+| test1.c:32:16:32:16 | i | semmle.label | i |
+| test1.c:33:3:33:12 | access to array | semmle.label | access to array |
+| test1.c:48:16:48:16 | i | semmle.label | i |
+| test1.c:53:7:53:16 | access to array | semmle.label | access to array |
+subpaths
+#select
+| test1.c:18:12:18:17 | access to array | test1.c:8:16:8:19 | argv | test1.c:18:12:18:17 | access to array | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | test1.c:8:16:8:19 | argv | a command-line argument |
+| test1.c:33:3:33:12 | access to array | test1.c:8:16:8:19 | argv | test1.c:33:3:33:12 | access to array | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | test1.c:8:16:8:19 | argv | a command-line argument |
+| test1.c:53:7:53:16 | access to array | test1.c:8:16:8:19 | argv | test1.c:53:7:53:16 | access to array | $@ flows to here and is used in an array indexing expression, potentially causing an invalid access. | test1.c:8:16:8:19 | argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,62 +1,20 @@
 edges
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
-| test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
 | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted |
 | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... |
 | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | (size_t)... |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size |
 | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size |
-| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
-| test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
 | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... |
 | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:124:18:124:31 | (const char *)... | test.cpp:128:24:128:41 | ... * ... |
-| test.cpp:124:18:124:31 | (const char *)... | test.cpp:128:24:128:41 | ... * ... |
 | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:133:19:133:32 | (const char *)... | test.cpp:135:10:135:27 | ... * ... |
-| test.cpp:133:19:133:32 | (const char *)... | test.cpp:135:10:135:27 | ... * ... |
 | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:148:20:148:33 | (const char *)... | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:148:20:148:33 | (const char *)... | test.cpp:152:11:152:28 | ... * ... |
-| test.cpp:209:8:209:23 | ReturnValue | test.cpp:241:9:241:24 | call to get_tainted_size |
 | test.cpp:209:8:209:23 | ReturnValue | test.cpp:241:9:241:24 | call to get_tainted_size |
 | test.cpp:211:14:211:19 | call to getenv | test.cpp:209:8:209:23 | ReturnValue |
-| test.cpp:211:14:211:27 | (const char *)... | test.cpp:209:8:209:23 | ReturnValue |
-| test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
 | test.cpp:224:23:224:23 | s | test.cpp:225:21:225:21 | s |
 | test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
-| test.cpp:230:21:230:21 | s | test.cpp:231:21:231:21 | s |
-| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | (size_t)... |
-| test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:245:11:245:20 | local_size |
 | test.cpp:237:24:237:29 | call to getenv | test.cpp:247:10:247:19 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | (size_t)... |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:239:9:239:18 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:245:11:245:20 | local_size |
-| test.cpp:237:24:237:37 | (const char *)... | test.cpp:247:10:247:19 | local_size |
 | test.cpp:245:11:245:20 | local_size | test.cpp:224:23:224:23 | s |
 | test.cpp:247:10:247:19 | local_size | test.cpp:230:21:230:21 | s |
 | test.cpp:251:2:251:9 | (reference dereference) [post update] | test.cpp:289:17:289:20 | size [post update] |
@@ -64,112 +22,57 @@ edges
 | test.cpp:251:18:251:23 | call to getenv | test.cpp:251:2:251:9 | (reference dereference) [post update] |
 | test.cpp:251:18:251:23 | call to getenv | test.cpp:289:17:289:20 | size [post update] |
 | test.cpp:251:18:251:23 | call to getenv | test.cpp:305:18:305:21 | size [post update] |
-| test.cpp:251:18:251:31 | (const char *)... | test.cpp:251:2:251:9 | (reference dereference) [post update] |
-| test.cpp:251:18:251:31 | (const char *)... | test.cpp:289:17:289:20 | size [post update] |
-| test.cpp:251:18:251:31 | (const char *)... | test.cpp:305:18:305:21 | size [post update] |
 | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:259:20:259:33 | (const char *)... | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:259:20:259:33 | (const char *)... | test.cpp:263:11:263:29 | ... * ... |
-| test.cpp:289:17:289:20 | size [post update] | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:289:17:289:20 | size [post update] | test.cpp:291:11:291:28 | ... * ... |
 | test.cpp:305:18:305:21 | size [post update] | test.cpp:308:10:308:27 | ... * ... |
-| test.cpp:305:18:305:21 | size [post update] | test.cpp:308:10:308:27 | ... * ... |
-subpaths
 nodes
 | test.cpp:40:21:40:24 | argv | semmle.label | argv |
-| test.cpp:40:21:40:24 | argv | semmle.label | argv |
-| test.cpp:43:38:43:44 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:43:38:43:44 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
-| test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
 | test.cpp:43:38:43:44 | tainted | semmle.label | tainted |
 | test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
-| test.cpp:44:38:44:63 | ... * ... | semmle.label | ... * ... |
 | test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:46:38:46:63 | ... + ... | semmle.label | ... + ... |
-| test.cpp:49:32:49:35 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:49:32:49:35 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:49:32:49:35 | size | semmle.label | size |
-| test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:49:32:49:35 | size | semmle.label | size |
 | test.cpp:50:26:50:29 | size | semmle.label | size |
-| test.cpp:50:26:50:29 | size | semmle.label | size |
-| test.cpp:50:26:50:29 | size | semmle.label | size |
-| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
-| test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
 | test.cpp:53:35:53:60 | ... * ... | semmle.label | ... * ... |
 | test.cpp:124:18:124:23 | call to getenv | semmle.label | call to getenv |
-| test.cpp:124:18:124:31 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
-| test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
 | test.cpp:128:24:128:41 | ... * ... | semmle.label | ... * ... |
 | test.cpp:133:19:133:24 | call to getenv | semmle.label | call to getenv |
-| test.cpp:133:19:133:32 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:135:10:135:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:148:20:148:25 | call to getenv | semmle.label | call to getenv |
-| test.cpp:148:20:148:33 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:209:8:209:23 | ReturnValue | semmle.label | ReturnValue |
 | test.cpp:211:14:211:19 | call to getenv | semmle.label | call to getenv |
-| test.cpp:211:14:211:27 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:224:23:224:23 | s | semmle.label | s |
-| test.cpp:225:21:225:21 | s | semmle.label | s |
-| test.cpp:225:21:225:21 | s | semmle.label | s |
 | test.cpp:225:21:225:21 | s | semmle.label | s |
 | test.cpp:230:21:230:21 | s | semmle.label | s |
 | test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:231:21:231:21 | s | semmle.label | s |
-| test.cpp:231:21:231:21 | s | semmle.label | s |
 | test.cpp:237:24:237:29 | call to getenv | semmle.label | call to getenv |
-| test.cpp:237:24:237:37 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:239:9:239:18 | (size_t)... | semmle.label | (size_t)... |
-| test.cpp:239:9:239:18 | (size_t)... | semmle.label | (size_t)... |
 | test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
-| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
-| test.cpp:239:9:239:18 | local_size | semmle.label | local_size |
-| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
 | test.cpp:241:9:241:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
 | test.cpp:245:11:245:20 | local_size | semmle.label | local_size |
 | test.cpp:247:10:247:19 | local_size | semmle.label | local_size |
 | test.cpp:251:2:251:9 | (reference dereference) [post update] | semmle.label | (reference dereference) [post update] |
-| test.cpp:251:2:251:9 | out_size [post update] | semmle.label | out_size [post update] |
 | test.cpp:251:18:251:23 | call to getenv | semmle.label | call to getenv |
-| test.cpp:251:18:251:31 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:259:20:259:25 | call to getenv | semmle.label | call to getenv |
-| test.cpp:259:20:259:33 | (const char *)... | semmle.label | (const char *)... |
-| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:263:11:263:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:289:17:289:20 | size [post update] | semmle.label | size [post update] |
 | test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:291:11:291:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:305:18:305:21 | size [post update] | semmle.label | size [post update] |
 | test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:308:10:308:27 | ... * ... | semmle.label | ... * ... |
+subpaths
 #select
-| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (argv) |
-| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:124:18:124:23 | call to getenv | user input (getenv) |
-| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:133:19:133:24 | call to getenv | user input (getenv) |
-| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:148:20:148:25 | call to getenv | user input (getenv) |
-| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
-| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
-| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (getenv) |
-| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow | test.cpp:211:14:211:19 | call to getenv | user input (getenv) |
-| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:259:20:259:25 | call to getenv | user input (getenv) |
-| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (getenv) |
-| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (getenv) |
+| test.cpp:43:31:43:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:44:31:44:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:44:38:44:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:46:31:46:36 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:46:38:46:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:49:25:49:30 | call to malloc | test.cpp:40:21:40:24 | argv | test.cpp:49:32:49:35 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:50:17:50:30 | new[] | test.cpp:40:21:40:24 | argv | test.cpp:50:26:50:29 | size | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:53:21:53:27 | call to realloc | test.cpp:40:21:40:24 | argv | test.cpp:53:35:53:60 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:40:21:40:24 | argv | user input (a command-line argument) |
+| test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:23 | call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:124:18:124:23 | call to getenv | user input (an environment variable) |
+| test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:24 | call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:133:19:133:24 | call to getenv | user input (an environment variable) |
+| test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:25 | call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:148:20:148:25 | call to getenv | user input (an environment variable) |
+| test.cpp:225:14:225:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:225:21:225:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:231:14:231:19 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:231:21:231:21 | s | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:239:2:239:7 | call to malloc | test.cpp:237:24:237:29 | call to getenv | test.cpp:239:9:239:18 | local_size | This allocation size is derived from $@ and might overflow | test.cpp:237:24:237:29 | call to getenv | user input (an environment variable) |
+| test.cpp:241:2:241:7 | call to malloc | test.cpp:211:14:211:19 | call to getenv | test.cpp:241:9:241:24 | call to get_tainted_size | This allocation size is derived from $@ and might overflow | test.cpp:211:14:211:19 | call to getenv | user input (an environment variable) |
+| test.cpp:263:4:263:9 | call to malloc | test.cpp:259:20:259:25 | call to getenv | test.cpp:263:11:263:29 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:259:20:259:25 | call to getenv | user input (an environment variable) |
+| test.cpp:291:4:291:9 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:291:11:291:28 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |
+| test.cpp:308:3:308:8 | call to malloc | test.cpp:251:18:251:23 | call to getenv | test.cpp:308:10:308:27 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:251:18:251:23 | call to getenv | user input (an environment variable) |


### PR DESCRIPTION
Initially, I was also going to modernize the sanitizers used in the three queries, but I realized that this code should be changed anyway once we merged the ongoing work on range analysis. So for now I've copied the ad-hoc sanitizers into these three queries to not change their behavior.