### PR TITLE
JS/Ruby: Represent non-positional arguments with Argument/Parameter tokens

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -133,6 +133,10 @@ bindingset[token]
 API::Node getExtraSuccessorFromInvoke(API::InvokeNode node, AccessPathToken token) {
   token.getName() = "Instance" and
   result = node.getInstance()
+  or
+  token.getName() = "Argument" and
+  token.getAnArgument() = "this" and
+  result.getARhs() = node.(DataFlow::CallNode).getReceiver()
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -120,6 +120,10 @@ API::Node getExtraSuccessorFromNode(API::Node node, AccessPathToken token) {
   // API graphs do not use store/load steps for arrays
   token.getName() = ["ArrayElement", "Element"] and
   result = node.getUnknownMember()
+  or
+  token.getName() = "Parameter" and
+  token.getAnArgument() = "this" and
+  result = node.getReceiver()
 }
 
 /**

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -33,6 +33,8 @@ taintFlow
 | test.js:95:17:95:24 | source() | test.js:95:17:95:24 | source() |
 | test.js:96:17:96:24 | source() | test.js:96:17:96:24 | source() |
 | test.js:97:17:97:24 | source() | test.js:97:17:97:24 | source() |
+| test.js:102:16:102:34 | testlib.getSource() | test.js:103:8:103:13 | source |
+| test.js:102:16:102:34 | testlib.getSource() | test.js:104:8:104:24 | source.continue() |
 isSink
 | test.js:54:18:54:25 | source() | test-sink |
 | test.js:55:22:55:29 | source() | test-sink |

--- a/javascript/ql/test/library-tests/frameworks/data/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/test.expected
@@ -14,69 +14,71 @@ taintFlow
 | test.js:24:43:24:50 | source() | test.js:24:8:24:51 | testlib ... urce()) |
 | test.js:31:29:31:36 | source() | test.js:32:10:32:10 | y |
 | test.js:37:29:37:36 | source() | test.js:38:10:38:10 | y |
-| test.js:46:18:46:25 | source() | test.js:46:18:46:25 | source() |
-| test.js:47:22:47:29 | source() | test.js:47:22:47:29 | source() |
-| test.js:49:24:49:31 | source() | test.js:49:24:49:31 | source() |
-| test.js:53:27:53:34 | source() | test.js:53:27:53:34 | source() |
-| test.js:58:31:58:38 | source() | test.js:58:31:58:38 | source() |
-| test.js:62:34:62:41 | source() | test.js:62:34:62:41 | source() |
-| test.js:67:31:67:38 | source() | test.js:67:31:67:38 | source() |
-| test.js:68:34:68:41 | source() | test.js:68:34:68:41 | source() |
-| test.js:72:36:72:43 | source() | test.js:72:36:72:43 | source() |
-| test.js:73:39:73:46 | source() | test.js:73:39:73:46 | source() |
-| test.js:75:28:75:35 | source() | test.js:75:28:75:35 | source() |
-| test.js:76:31:76:38 | source() | test.js:76:31:76:38 | source() |
-| test.js:77:34:77:41 | source() | test.js:77:34:77:41 | source() |
-| test.js:81:28:81:35 | source() | test.js:81:28:81:35 | source() |
-| test.js:87:17:87:24 | source() | test.js:87:17:87:24 | source() |
-| test.js:88:17:88:24 | source() | test.js:88:17:88:24 | source() |
-| test.js:89:17:89:24 | source() | test.js:89:17:89:24 | source() |
+| test.js:43:29:43:36 | source() | test.js:44:10:44:10 | y |
+| test.js:47:33:47:40 | source() | test.js:49:10:49:13 | this |
+| test.js:54:18:54:25 | source() | test.js:54:18:54:25 | source() |
+| test.js:55:22:55:29 | source() | test.js:55:22:55:29 | source() |
+| test.js:57:24:57:31 | source() | test.js:57:24:57:31 | source() |
+| test.js:61:27:61:34 | source() | test.js:61:27:61:34 | source() |
+| test.js:66:31:66:38 | source() | test.js:66:31:66:38 | source() |
+| test.js:70:34:70:41 | source() | test.js:70:34:70:41 | source() |
+| test.js:75:31:75:38 | source() | test.js:75:31:75:38 | source() |
+| test.js:76:34:76:41 | source() | test.js:76:34:76:41 | source() |
+| test.js:80:36:80:43 | source() | test.js:80:36:80:43 | source() |
+| test.js:81:39:81:46 | source() | test.js:81:39:81:46 | source() |
+| test.js:83:28:83:35 | source() | test.js:83:28:83:35 | source() |
+| test.js:84:31:84:38 | source() | test.js:84:31:84:38 | source() |
+| test.js:85:34:85:41 | source() | test.js:85:34:85:41 | source() |
+| test.js:89:28:89:35 | source() | test.js:89:28:89:35 | source() |
+| test.js:95:17:95:24 | source() | test.js:95:17:95:24 | source() |
+| test.js:96:17:96:24 | source() | test.js:96:17:96:24 | source() |
+| test.js:97:17:97:24 | source() | test.js:97:17:97:24 | source() |
 isSink
-| test.js:46:18:46:25 | source() | test-sink |
-| test.js:47:22:47:29 | source() | test-sink |
-| test.js:49:24:49:31 | source() | test-sink |
-| test.js:53:27:53:34 | source() | test-sink |
-| test.js:55:38:55:38 | 4 | test-sink |
-| test.js:56:38:56:38 | 4 | test-sink |
-| test.js:57:38:57:38 | 4 | test-sink |
-| test.js:58:31:58:38 | source() | test-sink |
-| test.js:60:41:60:41 | 3 | test-sink |
-| test.js:61:41:61:41 | 3 | test-sink |
-| test.js:62:34:62:41 | source() | test-sink |
-| test.js:63:34:63:34 | 3 | test-sink |
-| test.js:65:38:65:38 | 3 | test-sink |
-| test.js:65:41:65:41 | 4 | test-sink |
-| test.js:66:38:66:38 | 3 | test-sink |
-| test.js:66:41:66:41 | 4 | test-sink |
-| test.js:67:31:67:38 | source() | test-sink |
-| test.js:67:41:67:41 | 4 | test-sink |
-| test.js:68:31:68:31 | 3 | test-sink |
-| test.js:68:34:68:41 | source() | test-sink |
-| test.js:70:43:70:43 | 3 | test-sink |
-| test.js:70:46:70:46 | 4 | test-sink |
-| test.js:71:43:71:43 | 3 | test-sink |
-| test.js:71:46:71:46 | 4 | test-sink |
-| test.js:72:36:72:43 | source() | test-sink |
-| test.js:72:46:72:46 | 4 | test-sink |
-| test.js:73:36:73:36 | 3 | test-sink |
-| test.js:73:39:73:46 | source() | test-sink |
-| test.js:75:28:75:35 | source() | test-sink |
-| test.js:75:38:75:38 | 2 | test-sink |
-| test.js:75:41:75:41 | 3 | test-sink |
-| test.js:76:28:76:28 | 1 | test-sink |
-| test.js:76:31:76:38 | source() | test-sink |
-| test.js:76:41:76:41 | 3 | test-sink |
-| test.js:77:28:77:28 | 1 | test-sink |
-| test.js:77:31:77:31 | 2 | test-sink |
-| test.js:77:34:77:41 | source() | test-sink |
-| test.js:78:28:78:28 | 1 | test-sink |
-| test.js:78:31:78:31 | 2 | test-sink |
-| test.js:78:34:78:34 | 3 | test-sink |
-| test.js:81:28:81:35 | source() | test-sink |
-| test.js:82:28:82:28 | 1 | test-sink |
-| test.js:87:17:87:24 | source() | test-sink |
-| test.js:88:17:88:24 | source() | test-sink |
-| test.js:89:17:89:24 | source() | test-sink |
+| test.js:54:18:54:25 | source() | test-sink |
+| test.js:55:22:55:29 | source() | test-sink |
+| test.js:57:24:57:31 | source() | test-sink |
+| test.js:61:27:61:34 | source() | test-sink |
+| test.js:63:38:63:38 | 4 | test-sink |
+| test.js:64:38:64:38 | 4 | test-sink |
+| test.js:65:38:65:38 | 4 | test-sink |
+| test.js:66:31:66:38 | source() | test-sink |
+| test.js:68:41:68:41 | 3 | test-sink |
+| test.js:69:41:69:41 | 3 | test-sink |
+| test.js:70:34:70:41 | source() | test-sink |
+| test.js:71:34:71:34 | 3 | test-sink |
+| test.js:73:38:73:38 | 3 | test-sink |
+| test.js:73:41:73:41 | 4 | test-sink |
+| test.js:74:38:74:38 | 3 | test-sink |
+| test.js:74:41:74:41 | 4 | test-sink |
+| test.js:75:31:75:38 | source() | test-sink |
+| test.js:75:41:75:41 | 4 | test-sink |
+| test.js:76:31:76:31 | 3 | test-sink |
+| test.js:76:34:76:41 | source() | test-sink |
+| test.js:78:43:78:43 | 3 | test-sink |
+| test.js:78:46:78:46 | 4 | test-sink |
+| test.js:79:43:79:43 | 3 | test-sink |
+| test.js:79:46:79:46 | 4 | test-sink |
+| test.js:80:36:80:43 | source() | test-sink |
+| test.js:80:46:80:46 | 4 | test-sink |
+| test.js:81:36:81:36 | 3 | test-sink |
+| test.js:81:39:81:46 | source() | test-sink |
+| test.js:83:28:83:35 | source() | test-sink |
+| test.js:83:38:83:38 | 2 | test-sink |
+| test.js:83:41:83:41 | 3 | test-sink |
+| test.js:84:28:84:28 | 1 | test-sink |
+| test.js:84:31:84:38 | source() | test-sink |
+| test.js:84:41:84:41 | 3 | test-sink |
+| test.js:85:28:85:28 | 1 | test-sink |
+| test.js:85:31:85:31 | 2 | test-sink |
+| test.js:85:34:85:41 | source() | test-sink |
+| test.js:86:28:86:28 | 1 | test-sink |
+| test.js:86:31:86:31 | 2 | test-sink |
+| test.js:86:34:86:34 | 3 | test-sink |
+| test.js:89:28:89:35 | source() | test-sink |
+| test.js:90:28:90:28 | 1 | test-sink |
+| test.js:95:17:95:24 | source() | test-sink |
+| test.js:96:17:96:24 | source() | test-sink |
+| test.js:97:17:97:24 | source() | test-sink |
 syntaxErrors
 | Member[foo |
 | Member[foo] .Member[bar] |

--- a/javascript/ql/test/library-tests/frameworks/data/test.js
+++ b/javascript/ql/test/library-tests/frameworks/data/test.js
@@ -97,3 +97,10 @@ function testSinks() {
   testlib.sink3(source()); // NOT OK
   testlib.sink4(source()); // OK
 }
+
+function testFlowThroughReceiver() {
+  let source = testlib.getSource();
+  sink(source); // NOT OK
+  sink(source.continue()); // NOT OK
+  sink(source.blah()); // OK
+}

--- a/javascript/ql/test/library-tests/frameworks/data/test.js
+++ b/javascript/ql/test/library-tests/frameworks/data/test.js
@@ -40,6 +40,14 @@ function testPreserveTaint() {
   testlib.taintIntoCallback(source(), undefined, undefined, y => {
     sink(y); // OK - only callback 1-2 receive taint
   });
+  testlib.taintIntoCallback(source(), function(y) {
+    sink(y); // NOT OK
+    sink(this); // OK - receiver is not tainted
+  });
+  testlib.taintIntoCallbackThis(source(), function(y) {
+    sink(y); // OK - only receiver is tainted
+    sink(this); // NOT OK
+  });
 }
 
 function testSinks() {

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -38,9 +38,7 @@ class Sinks extends ModelInput::SinkModelCsv {
 }
 
 class Sources extends ModelInput::SourceModelCsv {
-  override predicate row(string row) {
-    row = "testlib;;Member[getSource].ReturnValue;test-source"
-  }
+  override predicate row(string row) { row = "testlib;;Member[getSource].ReturnValue;test-source" }
 }
 
 class BasicTaintTracking extends TaintTracking::Configuration {

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -9,6 +9,7 @@ class Steps extends ModelInput::SummaryModelCsv {
       [
         "testlib;;Member[preserveTaint];Argument[0];ReturnValue;taint",
         "testlib;;Member[taintIntoCallback];Argument[0];Argument[1..2].Parameter[0];taint",
+        "testlib;;Member[taintIntoCallbackThis];Argument[0];Argument[1..2].Parameter[this];taint",
         "testlib;;Member[preserveArgZeroAndTwo];Argument[0,2];ReturnValue;taint",
         "testlib;;Member[preserveAllButFirstArgument];Argument[1..];ReturnValue;taint",
         "testlib;;Member[preserveAllIfCall].Call;Argument[0..];ReturnValue;taint"

--- a/javascript/ql/test/library-tests/frameworks/data/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/data/test.ql
@@ -12,7 +12,8 @@ class Steps extends ModelInput::SummaryModelCsv {
         "testlib;;Member[taintIntoCallbackThis];Argument[0];Argument[1..2].Parameter[this];taint",
         "testlib;;Member[preserveArgZeroAndTwo];Argument[0,2];ReturnValue;taint",
         "testlib;;Member[preserveAllButFirstArgument];Argument[1..];ReturnValue;taint",
-        "testlib;;Member[preserveAllIfCall].Call;Argument[0..];ReturnValue;taint"
+        "testlib;;Member[preserveAllIfCall].Call;Argument[0..];ReturnValue;taint",
+        "testlib;;Member[getSource].ReturnValue.Member[continue];Argument[this];ReturnValue;taint",
       ]
   }
 }
@@ -36,11 +37,19 @@ class Sinks extends ModelInput::SinkModelCsv {
   }
 }
 
+class Sources extends ModelInput::SourceModelCsv {
+  override predicate row(string row) {
+    row = "testlib;;Member[getSource].ReturnValue;test-source"
+  }
+}
+
 class BasicTaintTracking extends TaintTracking::Configuration {
   BasicTaintTracking() { this = "BasicTaintTracking" }
 
   override predicate isSource(DataFlow::Node source) {
     source.(DataFlow::CallNode).getCalleeName() = "source"
+    or
+    source = ModelOutput::getASourceNode("test-source").getAnImmediateUse()
   }
 
   override predicate isSink(DataFlow::Node sink) {

--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -473,36 +473,6 @@ module API {
     /** Gets a data flow node that flows to the RHS of a def-node. */
     private DataFlow::LocalSourceNode defCand() { result = defCand(TypeBackTracker::end()) }
 
-    private Label::ApiLabel getLabelFromArgumentPosition(DataFlowDispatch::ArgumentPosition pos) {
-      exists(int n |
-        pos.isPositional(n) and
-        result = Label::parameter(n)
-      )
-      or
-      exists(string name |
-        pos.isKeyword(name) and
-        result = Label::keywordParameter(name)
-      )
-      or
-      pos.isBlock() and
-      result = Label::blockParameter()
-    }
-
-    private Label::ApiLabel getLabelFromParameterPosition(DataFlowDispatch::ParameterPosition pos) {
-      exists(int n |
-        pos.isPositional(n) and
-        result = Label::parameter(n)
-      )
-      or
-      exists(string name |
-        pos.isKeyword(name) and
-        result = Label::keywordParameter(name)
-      )
-      or
-      pos.isBlock() and
-      result = Label::blockParameter()
-    }
-
     /**
      * Holds if there should be a `lbl`-edge from the given call to an argument.
      */
@@ -512,7 +482,7 @@ module API {
     ) {
       exists(DataFlowDispatch::ArgumentPosition argPos |
         argument.sourceArgumentOf(call.asExpr(), argPos) and
-        lbl = getLabelFromArgumentPosition(argPos)
+        lbl = Label::getLabelFromArgumentPosition(argPos)
       )
     }
 
@@ -525,7 +495,7 @@ module API {
     ) {
       exists(DataFlowDispatch::ParameterPosition paramPos |
         paramNode.isSourceParameterOf(callable.asExpr().getExpr(), paramPos) and
-        lbl = getLabelFromParameterPosition(paramPos)
+        lbl = Label::getLabelFromParameterPosition(paramPos)
       )
     }
 
@@ -803,5 +773,37 @@ module API {
 
     /** Gets the label for the edge from the root node to a custom entry point of the given name. */
     LabelEntryPoint entryPoint(API::EntryPoint name) { result.getName() = name }
+
+    /** Gets the API graph label corresponding to the given argument position. */
+    Label::ApiLabel getLabelFromArgumentPosition(DataFlowDispatch::ArgumentPosition pos) {
+      exists(int n |
+        pos.isPositional(n) and
+        result = Label::parameter(n)
+      )
+      or
+      exists(string name |
+        pos.isKeyword(name) and
+        result = Label::keywordParameter(name)
+      )
+      or
+      pos.isBlock() and
+      result = Label::blockParameter()
+    }
+
+    /** Gets the API graph label corresponding to the given parameter position. */
+    Label::ApiLabel getLabelFromParameterPosition(DataFlowDispatch::ParameterPosition pos) {
+      exists(int n |
+        pos.isPositional(n) and
+        result = Label::parameter(n)
+      )
+      or
+      exists(string name |
+        pos.isKeyword(name) and
+        result = Label::keywordParameter(name)
+      )
+      or
+      pos.isBlock() and
+      result = Label::blockParameter()
+    }
   }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -257,6 +257,8 @@ private module Cached {
       name = any(KeywordParameter kp).getName()
       or
       exists(any(Call c).getKeywordArgument(name))
+      or
+      FlowSummaryImplSpecific::ParsePositions::isParsedKeywordParameterPosition(_, name)
     }
 
   cached
@@ -270,7 +272,11 @@ private module Cached {
       or
       FlowSummaryImplSpecific::ParsePositions::isParsedArgumentPosition(_, pos)
     } or
-    TKeywordParameterPosition(string name) { name = any(KeywordParameter kp).getName() }
+    TKeywordParameterPosition(string name) {
+      name = any(KeywordParameter kp).getName()
+      or
+      FlowSummaryImplSpecific::ParsePositions::isParsedKeywordArgumentPosition(_, name)
+    }
 }
 
 import Cached

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -79,10 +79,38 @@ SummaryComponent interpretComponentSpecific(AccessPathToken c) {
 string getComponentSpecificCsv(SummaryComponent sc) { none() }
 
 /** Gets the textual representation of a parameter position in the format used for flow summaries. */
-string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() }
+string getParameterPositionCsv(ParameterPosition pos) {
+  pos.isSelf() and result = "self"
+  or
+  pos.isBlock() and result = "block"
+  or
+  exists(int i |
+    pos.isPositional(i) and
+    result = i.toString()
+  )
+  or
+  exists(string name |
+    pos.isKeyword(name) and
+    result = name + ":"
+  )
+}
 
 /** Gets the textual representation of an argument position in the format used for flow summaries. */
