### PR TITLE
JavaScript: Improve detection of UMD modules.

### DIFF
--- a/javascript/ql/lib/Expressions/ExprHasNoEffect.qll
+++ b/javascript/ql/lib/Expressions/ExprHasNoEffect.qll
@@ -37,6 +37,8 @@ predicate inVoidContext(Expr e) {
   )
   or
   exists(LogicalBinaryExpr logical | e = logical.getRightOperand() and inVoidContext(logical))
+  or
+  exists(ConditionalExpr cond | e = cond.getABranch() | inVoidContext(cond))
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/AMD.qll
+++ b/javascript/ql/lib/semmle/javascript/AMD.qll
@@ -204,12 +204,21 @@ private class ConstantAmdDependencyPathElement extends PathExpr, ConstantString 
 }
 
 /**
+ * Holds if `nd` is nested inside an AMD module definition.
+ */
+private predicate inAmdModuleDefinition(AstNode nd) {
+  nd.getParent() instanceof AmdModuleDefinition
+  or
+  inAmdModuleDefinition(nd.getParent())
+}
+
+/**
  * Holds if `def` is an AMD module definition in `tl` which is not
  * nested inside another module definition.
  */
 private predicate amdModuleTopLevel(AmdModuleDefinition def, TopLevel tl) {
   def.getTopLevel() = tl and
-  not def.getParent+() instanceof AmdModuleDefinition
+  not inAmdModuleDefinition(def)
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/AMD.qll
+++ b/javascript/ql/lib/semmle/javascript/AMD.qll
@@ -5,6 +5,7 @@
 
 import javascript
 private import semmle.javascript.internal.CachedStages
+private import Expressions.ExprHasNoEffect
 
 /**
  * An AMD `define` call.
@@ -26,7 +27,7 @@ private import semmle.javascript.internal.CachedStages
  */
 class AmdModuleDefinition extends CallExpr {
   AmdModuleDefinition() {
-    getParent() instanceof ExprStmt and
+    inVoidContext(this) and
     getCallee().(GlobalVarAccess).getName() = "define" and
     exists(int n | n = getNumArgument() |
       n = 1

--- a/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
@@ -326,6 +326,7 @@ module XML {
       none()
     }
 
+    pragma[noinline]
     override DataFlow::Node getAResult() {
       result =
         parser

--- a/javascript/ql/test/library-tests/AMD/tests.expected
+++ b/javascript/ql/test/library-tests/AMD/tests.expected
@@ -12,6 +12,8 @@ amoModule_exports
 | tst5.js:1:1:6:3 | <toplevel> | foo | tst5.js:3:14:3:18 | a.foo |
 | tst.js:1:1:6:3 | <toplevel> | bar | tst.js:4:14:4:18 | b.bar |
 | tst.js:1:1:6:3 | <toplevel> | foo | tst.js:3:14:3:18 | a.foo |
+| umd2.js:1:1:12:4 | <toplevel> | bar | umd2.js:9:14:9:18 | a.foo |
+| umd2.js:1:1:12:4 | <toplevel> | foo | umd2.js:10:14:10:18 | b.bar |
 | umd.js:1:1:14:4 | <toplevel> | bar | umd.js:11:14:11:18 | a.foo |
 | umd.js:1:1:14:4 | <toplevel> | foo | umd.js:12:14:12:18 | b.bar |
 amdModule
@@ -25,6 +27,7 @@ amdModule
 | tst4.js:1:1:11:3 | <toplevel> | tst4.js:1:1:11:2 | define( ...   };\\n}) |
 | tst5.js:1:1:6:3 | <toplevel> | tst5.js:1:1:6:2 | define( ...   };\\n}) |
 | tst.js:1:1:6:3 | <toplevel> | tst.js:1:1:6:2 | define( ...   };\\n}) |
+| umd2.js:1:1:12:4 | <toplevel> | umd2.js:5:13:5:47 | define( ... actory) |
 | umd.js:1:1:14:4 | <toplevel> | umd.js:4:9:4:43 | define( ... actory) |
 getDependencyParameter
 | tst2.js:1:1:3:2 | define( ...  42;\\n}) | exports | tst2.js:1:30:1:36 | exports |
