### PR TITLE
Revert "Fix MaD workflows to be more resilient to missing files"

### DIFF
--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -54,17 +54,17 @@ jobs:
     - name: Generate CSV files on merge commit of the PR
       run: |
         echo "Running generator on merge"
-        PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci merge merge
+        PATH="$PATH:codeql-cli/codeql" python merge/misc/scripts/library-coverage/generate-report.py ci merge merge
         mkdir out_merge
-        mv framework-coverage-*.csv out_merge/
-        mv framework-coverage-*.rst out_merge/
+        cp framework-coverage-*.csv out_merge/
+        cp framework-coverage-*.rst out_merge/
     - name: Generate CSV files on base commit of the PR
       run: |
         echo "Running generator on base"
         PATH="$PATH:codeql-cli/codeql" python base/misc/scripts/library-coverage/generate-report.py ci base base
         mkdir out_base
-        mv framework-coverage-*.csv out_base/
-        mv framework-coverage-*.rst out_base/
+        cp framework-coverage-*.csv out_base/
+        cp framework-coverage-*.rst out_base/
     - name: Generate diff of coverage reports
       run: |
         python base/misc/scripts/library-coverage/compare-folders.py out_base out_merge comparison.md

--- a/misc/scripts/library-coverage/compare.py
+++ b/misc/scripts/library-coverage/compare.py
@@ -37,26 +37,17 @@ def compare_folders(folder1, folder2, output_file):
         # check if files exist in both folder1 and folder 2
         if not utils.check_file_exists(f"{folder1}/{generated_output_rst}"):
             expected_files += f"- {generated_output_rst} doesn't exist in folder {folder1}\n"
-            utils.subprocess_check_output(
-                ["touch", f"{folder1}/{generated_output_rst}"])
         if not utils.check_file_exists(f"{folder2}/{generated_output_rst}"):
             expected_files += f"- {generated_output_rst} doesn't exist in folder {folder2}\n"
-            utils.subprocess_check_output(
-                ["touch", f"{folder2}/{generated_output_rst}"])
         if not utils.check_file_exists(f"{folder1}/{generated_output_csv}"):
             expected_files += f"- {generated_output_csv} doesn't exist in folder {folder1}\n"
-            utils.subprocess_check_output(
-                ["touch", f"{folder1}/{generated_output_csv}"])
         if not utils.check_file_exists(f"{folder2}/{generated_output_csv}"):
             expected_files += f"- {generated_output_csv} doesn't exist in folder {folder2}\n"
-            utils.subprocess_check_output(
-                ["touch", f"{folder2}/{generated_output_csv}"])
-
-        return_md += f"\n### {lang}\n\n"
 
         if expected_files != "":
             print("Expected files are missing", file=sys.stderr)
-            return_md += f"#### Expected files are missing for {lang}\n{expected_files}\n\n"
+            return_md += f"\n### {lang}\n\n#### Expected files are missing for {lang}\n{expected_files}\n"
+            continue
 
         # compare contents of files
         cmp1 = compare_files(
@@ -66,7 +57,7 @@ def compare_folders(folder1, folder2, output_file):
 
         if cmp1 != "" or cmp2 != "":
             print("Generated file contents are not matching", file=sys.stderr)
-            return_md += f"#### Generated file changes for {lang}\n\n"
+            return_md += f"\n### {lang}\n\n#### Generated file changes for {lang}\n\n"
             if cmp1 != "":
                 return_md += f"- Changes to {generated_output_rst}:\n```diff\n{cmp1}```\n\n"
             if cmp2 != "":


### PR DESCRIPTION
Reverts github/codeql#8294

Reverting the PR, because it didn't handle correctly when no changes were detected in the coverage files.