### PR TITLE
JS/Ruby: Fix regexp in MaD checking

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModels.qll
@@ -413,10 +413,10 @@ predicate isValidNoArgumentTokenInIdentifyingAccessPath(string name) {
 bindingset[name, argument]
 predicate isValidTokenArgumentInIdentifyingAccessPath(string name, string argument) {
   name = ["Argument", "Parameter"] and
-  argument.regexpMatch("(N-|-)?\\d+(\\.\\.(N-|-)?\\d+)?")
+  argument.regexpMatch("(N-|-)?\\d+(\\.\\.((N-|-)?\\d+)?)?")
   or
   name = "WithArity" and
-  argument.regexpMatch("\\d+(\\.\\.\\d+)?")
+  argument.regexpMatch("\\d+(\\.\\.(\\d+)?)?")
   or
   Specific::isExtraValidTokenArgumentInIdentifyingAccessPath(name, argument)
 }

--- a/javascript/ql/test/library-tests/frameworks/data/warnings.expected
+++ b/javascript/ql/test/library-tests/frameworks/data/warnings.expected
@@ -1,10 +1,6 @@
 | CSV type row should have 5 columns but has 2: test;TooFewColumns |
 | CSV type row should have 5 columns but has 8: test;TooManyColumns;;;Member[Foo].Instance;too;many;columns |
 | Invalid argument '0-1' in token 'Argument[0-1]' in access path: Method[foo].Argument[0-1] |
-| Invalid argument '0..' in token 'Argument[0..]' in access path: Argument[0..].Member[password] |
-| Invalid argument '0..' in token 'Argument[0..]' in access path: Argument[0..].Member[username] |
-| Invalid argument '0..' in token 'Argument[0..]' in access path: Member[executeSql].Argument[0..].Parameter[1] |
-| Invalid argument '0..' in token 'Argument[0..]' in access path: Member[run].Argument[0..].Parameter[1] |
 | Invalid argument '*' in token 'Argument[*]' in access path: Method[foo].Argument[*] |
 | Invalid token 'Argument' is missing its arguments, in access path: Method[foo].Argument |
 | Invalid token 'Member' is missing its arguments, in access path: Method[foo].Member |

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModels.qll
@@ -413,10 +413,10 @@ predicate isValidNoArgumentTokenInIdentifyingAccessPath(string name) {
 bindingset[name, argument]
 predicate isValidTokenArgumentInIdentifyingAccessPath(string name, string argument) {
   name = ["Argument", "Parameter"] and
-  argument.regexpMatch("(N-|-)?\\d+(\\.\\.(N-|-)?\\d+)?")
+  argument.regexpMatch("(N-|-)?\\d+(\\.\\.((N-|-)?\\d+)?)?")
   or
   name = "WithArity" and
-  argument.regexpMatch("\\d+(\\.\\.\\d+)?")
+  argument.regexpMatch("\\d+(\\.\\.(\\d+)?)?")
   or
   Specific::isExtraValidTokenArgumentInIdentifyingAccessPath(name, argument)
 }


### PR DESCRIPTION
I'm not sure how I missed this, but the current regexp generates warnings about `Argument[0..]`.

This should not affect any queries so we can skip evaluation. I've verified that the DIL for the `js/xss` query unchanged.