### PR TITLE
C++: Port PrivateData.qll from C# and use it in cpp/cleartext-transmission

### DIFF
--- a/cpp/ql/lib/change-notes/2022-03-28-private-data.md
+++ b/cpp/ql/lib/change-notes/2022-03-28-private-data.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* A new library `semmle.code.cpp.security.PrivateData` has been added. The new library heuristically detects variables and functions dealing with sensitive private data, such as e-mail addresses and credit card numbers.

--- a/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateCleartextWrite.qll
@@ -4,7 +4,7 @@
 
 import cpp
 import semmle.code.cpp.dataflow.TaintTracking
-import experimental.semmle.code.cpp.security.PrivateData
+import semmle.code.cpp.security.PrivateData
 import semmle.code.cpp.security.FileWrite
 import semmle.code.cpp.security.BufferWrite
 

--- a/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateData.qll
@@ -1,5 +1,0 @@
-/**
- * DEPRECATED: use semmle.code.cpp.security.PrivateData instead.
- */
-
-import semmle.code.cpp.security.PrivateData

--- a/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/experimental/semmle/code/cpp/security/PrivateData.qll
@@ -1,52 +1,5 @@
 /**
- * Provides classes and predicates for identifying private data and functions for security.
- *
- * 'Private' data in general is anything that would compromise user privacy if exposed. This
- * library tries to guess where private data may either be stored in a variable or produced by a
- * function.
- *
- * This library is not concerned with credentials. See `SensitiveActions` for expressions related
- * to credentials.
+ * DEPRECATED: use semmle.code.cpp.security.PrivateData instead.
  */
 
-import cpp
-
-/** A string for `match` that identifies strings that look like they represent private data. */
-private string privateNames() {
-  result =
-    [
-      // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
-      // Government identifiers, such as Social Security Numbers
-      "%social%security%number%",
-      // Contact information, such as home addresses and telephone numbers
-      "%postcode%", "%zipcode%",
-      // result = "%telephone%" or
-      // Geographic location - where the user is (or was)
-      "%latitude%", "%longitude%",
-      // Financial data - such as credit card numbers, salary, bank accounts, and debts
-      "%creditcard%", "%salary%", "%bankaccount%",
-      // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
-      // result = "%email%" or
-      // result = "%mobile%" or
-      "%employer%",
-      // Health - medical conditions, insurance status, prescription records
-      "%medical%"
-    ]
-}
-
-/** An expression that might contain private data. */
-abstract class PrivateDataExpr extends Expr { }
-
-/** A functiond call that might produce private data. */
-class PrivateFunctionCall extends PrivateDataExpr, FunctionCall {
-  PrivateFunctionCall() {
-    exists(string s | this.getTarget().getName().toLowerCase() = s | s.matches(privateNames()))
-  }
-}
-
-/** An access to a variable that might contain private data. */
-class PrivateVariableAccess extends PrivateDataExpr, VariableAccess {
-  PrivateVariableAccess() {
-    exists(string s | this.getTarget().getName().toLowerCase() = s | s.matches(privateNames()))
-  }
-}
+import semmle.code.cpp.security.PrivateData

--- a/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
@@ -1,0 +1,66 @@
+/**
+ * Provides classes and predicates for identifying private data and methods for security.
+ *
+ * 'Private' data in general is anything that would compromise user privacy if exposed. This
+ * library tries to guess where private data may either be stored in a variable or produced by a
+ * method.
+ *
+ * This library is not concerned with credentials. See `SensitiveActions` for expressions related
+ * to credentials.
+ */
+
+import csharp
+import semmle.code.csharp.frameworks.system.windows.Forms
+
+/** A string for `match` that identifies strings that look like they represent private data. */
+private string privateNames() {
+  result =
+    [
+      // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
+      // Government identifiers, such as Social Security Numbers
+      "%social%security%number%",
+      // Contact information, such as home addresses and telephone numbers
+      "%postcode%", "%zipcode%", "%telephone%",
+      // Geographic location - where the user is (or was)
+      "%latitude%", "%longitude%",
+      // Financial data - such as credit card numbers, salary, bank accounts, and debts
+      "%creditcard%", "%salary%", "%bankaccount%",
+      // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
+      "%email%", "%mobile%", "%employer%",
+      // Health - medical conditions, insurance status, prescription records
+      "%medical%"
+    ]
+}
+
+/** An expression that might contain private data. */
+abstract class PrivateDataExpr extends Expr { }
+
+/** A method call that might produce private data. */
+class PrivateMethodCall extends PrivateDataExpr, MethodCall {
+  PrivateMethodCall() {
+    exists(string s | this.getTarget().getName().toLowerCase() = s | s.matches(privateNames()))
+  }
+}
+
+/** An indexer access that might produce private data. */
+class PrivateIndexerAccess extends PrivateDataExpr, IndexerAccess {
+  PrivateIndexerAccess() {
+    exists(string s | this.getAnIndex().getValue().toLowerCase() = s | s.matches(privateNames()))
+  }
+}
+
+/** An access to a variable that might contain private data. */
+class PrivateVariableAccess extends PrivateDataExpr, VariableAccess {
+  PrivateVariableAccess() {
+    exists(string s | this.getTarget().getName().toLowerCase() = s | s.matches(privateNames()))
+  }
+}
+
+/** Reading the text property of a control that might contain private data. */
+class PrivateControlAccess extends PrivateDataExpr {
+  PrivateControlAccess() {
+    exists(TextControl c |
+      this = c.getARead() and c.getName().toLowerCase().matches(privateNames())
+    )
+  }
+}

