### PR TITLE
Java: Revert #8325, Add CharacterLiteral to CompileTimeConstantExpr.getStringValue

### DIFF
--- a/java/ql/lib/change-notes/2022-03-11-revert-8325.md
+++ b/java/ql/lib/change-notes/2022-03-11-revert-8325.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+ * Re-removed support for `CharacterLiteral` from `CompileTimeConstantExpr.getStringValue()` to restore the convention that that predicate only applies to `String`-typed constants.

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -168,8 +168,6 @@ class CompileTimeConstantExpr extends Expr {
   string getStringValue() {
     result = this.(StringLiteral).getValue()
     or
-    result = this.(CharacterLiteral).getValue()
-    or
     result =
       this.(AddExpr).getLeftOperand().(CompileTimeConstantExpr).getStringValue() +
         this.(AddExpr).getRightOperand().(CompileTimeConstantExpr).getStringValue()

--- a/java/ql/test/library-tests/constants/CompileTimeConstantExpr.expected
+++ b/java/ql/test/library-tests/constants/CompileTimeConstantExpr.expected
@@ -15,4 +15,3 @@
 | constants/Constants.java:20:22:20:22 | 5 |
 | constants/Constants.java:20:27:20:27 | 1 |
 | constants/Constants.java:20:31:20:31 | 2 |
-| constants/Constants.java:21:22:21:24 | 'a' |

--- a/java/ql/test/library-tests/constants/PrintAst.expected
+++ b/java/ql/test/library-tests/constants/PrintAst.expected
@@ -66,11 +66,7 @@ constants/Constants.java:
 #   20|                 1: [IntegerLiteral] 5
 #   20|               1: [IntegerLiteral] 1
 #   20|               2: [IntegerLiteral] 2
-#   21|         11: [LocalVariableDeclStmt] var ...;
-#   21|           0: [TypeAccess] char
-#   21|           1: [LocalVariableDeclExpr] charLiteral
-#   21|             0: [CharacterLiteral] 'a'
-#   23|         12: [ReturnStmt] return ...
+#   22|         11: [ReturnStmt] return ...
 constants/Initializers.java:
 #    0| [CompilationUnit] Initializers
 #    3|   1: [Class] Initializers
@@ -516,13 +512,3 @@ constants/Values.java:
 #   90|           0: [TypeAccess] int
 #   90|           1: [LocalVariableDeclExpr] var_nonfinald_local
 #   90|             0: [VarAccess] var_field
-#   91|         68: [LocalVariableDeclStmt] var ...;
-#   91|           0: [TypeAccess] String
-#   91|           1: [LocalVariableDeclExpr] concatenatedString
-#   91|             0: [StringLiteral] "a" + "b"
-#   92|         69: [LocalVariableDeclStmt] var ...;
-#   92|           0: [TypeAccess] String
-#   92|           1: [LocalVariableDeclExpr] concatenatedChar
-#   92|             0: [AddExpr] ... + ...
-#   92|               0: [StringLiteral] "ab"
-#   92|               1: [CharacterLiteral] 'c'

--- a/java/ql/test/library-tests/constants/constants/Constants.java
+++ b/java/ql/test/library-tests/constants/constants/Constants.java
@@ -18,7 +18,6 @@ class Constants {
 		int paren = (12);
 		String string = "a string";
 		int ternary = (3 < 5) ? 1 : 2;
-		char charLiteral = 'a';
 		
 		return;
 	}

--- a/java/ql/test/library-tests/constants/constants/Values.java
+++ b/java/ql/test/library-tests/constants/constants/Values.java
@@ -88,7 +88,5 @@ class Values {
         int var_local = final_local; //42
         int var_param = notConstant; //Not constant
         int var_nonfinald_local = var_field; //Not constant
-        String concatenatedString = "a" + "b"; //ab
-        String concatenatedChar = "ab" + 'c'; //abc
     }
 }

--- a/java/ql/test/library-tests/constants/getStringValue.expected
+++ b/java/ql/test/library-tests/constants/getStringValue.expected
@@ -1,3 +1,0 @@
-| constants/Values.java:19:29:19:31 | '*' | * |
-| constants/Values.java:91:37:91:45 | "a" + "b" | ab |
-| constants/Values.java:92:35:92:44 | ... + ... | abc |

--- a/java/ql/test/library-tests/constants/getStringValue.ql
+++ b/java/ql/test/library-tests/constants/getStringValue.ql
@@ -1,9 +1,0 @@
-import semmle.code.java.Variable
-
-from Variable v, CompileTimeConstantExpr init, RefType enclosing, string constant
-where
-  v.getInitializer() = init and
-  init.getEnclosingCallable().getDeclaringType() = enclosing and
-  enclosing.hasQualifiedName("constants", "Values") and
-  constant = init.getStringValue()
-select init, constant


### PR DESCRIPTION
As pointed out in #8325's thread, this breaks the corner case of char-literal addition and the convention that getStringValue only applies to String-typed constants.