### PR TITLE
C++: Add additional command line injection tests

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -47,26 +47,29 @@ edges
 | test.cpp:180:13:180:19 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
 | test.cpp:180:22:180:29 | filename indirection | test.cpp:180:13:180:19 | strncat output argument |
 | test.cpp:180:22:180:29 | filename indirection | test.cpp:180:13:180:19 | strncat output argument |
-| test.cpp:186:53:186:60 | *filename | test.cpp:187:18:187:25 | filename indirection |
-| test.cpp:186:53:186:60 | *filename | test.cpp:188:20:188:24 | flags indirection |
-| test.cpp:186:53:186:60 | filename | test.cpp:187:18:187:25 | filename indirection |
-| test.cpp:186:53:186:60 | filename | test.cpp:188:20:188:24 | flags indirection |
+| test.cpp:186:47:186:54 | *filename | test.cpp:187:18:187:25 | filename indirection |
+| test.cpp:186:47:186:54 | *filename | test.cpp:188:20:188:24 | flags indirection |
+| test.cpp:186:47:186:54 | filename | test.cpp:187:18:187:25 | filename indirection |
+| test.cpp:186:47:186:54 | filename | test.cpp:188:20:188:24 | flags indirection |
 | test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
 | test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
 | test.cpp:187:18:187:25 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
 | test.cpp:187:18:187:25 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
 | test.cpp:188:11:188:17 | command [post update] | test.cpp:188:11:188:17 | command [post update] |
-| test.cpp:188:11:188:17 | command [post update] | test.cpp:196:16:196:22 | command [post update] |
-| test.cpp:188:11:188:17 | command [post update] | test.cpp:196:16:196:22 | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:196:10:196:16 | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:196:10:196:16 | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:205:10:205:16 | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:205:10:205:16 | command [post update] |
 | test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
 | test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
 | test.cpp:188:20:188:24 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
 | test.cpp:188:20:188:24 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
-| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:32:196:39 | filename |
-| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:32:196:39 | filename indirection |
-| test.cpp:196:16:196:22 | command [post update] | test.cpp:198:32:198:38 | command indirection |
-| test.cpp:196:32:196:39 | filename | test.cpp:186:53:186:60 | filename |
-| test.cpp:196:32:196:39 | filename indirection | test.cpp:186:53:186:60 | *filename |
+| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | filename |
+| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:26:196:33 | filename indirection |
+| test.cpp:196:10:196:16 | command [post update] | test.cpp:198:32:198:38 | command indirection |
+| test.cpp:196:26:196:33 | filename | test.cpp:186:47:186:54 | filename |
+| test.cpp:196:26:196:33 | filename indirection | test.cpp:186:47:186:54 | *filename |
+| test.cpp:205:10:205:16 | command [post update] | test.cpp:207:32:207:38 | command indirection |
 nodes
 | test.cpp:16:20:16:23 | argv | semmle.label | argv |
 | test.cpp:22:13:22:20 | sprintf output argument | semmle.label | sprintf output argument |
@@ -112,8 +115,8 @@ nodes
 | test.cpp:180:13:180:19 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:180:22:180:29 | filename indirection | semmle.label | filename indirection |
 | test.cpp:183:32:183:38 | command indirection | semmle.label | command indirection |
-| test.cpp:186:53:186:60 | *filename | semmle.label | *filename |
-| test.cpp:186:53:186:60 | filename | semmle.label | filename |
+| test.cpp:186:47:186:54 | *filename | semmle.label | *filename |
+| test.cpp:186:47:186:54 | filename | semmle.label | filename |
 | test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:187:18:187:25 | filename indirection | semmle.label | filename indirection |
 | test.cpp:188:11:188:17 | command [post update] | semmle.label | command [post update] |
@@ -121,10 +124,12 @@ nodes
 | test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
 | test.cpp:188:20:188:24 | flags indirection | semmle.label | flags indirection |
 | test.cpp:194:9:194:16 | fread output argument | semmle.label | fread output argument |