--- a/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
@@ -12,24 +12,28 @@
 
 import cpp
 
-/** A string for `match` that identifies strings that look like they represent private data. */
+/**
+ * A string for `regexpMatch` that identifies strings that look like they
+ * represent private data.
+ */
 private string privateNames() {
   result =
-    [
+    ".*(" +
       // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
       // Government identifiers, such as Social Security Numbers
-      "%social%security%",
+      "social.*security|" +
       // Contact information, such as home addresses and telephone numbers
-      "%postcode%", "%zipcode%", "%telephone%",
+      "postcode|zipcode|telephone|" +
       // Geographic location - where the user is (or was)
-      "%latitude%", "%longitude%",
+      "latitude|longitude|" +
       // Financial data - such as credit card numbers, salary, bank accounts, and debts
-      "%credit%card%", "%salary%", "%bank%account%",
+      "credit.*card|salary|bank.*account|" +
       // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
-      "%email%", "%mobile%", "%employer%",
+      "email|mobile|employer|" +
       // Health - medical conditions, insurance status, prescription records
-      "%medical%"
-    ]
+      "medical" +
+      // ---
+      ").*"
 }
 
 /**
@@ -37,7 +41,7 @@ private string privateNames() {
  */
 class PrivateDataVariable extends Variable {
   PrivateDataVariable() {
-    this.getName().toLowerCase().matches(privateNames()) and
+    this.getName().toLowerCase().regexpMatch(privateNames()) and
     not this.getUnspecifiedType() instanceof IntegralType
   }
 }
