### PR TITLE
JS: Add StoredXss XssThroughDom to all QL required for endpoint pipeline

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointTypes.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointTypes.qll
@@ -23,7 +23,7 @@ abstract class EndpointType extends TEndpointType {
 
 /** The `NotASink` class that can be predicted by endpoint scoring models. */
 class NotASinkType extends EndpointType, TNotASinkType {
-  override string getDescription() { result = "NotASink" }
+  override string getDescription() { result = "Negative" }
 
   override int getEncoding() { result = 0 }
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StoredXssATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/StoredXssATM.qll
@@ -1,0 +1,72 @@
+/**
+ * Provides a taint-tracking configuration for reasoning about stored
+ * cross-site scripting vulnerabilities.
+ * Is boosted by ATM.
+ */
+
+import javascript
+import AdaptiveThreatModeling
+import semmle.javascript.security.dataflow.Xss::StoredXss
+
+/**
+ * This module provides logic to filter candidate sinks to those which are likely XSS sinks.
+ */
+module SinkEndpointFilter {
+  private import StandardEndpointFilters as StandardEndpointFilters
+
+  /**
+   * Provides a set of reasons why a given data flow node should be excluded as a sink candidate.
+   *
+   * If this predicate has no results for a sink candidate `n`, then we should treat `n` as an
+   * effective sink.
+   */
+  string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
+    result = StandardEndpointFilters::getAReasonSinkExcluded(sinkCandidate)
+  }
+}
+
+class StoredXssATMConfig extends ATMConfig {
+  StoredXssATMConfig() { this = "StoredXssATMConfig" }
+
+  override predicate isKnownSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isKnownSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  override predicate isEffectiveSink(DataFlow::Node sinkCandidate) {
+    not exists(SinkEndpointFilter::getAReasonSinkExcluded(sinkCandidate))
+  }
+
+  override EndpointType getASinkEndpointType() { result instanceof XssSinkType }
+}
+
+/**
+ * A taint-tracking configuration for reasoning about XSS.
+ */
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "StoredXssATMConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isSink(DataFlow::Node sink) {
+    (sink instanceof Sink or any(StoredXssATMConfig cfg).isEffectiveSink(sink))
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    super.isSanitizer(node) or
+    node instanceof Sanitizer
+  }
+
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
+    guard instanceof SanitizerGuard
+  }
+}
+
+/** A file name, considered as a flow source for stored XSS. */
+class FileNameSourceAsSource extends Source {
+  FileNameSourceAsSource() { this instanceof FileNameSource }
+}
+
+/** An instance of user-controlled torrent information, considered as a flow source for stored XSS. */
+class UserControlledTorrentInfoAsSource extends Source {
+  UserControlledTorrentInfoAsSource() { this instanceof ParseTorrent::UserControlledTorrentInfo }
+}

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/XssThroughDomATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/XssThroughDomATM.qll
@@ -1,0 +1,72 @@
+/**
+ * Provides a taint-tracking configuration for reasoning about
+ * cross-site scripting vulnerabilities through the DOM.
+ * Is boosted by ATM.
+ */
+
+import javascript
+import AdaptiveThreatModeling
+private import semmle.javascript.dataflow.InferredTypes
+import semmle.javascript.security.dataflow.Xss::XssThroughDom
+private import semmle.javascript.security.dataflow.XssThroughDomCustomizations::XssThroughDom
+private import semmle.javascript.security.dataflow.Xss::DomBasedXss as DomBasedXss
+private import semmle.javascript.security.dataflow.UnsafeJQueryPluginCustomizations::UnsafeJQueryPlugin as UnsafeJQuery
+
+/**
+ * This module provides logic to filter candidate sinks to those which are likely XSS sinks.
+ */
+module SinkEndpointFilter {
+  private import StandardEndpointFilters as StandardEndpointFilters
+
+  /**
+   * Provides a set of reasons why a given data flow node should be excluded as a sink candidate.
+   *
+   * If this predicate has no results for a sink candidate `n`, then we should treat `n` as an
+   * effective sink.
+   */
+  string getAReasonSinkExcluded(DataFlow::Node sinkCandidate) {
+    result = StandardEndpointFilters::getAReasonSinkExcluded(sinkCandidate)
+  }
+}
+
+class XssThroughDOMATMConfig extends ATMConfig {
+  XssThroughDOMATMConfig() { this = "XssThroughDOMATMConfig" }
+
+  override predicate isKnownSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isKnownSink(DataFlow::Node sink) { sink instanceof DomBasedXss::Sink }
+
+  override predicate isEffectiveSink(DataFlow::Node sinkCandidate) {
+    not exists(SinkEndpointFilter::getAReasonSinkExcluded(sinkCandidate))
+  }
+
+  override EndpointType getASinkEndpointType() { result instanceof XssSinkType }
+}
+
+/**
+ * A taint-tracking configuration for reasoning about XSS through the DOM.
+ */
+class Configuration extends TaintTracking::Configuration {
+  Configuration() { this = "XssThroughDOMATMConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isSink(DataFlow::Node sink) {
+    (sink instanceof DomBasedXss::Sink or any(XssThroughDOMATMConfig cfg).isEffectiveSink(sink))
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    super.isSanitizer(node) or
+    node instanceof DomBasedXss::Sanitizer
+  }
+
+  override predicate isSanitizerGuard(TaintTracking::SanitizerGuardNode guard) {
+    guard instanceof TypeTestGuard or
+    guard instanceof UnsafeJQuery::PropertyPresenceSanitizer or
+    guard instanceof DomBasedXss::SanitizerGuard
+  }
+
+  override predicate isSanitizerEdge(DataFlow::Node pred, DataFlow::Node succ) {
+    DomBasedXss::isOptionallySanitizedEdge(pred, succ)
+  }
+}

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointData.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointData.qll
@@ -16,8 +16,10 @@ import experimental.adaptivethreatmodeling.EndpointTypes
 import experimental.adaptivethreatmodeling.FilteringReasons
 import experimental.adaptivethreatmodeling.NosqlInjectionATM as NosqlInjectionATM
 import experimental.adaptivethreatmodeling.SqlInjectionATM as SqlInjectionATM