-string getArgumentPositionCsv(ArgumentPosition pos) { result = pos.toString() }
+string getArgumentPositionCsv(ArgumentPosition pos) {
+  pos.isSelf() and result = "self"
+  or
+  pos.isBlock() and result = "block"
+  or
+  exists(int i |
+    pos.isPositional(i) and
+    result = i.toString()
+  )
+  or
+  exists(string name |
+    pos.isKeyword(name) and
+    result = name + ":"
+  )
+}
 
 /** Holds if input specification component `c` needs a reference. */
 predicate inputNeedsReferenceSpecific(string c) { none() }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -62,9 +62,6 @@ SummaryComponent interpretComponentSpecific(AccessPathToken c) {
   c = "Receiver" and // TODO: replace with Argument[self]
   result = FlowSummary::SummaryComponent::receiver()
   or
-  c = "BlockArgument" and // TODO: replace with Argument[block]
-  result = FlowSummary::SummaryComponent::block()
-  or
   c = "Argument[_]" and
   result = FlowSummary::SummaryComponent::argument(any(ParameterPosition pos | pos.isPositional(_)))
   or
@@ -82,10 +79,7 @@ SummaryComponent interpretComponentSpecific(AccessPathToken c) {
 }
 
 /** Gets the textual representation of a summary component in the format used for flow summaries. */
-string getComponentSpecificCsv(SummaryComponent sc) {
-  sc = TArgumentSummaryComponent(any(ParameterPosition pos | pos.isBlock())) and
-  result = "BlockArgument" // TODO: replace with Argument[block]
-}
+string getComponentSpecificCsv(SummaryComponent sc) { none() }
 
 /** Gets the textual representation of a parameter position in the format used for flow summaries. */
 string getParameterPositionCsv(ParameterPosition pos) { result = pos.toString() }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -55,15 +55,14 @@ predicate summaryElement(DataFlowCallable c, string input, string output, string
 /**
  * Gets the summary component for specification component `c`, if any.
  *
- * This covers all the Ruby-specific components of a flow summary, and
- * is currently restricted to `"BlockArgument"`.
+ * This covers all the Ruby-specific components of a flow summary.
  */
 bindingset[c]
 SummaryComponent interpretComponentSpecific(AccessPathToken c) {
-  c = "Receiver" and
+  c = "Receiver" and // TODO: replace with Argument[self]
   result = FlowSummary::SummaryComponent::receiver()
   or
-  c = "BlockArgument" and
+  c = "BlockArgument" and // TODO: replace with Argument[block]
   result = FlowSummary::SummaryComponent::block()
   or
   c = "Argument[_]" and
@@ -85,7 +84,7 @@ SummaryComponent interpretComponentSpecific(AccessPathToken c) {
 /** Gets the textual representation of a summary component in the format used for flow summaries. */
 string getComponentSpecificCsv(SummaryComponent sc) {
   sc = TArgumentSummaryComponent(any(ParameterPosition pos | pos.isBlock())) and
-  result = "BlockArgument"
+  result = "BlockArgument" // TODO: replace with Argument[block]
 }
 
 /** Gets the textual representation of a parameter position in the format used for flow summaries. */
@@ -184,6 +183,12 @@ ArgumentPosition parseParamBody(string s) {
     ParsePositions::isParsedParameterPosition(s, i) and
     result.isPositional(i)
   )
+  or
+  s = "self" and
+  result.isSelf()
+  or
+  s = "block" and
+  result.isBlock()
 }
 
 /** Gets the parameter position obtained by parsing `X` in `Argument[X]`. */
@@ -192,4 +197,10 @@ ParameterPosition parseArgBody(string s) {
     ParsePositions::isParsedArgumentPosition(s, i) and
     result.isPositional(i)
   )
+  or
+  s = "self" and
+  result.isSelf()
+  or
+  s = "block" and
+  result.isBlock()
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -59,9 +59,6 @@ predicate summaryElement(DataFlowCallable c, string input, string output, string
  */
 bindingset[c]
 SummaryComponent interpretComponentSpecific(AccessPathToken c) {
-  c = "Receiver" and // TODO: replace with Argument[self]
-  result = FlowSummary::SummaryComponent::receiver()
-  or
   c = "Argument[_]" and
   result = FlowSummary::SummaryComponent::argument(any(ParameterPosition pos | pos.isPositional(_)))
   or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -166,6 +166,16 @@ module ParsePositions {
     isArgBody(c) and
     i = AccessPath::parseInt(c)
   }
+
+  predicate isParsedKeywordParameterPosition(string c, string paramName) {
+    isParamBody(c) and
+    c = paramName + ":"
+  }
+
+  predicate isParsedKeywordArgumentPosition(string c, string paramName) {
+    isArgBody(c) and
+    c = paramName + ":"
+  }
 }
 
 /** Gets the argument position obtained by parsing `X` in `Parameter[X]`. */
@@ -173,6 +183,11 @@ ArgumentPosition parseParamBody(string s) {
   exists(int i |
     ParsePositions::isParsedParameterPosition(s, i) and
     result.isPositional(i)
+  )
+  or
+  exists(string name |
+    ParsePositions::isParsedKeywordParameterPosition(s, name) and
+    result.isKeyword(name)
   )
   or
   s = "self" and
@@ -187,6 +202,11 @@ ParameterPosition parseArgBody(string s) {
   exists(int i |
     ParsePositions::isParsedArgumentPosition(s, i) and
     result.isPositional(i)
+  )
+  or
+  exists(string name |
+    ParsePositions::isParsedKeywordArgumentPosition(s, name) and
+    result.isKeyword(name)
   )
   or
   s = "self" and

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveStorage.qll
@@ -24,7 +24,7 @@ private class Summaries extends ModelInput::SummaryModelCsv {
     row =
       [
         "activestorage;;Member[ActiveStorage].Member[Filename].Method[new];Argument[0];ReturnValue;taint",
-        "activestorage;;Member[ActiveStorage].Member[Filename].Instance.Method[sanitized];Receiver;ReturnValue;taint",
+        "activestorage;;Member[ActiveStorage].Member[Filename].Instance.Method[sanitized];Argument[self];ReturnValue;taint",
       ]
   }
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/Core.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/Core.qll
@@ -61,11 +61,11 @@ private class SplatSummary extends SummarizedCallable {
   override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
     (
       // *1 = [1]
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue.ArrayElement[0]"
       or
       // *[1] = [1]
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue"
     ) and
     preservesValue = true

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -605,7 +605,10 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"] and
+        [
+          "Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]",
+          "Argument[self].ArrayElement[?]"
+        ] and
       preservesValue = true
     }
 
@@ -956,7 +959,10 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].ArrayElement" and
       output =
-        ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]", "Argument[block].Parameter[0]"] and
+        [
+          "ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]",
+          "Argument[block].Parameter[0]"
+        ] and
       preservesValue = true
     }
 
@@ -1134,7 +1140,10 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].ArrayElement" and
       output =
-        ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]", "Argument[block].Parameter[0]"] and
+        [
+          "ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]",
+          "Argument[block].Parameter[0]"
+        ] and
       preservesValue = true
     }
 
@@ -1298,7 +1307,10 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[block].Parameter[0]", "Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+        [
+          "Argument[block].Parameter[0]", "Argument[self].ArrayElement[?]",
+          "ReturnValue.ArrayElement[?]"
+        ] and
       preservesValue = true
     }
 
@@ -1564,7 +1576,10 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[block].Parameter[0]", "Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+        [
+          "Argument[block].Parameter[0]", "Argument[self].ArrayElement[?]",
+          "ReturnValue.ArrayElement[?]"
+        ] and
       preservesValue = true
     }
 
@@ -1597,7 +1612,10 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
+        [
+          "Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]",
+          "Argument[block].Parameter[0]"
+        ] and
       preservesValue = true
     }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -66,7 +66,7 @@ module Array {
         input = "Argument[0].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
-        input = "BlockArgument.ReturnValue" and
+        input = "Argument[block].ReturnValue" and
         output = "ReturnValue.ArrayElement[?]"
       ) and
       preservesValue = true
@@ -440,7 +440,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue"] and
       preservesValue = true
     }
   }
@@ -450,7 +450,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -470,10 +470,10 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
-      input = "BlockArgument.ReturnValue" and
+      input = "Argument[block].ReturnValue" and
       output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -485,7 +485,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0].ArrayElement[?]"
+        output = "Argument[block].Parameter[0].ArrayElement[?]"
         or
         input = "Receiver" and output = "ReturnValue"
       ) and
@@ -534,7 +534,7 @@ module Array {
         input = "Receiver.ArrayElement" and
         output = ["Receiver.ArrayElement[?]", "ReturnValue"]
         or
-        input = "BlockArgument.ReturnValue" and
+        input = "Argument[block].ReturnValue" and
         output = "ReturnValue"
       ) and
       preservesValue = true
@@ -605,7 +605,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
+        ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
       preservesValue = true
     }
 
@@ -687,7 +687,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         input = "Receiver.ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
@@ -748,7 +748,7 @@ module Array {
         )
         or
         input = "Argument[0]" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         input = "Argument[1]" and output = "ReturnValue"
       ) and
@@ -768,7 +768,7 @@ module Array {
         output = "ReturnValue"
         or
         input = "Argument[0]" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
       ) and
       preservesValue = true
     }
