### PR TITLE
JS: private import javascript in DataFlow

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -18,7 +18,7 @@
  * modeled (except for immediately invoked functions as explained above).
  */
 
-import javascript
+private import javascript
 private import internal.CallGraphs
 private import internal.FlowSteps as FlowSteps
 private import internal.DataFlowNode


### PR DESCRIPTION
This prevents a circular dependency when we override shared concepts, which leads to ambiguous name resolution errors.

cherry-picked from from https://github.com/github/codeql/pull/8307

/cc @hmac who wrote the change originally

the https://github.com/github/codeql/pull/8307/commits/0d7d98d63d002118b52af503631d1367cfea8faf commit is not included, since the file it improved was deleted in https://github.com/github/codeql/commit/c2743177af8d869cd784ed025896559ffe1c8a33 (already merged into main)