+import experimental.adaptivethreatmodeling.StoredXssATM as StoredXssATM
 import experimental.adaptivethreatmodeling.TaintedPathATM as TaintedPathATM
 import experimental.adaptivethreatmodeling.XssATM as XssATM
+import experimental.adaptivethreatmodeling.XssThroughDomATM as XssThroughDomATM
 import Labels
 import NoFeaturizationRestrictionsConfig
 import Queries
@@ -29,9 +31,13 @@ AtmConfig getAtmCfg(Query query) {
   or
   query instanceof SqlInjectionQuery and result instanceof SqlInjectionATM::SqlInjectionAtmConfig
   or
-  query instanceof TaintedPathQuery and result instanceof TaintedPathATM::TaintedPathAtmConfig
+  query instanceof StoredXssQuery and result instanceof StoredXssATM::StoredXssATMConfig
   or
-  query instanceof XssQuery and result instanceof XssATM::DomBasedXssAtmConfig
+  query instanceof TaintedPathQuery and result instanceof TaintedPathATM::TaintedPathATMConfig
+  or
+  query instanceof XssQuery and result instanceof XssATM::DomBasedXssATMConfig
+  or
+  query instanceof XssThroughDomQuery and result instanceof XssThroughDomATM::XssThroughDOMATMConfig
 }
 
 /** DEPRECATED: Alias for getAtmCfg */
@@ -46,6 +52,10 @@ DataFlow::Configuration getDataFlowCfg(Query query) {
   query instanceof TaintedPathQuery and result instanceof TaintedPathATM::Configuration
   or
   query instanceof XssQuery and result instanceof XssATM::Configuration
+  or
+  query instanceof StoredXssQuery and result instanceof StoredXssATM::Configuration
+  or
+  query instanceof XssThroughDomQuery and result instanceof XssThroughDomATM::Configuration
 }
 
 /** Gets a known sink for the specified query. */

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointLabelEncoding.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointLabelEncoding.ql
@@ -8,4 +8,4 @@
 import experimental.adaptivethreatmodeling.EndpointTypes
 
 from EndpointType type
-select type.getEncoding() as encoding, type.getDescription() as description order by encoding
+select type.getEncoding() as encodingTypeEncoded, type.getDescription() as endpointType order by encodingTypeEncoded

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointLabelEncoding.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointLabelEncoding.ql
@@ -8,5 +8,4 @@
 import experimental.adaptivethreatmodeling.EndpointTypes
 
 from EndpointType type
-select type.getEncoding() as encodingTypeEncoded, type.getDescription() as endpointType order by
-    encodingTypeEncoded
+select type.getEncoding() as label, type.getDescription() as labelName order by label

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointLabelEncoding.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointLabelEncoding.ql
@@ -8,4 +8,5 @@
 import experimental.adaptivethreatmodeling.EndpointTypes
 
 from EndpointType type
-select type.getEncoding() as encodingTypeEncoded, type.getDescription() as endpointType order by encodingTypeEncoded
+select type.getEncoding() as encodingTypeEncoded, type.getDescription() as endpointType order by
+    encodingTypeEncoded

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
@@ -8,21 +8,41 @@ import experimental.adaptivethreatmodeling.SqlInjectionATM as SqlInjectionATM
 import experimental.adaptivethreatmodeling.NosqlInjectionATM as NosqlInjectionATM
 import experimental.adaptivethreatmodeling.TaintedPathATM as TaintedPathATM
 import experimental.adaptivethreatmodeling.XssATM as XssATM
