### PR TITLE
C#: Re-use asPartialModel in utility and test code.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -1022,46 +1022,6 @@ module Private {
     }
   }
 
-  /** Provides a query predicate for outputting a set of relevant flow summaries. */
-  module TestOutput {
-    /** A flow summary to include in the `summary/3` query predicate. */
-    abstract class RelevantSummarizedCallable extends SummarizedCallable {
-      /** Gets the string representation of this callable used by `summary/1`. */
-      abstract string getCallableCsv();
-
-      /** Holds if flow is propagated between `input` and `output`. */
-      predicate relevantSummary(
-        SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
-      ) {
-        this.propagatesFlow(input, output, preservesValue)
-      }
-    }
-
-    /** Render the kind in the format used in flow summaries. */
-    private string renderKind(boolean preservesValue) {
-      preservesValue = true and result = "value"
-      or
-      preservesValue = false and result = "taint"
-    }
-
-    /**
-     * A query predicate for outputting flow summaries in semi-colon separated format in QL tests.
-     * The syntax is: "namespace;type;overrides;name;signature;ext;inputspec;outputspec;kind",
-     * ext is hardcoded to empty.
-     */
-    query predicate summary(string csv) {
-      exists(
-        RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
-        boolean preservesValue
-      |
-        c.relevantSummary(input, output, preservesValue) and
-        csv =
-          c.getCallableCsv() + ";;" + getComponentStackCsv(input) + ";" +
-            getComponentStackCsv(output) + ";" + renderKind(preservesValue)
-      )
-    }
-  }
-
   /**
    * Provides query predicates for rendering the generated data flow graph for
    * a summarized callable.

--- a/csharp/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/csharp/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -33,7 +33,7 @@ predicate isRelevantContent(DataFlow::Content c) {
 bindingset[input, output, kind]
 string asSummaryModel(TargetApi api, string input, string output, string kind) {
   result =
-    asPartialModel(api) + input + ";" //
+    api.asPartialModel() + input + ";" //
       + output + ";" //
       + kind
 }
@@ -59,7 +59,7 @@ string asTaintModel(TargetApi api, string input, string output) {
  */
 bindingset[input, kind]
 string asSinkModel(TargetApi api, string input, string kind) {
-  result = asPartialModel(api) + input + ";" + kind
+  result = api.asPartialModel() + input + ";" + kind
 }
 
 /**
@@ -67,5 +67,5 @@ string asSinkModel(TargetApi api, string input, string kind) {
  */
 bindingset[output, kind]
 string asSourceModel(TargetApi api, string output, string kind) {
-  result = asPartialModel(api) + output + ";" + kind
+  result = api.asPartialModel() + output + ";" + kind
 }

--- a/csharp/ql/src/utils/model-generator/ModelGeneratorUtilsSpecific.qll
+++ b/csharp/ql/src/utils/model-generator/ModelGeneratorUtilsSpecific.qll
@@ -20,9 +20,6 @@ class TargetApi extends DataFlowCallable {
   }
 }
 
-/** Computes the first 6 columns for CSV rows. */
-string asPartialModel(TargetApi api) { result = api.asPartialModel() }
-
 /**
  * Holds for type `t` for fields that are relevant as an intermediate
  * read or write step in the data flow analysis.

--- a/csharp/ql/src/utils/model-generator/ModelGeneratorUtilsSpecific.qll
+++ b/csharp/ql/src/utils/model-generator/ModelGeneratorUtilsSpecific.qll
@@ -7,12 +7,12 @@ private import semmle.code.csharp.dataflow.internal.DataFlowDispatch
 private predicate isRelevantForModels(Callable api) { not api instanceof MainMethod }
 
 /**
- * A class of Callables that are relevant for generating summary, source and sinks models for.
+ * A class of DataFlowCallables that are relevant for generating summary, source and sinks models.
  *
  * In the Standard library and 3rd party libraries it the Callables that can be called
  * from outside the library itself.
  */
