### PR TITLE
Python: Flask: Identify body contents passed via named response parameter in invocations of Response constructor

### DIFF
--- a/python/ql/lib/change-notes/2022-03-30-flask-recognize-body-param.md
+++ b/python/ql/lib/change-notes/2022-03-30-flask-recognize-body-param.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The body content of those Flask `Response` objects which were constructed by explicitly referring to the `response` parameter is now detected.
+* Improved modeling of Flask `Response` objects, so passing a response body with the keyword argument `response` is now recognized.

--- a/python/ql/lib/change-notes/2022-03-30-flask-recognize-body-param.md
+++ b/python/ql/lib/change-notes/2022-03-30-flask-recognize-body-param.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The body content of those Flask `Response` objects which were constructed by explicitly referring to the `response` parameter is now detected.

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -122,7 +122,9 @@ module Flask {
     private class ClassInstantiation extends InstanceSource, DataFlow::CallCfgNode {
       ClassInstantiation() { this = classRef().getACall() }
 
-      override DataFlow::Node getBody() { result = this.getArg(0) }
+      override DataFlow::Node getBody() {
+        result in [this.getArg(0), this.getArgByName("response")]
+      }
 
       override string getMimetypeDefault() { result = "text/html" }
 

--- a/python/ql/test/library-tests/frameworks/flask/response_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/response_test.py
@@ -37,22 +37,28 @@ def html4():  # $requestHandler
 
 @app.route("/html5")  # $routeSetup="/html5"
 def html5():  # $requestHandler
+    resp = Response(response="<h1>hello</h1>")  # $HttpResponse mimetype=text/html responseBody="<h1>hello</h1>"
+    return resp  # $ SPURIOUS: HttpResponse mimetype=text/html responseBody=resp
+
+
+@app.route("/html6")  # $routeSetup="/html6"
+def html6():  # $requestHandler
     # note: flask.Flask.response_class is set to `flask.Response` by default.
     # it can be overridden, but we don't try to handle that right now.
     resp = Flask.response_class("<h1>hello</h1>")  # $HttpResponse mimetype=text/html responseBody="<h1>hello</h1>"
     return resp  # $ SPURIOUS: HttpResponse mimetype=text/html responseBody=resp
 
 
-@app.route("/html6")  # $routeSetup="/html6"
-def html6():  # $requestHandler
+@app.route("/html7")  # $routeSetup="/html7"
+def html7():  # $requestHandler
     # note: app.response_class (flask.Flask.response_class) is set to `flask.Response` by default.
     # it can be overridden, but we don't try to handle that right now.
     resp = app.response_class("<h1>hello</h1>")  # $HttpResponse mimetype=text/html responseBody="<h1>hello</h1>"
     return resp  # $ SPURIOUS: HttpResponse mimetype=text/html responseBody=resp
 
 
-@app.route("/html7")  # $routeSetup="/html7"
-def html7():  # $requestHandler
+@app.route("/html8")  # $routeSetup="/html8"
+def html8():  # $requestHandler
     resp = make_response()  # $HttpResponse mimetype=text/html
     resp.set_data("<h1>hello</h1>")  # $ MISSING: responseBody="<h1>hello</h1>"
     return resp  # $ SPURIOUS: HttpResponse mimetype=text/html responseBody=resp


### PR DESCRIPTION
As witnessed [here](https://github.com/Netflix/security_monkey/blob/develop/security_monkey/auth/modules.py#L266).

Note that Flask's [Response](https://github.com/pallets/flask/blob/main/src/flask/wrappers.py#L136) class inherits from `werkzeug`'s [Response](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/wrappers/response.py#L172) class.