### PR TITLE
C++: Make getUnderlyingType nomagic

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Type.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Type.qll
@@ -94,7 +94,8 @@ class Type extends Locatable, @type {
    * The result of this predicate will be the type itself, except in the case of a TypedefType or a Decltype,
    * in which case the result will be type which results from (possibly recursively) resolving typedefs.
    */
-  pragma[nomagic] Type getUnderlyingType() { result = this }
+  pragma[nomagic]
+  Type getUnderlyingType() { result = this }
 
   /**
    * Gets this type after specifiers have been deeply stripped and typedefs have been resolved.

--- a/cpp/ql/lib/semmle/code/cpp/Type.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Type.qll
@@ -94,7 +94,7 @@ class Type extends Locatable, @type {
    * The result of this predicate will be the type itself, except in the case of a TypedefType or a Decltype,
    * in which case the result will be type which results from (possibly recursively) resolving typedefs.
    */
-  Type getUnderlyingType() { result = this }
+  pragma[nomagic] Type getUnderlyingType() { result = this }
 
   /**
    * Gets this type after specifiers have been deeply stripped and typedefs have been resolved.


### PR DESCRIPTION
Motivated by some observations of `cpp/system-data-exposure` (by DCA), but the effects of this change will not be limited to this project, and may or may not be positive overall.  So I'll do a DCA run on this PR, then we can discuss...