-| test.cpp:196:16:196:22 | command [post update] | semmle.label | command [post update] |
-| test.cpp:196:32:196:39 | filename | semmle.label | filename |
-| test.cpp:196:32:196:39 | filename indirection | semmle.label | filename indirection |
+| test.cpp:196:10:196:16 | command [post update] | semmle.label | command [post update] |
+| test.cpp:196:26:196:33 | filename | semmle.label | filename |
+| test.cpp:196:26:196:33 | filename indirection | semmle.label | filename indirection |
 | test.cpp:198:32:198:38 | command indirection | semmle.label | command indirection |
+| test.cpp:205:10:205:16 | command [post update] | semmle.label | command [post update] |
+| test.cpp:207:32:207:38 | command indirection | semmle.label | command indirection |
 subpaths
 #select
 | test.cpp:23:12:23:19 | command1 | test.cpp:16:20:16:23 | argv | test.cpp:23:12:23:19 | command1 indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string) | test.cpp:16:20:16:23 | argv | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
@@ -141,3 +146,5 @@ subpaths
 | test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:174:9:174:16 | fread output argument | user input (String read by fread) | test.cpp:180:13:180:19 | strncat output argument | strncat output argument |
 | test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:194:9:194:16 | fread output argument | user input (String read by fread) | test.cpp:187:11:187:15 | strncat output argument | strncat output argument |
 | test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:194:9:194:16 | fread output argument | user input (String read by fread) | test.cpp:188:11:188:17 | strncat output argument | strncat output argument |
+| test.cpp:207:32:207:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:207:32:207:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:194:9:194:16 | fread output argument | user input (String read by fread) | test.cpp:187:11:187:15 | strncat output argument | strncat output argument |
+| test.cpp:207:32:207:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:207:32:207:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:194:9:194:16 | fread output argument | user input (String read by fread) | test.cpp:188:11:188:17 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/ExecTainted.expected
@@ -35,6 +35,38 @@ edges
 | test.cpp:142:11:142:17 | sprintf output argument | test.cpp:143:10:143:16 | command indirection |
 | test.cpp:142:31:142:33 | str indirection | test.cpp:142:11:142:17 | sprintf output argument |
 | test.cpp:142:31:142:33 | str indirection | test.cpp:142:11:142:17 | sprintf output argument |
+| test.cpp:174:9:174:16 | fread output argument | test.cpp:177:20:177:27 | filename indirection |
+| test.cpp:174:9:174:16 | fread output argument | test.cpp:178:22:178:26 | flags indirection |
+| test.cpp:174:9:174:16 | fread output argument | test.cpp:180:22:180:29 | filename indirection |
+| test.cpp:177:13:177:17 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
+| test.cpp:177:20:177:27 | filename indirection | test.cpp:177:13:177:17 | strncat output argument |
+| test.cpp:177:20:177:27 | filename indirection | test.cpp:177:13:177:17 | strncat output argument |
+| test.cpp:178:13:178:19 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
+| test.cpp:178:22:178:26 | flags indirection | test.cpp:178:13:178:19 | strncat output argument |
+| test.cpp:178:22:178:26 | flags indirection | test.cpp:178:13:178:19 | strncat output argument |
+| test.cpp:180:13:180:19 | strncat output argument | test.cpp:183:32:183:38 | command indirection |
+| test.cpp:180:22:180:29 | filename indirection | test.cpp:180:13:180:19 | strncat output argument |
+| test.cpp:180:22:180:29 | filename indirection | test.cpp:180:13:180:19 | strncat output argument |
+| test.cpp:186:53:186:60 | *filename | test.cpp:187:18:187:25 | filename indirection |
+| test.cpp:186:53:186:60 | *filename | test.cpp:188:20:188:24 | flags indirection |
+| test.cpp:186:53:186:60 | filename | test.cpp:187:18:187:25 | filename indirection |
+| test.cpp:186:53:186:60 | filename | test.cpp:188:20:188:24 | flags indirection |
+| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
+| test.cpp:187:11:187:15 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
+| test.cpp:187:18:187:25 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
+| test.cpp:187:18:187:25 | filename indirection | test.cpp:187:11:187:15 | strncat output argument |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:188:11:188:17 | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:196:16:196:22 | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | test.cpp:196:16:196:22 | command [post update] |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
+| test.cpp:188:11:188:17 | strncat output argument | test.cpp:188:11:188:17 | command [post update] |
+| test.cpp:188:20:188:24 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
+| test.cpp:188:20:188:24 | flags indirection | test.cpp:188:11:188:17 | strncat output argument |
+| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:32:196:39 | filename |
+| test.cpp:194:9:194:16 | fread output argument | test.cpp:196:32:196:39 | filename indirection |
+| test.cpp:196:16:196:22 | command [post update] | test.cpp:198:32:198:38 | command indirection |
+| test.cpp:196:32:196:39 | filename | test.cpp:186:53:186:60 | filename |
+| test.cpp:196:32:196:39 | filename indirection | test.cpp:186:53:186:60 | *filename |
 nodes
 | test.cpp:16:20:16:23 | argv | semmle.label | argv |
 | test.cpp:22:13:22:20 | sprintf output argument | semmle.label | sprintf output argument |
