### PR TITLE
Ruby: Fix bad name of lambda in test

### DIFF
--- a/ruby/ql/test/library-tests/ast/Ast.expected
+++ b/ruby/ql/test/library-tests/ast/Ast.expected
@@ -710,7 +710,7 @@ calls/calls.rb:
 #  350|     getAnOperand/getLeftOperand: [LocalVariableAccess] y
 #  350|     getAnOperand/getRightOperand: [IntegerLiteral] 1
 #  351|   getStmt: [AssignExpr] ... = ...
-#  351|     getAnOperand/getLeftOperand: [LocalVariableAccess] id
+#  351|     getAnOperand/getLeftOperand: [LocalVariableAccess] one
 #  351|     getAnOperand/getRightOperand: [Lambda] -> { ... }
 #  351|       getParameter: [SimpleParameter] x
 #  351|         getDefiningAccess: [LocalVariableAccess] x

--- a/ruby/ql/test/library-tests/ast/calls/calls.rb
+++ b/ruby/ql/test/library-tests/ast/calls/calls.rb
@@ -348,7 +348,7 @@ foo(X:)
 
 # calls inside lambdas
 y = 1
-id = ->(x) { y }
+one = ->(x) { y }
 f = ->(x) { foo x }
 g = ->(x) { unknown_call }
 h = -> (x) do


### PR DESCRIPTION
This isn't the identity function, so it's confusing for it to be named
so.
