### PR TITLE
C++: Add missing `security-severity` tags

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
+++ b/cpp/ql/src/Security/CWE/CWE-319/UseOfHttp.ql
@@ -3,6 +3,7 @@
  * @description Non-HTTPS connections can be intercepted by third parties.
  * @kind path-problem
  * @problem.severity warning
+ * @security-severity 8.1
  * @precision high
  * @id cpp/non-https-url
  * @tags security

--- a/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-326/InsufficientKeySize.ql
@@ -4,6 +4,7 @@
  *              allow an attacker to compromise security.
  * @kind path-problem
  * @problem.severity error
+ * @security-severity 7.5
  * @precision high
  * @id cpp/insufficient-key-size
  * @tags security


### PR DESCRIPTION
As identified by the new ql-for-ql query we added [here](https://github.com/github/codeql/pull/8437).