+import experimental.adaptivethreatmodeling.StoredXssATM as StoredXssATM
+import experimental.adaptivethreatmodeling.XssThroughDomATM as XssThroughDomATM
 import experimental.adaptivethreatmodeling.AdaptiveThreatModeling
 
-from string queryName, AtmConfig c, EndpointType e
+from string queryName, ATMConfig c, int endpointTypeEncoded
 where
   (
-    queryName = "SqlInjectionATM.ql" and
-    c instanceof SqlInjectionATM::SqlInjectionAtmConfig
+    queryName = "Unknown" and
+    endpointTypeEncoded = 0
     or
-    queryName = "NosqlInjectionATM.ql" and
-    c instanceof NosqlInjectionATM::NosqlInjectionAtmConfig
+    queryName = "NotASink" and
+    endpointTypeEncoded = 0
     or
-    queryName = "TaintedPathInjectionATM.ql" and
-    c instanceof TaintedPathATM::TaintedPathAtmConfig
+    queryName = "XssSink" and
+    c instanceof XssATM::DomBasedXssATMConfig and
+    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
     or
-    queryName = "XssATM.ql" and c instanceof XssATM::DomBasedXssAtmConfig
-  ) and
-  e = c.getASinkEndpointType()
-select queryName, e.getEncoding() as endpointTypeEncoded
+    queryName = "StoredXssSink" and
+    c instanceof StoredXssATM::StoredXssATMConfig and
+    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    or
+    queryName = "XssThroughDomSink" and
+    c instanceof XssThroughDomATM::XssThroughDOMATMConfig and
+    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    or
+    queryName = "SqlInjectionSink" and
+    c instanceof SqlInjectionATM::SqlInjectionATMConfig and
+    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    or
+    queryName = "NosqlInjectionSink" and
+    c instanceof NosqlInjectionATM::NosqlInjectionATMConfig and
+    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    or
+    queryName = "TaintedPathSink" and
+    c instanceof TaintedPathATM::TaintedPathATMConfig and
+    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+  )
+select queryName, endpointTypeEncoded order by endpointTypeEncoded

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointMapping.ql
@@ -12,37 +12,40 @@ import experimental.adaptivethreatmodeling.StoredXssATM as StoredXssATM
 import experimental.adaptivethreatmodeling.XssThroughDomATM as XssThroughDomATM
 import experimental.adaptivethreatmodeling.AdaptiveThreatModeling
 
-from string queryName, ATMConfig c, int endpointTypeEncoded
+from string queryName, ATMConfig c, int label
 where
   (
     queryName = "Unknown" and
-    endpointTypeEncoded = 0
+    label = 0
     or
     queryName = "NotASink" and
-    endpointTypeEncoded = 0
+    label = 0
+    or
+    queryName = "LikelyNotASink" and
+    label = 0
     or
     queryName = "XssSink" and
     c instanceof XssATM::DomBasedXssATMConfig and
-    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    label = c.getASinkEndpointType().getEncoding()
     or
     queryName = "StoredXssSink" and
     c instanceof StoredXssATM::StoredXssATMConfig and
-    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    label = c.getASinkEndpointType().getEncoding()
     or
     queryName = "XssThroughDomSink" and
     c instanceof XssThroughDomATM::XssThroughDOMATMConfig and
-    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    label = c.getASinkEndpointType().getEncoding()
     or
     queryName = "SqlInjectionSink" and
     c instanceof SqlInjectionATM::SqlInjectionATMConfig and
-    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    label = c.getASinkEndpointType().getEncoding()
     or
     queryName = "NosqlInjectionSink" and
     c instanceof NosqlInjectionATM::NosqlInjectionATMConfig and
-    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    label = c.getASinkEndpointType().getEncoding()
     or
     queryName = "TaintedPathSink" and
     c instanceof TaintedPathATM::TaintedPathATMConfig and
-    endpointTypeEncoded = c.getASinkEndpointType().getEncoding()
+    label = c.getASinkEndpointType().getEncoding()
   )
-select queryName, endpointTypeEncoded order by endpointTypeEncoded
+select queryName, label order by label

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/Queries.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/Queries.qll
@@ -8,7 +8,9 @@ newtype TQuery =
   TNosqlInjectionQuery() or
   TSqlInjectionQuery() or
   TTaintedPathQuery() or
