### PR TITLE
JS: Add dedicated API graph label for the receiver, instead of parameter -1

### DIFF
--- a/javascript/ql/lib/change-notes/2022-03-23-api-graph-receiver-label.md
+++ b/javascript/ql/lib/change-notes/2022-03-23-api-graph-receiver-label.md
@@ -1,0 +1,7 @@
+---
+category: fix
+---
+* The following predicates on `API::Node` have been changed so as not to include the receiver. The receiver should now only be accessed via `getReceiver()`.
+  - `getParameter(int i)` previously included the receiver when `i = -1`
+  - `getAParameter()` previously included the receiver
+  - `getLastParameter()` previously included the receiver for calls with no arguments

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -561,9 +561,10 @@ module API {
           rhs = f.getExceptionalReturn()
         )
         or
-        exists(int i |
-          lbl = Label::parameter(i) and
-          argumentPassing(base, i, rhs)
+        exists(int i | argumentPassing(base, i, rhs) |
+          lbl = Label::parameter(i)
+          or
+          i = -1 and lbl = Label::receiver()
         )
         or
         exists(DataFlow::SourceNode src, DataFlow::PropWrite pw |
@@ -1096,8 +1097,8 @@ module API {
      */
     LabelParameter parameter(int i) { result.getIndex() = i }
 
-    /** Gets the `parameter` edge label for the receiver. */
-    LabelParameter receiver() { result = parameter(-1) }
+    /** Gets the edge label for the receiver. */
+    LabelReceiver receiver() { any() }
 
     /** Gets the `return` edge label. */
     LabelReturn return() { any() }
@@ -1132,12 +1133,13 @@ module API {
         MkLabelUnknownMember() or
         MkLabelParameter(int i) {
           i =
-            [-1 .. max(int args |
+            [0 .. max(int args |
                 args = any(InvokeExpr invk).getNumArgument() or
                 args = any(Function f).getNumParameter()
               )] or
           i = [0 .. 10]
         } or
+        MkLabelReceiver() or
         MkLabelReturn() or
         MkLabelPromised() or
         MkLabelPromisedError() or
@@ -1224,6 +1226,11 @@ module API {
 
         /** Gets the index of the parameter for this label. */
         int getIndex() { result = i }
+      }
+
+      /** A label for the receiver of call, that is, the value passed as `this`. */
+      class LabelReceiver extends ApiLabel, MkLabelReceiver {
+        override string toString() { result = "receiver" }
       }
     }
   }

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -187,8 +187,7 @@ module API {
     }
 
     /**
-     * Gets a node representing a parameter or the receiver of the function represented by this
-     * node.
+     * Gets a node representing a parameter of the function represented by this node.
      *
      * This predicate may result in a mix of parameters from different call sites in cases where
      * there are multiple invocations of this API component.
@@ -198,8 +197,6 @@ module API {
     Node getAParameter() {
       Stages::ApiStage::ref() and
       result = this.getParameter(_)
-      or
-      result = this.getReceiver()
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
@@ -219,7 +219,6 @@ module ExternalApiUsedWithUntrustedData {
         or
         exists(string callbackName, int index |
           node = getNamedParameter(base.getParameter(index).getMember(callbackName), paramName) and
-          index != -1 and // ignore receiver
           result =
             basename + ".[callback " + index + " '" + callbackName + "'].[param '" + paramName +
               "']"

--- a/javascript/ql/test/ApiGraphs/bound-args/index.js
+++ b/javascript/ql/test/ApiGraphs/bound-args/index.js
@@ -1,7 +1,7 @@
 import bar from 'foo';
 
 let boundbar = bar.bind(
-    "receiver", // def (parameter -1 (member default (member exports (module foo))))
+    "receiver", // def (receiver (member default (member exports (module foo))))
     "firstarg"  // def (parameter 0 (member default (member exports (module foo))))
 );
 boundbar(
@@ -9,7 +9,7 @@ boundbar(
 )
 
 let boundbar2 = boundbar.bind(
-    "ignored", // !def (parameter -1 (member default (member exports (module foo))))
+    "ignored", // !def (receiver (member default (member exports (module foo))))
     "othersecondarg" // def (parameter 1 (member default (member exports (module foo))))
 )
 boundbar2(

--- a/javascript/ql/test/ApiGraphs/partial-invoke/index.js
+++ b/javascript/ql/test/ApiGraphs/partial-invoke/index.js
@@ -2,7 +2,7 @@ const cp = require('child_process');
 
 module.exports = function () {
     return cp.spawn.bind(
-        cp,   // def (parameter -1 (member spawn (member exports (module child_process))))
+        cp,   // def (receiver (member spawn (member exports (module child_process))))
         "cat" // def (parameter 0 (member spawn (member exports (module child_process))))
     );
 };

--- a/javascript/ql/test/library-tests/frameworks/Knex/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/Knex/test.expected
@@ -42,11 +42,11 @@ knexObject
 | tst.js:17:1:17:23 | use (return (member avg (return (member exports (module knex))))) |
 | tst.js:17:1:19:4 | use (return (member from (return (member avg (return (member exports (module knex))))))) |
 | tst.js:17:1:19:24 | use (return (member as (return (member from (return (member avg (return (member exports (module knex))))))))) |
-| tst.js:17:30:17:29 | use (parameter -1 (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))) |
-| tst.js:18:5:18:38 | use (return (member sum (parameter -1 (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))) |
-| tst.js:18:5:18:49 | use (return (member from (return (member sum (parameter -1 (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))))) |
-| tst.js:18:5:18:68 | use (return (member groupBy (return (member from (return (member sum (parameter -1 (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))))))) |
-| tst.js:18:5:18:77 | use (return (member as (return (member groupBy (return (member from (return (member sum (parameter -1 (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))))))))) |
+| tst.js:17:30:17:29 | use (receiver (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))) |
+| tst.js:18:5:18:38 | use (return (member sum (receiver (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))) |
+| tst.js:18:5:18:49 | use (return (member from (return (member sum (receiver (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))))) |
+| tst.js:18:5:18:68 | use (return (member groupBy (return (member from (return (member sum (receiver (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))))))) |
+| tst.js:18:5:18:77 | use (return (member as (return (member groupBy (return (member from (return (member sum (receiver (parameter 0 (member from (return (member avg (return (member exports (module knex)))))))))))))))) |
 | tst.js:21:1:21:38 | use (return (member column (return (member exports (module knex))))) |
 | tst.js:21:1:21:47 | use (return (member select (return (member column (return (member exports (module knex))))))) |
 | tst.js:21:1:21:61 | use (return (member from (return (member select (return (member column (return (member exports (module knex))))))))) |
@@ -70,14 +70,14 @@ knexObject
 | tst.js:42:1:42:13 | use (return (return (member exports (module knex)))) |
 | tst.js:42:1:45:3 | use (return (member where (return (return (member exports (module knex)))))) |
 | tst.js:42:1:48:4 | use (return (member andWhere (return (member where (return (return (member exports (module knex)))))))) |
-| tst.js:46:13:46:12 | use (parameter -1 (parameter 0 (member andWhere (return (member where (return (return (member exports (module knex))))))))) |
-| tst.js:47:5:47:29 | use (return (member where (parameter -1 (parameter 0 (member andWhere (return (member where (return (return (member exports (module knex))))))))))) |
+| tst.js:46:13:46:12 | use (receiver (parameter 0 (member andWhere (return (member where (return (return (member exports (module knex))))))))) |
+| tst.js:47:5:47:29 | use (return (member where (receiver (parameter 0 (member andWhere (return (member where (return (return (member exports (module knex))))))))))) |
 | tst.js:50:1:50:13 | use (return (return (member exports (module knex)))) |
 | tst.js:50:1:52:2 | use (return (member where (return (return (member exports (module knex)))))) |
 | tst.js:50:1:52:28 | use (return (member orWhere (return (member where (return (return (member exports (module knex)))))))) |
-| tst.js:50:21:50:20 | use (parameter -1 (parameter 0 (member where (return (return (member exports (module knex))))))) |
-| tst.js:51:3:51:21 | use (return (member where (parameter -1 (parameter 0 (member where (return (return (member exports (module knex))))))))) |
-| tst.js:51:3:51:44 | use (return (member orWhere (return (member where (parameter -1 (parameter 0 (member where (return (return (member exports (module knex))))))))))) |
+| tst.js:50:21:50:20 | use (receiver (parameter 0 (member where (return (return (member exports (module knex))))))) |
+| tst.js:51:3:51:21 | use (return (member where (receiver (parameter 0 (member where (return (return (member exports (module knex))))))))) |
+| tst.js:51:3:51:44 | use (return (member orWhere (return (member where (receiver (parameter 0 (member where (return (return (member exports (module knex))))))))))) |
 | tst.js:54:1:54:13 | use (return (return (member exports (module knex)))) |
 | tst.js:54:1:54:56 | use (return (member where (return (return (member exports (module knex)))))) |
 | tst.js:56:1:56:13 | use (return (return (member exports (module knex)))) |
@@ -100,9 +100,9 @@ knexObject
 | tst.js:70:1:70:13 | use (return (return (member exports (module knex)))) |
 | tst.js:70:1:72:2 | use (return (member whereNot (return (return (member exports (module knex)))))) |
 | tst.js:70:1:72:31 | use (return (member orWhereNot (return (member whereNot (return (return (member exports (module knex)))))))) |
-| tst.js:70:24:70:23 | use (parameter -1 (parameter 0 (member whereNot (return (return (member exports (module knex))))))) |
-| tst.js:71:3:71:21 | use (return (member where (parameter -1 (parameter 0 (member whereNot (return (return (member exports (module knex))))))))) |
-| tst.js:71:3:71:47 | use (return (member orWhereNot (return (member where (parameter -1 (parameter 0 (member whereNot (return (return (member exports (module knex))))))))))) |
+| tst.js:70:24:70:23 | use (receiver (parameter 0 (member whereNot (return (return (member exports (module knex))))))) |
+| tst.js:71:3:71:21 | use (return (member where (receiver (parameter 0 (member whereNot (return (return (member exports (module knex))))))))) |
+| tst.js:71:3:71:47 | use (return (member orWhereNot (return (member where (receiver (parameter 0 (member whereNot (return (return (member exports (module knex))))))))))) |
 | tst.js:74:19:74:31 | use (return (return (member exports (module knex)))) |
 | tst.js:74:19:75:30 | use (return (member whereNot (return (return (member exports (module knex)))))) |
 | tst.js:74:19:76:31 | use (return (member andWhere (return (member whereNot (return (return (member exports (module knex)))))))) |
@@ -128,10 +128,10 @@ knexObject
 | tst.js:97:1:97:40 | use (return (member whereNotNull (return (return (member exports (module knex)))))) |
 | tst.js:99:1:99:13 | use (return (return (member exports (module knex)))) |
 | tst.js:99:1:101:2 | use (return (member whereExists (return (return (member exports (module knex)))))) |
-| tst.js:99:27:99:26 | use (parameter -1 (parameter 0 (member whereExists (return (return (member exports (module knex))))))) |
-| tst.js:100:3:100:18 | use (return (member select (parameter -1 (parameter 0 (member whereExists (return (return (member exports (module knex))))))))) |
-| tst.js:100:3:100:35 | use (return (member from (return (member select (parameter -1 (parameter 0 (member whereExists (return (return (member exports (module knex))))))))))) |
-| tst.js:100:3:100:78 | use (return (member whereRaw (return (member from (return (member select (parameter -1 (parameter 0 (member whereExists (return (return (member exports (module knex))))))))))))) |
+| tst.js:99:27:99:26 | use (receiver (parameter 0 (member whereExists (return (return (member exports (module knex))))))) |
+| tst.js:100:3:100:18 | use (return (member select (receiver (parameter 0 (member whereExists (return (return (member exports (module knex))))))))) |
+| tst.js:100:3:100:35 | use (return (member from (return (member select (receiver (parameter 0 (member whereExists (return (return (member exports (module knex))))))))))) |
+| tst.js:100:3:100:78 | use (return (member whereRaw (return (member from (return (member select (receiver (parameter 0 (member whereExists (return (return (member exports (module knex))))))))))))) |
 | tst.js:103:1:103:13 | use (return (return (member exports (module knex)))) |
 | tst.js:103:1:103:103 | use (return (member whereExists (return (return (member exports (module knex)))))) |
 | tst.js:103:27:103:42 | use (return (member select (return (member exports (module knex))))) |
@@ -139,10 +139,10 @@ knexObject
 | tst.js:103:27:103:102 | use (return (member whereRaw (return (member from (return (member select (return (member exports (module knex))))))))) |
 | tst.js:105:1:105:13 | use (return (return (member exports (module knex)))) |
 | tst.js:105:1:107:2 | use (return (member whereNotExists (return (return (member exports (module knex)))))) |
-| tst.js:105:30:105:29 | use (parameter -1 (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))) |
-| tst.js:106:3:106:18 | use (return (member select (parameter -1 (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))))) |
-| tst.js:106:3:106:35 | use (return (member from (return (member select (parameter -1 (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))))))) |
-| tst.js:106:3:106:78 | use (return (member whereRaw (return (member from (return (member select (parameter -1 (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))))))))) |
+| tst.js:105:30:105:29 | use (receiver (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))) |
+| tst.js:106:3:106:18 | use (return (member select (receiver (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))))) |
+| tst.js:106:3:106:35 | use (return (member from (return (member select (receiver (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))))))) |
+| tst.js:106:3:106:78 | use (return (member whereRaw (return (member from (return (member select (receiver (parameter 0 (member whereNotExists (return (return (member exports (module knex))))))))))))) |
 | tst.js:109:1:109:13 | use (return (return (member exports (module knex)))) |
 | tst.js:109:1:109:45 | use (return (member whereBetween (return (return (member exports (module knex)))))) |
 | tst.js:111:1:111:13 | use (return (return (member exports (module knex)))) |


### PR DESCRIPTION
This changes the API graph label representing the receiver of call from `parameter -1` to `receiver`.

The member predicates of `API::Node` are affected as follows:
- `getParameter(i)` no longer has a result for `i = -1`, previously it returned the receiver.
- `getAParameter()` no longer includes the receiver.
- `getLastParameter()` no longer returns the receiver when the call has zero arguments. (🤦)

In theory this is not a behaviour-preserving change, but in practice it doesn't change much:
- There are 90 uses of `getParameter(i)` outside `ApiGraphs.qll`, all of them unaffected due to how they restrict `i`.
- There are 11 uses of `getAParameter`, some of which are affected, but as far as I can tell, none of them actually intended to get the receiver.
- There are 3 uses of `getLastParameter`, which are affected in theory but unlikely to matter in practice (since the modeled function expects >=1 arguments), and none of them intended to get the receiver.

This was motivated by an upcoming change in MaD, where we want to use `Argument[this]` to represent the receiver (`Argument[self]` in Python/Ruby).

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/api-graph-recei__default__code-scanning__2/reports) looks good. A few [spurious taint sources](https://github.com/github/codeql-dca-main/blob/data/asgerf/api-graph-recei__default__code-scanning__2/reports/alert-meta-comparison.md) have been removed, which referred to the receiver argument to a callback.