@@ -47,7 +51,7 @@ class PrivateDataVariable extends Variable {
  */
 class PrivateDataFunction extends Function {
   PrivateDataFunction() {
-    this.getName().toLowerCase().matches(privateNames()) and
+    this.getName().toLowerCase().regexpMatch(privateNames()) and
     not this.getUnspecifiedType() instanceof IntegralType
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
@@ -18,13 +18,13 @@ private string privateNames() {
     [
       // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
       // Government identifiers, such as Social Security Numbers
-      "%social%security%number%",
+      "%social%security%",
       // Contact information, such as home addresses and telephone numbers
       "%postcode%", "%zipcode%", "%telephone%",
       // Geographic location - where the user is (or was)
       "%latitude%", "%longitude%",
       // Financial data - such as credit card numbers, salary, bank accounts, and debts
-      "%creditcard%", "%salary%", "%bankaccount%",
+      "%credit%card%", "%salary%", "%bank%account%",
       // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
       "%email%", "%mobile%", "%employer%",
       // Health - medical conditions, insurance status, prescription records

--- a/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
@@ -21,13 +21,13 @@ private string privateNames() {
     ".*(" +
       // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
       // Government identifiers, such as Social Security Numbers
-      "social.*security|" +
+      "social.?security|" +
       // Contact information, such as home addresses and telephone numbers
-      "postcode|zipcode|telephone|" +
+      "post.?code|zip.?code|telephone|" +
       // Geographic location - where the user is (or was)
       "latitude|longitude|" +
       // Financial data - such as credit card numbers, salary, bank accounts, and debts
-      "credit.*card|salary|bank.*account|" +
+      "credit.?card|salary|bank.?account|" +
       // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
       "email|mobile|employer|" +
       // Health - medical conditions, insurance status, prescription records

--- a/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
@@ -1,13 +1,16 @@
 /**
  * Provides classes for heuristically identifying variables and functions that
- * might contain or return a password or other sensitive information.
+ * might contain or return a password or other credential.
+ *
+ * This library is not concerned with other kinds of sensitive private
+ * information. See `PrivateData.qll` for expressions related to that.
  */
 
 import cpp
 
 /**
  * Holds if the name `s` suggests something might contain or return a password
- * or other sensitive information.
+ * or other credential.
  */
 bindingset[s]
 private predicate suspicious(string s) {
@@ -16,7 +19,7 @@ private predicate suspicious(string s) {
 }
 
 /**
- * A variable that might contain a password or other sensitive information.
+ * A variable that might contain a password or other credential.
  */
 class SensitiveVariable extends Variable {
   SensitiveVariable() {
@@ -26,7 +29,7 @@ class SensitiveVariable extends Variable {
 }
 
 /**
- * A function that might return a password or other sensitive information.
+ * A function that might return a password or other credential.
  */
 class SensitiveFunction extends Function {
   SensitiveFunction() {
@@ -36,7 +39,7 @@ class SensitiveFunction extends Function {
 }
 
 /**
- * An expression whose value might be a password or other sensitive information.
+ * An expression whose value might be a password or other credential.
  */
 class SensitiveExpr extends Expr {
   SensitiveExpr() {

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -13,24 +13,38 @@
 
 import cpp
 import semmle.code.cpp.security.SensitiveExprs
+import semmle.code.cpp.security.PrivateData
 import semmle.code.cpp.dataflow.TaintTracking
 import semmle.code.cpp.models.interfaces.FlowSource
 import semmle.code.cpp.commons.File
 import DataFlow::PathGraph
 
+class SourceVariable extends Variable {
+  SourceVariable() {
+    this instanceof SensitiveVariable or
+    this instanceof PrivateDataVariable
+  }
+}
+
+class SourceFunction extends Function {
+  SourceFunction() {
+    this instanceof SensitiveFunction or
+    this instanceof PrivateDataFunction
+  }
+}
+
 /**
  * A DataFlow node corresponding to a variable or function call that
  * might contain or return a password or other sensitive information.
  */
-class SensitiveNode extends DataFlow::Node {
-  SensitiveNode() {
-    this.asExpr() = any(SensitiveVariable sv).getInitializer().getExpr() or
-    this.asExpr().(VariableAccess).getTarget() =
-      any(SensitiveVariable sv).(GlobalOrNamespaceVariable) or
-    this.asExpr().(VariableAccess).getTarget() = any(SensitiveVariable v | v instanceof Field) or
-    this.asUninitialized() instanceof SensitiveVariable or
-    this.asParameter() instanceof SensitiveVariable or
-    this.asExpr().(FunctionCall).getTarget() instanceof SensitiveFunction
+class SourceNode extends DataFlow::Node {
+  SourceNode() {
+    this.asExpr() = any(SourceVariable sv).getInitializer().getExpr() or
+    this.asExpr().(VariableAccess).getTarget() = any(SourceVariable sv).(GlobalOrNamespaceVariable) or
+    this.asExpr().(VariableAccess).getTarget() = any(SourceVariable v | v instanceof Field) or
+    this.asUninitialized() instanceof SourceVariable or
+    this.asParameter() instanceof SourceVariable or
+    this.asExpr().(FunctionCall).getTarget() instanceof SourceFunction
   }
 }
 
@@ -207,7 +221,7 @@ class Encrypted extends Expr {
 class FromSensitiveConfiguration extends TaintTracking::Configuration {
   FromSensitiveConfiguration() { this = "FromSensitiveConfiguration" }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof SensitiveNode }
+  override predicate isSource(DataFlow::Node source) { source instanceof SourceNode }
 
   override predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(NetworkSendRecv nsr).getDataExpr()

--- a/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
+++ b/cpp/ql/src/Security/CWE/CWE-311/CleartextTransmission.ql
@@ -9,6 +9,7 @@
  * @id cpp/cleartext-transmission
  * @tags security
  *       external/cwe/cwe-319
+ *       external/cwe/cwe-359
  */
 
 import cpp

--- a/cpp/ql/src/change-notes/2022-03-28-cleartext-transmission.md
+++ b/cpp/ql/src/change-notes/2022-03-28-cleartext-transmission.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/cleartext-transmission` query now recognizes additional sources, for sensitive private data such as e-mail addresses and credit card numbers.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -226,6 +226,7 @@ nodes
 | test3.cpp:507:18:507:39 | social_security_number | semmle.label | social_security_number |
 | test3.cpp:508:18:508:33 | socialSecurityNo | semmle.label | socialSecurityNo |
 | test3.cpp:509:18:509:29 | homePostCode | semmle.label | homePostCode |
+| test3.cpp:510:18:510:28 | my_zip_code | semmle.label | my_zip_code |
 | test3.cpp:511:18:511:26 | telephone | semmle.label | telephone |
 | test3.cpp:512:18:512:36 | mobile_phone_number | semmle.label | mobile_phone_number |
 | test3.cpp:513:18:513:22 | email | semmle.label | email |
@@ -273,6 +274,7 @@ subpaths
 | test3.cpp:507:2:507:5 | call to send | test3.cpp:507:18:507:39 | social_security_number | test3.cpp:507:18:507:39 | social_security_number | This operation transmits 'social_security_number', which may contain unencrypted sensitive data from $@ | test3.cpp:507:18:507:39 | social_security_number | social_security_number |
 | test3.cpp:508:2:508:5 | call to send | test3.cpp:508:18:508:33 | socialSecurityNo | test3.cpp:508:18:508:33 | socialSecurityNo | This operation transmits 'socialSecurityNo', which may contain unencrypted sensitive data from $@ | test3.cpp:508:18:508:33 | socialSecurityNo | socialSecurityNo |
 | test3.cpp:509:2:509:5 | call to send | test3.cpp:509:18:509:29 | homePostCode | test3.cpp:509:18:509:29 | homePostCode | This operation transmits 'homePostCode', which may contain unencrypted sensitive data from $@ | test3.cpp:509:18:509:29 | homePostCode | homePostCode |
+| test3.cpp:510:2:510:5 | call to send | test3.cpp:510:18:510:28 | my_zip_code | test3.cpp:510:18:510:28 | my_zip_code | This operation transmits 'my_zip_code', which may contain unencrypted sensitive data from $@ | test3.cpp:510:18:510:28 | my_zip_code | my_zip_code |
 | test3.cpp:511:2:511:5 | call to send | test3.cpp:511:18:511:26 | telephone | test3.cpp:511:18:511:26 | telephone | This operation transmits 'telephone', which may contain unencrypted sensitive data from $@ | test3.cpp:511:18:511:26 | telephone | telephone |
 | test3.cpp:512:2:512:5 | call to send | test3.cpp:512:18:512:36 | mobile_phone_number | test3.cpp:512:18:512:36 | mobile_phone_number | This operation transmits 'mobile_phone_number', which may contain unencrypted sensitive data from $@ | test3.cpp:512:18:512:36 | mobile_phone_number | mobile_phone_number |
 | test3.cpp:513:2:513:5 | call to send | test3.cpp:513:18:513:22 | email | test3.cpp:513:18:513:22 | email | This operation transmits 'email', which may contain unencrypted sensitive data from $@ | test3.cpp:513:18:513:22 | email | email |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -224,10 +224,13 @@ nodes
 | test3.cpp:429:7:429:14 | password | semmle.label | password |
 | test3.cpp:431:8:431:15 | password | semmle.label | password |
 | test3.cpp:507:18:507:39 | social_security_number | semmle.label | social_security_number |
+| test3.cpp:508:18:508:33 | socialSecurityNo | semmle.label | socialSecurityNo |
 | test3.cpp:509:18:509:29 | homePostCode | semmle.label | homePostCode |
 | test3.cpp:511:18:511:26 | telephone | semmle.label | telephone |
 | test3.cpp:512:18:512:36 | mobile_phone_number | semmle.label | mobile_phone_number |
 | test3.cpp:513:18:513:22 | email | semmle.label | email |
+| test3.cpp:514:18:514:38 | my_credit_card_number | semmle.label | my_credit_card_number |
+| test3.cpp:515:18:515:35 | my_bank_account_no | semmle.label | my_bank_account_no |
 | test3.cpp:516:18:516:29 | employerName | semmle.label | employerName |
 | test3.cpp:517:18:517:29 | medical_info | semmle.label | medical_info |
 | test3.cpp:526:44:526:54 | my_latitude | semmle.label | my_latitude |
@@ -268,10 +271,13 @@ subpaths
 | test3.cpp:420:3:420:6 | call to recv | test3.cpp:420:17:420:24 | password | test3.cpp:420:17:420:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:420:17:420:24 | password | password |
 | test3.cpp:431:2:431:6 | call to fgets | test3.cpp:429:7:429:14 | password | test3.cpp:431:8:431:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:429:7:429:14 | password | password |
 | test3.cpp:507:2:507:5 | call to send | test3.cpp:507:18:507:39 | social_security_number | test3.cpp:507:18:507:39 | social_security_number | This operation transmits 'social_security_number', which may contain unencrypted sensitive data from $@ | test3.cpp:507:18:507:39 | social_security_number | social_security_number |
+| test3.cpp:508:2:508:5 | call to send | test3.cpp:508:18:508:33 | socialSecurityNo | test3.cpp:508:18:508:33 | socialSecurityNo | This operation transmits 'socialSecurityNo', which may contain unencrypted sensitive data from $@ | test3.cpp:508:18:508:33 | socialSecurityNo | socialSecurityNo |
 | test3.cpp:509:2:509:5 | call to send | test3.cpp:509:18:509:29 | homePostCode | test3.cpp:509:18:509:29 | homePostCode | This operation transmits 'homePostCode', which may contain unencrypted sensitive data from $@ | test3.cpp:509:18:509:29 | homePostCode | homePostCode |
 | test3.cpp:511:2:511:5 | call to send | test3.cpp:511:18:511:26 | telephone | test3.cpp:511:18:511:26 | telephone | This operation transmits 'telephone', which may contain unencrypted sensitive data from $@ | test3.cpp:511:18:511:26 | telephone | telephone |
 | test3.cpp:512:2:512:5 | call to send | test3.cpp:512:18:512:36 | mobile_phone_number | test3.cpp:512:18:512:36 | mobile_phone_number | This operation transmits 'mobile_phone_number', which may contain unencrypted sensitive data from $@ | test3.cpp:512:18:512:36 | mobile_phone_number | mobile_phone_number |
 | test3.cpp:513:2:513:5 | call to send | test3.cpp:513:18:513:22 | email | test3.cpp:513:18:513:22 | email | This operation transmits 'email', which may contain unencrypted sensitive data from $@ | test3.cpp:513:18:513:22 | email | email |
+| test3.cpp:514:2:514:5 | call to send | test3.cpp:514:18:514:38 | my_credit_card_number | test3.cpp:514:18:514:38 | my_credit_card_number | This operation transmits 'my_credit_card_number', which may contain unencrypted sensitive data from $@ | test3.cpp:514:18:514:38 | my_credit_card_number | my_credit_card_number |
+| test3.cpp:515:2:515:5 | call to send | test3.cpp:515:18:515:35 | my_bank_account_no | test3.cpp:515:18:515:35 | my_bank_account_no | This operation transmits 'my_bank_account_no', which may contain unencrypted sensitive data from $@ | test3.cpp:515:18:515:35 | my_bank_account_no | my_bank_account_no |
 | test3.cpp:516:2:516:5 | call to send | test3.cpp:516:18:516:29 | employerName | test3.cpp:516:18:516:29 | employerName | This operation transmits 'employerName', which may contain unencrypted sensitive data from $@ | test3.cpp:516:18:516:29 | employerName | employerName |
 | test3.cpp:517:2:517:5 | call to send | test3.cpp:517:18:517:29 | medical_info | test3.cpp:517:18:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@ | test3.cpp:517:18:517:29 | medical_info | medical_info |
 | test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:526:44:526:54 | my_latitude | my_latitude |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -92,6 +92,8 @@ edges
 | test3.cpp:398:18:398:25 | password | test3.cpp:400:33:400:40 | password |
 | test3.cpp:421:21:421:28 | password | test3.cpp:421:3:421:17 | call to decrypt_inplace |
 | test3.cpp:429:7:429:14 | password | test3.cpp:431:8:431:15 | password |
+| test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer |
+| test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -221,6 +223,17 @@ nodes
 | test3.cpp:421:21:421:28 | password | semmle.label | password |
 | test3.cpp:429:7:429:14 | password | semmle.label | password |
 | test3.cpp:431:8:431:15 | password | semmle.label | password |
+| test3.cpp:507:18:507:39 | social_security_number | semmle.label | social_security_number |
+| test3.cpp:509:18:509:29 | homePostCode | semmle.label | homePostCode |
+| test3.cpp:511:18:511:26 | telephone | semmle.label | telephone |
+| test3.cpp:512:18:512:36 | mobile_phone_number | semmle.label | mobile_phone_number |
+| test3.cpp:513:18:513:22 | email | semmle.label | email |
+| test3.cpp:516:18:516:29 | employerName | semmle.label | employerName |
+| test3.cpp:517:18:517:29 | medical_info | semmle.label | medical_info |
+| test3.cpp:526:44:526:54 | my_latitude | semmle.label | my_latitude |
+| test3.cpp:527:15:527:20 | buffer | semmle.label | buffer |
+| test3.cpp:532:45:532:58 | home_longitude | semmle.label | home_longitude |
+| test3.cpp:533:15:533:20 | buffer | semmle.label | buffer |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -254,3 +267,12 @@ subpaths
 | test3.cpp:414:3:414:6 | call to recv | test3.cpp:414:17:414:24 | password | test3.cpp:414:17:414:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:414:17:414:24 | password | password |
 | test3.cpp:420:3:420:6 | call to recv | test3.cpp:420:17:420:24 | password | test3.cpp:420:17:420:24 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:420:17:420:24 | password | password |
 | test3.cpp:431:2:431:6 | call to fgets | test3.cpp:429:7:429:14 | password | test3.cpp:431:8:431:15 | password | This operation receives into 'password', which may put unencrypted sensitive data into $@ | test3.cpp:429:7:429:14 | password | password |
+| test3.cpp:507:2:507:5 | call to send | test3.cpp:507:18:507:39 | social_security_number | test3.cpp:507:18:507:39 | social_security_number | This operation transmits 'social_security_number', which may contain unencrypted sensitive data from $@ | test3.cpp:507:18:507:39 | social_security_number | social_security_number |
+| test3.cpp:509:2:509:5 | call to send | test3.cpp:509:18:509:29 | homePostCode | test3.cpp:509:18:509:29 | homePostCode | This operation transmits 'homePostCode', which may contain unencrypted sensitive data from $@ | test3.cpp:509:18:509:29 | homePostCode | homePostCode |
+| test3.cpp:511:2:511:5 | call to send | test3.cpp:511:18:511:26 | telephone | test3.cpp:511:18:511:26 | telephone | This operation transmits 'telephone', which may contain unencrypted sensitive data from $@ | test3.cpp:511:18:511:26 | telephone | telephone |
+| test3.cpp:512:2:512:5 | call to send | test3.cpp:512:18:512:36 | mobile_phone_number | test3.cpp:512:18:512:36 | mobile_phone_number | This operation transmits 'mobile_phone_number', which may contain unencrypted sensitive data from $@ | test3.cpp:512:18:512:36 | mobile_phone_number | mobile_phone_number |
+| test3.cpp:513:2:513:5 | call to send | test3.cpp:513:18:513:22 | email | test3.cpp:513:18:513:22 | email | This operation transmits 'email', which may contain unencrypted sensitive data from $@ | test3.cpp:513:18:513:22 | email | email |
+| test3.cpp:516:2:516:5 | call to send | test3.cpp:516:18:516:29 | employerName | test3.cpp:516:18:516:29 | employerName | This operation transmits 'employerName', which may contain unencrypted sensitive data from $@ | test3.cpp:516:18:516:29 | employerName | employerName |
+| test3.cpp:517:2:517:5 | call to send | test3.cpp:517:18:517:29 | medical_info | test3.cpp:517:18:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@ | test3.cpp:517:18:517:29 | medical_info | medical_info |
+| test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:526:44:526:54 | my_latitude | my_latitude |
+| test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:532:45:532:58 | home_longitude | home_longitude |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -94,6 +94,8 @@ edges
 | test3.cpp:429:7:429:14 | password | test3.cpp:431:8:431:15 | password |
 | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer |
 | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer |
+| test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer |
+| test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -238,6 +240,10 @@ nodes
 | test3.cpp:527:15:527:20 | buffer | semmle.label | buffer |
 | test3.cpp:532:45:532:58 | home_longitude | semmle.label | home_longitude |
 | test3.cpp:533:15:533:20 | buffer | semmle.label | buffer |
+| test3.cpp:551:47:551:58 | salaryString | semmle.label | salaryString |
+| test3.cpp:552:15:552:20 | buffer | semmle.label | buffer |
+| test3.cpp:556:19:556:30 | salaryString | semmle.label | salaryString |
+| test3.cpp:559:15:559:20 | buffer | semmle.label | buffer |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -284,3 +290,5 @@ subpaths
 | test3.cpp:517:2:517:5 | call to send | test3.cpp:517:18:517:29 | medical_info | test3.cpp:517:18:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@ | test3.cpp:517:18:517:29 | medical_info | medical_info |
 | test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:526:44:526:54 | my_latitude | my_latitude |
 | test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:532:45:532:58 | home_longitude | home_longitude |
+| test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:551:47:551:58 | salaryString | salaryString |
+| test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:556:19:556:30 | salaryString | salaryString |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -495,7 +495,7 @@ struct person_info
 	double my_latitude;
 	double home_longitude;
 	int newSalary;
-
+	char *salaryString;
 	// not sensitive
 	char *license_key_hash;
 	char *my_zip_file;
@@ -544,5 +544,18 @@ void tests2(person_info *pi)
 
 		snprintf(buffer, 1024, "salary = %i\n", sal);
 		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+	}
+	{
+		char buffer[1024];
+
+		snprintf(buffer, 1024, "salary = %s\n", pi->salaryString);
+		send(val(), buffer, strlen(buffer), val()); // BAD
+	}
+	{
+		char buffer[1024];
+		char *sal = pi->salaryString;
+
+		snprintf(buffer, 1024, "salary = %s\n", sal);
+		send(val(), buffer, strlen(buffer), val()); // BAD
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -504,17 +504,17 @@ struct person_info
 void tests2(person_info *pi)
 {
 	// direct cases
-	send(val(), pi->social_security_number, strlen(pi->social_security_number), val()); // BAD [NOT DETECTED]
+	send(val(), pi->social_security_number, strlen(pi->social_security_number), val()); // BAD
 	send(val(), pi->socialSecurityNo, strlen(pi->socialSecurityNo), val()); // BAD [NOT DETECTED]
-	send(val(), pi->homePostCode, strlen(pi->homePostCode), val()); // BAD [NOT DETECTED]
+	send(val(), pi->homePostCode, strlen(pi->homePostCode), val()); // BAD
 	send(val(), pi->my_zip_code, strlen(pi->my_zip_code), val()); // BAD [NOT DETECTED]
-	send(val(), pi->telephone, strlen(pi->telephone), val()); // BAD [NOT DETECTED]
-	send(val(), pi->mobile_phone_number, strlen(pi->mobile_phone_number), val()); // BAD [NOT DETECTED]
-	send(val(), pi->email, strlen(pi->email), val()); // BAD [NOT DETECTED]
+	send(val(), pi->telephone, strlen(pi->telephone), val()); // BAD
+	send(val(), pi->mobile_phone_number, strlen(pi->mobile_phone_number), val()); // BAD
+	send(val(), pi->email, strlen(pi->email), val()); // BAD
 	send(val(), pi->my_credit_card_number, strlen(pi->my_credit_card_number), val()); // BAD [NOT DETECTED]
 	send(val(), pi->my_bank_account_no, strlen(pi->my_bank_account_no), val()); // BAD [NOT DETECTED]
-	send(val(), pi->employerName, strlen(pi->employerName), val()); // BAD [NOT DETECTED]
-	send(val(), pi->medical_info, strlen(pi->medical_info), val()); // BAD [NOT DETECTED]
+	send(val(), pi->employerName, strlen(pi->employerName), val()); // BAD
+	send(val(), pi->medical_info, strlen(pi->medical_info), val()); // BAD
 	send(val(), pi->license_key, strlen(pi->license_key), val()); // BAD [NOT DETECTED]
 	send(val(), pi->license_key_hash, strlen(pi->license_key_hash), val()); // GOOD
 	send(val(), pi->my_zip_file, strlen(pi->my_zip_file), val()); // GOOD
@@ -524,13 +524,13 @@ void tests2(person_info *pi)
 		char buffer[1024];
 
 		snprintf(buffer, 1024, "lat = %f\n", pi->my_latitude);
-		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+		send(val(), buffer, strlen(buffer), val()); // BAD
 	}
 	{
 		char buffer[1024];
 
 		snprintf(buffer, 1024, "long = %f\n", pi->home_longitude);
-		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+		send(val(), buffer, strlen(buffer), val()); // BAD
 	}
 	{
 		char buffer[1024];

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -505,14 +505,14 @@ void tests2(person_info *pi)
 {
 	// direct cases
 	send(val(), pi->social_security_number, strlen(pi->social_security_number), val()); // BAD
-	send(val(), pi->socialSecurityNo, strlen(pi->socialSecurityNo), val()); // BAD [NOT DETECTED]
+	send(val(), pi->socialSecurityNo, strlen(pi->socialSecurityNo), val()); // BAD
 	send(val(), pi->homePostCode, strlen(pi->homePostCode), val()); // BAD
 	send(val(), pi->my_zip_code, strlen(pi->my_zip_code), val()); // BAD [NOT DETECTED]
 	send(val(), pi->telephone, strlen(pi->telephone), val()); // BAD
 	send(val(), pi->mobile_phone_number, strlen(pi->mobile_phone_number), val()); // BAD
 	send(val(), pi->email, strlen(pi->email), val()); // BAD
-	send(val(), pi->my_credit_card_number, strlen(pi->my_credit_card_number), val()); // BAD [NOT DETECTED]
-	send(val(), pi->my_bank_account_no, strlen(pi->my_bank_account_no), val()); // BAD [NOT DETECTED]
+	send(val(), pi->my_credit_card_number, strlen(pi->my_credit_card_number), val()); // BAD
+	send(val(), pi->my_bank_account_no, strlen(pi->my_bank_account_no), val()); // BAD
 	send(val(), pi->employerName, strlen(pi->employerName), val()); // BAD
 	send(val(), pi->medical_info, strlen(pi->medical_info), val()); // BAD
 	send(val(), pi->license_key, strlen(pi->license_key), val()); // BAD [NOT DETECTED]

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -5,7 +5,7 @@ typedef unsigned long size_t;
 int stdout_fileno = STDOUT_FILENO;
 
 size_t strlen(const char *s);
-
+int snprintf(char *s, size_t n, const char *format, ...);
 void send(int fd, const void *buf, size_t bufLen, int d);
 void recv(int fd, void *buf, size_t bufLen, int d);
 void read(int fd, void *buf, size_t bufLen);
@@ -472,5 +472,77 @@ void test_tty()
 		}
 
 		recv(f, password, 256, val()); // GOOD: from terminal or stdin
+	}
+}
+
+// ---
+
+struct person_info
+{
+	// sensitive
+	char *social_security_number;
+	char *socialSecurityNo;
+	char *homePostCode;
+	char *my_zip_code;
+	char *telephone;
+	char *mobile_phone_number;
+	char *email;
+	char *my_credit_card_number;
+	char *my_bank_account_no;
+	char *employerName;
+	char medical_info[8 * 1024];
+	char *license_key;
+	double my_latitude;
+	double home_longitude;
+	int newSalary;
+
+	// not sensitive
+	char *license_key_hash;
+	char *my_zip_file;
+};
+
+void tests2(person_info *pi)
+{
+	// direct cases
+	send(val(), pi->social_security_number, strlen(pi->social_security_number), val()); // BAD [NOT DETECTED]
+	send(val(), pi->socialSecurityNo, strlen(pi->socialSecurityNo), val()); // BAD [NOT DETECTED]
+	send(val(), pi->homePostCode, strlen(pi->homePostCode), val()); // BAD [NOT DETECTED]
+	send(val(), pi->my_zip_code, strlen(pi->my_zip_code), val()); // BAD [NOT DETECTED]
+	send(val(), pi->telephone, strlen(pi->telephone), val()); // BAD [NOT DETECTED]
+	send(val(), pi->mobile_phone_number, strlen(pi->mobile_phone_number), val()); // BAD [NOT DETECTED]
+	send(val(), pi->email, strlen(pi->email), val()); // BAD [NOT DETECTED]
+	send(val(), pi->my_credit_card_number, strlen(pi->my_credit_card_number), val()); // BAD [NOT DETECTED]
+	send(val(), pi->my_bank_account_no, strlen(pi->my_bank_account_no), val()); // BAD [NOT DETECTED]
+	send(val(), pi->employerName, strlen(pi->employerName), val()); // BAD [NOT DETECTED]
+	send(val(), pi->medical_info, strlen(pi->medical_info), val()); // BAD [NOT DETECTED]
+	send(val(), pi->license_key, strlen(pi->license_key), val()); // BAD [NOT DETECTED]
+	send(val(), pi->license_key_hash, strlen(pi->license_key_hash), val()); // GOOD
+	send(val(), pi->my_zip_file, strlen(pi->my_zip_file), val()); // GOOD
+
+	// indirect cases
+	{
+		char buffer[1024];
+
+		snprintf(buffer, 1024, "lat = %f\n", pi->my_latitude);
+		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+	}
+	{
+		char buffer[1024];
+
+		snprintf(buffer, 1024, "long = %f\n", pi->home_longitude);
+		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+	}
+	{
+		char buffer[1024];
+
+		snprintf(buffer, 1024, "salary = %i\n", pi->newSalary);
+		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
+	}
+	{
+		char buffer[1024];
+		int sal = pi->newSalary;
+
+		snprintf(buffer, 1024, "salary = %i\n", sal);
+		send(val(), buffer, strlen(buffer), val()); // BAD [NOT DETECTED]
 	}
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -507,7 +507,7 @@ void tests2(person_info *pi)
 	send(val(), pi->social_security_number, strlen(pi->social_security_number), val()); // BAD
 	send(val(), pi->socialSecurityNo, strlen(pi->socialSecurityNo), val()); // BAD
 	send(val(), pi->homePostCode, strlen(pi->homePostCode), val()); // BAD
-	send(val(), pi->my_zip_code, strlen(pi->my_zip_code), val()); // BAD [NOT DETECTED]
+	send(val(), pi->my_zip_code, strlen(pi->my_zip_code), val()); // BAD
 	send(val(), pi->telephone, strlen(pi->telephone), val()); // BAD
 	send(val(), pi->mobile_phone_number, strlen(pi->mobile_phone_number), val()); // BAD
 	send(val(), pi->email, strlen(pi->email), val()); // BAD


### PR DESCRIPTION
Port `PrivateData.qll` from C#.
 - the C# version was chosen as a base, rather than the version in experimental as had been originally planned.  They appear to be extremely similar, but the C# version is more complete.
 - the experimental version has been deprecated.
 - additional enhancements / tuning has been done to maximize results with minimal FPs.

Use `PrivateData.qll` in `cpp/cleartext-transmission`.
 - on LGTM we find a small number of new results, generally I think they're good, a few are weak or FP results.
 - `cpp/cleartext-storage-buffer`, `cpp/cleartext-storage-file` and `cpp/cleartext-storage-database` might also benefit, but I need to further investigate whether results are good for these queries.