### PR TITLE
JS: write all CSV rows as literals

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
@@ -565,6 +565,10 @@ private module SpannerCsv {
           "@google-cloud/spanner;~SqlExecutorDirect;@google-cloud/spanner;Database;Member[run,runPartitionedUpdate,runStream]",
           "@google-cloud/spanner;~SqlExecutorDirect;@google-cloud/spanner;Transaction;Member[run,runStream,runUpdate]",
           "@google-cloud/spanner;~SqlExecutorDirect;@google-cloud/spanner;BatchTransaction;Member[createQueryPartitions]",
+          "@google-cloud/spanner;~SpannerObject;@google-cloud/spanner;v1.SpannerClient;",
+          "@google-cloud/spanner;~SpannerObject;@google-cloud/spanner;Database;",
+          "@google-cloud/spanner;~SpannerObject;@google-cloud/spanner;Transaction;",
+          "@google-cloud/spanner;~SpannerObject;@google-cloud/spanner;Snapshot;",
         ]
     }
   }
@@ -584,21 +588,14 @@ private module SpannerCsv {
   }
 
   class SpannerSources extends ModelInput::SourceModelCsv {
-    string spannerClass() { result = ["v1.SpannerClient", "Database", "Transaction", "Snapshot",] }
-
-    string resultPath() {
-      result =
-        [
-          "Member[executeSql].Argument[0..].Parameter[1]",
-          "Member[executeSql].ReturnValue.Awaited.Member[0]", "Member[run].ReturnValue.Awaited",
-          "Member[run].Argument[0..].Parameter[1]",
-        ]
-    }
-
     override predicate row(string row) {
       row =
-        "@google-cloud/spanner;" + this.spannerClass() + ";" + this.resultPath() +
-          ";database-access-result"
+        [
+          "@google-cloud/spanner;~SpannerObject;Member[executeSql].Argument[0..].Parameter[1];database-access-result",
+          "@google-cloud/spanner;~SpannerObject;Member[executeSql].ReturnValue.Awaited.Member[0];database-access-result",
+          "@google-cloud/spanner;~SpannerObject;Member[run].ReturnValue.Awaited;database-access-result",
+          "@google-cloud/spanner;~SpannerObject;Member[run].Argument[0..].Parameter[1];database-access-result",
+        ]
     }
   }
 }


### PR DESCRIPTION
Rewrites some dynamically generated CSV rows to use type-definition rows instead.