### PR TITLE
C++: Fix expensive getWideCharType().

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -92,7 +92,8 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
    * snapshots there may be multiple results where we can't tell which is correct for a
    * particular function.
    */
-  pragma[nomagic] Type getWideCharType() {
+  pragma[nomagic]
+  Type getWideCharType() {
     result = getFormatCharType() and
     result.getSize() > 1
     or

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -97,7 +97,7 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
     result.getSize() > 1
     or
     not getFormatCharType().getSize() > 1 and
-    result = getAFormatterWideTypeOrDefault() // may have more than one result
+    result = pragma[only_bind_out](getAFormatterWideTypeOrDefault()) // may have more than one result
   }
 
   /**

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -92,12 +92,12 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
    * snapshots there may be multiple results where we can't tell which is correct for a
    * particular function.
    */
-  Type getWideCharType() {
+  pragma[nomagic] Type getWideCharType() {
     result = getFormatCharType() and
     result.getSize() > 1
     or
     not getFormatCharType().getSize() > 1 and
-    result = pragma[only_bind_out](getAFormatterWideTypeOrDefault()) // may have more than one result
+    result = getAFormatterWideTypeOrDefault() // may have more than one result
   }
 
   /**


### PR DESCRIPTION
Fix a potential issue with `FormattingFunction::getWideCharType` that was identified in the 'Join-order badness' section of a nightly DCA run.  The goals here is to fix the potential issue - I have not found or looked for projects where this problem blows up enough to cause a significant overall slowdown in practice.

The issue appears to come from `getAFormatterWideTypeOrDefault`, specifically `not exists(getAFormatterWideType())` within that which creates a surprising amount of computation.

Before (`wireshark`, `NoSpaceForZeroTerminator.ql`):
```
[2022-03-17 14:58:13] (772s) Tuple counts for FormattingFunction::FormattingFunction::getWideCharType_dispred#bb/2@346c7dg5 after 74ms:
                      81      ~0%     {1} r1 = FormattingFunction::FormattingFunction::getDefaultCharType_dispred#bf#shared AND NOT FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#antijoin_rhs(Lhs.0 'this')
                      3315492 ~0%     {2} r2 = JOIN r1 WITH m#FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#mcpe_result CARTESIAN PRODUCT OUTPUT Rhs.0, Lhs.0 'this'
                      162     ~1%     {2} r3 = JOIN r2 WITH FormattingFunction::getAFormatterWideTypeOrDefault#b ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0 'result'
                      
                      81      ~1%     {2} r4 = JOIN FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#shared WITH m#FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#mcpe_result ON FIRST 1 OUTPUT Lhs.0 'result', Lhs.1 'this'
                      81      ~3%     {3} r5 = JOIN r4 WITH Type::Type::getSize_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0 'result', Rhs.1
                      0       ~0%     {3} r6 = SELECT r5 ON In.2 > 1
                      0       ~0%     {2} r7 = SCAN r6 OUTPUT In.0 'this', In.1 'result'
                      
                      162     ~1%     {2} r8 = r3 UNION r7
                                      return r8
```

After (`wireshark`, `NoSpaceForZeroTerminator.ql`):
```
[2022-03-17 15:20:20] (960s) Tuple counts for FormattingFunction::FormattingFunction::getWideCharType_dispred#bb/2@8e3a1db0 after 0ms:
                      162 ~0%       {2} r1 = JOIN FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#shared WITH FormattingFunction::FormattingFunction#class#f ON FIRST 1 OUTPUT Lhs.1 'result', Lhs.0 'this'
                      
                      162 ~0%       {2} r2 = r1 AND NOT FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#antijoin_rhs(Lhs.0 'result', Lhs.1 'this')
                      162 ~1%       {2} r3 = SCAN r2 OUTPUT In.1 'this', In.0 'result'
                      
                      162 ~0%       {2} r4 = r1 AND NOT FormattingFunction::FormattingFunction::getWideCharType_dispred#bb#antijoin_rhs(Lhs.0 'result', Lhs.1 'this')
                      162 ~1%       {2} r5 = SCAN r4 OUTPUT In.1 'this', In.0 'result'
                      
                      324 ~103%     {2} r6 = r3 UNION r5
                      
                      81  ~1%       {2} r7 = JOIN FormattingFunction::FormattingFunction::getDefaultCharType_dispred#bf#shared WITH FormattingFunction::FormattingFunction::getFormatCharType_dispred#ff ON FIRST 1 OUTPUT Rhs.1 'result', Lhs.0 'this'
                      81  ~1%       {2} r8 = JOIN r7 WITH m#Printf::FormatLiteral::getDefaultCharType_dispred#fb ON FIRST 1 OUTPUT Lhs.0 'result', Lhs.1 'this'
                      81  ~3%       {3} r9 = JOIN r8 WITH Type::Type::getSize_dispred#ff ON FIRST 1 OUTPUT Lhs.1 'this', Lhs.0 'result', Rhs.1
                      
                      0   ~0%       {3} r10 = SELECT r9 ON In.2 > 1
                      0   ~0%       {2} r11 = SCAN r10 OUTPUT In.0 'this', In.1 'result'
                      
                      0   ~0%       {3} r12 = SELECT r9 ON In.2 > 1
                      0   ~0%       {2} r13 = SCAN r12 OUTPUT In.0 'this', In.1 'result'
                      
                      0   ~0%       {2} r14 = r11 UNION r13
                      324 ~103%     {2} r15 = r6 UNION r14
                                    return r15
```

I saw similar results on `vim`, and in some brief tests using other queries.  I'll also start a DCA run on this PR shortly, and we'll see what the 'Join-order badness' section says now.