@@ -35,6 +38,8 @@ getDependencyParameter
 | tst5.js:1:1:6:2 | define( ...   };\\n}) | ./dir/b | tst5.js:1:40:1:44 | {bar} |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | ./a | tst.js:1:37:1:37 | a |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | ./dir/b | tst.js:1:40:1:40 | b |
+| umd2.js:5:13:5:47 | define( ... actory) | ./a | umd2.js:7:19:7:19 | a |
+| umd2.js:5:13:5:47 | define( ... actory) | ./dir/b | umd2.js:7:22:7:22 | b |
 | umd.js:4:9:4:43 | define( ... actory) | ./a | umd.js:9:19:9:19 | a |
 | umd.js:4:9:4:43 | define( ... actory) | ./dir/b | umd.js:9:22:9:22 | b |
 amdModuleDefinition
@@ -48,6 +53,8 @@ amdModuleDefinition
 | tst4.js:1:1:11:2 | define( ...   };\\n}) | tst4.js:6:11:11:1 | functio ...    };\\n} |
 | tst5.js:1:1:6:2 | define( ...   };\\n}) | tst5.js:1:28:6:1 | functio ...    };\\n} |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | tst.js:1:28:6:1 | functio ...    };\\n} |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:1:22:1:28 | factory |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:7:9:12:1 | functio ...    };\\n} |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:9:9:14:1 | functio ...    };\\n} |
 amdModuleDependencies
@@ -61,6 +68,8 @@ amdModuleDependencies
 | tst5.js:1:1:6:2 | define( ...   };\\n}) | tst5.js:1:16:1:24 | './dir/b' |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | tst.js:1:9:1:13 | './a' |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | tst.js:1:16:1:24 | './dir/b' |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:5:21:5:25 | './a' |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:5:28:5:36 | './dir/b' |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:4:17:4:21 | './a' |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:4:24:4:32 | './dir/b' |
 amdModuleExportedSymbol
@@ -77,6 +86,8 @@ amdModuleExportedSymbol
 | tst5.js:1:1:6:3 | <toplevel> | foo |
 | tst.js:1:1:6:3 | <toplevel> | bar |
 | tst.js:1:1:6:3 | <toplevel> | foo |
+| umd2.js:1:1:12:4 | <toplevel> | bar |
+| umd2.js:1:1:12:4 | <toplevel> | foo |
 | umd.js:1:1:14:4 | <toplevel> | bar |
 | umd.js:1:1:14:4 | <toplevel> | foo |
 amdModuleExpr
@@ -88,6 +99,12 @@ amdModuleExpr
 | tst4.js:1:1:11:2 | define( ...   };\\n}) | tst4.js:7:12:10:5 | {\\n      ... r\\n    } | tst4.js:7:12:10:5 | {\\n      ... r\\n    } |
 | tst5.js:1:1:6:2 | define( ...   };\\n}) | tst5.js:2:12:5:5 | {\\n      ... r\\n    } | tst5.js:2:12:5:5 | {\\n      ... r\\n    } |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | tst.js:2:12:5:5 | {\\n      ... r\\n    } | tst.js:2:12:5:5 | {\\n      ... r\\n    } |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:1:22:1:28 | factory | umd2.js:1:22:1:28 | factory |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:1:22:1:28 | factory | umd2.js:7:9:12:1 | functio ...    };\\n} |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:1:22:1:28 | factory | umd2.js:8:12:11:5 | {\\n      ... r\\n    } |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:8:12:11:5 | {\\n      ... r\\n    } | umd2.js:1:22:1:28 | factory |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:8:12:11:5 | {\\n      ... r\\n    } | umd2.js:7:9:12:1 | functio ...    };\\n} |
