### PR TITLE
JS/Ruby/Python: rename RegExpTreeView.qll to ReDoSUtilSpecific.qll

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/performance/ReDoSUtil.qll
+++ b/javascript/ql/lib/semmle/javascript/security/performance/ReDoSUtil.qll
@@ -12,7 +12,7 @@
  * states that will cause backtracking (a rejecting suffix exists).
  */
 
-import RegExpTreeView
+import ReDoSUtilSpecific
 
 /**
  * A configuration for which parts of a regular expression should be considered relevant for

--- a/javascript/ql/lib/semmle/javascript/security/performance/ReDoSUtilSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/security/performance/ReDoSUtilSpecific.qll
@@ -1,7 +1,5 @@
 /**
- * This module should provide a class hierarchy corresponding to a parse tree of regular expressions.
- *
- * Since the javascript extractor already provides such a hierarchy, we simply import that.
+ * Provides JavaScript-specific definitions for use in the ReDoSUtil module.
  */
 
 import javascript

--- a/python/ql/lib/semmle/python/security/performance/ReDoSUtil.qll
+++ b/python/ql/lib/semmle/python/security/performance/ReDoSUtil.qll
@@ -12,7 +12,7 @@
  * states that will cause backtracking (a rejecting suffix exists).
  */
 
-import RegExpTreeView
+import ReDoSUtilSpecific
 
 /**
  * A configuration for which parts of a regular expression should be considered relevant for

--- a/python/ql/src/Security/CWE-020/HostnameRegexpSpecific.qll
+++ b/python/ql/src/Security/CWE-020/HostnameRegexpSpecific.qll
@@ -1,3 +1,3 @@
-import semmle.python.security.performance.RegExpTreeView
+import semmle.python.RegexTreeView
 import semmle.python.dataflow.new.DataFlow
 import semmle.python.dataflow.new.Regexp

--- a/ruby/ql/lib/codeql/ruby/security/performance/ReDoSUtil.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/ReDoSUtil.qll
@@ -12,7 +12,7 @@
  * states that will cause backtracking (a rejecting suffix exists).
  */
 
-import RegExpTreeView
+import ReDoSUtilSpecific
 
 /**
  * A configuration for which parts of a regular expression should be considered relevant for


### PR DESCRIPTION
 In https://github.com/github/codeql/pull/8489#pullrequestreview-917455000 @nickrolfe  pointed out that 
> having two different RegExpTreeView.qll files seems undesirable. Can they be merged?

There are two files named `RegExpTreeView.qll` in the Python and Ruby libraries. One of them contains language specific implementations of classes/predicates needed the the shared `ReDoSUtil.qll` module. As a result they cannot be merged, however, renaming that module to `ReDoSUtilSpecific.qll` avoids the name clash and also makes it clear that the module is just "implementation details".