### PR TITLE
QL: two small improvements

### DIFF
--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -1129,6 +1129,21 @@ class Import extends TImport, ModuleMember, ModuleRef {
     result = imp.getChild(0).(QL::ImportModuleExpr).getChild().getName(i).getValue()
   }
 
+  /**
+   * Gets the full string specifying the module being imported.
+   */
+  string getImportString() {
+    exists(string selec |
+      not exists(getQualifiedName(_)) and selec = ""
+      or
+      selec =
+        "::" + strictconcat(int i, string q | q = this.getSelectionName(i) | q, "::" order by i)
+    |
+      result =
+        strictconcat(int i, string q | q = this.getQualifiedName(i) | q, "." order by i) + selec
+    )
+  }
+
   final override FileOrModule getResolvedModule() { resolve(this, result) }
 }
 

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -135,6 +135,8 @@ class TopLevel extends TTopLevel, AstNode {
     pred = directMember("getAModule") and result = this.getAModule()
     or
     pred = directMember("getANewType") and result = this.getANewType()
+    or
+    pred = directMember("getQLDoc") and result = this.getQLDoc()
   }
 
   QLDoc getQLDocFor(ModuleMember m) {


### PR DESCRIPTION
The toplevel QLDoc was disconnected from the Ast, so it showed up in the wrong location when using the "View AST" feature in VSCode. 

And a `getImportString` utility predicate might be useful to have. 