### PR TITLE
disallow lowercase import-as aliases

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/Linq.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/Linq.qll
@@ -2,14 +2,14 @@
  * Provides classes related to the namespace `System.Linq`.
  */
 
-private import csharp as csharp
+private import csharp as CSharp
 private import semmle.code.csharp.frameworks.System as System
 private import semmle.code.csharp.dataflow.ExternalFlow as ExternalFlow
 
 /** Definitions relating to the `System.Linq` namespace. */
 module SystemLinq {
   /** The `System.Linq` namespace. */
-  class Namespace extends csharp::Namespace {
+  class Namespace extends CSharp::Namespace {
     Namespace() {
       this.getParentNamespace() instanceof System::SystemNamespace and
       this.hasUndecoratedName("Linq")
@@ -17,7 +17,7 @@ module SystemLinq {
   }
 
   /** A class in the `System.Linq` namespace. */
-  class Class extends csharp::Class {
+  class Class extends CSharp::Class {
     Class() { this.getNamespace() instanceof Namespace }
   }
 
@@ -26,10 +26,10 @@ module SystemLinq {
     SystemLinqEnumerableClass() { this.hasName("Enumerable") }
 
     /** Gets a `Count()` method. */
-    csharp::ExtensionMethod getACountMethod() { result = this.getAMethod("Count<>") }
+    CSharp::ExtensionMethod getACountMethod() { result = this.getAMethod("Count<>") }
 
     /** Gets an `Any()` method. */
-    csharp::ExtensionMethod getAnAnyMethod() { result = this.getAMethod("Any<>") }
+    CSharp::ExtensionMethod getAnAnyMethod() { result = this.getAMethod("Any<>") }
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/data/Common.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/data/Common.qll
@@ -2,14 +2,14 @@
  * Provides classes related to the namespace `System.Data.Common`.
  */
 
-private import csharp as csharp
+private import csharp as CSharp
 private import semmle.code.csharp.frameworks.system.Data as Data
 private import semmle.code.csharp.dataflow.ExternalFlow as ExternalFlow
 
 /** Definitions relating to the `System.Data.Common` namespace. */
 module SystemDataCommon {
   /** The `System.Data.Common` namespace. */
-  class Namespace extends csharp::Namespace {
+  class Namespace extends CSharp::Namespace {
     Namespace() {
       this.getParentNamespace() instanceof Data::SystemDataNamespace and
       this.hasName("Common")
@@ -17,7 +17,7 @@ module SystemDataCommon {
   }
 
   /** A class in the `System.Data.Common` namespace. */
-  class Class extends csharp::Class {
+  class Class extends CSharp::Class {
     Class() { this.getNamespace() instanceof Namespace }
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/data/Entity.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/data/Entity.qll
@@ -2,13 +2,13 @@
  * Provides classes related to the Entity Framework namespace `System.Data.Entity`.
  */
 
-private import csharp as csharp
+private import csharp as CSharp
 private import semmle.code.csharp.frameworks.system.Data as Data
 
 /** Definitions relating to the `System.Data.Entity` namespace. */
 module SystemDataEntity {
   /** The `System.Data.Entity` namespace. */
-  class Namespace extends csharp::Namespace {
+  class Namespace extends CSharp::Namespace {
     Namespace() {
       this.getParentNamespace() instanceof Data::SystemDataNamespace and
       this.hasName("Entity")
@@ -16,7 +16,7 @@ module SystemDataEntity {
   }
 
   /** A class in the `System.Data.Entity` namespace. */
-  class Class extends csharp::Class {
+  class Class extends CSharp::Class {
     Class() { this.getNamespace() instanceof Namespace }
   }
 
@@ -25,28 +25,28 @@ module SystemDataEntity {
     Database() { this.hasName("Database") }
 
     /** Gets the `ExecuteSqlCommand` method. */
-    csharp::Method getExecuteSqlCommandMethod() { result = this.getAMethod("ExecuteSqlCommand") }
+    CSharp::Method getExecuteSqlCommandMethod() { result = this.getAMethod("ExecuteSqlCommand") }
 
     /** Gets the `ExecuteSqlCommandAsync` method. */
-    csharp::Method getExecuteSqlCommandAsyncMethod() {
+    CSharp::Method getExecuteSqlCommandAsyncMethod() {
       result = this.getAMethod("ExecuteSqlCommandAsync")
     }
 
     /** Gets the `SqlQuery` method. */
-    csharp::Method getSqlQueryMethod() { result = this.getAMethod("SqlQuery") }
+    CSharp::Method getSqlQueryMethod() { result = this.getAMethod("SqlQuery") }
   }
 
   /** The `System.Data.Entity.DbSet` class. */
   class DbSet extends Class {
     DbSet() {
-      this.getUnboundDeclaration().(csharp::UnboundGenericClass).getUndecoratedName() = "DbSet"
+      this.getUnboundDeclaration().(CSharp::UnboundGenericClass).getUndecoratedName() = "DbSet"
     }
 
     /** Gets the `SqlQuery` method. */
-    csharp::Method getSqlQueryMethod() { result = this.getAMethod("SqlQuery") }
+    CSharp::Method getSqlQueryMethod() { result = this.getAMethod("SqlQuery") }
 
     /** Gets the `DbSet` type, if any. */
-    csharp::Type getDbSetType() { result = this.(csharp::ConstructedType).getTypeArgument(0) }
+    CSharp::Type getDbSetType() { result = this.(CSharp::ConstructedType).getTypeArgument(0) }
   }
 
   /** The `System.Data.Entity.DbContext` class. */
@@ -55,23 +55,23 @@ module SystemDataEntity {
   }
 
   /** A user provided sub type of `DbContext`. */
-  class CustomDbContext extends csharp::Class {
+  class CustomDbContext extends CSharp::Class {
     CustomDbContext() {
       this.fromSource() and
       this.getABaseType+() instanceof DbContext
     }
 
     /** Gets a property that has the type `DbSet`. */
-    csharp::Property getADbSetProperty() {
+    CSharp::Property getADbSetProperty() {
       result = this.getAProperty() and
       result.getType() instanceof DbSet
     }
   }
 
   /** An Entity Framework entity, as referenced from a `CustomDbContext`. */
-  class Entity extends csharp::Class {
+  class Entity extends CSharp::Class {
     Entity() {
-      exists(CustomDbContext dbContext, csharp::Property p |
+      exists(CustomDbContext dbContext, CSharp::Property p |
         p = dbContext.getADbSetProperty() and
         this = p.getType().(DbSet).getDbSetType()
       )
@@ -82,7 +82,7 @@ module SystemDataEntity {
 /** Definitions relating to the `System.Data.Entity.Infrastructure` namespace. */
 module SystemDataEntityInfrastructure {
   /** The `System.Data.Entity.Infrastructure` namespace. */
-  class Namespace extends csharp::Namespace {
+  class Namespace extends CSharp::Namespace {
     Namespace() {
       this.getParentNamespace() instanceof SystemDataEntity::Namespace and
       this.hasName("Infrastructure")
@@ -90,7 +90,7 @@ module SystemDataEntityInfrastructure {
   }
 
   /** A class in the `System.Data.Entity.Infrastructure` namespace. */
-  class Class extends csharp::Class {
+  class Class extends CSharp::Class {
     Class() { this.getNamespace() instanceof Namespace }
   }
 
@@ -99,7 +99,7 @@ module SystemDataEntityInfrastructure {
     DbRawSqlQuery() {
       this.getABaseType*()
           .getUnboundDeclaration()
-          .(csharp::UnboundGenericClass)
+          .(CSharp::UnboundGenericClass)
           .getUndecoratedName() = "DbRawSqlQuery"
     }
   }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/linq/Expressions.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/linq/Expressions.qll
@@ -2,13 +2,13 @@
  * Provides classes related to the namespace `System.Linq.Expressions`.
  */
 
-private import csharp as csharp
+private import csharp as CSharp
 private import semmle.code.csharp.frameworks.system.Linq
 
 /** Definitions relating to the `System.Linq.Expressions` namespace. */
 module SystemLinqExpressions {
   /** The `System.Linq.Expressions` namespace. */
-  class Namespace extends csharp::Namespace {
+  class Namespace extends CSharp::Namespace {
     Namespace() {
       this.getParentNamespace() instanceof SystemLinq::Namespace and
       this.hasName("Expressions")
@@ -16,12 +16,12 @@ module SystemLinqExpressions {
   }
 
   /** A class in the `System.Linq.Expressions` namespace. */
-  class Class extends csharp::Class {
+  class Class extends CSharp::Class {
     Class() { this.getNamespace() instanceof Namespace }
   }
 
   /** The `Expression<TDelegate>` class. */
-  class ExpressionDelegate extends Class, csharp::UnboundGenericClass {
+  class ExpressionDelegate extends Class, CSharp::UnboundGenericClass {
     ExpressionDelegate() { this.hasName("Expression<>") }
   }
 
@@ -30,20 +30,20 @@ module SystemLinqExpressions {
    * or a type of the form `Expression<T>`, where `T` is an actual
    * `delegate` type.
    */
-  class DelegateExtType extends csharp::Type {
-    csharp::DelegateType dt;
+  class DelegateExtType extends CSharp::Type {
+    CSharp::DelegateType dt;
 
     DelegateExtType() {
       this = dt
       or
       this =
-        any(csharp::ConstructedClass cc |
+        any(CSharp::ConstructedClass cc |
           cc.getUnboundGeneric() instanceof ExpressionDelegate and
           dt = cc.getTypeArgument(0)
         )
     }
 
     /** Gets the underlying `delegate` type. */
-    csharp::DelegateType getDelegateType() { result = dt }
+    CSharp::DelegateType getDelegateType() { result = dt }
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/xml/XPath.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/xml/XPath.qll
@@ -1,20 +1,20 @@
 /** Provides classes related to the namespace `System.Xml.XPath`. */
 
-import csharp as csharp
-private import semmle.code.csharp.frameworks.system.Xml as xml
+import csharp as CSharp
+private import semmle.code.csharp.frameworks.system.Xml as Xml
 
 /** Definitions relating to the `System.Xml.XPath` namespace. */
 module SystemXmlXPath {
   /** The `System.Xml.XPath` namespace. */
-  class Namespace extends csharp::Namespace {
+  class Namespace extends CSharp::Namespace {
     Namespace() {
-      this.getParentNamespace() instanceof xml::SystemXmlNamespace and
+      this.getParentNamespace() instanceof Xml::SystemXmlNamespace and
       this.hasName("XPath")
     }
   }
 
   /** A class in the `System.Xml.XPath` namespace. */
-  class Class extends csharp::Class {
+  class Class extends CSharp::Class {
     Class() { this.getNamespace() instanceof Namespace }
   }
 
@@ -28,17 +28,17 @@ module SystemXmlXPath {
     XPathNavigator() { this.hasName("XPathNavigator") }
 
     /** Gets a method that selects nodes. */
-    csharp::Method getASelectMethod() {
+    CSharp::Method getASelectMethod() {
       result = this.getAMethod() and result.getName().matches("Select%")
     }
 
     /** Gets the `Compile` method. */
-    csharp::Method getCompileMethod() { result = this.getAMethod("Compile") }
+    CSharp::Method getCompileMethod() { result = this.getAMethod("Compile") }
 
     /** Gets an `Evaluate` method. */
-    csharp::Method getAnEvaluateMethod() { result = this.getAMethod("Evaluate") }
+    CSharp::Method getAnEvaluateMethod() { result = this.getAMethod("Evaluate") }
 
     /** Gets a `Matches` method. */
-    csharp::Method getAMatchesMethod() { result = this.getAMethod("Matches") }
+    CSharp::Method getAMatchesMethod() { result = this.getAMethod("Matches") }
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/system/xml/XPath.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/system/xml/XPath.qll
@@ -1,6 +1,6 @@
 /** Provides classes related to the namespace `System.Xml.XPath`. */
 
-import csharp as CSharp
+private import csharp as CSharp
 private import semmle.code.csharp.frameworks.system.Xml as Xml
 
 /** Definitions relating to the `System.Xml.XPath` namespace. */

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/ATMConfig.qll
@@ -4,7 +4,7 @@
  * Configures boosting for adaptive threat modeling (ATM).
  */
 
-private import javascript as raw
+private import javascript as JS
 import EndpointTypes
 
 /**
@@ -37,14 +37,14 @@ abstract class AtmConfig extends string {
    *
    * Holds if `source` is a known source of flow.
    */
-  predicate isKnownSource(raw::DataFlow::Node source) { none() }
+  predicate isKnownSource(JS::DataFlow::Node source) { none() }
 
   /**
    * EXPERIMENTAL. This API may change in the future.
    *
    * Holds if `sink` is a known sink of flow.
    */
-  predicate isKnownSink(raw::DataFlow::Node sink) { none() }
+  predicate isKnownSink(JS::DataFlow::Node sink) { none() }
 
   /**
    * EXPERIMENTAL. This API may change in the future.
@@ -52,7 +52,7 @@ abstract class AtmConfig extends string {
    * Holds if the candidate source `candidateSource` predicted by the machine learning model should be
    * an effective source, i.e. one considered as a possible source of flow in the boosted query.
    */
-  predicate isEffectiveSource(raw::DataFlow::Node candidateSource) { none() }
+  predicate isEffectiveSource(JS::DataFlow::Node candidateSource) { none() }
 
   /**
    * EXPERIMENTAL. This API may change in the future.
@@ -60,7 +60,7 @@ abstract class AtmConfig extends string {
    * Holds if the candidate sink `candidateSink` predicted by the machine learning model should be
    * an effective sink, i.e. one considered as a possible sink of flow in the boosted query.
    */
-  predicate isEffectiveSink(raw::DataFlow::Node candidateSink) { none() }
+  predicate isEffectiveSink(JS::DataFlow::Node candidateSink) { none() }
 
   /**
    * EXPERIMENTAL. This API may change in the future.

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/AdaptiveThreatModeling.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/AdaptiveThreatModeling.qll
@@ -4,8 +4,8 @@
  * Provides information about the results of boosted queries for use in adaptive threat modeling (ATM).
  */
 
-private import javascript as raw
-private import raw::DataFlow as DataFlow
+private import javascript as JS
+private import JS::DataFlow as DataFlow
 import ATMConfig
 private import BaseScoring
 private import EndpointScoring as EndpointScoring

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/AdaptiveThreatModeling.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/AdaptiveThreatModeling.qll
@@ -4,8 +4,7 @@
  * Provides information about the results of boosted queries for use in adaptive threat modeling (ATM).
  */
 
-private import javascript as JS
-private import JS::DataFlow as DataFlow
+private import javascript::DataFlow as DataFlow
 import ATMConfig
 private import BaseScoring
 private import EndpointScoring as EndpointScoring

--- a/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
@@ -2,9 +2,9 @@
  * Provides classes for working with XML parser APIs.
  */
 
-private import javascript as js
-private import js::DataFlow as DataFlow
-private import js::API as API
+private import javascript as JS
+private import JS::DataFlow as DataFlow
+private import JS::API as API
 
 module XML {
   /**
@@ -21,9 +21,9 @@ module XML {
   /**
    * A call to an XML parsing function.
    */
-  abstract class ParserInvocation extends js::InvokeExpr {
+  abstract class ParserInvocation extends JS::InvokeExpr {
     /** Gets an argument to this call that is parsed as XML. */
-    abstract js::Expr getSourceArgument();
+    abstract JS::Expr getSourceArgument();
 
     /** Holds if this call to the XML parser resolves entities of the given `kind`. */
     abstract predicate resolvesEntities(EntityKind kind);
@@ -46,14 +46,14 @@ module XML {
       )
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(EntityKind kind) {
       // internal entities are always resolved
       kind = InternalEntity()
       or
       // other entities are only resolved if the configuration option `noent` is set to `true`
-      exists(js::Expr noent |
+      exists(JS::Expr noent |
         hasOptionArgument(1, "noent", noent) and
         noent.mayHaveBooleanValue(true)
       )
@@ -121,7 +121,7 @@ module XML {
       this = parser.getMember("parseString").getACall().asExpr()
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(EntityKind kind) {
       // entities are resolved by default
@@ -144,7 +144,7 @@ module XML {
       this = parser.getMember("push").getACall().asExpr()
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(EntityKind kind) {
       // entities are resolved by default
@@ -167,7 +167,7 @@ module XML {
       this = parser.getMember(["parse", "write"]).getACall().asExpr()
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(EntityKind kind) {
       // only internal entities are resolved by default
@@ -193,7 +193,7 @@ module XML {
       getArgument(1).mayHaveStringValue(any(string tp | tp.matches("%xml%")))
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) { kind = InternalEntity() }
 
@@ -215,7 +215,7 @@ module XML {
       )
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) { any() }
   }
@@ -225,10 +225,10 @@ module XML {
    */
   private class GoogDomXmlParserInvocation extends XML::ParserInvocation {
     GoogDomXmlParserInvocation() {
-      this.getCallee().(js::PropAccess).getQualifiedName() = "goog.dom.xml.loadXml"
+      this.getCallee().(JS::PropAccess).getQualifiedName() = "goog.dom.xml.loadXml"
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) { kind = InternalEntity() }
   }
@@ -246,7 +246,7 @@ module XML {
       )
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) {
       // sax-js (the parser used) does not expand entities.
@@ -273,7 +273,7 @@ module XML {
       this = parser.getAMemberCall("write").asExpr()
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) {
       // sax-js does not expand entities.
@@ -302,7 +302,7 @@ module XML {
             .asExpr()
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) {
       // xml-js does not expand custom entities.
@@ -323,7 +323,7 @@ module XML {
       this = parser.getReturn().getMember("write").getACall().asExpr()
     }
 
-    override js::Expr getSourceArgument() { result = getArgument(0) }
+    override JS::Expr getSourceArgument() { result = getArgument(0) }
 
     override predicate resolvesEntities(XML::EntityKind kind) {
       // htmlparser2 does not expand entities.
@@ -341,7 +341,7 @@ module XML {
     }
   }
 
-  private class XmlParserTaintStep extends js::TaintTracking::SharedTaintStep {
+  private class XmlParserTaintStep extends JS::TaintTracking::SharedTaintStep {
     override predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(XML::ParserInvocation parser |
         pred.asExpr() = parser.getSourceArgument() and

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -13,13 +13,13 @@
  * ```
  */
 
-private import javascript as js
-private import js::DataFlow as DataFlow
+private import javascript as JS
+private import JS::DataFlow as DataFlow
 private import ApiGraphModels
 
-class Unit = js::Unit;
+class Unit = JS::Unit;
 
-module API = js::API;
+module API = JS::API;
 
 import semmle.javascript.frameworks.data.internal.AccessPathSyntax as AccessPathSyntax
 private import AccessPathSyntax

--- a/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
+++ b/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
@@ -27,6 +27,8 @@ string getName(AstNode node, string kind) {
   result = node.(FieldDecl).getName() and kind = "field"
   or
   result = node.(Module).getName() and kind = "module"
+  or
+  result = node.(Import).importedAs() and kind = "import"
 }
 
 string prettyPluralKind(string kind) {
@@ -45,6 +47,8 @@ string prettyPluralKind(string kind) {
   kind = "field" and result = "fields"
   or
   kind = "module" and result = "modules"
+  or
+  kind = "import" and result = "imports"
 }
 
 /**

--- a/ql/ql/src/queries/style/NameCasing.ql
+++ b/ql/ql/src/queries/style/NameCasing.ql
@@ -13,7 +13,7 @@ import codeql_ql.style.AcronymsShouldBeCamelCaseQuery as AcronymsQuery
 
 predicate shouldBeUpperCase(AstNode node, string name, string kind) {
   name = AcronymsQuery::getName(node, kind) and
-  kind = ["class", "newtypeBranch", "newtype", "module"]
+  kind = ["class", "newtypeBranch", "newtype", "module", "import"]
 }
 
 predicate shouldBeLowerCase(AstNode node, string name, string kind) {

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplSpecific.qll
@@ -1,4 +1,4 @@
-private import ruby as rb
+private import ruby as RB
 private import ControlFlowGraphImpl as Impl
 private import Completion as Comp
 private import codeql.ruby.ast.internal.Synthesis
@@ -6,11 +6,11 @@ private import Splitting as Splitting
 private import codeql.ruby.CFG as CFG
 
 /** The base class for `ControlFlowTree`. */
-class ControlFlowTreeBase extends rb::AstNode {
+class ControlFlowTreeBase extends RB::AstNode {
   ControlFlowTreeBase() { not any(Synthesis s).excludeFromControlFlowTree(this) }
 }
 
-class ControlFlowElement = rb::AstNode;
+class ControlFlowElement = RB::AstNode;
 
 class Completion = Comp::Completion;
 
@@ -69,6 +69,6 @@ predicate isAbnormalExitType(SuccessorType t) {
   t instanceof CFG::SuccessorTypes::ExitSuccessor
 }
 
-class Location = rb::Location;
+class Location = RB::Location;
 
 class Node = CFG::CfgNode;


### PR DESCRIPTION
This was mostly due to me missing a case in the `getName()` predicate. 

Ignore the new `Acronyms should be PascalCase/camelCase` warnings, I'll fix them [over here](https://github.com/github/codeql/pull/8444). 