-  TXssQuery()
+  TXssQuery() or
+  TStoredXssQuery() or
+  TXssThroughDomQuery()
 
 abstract class Query extends TQuery {
   abstract string getName();
@@ -24,10 +26,18 @@ class SqlInjectionQuery extends Query, TSqlInjectionQuery {
   override string getName() { result = "SqlInjection" }
 }
 
+class StoredXssQuery extends Query, TStoredXssQuery {
+  override string getName() { result = "StoredXss" }
+}
+
 class TaintedPathQuery extends Query, TTaintedPathQuery {
   override string getName() { result = "TaintedPath" }
 }
 
 class XssQuery extends Query, TXssQuery {
   override string getName() { result = "Xss" }
+}
+
+class XssThroughDomQuery extends Query, TXssThroughDomQuery {
+  override string getName() { result = "XssThroughDom" }
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/StoredXssATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/StoredXssATM.ql
@@ -1,0 +1,29 @@
+/**
+ * For internal use only.
+ *
+ * @name Stored cross-site scripting (boosted)
+ * @description Using uncontrolled stored values in HTML allows for a stored cross-site scripting vulnerability.
+ * @kind path-problem
+ * @scored
+ * @problem.severity error
+ * @security-severity 6.1
+ * @id adaptive-threat-modeling/js/stored-xss
+ * @tags experimental experimental/atm security external/cwe/cwe-079 external/cwe/cwe-116
+ */
+
+import experimental.adaptivethreatmodeling.StoredXssATM
+import ATM::ResultsInfo
+import DataFlow::PathGraph
+
+from
+  DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score,
+  string scoreString
+where
+  cfg.hasFlowPath(source, sink) and
+  not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
+  score = getScoreForFlow(source.getNode(), sink.getNode()) and
+  scoreString = getScoreStringForFlow(source.getNode(), sink.getNode())
+select sink.getNode(), source, sink,
+  "[Score = " + scoreString + "] This may be a js/stored-xss result depending on $@ " +
+    getAdditionalAlertInfo(source.getNode(), sink.getNode()), source.getNode(),
+  "a user-provided value", score

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/XssThroughDomATM.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/XssThroughDomATM.ql
@@ -1,0 +1,29 @@
+/**
+ * For internal use only.
+ *
+ * @name DOM text reinterpreted as HTML (boosted)
+ * @description Reinterpreting text from the DOM as HTML can lead to a cross-site scripting vulnerability.
+ * @kind path-problem
+ * @scored
+ * @problem.severity warning
+ * @security-severity 6.1
+ * @id adaptive-threat-modeling/js/xss-through-dom
+ * @tags experimental experimental/atm security external/cwe/cwe-079 external/cwe/cwe-116
+ */
+
+import experimental.adaptivethreatmodeling.XssThroughDomATM
+import ATM::ResultsInfo
+import DataFlow::PathGraph
+
+from
+  DataFlow::Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, float score,
+  string scoreString
+where
+  cfg.hasFlowPath(source, sink) and
+  not isFlowLikelyInBaseQuery(source.getNode(), sink.getNode()) and
+  score = getScoreForFlow(source.getNode(), sink.getNode()) and
+  scoreString = getScoreStringForFlow(source.getNode(), sink.getNode())
+select sink.getNode(), source, sink,
+  "[Score = " + scoreString + "] This may be a js/xss-through-dom result depending on $@ " +
+    getAdditionalAlertInfo(source.getNode(), sink.getNode()), source.getNode(),
+  "a user-provided value", score

--- a/javascript/ql/experimental/adaptivethreatmodeling/src/codeql-suites/javascript-atm-code-scanning.qls
+++ b/javascript/ql/experimental/adaptivethreatmodeling/src/codeql-suites/javascript-atm-code-scanning.qls
@@ -1,2 +1,5 @@
 - description: ATM boosted Code Scanning queries for JavaScript
 - queries: .
+- exclude:
+    query filename: StoredXssATM.ql
+    query filename: XssThroughDomATM.ql


### PR DESCRIPTION
This PR modifies all the necessary QL code in order to add the `StoredXss` and `XssThroughDom` security queries to the adaptive threat modelling endpoint pipeline. In particular:

- Cherry picked @esbena's commits to add the `*ATM.ql` and `*ATM.qll` files for each new security query.

- The extraction query used in the endpoint pipeline, `ExtractEndpointData.qll`, was modified to use the new security queries. 

- The new queries were also added to `Queries.qll` and `EndpointTypes.qll`.

- Finally, the queries that producing the encoding and mapping files in the endpoint pipeline, `ExtractEndpointLabelEncoding.ql` and `ExtractEndpointMapping.ql`, were updated to include the new security queries.

Note: the endpoint pipeline won't actually start produced JSONL files for these queries until we update the QL library SHAs in `config.json` of `main` in the backend repo.