### PR TITLE
QL: add restrictive transitive closure query

### DIFF
--- a/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/Predicate.qll
@@ -53,10 +53,12 @@ private module Cached {
   }
 
   private predicate resolvePredicateCall(PredicateCall pc, PredicateOrBuiltin p) {
+    // calls to class methods
     exists(Class c, ClassType t |
       c = pc.getParent*() and
       t = c.getType() and
-      p = t.getClassPredicate(pc.getPredicateName(), pc.getNumberOfArguments())
+      p = t.getClassPredicate(pc.getPredicateName(), pc.getNumberOfArguments()) and
+      not exists(pc.getQualifier()) // no module qualifier
     )
     or
     exists(FileOrModule m, boolean public |

--- a/ql/ql/src/queries/bugs/RestrictiveClosure.ql
+++ b/ql/ql/src/queries/bugs/RestrictiveClosure.ql
@@ -1,0 +1,53 @@
+/**
+ * @name Restrictive transitive closure
+ * @description The transitive closure operation might restrict the type even when taking zero steps.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/restrictive-transitive-closure
+ * @tags correctness
+ *       maintainability
+ * @precision high
+ */
+
+import ql
+
+Class base(Call c) {
+  result = c.(MemberCall).getBase().getType().getDeclaration()
+  or
+  not c instanceof MemberCall and
+  result = c.getTarget().(ClassPredicate).getParent()
+}
+
+Call closureCall() { result.isClosure("*") }
+
+Class return(Call c) { result = c.getTarget().getReturnType().getDeclaration() }
+
+Class superClass(Class c) { result = c.getASuperType().getResolvedType().getDeclaration() }
+
+from Call c, Class return, Class base
+where
+  c = closureCall() and
+  return = return(c) and
+  base = base(c) and
+  return != base and
+  // We aren't restricted anyway from the sorounding code.
+  not superClass*(base) = return and
+  not exists(InstanceOf inst |
+    inst.getExpr() = c and
+    superClass*(inst.getType().getResolvedType().getDeclaration()) = return
+  ) and
+  not exists(ComparisonFormula comp, Expr operand | comp.getOperator() = "=" |
+    comp.getAnOperand() = c and
+    operand != c and
+    operand = comp.getAnOperand() and
+    superClass*(operand.getType().getDeclaration()) = return
+  ) and
+  // If the result is used in a call, then we only flag if the "closure in the middle" could be removed.
+  not exists(MemberCall memberCall | memberCall.getBase() = c |
+    not exists(ClassPredicate pred |
+      pred = superClass*(base).getClassPredicate(memberCall.getMemberName()) and
+      memberCall.getNumberOfArguments() = pred.getArity()
+    )
+  )
+select c, "Closure restricts type from $@ to $@, even when taking zero steps", base, base.getName(),
+  return, return.getName()


### PR DESCRIPTION
Identifies the mistake fixed in this PR: https://github.com/github/codeql/pull/8380 

Basically, a transitive closure might restrict the type when you do zero steps through it, which might not be intentional.  
I think the results found by the query are benign (except for the one already fixed).  

---- 

Drive-by fix to the callgraph, example below:   

```CodeQL
module Foo {
  predicate bar() {none()}
}
class C {
  predicate bar() {none()}
  predicate test() {
    Foo::bar() // <- would spuriously resolve to C::bar() (on top of Foo::bar()). 
  }
}
```