### PR TITLE
Ruby: Fix bad join-order in `RegExpTerm::hasLocationInfo`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/performance/RegExpTreeView.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/RegExpTreeView.qll
@@ -190,15 +190,21 @@ class RegExpTerm extends RegExpParent {
 
   Location getLocation() { result = re.getLocation() }
 
+  pragma[noinline]
+  private predicate componentHasLocationInfo(
+    int i, string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    re.getComponent(i)
+        .getLocation()
+        .hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
     exists(int re_start, int re_end |
-      re.getComponent(0).getLocation().hasLocationInfo(filepath, startline, re_start, _, _) and
-      re.getComponent(re.getNumberOfComponents() - 1)
-          .getLocation()
-          .hasLocationInfo(filepath, _, _, endline, re_end)
-    |
+      this.componentHasLocationInfo(0, filepath, startline, re_start, _, _) and
+      this.componentHasLocationInfo(re.getNumberOfComponents() - 1, filepath, _, _, endline, re_end) and
       startcolumn = re_start + start and
       endcolumn = re_start + end - 1
     )


### PR DESCRIPTION
Before:
```
[2022-03-23 14:50:16] (776s) Tuple counts for RegExpTreeView::RegExpTerm::hasLocationInfo#dispred#f0820431#ffffff/6@5f6cf7if after 1m4s:
                      707103    ~7%     {2} r1 = SCAN Literal::StringlikeLiteral::getNumberOfComponents#dispred#f0820431#ff OUTPUT In.0, (In.1 - 1)
                      64721     ~0%     {5} r2 = JOIN r1 WITH RegExpTreeView::RegExpTerm#7783c185#ffff_1023#join_rhs ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Rhs.1 'this', Rhs.2, Rhs.3
                      64721     ~0%     {5} r3 = JOIN r2 WITH Literal::StringlikeLiteral::getComponent#dispred#f0820431#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.0, Lhs.2 'this', Lhs.3, Lhs.4
                      64721     ~0%     {5} r4 = JOIN r3 WITH AST::AstNode::getLocation#dispred#f0820431#bf ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2 'this', Lhs.3, Lhs.4
                      64721     ~3%     {6} r5 = JOIN r4 WITH Locations::Location::hasLocationInfo#dispred#f0820431#ffffff ON FIRST 1 OUTPUT Rhs.1 'filepath', Lhs.1, Lhs.2 'this', Lhs.3, Lhs.4, Rhs.4 'endline'
                      353247577 ~1%     {10} r6 = JOIN r5 WITH Locations::Location::hasLocationInfo#dispred#f0820431#ffffff_1023#join_rhs ON FIRST 1 OUTPUT Lhs.1, 0, Lhs.2 'this', Lhs.3, Lhs.4, Lhs.0 'filepath', Lhs.5 'endline', Rhs.1, Rhs.2 'startline', Rhs.3
                      353247577 ~0%     {9} r7 = JOIN r6 WITH Literal::StringlikeLiteral::getComponent#dispred#f0820431#fff ON FIRST 2 OUTPUT Rhs.2, Lhs.7, Lhs.2 'this', Lhs.3, Lhs.4, Lhs.5 'filepath', Lhs.6 'endline', Lhs.8 'startline', Lhs.9
                      64721     ~2%     {6} r8 = JOIN r7 WITH AST::AstNode::getLocation#dispred#f0820431#bf ON FIRST 2 OUTPUT Lhs.2 'this', Lhs.5 'filepath', Lhs.7 'startline', (Lhs.8 + Lhs.3), Lhs.6 'endline', ((Lhs.8 + Lhs.4) - 1)
                                        return r8
```

After:
```
[2022-03-23 14:58:35] (247s) Tuple counts for RegExpTreeView::RegExpTerm::componentHasLocationInfo#f0820431#fbfffff/7@de55ac7l after 1.1s:
                      12956   ~0%     {3} r1 = SCAN files OUTPUT In.0, 0, In.1 'filepath'
                      9850785 ~0%     {7} r2 = JOIN r1 WITH locations_default_102345#join_rhs ON FIRST 1 OUTPUT Rhs.1, 0, Lhs.2 'filepath', Rhs.2 'startline', Rhs.3 'startcolumn', Rhs.4 'endline', Rhs.5 'endcolumn'
                      823486  ~0%     {8} r3 = JOIN r2 WITH AST::AstNode::getLocation#dispred#f0820431#bf_10#join_rhs ON FIRST 1 OUTPUT 0, Rhs.1, 0, Lhs.2 'filepath', Lhs.3 'startline', Lhs.4 'startcolumn', Lhs.5 'endline', Lhs.6 'endcolumn'
                      698251  ~4%     {7} r4 = JOIN r3 WITH Literal::StringlikeLiteral::getComponent#dispred#f0820431#fff_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, 0, Lhs.3 'filepath', Lhs.4 'startline', Lhs.5 'startcolumn', Lhs.6 'endline', Lhs.7 'endcolumn'
                      64721   ~1%     {7} r5 = JOIN r4 WITH RegExpTreeView::RegExpTerm#7783c185#ffff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1 'this', 0, Lhs.2 'filepath', Lhs.3 'startline', Lhs.4 'startcolumn', Lhs.5 'endline', Lhs.6 'endcolumn'
                                      return r5

[2022-03-23 14:58:35] (247s) Tuple counts for RegExpTreeView::RegExpTerm::hasLocationInfo#dispred#f0820431#ffffff/6@ad66b12q after 53ms:
                      707103 ~7%     {2} r1 = SCAN Literal::StringlikeLiteral::getNumberOfComponents#dispred#f0820431#ff OUTPUT In.0, (In.1 - 1)
                      64721  ~0%     {4} r2 = JOIN r1 WITH RegExpTreeView::RegExpTerm#7783c185#ffff_1023#join_rhs ON FIRST 1 OUTPUT Rhs.1 'this', Lhs.1, Rhs.2, Rhs.3
                      64721  ~5%     {5} r3 = JOIN r2 WITH project#RegExpTreeView::RegExpTerm::componentHasLocationInfo#f0820431#bffffff ON FIRST 2 OUTPUT Lhs.0 'this', Rhs.2 'filepath', Lhs.2, Lhs.3, Rhs.3 'endline'
                      64721  ~2%     {6} r4 = JOIN r3 WITH project#RegExpTreeView::RegExpTerm::componentHasLocationInfo#f0820431#fbfffff ON FIRST 2 OUTPUT Lhs.0 'this', Lhs.1 'filepath', Rhs.2 'startline', (Rhs.3 + Lhs.2), Lhs.4 'endline', ((Rhs.3 + Lhs.3) - 1)
                                     return r4
```