@@ -72,6 +104,27 @@ nodes
 | test.cpp:142:11:142:17 | sprintf output argument | semmle.label | sprintf output argument |
 | test.cpp:142:31:142:33 | str indirection | semmle.label | str indirection |
 | test.cpp:143:10:143:16 | command indirection | semmle.label | command indirection |
+| test.cpp:174:9:174:16 | fread output argument | semmle.label | fread output argument |
+| test.cpp:177:13:177:17 | strncat output argument | semmle.label | strncat output argument |
+| test.cpp:177:20:177:27 | filename indirection | semmle.label | filename indirection |
+| test.cpp:178:13:178:19 | strncat output argument | semmle.label | strncat output argument |
+| test.cpp:178:22:178:26 | flags indirection | semmle.label | flags indirection |
+| test.cpp:180:13:180:19 | strncat output argument | semmle.label | strncat output argument |
+| test.cpp:180:22:180:29 | filename indirection | semmle.label | filename indirection |
+| test.cpp:183:32:183:38 | command indirection | semmle.label | command indirection |
+| test.cpp:186:53:186:60 | *filename | semmle.label | *filename |
+| test.cpp:186:53:186:60 | filename | semmle.label | filename |
+| test.cpp:187:11:187:15 | strncat output argument | semmle.label | strncat output argument |
+| test.cpp:187:18:187:25 | filename indirection | semmle.label | filename indirection |
+| test.cpp:188:11:188:17 | command [post update] | semmle.label | command [post update] |
+| test.cpp:188:11:188:17 | command [post update] | semmle.label | command [post update] |
+| test.cpp:188:11:188:17 | strncat output argument | semmle.label | strncat output argument |
+| test.cpp:188:20:188:24 | flags indirection | semmle.label | flags indirection |
+| test.cpp:194:9:194:16 | fread output argument | semmle.label | fread output argument |
+| test.cpp:196:16:196:22 | command [post update] | semmle.label | command [post update] |
+| test.cpp:196:32:196:39 | filename | semmle.label | filename |
+| test.cpp:196:32:196:39 | filename indirection | semmle.label | filename indirection |
+| test.cpp:198:32:198:38 | command indirection | semmle.label | command indirection |
 subpaths
 #select
 | test.cpp:23:12:23:19 | command1 | test.cpp:16:20:16:23 | argv | test.cpp:23:12:23:19 | command1 indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string) | test.cpp:16:20:16:23 | argv | user input (a command-line argument) | test.cpp:22:13:22:20 | sprintf output argument | sprintf output argument |
