### PR TITLE
C++: Fix join in `cpp/return-stack-allocated-memory`

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -75,14 +75,6 @@ class ReturnStackAllocatedMemoryConfig extends MustFlowConfiguration {
   }
 }
 
-predicate instrHasEnclosingCallable(VariableAddressInstruction var, Function f) {
-  f = var.getEnclosingFunction()
-}
-
-predicate nodeHasEnclosingCallable(DataFlow::Node node, Function f) {
-  f = node.getEnclosingCallable()
-}
-
 from
   MustFlowPathNode source, MustFlowPathNode sink, VariableAddressInstruction var,
   ReturnStackAllocatedMemoryConfig conf, Function f
@@ -91,7 +83,7 @@ where
   source.getNode().asInstruction() = var and
   // Only raise an alert if we're returning from the _same_ callable as the on that
   // declared the stack variable.
-  instrHasEnclosingCallable(var, pragma[only_bind_into](f)) and
-  nodeHasEnclosingCallable(sink.getNode(), pragma[only_bind_into](f))
+  var.getEnclosingFunction() = pragma[only_bind_into](f) and
+  sink.getNode().getEnclosingCallable() = pragma[only_bind_into](f)
 select sink.getNode(), source, sink, "May return stack-allocated memory from $@.", var.getAst(),
   var.getAst().toString()


### PR DESCRIPTION
Fixes a bad join in 'cpp/return-stack-allocated-memory' where we'd get a join on the enclosing callable of two nodes.

Before:
```ql
Tuple counts for #select#cpe#12356#fffff/5@087a720v after 32.7s:
  106500    ~0%     {2} r1 = SCAN MustFlow::MkLocalPathNode#fff OUTPUT In.0 'select', In.2 'sink'
  106000    ~1%     {3} r2 = JOIN r1 WITH DataFlowUtil::Node::getEnclosingCallable_dispred#fb ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'select', Lhs.1 'sink'
  951733500 ~0%     {3} r3 = JOIN r2 WITH Instruction::Instruction::getEnclosingFunction_dispred#3#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'select', Lhs.2 'sink'
  58201000  ~0%     {3} r4 = JOIN r3 WITH project#Instruction::VariableAddressInstruction#class#3#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'select', Lhs.2 'sink'
  58200500  ~0%     {4} r5 = JOIN r4 WITH SSAConstruction::Cached::getInstructionAST#2#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'select', Lhs.2 'sink', Rhs.1 'select#3'
  58200000  ~0%     {5} r6 = JOIN r5 WITH SSAConstruction::Cached::getInstructionAST#2#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'select', Lhs.2 'sink', Lhs.3 'select#3', Rhs.1 'select#3'
  58199500  ~0%     {5} r7 = JOIN r6 WITH DataFlowUtil::Cached::TInstructionNode#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'select', Lhs.2 'sink', Lhs.3 'select#3', Lhs.4
  46580500  ~1%     {5} r8 = JOIN r7 WITH MustFlow::MkLocalPathNode#fff ON FIRST 1 OUTPUT Rhs.2 'sink', Lhs.2 'sink', Lhs.1 'select', Lhs.3 'select#3', Lhs.4
  0         ~0%     {5} r9 = JOIN r8 WITH MustFlow::MustFlowConfiguration::hasFlowPath_dispred#fff#cpe#23 ON FIRST 2 OUTPUT Lhs.4, Lhs.2 'select', Lhs.1 'sink', Lhs.3 'select#3', Lhs.0 'source'
  0         ~0%     {5} r10 = JOIN r9 WITH Element::ElementBase::toString_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'select', Lhs.4 'source', Lhs.2 'sink', Lhs.3 'select#3', Rhs.1 'select#4'
  return r10
```

(I stopped the evaluation before the predicate was completed, so the numbers don't totally reflect _how_ bad it really was.)

After:
```ql
Tuple counts for #select#cpe#12356#fffff/5@e2b1a0oh after 111ms:
  363683 ~2%     {2} r1 = SCAN MustFlow::MkLocalPathNode#fff OUTPUT In.0 'select', In.2 'sink'
  363683 ~5%     {3} r2 = JOIN r1 WITH ReturnStackAllocatedMemory::nodeHasEnclosingCallable#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.0 'select', Lhs.1 'sink'
  363683 ~2%     {3} r3 = JOIN r2 WITH functions ON FIRST 1 OUTPUT Lhs.2 'sink', Lhs.1 'select', Lhs.0
  16002  ~3%     {4} r4 = JOIN r3 WITH MustFlow::MustFlowConfiguration::hasFlowPath_dispred#fff#cpe#23_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'source', Lhs.1 'select', Lhs.0 'sink', Lhs.2
  16002  ~0%     {5} r5 = JOIN r4 WITH MustFlow::MkLocalPathNode#fff_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'select', Lhs.2 'sink', Lhs.3, Lhs.0 'source'
  16002  ~5%     {5} r6 = JOIN r5 WITH DataFlowUtil::Cached::TInstructionNode#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'select', Lhs.2 'sink', Lhs.3, Lhs.4 'source'
  16002  ~3%     {6} r7 = JOIN r6 WITH SSAConstruction::Cached::getInstructionAST#2#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.1 'select', Lhs.2 'sink', Lhs.3, Lhs.4 'source', Rhs.1 'select#3'
  16002  ~0%     {7} r8 = JOIN r7 WITH SSAConstruction::Cached::getInstructionAST#2#ff ON FIRST 1 OUTPUT Lhs.0, Lhs.3, Lhs.1 'select', Lhs.2 'sink', Lhs.4 'source', Lhs.5 'select#3', Rhs.1 'select#3'
  0      ~0%     {5} r9 = JOIN r8 WITH ReturnStackAllocatedMemory::instrHasEnclosingCallable#ff ON FIRST 2 OUTPUT Lhs.6, Lhs.2 'select', Lhs.3 'sink', Lhs.4 'source', Lhs.5 'select#3'
  0      ~0%     {5} r10 = JOIN r9 WITH Element::ElementBase::toString_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'select', Lhs.3 'source', Lhs.2 'sink', Lhs.4 'select#3', Rhs.1 'select#4'
  return r10
```