-class TargetApi extends Callable {
+class TargetApi extends DataFlowCallable {
   TargetApi() {
     [this.(Modifiable), this.(Accessor).getDeclaration()].isEffectivelyPublic() and
     this.fromSource() and
@@ -20,44 +20,8 @@ class TargetApi extends Callable {
   }
 }
 
-private string parameterQualifiedTypeNamesToString(TargetApi api) {
-  result =
-    concat(Parameter p, int i |
-      p = api.getParameter(i)
-    |
-      p.getType().getQualifiedName(), "," order by i
-    )
-}
-
-/** Holds if the summary should apply for all overrides of this. */
-private predicate isBaseCallableOrPrototype(TargetApi api) {
-  api.getDeclaringType() instanceof Interface
-  or
-  exists(Modifiable m | m = [api.(Modifiable), api.(Accessor).getDeclaration()] |
-    m.isAbstract()
-    or
-    api.getDeclaringType().(Modifiable).isAbstract() and m.(Virtualizable).isVirtual()
-  )
-}
-
-/** Gets a string representing whether the summary should apply for all overrides of this. */
-private string getCallableOverride(TargetApi api) {
-  if isBaseCallableOrPrototype(api) then result = "true" else result = "false"
-}
-
 /** Computes the first 6 columns for CSV rows. */
-string asPartialModel(TargetApi api) {
-  exists(string namespace, string type |
-    api.getDeclaringType().hasQualifiedName(namespace, type) and
-    result =
-      namespace + ";" //
-        + type + ";" //
-        + getCallableOverride(api) + ";" //
-        + api.getName() + ";" //
-        + "(" + parameterQualifiedTypeNamesToString(api) + ")" //
-        + /* ext + */ ";" //
-  )
-}
+string asPartialModel(TargetApi api) { result = api.asPartialModel() }
 
 /**
  * Holds for type `t` for fields that are relevant as an intermediate

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummaries.ql
@@ -1,5 +1,5 @@
 import shared.FlowSummaries
 
-private class IncludeAllSummarizedCallable extends IncludeSummarizedCallable {
+private class IncludeAllSummarizedCallable extends RelevantSummarizedCallable {
   IncludeAllSummarizedCallable() { this instanceof SummarizedCallable }
 }

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.ql
@@ -1,7 +1,7 @@
 import shared.FlowSummaries
 private import semmle.code.csharp.dataflow.ExternalFlow
 
-class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable {
+class IncludeFilteredSummarizedCallable extends RelevantSummarizedCallable {
   IncludeFilteredSummarizedCallable() { this instanceof SummarizedCallable }
 
   /**
@@ -13,7 +13,7 @@ class IncludeFilteredSummarizedCallable extends IncludeSummarizedCallable {
     SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
   ) {
     this.propagatesFlow(input, output, preservesValue) and
-    not exists(IncludeSummarizedCallable rsc |
+    not exists(RelevantSummarizedCallable rsc |
       rsc.isBaseCallableOrPrototype() and
       rsc.propagatesFlow(input, output, preservesValue) and
       this.(UnboundCallable).overridesOrImplementsUnbound(rsc)

--- a/csharp/ql/test/library-tests/frameworks/EntityFramework/FlowSummaries.ql
+++ b/csharp/ql/test/library-tests/frameworks/EntityFramework/FlowSummaries.ql
@@ -1,6 +1,6 @@
 import semmle.code.csharp.frameworks.EntityFramework::EntityFramework
 import shared.FlowSummaries
 
-private class IncludeEFSummarizedCallable extends IncludeSummarizedCallable {
+private class IncludeEFSummarizedCallable extends RelevantSummarizedCallable {
   IncludeEFSummarizedCallable() { this instanceof EFSummarizedCallable }
 }

--- a/csharp/ql/test/shared/FlowSummaries.qll
+++ b/csharp/ql/test/shared/FlowSummaries.qll
@@ -3,17 +3,15 @@ import semmle.code.csharp.dataflow.internal.FlowSummaryImpl
 
 /** A flow summary to include in the `summary/3` query predicate. */
 abstract class RelevantSummarizedCallable extends SummarizedCallable {
+  RelevantSummarizedCallable() {
+    [this.(Modifiable), this.(Accessor).getDeclaration()].isEffectivelyPublic()
+  }
+
   /** Holds if flow is propagated between `input` and `output`. */
   predicate relevantSummary(
     SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
   ) {
     this.propagatesFlow(input, output, preservesValue)
-  }
-}
-
-abstract class IncludeSummarizedCallable extends RelevantSummarizedCallable {
-  IncludeSummarizedCallable() {
-    [this.(Modifiable), this.(Accessor).getDeclaration()].isEffectivelyPublic()
   }
 }
 

--- a/csharp/ql/test/shared/FlowSummaries.qll
+++ b/csharp/ql/test/shared/FlowSummaries.qll
@@ -1,44 +1,42 @@
 import semmle.code.csharp.dataflow.FlowSummary
-import semmle.code.csharp.dataflow.internal.FlowSummaryImpl::Private::TestOutput
+import semmle.code.csharp.dataflow.internal.FlowSummaryImpl
+
+/** A flow summary to include in the `summary/3` query predicate. */
+abstract class RelevantSummarizedCallable extends SummarizedCallable {
+  /** Holds if flow is propagated between `input` and `output`. */
+  predicate relevantSummary(
+    SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
+  ) {
+    this.propagatesFlow(input, output, preservesValue)
+  }
+}
 
 abstract class IncludeSummarizedCallable extends RelevantSummarizedCallable {
   IncludeSummarizedCallable() {
     [this.(Modifiable), this.(Accessor).getDeclaration()].isEffectivelyPublic()
   }
+}
 
-  /** Gets the qualified parameter types of this callable as a comma-separated string. */
-  private string parameterQualifiedTypeNamesToString() {
-    result =
-      concat(Parameter p, int i |
-        p = this.getParameter(i)
-      |
-        p.getType().getQualifiedName(), "," order by i
-      )
-  }
+/** Render the kind in the format used in flow summaries. */
+private string renderKind(boolean preservesValue) {
+  preservesValue = true and result = "value"
+  or
+  preservesValue = false and result = "taint"
+}
 
-  /** Holds if the summary should apply for all overrides of this. */
-  predicate isBaseCallableOrPrototype() {
-    this.getDeclaringType() instanceof Interface
-    or
-    exists(Modifiable m | m = [this.(Modifiable), this.(Accessor).getDeclaration()] |
-      m.isAbstract()
-      or
-      this.getDeclaringType().(Modifiable).isAbstract() and m.(Virtualizable).isVirtual()
-    )
-  }
-
-  /** Gets a string representing whether the summary should apply for all overrides of this. */
-  private string getCallableOverride() {
-    if this.isBaseCallableOrPrototype() then result = "true" else result = "false"
-  }
-
-  /** Gets a string representing the callable in semi-colon separated format for use in flow summaries. */
-  final override string getCallableCsv() {
-    exists(string namespace, string type |
-      this.getDeclaringType().hasQualifiedName(namespace, type) and
-      result =
-        namespace + ";" + type + ";" + this.getCallableOverride() + ";" + this.getName() + ";" + "("
-          + this.parameterQualifiedTypeNamesToString() + ")"
-    )
-  }
+/**
+ * A query predicate for outputting flow summaries in semi-colon separated format in QL tests.
+ * The syntax is: "namespace;type;overrides;name;signature;ext;inputspec;outputspec;kind",
+ * ext is hardcoded to empty.
+ */
+query predicate summary(string csv) {
+  exists(
+    RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
+    boolean preservesValue
+  |
+    c.relevantSummary(input, output, preservesValue) and
+    csv =
+      c.asPartialModel() + ";" + Public::getComponentStackCsv(input) + ";" +
+        Public::getComponentStackCsv(output) + ";" + renderKind(preservesValue)
+  )
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -1022,46 +1022,6 @@ module Private {
     }
   }
 
-  /** Provides a query predicate for outputting a set of relevant flow summaries. */
-  module TestOutput {
-    /** A flow summary to include in the `summary/3` query predicate. */
-    abstract class RelevantSummarizedCallable extends SummarizedCallable {
-      /** Gets the string representation of this callable used by `summary/1`. */
-      abstract string getCallableCsv();
-
-      /** Holds if flow is propagated between `input` and `output`. */
-      predicate relevantSummary(
-        SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
-      ) {
-        this.propagatesFlow(input, output, preservesValue)
-      }
-    }
-
-    /** Render the kind in the format used in flow summaries. */
-    private string renderKind(boolean preservesValue) {
-      preservesValue = true and result = "value"
-      or
-      preservesValue = false and result = "taint"
-    }
-
-    /**
-     * A query predicate for outputting flow summaries in semi-colon separated format in QL tests.
-     * The syntax is: "namespace;type;overrides;name;signature;ext;inputspec;outputspec;kind",
-     * ext is hardcoded to empty.
-     */
-    query predicate summary(string csv) {
-      exists(
-        RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
-        boolean preservesValue
-      |
-        c.relevantSummary(input, output, preservesValue) and
-        csv =
-          c.getCallableCsv() + ";;" + getComponentStackCsv(input) + ";" +
-            getComponentStackCsv(output) + ";" + renderKind(preservesValue)
-      )
-    }
-  }
-
   /**
    * Provides query predicates for rendering the generated data flow graph for
    * a summarized callable.

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtils.qll
@@ -33,7 +33,7 @@ predicate isRelevantContent(DataFlow::Content c) {
 bindingset[input, output, kind]
 string asSummaryModel(TargetApi api, string input, string output, string kind) {
   result =
-    asPartialModel(api) + input + ";" //
+    api.asPartialModel() + input + ";" //
       + output + ";" //
       + kind
 }
@@ -59,7 +59,7 @@ string asTaintModel(TargetApi api, string input, string output) {
  */
 bindingset[input, kind]
 string asSinkModel(TargetApi api, string input, string kind) {
-  result = asPartialModel(api) + input + ";" + kind
+  result = api.asPartialModel() + input + ";" + kind
 }
 
 /**
@@ -67,5 +67,5 @@ string asSinkModel(TargetApi api, string input, string kind) {
  */
 bindingset[output, kind]
 string asSourceModel(TargetApi api, string output, string kind) {
-  result = asPartialModel(api) + output + ";" + kind
+  result = api.asPartialModel() + output + ";" + kind
 }

--- a/java/ql/src/utils/model-generator/ModelGeneratorUtilsSpecific.qll
+++ b/java/ql/src/utils/model-generator/ModelGeneratorUtilsSpecific.qll
@@ -92,8 +92,6 @@ class TargetApi extends Callable {
   }
 }
 
-string asPartialModel(TargetApi api) { result = api.asPartialModel() }
-
 private predicate isPrimitiveTypeUsedForBulkData(Type t) {
   t.getName().regexpMatch("byte|char|Byte|Character")
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -1022,46 +1022,6 @@ module Private {
     }
   }
 
-  /** Provides a query predicate for outputting a set of relevant flow summaries. */
-  module TestOutput {
-    /** A flow summary to include in the `summary/3` query predicate. */
-    abstract class RelevantSummarizedCallable extends SummarizedCallable {
-      /** Gets the string representation of this callable used by `summary/1`. */
-      abstract string getCallableCsv();
-
-      /** Holds if flow is propagated between `input` and `output`. */
-      predicate relevantSummary(
-        SummaryComponentStack input, SummaryComponentStack output, boolean preservesValue
-      ) {
-        this.propagatesFlow(input, output, preservesValue)
-      }
-    }
-
-    /** Render the kind in the format used in flow summaries. */
-    private string renderKind(boolean preservesValue) {
-      preservesValue = true and result = "value"
-      or
-      preservesValue = false and result = "taint"
-    }
-
-    /**
-     * A query predicate for outputting flow summaries in semi-colon separated format in QL tests.
-     * The syntax is: "namespace;type;overrides;name;signature;ext;inputspec;outputspec;kind",
-     * ext is hardcoded to empty.
-     */
-    query predicate summary(string csv) {
-      exists(
-        RelevantSummarizedCallable c, SummaryComponentStack input, SummaryComponentStack output,
-        boolean preservesValue
-      |
-        c.relevantSummary(input, output, preservesValue) and
-        csv =
-          c.getCallableCsv() + ";;" + getComponentStackCsv(input) + ";" +
-            getComponentStackCsv(output) + ";" + renderKind(preservesValue)
-      )
-    }
-  }
-
   /**
    * Provides query predicates for rendering the generated data flow graph for
    * a summarized callable.


### PR DESCRIPTION
In this PR we
* Push the declaration of asPartialModel downwards and into DataFlowCallable to allow sharing between test code and utility code.
* Move RelevantSummarizedCallable out of the shared flow summary implementation (it was only used by C#). This simplifies the implementation as we can reduce the height of the inheritance hierarchy.
* Base the TargetApi for C# on DataFlowCallable (ie. only Callables with unbound declarations), which we should have done in the first place.