@@ -83,3 +136,8 @@ subpaths
 | test.cpp:114:25:114:29 | call to c_str | test.cpp:113:20:113:25 | call to getenv | test.cpp:114:25:114:29 | call to c_str indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string) | test.cpp:113:20:113:25 | call to getenv | user input (an environment variable) | test.cpp:114:17:114:17 | Call | Call |
 | test.cpp:120:25:120:28 | call to data | test.cpp:119:20:119:25 | call to getenv | test.cpp:120:10:120:30 | call to data indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string) | test.cpp:119:20:119:25 | call to getenv | user input (an environment variable) | test.cpp:120:17:120:17 | Call | Call |
 | test.cpp:143:10:143:16 | command | test.cpp:140:9:140:11 | fread output argument | test.cpp:143:10:143:16 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to system(string) | test.cpp:140:9:140:11 | fread output argument | user input (String read by fread) | test.cpp:142:11:142:17 | sprintf output argument | sprintf output argument |
+| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:174:9:174:16 | fread output argument | user input (String read by fread) | test.cpp:177:13:177:17 | strncat output argument | strncat output argument |
+| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:174:9:174:16 | fread output argument | user input (String read by fread) | test.cpp:178:13:178:19 | strncat output argument | strncat output argument |
+| test.cpp:183:32:183:38 | command | test.cpp:174:9:174:16 | fread output argument | test.cpp:183:32:183:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:174:9:174:16 | fread output argument | user input (String read by fread) | test.cpp:180:13:180:19 | strncat output argument | strncat output argument |
+| test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:194:9:194:16 | fread output argument | user input (String read by fread) | test.cpp:187:11:187:15 | strncat output argument | strncat output argument |
+| test.cpp:198:32:198:38 | command | test.cpp:194:9:194:16 | fread output argument | test.cpp:198:32:198:38 | command indirection | This argument to an OS command is derived from $@, dangerously concatenated into $@, and then passed to execl | test.cpp:194:9:194:16 | fread output argument | user input (String read by fread) | test.cpp:188:11:188:17 | strncat output argument | strncat output argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/test.cpp
@@ -168,6 +168,35 @@ void test15(FILE *f) {
   system(command); // GOOD: the user string was converted to an integer and back
 }
 
+void test16(FILE *f, bool use_flags) {
+  // BAD: the user string is injected directly into a command
+  char command[1000] = "mv ", flags[1000] = "-R", filename[1000];
+  fread(filename, 1, 1000, f);
+
+  if (use_flags) {
+    strncat(flags, filename, 1000);
+    strncat(command, flags, 1000);
+  } else {
+    strncat(command, filename, 1000);
+  }
+
+  execl("/bin/sh", "sh", "-c", command);
+}
+
+void test17_inner(char *command, char *flags, char *filename) {
+  strncat(flags, filename, 1000);
+  strncat(command, flags, 1000);
+}
+
+void test17(FILE *f) {
+  // BAD: the user string is injected directly into a command
+  char command[1000] = "mv ", flags[1000] = "-R", filename[1000];
+  fread(filename, 1, 1000, f);
+
+  test17_inner(command, flags, filename);
+
+  execl("/bin/sh", "sh", "-c", command);
+}
 
 // TODO: test for call context sensitivity at concatenation site
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-078/semmle/ExecTainted/test.cpp
@@ -183,7 +183,7 @@ void test16(FILE *f, bool use_flags) {
   execl("/bin/sh", "sh", "-c", command);
 }
 
-void test17_inner(char *command, char *flags, char *filename) {
+void concat(char *command, char *flags, char *filename) {
   strncat(flags, filename, 1000);
   strncat(command, flags, 1000);
 }
@@ -193,11 +193,18 @@ void test17(FILE *f) {
   char command[1000] = "mv ", flags[1000] = "-R", filename[1000];
   fread(filename, 1, 1000, f);
 
-  test17_inner(command, flags, filename);
+  concat(command, flags, filename);
 
   execl("/bin/sh", "sh", "-c", command);
 }
 
-// TODO: test for call context sensitivity at concatenation site
+void test18() {
+  // GOOD [FALSE POSITIVE]
+  char command[1000] = "ls ", flags[1000] = "-l", filename[1000] = ".";
+
+  concat(command, flags, filename);
+
+  execl("/bin/sh", "sh", "-c", command);
+}
 
 // open question: do we want to report certain sources even when they're the start of the string?


### PR DESCRIPTION
One additional test involving branching and one additional test involving `strncat` in a called subroutine.