### PR TITLE
Ruby: Minor change of SSRF concept

### DIFF
--- a/ruby/ql/lib/change-notes/2022-03-09-http-client-getaurlpart.md
+++ b/ruby/ql/lib/change-notes/2022-03-09-http-client-getaurlpart.md
@@ -1,4 +1,4 @@
 ---
 category: breaking
 ---
-* The `getURL` member-predicate of the `HTTP::Client::Request` and `HTTP::Client::Request::Range` classes from `Concepts.qll` have been renamed to `getAUrlPart`.
+* The `getURL` member-predicates of the `HTTP::Client::Request` and `HTTP::Client::Request::Range` classes from `Concepts.qll` have been renamed to `getAUrlPart`.

--- a/ruby/ql/lib/change-notes/2022-03-09-http-client-getaurlpart.md
+++ b/ruby/ql/lib/change-notes/2022-03-09-http-client-getaurlpart.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+* The `getURL` member-predicate of the `HTTP::Client::Request` and `HTTP::Client::Request::Range` classes from `Concepts.qll` have been renamed to `getAUrlPart`.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -485,6 +485,14 @@ module HTTP {
       DataFlow::Node getResponseBody() { result = super.getResponseBody() }
 
       /**
+       * DEPRECATED: Use `getAUrlPart` instead.
+       *
+       * Gets a node that contributes to the URL of the request.
+       * Depending on the framework, a request may have multiple nodes which contribute to the URL.
+       */
+      deprecated DataFlow::Node getURL() { result = super.getURL() }
+
+      /**
        * Gets a data-flow node that contributes to the URL of the request.
        * Depending on the framework, a request may have multiple nodes which contribute to the URL.
        */
@@ -514,6 +522,14 @@ module HTTP {
       abstract class Range extends MethodCall {
         /** Gets a node which returns the body of the response */
         abstract DataFlow::Node getResponseBody();
+
+        /**
+         * DEPRECATED: overwrite `getAUrlPart` instead.
+         *
+         * Gets a node that contributes to the URL of the request.
+         * Depending on the framework, a request may have multiple nodes which contribute to the URL.
+         */
+        deprecated DataFlow::Node getURL() { none() }
 
         /**
          * Gets a data-flow node that contributes to the URL of the request.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -490,7 +490,7 @@ module HTTP {
        * Gets a node that contributes to the URL of the request.
        * Depending on the framework, a request may have multiple nodes which contribute to the URL.
        */
-      deprecated DataFlow::Node getURL() { result = super.getURL() }
+      deprecated DataFlow::Node getURL() { result = super.getURL() or result = super.getAUrlPart() }
 
       /**
        * Gets a data-flow node that contributes to the URL of the request.

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -515,10 +515,10 @@ module HTTP {
         /** Gets a node which returns the body of the response */
         abstract DataFlow::Node getResponseBody();
 
-      /**
-       * Gets a data-flow node that contributes to the URL of the request.
-       * Depending on the framework, a request may have multiple nodes which contribute to the URL.
-       */
+        /**
+         * Gets a data-flow node that contributes to the URL of the request.
+         * Depending on the framework, a request may have multiple nodes which contribute to the URL.
+         */
         abstract DataFlow::Node getAUrlPart();
 
         /** Gets a string that identifies the framework used for this request. */

--- a/ruby/ql/lib/codeql/ruby/Concepts.qll
+++ b/ruby/ql/lib/codeql/ruby/Concepts.qll
@@ -485,10 +485,10 @@ module HTTP {
       DataFlow::Node getResponseBody() { result = super.getResponseBody() }
 
       /**
-       * Gets a node that contributes to the URL of the request.
+       * Gets a data-flow node that contributes to the URL of the request.
        * Depending on the framework, a request may have multiple nodes which contribute to the URL.
        */
-      DataFlow::Node getURL() { result = super.getURL() }
+      DataFlow::Node getAUrlPart() { result = super.getAUrlPart() }
 
       /** Gets a string that identifies the framework used for this request. */
       string getFramework() { result = super.getFramework() }
@@ -515,11 +515,11 @@ module HTTP {
         /** Gets a node which returns the body of the response */
         abstract DataFlow::Node getResponseBody();
 
-        /**
-         * Gets a node that contributes to the URL of the request.
-         * Depending on the framework, a request may have multiple nodes which contribute to the URL.
-         */
-        abstract DataFlow::Node getURL();
+      /**
+       * Gets a data-flow node that contributes to the URL of the request.
+       * Depending on the framework, a request may have multiple nodes which contribute to the URL.
+       */
+        abstract DataFlow::Node getAUrlPart();
 
         /** Gets a string that identifies the framework used for this request. */
         abstract string getFramework();

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -52,7 +52,7 @@ class ExconHttpRequest extends HTTP::Client::Request::Range {
 
   override DataFlow::Node getResponseBody() { result = requestNode.getAMethodCall("body") }
 
-  override DataFlow::Node getURL() {
+  override DataFlow::Node getAUrlPart() {
     // For one-off requests, the URL is in the first argument of the request method call.
     // For connection re-use, the URL is split between the first argument of the `new` call
     // and the `path` keyword argument of the request method call.

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
@@ -45,7 +45,7 @@ class FaradayHttpRequest extends HTTP::Client::Request::Range {
 
   override DataFlow::Node getResponseBody() { result = requestNode.getAMethodCall("body") }
 
-  override DataFlow::Node getURL() {
+  override DataFlow::Node getAUrlPart() {
     result = requestUse.getArgument(0) or
     result = connectionUse.(DataFlow::CallNode).getArgument(0) or
     result = connectionUse.(DataFlow::CallNode).getKeywordArgument("url")

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
@@ -36,7 +36,7 @@ class HttpClientRequest extends HTTP::Client::Request::Range {
     this = requestUse.asExpr().getExpr()
   }
 
-  override DataFlow::Node getURL() { result = requestUse.getArgument(0) }
+  override DataFlow::Node getAUrlPart() { result = requestUse.getArgument(0) }
 
   override DataFlow::Node getResponseBody() {
     // The `get_content` and `post_content` methods return the response body as

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -35,7 +35,7 @@ class HttpartyRequest extends HTTP::Client::Request::Range {
     this = requestUse.asExpr().getExpr()
   }
 
-  override DataFlow::Node getURL() { result = requestUse.getArgument(0) }
+  override DataFlow::Node getAUrlPart() { result = requestUse.getArgument(0) }
 
   override DataFlow::Node getResponseBody() {
     // If HTTParty can recognise the response type, it will parse and return it

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -51,7 +51,7 @@ class NetHttpRequest extends HTTP::Client::Request::Range {
    * Gets the node representing the URL of the request.
    * Currently unused, but may be useful in future, e.g. to filter out certain requests.
    */
-  override DataFlow::Node getURL() { result = request.getArgument(0) }
+  override DataFlow::Node getAUrlPart() { result = request.getArgument(0) }
 
   override DataFlow::Node getResponseBody() { result = responseBody }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -32,7 +32,7 @@ class OpenUriRequest extends HTTP::Client::Request::Range {
     this = requestUse.asExpr().getExpr()
   }
 
-  override DataFlow::Node getURL() { result = requestUse.getArgument(0) }
+  override DataFlow::Node getAUrlPart() { result = requestUse.getArgument(0) }
 
   override DataFlow::Node getResponseBody() {
     result = requestNode.getAMethodCall(["read", "readlines"])
@@ -65,7 +65,7 @@ class OpenUriKernelOpenRequest extends HTTP::Client::Request::Range {
     this = requestUse.asExpr().getExpr()
   }
 
-  override DataFlow::Node getURL() { result = requestUse.getArgument(0) }
+  override DataFlow::Node getAUrlPart() { result = requestUse.getArgument(0) }
 
   override DataFlow::CallNode getResponseBody() {
     result.asExpr().getExpr().(MethodCall).getMethodName() in ["read", "readlines"] and

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
@@ -38,7 +38,7 @@ class RestClientHttpRequest extends HTTP::Client::Request::Range {
     )
   }
 
-  override DataFlow::Node getURL() {
+  override DataFlow::Node getAUrlPart() {
     result = requestUse.getKeywordArgument("url")
     or
     result = requestUse.getArgument(0) and

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -26,7 +26,7 @@ class TyphoeusHttpRequest extends HTTP::Client::Request::Range {
     this = requestUse.asExpr().getExpr()
   }
 
-  override DataFlow::Node getURL() { result = requestUse.getArgument(0) }
+  override DataFlow::Node getAUrlPart() { result = requestUse.getArgument(0) }
 
   override DataFlow::Node getResponseBody() { result = requestNode.getAMethodCall("body") }
 

--- a/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryCustomizations.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryCustomizations.qll
@@ -43,7 +43,7 @@ module ServerSideRequestForgery {
 
   /** The URL of an HTTP request, considered as a sink. */
   class HttpRequestAsSink extends Sink {
-    HttpRequestAsSink() { exists(HTTP::Client::Request req | req.getURL() = this) }
+    HttpRequestAsSink() { exists(HTTP::Client::Request req | req.getAUrlPart() = this) }
   }
 
   /** A string interpolation with a fixed prefix, considered as a flow sanitizer. */

--- a/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.ql
+++ b/ruby/ql/test/library-tests/frameworks/http_clients/HttpClients.ql
@@ -2,9 +2,9 @@ import codeql.ruby.Concepts
 import codeql.ruby.DataFlow
 
 query predicate httpRequests(
-  HTTP::Client::Request r, string framework, DataFlow::Node url, DataFlow::Node responseBody
+  HTTP::Client::Request r, string framework, DataFlow::Node urlPart, DataFlow::Node responseBody
 ) {
   r.getFramework() = framework and
-  r.getURL() = url and
+  r.getAUrlPart() = urlPart and
   r.getResponseBody() = responseBody
 }


### PR DESCRIPTION
When I added the Python query in https://github.com/github/codeql/pull/7420, I did some minor changes. This is only part of those changes, I will do another PR for the changes I made to `disablesCertificateValidation` once I have had time to change our query. (this PR had been laying around for some time, so will do it now so I wont forget about it).

I'm of the understanding that we can just make any breaking changes to the API as we want, since Ruby is still in beta, so that's why I haven't done any kind of deprecation :wink: 

Notice that the change-note [would bump the major version of the library pack](https://github.com/github/codeql/blob/main/docs/change-notes.md#library-pack-change-categories). If you don't want this, let me know, and I can change things :blush: 