@@ -783,7 +783,7 @@ module Array {
     override MethodCall getACall() { result = mc }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["Argument[0]", "BlockArgument.ReturnValue"] and
+      input = ["Argument[0]", "Argument[block].ReturnValue"] and
       output = "Receiver.ArrayElement[?]" and
       preservesValue = true
     }
@@ -856,7 +856,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -956,7 +956,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]", "BlockArgument.Parameter[0]"] and
+        ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
 
@@ -1011,7 +1011,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0].ArrayElement[?]"
+        output = "Argument[block].Parameter[0].ArrayElement[?]"
         or
         input = "Receiver" and
         output = "ReturnValue"
@@ -1134,7 +1134,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]", "BlockArgument.Parameter[0]"] and
+        ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
 
@@ -1298,7 +1298,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["BlockArgument.Parameter[0]", "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+        ["Argument[block].Parameter[0]", "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
 
@@ -1546,8 +1546,8 @@ module Array {
       input = "Receiver.ArrayElement" and
       output =
         [
-          "BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]", "Receiver.ArrayElement[?]",
-          "ReturnValue.ArrayElement[?]"
+          "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
+          "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"
         ] and
       preservesValue = true
     }
@@ -1564,7 +1564,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["BlockArgument.Parameter[0]", "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+        ["Argument[block].Parameter[0]", "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
 
@@ -1597,7 +1597,7 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]", "BlockArgument.Parameter[0]"] and
+        ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
 
@@ -1692,7 +1692,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -1702,7 +1702,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]"] and
+      output = ["Argument[block].Parameter[0]", "Argument[block].Parameter[1]"] and
       preservesValue = true
     }
   }
@@ -1713,10 +1713,10 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
-      input = "BlockArgument.ReturnValue" and
+      input = "Argument[block].ReturnValue" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1728,10 +1728,10 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
-      input = ["BlockArgument.ReturnValue.ArrayElement", "BlockArgument.ReturnValue"] and
+      input = ["Argument[block].ReturnValue.ArrayElement", "Argument[block].ReturnValue"] and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1752,7 +1752,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -1762,7 +1762,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -1774,7 +1774,7 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = ["BlockArgument.Parameter[0]", "ReturnValue"]
+        output = ["Argument[block].Parameter[0]", "ReturnValue"]
         or
         input = "Argument[0].ReturnValue" and
         output = "ReturnValue"
@@ -1832,7 +1832,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["ReturnValue.ArrayElement[?]", "BlockArgument.Parameter[0]"] and
+      output = ["ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
   }
@@ -1842,7 +1842,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0].ArrayElement[?]" and
+      output = "Argument[block].Parameter[0].ArrayElement[?]" and
       preservesValue = true
     }
   }
@@ -1853,7 +1853,7 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         input = "Receiver.ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
@@ -1873,7 +1873,7 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0].ArrayElement[?]"
+        output = "Argument[block].Parameter[0].ArrayElement[?]"
         or
         input = "Receiver.ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
@@ -1893,7 +1893,7 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         input = "Receiver.ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
@@ -1913,10 +1913,10 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         input = "Argument[0]" and
-        output = ["BlockArgument.Parameter[1]", "ReturnValue"]
+        output = ["Argument[block].Parameter[1]", "ReturnValue"]
       ) and
       preservesValue = true
     }
@@ -1927,7 +1927,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -1937,7 +1937,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -2019,9 +2019,9 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
-        input = "BlockArgument.ReturnValue" and
+        input = "Argument[block].ReturnValue" and
         output = "ReturnValue.ArrayElement[?]"
       ) and
       preservesValue = true
@@ -2044,7 +2044,7 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       // TODO: Add flow to return value once we have flow through hashes
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -2068,12 +2068,12 @@ module Enumerable {
       // second block parameter.
       (
         input = "Receiver.ArrayElement[0]" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         exists(ArrayIndex i | i > 0 | input = "Receiver.ArrayElement[" + i + "]") and
-        output = "BlockArgument.Parameter[1]"
+        output = "Argument[block].Parameter[1]"
         or
-        input = "BlockArgument.ReturnValue" and output = "ReturnValue"
+        input = "Argument[block].ReturnValue" and output = "ReturnValue"
       ) and
       preservesValue = true
     }
@@ -2086,13 +2086,13 @@ module Enumerable {
       (
         // The first argument of the call is passed to the first block parameter.
         input = "Argument[0]" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         // Each element in the receiver is passed to the second block parameter.
         exists(ArrayIndex i | input = "Receiver.ArrayElement[" + i + "]") and
-        output = "BlockArgument.Parameter[1]"
+        output = "Argument[block].Parameter[1]"
         or
-        input = "BlockArgument.ReturnValue" and output = "ReturnValue"
+        input = "Argument[block].ReturnValue" and output = "ReturnValue"
       ) and
       preservesValue = true
     }
@@ -2115,7 +2115,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue"] and
       preservesValue = true
     }
   }
@@ -2128,7 +2128,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -2179,7 +2179,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]", "ReturnValue"] and
+      output = ["Argument[block].Parameter[0]", "Argument[block].Parameter[1]", "ReturnValue"] and
       preservesValue = true
     }
   }
@@ -2194,7 +2194,10 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]", "ReturnValue.ArrayElement[?]"] and
+        [
+          "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
+          "ReturnValue.ArrayElement[?]"
+        ] and
       preservesValue = true
     }
   }
@@ -2230,7 +2233,10 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]", "ReturnValue.ArrayElement[?]"] and
+        [
+          "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
+          "ReturnValue.ArrayElement[?]"
+        ] and
       preservesValue = true
     }
   }
@@ -2240,7 +2246,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -2250,7 +2256,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?].ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?].ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -2260,7 +2266,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -2270,7 +2276,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -2281,7 +2287,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -2291,7 +2297,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -2301,7 +2307,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]"] and
+      output = ["Argument[block].Parameter[0]", "Argument[block].Parameter[1]"] and
       preservesValue = true
     }
   }
@@ -2312,7 +2318,10 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
       output =
-        ["BlockArgument.Parameter[0]", "BlockArgument.Parameter[1]", "ReturnValue.ArrayElement[?]"] and
+        [
+          "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
+          "ReturnValue.ArrayElement[?]"
+        ] and
       preservesValue = true
     }
   }
@@ -2322,7 +2331,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue.ArrayElement[?]"] and
+      output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -2332,7 +2341,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
   }
@@ -2389,7 +2398,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
       // We can't know the size of the return value, but we know that indices
@@ -2418,7 +2427,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver.ArrayElement" and
-      output = ["ReturnValue.ArrayElement[?]", "BlockArgument.Parameter[0]"] and
+      output = ["ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
   }
@@ -2438,11 +2447,11 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         input = "Receiver.ArrayElement" and
-        output = "BlockArgument.Parameter[0].ArrayElement[0]"
+        output = "Argument[block].Parameter[0].ArrayElement[0]"
         or
         exists(int i | i in [0 .. (mc.getNumberOfArguments() - 1)] |
           input = "Argument[" + i + "].ArrayElement" and
-          output = "BlockArgument.Parameter[0].ArrayElement[" + (i + 1) + "]"
+          output = "Argument[block].Parameter[0].ArrayElement[" + (i + 1) + "]"
         )
       ) and
       preservesValue = true

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -100,7 +100,7 @@ module Array {
     override BitwiseAndExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["Receiver.ArrayElement", "Argument[0].ArrayElement"] and
+      input = ["Argument[self].ArrayElement", "Argument[0].ArrayElement"] and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -112,7 +112,7 @@ module Array {
     override BitwiseOrExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["Receiver.ArrayElement", "Argument[0].ArrayElement"] and
+      input = ["Argument[self].ArrayElement", "Argument[0].ArrayElement"] and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -124,7 +124,7 @@ module Array {
     override MulExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -138,11 +138,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
         or
-        input = ["Receiver.ArrayElement[?]", "Argument[0].ArrayElement"] and
+        input = ["Argument[self].ArrayElement[?]", "Argument[0].ArrayElement"] and
         output = "ReturnValue.ArrayElement[?]"
       ) and
       preservesValue = true
@@ -155,7 +155,7 @@ module Array {
     override SubExpr getACall() { any() }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -170,15 +170,15 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         input = "Argument[0]" and
-        output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"]
+        output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"]
       ) and
       preservesValue = true
     }
@@ -205,7 +205,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement[" + [i.toString(), "?"] + "]" and
+      input = "Argument[self].ArrayElement[" + [i.toString(), "?"] + "]" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -223,7 +223,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["ReturnValue", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -266,11 +266,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i | i >= start and i <= end |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + (i - start) + "]"
         )
       )
@@ -302,7 +302,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -330,7 +330,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[1]" and
-      output = "Receiver.ArrayElement[" + c.getIndex() + "]" and
+      output = "Argument[self].ArrayElement[" + c.getIndex() + "]" and
       preservesValue = true
     }
 
@@ -350,7 +350,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[1]" and
-      output = "Receiver.ArrayElement[?]" and
+      output = "Argument[self].ArrayElement[?]" and
       preservesValue = true
     }
   }
@@ -374,8 +374,8 @@ module Array {
       // done in `ElementReferenceRangeReadKnownSummary`.
       exists(string arg |
         arg = "Argument[" + (mc.getNumberOfArguments() - 1) + "]" and
-        input = [arg + ".ArrayElement", arg, "Receiver.ArrayElement"] and
-        output = "Receiver.ArrayElement[?]" and
+        input = [arg + ".ArrayElement", arg, "Argument[self].ArrayElement"] and
+        output = "Argument[self].ArrayElement[?]" and
         preservesValue = true
       )
     }
