### PR TITLE
JS: add missing @security-severity to JS queries

### DIFF
--- a/javascript/ql/src/Security/CWE-094/UnsafeCodeConstruction.ql
+++ b/javascript/ql/src/Security/CWE-094/UnsafeCodeConstruction.ql
@@ -4,6 +4,7 @@
  *              user to execute arbitrary code.
  * @kind path-problem
  * @problem.severity warning
+ * @security-severity 6.1
  * @precision medium
  * @id js/unsafe-code-construction
  * @tags security

--- a/javascript/ql/src/Security/CWE-347/MissingJWTKeyVerification.ql
+++ b/javascript/ql/src/Security/CWE-347/MissingJWTKeyVerification.ql
@@ -3,6 +3,7 @@
  * @description The application does not verify the JWT payload with a cryptographic secret or public key.
  * @kind problem
  * @problem.severity warning
+ * @security-severity 7.0
  * @precision high
  * @id js/jwt-missing-verification
  * @tags security

--- a/ql/ql/src/queries/style/MissingSecurityMetadata.ql
+++ b/ql/ql/src/queries/style/MissingSecurityMetadata.ql
@@ -41,7 +41,10 @@ predicate missingSecurityTag(QLDoc doc) {
 from TopLevel t, string msg
 where
   t.getLocation().getFile().getBaseName().matches("%.ql") and
-  not t.getLocation().getFile().getRelativePath().matches(["%/experimental/%", "%/examples/%"]) and
+  not t.getLocation()
+      .getFile()
+      .getRelativePath()
+      .matches("%/" + ["experimental", "examples", "test"] + "/%") and
   (
     missingSecuritySeverity(t.getQLDoc()) and
     msg = "This query file is missing a `@security-severity` tag."


### PR DESCRIPTION
And stop the QL-for-QL query from flagging queries in a `test` folder.  