### PR TITLE
Rename all upper-case variables, and all lower-case modules

### DIFF
--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRs.ql
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRs.ql
@@ -55,7 +55,7 @@ class JaxRsTest extends InlineExpectationsTest {
     or
     tag = "ResourceMethodOnResourceClass" and
     exists(JaxRsResourceMethod resourceMethod |
-      resourceMethod = any(JaxRsResourceClass ResourceClass).getAResourceMethod()
+      resourceMethod = any(JaxRsResourceClass resourceClass).getAResourceMethod()
     |
       resourceMethod.getLocation() = location and
       element = resourceMethod.toString() and

--- a/java/ql/test/library-tests/structure/TypeGetCompilationUnit.ql
+++ b/java/ql/test/library-tests/structure/TypeGetCompilationUnit.ql
@@ -2,8 +2,8 @@ import semmle.code.java.Type
 
 predicate typeIsInCU(Type tpe, CompilationUnit cu) { tpe.getCompilationUnit() = cu }
 
-from Type tpe, CompilationUnit Ajava
+from Type tpe, CompilationUnit aJava
 where
-  Ajava.hasName("A") and
-  typeIsInCU(tpe, Ajava)
+  aJava.hasName("A") and
+  typeIsInCU(tpe, aJava)
 select tpe

--- a/javascript/ql/lib/change-notes/2022-02-07-deprecated-modules.md
+++ b/javascript/ql/lib/change-notes/2022-02-07-deprecated-modules.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some modules that started with a lowercase letter has been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/javascript/ql/lib/change-notes/2022-02-07-deprecated-modules.md
+++ b/javascript/ql/lib/change-notes/2022-02-07-deprecated-modules.md
@@ -1,5 +1,5 @@
 ---
 category: deprecated
 ---
-* Some modules that started with a lowercase letter has been renamed to follow our style-guide. 
+* Some modules that started with a lowercase letter have been renamed to follow our style-guide. 
   The old name still exists as a deprecated alias.

--- a/javascript/ql/lib/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Logging.qll
@@ -123,7 +123,7 @@ private module Winston {
 /**
  * Provides classes for working with [log4js](https://github.com/log4js-node/log4js-node).
  */
-private module log4js {
+private module Log4js {
   /**
    * A call to the log4js logging mechanism.
    */

--- a/javascript/ql/lib/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/UriLibraries.qll
@@ -14,10 +14,13 @@ abstract deprecated class UriLibraryStep extends DataFlow::ValueNode {
   predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
 }
 
+/** DEPRECATED: Alias for `Urijs` */
+deprecated module urijs = Urijs;
+
 /**
  * Provides classes for working with [urijs](http://medialize.github.io/URI.js/) code.
  */
-module urijs {
+module Urijs {
   /**
    * Gets a data flow source node for the urijs library.
    */
@@ -80,10 +83,13 @@ module urijs {
   }
 }
 
+/** DEPRECATED: Alias for `Uridashjs` */
+deprecated module uridashjs = Uridashjs;
+
 /**
  * Provides classes for working with [uri-js](https://github.com/garycourt/uri-js) code.
  */
-module uridashjs {
+module Uridashjs {
   /**
    * Gets a data flow source node for member `name` of the uridashjs library.
    */
@@ -105,10 +111,13 @@ module uridashjs {
   }
 }
 
+/** DEPRECATED: Alias for `Punycode` */
+deprecated module punycode = Punycode;
+
 /**
  * Provides classes for working with [punycode](https://github.com/bestiejs/punycode.js) code.
  */
-module punycode {
+module Punycode {
   /**
    * Gets a data flow source node for member `name` of the punycode library.
    */
@@ -130,10 +139,13 @@ module punycode {
   }
 }
 
+/** DEPRECATED: Alias for `UrlParse` */
+deprecated module urlParse = UrlParse;
+
 /**
  * Provides classes for working with [url-parse](https://github.com/unshiftio/url-parse) code.
  */
-module urlParse {
+module UrlParse {
   /**
    * Gets a data flow source node for the url-parse library.
    */
@@ -167,10 +179,13 @@ module urlParse {
   }
 }
 
+/** DEPRECATED: Alias for `Querystringify` */
+deprecated module querystringify = Querystringify;
+
 /**
  * Provides classes for working with [querystringify](https://github.com/unshiftio/querystringify) code.
  */
-module querystringify {
+module Querystringify {
   /**
    * Gets a data flow source node for member `name` of the querystringify library.
    */
@@ -197,10 +212,13 @@ module querystringify {
   }
 }
 
+/** DEPRECATED: Alias for `Querydashstring` */
+deprecated module querydashstring = Querydashstring;
+
 /**
  * Provides classes for working with [query-string](https://github.com/sindresorhus/query-string) code.
  */
-module querydashstring {
+module Querydashstring {
   /**
    * Gets a data flow source node for member `name` of the query-string library.
    */
@@ -222,10 +240,13 @@ module querydashstring {
   }
 }
 
+/** DEPRECATED: Alias for `Url` */
+deprecated module url = Url;
+
 /**
  * Provides classes for working with [url](https://nodejs.org/api/url.html) code.
  */
-module url {
+module Url {
   /**
    * Gets a data flow source node for member `name` of the url library.
    */
@@ -245,10 +266,13 @@ module url {
   }
 }
 
+/** DEPRECATED: Alias for `Querystring` */
+deprecated module querystring = Querystring;
+
 /**
  * Provides classes for working with [querystring](https://nodejs.org/api/querystring.html) code.
  */
-module querystring {
+module Querystring {
   /**
    * Gets a data flow source node for member `name` of the querystring library.
    */
@@ -408,7 +432,7 @@ private module ClosureLibraryUri {
   /**
    * Provides classes for working with [path](https://nodejs.org/api/path.html) code.
    */
-  module path {
+  module Path {
     /**
      * A taint step in the path module.
      */

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/tests.ql
@@ -1,21 +1,21 @@
 import javascript
 
-query predicate punycode(DataFlow::Node n) { n = punycode::punycodeMember(_) }
+query predicate punycode(DataFlow::Node n) { n = Punycode::punycodeMember(_) }
 
-query predicate querydashstring(DataFlow::Node n) { n = querydashstring::querydashstringMember(_) }
+query predicate querydashstring(DataFlow::Node n) { n = Querydashstring::querydashstringMember(_) }
 
-query predicate querystring(DataFlow::Node n) { n = querystring::querystringMember(_) }
+query predicate querystring(DataFlow::Node n) { n = Querystring::querystringMember(_) }
 
-query predicate querystringify(DataFlow::Node n) { n = querystringify::querystringifyMember(_) }
+query predicate querystringify(DataFlow::Node n) { n = Querystringify::querystringifyMember(_) }
 
-query predicate uridashjs(DataFlow::Node n) { n = uridashjs::uridashjsMember(_) }
+query predicate uridashjs(DataFlow::Node n) { n = Uridashjs::uridashjsMember(_) }
 
-query predicate urijs(DataFlow::Node n) { n = urijs::urijs() }
+query predicate urijs(DataFlow::Node n) { n = Urijs::urijs() }
 
 query predicate uriLibraryStep(DataFlow::Node pred, DataFlow::Node succ) {
   TaintTracking::uriStep(pred, succ)
 }
 
-query predicate url(DataFlow::Node n) { n = url::urlMember(_) }
+query predicate url(DataFlow::Node n) { n = Url::urlMember(_) }
 
-query predicate urlParse(DataFlow::Node n) { n = urlParse::urlParse() }
+query predicate urlParse(DataFlow::Node n) { n = UrlParse::urlParse() }

--- a/python/ql/lib/change-notes/2022-02-07-deprecated-modules.md
+++ b/python/ql/lib/change-notes/2022-02-07-deprecated-modules.md
@@ -1,0 +1,5 @@
+---
+category: deprecated
+---
+* Some modules that started with a lowercase letter has been renamed to follow our style-guide. 
+  The old name still exists as a deprecated alias.

--- a/python/ql/lib/change-notes/2022-02-07-deprecated-modules.md
+++ b/python/ql/lib/change-notes/2022-02-07-deprecated-modules.md
@@ -1,5 +1,5 @@
 ---
 category: deprecated
 ---
-* Some modules that started with a lowercase letter has been renamed to follow our style-guide. 
+* Some modules that started with a lowercase letter have been renamed to follow our style-guide. 
   The old name still exists as a deprecated alias.

--- a/python/ql/lib/semmle/python/Metrics.qll
+++ b/python/ql/lib/semmle/python/Metrics.qll
@@ -27,9 +27,9 @@ class FunctionMetrics extends Function {
    *  P = the number of connected components, which for a single function is 1.
    */
   int getCyclomaticComplexity() {
-    exists(int E, int N |
-      N = count(BasicBlock b | b = this.getABasicBlock() and b.likelyReachable()) and
-      E =
+    exists(int e, int n |
+      n = count(BasicBlock b | b = this.getABasicBlock() and b.likelyReachable()) and
+      e =
         count(BasicBlock b1, BasicBlock b2 |
           b1 = this.getABasicBlock() and
           b1.likelyReachable() and
@@ -39,7 +39,7 @@ class FunctionMetrics extends Function {
           not b1.unlikelySuccessor(b2)
         )
     |
-      result = E - N + 2
+      result = e - n + 2
     )
   }
 

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -39,8 +39,11 @@ predicate isArgumentNode(ArgumentNode arg, DataFlowCall c, ArgumentPosition pos)
 //--------
 predicate isExpressionNode(ControlFlowNode node) { node.getNode() instanceof Expr }
 
+/** DEPRECATED: Alias for `SyntheticPreUpdateNode` */
+deprecated module syntheticPreUpdateNode = SyntheticPreUpdateNode;
+
 /** A module collecting the different reasons for synthesising a pre-update node. */
-module syntheticPreUpdateNode {
+module SyntheticPreUpdateNode {
   class SyntheticPreUpdateNode extends Node, TSyntheticPreUpdateNode {
     NeedsSyntheticPreUpdateNode post;
 
@@ -78,10 +81,13 @@ module syntheticPreUpdateNode {
   CfgNode objectCreationNode() { result.getNode().(CallNode) = any(ClassCall c).getNode() }
 }
 
-import syntheticPreUpdateNode
+import SyntheticPreUpdateNode
+
+/** DEPRECATED: Alias for `SyntheticPostUpdateNode` */
+deprecated module syntheticPostUpdateNode = SyntheticPostUpdateNode;
 
 /** A module collecting the different reasons for synthesising a post-update node. */
-module syntheticPostUpdateNode {
+module SyntheticPostUpdateNode {
   /** A post-update node is synthesized for all nodes which satisfy `NeedsSyntheticPostUpdateNode`. */
   class SyntheticPostUpdateNode extends PostUpdateNode, TSyntheticPostUpdateNode {
     NeedsSyntheticPostUpdateNode pre;
@@ -177,7 +183,7 @@ module syntheticPostUpdateNode {
   }
 }
 
-import syntheticPostUpdateNode
+import SyntheticPostUpdateNode
 
 class DataFlowExpr = Expr;
 

--- a/python/ql/lib/semmle/python/frameworks/Django.qll
+++ b/python/ql/lib/semmle/python/frameworks/Django.qll
@@ -526,8 +526,11 @@ module PrivateDjango {
   /** Gets a reference to the `django` module. */
   API::Node django() { result = API::moduleImport("django") }
 
+  /** DEPRECATED: Alias for `DjangoImpl` */
+  deprecated module django = DjangoImpl;
+
   /** Provides models for the `django` module. */
-  module django {
+  module DjangoImpl {
     // -------------------------------------------------------------------------
     // django.db
     // -------------------------------------------------------------------------
@@ -541,8 +544,11 @@ module PrivateDjango {
       DjangoDb() { this = API::moduleImport("django").getMember("db") }
     }
 
+    /** DEPRECATED: Alias for `DB` */
+    deprecated module db = DB;
+
     /** Provides models for the `django.db` module. */
-    module db {
+    module DB {
       /** Gets a reference to the `django.db.connection` object. */
       API::Node connection() { result = db().getMember("connection") }
 
@@ -557,8 +563,11 @@ module PrivateDjango {
       /** Gets a reference to the `django.db.models` module. */
       API::Node models() { result = db().getMember("models") }
 
+      /** DEPRECATED: Alias for `Models` */
+      deprecated module models = Models;
+
       /** Provides models for the `django.db.models` module. */
-      module models {
+      module Models {
         /**
          * Provides models for the `django.db.models.Model` class and subclasses.
          *
@@ -608,8 +617,11 @@ module PrivateDjango {
         /** Gets a reference to the `django.db.models.expressions` module. */
         API::Node expressions() { result = models().getMember("expressions") }
 
+        /** DEPRECATED: Alias for `Expressions` */
+        deprecated module expressions = Expressions;
+
         /** Provides models for the `django.db.models.expressions` module. */
-        module expressions {
+        module Expressions {
           /** Provides models for the `django.db.models.expressions.RawSql` class. */
           module RawSql {
             /**
@@ -662,8 +674,8 @@ module PrivateDjango {
       DataFlow::Node sql;
 
       ObjectsAnnotate() {
-        this = django::db::models::querySetReturningMethod("annotate").getACall() and
-        django::db::models::expressions::RawSql::instance(sql) in [
+        this = DjangoImpl::DB::Models::querySetReturningMethod("annotate").getACall() and
+        DjangoImpl::DB::Models::Expressions::RawSql::instance(sql) in [
             this.getArg(_), this.getArgByName(_)
           ]
       }
@@ -680,8 +692,8 @@ module PrivateDjango {
       DataFlow::Node sql;
 
       ObjectsAlias() {
-        this = django::db::models::querySetReturningMethod("alias").getACall() and
-        django::db::models::expressions::RawSql::instance(sql) in [
+        this = DjangoImpl::DB::Models::querySetReturningMethod("alias").getACall() and
+        DjangoImpl::DB::Models::Expressions::RawSql::instance(sql) in [
             this.getArg(_), this.getArgByName(_)
           ]
       }
@@ -697,7 +709,7 @@ module PrivateDjango {
      * - https://docs.djangoproject.com/en/3.1/ref/models/querysets/#raw
      */
     private class ObjectsRaw extends SqlExecution::Range, DataFlow::CallCfgNode {
-      ObjectsRaw() { this = django::db::models::querySetReturningMethod("raw").getACall() }
+      ObjectsRaw() { this = DjangoImpl::DB::Models::querySetReturningMethod("raw").getACall() }
 
       override DataFlow::Node getSql() { result = this.getArg(0) }
     }
@@ -708,7 +720,7 @@ module PrivateDjango {
      * See https://docs.djangoproject.com/en/3.1/ref/models/querysets/#extra
      */
     private class ObjectsExtra extends SqlExecution::Range, DataFlow::CallCfgNode {
-      ObjectsExtra() { this = django::db::models::querySetReturningMethod("extra").getACall() }
+      ObjectsExtra() { this = DjangoImpl::DB::Models::querySetReturningMethod("extra").getACall() }
 
       override DataFlow::Node getSql() {
         result in [
@@ -723,8 +735,11 @@ module PrivateDjango {
     /** Gets a reference to the `django.urls` module. */
     API::Node urls() { result = django().getMember("urls") }
 
+    /** DEPRECATED: Alias for `Urls` */
+    deprecated module urls = Urls;
+
     /** Provides models for the `django.urls` module */
-    module urls {
+    module Urls {
       /**
        * Gets a reference to the `django.urls.path` function.
        * See https://docs.djangoproject.com/en/3.0/ref/urls/#path
@@ -744,10 +759,16 @@ module PrivateDjango {
     /** Gets a reference to the `django.conf` module. */
     API::Node conf() { result = django().getMember("conf") }
 
+    /** DEPRECATED: Alias for `Conf` */
+    deprecated module conf = Conf;
+
     /** Provides models for the `django.conf` module */
-    module conf {
+    module Conf {
+      /** DEPRECATED: Alias for `ConfUrls` */
+      deprecated module conf_urls = ConfUrls;
+
       /** Provides models for the `django.conf.urls` module */
-      module conf_urls {
+      module ConfUrls {
         // -------------------------------------------------------------------------
         // django.conf.urls
         // -------------------------------------------------------------------------
@@ -770,16 +791,22 @@ module PrivateDjango {
     /** Gets a reference to the `django.http` module. */
     API::Node http() { result = django().getMember("http") }
 
+    /** DEPRECATED: Alias for `Http` */
+    deprecated module http = Http;
+
     /** Provides models for the `django.http` module */
-    module http {
+    module Http {
       // ---------------------------------------------------------------------------
       // django.http.request
       // ---------------------------------------------------------------------------
       /** Gets a reference to the `django.http.request` module. */
       API::Node request() { result = http().getMember("request") }
 
+      /** DEPRECATED: Alias for `Request` */
+      deprecated module request = Request;
+
       /** Provides models for the `django.http.request` module. */
-      module request {
+      module Request {
         /**
          * Provides models for the `django.http.request.HttpRequest` class
          *
@@ -860,7 +887,7 @@ module PrivateDjango {
               // special handling of the `build_absolute_uri` method, see
               // https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpRequest.build_absolute_uri
               exists(DataFlow::AttrRead attr, DataFlow::CallCfgNode call, DataFlow::Node instance |
-                instance = django::http::request::HttpRequest::instance() and
+                instance = DjangoImpl::Http::Request::HttpRequest::instance() and
                 attr.getObject() = instance
               |
                 attr.getAttributeName() = "build_absolute_uri" and
@@ -937,8 +964,11 @@ module PrivateDjango {
       /** Gets a reference to the `django.http.response` module. */
       API::Node response() { result = http().getMember("response") }
 
+      /** DEPRECATED: Alias for `Response` */
+      deprecated module response = Response;
+
       /** Provides models for the `django.http.response` module */
-      module response {
+      module Response {
         /**
          * Provides models for the `django.http.response.HttpResponse` class
          *
@@ -1672,17 +1702,17 @@ module PrivateDjango {
 
         /** Gets a reference to the `django.http.response.HttpResponse.write` function. */
         private DataFlow::TypeTrackingNode write(
-          django::http::response::HttpResponse::InstanceSource instance, DataFlow::TypeTracker t
+          DjangoImpl::Http::Response::HttpResponse::InstanceSource instance, DataFlow::TypeTracker t
         ) {
           t.startInAttr("write") and
-          instance = django::http::response::HttpResponse::instance() and
+          instance = DjangoImpl::Http::Response::HttpResponse::instance() and
           result = instance
           or
           exists(DataFlow::TypeTracker t2 | result = write(instance, t2).track(t2, t))
         }
 
         /** Gets a reference to the `django.http.response.HttpResponse.write` function. */
-        DataFlow::Node write(django::http::response::HttpResponse::InstanceSource instance) {
+        DataFlow::Node write(DjangoImpl::Http::Response::HttpResponse::InstanceSource instance) {
           write(instance, DataFlow::TypeTracker::end()).flowsTo(result)
         }
 
@@ -1692,7 +1722,7 @@ module PrivateDjango {
          * See https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.HttpResponse.write
          */
         class HttpResponseWriteCall extends HTTP::Server::HttpResponse::Range, DataFlow::CallCfgNode {
-          django::http::response::HttpResponse::InstanceSource instance;
+          DjangoImpl::Http::Response::HttpResponse::InstanceSource instance;
 
           HttpResponseWriteCall() { this.getFunction() = write(instance) }
 
@@ -1713,7 +1743,7 @@ module PrivateDjango {
         class DjangoResponseSetCookieCall extends HTTP::Server::CookieWrite::Range,
           DataFlow::MethodCallNode {
           DjangoResponseSetCookieCall() {
-            this.calls(django::http::response::HttpResponse::instance(), "set_cookie")
+            this.calls(DjangoImpl::Http::Response::HttpResponse::instance(), "set_cookie")
           }
 
           override DataFlow::Node getHeaderArg() { none() }
@@ -1733,7 +1763,7 @@ module PrivateDjango {
         class DjangoResponseDeleteCookieCall extends HTTP::Server::CookieWrite::Range,
           DataFlow::MethodCallNode {
           DjangoResponseDeleteCookieCall() {
-            this.calls(django::http::response::HttpResponse::instance(), "delete_cookie")
+            this.calls(DjangoImpl::Http::Response::HttpResponse::instance(), "delete_cookie")
           }
 
           override DataFlow::Node getHeaderArg() { none() }
@@ -1760,7 +1790,7 @@ module PrivateDjango {
               this.asCfgNode() = subscript
             |
               cookieLookup.getAttributeName() = "cookies" and
-              cookieLookup.getObject() = django::http::response::HttpResponse::instance() and
+              cookieLookup.getObject() = DjangoImpl::Http::Response::HttpResponse::instance() and
               exists(DataFlow::Node subscriptObj |
                 subscriptObj.asCfgNode() = subscript.getObject()
               |
@@ -1786,8 +1816,11 @@ module PrivateDjango {
     /** Gets a reference to the `django.shortcuts` module. */
     API::Node shortcuts() { result = django().getMember("shortcuts") }
 
+    /** DEPRECATED: Alias for `Shortcuts` */
+    deprecated module shortcuts = Shortcuts;
+
     /** Provides models for the `django.shortcuts` module */
-    module shortcuts {
+    module Shortcuts {
       /**
        * Gets a reference to the `django.shortcuts.redirect` function
        *
@@ -2063,7 +2096,7 @@ module PrivateDjango {
    * See https://docs.djangoproject.com/en/3.0/ref/urls/#path
    */
   private class DjangoUrlsPathCall extends DjangoRouteSetup, DataFlow::CallCfgNode {
-    DjangoUrlsPathCall() { this = django::urls::path().getACall() }
+    DjangoUrlsPathCall() { this = DjangoImpl::Urls::path().getACall() }
 
     override DataFlow::Node getUrlPatternArg() {
       result in [this.getArg(0), this.getArgByName("route")]
@@ -2146,7 +2179,7 @@ module PrivateDjango {
    */
   private class DjangoUrlsRePathCall extends DjangoRegexRouteSetup, DataFlow::CallCfgNode {
     DjangoUrlsRePathCall() {
-      this = django::urls::re_path().getACall() and
+      this = DjangoImpl::Urls::re_path().getACall() and
       // `django.conf.urls.url` (which we support directly with
       // `DjangoConfUrlsUrlCall`), is implemented in Django 2+ as backward compatibility
       // using `django.urls.re_path`. See
@@ -2176,7 +2209,7 @@ module PrivateDjango {
    * See https://docs.djangoproject.com/en/1.11/ref/urls/#django.conf.urls.url
    */
   private class DjangoConfUrlsUrlCall extends DjangoRegexRouteSetup, DataFlow::CallCfgNode {
-    DjangoConfUrlsUrlCall() { this = django::conf::conf_urls::url().getACall() }
+    DjangoConfUrlsUrlCall() { this = DjangoImpl::Conf::ConfUrls::url().getACall() }
 
     override DataFlow::Node getUrlPatternArg() {
       result in [this.getArg(0), this.getArgByName("regex")]
@@ -2189,7 +2222,7 @@ module PrivateDjango {
   // HttpRequest taint modeling
   // ---------------------------------------------------------------------------
   /** A parameter that will receive the django `HttpRequest` instance when a request handler is invoked. */
-  private class DjangoRequestHandlerRequestParam extends django::http::request::HttpRequest::InstanceSource,
+  private class DjangoRequestHandlerRequestParam extends DjangoImpl::Http::Request::HttpRequest::InstanceSource,
     RemoteFlowSource::Range, DataFlow::ParameterNode {
     DjangoRequestHandlerRequestParam() {
       this.getParameter() = any(DjangoRouteSetup setup).getARequestHandler().getRequestParam()
@@ -2206,7 +2239,7 @@ module PrivateDjango {
    *
    * See https://docs.djangoproject.com/en/3.1/topics/class-based-views/generic-display/#dynamic-filtering
    */
-  private class DjangoViewClassRequestAttributeRead extends django::http::request::HttpRequest::InstanceSource,
+  private class DjangoViewClassRequestAttributeRead extends DjangoImpl::Http::Request::HttpRequest::InstanceSource,
     RemoteFlowSource::Range, DataFlow::Node {
     DjangoViewClassRequestAttributeRead() {
       exists(DataFlow::AttrRead read | this = read |
@@ -2253,7 +2286,7 @@ module PrivateDjango {
    */
   private class DjangoShortcutsRedirectCall extends HTTP::Server::HttpRedirectResponse::Range,
     DataFlow::CallCfgNode {
-    DjangoShortcutsRedirectCall() { this = django::shortcuts::redirect().getACall() }
+    DjangoShortcutsRedirectCall() { this = DjangoImpl::Shortcuts::redirect().getACall() }
 
     /**
      * Gets the data-flow node that specifies the location of this HTTP redirect response.

--- a/python/ql/lib/semmle/python/frameworks/Fabric.qll
+++ b/python/ql/lib/semmle/python/frameworks/Fabric.qll
@@ -24,7 +24,7 @@ private module FabricV1 {
   API::Node fabric() { result = API::moduleImport("fabric") }
 
   /** Provides models for the `fabric` module. */
-  module fabric {
+  module Fabric {
     // -------------------------------------------------------------------------
     // fabric.api
     // -------------------------------------------------------------------------
@@ -32,7 +32,7 @@ private module FabricV1 {
     API::Node api() { result = fabric().getMember("api") }
 
     /** Provides models for the `fabric.api` module */
-    module api {
+    module Api {
       /**
        * A call to either
        * - `fabric.api.local`
@@ -66,7 +66,7 @@ private module FabricV2 {
   API::Node fabric() { result = API::moduleImport("fabric") }
 
   /** Provides models for the `fabric` module. */
-  module fabric {
+  module Fabric {
     // -------------------------------------------------------------------------
     // fabric.connection
     // -------------------------------------------------------------------------
@@ -74,13 +74,13 @@ private module FabricV2 {
     API::Node connection() { result = fabric().getMember("connection") }
 
     /** Provides models for the `fabric.connection` module */
-    module connection {
+    module Connection {
       /**
        * Provides models for the `fabric.connection.Connection` class
        *
        * See https://docs.fabfile.org/en/2.5/api/connection.html#fabric.connection.Connection.
        */
-      module Connection {
+      module ConnectionClass {
         /** Gets a reference to the `fabric.connection.Connection` class. */
         API::Node classRef() {
           result = fabric().getMember("Connection")
@@ -155,7 +155,7 @@ private module FabricV2 {
     private class FabricConnectionRunSudoLocalCall extends SystemCommandExecution::Range,
       DataFlow::CallCfgNode {
       FabricConnectionRunSudoLocalCall() {
-        this.getFunction() = fabric::connection::Connection::instanceRunMethods()
+        this.getFunction() = Fabric::Connection::ConnectionClass::instanceRunMethods()
       }
 
       override DataFlow::Node getCommand() {
@@ -170,16 +170,16 @@ private module FabricV2 {
     API::Node tasks() { result = fabric().getMember("tasks") }
 
     /** Provides models for the `fabric.tasks` module */
-    module tasks {
+    module Tasks {
       /** Gets a reference to the `fabric.tasks.task` decorator. */
       API::Node task() { result in [tasks().getMember("task"), fabric().getMember("task")] }
     }
 
-    class FabricTaskFirstParamConnectionInstance extends fabric::connection::Connection::InstanceSource,
+    class FabricTaskFirstParamConnectionInstance extends Fabric::Connection::ConnectionClass::InstanceSource,
       DataFlow::ParameterNode {
       FabricTaskFirstParamConnectionInstance() {
         exists(Function func |
-          func.getADecorator() = fabric::tasks::task().getAUse().asExpr() and
+          func.getADecorator() = Fabric::Tasks::task().getAUse().asExpr() and
           this.getParameter() = func.getArg(0)
         )
       }
@@ -192,7 +192,7 @@ private module FabricV2 {
     API::Node group() { result = fabric().getMember("group") }
 
     /** Provides models for the `fabric.group` module */
-    module group {
+    module Group {
       /**
        * Provides models for the `fabric.group.Group` class and its subclasses.
        *
@@ -204,7 +204,7 @@ private module FabricV2 {
        * - https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.SerialGroup
        * - https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.ThreadingGroup
        */
-      module Group {
+      module GroupClass {
         /**
          * A source of instances of a subclass of `fabric.group, extend this class to model new instances.Group`
          *
@@ -236,7 +236,9 @@ private module FabricV2 {
        * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.Group.run
        */
       private class FabricGroupRunCall extends SystemCommandExecution::Range, DataFlow::CallCfgNode {
-        FabricGroupRunCall() { this = fabric::group::Group::subclassInstanceRunMethod().getACall() }
+        FabricGroupRunCall() {
+          this = Fabric::Group::GroupClass::subclassInstanceRunMethod().getACall()
+        }
 
         override DataFlow::Node getCommand() {
           result = [this.getArg(0), this.getArgByName("command")]
@@ -249,7 +251,7 @@ private module FabricV2 {
        * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.SerialGroup.
        */
       module SerialGroup {
-        private class ClassInstantiation extends Group::ModeledSubclass {
+        private class ClassInstantiation extends GroupClass::ModeledSubclass {
           ClassInstantiation() {
             this = group().getMember("SerialGroup")
             or
@@ -264,7 +266,7 @@ private module FabricV2 {
        * See https://docs.fabfile.org/en/2.5/api/group.html#fabric.group.ThreadingGroup.
        */
       module ThreadingGroup {
-        private class ClassInstantiation extends Group::ModeledSubclass {
+        private class ClassInstantiation extends GroupClass::ModeledSubclass {
           ClassInstantiation() {
             this = group().getMember("ThreadingGroup")
             or

--- a/python/ql/lib/semmle/python/frameworks/Invoke.qll
+++ b/python/ql/lib/semmle/python/frameworks/Invoke.qll
@@ -20,14 +20,14 @@ private module Invoke {
   API::Node invoke() { result = API::moduleImport("invoke") }
 
   /** Provides models for the `invoke` module. */
-  module invoke {
+  module InvokeModule {
     /** Gets a reference to the `invoke.context` module. */
     API::Node context() { result = invoke().getMember("context") }
 
     /** Provides models for the `invoke.context` module */
-    module context {
+    module Context {
       /** Provides models for the `invoke.context.Context` class */
-      module Context {
+      module ContextClass {
         /** Gets a reference to the `invoke.context.Context` class. */
         API::Node classRef() {
           result = API::moduleImport("invoke").getMember("context").getMember("Context")
@@ -39,7 +39,7 @@ private module Invoke {
         private DataFlow::TypeTrackingNode instance(DataFlow::TypeTracker t) {
           t.start() and
           (
-            result = invoke::context::Context::classRef().getACall()
+            result = InvokeModule::Context::ContextClass::classRef().getACall()
             or
             exists(Function func |
               func.getADecorator() = invoke().getMember("task").getAUse().asExpr() and
@@ -56,7 +56,7 @@ private module Invoke {
         /** Gets a reference to the `run` or `sudo` methods on a `invoke.context.Context` instance. */
         private DataFlow::TypeTrackingNode instanceRunMethods(DataFlow::TypeTracker t) {
           t.startInAttr(["run", "sudo"]) and
-          result = invoke::context::Context::instance()
+          result = InvokeModule::Context::ContextClass::instance()
           or
           exists(DataFlow::TypeTracker t2 | result = instanceRunMethods(t2).track(t2, t))
         }
@@ -77,7 +77,7 @@ private module Invoke {
   private class InvokeRunCommandCall extends SystemCommandExecution::Range, DataFlow::CallCfgNode {
     InvokeRunCommandCall() {
       this = invoke().getMember(["run", "sudo"]).getACall() or
-      this.getFunction() = invoke::context::Context::instanceRunMethods()
+      this.getFunction() = InvokeModule::Context::ContextClass::instanceRunMethods()
     }
 
     override DataFlow::Node getCommand() {

--- a/python/ql/lib/semmle/python/frameworks/Mysql.qll
+++ b/python/ql/lib/semmle/python/frameworks/Mysql.qll
@@ -25,7 +25,7 @@ private module Mysql {
   // mysql
   // ---------------------------------------------------------------------------
   /** Provides models for the `mysql` module. */
-  module mysql {
+  module MysqlMod {
     /**
      * The mysql.connector module
      * See https://dev.mysql.com/doc/connector-python/en/connector-python-example-connecting.html

--- a/python/ql/lib/semmle/python/frameworks/RestFramework.qll
+++ b/python/ql/lib/semmle/python/frameworks/RestFramework.qll
@@ -220,7 +220,7 @@ private module RestFramework {
      *
      * Use the predicate `Request::instance()` to get references to instances of `rest_framework.request.Request`.
      */
-    abstract class InstanceSource extends PrivateDjango::DjangoImpl::http::request::HttpRequest::InstanceSource {
+    abstract class InstanceSource extends PrivateDjango::DjangoImpl::Http::Request::HttpRequest::InstanceSource {
     }
 
     /** A direct instantiation of `rest_framework.request.Request`. */
@@ -307,7 +307,7 @@ private module RestFramework {
     abstract class InstanceSource extends DataFlow::LocalSourceNode { }
 
     /** A direct instantiation of `rest_framework.response.Response`. */
-    private class ClassInstantiation extends PrivateDjango::DjangoImpl::http::response::HttpResponse::InstanceSource,
+    private class ClassInstantiation extends PrivateDjango::DjangoImpl::Http::Response::HttpResponse::InstanceSource,
       DataFlow::CallCfgNode {
       ClassInstantiation() { this = classRef().getACall() }
 

--- a/python/ql/lib/semmle/python/frameworks/RestFramework.qll
+++ b/python/ql/lib/semmle/python/frameworks/RestFramework.qll
@@ -220,7 +220,7 @@ private module RestFramework {
      *
      * Use the predicate `Request::instance()` to get references to instances of `rest_framework.request.Request`.
      */
-    abstract class InstanceSource extends PrivateDjango::django::http::request::HttpRequest::InstanceSource {
+    abstract class InstanceSource extends PrivateDjango::DjangoImpl::http::request::HttpRequest::InstanceSource {
     }
 
     /** A direct instantiation of `rest_framework.request.Request`. */
@@ -307,7 +307,7 @@ private module RestFramework {
     abstract class InstanceSource extends DataFlow::LocalSourceNode { }
 
     /** A direct instantiation of `rest_framework.response.Response`. */
-    private class ClassInstantiation extends PrivateDjango::django::http::response::HttpResponse::InstanceSource,
+    private class ClassInstantiation extends PrivateDjango::DjangoImpl::http::response::HttpResponse::InstanceSource,
       DataFlow::CallCfgNode {
       ClassInstantiation() { this = classRef().getACall() }
 

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -308,7 +308,7 @@ private module StdlibPrivate {
   API::Node os() { result = API::moduleImport("os") }
 
   /** Provides models for the `os` module. */
-  module os {
+  module OS {
     /** Gets a reference to the `os.path` module. */
     API::Node path() {
       result = os().getMember("path")
@@ -323,7 +323,7 @@ private module StdlibPrivate {
     }
 
     /** Provides models for the `os.path` module */
-    module path {
+    module OsPath {
       /** Gets a reference to the `os.path.join` function. */
       API::Node join() { result = path().getMember("join") }
     }
@@ -945,7 +945,7 @@ private module StdlibPrivate {
           // these raise errors if the file does not exist
           "getatime", "getmtime", "getctime", "getsize"
         ] and
-      this = os::path().getMember(name).getACall()
+      this = OS::path().getMember(name).getACall()
     }
 
     override DataFlow::Node getAPathArgument() {
@@ -961,7 +961,7 @@ private module StdlibPrivate {
 
   /** A call to `os.path.samefile` will raise an exception if an `os.stat()` call on either pathname fails. */
   private class OsPathSamefileCall extends FileSystemAccess::Range, DataFlow::CallCfgNode {
-    OsPathSamefileCall() { this = os::path().getMember("samefile").getACall() }
+    OsPathSamefileCall() { this = OS::path().getMember("samefile").getACall() }
 
     override DataFlow::Node getAPathArgument() {
       result in [
@@ -995,7 +995,7 @@ private module StdlibPrivate {
 
     OsPathComputation() {
       methodName = pathComputation() and
-      this = os::path().getMember(methodName).getACall()
+      this = OS::path().getMember(methodName).getACall()
     }
 
     DataFlow::Node getPathArg() {
@@ -1022,7 +1022,7 @@ private module StdlibPrivate {
    * See https://docs.python.org/3/library/os.path.html#os.path.normpath
    */
   private class OsPathNormpathCall extends Path::PathNormalization::Range, DataFlow::CallCfgNode {
-    OsPathNormpathCall() { this = os::path().getMember("normpath").getACall() }
+    OsPathNormpathCall() { this = OS::path().getMember("normpath").getACall() }
 
     override DataFlow::Node getPathArg() { result in [this.getArg(0), this.getArgByName("path")] }
   }
@@ -1032,7 +1032,7 @@ private module StdlibPrivate {
    * See https://docs.python.org/3/library/os.path.html#os.path.abspath
    */
   private class OsPathAbspathCall extends Path::PathNormalization::Range, DataFlow::CallCfgNode {
-    OsPathAbspathCall() { this = os::path().getMember("abspath").getACall() }
+    OsPathAbspathCall() { this = OS::path().getMember("abspath").getACall() }
 
     override DataFlow::Node getPathArg() { result in [this.getArg(0), this.getArgByName("path")] }
   }
@@ -1042,7 +1042,7 @@ private module StdlibPrivate {
    * See https://docs.python.org/3/library/os.path.html#os.path.realpath
    */
   private class OsPathRealpathCall extends Path::PathNormalization::Range, DataFlow::CallCfgNode {
-    OsPathRealpathCall() { this = os::path().getMember("realpath").getACall() }
+    OsPathRealpathCall() { this = OS::path().getMember("realpath").getACall() }
 
     override DataFlow::Node getPathArg() { result in [this.getArg(0), this.getArgByName("path")] }
   }
@@ -1143,7 +1143,7 @@ private module StdlibPrivate {
     override predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
       exists(CallNode call |
         nodeTo.asCfgNode() = call and
-        call = os::path::join().getACall().asCfgNode() and
+        call = OS::OsPath::join().getACall().asCfgNode() and
         call.getAnArg() = nodeFrom.asCfgNode()
       )
       // TODO: Handle pathlib (like we do for os.path.join)
@@ -1662,7 +1662,7 @@ private module StdlibPrivate {
   API::Node cgi() { result = API::moduleImport("cgi") }
 
   /** Provides models for the `cgi` module. */
-  module cgi {
+  module Cgi {
     /**
      * Provides models for the `cgi.FieldStorage` class
      *
@@ -1862,7 +1862,7 @@ private module StdlibPrivate {
   API::Node http() { result = API::moduleImport("http") }
 
   /** Provides models for the `http` module. */
-  module http {
+  module Http {
     // -------------------------------------------------------------------------
     // http.server
     // -------------------------------------------------------------------------
@@ -1870,7 +1870,7 @@ private module StdlibPrivate {
     API::Node server() { result = http().getMember("server") }
 
     /** Provides models for the `http.server` module */
-    module server {
+    module Server {
       /**
        * Provides models for the `http.server.BaseHTTPRequestHandler` class (Python 3 only).
        *
@@ -1926,9 +1926,9 @@ private module StdlibPrivate {
           SimpleHttpServer::SimpleHttpRequestHandler::classRef(),
           CGIHTTPServer::CGIHTTPRequestHandler::classRef(),
           // Python 3
-          http::server::BaseHttpRequestHandler::classRef(),
-          http::server::SimpleHttpRequestHandler::classRef(),
-          http::server::CGIHTTPRequestHandler::classRef()
+          Http::Server::BaseHttpRequestHandler::classRef(),
+          Http::Server::SimpleHttpRequestHandler::classRef(),
+          Http::Server::CGIHTTPRequestHandler::classRef()
         ].getASubclass*()
     }
 

--- a/python/ql/lib/semmle/python/frameworks/Tornado.qll
+++ b/python/ql/lib/semmle/python/frameworks/Tornado.qll
@@ -72,7 +72,7 @@ private module Tornado {
   API::Node tornado() { result = API::moduleImport("tornado") }
 
   /** Provides models for the `tornado` module. */
-  module tornado {
+  module TornadoModule {
     // -------------------------------------------------------------------------
     // tornado.web
     // -------------------------------------------------------------------------
@@ -80,7 +80,7 @@ private module Tornado {
     API::Node web() { result = tornado().getMember("web") }
 
     /** Provides models for the `tornado.web` module */
-    module web {
+    module Web {
       /**
        * Provides models for the `tornado.web.RequestHandler` class and subclasses.
        *
@@ -199,7 +199,7 @@ private module Tornado {
           override string getAsyncMethodName() { none() }
         }
 
-        private class RequestAttrAccess extends tornado::httputil::HttpServerRequest::InstanceSource {
+        private class RequestAttrAccess extends TornadoModule::HttpUtil::HttpServerRequest::InstanceSource {
           RequestAttrAccess() {
             this.(DataFlow::AttrRead).getObject() = instance() and
             this.(DataFlow::AttrRead).getAttributeName() = "request"
@@ -263,7 +263,7 @@ private module Tornado {
     API::Node httputil() { result = tornado().getMember("httputil") }
 
     /** Provides models for the `tornado.httputil` module */
-    module httputil {
+    module HttpUtil {
       /**
        * Provides models for the `tornado.httputil.HttpServerRequest` class
        *
@@ -359,12 +359,14 @@ private module Tornado {
   // ---------------------------------------------------------------------------
   /** Gets a sequence that defines a number of route rules */
   SequenceNode routeSetupRuleList() {
-    exists(CallNode call | call = any(tornado::web::Application::ClassInstantiation c).asCfgNode() |
+    exists(CallNode call |
+      call = any(TornadoModule::Web::Application::ClassInstantiation c).asCfgNode()
+    |
       result in [call.getArg(0), call.getArgByName("handlers")]
     )
     or
     exists(CallNode call |
-      call.getFunction() = tornado::web::Application::add_handlers().asCfgNode()
+      call.getFunction() = TornadoModule::Web::Application::add_handlers().asCfgNode()
     |
       result in [call.getArg(1), call.getArgByName("host_handlers")]
     )
@@ -406,7 +408,7 @@ private module Tornado {
     override DataFlow::Node getUrlPatternArg() { result.asCfgNode() = node.getElement(0) }
 
     override Function getARequestHandler() {
-      exists(tornado::web::RequestHandler::RequestHandlerClass cls |
+      exists(TornadoModule::Web::RequestHandler::RequestHandlerClass cls |
         cls.getARef().asCfgNode() = node.getElement(1) and
         result = cls.getARequestHandler()
       )
@@ -437,7 +439,7 @@ private module Tornado {
   /** A request handler defined in a tornado RequestHandler class, that has no known route. */
   private class TornadoRequestHandlerWithoutKnownRoute extends HTTP::Server::RequestHandler::Range {
     TornadoRequestHandlerWithoutKnownRoute() {
-      exists(tornado::web::RequestHandler::RequestHandlerClass cls |
+      exists(TornadoModule::Web::RequestHandler::RequestHandlerClass cls |
         cls.getARequestHandler() = this
       ) and
       not exists(TornadoRouteSetup setup | setup.getARequestHandler() = this)
@@ -465,7 +467,7 @@ private module Tornado {
   private class TornadoRequestHandlerRedirectCall extends HTTP::Server::HttpRedirectResponse::Range,
     DataFlow::CallCfgNode {
     TornadoRequestHandlerRedirectCall() {
-      this.getFunction() = tornado::web::RequestHandler::redirectMethod()
+      this.getFunction() = TornadoModule::Web::RequestHandler::redirectMethod()
     }
 
     override DataFlow::Node getRedirectLocation() {
@@ -487,7 +489,7 @@ private module Tornado {
   private class TornadoRequestHandlerWriteCall extends HTTP::Server::HttpResponse::Range,
     DataFlow::CallCfgNode {
     TornadoRequestHandlerWriteCall() {
-      this.getFunction() = tornado::web::RequestHandler::writeMethod()
+      this.getFunction() = TornadoModule::Web::RequestHandler::writeMethod()
     }
 
     override DataFlow::Node getBody() { result in [this.getArg(0), this.getArgByName("chunk")] }
@@ -505,7 +507,7 @@ private module Tornado {
   class TornadoRequestHandlerSetCookieCall extends HTTP::Server::CookieWrite::Range,
     DataFlow::MethodCallNode {
     TornadoRequestHandlerSetCookieCall() {
-      this.calls(tornado::web::RequestHandler::instance(), "set_cookie")
+      this.calls(TornadoModule::Web::RequestHandler::instance(), "set_cookie")
     }
 
     override DataFlow::Node getHeaderArg() { none() }

--- a/python/ql/lib/semmle/python/strings.qll
+++ b/python/ql/lib/semmle/python/strings.qll
@@ -18,9 +18,9 @@ predicate mapping_format(StrConst e) {
  */
 
 private string conversion_specifier_string(StrConst e, int number, int position) {
-  exists(string s, string REGEX | s = e.getText() |
-    REGEX = "%(\\([^)]*\\))?[#0\\- +]*(\\*|[0-9]*)(\\.(\\*|[0-9]*))?(h|H|l|L)?[badiouxXeEfFgGcrs%]" and
-    result = s.regexpFind(REGEX, number, position)
+  exists(string s, string regex | s = e.getText() |
+    regex = "%(\\([^)]*\\))?[#0\\- +]*(\\*|[0-9]*)(\\.(\\*|[0-9]*))?(h|H|l|L)?[badiouxXeEfFgGcrs%]" and
+    result = s.regexpFind(regex, number, position)
   )
 }
 

--- a/python/ql/src/experimental/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Django.qll
@@ -11,15 +11,15 @@ private import semmle.python.ApiGraphs
 import semmle.python.dataflow.new.RemoteFlowSources
 
 private module ExperimentalPrivateDjango {
-  private module django {
+  private module DjangoMod {
     API::Node http() { result = API::moduleImport("django").getMember("http") }
 
-    module http {
+    module Http {
       API::Node response() { result = http().getMember("response") }
 
       API::Node request() { result = http().getMember("request") }
 
-      module request {
+      module Request {
         module HttpRequest {
           class DjangoGETParameter extends DataFlow::Node, RemoteFlowSource::Range {
             DjangoGETParameter() { this = request().getMember("GET").getMember("get").getACall() }
@@ -29,7 +29,7 @@ private module ExperimentalPrivateDjango {
         }
       }
 
-      module response {
+      module Response {
         module HttpResponse {
           API::Node baseClassRef() {
             result = response().getMember("HttpResponse").getReturn()

--- a/python/ql/src/experimental/semmle/python/frameworks/Werkzeug.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Werkzeug.qll
@@ -12,7 +12,7 @@ private import experimental.semmle.python.Concepts
 private import semmle.python.ApiGraphs
 
 private module Werkzeug {
-  module datastructures {
+  module Datastructures {
     module Headers {
       class WerkzeugHeaderAddCall extends DataFlow::CallCfgNode, HeaderDeclaration::Range {
         WerkzeugHeaderAddCall() {

--- a/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
+++ b/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
@@ -29,6 +29,24 @@ string getName(AstNode node, string kind) {
   result = node.(Module).getName() and kind = "module"
 }
 
+string prettyPluralKind(string kind) {
+  kind = "class" and result = "classes"
+  or
+  kind = "classlessPredicate" and result = "predicates"
+  or
+  kind = "classPredicate" and result = "class predicates"
+  or
+  kind = "newtypeBranch" and result = "newtype branches"
+  or
+  kind = "newtype" and result = "newtypes"
+  or
+  kind = "variable" and result = "variables"
+  or
+  kind = "field" and result = "fields"
+  or
+  kind = "module" and result = "modules"
+}
+
 /**
  * Holds if `name` seems to contain an upper-cased acronym that could be pascal-cased.
  * `name` is the name of `node`, and `kind` describes what kind of definition `node` is.

--- a/ql/ql/src/queries/style/NameCasing.ql
+++ b/ql/ql/src/queries/style/NameCasing.ql
@@ -1,9 +1,9 @@
 /**
- * @name No upper case variables
+ * @name Correct casing on name declaraions
  * @description Variables/fields/predicates should be lower-case, classes/modules should be upper-case
  * @kind problem
  * @problem.severity error
- * @id ql/no-upper-case-variables
+ * @id ql/name-casing
  * @tags correctness
  * @precision very-high
  */

--- a/ql/ql/src/queries/style/NoUppercaseVariables.ql
+++ b/ql/ql/src/queries/style/NoUppercaseVariables.ql
@@ -31,11 +31,11 @@ from string name, AstNode node, string message, string kind
 where
   (
     shouldBeLowerCase(node, name, kind) and
-    name.regexpMatch("[A-Z].*") and
+    name.regexpMatch("[^a-z].*") and
     message = "lowercase"
     or
     shouldBeUpperCase(node, name, kind) and
-    name.regexpMatch("[a-z].*") and
+    name.regexpMatch("[^A-Z].*") and
     message = "uppercase"
   ) and
   not node.hasAnnotation("deprecated")

--- a/ql/ql/src/queries/style/NoUppercaseVariables.ql
+++ b/ql/ql/src/queries/style/NoUppercaseVariables.ql
@@ -32,11 +32,11 @@ where
   (
     shouldBeLowerCase(node, name, kind) and
     name.regexpMatch("[^a-z].*") and
-    message = "lowercase"
+    message = "a lowercase"
     or
     shouldBeUpperCase(node, name, kind) and
     name.regexpMatch("[^A-Z].*") and
-    message = "uppercase"
+    message = "an uppercase"
   ) and
   not node.hasAnnotation("deprecated")
-select node, prettyKind(kind) + " should start with an " + message + " letter."
+select node, prettyKind(kind) + " should start with " + message + " letter."

--- a/ql/ql/src/queries/style/NoUppercaseVariables.ql
+++ b/ql/ql/src/queries/style/NoUppercaseVariables.ql
@@ -1,0 +1,42 @@
+/**
+ * @name No upper case variables
+ * @description Variables/fields/predicates should be lower-case, classes/modules should be upper-case
+ * @kind problem
+ * @problem.severity error
+ * @id ql/no-upper-case-variables
+ * @tags correctness
+ * @precision very-high
+ */
+
+import ql
+import codeql_ql.style.AcronymsShouldBeCamelCaseQuery as AcronymsQuery
+
+predicate shouldBeUpperCase(AstNode node, string name, string kind) {
+  name = AcronymsQuery::getName(node, kind) and
+  kind = ["class", "newtypeBranch", "newtype", "module"]
+}
+
+predicate shouldBeLowerCase(AstNode node, string name, string kind) {
+  name = AcronymsQuery::getName(node, kind) and
+  not shouldBeUpperCase(node, name, kind)
+}
+
+string prettyKind(string kind) {
+  exists(string prettyLower | prettyLower = AcronymsQuery::prettyPluralKind(kind) |
+    result = prettyLower.prefix(1).toUpperCase() + prettyLower.suffix(1)
+  )
+}
+
+from string name, AstNode node, string message, string kind
+where
+  (
+    shouldBeLowerCase(node, name, kind) and
+    name.regexpMatch("[A-Z].*") and
+    message = "lowercase"
+    or
+    shouldBeUpperCase(node, name, kind) and
+    name.regexpMatch("[a-z].*") and
+    message = "uppercase"
+  ) and
+  not node.hasAnnotation("deprecated")
+select node, prettyKind(kind) + " should start with an " + message + " letter."


### PR DESCRIPTION
~~TODO: Wait for https://github.com/github/codeql/pull/8323.~~ 

Adds a QL-for-QL queries that puts every name definitions in two categories:  
- Things that should start with an upper-case letter. 
- Things that should start with a lower-case letter. 

Every violation of the above is fixed as part of this PR, luckily almost no code violated the above.  
A few modules in the public API started with a lower-case letter, I've left a deprecated alias for those.  

/cc @jbj 