### PR TITLE
ATM: undo unsound performance optimizations

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/AdaptiveThreatModeling.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/AdaptiveThreatModeling.qll
@@ -34,6 +34,7 @@ module ATM {
      */
     pragma[inline]
     float getScoreForFlow(DataFlow::Node source, DataFlow::Node sink) {
+      Optimizations::hasFlow(source, sink) and
       shouldResultBeIncluded(source, sink) and
       result = unique(float s | s = any(ScoringResults results).getScoreForFlow(source, sink))
     }
@@ -117,6 +118,28 @@ module ATM {
             any(string s | if sourceOrigins != "" then s = sourceOrigins else s = "unknown") +
             "; sink origins: " +
             any(string s | if sinkOrigins != "" then s = sinkOrigins else s = "unknown") + "]"
+      )
+    }
+  }
+
+  /**
+   * Predicates for performance improvements that should not affect the semantics.
+   */
+  module Optimizations {
+    /**
+     * EXPERIMENTAL. This API may change in the future.
+     *
+     * Holds if data may flow from `source` to `sink` for *some* configuration.
+     *
+     * This is a variant of `Configuration::hasFlow`, that does not require the precense of a source and a sink.
+     */
+    predicate hasFlow(DataFlow::Node source, DataFlow::Node sink) {
+      exists(DataFlow::Configuration cfg |
+        exists(DataFlow::SourcePathNode flowsource, DataFlow::SinkPathNode flowsink |
+          cfg.hasFlowPath(flowsource, flowsink) and
+          source = flowsource.getNode() and
+          sink = flowsink.getNode()
+        )
       )
     }
   }

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointScoring.qll
@@ -9,6 +9,7 @@ private import BaseScoring
 private import EndpointFeatures as EndpointFeatures
 private import FeaturizationConfig
 private import EndpointTypes
+private import AdaptiveThreatModeling
 
 private string getACompatibleModelChecksum() {
   availableMlModels(result, "javascript", _, "atm-endpoint-scoring")
@@ -23,9 +24,11 @@ module ModelScoring {
     RelevantFeaturizationConfig() { this = "RelevantFeaturization" }
 
     override DataFlow::Node getAnEndpointToFeaturize() {
-      getCfg().isEffectiveSource(result)
+      getCfg().isEffectiveSource(result) and
+      ATM::Optimizations::hasFlow(result, _)
       or
-      getCfg().isEffectiveSink(result)
+      getCfg().isEffectiveSink(result) and
+      ATM::Optimizations::hasFlow(_, result)
     }
   }
 
@@ -146,6 +149,7 @@ module Debugging {
   query predicate endpointScores = ModelScoring::endpointScores/3;
 
   query predicate shouldResultBeIncluded(DataFlow::Node source, DataFlow::Node sink) {
+    ATM::Optimizations::hasFlow(source, sink) and
     any(ScoringResults scoringResults).shouldResultBeIncluded(source, sink)
   }
 }


### PR DESCRIPTION
For an ordinary path-problem query, it is a requirement that at least one sink exists, otherwise there is nothing to alert on.
Thus the optimization with checking `isSink(_, this, _)` pruning in `Configuration::hasFlow` is sound.

For programs without any relevant sinks (which is likely to be the case when ATM is used), the `Configuration::hasFlow` calls will not hold due to the above pruning step.
The optimizations removed in this commit are thus unsound for programs without any relevant sinks.

Relevant pings: @henrymercer @adityasharad

Hopefully performance works out without this 🤞🏻🤞🏻.

## Impact

This means that it now is possible to predict sinks in programs without any known sinks(!!!).

## Testing

Testing this is presumably tricky at the moment due to the required presence of a mlmodel. So I include my own manual test case for completeness and posterity.

### Example database sources

```js
// danger_sink_call.js
danger(sink)
```

```typescript
// flow_to_predicted_sink.ts
// carefully selected file content that presently predicts `req.params.id` to be a sink
import { Request } from "express";

module.exports = function retrieveBasket() {
  return (req: Request) => {
    models.Basket.findOne({
      where: { id: req.params.id }
    });
  };
};
```
### Example query that produces no/some results without/with this PR.

```ql
import DataFlow::PathGraph
import experimental.adaptivethreatmodeling.TaintedPathATM
import experimental.adaptivethreatmodeling.EndpointFeatures
import experimental.adaptivethreatmodeling.EndpointScoring

from DataFlow::Node scored, EndpointType type, string basename, float scoreNum, string description
where
  description = type.getDescription() and
  ModelScoring::endpointScores(scored, type.getEncoding(), scoreNum) and
  scored.getFile().getBaseName() = basename and
  basename = ["danger_sink_call.js", "flow_to_predicted_sink.ts"]
select scored, basename, description, scoreNum
```

### Confirming that `hasFlow(...)` works for the full ATM query without any known sinks

Run `TaintedPathATM.ql`.