### PR TITLE
C#: Avoid combinatorial explosion in structural comparison library

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/commons/StructuralComparison.qll
+++ b/csharp/ql/lib/semmle/code/csharp/commons/StructuralComparison.qll
@@ -87,7 +87,9 @@ private class GvnCons extends Gvn, TGvnCons {
 pragma[noinline]
 private predicate gvnKindDeclaration(Expr e, int kind, boolean isTargetThis, Declaration d) {
   isTargetThis = isTargetThis(e) and
-  d = referenceAttribute(e) and
+  // guard against elements with multiple declaration targets (DB inconsistency),
+  // which may result in a combinatorial explosion
+  d = unique(Declaration d0 | d0 = referenceAttribute(e) | d0) and
   expressions(e, kind, _)
 }
 


### PR DESCRIPTION
In cases where the target of a call/access has multiple values (which is a DB inconsistency), the GVN construction underlying the structural comparision library may run into a combinatorial explosion. This change excludes such expressions from the GVN construction.