### PR TITLE
Ruby: fix bug with captured variable reads in lambdas

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ast/internal/Variable.qll
+++ b/ruby/ql/lib/codeql/ruby/ast/internal/Variable.qll
@@ -406,7 +406,11 @@ import Cached
 
 /** Holds if this scope inherits `name` from an outer scope `outer`. */
 private predicate inherits(Scope::Range scope, string name, Scope::Range outer) {
-  (scope instanceof Ruby::Block or scope instanceof Ruby::DoBlock) and
+  (
+    scope instanceof Ruby::Block or
+    scope instanceof Ruby::DoBlock or
+    scope instanceof Ruby::Lambda
+  ) and
   not scopeDefinesParameterVariable(scope, name, _) and
   (
     outer = scope.getOuterScope() and

--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -714,8 +714,7 @@ calls/calls.rb:
 #  351|     getAnOperand/getRightOperand: [Lambda] -> { ... }
 #  351|       getParameter: [SimpleParameter] x
 #  351|         getDefiningAccess: [LocalVariableAccess] x
-#  351|       getStmt: [MethodCall] call to y
-#  351|         getReceiver: [SelfVariableAccess] self
+#  351|       getStmt: [LocalVariableAccess] y
 #  352|   getStmt: [AssignExpr] ... = ...
 #  352|     getAnOperand/getLeftOperand: [LocalVariableAccess] f
 #  352|     getAnOperand/getRightOperand: [Lambda] -> { ... }
@@ -737,8 +736,7 @@ calls/calls.rb:
 #  354|       getParameter: [SimpleParameter] x
 #  354|         getDefiningAccess: [LocalVariableAccess] x
 #  355|       getStmt: [LocalVariableAccess] x
-#  356|       getStmt: [MethodCall] call to y
-#  356|         getReceiver: [SelfVariableAccess] self
+#  356|       getStmt: [LocalVariableAccess] y
 #  357|       getStmt: [MethodCall] call to unknown_call
 #  357|         getReceiver: [SelfVariableAccess] self
 control/cases.rb:

--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -706,6 +706,41 @@ calls/calls.rb:
 #  347|       getKey: [SymbolLiteral] :X
 #  347|         getComponent: [StringTextComponent] X
 #  347|       getValue: [ConstantReadAccess] X
+#  350|   getStmt: [AssignExpr] ... = ...
+#  350|     getAnOperand/getLeftOperand: [LocalVariableAccess] y
+#  350|     getAnOperand/getRightOperand: [IntegerLiteral] 1
+#  351|   getStmt: [AssignExpr] ... = ...
+#  351|     getAnOperand/getLeftOperand: [LocalVariableAccess] id
+#  351|     getAnOperand/getRightOperand: [Lambda] -> { ... }
+#  351|       getParameter: [SimpleParameter] x
+#  351|         getDefiningAccess: [LocalVariableAccess] x
+#  351|       getStmt: [MethodCall] call to y
+#  351|         getReceiver: [SelfVariableAccess] self
+#  352|   getStmt: [AssignExpr] ... = ...
+#  352|     getAnOperand/getLeftOperand: [LocalVariableAccess] f
+#  352|     getAnOperand/getRightOperand: [Lambda] -> { ... }
+#  352|       getParameter: [SimpleParameter] x
+#  352|         getDefiningAccess: [LocalVariableAccess] x
+#  352|       getStmt: [MethodCall] call to foo
+#  352|         getReceiver: [SelfVariableAccess] self
+#  352|         getArgument: [LocalVariableAccess] x
+#  353|   getStmt: [AssignExpr] ... = ...
+#  353|     getAnOperand/getLeftOperand: [LocalVariableAccess] g
+#  353|     getAnOperand/getRightOperand: [Lambda] -> { ... }
+#  353|       getParameter: [SimpleParameter] x
+#  353|         getDefiningAccess: [LocalVariableAccess] x
+#  353|       getStmt: [MethodCall] call to unknown_call
+#  353|         getReceiver: [SelfVariableAccess] self
+#  354|   getStmt: [AssignExpr] ... = ...
+#  354|     getAnOperand/getLeftOperand: [LocalVariableAccess] h
+#  354|     getAnOperand/getRightOperand: [Lambda] -> { ... }
+#  354|       getParameter: [SimpleParameter] x
+#  354|         getDefiningAccess: [LocalVariableAccess] x
+#  355|       getStmt: [LocalVariableAccess] x
+#  356|       getStmt: [MethodCall] call to y
+#  356|         getReceiver: [SelfVariableAccess] self
+#  357|       getStmt: [MethodCall] call to unknown_call
+#  357|         getReceiver: [SelfVariableAccess] self
 control/cases.rb:
 #    1| [Toplevel] cases.rb
 #    2|   getStmt: [AssignExpr] ... = ...

--- a/ruby/ql/test/library-tests/ast/ValueText.expected
+++ b/ruby/ql/test/library-tests/ast/ValueText.expected
@@ -73,6 +73,7 @@ exprValue
 | calls/calls.rb:346:5:346:5 | :X | :X |
 | calls/calls.rb:346:8:346:9 | 42 | 42 |
 | calls/calls.rb:347:5:347:5 | :X | :X |
+| calls/calls.rb:350:5:350:5 | 1 | 1 |
 | constants/constants.rb:3:19:3:27 | "const_a" | const_a |
 | constants/constants.rb:6:15:6:23 | "const_b" | const_b |
 | constants/constants.rb:17:12:17:18 | "Hello" | Hello |
@@ -927,6 +928,7 @@ exprCfgNodeValue
 | calls/calls.rb:346:5:346:5 | :X | :X |
 | calls/calls.rb:346:8:346:9 | 42 | 42 |
 | calls/calls.rb:347:5:347:5 | :X | :X |
+| calls/calls.rb:350:5:350:5 | 1 | 1 |
 | constants/constants.rb:3:19:3:27 | "const_a" | const_a |
 | constants/constants.rb:6:15:6:23 | "const_b" | const_b |
 | constants/constants.rb:17:12:17:18 | "Hello" | Hello |

--- a/ruby/ql/test/library-tests/ast/calls/calls.expected
+++ b/ruby/ql/test/library-tests/ast/calls/calls.expected
@@ -369,10 +369,8 @@ callsWithReceiver
 | calls.rb:345:1:345:15 | call to foo | calls.rb:345:1:345:15 | self |
 | calls.rb:346:1:346:10 | call to foo | calls.rb:346:1:346:10 | self |
 | calls.rb:347:1:347:7 | call to foo | calls.rb:347:1:347:7 | self |
-| calls.rb:351:14:351:14 | call to y | calls.rb:351:14:351:14 | self |
 | calls.rb:352:13:352:17 | call to foo | calls.rb:352:13:352:17 | self |
 | calls.rb:353:13:353:24 | call to unknown_call | calls.rb:353:13:353:24 | self |
-| calls.rb:356:3:356:3 | call to y | calls.rb:356:3:356:3 | self |
 | calls.rb:357:3:357:14 | call to unknown_call | calls.rb:357:3:357:14 | self |
 callsWithBlock
 | calls.rb:17:1:17:17 | call to foo | calls.rb:17:5:17:17 | { ... } |

--- a/ruby/ql/test/library-tests/ast/calls/calls.expected
+++ b/ruby/ql/test/library-tests/ast/calls/calls.expected
@@ -113,6 +113,7 @@ callsWithArguments
 | calls.rb:345:1:345:15 | call to foo | foo | 1 | calls.rb:345:9:345:14 | Pair |
 | calls.rb:346:1:346:10 | call to foo | foo | 0 | calls.rb:346:5:346:9 | Pair |
 | calls.rb:347:1:347:7 | call to foo | foo | 0 | calls.rb:347:5:347:6 | Pair |
+| calls.rb:352:13:352:17 | call to foo | foo | 0 | calls.rb:352:17:352:17 | x |
 callsWithReceiver
 | calls.rb:2:1:2:5 | call to foo | calls.rb:2:1:2:5 | self |
 | calls.rb:5:1:5:10 | call to bar | calls.rb:5:1:5:3 | Foo |
@@ -368,6 +369,11 @@ callsWithReceiver
 | calls.rb:345:1:345:15 | call to foo | calls.rb:345:1:345:15 | self |
 | calls.rb:346:1:346:10 | call to foo | calls.rb:346:1:346:10 | self |
 | calls.rb:347:1:347:7 | call to foo | calls.rb:347:1:347:7 | self |
+| calls.rb:351:14:351:14 | call to y | calls.rb:351:14:351:14 | self |
+| calls.rb:352:13:352:17 | call to foo | calls.rb:352:13:352:17 | self |
+| calls.rb:353:13:353:24 | call to unknown_call | calls.rb:353:13:353:24 | self |
+| calls.rb:356:3:356:3 | call to y | calls.rb:356:3:356:3 | self |
+| calls.rb:357:3:357:14 | call to unknown_call | calls.rb:357:3:357:14 | self |
 callsWithBlock
 | calls.rb:17:1:17:17 | call to foo | calls.rb:17:5:17:17 | { ... } |
 | calls.rb:20:1:22:3 | call to foo | calls.rb:20:5:22:3 | do ... end |

--- a/ruby/ql/test/library-tests/ast/calls/calls.rb
+++ b/ruby/ql/test/library-tests/ast/calls/calls.rb
@@ -345,3 +345,14 @@ foo(x: 42)
 foo(x:, novar:)
 foo(X: 42)
 foo(X:)
+
+# calls inside lambdas
+y = 1
+id = ->(x) { y }
+f = ->(x) { foo x }
+g = ->(x) { unknown_call }
+h = -> (x) do
+  x
+  y
+  unknown_call
+end


### PR DESCRIPTION
In the following example, we currently identify the read of `x` as a method call:
```ruby
x = 1
f = ->(y) { x }
```

This change fixes that, so we instead identify it as a captured variable read.

[Evaluation](https://github.com/github/codeql-dca-main/blob/data/hmac/pr-8517-99b5c58__nightly__lgtm-full/reports/summaries/any.md#analysis-time-per-source) shows no significant performance impact, and otherwise no changes that I can see.