@@ -390,7 +390,7 @@ module Array {
     AssocSummary() { this = ["assoc", "rassoc"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement.ArrayElement" and
+      input = "Argument[self].ArrayElement.ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -415,7 +415,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement[" + [i.toString(), "?"] + "]" and
+      input = "Argument[self].ArrayElement[" + [i.toString(), "?"] + "]" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -429,7 +429,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -439,7 +439,7 @@ module Array {
     BSearchSummary() { this = "bsearch" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue"] and
       preservesValue = true
     }
@@ -449,7 +449,7 @@ module Array {
     BSearchIndexSummary() { this = "bsearch_index" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -469,12 +469,12 @@ module Array {
     CollectBangSummary() { this = ["collect!", "map!"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
       input = "Argument[block].ReturnValue" and
-      output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
+      output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -484,10 +484,10 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0].ArrayElement[?]"
         or
-        input = "Receiver" and output = "ReturnValue"
+        input = "Argument[self]" and output = "ReturnValue"
       ) and
       preservesValue = true
     }
@@ -497,8 +497,8 @@ module Array {
     CompactBangSummary() { this = "compact!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
+      input = "Argument[self].ArrayElement" and
+      output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -508,7 +508,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[_].ArrayElement" and
-      output = "Receiver.ArrayElement[?]" and
+      output = "Argument[self].ArrayElement[?]" and
       preservesValue = true
     }
   }
@@ -520,7 +520,7 @@ module Array {
       // The documentation of `deconstruct` is blank, but the implementation
       // shows that it just returns the receiver, unchanged:
       // https://github.com/ruby/ruby/blob/71bc99900914ef3bc3800a22d9221f5acf528082/array.c#L7810-L7814.
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -531,8 +531,8 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
-        output = ["Receiver.ArrayElement[?]", "ReturnValue"]
+        input = "Argument[self].ArrayElement" and
+        output = ["Argument[self].ArrayElement[?]", "ReturnValue"]
         or
         input = "Argument[block].ReturnValue" and
         output = "ReturnValue"
@@ -571,15 +571,15 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement[?]" and
-        output = ["ReturnValue", "Receiver.ArrayElement[?]"]
+        input = "Argument[self].ArrayElement[?]" and
+        output = ["ReturnValue", "Argument[self].ArrayElement[?]"]
         or
-        exists(ArrayIndex j | input = "Receiver.ArrayElement[" + j + "]" |
-          j < i and output = "Receiver.ArrayElement[" + j + "]"
+        exists(ArrayIndex j | input = "Argument[self].ArrayElement[" + j + "]" |
+          j < i and output = "Argument[self].ArrayElement[" + j + "]"
           or
           j = i and output = "ReturnValue"
           or
-          j > i and output = "Receiver.ArrayElement[" + (j - 1) + "]"
+          j > i and output = "Argument[self].ArrayElement[" + (j - 1) + "]"
         )
       ) and
       preservesValue = true
@@ -593,8 +593,8 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["ReturnValue", "Receiver.ArrayElement[?]"] and
+      input = "Argument[self].ArrayElement" and
+      output = ["ReturnValue", "Argument[self].ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -603,9 +603,9 @@ module Array {
     DeleteIfSummary() { this = "delete_if" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
+        ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"] and
       preservesValue = true
     }
 
@@ -674,7 +674,7 @@ module Array {
     override MethodCall getACall() { result = dig }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" + buildDigInputSpec(dig) and
+      input = "Argument[self]" + buildDigInputSpec(dig) and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -686,14 +686,14 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0]"
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
       ) and
@@ -706,11 +706,11 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
       ) and
@@ -738,13 +738,13 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement[?]" and
-        output = ["ReturnValue", "Receiver.ArrayElement[?]"]
+        input = "Argument[self].ArrayElement[?]" and
+        output = ["ReturnValue", "Argument[self].ArrayElement[?]"]
         or
-        exists(ArrayIndex j | input = "Receiver.ArrayElement[" + j + "]" |
+        exists(ArrayIndex j | input = "Argument[self].ArrayElement[" + j + "]" |
           j = i and output = "ReturnValue"
           or
-          j != i and output = "Receiver.ArrayElement[" + j + "]"
+          j != i and output = "Argument[self].ArrayElement[" + j + "]"
         )
         or
         input = "Argument[0]" and
@@ -764,7 +764,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = ["Receiver.ArrayElement", "Argument[1]"] and
+        input = ["Argument[self].ArrayElement", "Argument[1]"] and
         output = "ReturnValue"
         or
         input = "Argument[0]" and
@@ -784,7 +784,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = ["Argument[0]", "Argument[block].ReturnValue"] and
-      output = "Receiver.ArrayElement[?]" and
+      output = "Argument[self].ArrayElement[?]" and
       preservesValue = true
     }
   }
@@ -821,8 +821,8 @@ module Array {
       (
         input =
           [
-            "Receiver.ArrayElement", "Receiver.ArrayElement.ArrayElement",
-            "Receiver.ArrayElement.ArrayElement.ArrayElement"
+            "Argument[self].ArrayElement", "Argument[self].ArrayElement.ArrayElement",
+            "Argument[self].ArrayElement.ArrayElement.ArrayElement"
           ] and
         output = "ReturnValue.ArrayElement[?]"
       ) and
@@ -837,10 +837,10 @@ module Array {
       (
         input =
           [
-            "Receiver.ArrayElement", "Receiver.ArrayElement.ArrayElement",
-            "Receiver.ArrayElement.ArrayElement.ArrayElement"
+            "Argument[self].ArrayElement", "Argument[self].ArrayElement.ArrayElement",
+            "Argument[self].ArrayElement.ArrayElement.ArrayElement"
           ] and
-        output = ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"]
+        output = ["Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"]
       ) and
       preservesValue = true
     }
@@ -855,7 +855,7 @@ module Array {
     IndexSummary() { this = ["index", "rindex"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -881,22 +881,22 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       exists(int numValues, string r |
         numValues = mc.getNumberOfArguments() - 1 and
-        r = ["ReturnValue", "Receiver"] and
+        r = ["ReturnValue", "Argument[self]"] and
         preservesValue = true
       |
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = r + ".ArrayElement[?]"
         or
         exists(ArrayIndex j |
           // Existing elements before the insertion point are unaffected.
           j < i and
-          input = "Receiver.ArrayElement[" + j + "]" and
+          input = "Argument[self].ArrayElement[" + j + "]" and
           output = r + ".ArrayElement[" + j + "]"
           or
           // Existing elements after the insertion point are shifted by however
           // many values we're inserting.
           j >= i and
-          input = "Receiver.ArrayElement[" + j + "]" and
+          input = "Argument[self].ArrayElement[" + j + "]" and
           output = r + ".ArrayElement[" + (j + numValues) + "]"
         )
         or
@@ -921,11 +921,11 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement"
+        input = "Argument[self].ArrayElement"
         or
         exists(int j | j in [1 .. mc.getNumberOfArguments() - 1] | input = "Argument[" + j + "]")
       ) and
-      output = ["ReturnValue", "Receiver"] + ".ArrayElement[?]" and
+      output = ["ReturnValue", "Argument[self]"] + ".ArrayElement[?]" and
       preservesValue = true
     }
   }
@@ -937,7 +937,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement"
+        input = "Argument[self].ArrayElement"
         or
         exists(int i | i in [0 .. mc.getNumberOfArguments() - 1] |
           input = "Argument[" + i + "].ArrayElement"
@@ -954,9 +954,9 @@ module Array {
     KeepIfSummary() { this = "keep_if" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
-        ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]", "Argument[block].Parameter[0]"] and
+        ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
 
@@ -979,7 +979,7 @@ module Array {
     LastNoArgSummary() { this = "last(no_arg)" and mc.getNumberOfArguments() = 0 }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -989,7 +989,7 @@ module Array {
     LastArgSummary() { this = "last(arg)" and mc.getNumberOfArguments() > 0 }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -999,7 +999,7 @@ module Array {
     PackSummary() { this = "pack" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue" and
       preservesValue = false
     }
@@ -1010,10 +1010,10 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0].ArrayElement[?]"
         or
-        input = "Receiver" and
+        input = "Argument[self]" and
         output = "ReturnValue"
       ) and
       preservesValue = true
@@ -1036,7 +1036,7 @@ module Array {
     // clears the last element of the receiver, and we can't be precise about
     // which particular element flows to the return value.
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -1049,7 +1049,7 @@ module Array {
     // clears elements from the end of the receiver, and we can't be precise
     // about which particular elements flow to the return value.
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1069,16 +1069,16 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       exists(int num | num = mc.getNumberOfArguments() and preservesValue = true |
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
-          output = "Receiver.ArrayElement[" + (i + num) + "]"
+          input = "Argument[self].ArrayElement[" + i + "]" and
+          output = "Argument[self].ArrayElement[" + (i + num) + "]"
         )
         or
-        input = "Receiver.ArrayElement[?]" and
-        output = "Receiver.ArrayElement[?]"
+        input = "Argument[self].ArrayElement[?]" and
+        output = "Argument[self].ArrayElement[?]"
         or
         exists(int i | i in [0 .. (num - 1)] |
           input = "Argument[" + i + "]" and
-          output = "Receiver.ArrayElement[" + i + "]"
+          output = "Argument[self].ArrayElement[" + i + "]"
         )
       )
     }
@@ -1094,7 +1094,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement"
+        input = "Argument[self].ArrayElement"
         or
         exists(int i | i in [0 .. (mc.getNumberOfArguments() - 1)] |
           input = "Argument[" + i + "].ArrayElement"
@@ -1112,16 +1112,16 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(int i | i in [0 .. (mc.getNumberOfArguments() - 1)] |
           input = "Argument[" + i + "]" and
-          output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"]
+          output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"]
         )
       ) and
       preservesValue = true
@@ -1132,9 +1132,9 @@ module Array {
     RejectBangSummary() { this = "reject!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
-        ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]", "Argument[block].Parameter[0]"] and
+        ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
 
@@ -1148,7 +1148,7 @@ module Array {
     ReplaceSummary() { this = "replace" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      exists(string r | r = ["ReturnValue", "Receiver"] and preservesValue = true |
+      exists(string r | r = ["ReturnValue", "Argument[self]"] and preservesValue = true |
         input = "Argument[0].ArrayElement[?]" and
         output = r + ".ArrayElement[?]"
         or
@@ -1169,7 +1169,7 @@ module Array {
     ReverseSummary() { this = "reverse" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1179,8 +1179,8 @@ module Array {
     ReverseBangSummary() { this = "reverse!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["Receiver", "ReturnValue"] + ".ArrayElement[?]" and
+      input = "Argument[self].ArrayElement" and
+      output = ["Argument[self]", "ReturnValue"] + ".ArrayElement[?]" and
       preservesValue = true
     }
   }
@@ -1207,11 +1207,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           (
             i < c and output = "ReturnValue.ArrayElement[?]"
             or
@@ -1230,7 +1230,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1261,12 +1261,12 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      exists(string r | r = ["Receiver", "ReturnValue"] and preservesValue = true |
-        input = "Receiver.ArrayElement[?]" and
+      exists(string r | r = ["Argument[self]", "ReturnValue"] and preservesValue = true |
+        input = "Argument[self].ArrayElement[?]" and
         output = r + ".ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           (
             i < c and output = r + ".ArrayElement[?]"
             or
@@ -1285,8 +1285,8 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+      input = "Argument[self].ArrayElement" and
+      output = ["Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -1296,9 +1296,9 @@ module Array {
     SelectBangSummary() { this = ["select!", "filter!"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[block].Parameter[0]", "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+        ["Argument[block].Parameter[0]", "Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
 
@@ -1328,13 +1328,13 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
-        output = ["ReturnValue", "Receiver.ArrayElement[?]"]
+        input = "Argument[self].ArrayElement[?]" and
+        output = ["ReturnValue", "Argument[self].ArrayElement[?]"]
         or
-        exists(ArrayIndex i | input = "Receiver.ArrayElement[" + i + "]" |
+        exists(ArrayIndex i | input = "Argument[self].ArrayElement[" + i + "]" |
           i = 0 and output = "ReturnValue"
           or
-          i > 0 and output = "Receiver.ArrayElement[" + (i - 1) + "]"
+          i > 0 and output = "Argument[self].ArrayElement[" + (i - 1) + "]"
         )
       )
     }
@@ -1351,13 +1351,13 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
-        output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"]
+        input = "Argument[self].ArrayElement[?]" and
+        output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"]
         or
-        exists(ArrayIndex i | input = "Receiver.ArrayElement[" + i + "]" |
+        exists(ArrayIndex i | input = "Argument[self].ArrayElement[" + i + "]" |
           i < n and output = "ReturnValue.ArrayElement[" + i + "]"
           or
-          i >= n and output = "Receiver.ArrayElement[" + (i - n) + "]"
+          i >= n and output = "Argument[self].ArrayElement[" + (i - n) + "]"
         )
       )
     }
@@ -1371,8 +1371,8 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+      input = "Argument[self].ArrayElement" and
+      output = ["Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -1381,7 +1381,7 @@ module Array {
     ShuffleSummary() { this = "shuffle" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1391,8 +1391,8 @@ module Array {
     ShuffleBangSummary() { this = "shuffle!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"] and
+      input = "Argument[self].ArrayElement" and
+      output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -1424,15 +1424,15 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
-        output = ["ReturnValue", "Receiver.ArrayElement[?]"]
+        input = "Argument[self].ArrayElement[?]" and
+        output = ["ReturnValue", "Argument[self].ArrayElement[?]"]
         or
-        exists(ArrayIndex i | input = "Receiver.ArrayElement[" + i + "]" |
-          i < n and output = "Receiver.ArrayElement[" + i + "]"
+        exists(ArrayIndex i | input = "Argument[self].ArrayElement[" + i + "]" |
+          i < n and output = "Argument[self].ArrayElement[" + i + "]"
           or
           i = n and output = "ReturnValue"
           or
-          i > n and output = "Receiver.ArrayElement[" + (i - 1) + "]"
+          i > n and output = "Argument[self].ArrayElement[" + (i - 1) + "]"
         )
       )
     }
@@ -1450,10 +1450,10 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
         [
-          "Receiver.ArrayElement[?]",
+          "Argument[self].ArrayElement[?]",
           "ReturnValue.ArrayElement[?]", // Return value is an array if the argument is a range
           "ReturnValue" // Return value is an element if the argument is an integer
         ] and
@@ -1494,15 +1494,15 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
-        output = ["ReturnValue.ArrayElement[?]", "Receiver.ArrayElement[?]"]
+        input = "Argument[self].ArrayElement[?]" and
+        output = ["ReturnValue.ArrayElement[?]", "Argument[self].ArrayElement[?]"]
         or
-        exists(ArrayIndex i | input = "Receiver.ArrayElement[" + i + "]" |
-          i < start and output = "Receiver.ArrayElement[" + i + "]"
+        exists(ArrayIndex i | input = "Argument[self].ArrayElement[" + i + "]" |
+          i < start and output = "Argument[self].ArrayElement[" + i + "]"
           or
           i >= start and i <= end and output = "ReturnValue.ArrayElement[" + (i - start) + "]"
           or
-          i > end and output = "Receiver.ArrayElement[" + (i - (end - start + 1)) + "]"
+          i > end and output = "Argument[self].ArrayElement[" + (i - (end - start + 1)) + "]"
         )
       )
     }
@@ -1533,8 +1533,8 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
-      output = ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+      input = "Argument[self].ArrayElement" and
+      output = ["Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
   }
@@ -1543,11 +1543,11 @@ module Array {
     SortBangSummary() { this = "sort!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
         [
           "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
-          "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"
+          "Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"
         ] and
       preservesValue = true
     }
@@ -1562,9 +1562,9 @@ module Array {
     SortByBangSummary() { this = "sort_by!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
-        ["Argument[block].Parameter[0]", "Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
+        ["Argument[block].Parameter[0]", "Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
 
@@ -1580,11 +1580,11 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?].ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?].ArrayElement[?]"
         or
         exists(ArrayIndex i, ArrayIndex j |
-          input = "Receiver.ArrayElement[" + j + "].ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + j + "].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "].ArrayElement[" + j + "]"
         )
       )
@@ -1595,9 +1595,9 @@ module Array {
     UniqBangSummary() { this = "uniq!" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
-        ["Receiver.ArrayElement[?]", "ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
+        ["Argument[self].ArrayElement[?]", "ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
 
@@ -1612,7 +1612,7 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement"
+        input = "Argument[self].ArrayElement"
         or
         exists(int i | i in [0 .. mc.getNumberOfArguments() - 1] |
           input = "Argument[" + i + "].ArrayElement"
@@ -1646,14 +1646,14 @@ module Array {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = true and
       (
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex elementIndex, int argIndex |
           argIndex in [0 .. mc.getNumberOfArguments() - 1] and
           mc.getArgument(argIndex).getConstantValue().isInt(elementIndex)
         |
-          input = "Receiver.ArrayElement[" + elementIndex + "]" and
+          input = "Argument[self].ArrayElement[" + elementIndex + "]" and
           output = "ReturnValue.ArrayElement[" + argIndex + "]"
         )
       )
@@ -1673,7 +1673,7 @@ module Array {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1691,7 +1691,7 @@ module Enumerable {
     ChunkSummary() { this = "chunk" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -1701,7 +1701,7 @@ module Enumerable {
     ChunkWhileSummary() { this = "chunk_while" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "Argument[block].Parameter[1]"] and
       preservesValue = true
     }
@@ -1712,7 +1712,7 @@ module Enumerable {
     CollectSummary() { this = ["collect", "map"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
@@ -1727,7 +1727,7 @@ module Enumerable {
     CollectConcatSummary() { this = ["collect_concat", "flat_map"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
@@ -1741,7 +1741,7 @@ module Enumerable {
     CompactSummary() { this = "compact" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1751,7 +1751,7 @@ module Enumerable {
     CountSummary() { this = "count" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -1761,7 +1761,7 @@ module Enumerable {
     CycleSummary() { this = "cycle" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -1773,7 +1773,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = ["Argument[block].Parameter[0]", "ReturnValue"]
         or
         input = "Argument[0].ReturnValue" and
@@ -1802,11 +1802,11 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex j |
-          input = "Receiver.ArrayElement[" + j + "]" and
+          input = "Argument[self].ArrayElement[" + j + "]" and
           output = "ReturnValue.ArrayElement[" + (j - i) + "]"
         )
       ) and
@@ -1821,7 +1821,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -1831,7 +1831,7 @@ module Enumerable {
     DropWhileSummary() { this = "drop_while" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
@@ -1841,7 +1841,7 @@ module Enumerable {
     EachConsSummary() { this = "each_cons" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0].ArrayElement[?]" and
       preservesValue = true
     }
@@ -1852,14 +1852,14 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0]"
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
       ) and
@@ -1872,14 +1872,14 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0].ArrayElement[?]"
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
       ) and
@@ -1892,14 +1892,14 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0]"
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
       ) and
@@ -1912,7 +1912,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0]"
         or
         input = "Argument[0]" and
@@ -1926,7 +1926,7 @@ module Enumerable {
     FilterMapSummary() { this = "filter_map" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -1936,7 +1936,7 @@ module Enumerable {
     FindIndexSummary() { this = "find_index" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -1955,7 +1955,7 @@ module Enumerable {
     FirstNoArgSummary() { this = "first(no_arg)" and mc.getNumberOfArguments() = 0 }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["Receiver.ArrayElement[0]", "Receiver.ArrayElement[?]"] and
+      input = ["Argument[self].ArrayElement[0]", "Argument[self].ArrayElement[?]"] and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -1972,11 +1972,11 @@ module Enumerable {
       (
         exists(ArrayIndex i |
           i < n and
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
       ) and
       preservesValue = true
@@ -1993,11 +1993,11 @@ module Enumerable {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "]"
         )
         or
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
       ) and
       preservesValue = true
@@ -2018,7 +2018,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0]"
         or
         input = "Argument[block].ReturnValue" and
@@ -2032,7 +2032,7 @@ module Enumerable {
     GrepNoBlockSummary() { this = mc.getMethodName() + "(no_block)" and not exists(mc.getBlock()) }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -2043,7 +2043,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       // TODO: Add flow to return value once we have flow through hashes
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -2067,10 +2067,10 @@ module Enumerable {
       // parameter (first iteration only). All other elements are passed to the
       // second block parameter.
       (
-        input = "Receiver.ArrayElement[0]" and
+        input = "Argument[self].ArrayElement[0]" and
         output = "Argument[block].Parameter[0]"
         or
-        exists(ArrayIndex i | i > 0 | input = "Receiver.ArrayElement[" + i + "]") and
+        exists(ArrayIndex i | i > 0 | input = "Argument[self].ArrayElement[" + i + "]") and
         output = "Argument[block].Parameter[1]"
         or
         input = "Argument[block].ReturnValue" and output = "ReturnValue"
@@ -2089,7 +2089,7 @@ module Enumerable {
         output = "Argument[block].Parameter[0]"
         or
         // Each element in the receiver is passed to the second block parameter.
-        exists(ArrayIndex i | input = "Receiver.ArrayElement[" + i + "]") and
+        exists(ArrayIndex i | input = "Argument[self].ArrayElement[" + i + "]") and
         output = "Argument[block].Parameter[1]"
         or
         input = "Argument[block].ReturnValue" and output = "ReturnValue"
@@ -2114,7 +2114,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue"] and
       preservesValue = true
     }
@@ -2127,7 +2127,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -2150,7 +2150,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -2164,7 +2164,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -2178,7 +2178,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "Argument[block].Parameter[1]", "ReturnValue"] and
       preservesValue = true
     }
@@ -2192,7 +2192,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
         [
           "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
@@ -2218,7 +2218,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = true
     }
@@ -2231,7 +2231,7 @@ module Enumerable {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
         [
           "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
@@ -2245,7 +2245,7 @@ module Enumerable {
     MinmaxBySummary() { this = "minmax_by" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -2255,7 +2255,7 @@ module Enumerable {
     PartitionSummary() { this = "partition" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?].ArrayElement[?]"] and
       preservesValue = true
     }
@@ -2265,7 +2265,7 @@ module Enumerable {
     QuerySummary() { this = ["all?", "any?", "none?", "one?"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -2275,7 +2275,7 @@ module Enumerable {
     RejectSummary() { this = "reject" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -2286,7 +2286,7 @@ module Enumerable {
     SelectSummary() { this = ["select", "find_all", "filter"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -2296,7 +2296,7 @@ module Enumerable {
     SliceBeforeAfterSummary() { this = ["slice_before", "slice_after"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -2306,7 +2306,7 @@ module Enumerable {
     SliceWhenSummary() { this = "slice_when" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "Argument[block].Parameter[1]"] and
       preservesValue = true
     }
@@ -2316,7 +2316,7 @@ module Enumerable {
     SortSummary() { this = "sort" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output =
         [
           "Argument[block].Parameter[0]", "Argument[block].Parameter[1]",
@@ -2330,7 +2330,7 @@ module Enumerable {
     SortBySummary() { this = "sort_by" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["Argument[block].Parameter[0]", "ReturnValue.ArrayElement[?]"] and
       preservesValue = true
     }
@@ -2340,7 +2340,7 @@ module Enumerable {
     SumSummary() { this = "sum" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
     }
@@ -2365,11 +2365,11 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?]"
         or
         exists(ArrayIndex j | j < i |
-          input = "Receiver.ArrayElement[" + j + "]" and
+          input = "Argument[self].ArrayElement[" + j + "]" and
           output = "ReturnValue.ArrayElement[" + j + "]"
         )
       ) and
@@ -2387,7 +2387,7 @@ module Enumerable {
       // When the index is unknown, we can't know the size of the result, but we
       // know that indices are preserved, so, as an approximation, we just treat
       // it like the array is copied.
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -2397,14 +2397,14 @@ module Enumerable {
     TakeWhileSummary() { this = "take_while" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = true
       or
       // We can't know the size of the return value, but we know that indices
       // are preserved, so, as an approximation, we just treat it like the array
       // is copied.
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -2416,7 +2416,7 @@ module Enumerable {
     ToASummary() { this = ["to_a", "entries", "to_ary"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue" and
       preservesValue = true
     }
@@ -2426,7 +2426,7 @@ module Enumerable {
     UniqSummary() { this = "uniq" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver.ArrayElement" and
+      input = "Argument[self].ArrayElement" and
       output = ["ReturnValue.ArrayElement[?]", "Argument[block].Parameter[0]"] and
       preservesValue = true
     }
@@ -2446,7 +2446,7 @@ module Enumerable {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Receiver.ArrayElement" and
+        input = "Argument[self].ArrayElement" and
         output = "Argument[block].Parameter[0].ArrayElement[0]"
         or
         exists(int i | i in [0 .. (mc.getNumberOfArguments() - 1)] |
@@ -2465,12 +2465,12 @@ module Enumerable {
       (
         // receiver[i] -> return_value[i][0]
         exists(ArrayIndex i |
-          input = "Receiver.ArrayElement[" + i + "]" and
+          input = "Argument[self].ArrayElement[" + i + "]" and
           output = "ReturnValue.ArrayElement[" + i + "].ArrayElement[0]"
         )
         or
         // receiver[?] -> return_value[?][0]
-        input = "Receiver.ArrayElement[?]" and
+        input = "Argument[self].ArrayElement[?]" and
         output = "ReturnValue.ArrayElement[?].ArrayElement[0]"
         or
         // arg_j[i] -> return_value[i][j+1]

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
@@ -17,7 +17,7 @@ module String {
    * Taint-preserving (but not value-preserving) flow from the receiver to the return value.
    */
   private predicate taintIdentityFlow(string input, string output, boolean preservesValue) {
-    input = "Receiver" and
+    input = "Argument[self]" and
     output = "ReturnValue" and
     preservesValue = false
   }
@@ -58,7 +58,7 @@ module String {
     FormatSummary() { this = "%" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["Receiver", "Argument[0]", "Argument[0].ArrayElement"] and
+      input = ["Argument[self]", "Argument[0]", "Argument[0].ArrayElement"] and
       output = "ReturnValue" and
       preservesValue = false
     }
@@ -94,7 +94,7 @@ module String {
     CapitalizeSummary() { this = ["capitalize", "capitalize!"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" and
+      input = "Argument[self]" and
       preservesValue = false and
       output = "ReturnValue"
     }
@@ -125,9 +125,9 @@ module String {
       taintIdentityFlow(input, output, preservesValue)
       or
       this = ["chomp!", "chop!"] and
-      input = "Receiver" and
+      input = "Argument[self]" and
       preservesValue = false and
-      output = "Receiver"
+      output = "Argument[self]"
     }
   }
 
@@ -152,8 +152,8 @@ module String {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = ["Receiver", "Argument[_]"] and
-      output = ["ReturnValue", "Receiver"] and
+      input = ["Argument[self]", "Argument[_]"] and
+      output = ["ReturnValue", "Argument[self]"] and
       preservesValue = false
     }
   }
@@ -212,7 +212,7 @@ module String {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = false and
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = ["Argument[block].Parameter[0]", "ReturnValue"]
     }
   }
@@ -225,7 +225,7 @@ module String {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = false and
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue.ArrayElement[?]"
     }
   }
@@ -278,7 +278,7 @@ module String {
       // block return -> return value
       preservesValue = false and
       output = "ReturnValue" and
-      input = ["Receiver", "Argument[1]", "Argument[block].ReturnValue"]
+      input = ["Argument[self]", "Argument[1]", "Argument[block].ReturnValue"]
     }
   }
 
@@ -339,7 +339,7 @@ module String {
     PartitionSummary() { this = ["partition", "rpartition"] }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue.ArrayElement[" + [0, 1, 2] + "]" and
       preservesValue = false
     }
@@ -353,7 +353,7 @@ module String {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Argument[0]" and
-      output = ["ReturnValue", "Receiver"] and
+      output = ["ReturnValue", "Argument[self]"] and
       preservesValue = false
     }
     // TODO: we should also clear any existing content in Receiver
@@ -386,7 +386,7 @@ module String {
     ScanBlockSummary() { this = "scan_with_block" and exists(mc.getBlock()) }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" and
+      input = "Argument[self]" and
       preservesValue = false and
       output =
         [
@@ -404,7 +404,7 @@ module String {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       // scan(pattern) -> array
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = false
     }
@@ -430,7 +430,7 @@ module String {
       or
       preservesValue = false and
       (
-        input = "Receiver" and
+        input = "Argument[self]" and
         output = "Argument[block].Parameter[0]"
         or
         input = "Argument[0]" and output = "ReturnValue"
@@ -471,7 +471,7 @@ module String {
     ShellSplitSummary() { this = "shellsplit" }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = false
     }
@@ -551,7 +551,7 @@ module String {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       taintIdentityFlow(input, output, preservesValue)
       or
-      input = ["Receiver", "Argument[0]"] and
+      input = ["Argument[self]", "Argument[0]"] and
       output = "Argument[block].Parameter[0]" and
       preservesValue = false
       or
@@ -571,7 +571,7 @@ module String {
     }
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
-      input = "Receiver" and
+      input = "Argument[self]" and
       output = "Argument[block].Parameter[0]" and
       preservesValue = false
       or

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
@@ -356,7 +356,7 @@ module String {
       output = ["ReturnValue", "Argument[self]"] and
       preservesValue = false
     }
-    // TODO: we should also clear any existing content in Receiver
+    // TODO: we should also clear any existing content in Argument[self]
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/String.qll
@@ -213,7 +213,7 @@ module String {
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       preservesValue = false and
       input = "Receiver" and
-      output = ["BlockArgument.Parameter[0]", "ReturnValue"]
+      output = ["Argument[block].Parameter[0]", "ReturnValue"]
     }
   }
 
@@ -278,7 +278,7 @@ module String {
       // block return -> return value
       preservesValue = false and
       output = "ReturnValue" and
-      input = ["Receiver", "Argument[1]", "BlockArgument.ReturnValue"]
+      input = ["Receiver", "Argument[1]", "Argument[block].ReturnValue"]
     }
   }
 
@@ -394,7 +394,7 @@ module String {
           "ReturnValue",
           // scan(pattern) {|match, ...| block } -> str
           // Parameter[_] doesn't seem to work
-          "BlockArgument.Parameter[" + [0 .. 10] + "]"
+          "Argument[block].Parameter[" + [0 .. 10] + "]"
         ]
     }
   }
@@ -431,11 +431,11 @@ module String {
       preservesValue = false and
       (
         input = "Receiver" and
-        output = "BlockArgument.Parameter[0]"
+        output = "Argument[block].Parameter[0]"
         or
         input = "Argument[0]" and output = "ReturnValue"
         or
-        input = "BlockArgument.ReturnValue" and
+        input = "Argument[block].ReturnValue" and
         output = "ReturnValue"
       )
     }
@@ -552,10 +552,10 @@ module String {
       taintIdentityFlow(input, output, preservesValue)
       or
       input = ["Receiver", "Argument[0]"] and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = false
       or
-      input = "BlockArgument.ReturnValue" and
+      input = "Argument[block].ReturnValue" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = false
     }
@@ -572,10 +572,10 @@ module String {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       input = "Receiver" and
-      output = "BlockArgument.Parameter[0]" and
+      output = "Argument[block].Parameter[0]" and
       preservesValue = false
       or
-      input = "BlockArgument.ReturnValue" and
+      input = "Argument[block].ReturnValue" and
       output = "ReturnValue.ArrayElement[?]" and
       preservesValue = false
     }

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -26,6 +26,8 @@ class Unit = DataFlowPrivate::Unit;
 import codeql.ruby.ApiGraphs
 import codeql.ruby.dataflow.internal.AccessPathSyntax as AccessPathSyntax
 private import AccessPathSyntax
+private import codeql.ruby.dataflow.internal.FlowSummaryImplSpecific as FlowSummaryImplSpecific
+private import codeql.ruby.dataflow.internal.DataFlowDispatch as DataFlowDispatch
 
 /**
  * Holds if models describing `package` may be relevant for the analysis of this database.
@@ -107,8 +109,13 @@ API::Node getExtraSuccessorFromNode(API::Node node, AccessPathToken token) {
   token.getName() = "Instance" and
   result = node.getInstance()
   or
-  token.getName() = "BlockArgument" and
+  token.getName() = "BlockArgument" and // TODO: replace with Argument[block]
   result = node.getBlock()
+  or
+  token.getName() = "Parameter" and
+  result =
+    node.getASuccessor(API::Label::getLabelFromArgumentPosition(FlowSummaryImplSpecific::parseParamBody(token
+              .getAnArgument())))
   // Note: The "ArrayElement" token is not implemented yet, as it ultimately requires type-tracking and
   // API graphs to be aware of the steps involving ArrayElement contributed by the standard library model.
   // Type-tracking cannot summarize function calls on its own, so it doesn't benefit from synthesized callables.
@@ -118,7 +125,12 @@ API::Node getExtraSuccessorFromNode(API::Node node, AccessPathToken token) {
  * Gets a Ruby-specific API graph successor of `node` reachable by resolving `token`.
  */
 bindingset[token]
-API::Node getExtraSuccessorFromInvoke(InvokeNode node, AccessPathToken token) { none() }
+API::Node getExtraSuccessorFromInvoke(InvokeNode node, AccessPathToken token) {
+  token.getName() = "Argument" and
+  result =
+    node.getASuccessor(API::Label::getLabelFromParameterPosition(FlowSummaryImplSpecific::parseArgBody(token
+              .getAnArgument())))
+}
 
 /**
  * Holds if `invoke` matches the Ruby-specific call site filter in `token`.
@@ -165,4 +177,7 @@ bindingset[name, argument]
 predicate isExtraValidTokenArgumentInIdentifyingAccessPath(string name, string argument) {
   name = ["Member", "Method"] and
   exists(argument)
+  or
+  name = ["Argument", "Parameter"] and
+  argument = ["self", "block"]
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -176,5 +176,9 @@ predicate isExtraValidTokenArgumentInIdentifyingAccessPath(string name, string a
   exists(argument)
   or
   name = ["Argument", "Parameter"] and
-  argument = ["self", "block"]
+  (
+    argument = ["self", "block"]
+    or
+    argument.regexpMatch("\\w+:") // keyword argument
+  )
 }

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -109,9 +109,6 @@ API::Node getExtraSuccessorFromNode(API::Node node, AccessPathToken token) {
   token.getName() = "Instance" and
   result = node.getInstance()
   or
-  token.getName() = "BlockArgument" and // TODO: replace with Argument[block]
-  result = node.getBlock()
-  or
   token.getName() = "Parameter" and
   result =
     node.getASuccessor(API::Label::getLabelFromArgumentPosition(FlowSummaryImplSpecific::parseParamBody(token
@@ -158,7 +155,7 @@ InvokeNode getAnInvocationOf(API::Node node) { result = node }
  */
 bindingset[name]
 predicate isExtraValidTokenNameInIdentifyingAccessPath(string name) {
-  name = ["Member", "Method", "Instance", "WithBlock", "WithoutBlock", "BlockArgument"]
+  name = ["Member", "Method", "Instance", "WithBlock", "WithoutBlock"]
 }
 
 /**
@@ -166,7 +163,7 @@ predicate isExtraValidTokenNameInIdentifyingAccessPath(string name) {
  * in an identifying access path.
  */
 predicate isExtraValidNoArgumentTokenInIdentifyingAccessPath(string name) {
-  name = ["Instance", "WithBlock", "WithoutBlock", "BlockArgument"]
+  name = ["Instance", "WithBlock", "WithoutBlock"]
 }
 
 /**

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -10,6 +10,8 @@ edges
 | summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:35:16:35:22 | tainted |
 | summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:36:21:36:27 | tainted |
 | summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:51:24:51:30 | tainted :  |
+| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:54:23:54:29 | tainted :  |
 | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:1:11:1:26 | call to identity :  |
 | summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
 | summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:12:7:3 | call to apply_block :  |
@@ -32,6 +34,11 @@ edges
 | summaries.rb:42:24:42:24 | t :  | summaries.rb:42:8:42:25 | call to matchedByName |
 | summaries.rb:44:8:44:8 | t :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv |
 | summaries.rb:48:24:48:30 | "taint" :  | summaries.rb:48:8:48:31 | call to preserveTaint |
+| summaries.rb:51:24:51:30 | tainted :  | summaries.rb:51:6:51:31 | call to namedArg |
+| summaries.rb:54:23:54:29 | tainted :  | summaries.rb:54:40:54:40 | x :  |
+| summaries.rb:54:40:54:40 | x :  | summaries.rb:55:8:55:8 | x |
+| summaries.rb:62:24:62:30 | "taint" :  | summaries.rb:62:8:62:31 | call to preserveTaint |
+| summaries.rb:65:26:65:32 | "taint" :  | summaries.rb:65:8:65:33 | call to preserveTaint |
 nodes
 | summaries.rb:1:11:1:26 | call to identity :  | semmle.label | call to identity :  |
 | summaries.rb:1:20:1:26 | "taint" :  | semmle.label | "taint" :  |
@@ -69,6 +76,15 @@ nodes
 | summaries.rb:44:8:44:27 | call to matchedByNameRcv | semmle.label | call to matchedByNameRcv |
 | summaries.rb:48:8:48:31 | call to preserveTaint | semmle.label | call to preserveTaint |
 | summaries.rb:48:24:48:30 | "taint" :  | semmle.label | "taint" :  |
+| summaries.rb:51:6:51:31 | call to namedArg | semmle.label | call to namedArg |
+| summaries.rb:51:24:51:30 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:54:23:54:29 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:54:40:54:40 | x :  | semmle.label | x :  |
+| summaries.rb:55:8:55:8 | x | semmle.label | x |
+| summaries.rb:62:8:62:31 | call to preserveTaint | semmle.label | call to preserveTaint |
+| summaries.rb:62:24:62:30 | "taint" :  | semmle.label | "taint" :  |
+| summaries.rb:65:8:65:33 | call to preserveTaint | semmle.label | call to preserveTaint |
+| summaries.rb:65:26:65:32 | "taint" :  | semmle.label | "taint" :  |
 subpaths
 invalidSpecComponent
 invalidOutputSpecComponent
@@ -90,6 +106,10 @@ invalidOutputSpecComponent
 | summaries.rb:42:8:42:25 | call to matchedByName | summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:42:8:42:25 | call to matchedByName | $@ | summaries.rb:40:7:40:13 | "taint" :  | "taint" :  |
 | summaries.rb:44:8:44:27 | call to matchedByNameRcv | summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv | $@ | summaries.rb:40:7:40:13 | "taint" :  | "taint" :  |
 | summaries.rb:48:8:48:31 | call to preserveTaint | summaries.rb:48:24:48:30 | "taint" :  | summaries.rb:48:8:48:31 | call to preserveTaint | $@ | summaries.rb:48:24:48:30 | "taint" :  | "taint" :  |
+| summaries.rb:51:6:51:31 | call to namedArg | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:51:6:51:31 | call to namedArg | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
+| summaries.rb:55:8:55:8 | x | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:55:8:55:8 | x | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
+| summaries.rb:62:8:62:31 | call to preserveTaint | summaries.rb:62:24:62:30 | "taint" :  | summaries.rb:62:8:62:31 | call to preserveTaint | $@ | summaries.rb:62:24:62:30 | "taint" :  | "taint" :  |
+| summaries.rb:65:8:65:33 | call to preserveTaint | summaries.rb:65:26:65:32 | "taint" :  | summaries.rb:65:8:65:33 | call to preserveTaint | $@ | summaries.rb:65:26:65:32 | "taint" :  | "taint" :  |
 warning
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,115 +1,27 @@
-edges
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:4:24:4:30 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:16:36:16:42 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:20:25:20:31 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:26:31:26:37 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:30:24:30:30 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:31:27:31:33 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:34:16:34:22 | tainted |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:35:16:35:22 | tainted |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:36:21:36:27 | tainted |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:37:36:37:42 | tainted |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:51:24:51:30 | tainted :  |
-| summaries.rb:1:11:1:26 | call to identity :  | summaries.rb:54:23:54:29 | tainted :  |
-| summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:1:11:1:26 | call to identity :  |
-| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
-| summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:12:7:3 | call to apply_block :  |
-| summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:36:4:36 | x :  |
-| summaries.rb:4:36:4:36 | x :  | summaries.rb:5:8:5:8 | x |
-| summaries.rb:11:17:11:17 | x :  | summaries.rb:12:8:12:8 | x |
-| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:18:6:18:13 | tainted3 |
-| summaries.rb:16:36:16:42 | tainted :  | summaries.rb:11:17:11:17 | x :  |
-| summaries.rb:16:36:16:42 | tainted :  | summaries.rb:16:12:16:43 | call to apply_lambda :  |
-| summaries.rb:20:12:20:32 | call to firstArg :  | summaries.rb:21:6:21:13 | tainted4 |
-| summaries.rb:20:25:20:31 | tainted :  | summaries.rb:20:12:20:32 | call to firstArg :  |
-| summaries.rb:26:12:26:38 | call to secondArg :  | summaries.rb:27:6:27:13 | tainted5 |
-| summaries.rb:26:31:26:37 | tainted :  | summaries.rb:26:12:26:38 | call to secondArg :  |
-| summaries.rb:30:24:30:30 | tainted :  | summaries.rb:30:6:30:42 | call to onlyWithBlock |
-| summaries.rb:31:27:31:33 | tainted :  | summaries.rb:31:6:31:34 | call to onlyWithoutBlock |
-| summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:41:24:41:24 | t :  |
-| summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:42:24:42:24 | t :  |
-| summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:44:8:44:8 | t :  |
-| summaries.rb:41:24:41:24 | t :  | summaries.rb:41:8:41:25 | call to matchedByName |
-| summaries.rb:42:24:42:24 | t :  | summaries.rb:42:8:42:25 | call to matchedByName |
-| summaries.rb:44:8:44:8 | t :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv |
-| summaries.rb:48:24:48:30 | "taint" :  | summaries.rb:48:8:48:31 | call to preserveTaint |
-| summaries.rb:51:24:51:30 | tainted :  | summaries.rb:51:6:51:31 | call to namedArg |
-| summaries.rb:54:23:54:29 | tainted :  | summaries.rb:54:40:54:40 | x :  |
-| summaries.rb:54:40:54:40 | x :  | summaries.rb:55:8:55:8 | x |
-| summaries.rb:62:24:62:30 | "taint" :  | summaries.rb:62:8:62:31 | call to preserveTaint |
-| summaries.rb:65:26:65:32 | "taint" :  | summaries.rb:65:8:65:33 | call to preserveTaint |
-nodes
-| summaries.rb:1:11:1:26 | call to identity :  | semmle.label | call to identity :  |
-| summaries.rb:1:20:1:26 | "taint" :  | semmle.label | "taint" :  |
-| summaries.rb:2:6:2:12 | tainted | semmle.label | tainted |
-| summaries.rb:4:12:7:3 | call to apply_block :  | semmle.label | call to apply_block :  |
-| summaries.rb:4:24:4:30 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:4:36:4:36 | x :  | semmle.label | x :  |
-| summaries.rb:5:8:5:8 | x | semmle.label | x |
-| summaries.rb:9:6:9:13 | tainted2 | semmle.label | tainted2 |
-| summaries.rb:11:17:11:17 | x :  | semmle.label | x :  |
-| summaries.rb:12:8:12:8 | x | semmle.label | x |
-| summaries.rb:16:12:16:43 | call to apply_lambda :  | semmle.label | call to apply_lambda :  |
-| summaries.rb:16:36:16:42 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:18:6:18:13 | tainted3 | semmle.label | tainted3 |
-| summaries.rb:20:12:20:32 | call to firstArg :  | semmle.label | call to firstArg :  |
-| summaries.rb:20:25:20:31 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:21:6:21:13 | tainted4 | semmle.label | tainted4 |
-| summaries.rb:26:12:26:38 | call to secondArg :  | semmle.label | call to secondArg :  |
-| summaries.rb:26:31:26:37 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:27:6:27:13 | tainted5 | semmle.label | tainted5 |
-| summaries.rb:30:6:30:42 | call to onlyWithBlock | semmle.label | call to onlyWithBlock |
-| summaries.rb:30:24:30:30 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:31:6:31:34 | call to onlyWithoutBlock | semmle.label | call to onlyWithoutBlock |
-| summaries.rb:31:27:31:33 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:34:16:34:22 | tainted | semmle.label | tainted |
-| summaries.rb:35:16:35:22 | tainted | semmle.label | tainted |
-| summaries.rb:36:21:36:27 | tainted | semmle.label | tainted |
-| summaries.rb:37:36:37:42 | tainted | semmle.label | tainted |
-| summaries.rb:40:7:40:13 | "taint" :  | semmle.label | "taint" :  |
-| summaries.rb:41:8:41:25 | call to matchedByName | semmle.label | call to matchedByName |
-| summaries.rb:41:24:41:24 | t :  | semmle.label | t :  |
-| summaries.rb:42:8:42:25 | call to matchedByName | semmle.label | call to matchedByName |
-| summaries.rb:42:24:42:24 | t :  | semmle.label | t :  |
-| summaries.rb:44:8:44:8 | t :  | semmle.label | t :  |
-| summaries.rb:44:8:44:27 | call to matchedByNameRcv | semmle.label | call to matchedByNameRcv |
-| summaries.rb:48:8:48:31 | call to preserveTaint | semmle.label | call to preserveTaint |
-| summaries.rb:48:24:48:30 | "taint" :  | semmle.label | "taint" :  |
-| summaries.rb:51:6:51:31 | call to namedArg | semmle.label | call to namedArg |
-| summaries.rb:51:24:51:30 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:54:23:54:29 | tainted :  | semmle.label | tainted :  |
-| summaries.rb:54:40:54:40 | x :  | semmle.label | x :  |
-| summaries.rb:55:8:55:8 | x | semmle.label | x |
-| summaries.rb:62:8:62:31 | call to preserveTaint | semmle.label | call to preserveTaint |
-| summaries.rb:62:24:62:30 | "taint" :  | semmle.label | "taint" :  |
-| summaries.rb:65:8:65:33 | call to preserveTaint | semmle.label | call to preserveTaint |
-| summaries.rb:65:26:65:32 | "taint" :  | semmle.label | "taint" :  |
-subpaths
+failures
+| summaries.rb:2:6:2:12 | tainted | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:5:8:5:8 | x | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:9:6:9:13 | tainted2 | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:12:8:12:8 | x | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:18:6:18:13 | tainted3 | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:21:6:21:13 | tainted4 | Unexpected result: hasTaintFlow=tainted |
+| summaries.rb:27:6:27:13 | tainted5 | Unexpected result: hasTaintFlow=tainted |
+| summaries.rb:30:6:30:42 | call to onlyWithBlock | Unexpected result: hasTaintFlow=tainted |
+| summaries.rb:31:6:31:34 | call to onlyWithoutBlock | Unexpected result: hasTaintFlow=tainted |
+| summaries.rb:34:16:34:22 | tainted | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:35:16:35:22 | tainted | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:36:21:36:27 | tainted | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:37:36:37:42 | tainted | Unexpected result: hasValueFlow=tainted |
+| summaries.rb:41:8:41:25 | call to matchedByName | Unexpected result: hasTaintFlow=t |
+| summaries.rb:42:8:42:25 | call to matchedByName | Unexpected result: hasTaintFlow=t |
+| summaries.rb:44:8:44:27 | call to matchedByNameRcv | Unexpected result: hasTaintFlow=t |
+| summaries.rb:48:8:48:42 | call to preserveTaint | Unexpected result: hasTaintFlow=blockArg |
+| summaries.rb:51:6:51:31 | call to namedArg | Unexpected result: hasTaintFlow=tainted |
+| summaries.rb:55:8:55:8 | x | Unexpected result: hasTaintFlow=tainted |
+| summaries.rb:62:8:62:54 | call to preserveTaint | Unexpected result: hasTaintFlow=startInNamedCallback |
+| summaries.rb:65:8:65:57 | call to preserveTaint | Unexpected result: hasTaintFlow=startInNamedParameter |
 invalidSpecComponent
 invalidOutputSpecComponent
-#select
-| summaries.rb:2:6:2:12 | tainted | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:2:6:2:12 | tainted | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:5:8:5:8 | x | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:5:8:5:8 | x | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:9:6:9:13 | tainted2 | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:9:6:9:13 | tainted2 | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:12:8:12:8 | x | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:12:8:12:8 | x | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:18:6:18:13 | tainted3 | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:18:6:18:13 | tainted3 | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:21:6:21:13 | tainted4 | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:21:6:21:13 | tainted4 | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:27:6:27:13 | tainted5 | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:27:6:27:13 | tainted5 | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:30:6:30:42 | call to onlyWithBlock | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:30:6:30:42 | call to onlyWithBlock | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:31:6:31:34 | call to onlyWithoutBlock | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:31:6:31:34 | call to onlyWithoutBlock | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:34:16:34:22 | tainted | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:34:16:34:22 | tainted | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:35:16:35:22 | tainted | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:35:16:35:22 | tainted | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:36:21:36:27 | tainted | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:36:21:36:27 | tainted | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:37:36:37:42 | tainted | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:37:36:37:42 | tainted | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:41:8:41:25 | call to matchedByName | summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:41:8:41:25 | call to matchedByName | $@ | summaries.rb:40:7:40:13 | "taint" :  | "taint" :  |
-| summaries.rb:42:8:42:25 | call to matchedByName | summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:42:8:42:25 | call to matchedByName | $@ | summaries.rb:40:7:40:13 | "taint" :  | "taint" :  |
-| summaries.rb:44:8:44:27 | call to matchedByNameRcv | summaries.rb:40:7:40:13 | "taint" :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv | $@ | summaries.rb:40:7:40:13 | "taint" :  | "taint" :  |
-| summaries.rb:48:8:48:31 | call to preserveTaint | summaries.rb:48:24:48:30 | "taint" :  | summaries.rb:48:8:48:31 | call to preserveTaint | $@ | summaries.rb:48:24:48:30 | "taint" :  | "taint" :  |
-| summaries.rb:51:6:51:31 | call to namedArg | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:51:6:51:31 | call to namedArg | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:55:8:55:8 | x | summaries.rb:1:20:1:26 | "taint" :  | summaries.rb:55:8:55:8 | x | $@ | summaries.rb:1:20:1:26 | "taint" :  | "taint" :  |
-| summaries.rb:62:8:62:31 | call to preserveTaint | summaries.rb:62:24:62:30 | "taint" :  | summaries.rb:62:8:62:31 | call to preserveTaint | $@ | summaries.rb:62:24:62:30 | "taint" :  | "taint" :  |
-| summaries.rb:65:8:65:33 | call to preserveTaint | summaries.rb:65:26:65:32 | "taint" :  | summaries.rb:65:8:65:33 | call to preserveTaint | $@ | summaries.rb:65:26:65:32 | "taint" :  | "taint" :  |
 warning
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,6 +1,158 @@
 failures
+edges
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:2:6:2:12 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:4:24:4:30 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:4:24:4:30 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:16:36:16:42 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:16:36:16:42 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:20:25:20:31 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:26:31:26:37 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:30:24:30:30 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:31:27:31:33 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:34:16:34:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:34:16:34:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:35:16:35:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:35:16:35:22 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:36:21:36:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:36:21:36:27 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:37:36:37:42 | tainted |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:51:24:51:30 | tainted :  |
+| summaries.rb:1:11:1:36 | call to identity :  | summaries.rb:54:23:54:29 | tainted :  |
+| summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
+| summaries.rb:1:20:1:36 | call to source :  | summaries.rb:1:11:1:36 | call to identity :  |
+| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
+| summaries.rb:4:12:7:3 | call to apply_block :  | summaries.rb:9:6:9:13 | tainted2 |
+| summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:12:7:3 | call to apply_block :  |
+| summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:12:7:3 | call to apply_block :  |
+| summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:36:4:36 | x :  |
+| summaries.rb:4:24:4:30 | tainted :  | summaries.rb:4:36:4:36 | x :  |
+| summaries.rb:4:36:4:36 | x :  | summaries.rb:5:8:5:8 | x |
+| summaries.rb:4:36:4:36 | x :  | summaries.rb:5:8:5:8 | x |
+| summaries.rb:11:17:11:17 | x :  | summaries.rb:12:8:12:8 | x |
+| summaries.rb:11:17:11:17 | x :  | summaries.rb:12:8:12:8 | x |
+| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:18:6:18:13 | tainted3 |
+| summaries.rb:16:12:16:43 | call to apply_lambda :  | summaries.rb:18:6:18:13 | tainted3 |
+| summaries.rb:16:36:16:42 | tainted :  | summaries.rb:11:17:11:17 | x :  |
+| summaries.rb:16:36:16:42 | tainted :  | summaries.rb:11:17:11:17 | x :  |
+| summaries.rb:16:36:16:42 | tainted :  | summaries.rb:16:12:16:43 | call to apply_lambda :  |
+| summaries.rb:16:36:16:42 | tainted :  | summaries.rb:16:12:16:43 | call to apply_lambda :  |
+| summaries.rb:20:12:20:32 | call to firstArg :  | summaries.rb:21:6:21:13 | tainted4 |
+| summaries.rb:20:25:20:31 | tainted :  | summaries.rb:20:12:20:32 | call to firstArg :  |
+| summaries.rb:26:12:26:38 | call to secondArg :  | summaries.rb:27:6:27:13 | tainted5 |
+| summaries.rb:26:31:26:37 | tainted :  | summaries.rb:26:12:26:38 | call to secondArg :  |
+| summaries.rb:30:24:30:30 | tainted :  | summaries.rb:30:6:30:42 | call to onlyWithBlock |
+| summaries.rb:31:27:31:33 | tainted :  | summaries.rb:31:6:31:34 | call to onlyWithoutBlock |
+| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:41:24:41:24 | t :  |
+| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:42:24:42:24 | t :  |
+| summaries.rb:40:7:40:17 | call to source :  | summaries.rb:44:8:44:8 | t :  |
+| summaries.rb:41:24:41:24 | t :  | summaries.rb:41:8:41:25 | call to matchedByName |
+| summaries.rb:42:24:42:24 | t :  | summaries.rb:42:8:42:25 | call to matchedByName |
+| summaries.rb:44:8:44:8 | t :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv |
+| summaries.rb:48:24:48:41 | call to source :  | summaries.rb:48:8:48:42 | call to preserveTaint |
+| summaries.rb:51:24:51:30 | tainted :  | summaries.rb:51:6:51:31 | call to namedArg |
+| summaries.rb:54:23:54:29 | tainted :  | summaries.rb:54:40:54:40 | x :  |
+| summaries.rb:54:40:54:40 | x :  | summaries.rb:55:8:55:8 | x |
+| summaries.rb:62:24:62:53 | call to source :  | summaries.rb:62:8:62:54 | call to preserveTaint |
+| summaries.rb:65:26:65:56 | call to source :  | summaries.rb:65:8:65:57 | call to preserveTaint |
+nodes
+| summaries.rb:1:11:1:36 | call to identity :  | semmle.label | call to identity :  |
+| summaries.rb:1:11:1:36 | call to identity :  | semmle.label | call to identity :  |
+| summaries.rb:1:20:1:36 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:1:20:1:36 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:2:6:2:12 | tainted | semmle.label | tainted |
+| summaries.rb:2:6:2:12 | tainted | semmle.label | tainted |
+| summaries.rb:4:12:7:3 | call to apply_block :  | semmle.label | call to apply_block :  |
+| summaries.rb:4:12:7:3 | call to apply_block :  | semmle.label | call to apply_block :  |
+| summaries.rb:4:24:4:30 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:4:24:4:30 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:4:36:4:36 | x :  | semmle.label | x :  |
+| summaries.rb:4:36:4:36 | x :  | semmle.label | x :  |
+| summaries.rb:5:8:5:8 | x | semmle.label | x |
+| summaries.rb:5:8:5:8 | x | semmle.label | x |
+| summaries.rb:9:6:9:13 | tainted2 | semmle.label | tainted2 |
+| summaries.rb:9:6:9:13 | tainted2 | semmle.label | tainted2 |
+| summaries.rb:11:17:11:17 | x :  | semmle.label | x :  |
+| summaries.rb:11:17:11:17 | x :  | semmle.label | x :  |
+| summaries.rb:12:8:12:8 | x | semmle.label | x |
+| summaries.rb:12:8:12:8 | x | semmle.label | x |
+| summaries.rb:16:12:16:43 | call to apply_lambda :  | semmle.label | call to apply_lambda :  |
+| summaries.rb:16:12:16:43 | call to apply_lambda :  | semmle.label | call to apply_lambda :  |
+| summaries.rb:16:36:16:42 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:16:36:16:42 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:18:6:18:13 | tainted3 | semmle.label | tainted3 |
+| summaries.rb:18:6:18:13 | tainted3 | semmle.label | tainted3 |
+| summaries.rb:20:12:20:32 | call to firstArg :  | semmle.label | call to firstArg :  |
+| summaries.rb:20:25:20:31 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:21:6:21:13 | tainted4 | semmle.label | tainted4 |
+| summaries.rb:26:12:26:38 | call to secondArg :  | semmle.label | call to secondArg :  |
+| summaries.rb:26:31:26:37 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:27:6:27:13 | tainted5 | semmle.label | tainted5 |
+| summaries.rb:30:6:30:42 | call to onlyWithBlock | semmle.label | call to onlyWithBlock |
+| summaries.rb:30:24:30:30 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:31:6:31:34 | call to onlyWithoutBlock | semmle.label | call to onlyWithoutBlock |
+| summaries.rb:31:27:31:33 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:34:16:34:22 | tainted | semmle.label | tainted |
+| summaries.rb:34:16:34:22 | tainted | semmle.label | tainted |
+| summaries.rb:35:16:35:22 | tainted | semmle.label | tainted |
+| summaries.rb:35:16:35:22 | tainted | semmle.label | tainted |
+| summaries.rb:36:21:36:27 | tainted | semmle.label | tainted |
+| summaries.rb:36:21:36:27 | tainted | semmle.label | tainted |
+| summaries.rb:37:36:37:42 | tainted | semmle.label | tainted |
+| summaries.rb:37:36:37:42 | tainted | semmle.label | tainted |
+| summaries.rb:40:7:40:17 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:41:8:41:25 | call to matchedByName | semmle.label | call to matchedByName |
+| summaries.rb:41:24:41:24 | t :  | semmle.label | t :  |
+| summaries.rb:42:8:42:25 | call to matchedByName | semmle.label | call to matchedByName |
+| summaries.rb:42:24:42:24 | t :  | semmle.label | t :  |
+| summaries.rb:44:8:44:8 | t :  | semmle.label | t :  |
+| summaries.rb:44:8:44:27 | call to matchedByNameRcv | semmle.label | call to matchedByNameRcv |
+| summaries.rb:48:8:48:42 | call to preserveTaint | semmle.label | call to preserveTaint |
+| summaries.rb:48:24:48:41 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:51:6:51:31 | call to namedArg | semmle.label | call to namedArg |
+| summaries.rb:51:24:51:30 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:54:23:54:29 | tainted :  | semmle.label | tainted :  |
+| summaries.rb:54:40:54:40 | x :  | semmle.label | x :  |
+| summaries.rb:55:8:55:8 | x | semmle.label | x |
+| summaries.rb:62:8:62:54 | call to preserveTaint | semmle.label | call to preserveTaint |
+| summaries.rb:62:24:62:53 | call to source :  | semmle.label | call to source :  |
+| summaries.rb:65:8:65:57 | call to preserveTaint | semmle.label | call to preserveTaint |
+| summaries.rb:65:26:65:56 | call to source :  | semmle.label | call to source :  |
+subpaths
 invalidSpecComponent
 invalidOutputSpecComponent
+#select
+| summaries.rb:2:6:2:12 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:2:6:2:12 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:2:6:2:12 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:2:6:2:12 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:5:8:5:8 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:5:8:5:8 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:5:8:5:8 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:5:8:5:8 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:9:6:9:13 | tainted2 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:9:6:9:13 | tainted2 | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:9:6:9:13 | tainted2 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:9:6:9:13 | tainted2 | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:12:8:12:8 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:12:8:12:8 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:12:8:12:8 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:12:8:12:8 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:18:6:18:13 | tainted3 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:18:6:18:13 | tainted3 | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:18:6:18:13 | tainted3 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:18:6:18:13 | tainted3 | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:21:6:21:13 | tainted4 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:21:6:21:13 | tainted4 | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:27:6:27:13 | tainted5 | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:27:6:27:13 | tainted5 | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:30:6:30:42 | call to onlyWithBlock | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:30:6:30:42 | call to onlyWithBlock | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:31:6:31:34 | call to onlyWithoutBlock | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:31:6:31:34 | call to onlyWithoutBlock | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:34:16:34:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:34:16:34:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:34:16:34:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:34:16:34:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:35:16:35:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:35:16:35:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:35:16:35:22 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:35:16:35:22 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:36:21:36:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:36:21:36:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:36:21:36:27 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:36:21:36:27 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:37:36:37:42 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:37:36:37:42 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:37:36:37:42 | tainted | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:37:36:37:42 | tainted | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:41:8:41:25 | call to matchedByName | summaries.rb:40:7:40:17 | call to source :  | summaries.rb:41:8:41:25 | call to matchedByName | $@ | summaries.rb:40:7:40:17 | call to source :  | call to source :  |
+| summaries.rb:42:8:42:25 | call to matchedByName | summaries.rb:40:7:40:17 | call to source :  | summaries.rb:42:8:42:25 | call to matchedByName | $@ | summaries.rb:40:7:40:17 | call to source :  | call to source :  |
+| summaries.rb:44:8:44:27 | call to matchedByNameRcv | summaries.rb:40:7:40:17 | call to source :  | summaries.rb:44:8:44:27 | call to matchedByNameRcv | $@ | summaries.rb:40:7:40:17 | call to source :  | call to source :  |
+| summaries.rb:48:8:48:42 | call to preserveTaint | summaries.rb:48:24:48:41 | call to source :  | summaries.rb:48:8:48:42 | call to preserveTaint | $@ | summaries.rb:48:24:48:41 | call to source :  | call to source :  |
+| summaries.rb:51:6:51:31 | call to namedArg | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:51:6:51:31 | call to namedArg | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:55:8:55:8 | x | summaries.rb:1:20:1:36 | call to source :  | summaries.rb:55:8:55:8 | x | $@ | summaries.rb:1:20:1:36 | call to source :  | call to source :  |
+| summaries.rb:62:8:62:54 | call to preserveTaint | summaries.rb:62:24:62:53 | call to source :  | summaries.rb:62:8:62:54 | call to preserveTaint | $@ | summaries.rb:62:24:62:53 | call to source :  | call to source :  |
+| summaries.rb:65:8:65:57 | call to preserveTaint | summaries.rb:65:26:65:56 | call to source :  | summaries.rb:65:8:65:57 | call to preserveTaint | $@ | summaries.rb:65:26:65:56 | call to source :  | call to source :  |
 warning
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -1,25 +1,4 @@
 failures
-| summaries.rb:2:6:2:12 | tainted | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:5:8:5:8 | x | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:9:6:9:13 | tainted2 | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:12:8:12:8 | x | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:18:6:18:13 | tainted3 | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:21:6:21:13 | tainted4 | Unexpected result: hasTaintFlow=tainted |
-| summaries.rb:27:6:27:13 | tainted5 | Unexpected result: hasTaintFlow=tainted |
-| summaries.rb:30:6:30:42 | call to onlyWithBlock | Unexpected result: hasTaintFlow=tainted |
-| summaries.rb:31:6:31:34 | call to onlyWithoutBlock | Unexpected result: hasTaintFlow=tainted |
-| summaries.rb:34:16:34:22 | tainted | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:35:16:35:22 | tainted | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:36:21:36:27 | tainted | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:37:36:37:42 | tainted | Unexpected result: hasValueFlow=tainted |
-| summaries.rb:41:8:41:25 | call to matchedByName | Unexpected result: hasTaintFlow=t |
-| summaries.rb:42:8:42:25 | call to matchedByName | Unexpected result: hasTaintFlow=t |
-| summaries.rb:44:8:44:27 | call to matchedByNameRcv | Unexpected result: hasTaintFlow=t |
-| summaries.rb:48:8:48:42 | call to preserveTaint | Unexpected result: hasTaintFlow=blockArg |
-| summaries.rb:51:6:51:31 | call to namedArg | Unexpected result: hasTaintFlow=tainted |
-| summaries.rb:55:8:55:8 | x | Unexpected result: hasTaintFlow=tainted |
-| summaries.rb:62:8:62:54 | call to preserveTaint | Unexpected result: hasTaintFlow=startInNamedCallback |
-| summaries.rb:65:8:65:57 | call to preserveTaint | Unexpected result: hasTaintFlow=startInNamedParameter |
 invalidSpecComponent
 invalidOutputSpecComponent
 warning

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -9,6 +9,7 @@ import codeql.ruby.dataflow.internal.FlowSummaryImpl
 import codeql.ruby.dataflow.internal.AccessPathSyntax
 import codeql.ruby.frameworks.data.ModelsAsData
 import TestUtilities.InlineFlowTest
+import DataFlow::PathGraph
 
 query predicate invalidSpecComponent(SummarizedCallable sc, string s, string c) {
   (sc.propagatesFlowExt(s, _, _) or sc.propagatesFlowExt(_, s, _)) and
@@ -132,3 +133,7 @@ class CustomTaintSink extends DefaultTaintFlowConf {
     sink = ModelOutput::getASinkNode("test-sink").getARhs()
   }
 }
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Configuration conf
+where conf.hasFlowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -42,10 +42,10 @@ private class SummarizedCallableApplyBlock extends SummarizedCallable {
 
   override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
     input = "Argument[0]" and
-    output = "BlockArgument.Parameter[0]" and
+    output = "Argument[block].Parameter[0]" and
     preservesValue = true
     or
-    input = "BlockArgument.ReturnValue" and
+    input = "Argument[block].ReturnValue" and
     output = "ReturnValue" and
     preservesValue = true
   }
@@ -75,9 +75,9 @@ private class StepsFromModel extends ModelInput::SummaryModelCsv {
         ";;Member[Foo].Method[secondArg];Argument[1];ReturnValue;taint",
         ";;Member[Foo].Method[onlyWithoutBlock].WithoutBlock;Argument[0];ReturnValue;taint",
         ";;Member[Foo].Method[onlyWithBlock].WithBlock;Argument[0];ReturnValue;taint",
-        ";;Member[Foo].Method[blockArg].BlockArgument.Parameter[0].Method[preserveTaint];Argument[0];ReturnValue;taint",
+        ";;Member[Foo].Method[blockArg].Argument[block].Parameter[0].Method[preserveTaint];Argument[0];ReturnValue;taint",
         ";any;Method[matchedByName];Argument[0];ReturnValue;taint",
-        ";any;Method[matchedByNameRcv];Receiver;ReturnValue;taint",
+        ";any;Method[matchedByNameRcv];Argument[self];ReturnValue;taint",
       ]
   }
 }

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.ql
@@ -76,6 +76,11 @@ private class StepsFromModel extends ModelInput::SummaryModelCsv {
         ";;Member[Foo].Method[onlyWithoutBlock].WithoutBlock;Argument[0];ReturnValue;taint",
         ";;Member[Foo].Method[onlyWithBlock].WithBlock;Argument[0];ReturnValue;taint",
         ";;Member[Foo].Method[blockArg].Argument[block].Parameter[0].Method[preserveTaint];Argument[0];ReturnValue;taint",
+        ";;Member[Foo].Method[namedArg];Argument[foo:];ReturnValue;taint",
+        ";;Member[Foo].Method[intoNamedCallback];Argument[0];Argument[foo:].Parameter[0];taint",
+        ";;Member[Foo].Method[intoNamedParameter];Argument[0];Argument[0].Parameter[foo:];taint",
+        ";;Member[Foo].Method[startInNamedCallback].Argument[foo:].Parameter[0].Method[preserveTaint];Argument[0];ReturnValue;taint",
+        ";;Member[Foo].Method[startInNamedParameter].Argument[0].Parameter[foo:].Method[preserveTaint];Argument[0];ReturnValue;taint",
         ";any;Method[matchedByName];Argument[0];ReturnValue;taint",
         ";any;Method[matchedByNameRcv];Argument[self];ReturnValue;taint",
       ]

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -47,3 +47,20 @@ end
 Foo.blockArg do |x|
   sink(x.preserveTaint("taint"))
 end
+
+sink(Foo.namedArg(foo: tainted))
+sink(Foo.namedArg(tainted))
+
+Foo.intoNamedCallback(tainted, foo: ->(x) {
+  sink(x)
+})
+Foo.intoNamedParameter(tainted, ->(foo:) {
+  sink(foo)
+})
+
+Foo.startInNamedCallback(foo: ->(x) {
+  sink(x.preserveTaint("taint"))
+})
+Foo.startInNamedParameter(->(foo:) {
+  sink(foo.preserveTaint("taint"))
+})

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -1,66 +1,66 @@
 tainted = identity source("tainted")
-sink tainted
+sink tainted # $ hasValueFlow=tainted
 
 tainted2 = apply_block tainted do |x|
-  sink x
+  sink x # $ hasValueFlow=tainted
   x
 end
 
-sink tainted2
+sink tainted2 # $ hasValueFlow=tainted
 
 my_lambda = -> (x) {
-  sink x
+  sink x # $ hasValueFlow=tainted
   x
 }
 
 tainted3 = apply_lambda(my_lambda, tainted)
 
-sink(tainted3)
+sink(tainted3) # $ hasValueFlow=tainted
 
 tainted4 = Foo.firstArg(tainted)
-sink(tainted4)
+sink(tainted4) # $ hasTaintFlow=tainted
 
 notTainted = Foo.firstArg(nil, tainted))
 sink(notTainted)
 
 tainted5 = Foo.secondArg(nil, tainted)
-sink(tainted5)
+sink(tainted5) # $ hasTaintFlow=tainted
 
 sink(Foo.onlyWithBlock(tainted))
-sink(Foo.onlyWithBlock(tainted) do |x| end)
-sink(Foo.onlyWithoutBlock(tainted))
+sink(Foo.onlyWithBlock(tainted) do |x| end) # $ hasTaintFlow=tainted
+sink(Foo.onlyWithoutBlock(tainted)) # $ hasTaintFlow=tainted
 sink(Foo.onlyWithoutBlock(tainted) do |x| end)
 
-Foo.new.method(tainted)
-Bar.new.method(tainted)
-Bar.new.next.method(tainted)
-Bar.new.next.next.next.next.method(tainted)
+Foo.new.method(tainted) # $ hasValueFlow=tainted
+Bar.new.method(tainted) # $ hasValueFlow=tainted
+Bar.new.next.method(tainted) # $ hasValueFlow=tainted
+Bar.new.next.next.next.next.method(tainted) # $ hasValueFlow=tainted
 
 def userDefinedFunction(x, y)
   t = source("t")
-  sink(x.matchedByName(t))
-  sink(y.matchedByName(t))
+  sink(x.matchedByName(t)) # $ hasTaintFlow=t
+  sink(y.matchedByName(t)) # $ hasTaintFlow=t
   sink(x.unmatchedName(t))
-  sink(t.matchedByNameRcv())
+  sink(t.matchedByNameRcv()) # $ hasTaintFlow=t
 end
 
 Foo.blockArg do |x|
-  sink(x.preserveTaint(source("blockArg")))
+  sink(x.preserveTaint(source("blockArg"))) # $ hasTaintFlow=blockArg
 end
 
-sink(Foo.namedArg(foo: tainted))
+sink(Foo.namedArg(foo: tainted)) # $ hasTaintFlow=tainted
 sink(Foo.namedArg(tainted))
 
 Foo.intoNamedCallback(tainted, foo: ->(x) {
-  sink(x)
+  sink(x) # $ hasTaintFlow=tainted
 })
 Foo.intoNamedParameter(tainted, ->(foo:) {
-  sink(foo)
+  sink(foo) # $ MISSING: hasTaintFlow=tainted
 })
 
 Foo.startInNamedCallback(foo: ->(x) {
-  sink(x.preserveTaint(source("startInNamedCallback")))
+  sink(x.preserveTaint(source("startInNamedCallback"))) # $ hasTaintFlow=startInNamedCallback
 })
 Foo.startInNamedParameter(->(foo:) {
-  sink(foo.preserveTaint(source("startInNamedParameter")))
+  sink(foo.preserveTaint(source("startInNamedParameter"))) # $ hasTaintFlow=startInNamedParameter
 })

--- a/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
+++ b/ruby/ql/test/library-tests/dataflow/summaries/summaries.rb
@@ -1,4 +1,4 @@
-tainted = identity "taint"
+tainted = identity source("tainted")
 sink tainted
 
 tainted2 = apply_block tainted do |x|
@@ -37,7 +37,7 @@ Bar.new.next.method(tainted)
 Bar.new.next.next.next.next.method(tainted)
 
 def userDefinedFunction(x, y)
-  t = "taint"
+  t = source("t")
   sink(x.matchedByName(t))
   sink(y.matchedByName(t))
   sink(x.unmatchedName(t))
@@ -45,7 +45,7 @@ def userDefinedFunction(x, y)
 end
 
 Foo.blockArg do |x|
-  sink(x.preserveTaint("taint"))
+  sink(x.preserveTaint(source("blockArg")))
 end
 
 sink(Foo.namedArg(foo: tainted))
@@ -59,8 +59,8 @@ Foo.intoNamedParameter(tainted, ->(foo:) {
 })
 
 Foo.startInNamedCallback(foo: ->(x) {
-  sink(x.preserveTaint("taint"))
+  sink(x.preserveTaint(source("startInNamedCallback")))
 })
 Foo.startInNamedParameter(->(foo:) {
-  sink(foo.preserveTaint("taint"))
+  sink(foo.preserveTaint(source("startInNamedParameter")))
 })


### PR DESCRIPTION
Previously we had separate tokens for non-positional arguments, like `Receiver` and `BlockArgument`.

Now these are represented as operands to `Argument`/`Parameter` tokens, as discussed with @hvitved:

Ruby:
- `Argument[self]` for the receiver (previously `Receiver`)
- `Argument[block]` for the block argument (previously `BlockArgument`)
- `Argument[foo:]` for a keyword argument named `foo` (previously not implemented)

JS:
- `Argument[this]` for the receiver (previously `Argument[-1]`)

All of the above also apply to the `Parameter` token.

The names `self` and `this` were chosen to coincide with the keyword/convention from the language.