### PR TITLE
QL: add query detecting ordering by a constant

### DIFF
--- a/ql/ql/src/queries/bugs/OrderByConst.ql
+++ b/ql/ql/src/queries/bugs/OrderByConst.ql
@@ -1,0 +1,28 @@
+/**
+ * @name Order by const
+ * @description Ordering by a constant has no effect, and is an indication is a misplaced order by clause.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/order-by-const
+ * @tags correctness
+ *       maintainability
+ * @precision medium
+ */
+
+import ql
+
+Expr getAnOrderBy(AstNode parent, string kind) {
+  result = parent.(FullAggregate).getOrderBy(_) and
+  kind = parent.(FullAggregate).getKind() + " aggregate"
+  or
+  result = parent.(Select).getOrderBy(_) and kind = "select"
+  or
+  result = parent.(ExprAggregate).getOrderBy(_) and
+  kind = parent.(ExprAggregate).getKind() + " aggregate"
+}
+
+from Expr orderBy, AstNode parent, string kind
+where
+  orderBy = getAnOrderBy(parent, kind) and
+  orderBy instanceof Literal
+select orderBy, "Ordering $@ by a constant.", parent, kind

--- a/ql/ql/test/queries/bugs/OrderByConst/Foo.qll
+++ b/ql/ql/test/queries/bugs/OrderByConst/Foo.qll
@@ -1,0 +1,10 @@
+string foo() {
+  result = concat(string x | x = [0 .. 10].toString() | x order by x desc, ", ") // BAD
+  or
+  result = concat(string x | x = [0 .. 10].toString() | x, ", " order by x desc) // GOOD
+}
+
+class Even extends int {
+  bindingset[this]
+  Even() { this % 2 = 0 }
+}

--- a/ql/ql/test/queries/bugs/OrderByConst/OrderByConst.expected
+++ b/ql/ql/test/queries/bugs/OrderByConst/OrderByConst.expected
@@ -1,0 +1,1 @@
+| Foo.qll:2:76:2:79 | String | Ordering $@ by a constant. | Foo.qll:2:12:2:80 | FullAggregate[concat] | concat aggregate |

--- a/ql/ql/test/queries/bugs/OrderByConst/OrderByConst.qlref
+++ b/ql/ql/test/queries/bugs/OrderByConst/OrderByConst.qlref
@@ -1,0 +1,1 @@
+queries/bugs/OrderByConst.ql


### PR DESCRIPTION
This was a mistake I made myself recently.  
I never committed the mistake, but that could have happened.  

No results in `github/codeql` :tada: 