+| umd2.js:5:13:5:47 | define( ... actory) | umd2.js:8:12:11:5 | {\\n      ... r\\n    } | umd2.js:8:12:11:5 | {\\n      ... r\\n    } |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory | umd.js:1:18:1:24 | factory |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory | umd.js:9:9:14:1 | functio ...    };\\n} |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory | umd.js:10:12:13:5 | {\\n      ... r\\n    } |
@@ -103,5 +120,9 @@ amdModuleImportedModule
 | tst5.js:1:1:6:3 | <toplevel> | tst5.js:1:16:1:24 | './dir/b' | dir/b.js:1:1:3:3 | <toplevel> |
 | tst.js:1:1:6:3 | <toplevel> | tst.js:1:9:1:13 | './a' | a.js:1:1:3:3 | <toplevel> |
 | tst.js:1:1:6:3 | <toplevel> | tst.js:1:16:1:24 | './dir/b' | dir/b.js:1:1:3:3 | <toplevel> |
+| umd2.js:1:1:12:4 | <toplevel> | umd2.js:3:34:3:47 | require('./a') | a.js:1:1:3:3 | <toplevel> |
+| umd2.js:1:1:12:4 | <toplevel> | umd2.js:3:50:3:67 | require('./dir/b') | dir/b.js:1:1:3:3 | <toplevel> |
+| umd2.js:1:1:12:4 | <toplevel> | umd2.js:5:21:5:25 | './a' | a.js:1:1:3:3 | <toplevel> |
+| umd2.js:1:1:12:4 | <toplevel> | umd2.js:5:28:5:36 | './dir/b' | dir/b.js:1:1:3:3 | <toplevel> |
 | umd.js:1:1:14:4 | <toplevel> | umd.js:4:17:4:21 | './a' | a.js:1:1:3:3 | <toplevel> |
 | umd.js:1:1:14:4 | <toplevel> | umd.js:4:24:4:32 | './dir/b' | dir/b.js:1:1:3:3 | <toplevel> |

--- a/javascript/ql/test/library-tests/AMD/umd2.js
+++ b/javascript/ql/test/library-tests/AMD/umd2.js
@@ -1,0 +1,12 @@
+; (function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ?
+        module.exports = factory(require('./a'), require('./dir/b')) :
+        typeof define === 'function' && define.amd ?
+            define(['./a', './dir/b'], factory) :
+            global.mymodule = factory(global.a, global.dir.b)
+}(this, function (a, b) {
+    return {
+        bar: a.foo,
+        foo: b.bar
+    };
+}));

--- a/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/ExprHasNoEffect.expected
+++ b/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/ExprHasNoEffect.expected
@@ -10,4 +10,5 @@
 | tst.js:50:3:50:49 | new Syn ... o me?") | This expression has no effect. |
 | tst.js:51:3:51:36 | new Err ... age(e)) | This expression has no effect. |
 | tst.js:62:2:62:20 | o.trivialNonGetter1 | This expression has no effect. |
+| tst.js:78:24:78:24 | o | This expression has no effect. |
 | uselessfn.js:1:1:1:15 | (functi ... .");\\n}) | This expression has no effect. |

--- a/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/ExprHasNoEffect/tst.js
@@ -73,5 +73,11 @@ function g() {
 	Object.defineProperty(o, "nonTrivialGetter2", unknownGetterDef());
 	o.nonTrivialGetter2; // OK
 	
-	(o: empty); // OK.
+	(o: empty); // OK
+
+	testSomeCondition() ? o : // NOT OK
+		doSomethingDangerous();
+
+	consume(testSomeCondition() ? o : // OK
+		doSomethingDangerous());
 };


### PR DESCRIPTION
Specifically, we now detect this pattern:

```js
(function (global, factory) {
    checkForNodeJS() ? module.exports = factory(...) :
    checkForAmd() ? define(..., factory) :
    global.mymodule = factory(...)
}(this, function (...) { ... });
```

We previously missed it because we expected the `define` to appear as an expression statement, but here it is nested a bit more deeply.

I fixed this by using the `inVoidContext` predicate we use in a few other queries, which however needed a bit of extra work. I'm curious to see whether that has any knock-on effects on performance or results, if it does I'm happy to switch to a more targeted fix.