### PR TITLE
JS: refactor most library models away from AST nodes

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CoreKnowledge.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/CoreKnowledge.qll
@@ -175,7 +175,7 @@ predicate isOtherModeledArgument(DataFlow::Node n, FilteringReason reason) {
   or
   n instanceof CryptographicKey and reason instanceof CryptographicKeyReason
   or
-  any(CryptographicOperation op).getInput().flow() = n and
+  any(CryptographicOperation op).getInput() = n and
   reason instanceof CryptographicOperationFlowReason
   or
   exists(DataFlow::CallNode call | n = call.getAnArgument() |

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/EndpointFeatures.qll
@@ -144,7 +144,7 @@ private module AccessPaths {
       not param = base.getReceiver()
     |
       result = param and
-      name = param.asSource().asExpr().(Parameter).getName()
+      name = param.asSource().(DataFlow::ParameterNode).getName()
       or
       param.asSource().asExpr() instanceof DestructuringPattern and
       result = param.getMember(name)

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -42,10 +42,10 @@ module SinkEndpointFilter {
       result = "modeled database access"
       or
       // Remove calls to APIs that aren't relevant to NoSQL injection
-      call.getReceiver().asExpr() instanceof HTTP::RequestExpr and
+      call.getReceiver() instanceof HTTP::RequestNode and
       result = "receiver is a HTTP request expression"
       or
-      call.getReceiver().asExpr() instanceof HTTP::ResponseExpr and
+      call.getReceiver() instanceof HTTP::ResponseNode and
       result = "receiver is a HTTP response expression"
     )
     or

--- a/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/lib/experimental/adaptivethreatmodeling/NosqlInjectionATM.qll
@@ -115,7 +115,7 @@ predicate isBaseAdditionalFlowStep(
   inlbl = TaintedObject::label() and
   outlbl = TaintedObject::label() and
   exists(NoSql::Query query, DataFlow::SourceNode queryObj |
-    queryObj.flowsToExpr(query) and
+    queryObj.flowsTo(query) and
     queryObj.flowsTo(trg) and
     src = queryObj.getAPropertyWrite().getRhs()
   )

--- a/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
+++ b/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
@@ -5,7 +5,7 @@ category: breaking
   The types of some classes have been changed, and these changes may break existing code.
   Other classes and predicates have been renamed, in these cases the old name is still available as a deprecated feature.
 
-* The basetype of the following list of classes has changed from an expression to a dataflow node, and and thus code using these classes might break. 
+* The basetype of the following list of classes has changed from an expression to a dataflow node, and thus code using these classes might break. 
   The fix to these breakages is usually to use `asExpr()` to get an expression from a dataflow node, or to use `.flow()` to get a dataflow node from an expression.  
    - DOM.qll#WebStorageWrite
    - CryptoLibraries.qll#CryptographicOperation

--- a/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
+++ b/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Many library models have been rewritten to use dataflow nodes instead of the AST.
+  These changes include some renamings where the old name is still available as a deprecated feature.

--- a/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
+++ b/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
@@ -1,5 +1,6 @@
 ---
-category: minorAnalysis
+category: breaking
 ---
 * Many library models have been rewritten to use dataflow nodes instead of the AST.
-  These changes include some renamings where the old name is still available as a deprecated feature.
+  The types of some classes have been changed, and these changes may break existing code.
+  Other classes and predicates have been renamed, in these cases the old name is still available as a deprecated feature.

--- a/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
+++ b/javascript/ql/lib/change-notes/2022-04-04-dataflow-models.md
@@ -4,3 +4,54 @@ category: breaking
 * Many library models have been rewritten to use dataflow nodes instead of the AST.
   The types of some classes have been changed, and these changes may break existing code.
   Other classes and predicates have been renamed, in these cases the old name is still available as a deprecated feature.
+
+* The basetype of the following list of classes has changed from an expression to a dataflow node, and and thus code using these classes might break. 
+  The fix to these breakages is usually to use `asExpr()` to get an expression from a dataflow node, or to use `.flow()` to get a dataflow node from an expression.  
+   - DOM.qll#WebStorageWrite
+   - CryptoLibraries.qll#CryptographicOperation
+   - Express.qll#Express::RequestBodyAccess
+   - HTTP.qll#HTTP::ResponseBody
+   - HTTP.qll#HTTP::CookieDefinition
+   - HTTP.qll#HTTP::ServerDefinition
+   - HTTP.qll#HTTP::RouteSetup
+   - NoSQL.qll#NoSql::Query
+   - SQL.qll#SQL::SqlString
+   - SQL.qll#SQL::SqlSanitizer
+   - HTTP.qll#ResponseBody
+   - HTTP.qll#CookieDefinition
+   - HTTP.qll#ServerDefinition
+   - HTTP.qll#RouteSetup
+   - HTTP.qll#HTTP::RedirectInvocation
+   - HTTP.qll#RedirectInvocation
+   - Express.qll#Express::RouterDefinition
+   - AngularJSCore.qll#LinkFunction
+   - Connect.qll#Connect::StandardRouteHandler
+   - CryptoLibraries.qll#CryptographicKeyCredentialsExpr
+   - AWS.qll#AWS::Credentials
+   - Azure.qll#Azure::Credentials
+   - Connect.qll#Connect::Credentials
+   - DigitalOcean.qll#DigitalOcean::Credentials
+   - Express.qll#Express::Credentials
+   - NodeJSLib.qll#NodeJSLib::Credentials
+   - PkgCloud.qll#PkgCloud::Credentials
+   - Request.qll#Request::Credentials
+   - ServiceDefinitions.qll#InjectableFunctionServiceRequest
+   - SensitiveActions.qll#SensitiveVariableAccess
+   - SensitiveActions.qll#CleartextPasswordExpr
+   - Connect.qll#Connect::ServerDefinition
+   - Restify.qll#Restify::ServerDefinition
+   - Connect.qll#Connect::RouteSetup
+   - Express.qll#Express::RouteSetup
+   - Fastify.qll#Fastify::RouteSetup
+   - Hapi.qll#Hapi::RouteSetup
+   - Koa.qll#Koa::RouteSetup
+   - Restify.qll#Restify::RouteSetup
+   - NodeJSLib.qll#NodeJSLib::RouteSetup
+   - Express.qll#Express::StandardRouteHandler
+   - Express.qll#Express::SetCookie
+   - Hapi.qll#Hapi::RouteHandler
+   - HTTP.qll#HTTP::Servers::StandardHeaderDefinition
+   - HTTP.qll#Servers::StandardHeaderDefinition
+   - Hapi.qll#Hapi::ServerDefinition
+   - Koa.qll#Koa::AppDefinition
+   - SensitiveActions.qll#SensitiveCall

--- a/javascript/ql/lib/semmle/javascript/Expr.qll
+++ b/javascript/ql/lib/semmle/javascript/Expr.qll
@@ -167,7 +167,7 @@ class Expr extends @expr, ExprOrStmt, ExprOrType, AST::ValueNode {
   /**
    * Holds if this expression may refer to the initial value of parameter `p`.
    */
-  predicate mayReferToParameter(Parameter p) { this.flow().mayReferToParameter(p) }
+  predicate mayReferToParameter(Parameter p) { DataFlow::parameterNode(p).flowsToExpr(this) }
 
   /**
    * Gets the static type of this expression, as determined by the TypeScript type system.

--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -139,9 +139,12 @@ module DataFlow {
     }
 
     /**
+     * DEPRECATED: Use `DataFlow::ParameterNode::flowsTo()` instead.
      * Holds if this expression may refer to the initial value of parameter `p`.
      */
-    predicate mayReferToParameter(Parameter p) { parameterNode(p).(SourceNode).flowsTo(this) }
+    deprecated predicate mayReferToParameter(Parameter p) {
+      parameterNode(p).(SourceNode).flowsTo(this)
+    }
 
     /**
      * Holds if this element is at the specified location.

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -472,6 +472,12 @@ class FunctionNode extends DataFlow::ValueNode, DataFlow::SourceNode {
   /** Gets a parameter of this function. */
   ParameterNode getAParameter() { result = this.getParameter(_) }
 
+  /** Gets the parameter named `name` of this function, if any. */
+  DataFlow::ParameterNode getParameterByName(string name) {
+    result = getAParameter() and
+    result.getName() = name
+  }
+
   /** Gets the number of parameters declared on this function. */
   int getNumParameter() { result = count(astNode.getAParameter()) }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -562,6 +562,14 @@ class ObjectLiteralNode extends DataFlow::ValueNode, DataFlow::SourceNode {
   DataFlow::FunctionNode getPropertySetter(string name) {
     result = astNode.getPropertyByName(name).(PropertySetter).getInit().flow()
   }
+
+  /** Gets the value of a computed property name of this object literal, such as `x` in `{[x]: 1}` */
+  DataFlow::Node getAComputedPropertyName() {
+    exists(Property prop | prop = astNode.getAProperty() |
+      prop.isComputed() and
+      result = prop.getNameExpr().flow()
+    )
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -474,7 +474,7 @@ class FunctionNode extends DataFlow::ValueNode, DataFlow::SourceNode {
 
   /** Gets the parameter named `name` of this function, if any. */
   DataFlow::ParameterNode getParameterByName(string name) {
-    result = getAParameter() and
+    result = this.getAParameter() and
     result.getName() = name
   }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -482,17 +482,13 @@ module TaintTracking {
    */
   private class HeapTaintStep extends SharedTaintStep {
     override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(Expr e, Expr f | e = succ.asExpr() and f = pred.asExpr() |
-        exists(Property prop | e.(ObjectExpr).getAProperty() = prop |
-          prop.isComputed() and f = prop.getNameExpr()
-        )
-        or
-        // spreading a tainted object into an object literal gives a tainted object
-        e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
-        or
-        // spreading a tainted value into an array literal gives a tainted array
-        e.(ArrayExpr).getAnElement().(SpreadElement).getOperand() = f
-      )
+      succ.(DataFlow::ObjectLiteralNode).getAComputedPropertyName() = pred
+      or
+      // spreading a tainted object into an object literal gives a tainted object
+      succ.(DataFlow::ObjectLiteralNode).getASpreadProperty() = pred
+      or
+      // spreading a tainted value into an array literal gives a tainted array
+      succ.(DataFlow::ArrayCreationNode).getASpreadArgument() = pred
       or
       // arrays with tainted elements and objects with tainted property names are tainted
       succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and

--- a/javascript/ql/lib/semmle/javascript/frameworks/AWS.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AWS.qll
@@ -8,19 +8,19 @@ module AWS {
   /**
    * Holds if the `i`th argument of `invk` is an object hash for `AWS.Config`.
    */
-  private predicate takesConfigurationObject(InvokeExpr invk, int i) {
+  private predicate takesConfigurationObject(DataFlow::InvokeNode invk, int i) {
     exists(DataFlow::ModuleImportNode mod | mod.getPath() = "aws-sdk" |
       // `AWS.config.update(nd)`
-      invk = mod.getAPropertyRead("config").getAMemberCall("update").asExpr() and
+      invk = mod.getAPropertyRead("config").getAMemberCall("update") and
       i = 0
       or
       exists(DataFlow::SourceNode cfg | cfg = mod.getAConstructorInvocation("Config") |
         // `new AWS.Config(nd)`
-        invk = cfg.asExpr() and
+        invk = cfg and
         i = 0
         or
         // `var config = new AWS.Config(...); config.update(nd);`
-        invk = cfg.getAMemberCall("update").asExpr() and
+        invk = cfg.getAMemberCall("update") and
         i = 0
       )
     )
@@ -29,13 +29,13 @@ module AWS {
   /**
    * An expression that is used as an AWS config value: `{ accessKeyId: <user>, secretAccessKey: <password>}`.
    */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
-      exists(string prop, InvokeExpr invk, int i |
+      exists(string prop, DataFlow::InvokeNode invk, int i |
         takesConfigurationObject(invk, i) and
-        invk.hasOptionArgument(i, prop, this)
+        this = invk.getOptionArgument(i, prop)
       |
         prop = "accessKeyId" and kind = "user name"
         or

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -105,8 +105,8 @@ class AngularModule extends TAngularModule {
   /**
    * Get the array of dependencies from this module's definition.
    */
-  ArrayExpr getDependencyArray() {
-    this.getADefinition().getArgument(1).getALocalSource().asExpr() = result
+  DataFlow::ArrayCreationNode getDependencyArray() {
+    this.getADefinition().getArgument(1).getALocalSource() = result
   }
 
   /**
@@ -160,14 +160,10 @@ class ModuleApiCall extends DataFlow::CallNode {
   string getMethodName() { result = methodName }
 }
 
-class ModuleApiCallDependencyInjection extends DependencyInjection {
-  ModuleApiCall call;
+class ModuleApiCallDependencyInjection extends DependencyInjection instanceof ModuleApiCall {
   string methodName;
 
-  ModuleApiCallDependencyInjection() {
-    this = call and
-    methodName = call.getMethodName()
-  }
+  ModuleApiCallDependencyInjection() { methodName = super.getMethodName() }
 
   /**
    * Gets the argument position for this method call that expects an injectable function.
@@ -183,7 +179,7 @@ class ModuleApiCallDependencyInjection extends DependencyInjection {
   }
 
   override DataFlow::Node getAnInjectableFunction() {
-    result = call.getArgument(this.injectableArgPos())
+    result = super.getArgument(this.injectableArgPos())
   }
 }
 
@@ -266,10 +262,10 @@ abstract class CustomDirective extends DirectiveInstance {
   DataFlow::SourceNode getMember(string name) { result.flowsTo(this.getMemberInit(name)) }
 
   /** Gets the method `name` of this directive. */
-  Function getMethod(string name) { DataFlow::valueNode(result) = this.getMember(name) }
+  DataFlow::FunctionNode getMethod(string name) { result = this.getMember(name) }
 
   /** Gets a link function of this directive. */
-  abstract Function getALinkFunction();
+  abstract DataFlow::FunctionNode getALinkFunction();
 
   /** Holds if this directive's properties are bound to the controller. */
   abstract predicate bindsToController();
@@ -332,10 +328,10 @@ class GeneralDirective extends CustomDirective, MkCustomDirective {
 
   /** Gets a node that contributes to the return value of the factory function. */
   override DataFlow::SourceNode getAnInstantiation() {
-    exists(Function factory, InjectableFunction f |
+    exists(DataFlow::FunctionNode factory, InjectableFunction f |
       f = definition.getAFactoryFunction() and
       factory = f.asFunction() and
-      result.flowsToExpr(factory.getAReturnedExpr())
+      result.flowsTo(factory.getAReturn())
     )
   }
 
@@ -344,7 +340,7 @@ class GeneralDirective extends CustomDirective, MkCustomDirective {
   }
 
   /** Gets the compile function of this directive, if any. */
-  Function getCompileFunction() { result = this.getMethod("compile") }
+  DataFlow::FunctionNode getCompileFunction() { result = this.getMethod("compile") }
 
   /**
    * Gets a pre/post link function of this directive defined on its definition object.
@@ -365,9 +361,8 @@ class GeneralDirective extends CustomDirective, MkCustomDirective {
     result = this.getMember("link").getAPropertySource(kind)
     or
     // { compile: function() { ... return link; } }
-    exists(Expr compileReturn, DataFlow::SourceNode compileReturnSrc |
-      compileReturn = this.getCompileFunction().getAReturnedExpr() and
-      compileReturnSrc.flowsToExpr(compileReturn)
+    exists(DataFlow::SourceNode compileReturnSrc |
+      compileReturnSrc.flowsTo(this.getCompileFunction().getAReturn())
     |
       // link = function postLink() { ... }
       kind = "post" and
@@ -380,12 +375,12 @@ class GeneralDirective extends CustomDirective, MkCustomDirective {
   }
 
   /** Gets the pre-link function of this directive. */
-  Function getPreLinkFunction() { result = this.getLinkFunction("pre").getAstNode() }
+  DataFlow::FunctionNode getPreLinkFunction() { result = this.getLinkFunction("pre") }
 
   /** Gets the post-link function of this directive. */
-  Function getPostLinkFunction() { result = this.getLinkFunction("post").getAstNode() }
+  DataFlow::FunctionNode getPostLinkFunction() { result = this.getLinkFunction("post") }
 
-  override Function getALinkFunction() { result = this.getLinkFunction(_).getAstNode() }
+  override DataFlow::FunctionNode getALinkFunction() { result = this.getLinkFunction(_) }
 
   override predicate bindsToController() {
     this.getMemberInit("bindToController").asExpr().mayHaveBooleanValue(true)
@@ -412,7 +407,7 @@ class ComponentDirective extends CustomDirective, MkCustomComponent {
     comp.getConfig().hasPropertyWrite(name, result)
   }
 
-  override Function getALinkFunction() { none() }
+  override DataFlow::FunctionNode getALinkFunction() { none() }
 
   override predicate bindsToController() { none() }
 
@@ -561,13 +556,12 @@ class DirectiveTargetName extends string {
  *
  * See https://docs.angularjs.org/api/ng/service/$location for details.
  */
-private class LocationFlowSource extends RemoteFlowSource {
+private class LocationFlowSource extends RemoteFlowSource instanceof DataFlow::MethodCallNode {
   LocationFlowSource() {
-    exists(ServiceReference service, MethodCallExpr mce, string m, int n |
+    exists(ServiceReference service, string m, int n |
       service.getName() = "$location" and
-      this.asExpr() = mce and
-      mce = service.getAMethodCall(m) and
-      n = mce.getNumArgument()
+      this = service.getAMethodCall(m) and
+      n = super.getNumArgument()
     |
       m = "search" and n < 2
       or
@@ -605,7 +599,7 @@ private class JQLiteObject extends JQuery::ObjectSource::Range {
   JQLiteObject() {
     this = angular().getAMemberCall("element")
     or
-    exists(Parameter param | this = DataFlow::parameterNode(param) |
+    exists(DataFlow::ParameterNode param | this = param |
       // element parameters to user-functions invoked by AngularJS
       param = any(LinkFunction link).getElementParameter()
       or
@@ -613,13 +607,13 @@ private class JQLiteObject extends JQuery::ObjectSource::Range {
         param = d.getCompileFunction().getParameter(0)
         or
         exists(DataFlow::FunctionNode f, int i |
-          f.flowsToExpr(d.getCompileFunction().getAReturnedExpr()) and i = 1
+          f.flowsTo(d.getCompileFunction().getAReturn()) and i = 1
           or
           f = d.getMember("template") and i = 0
           or
           f = d.getMember("templateUrl") and i = 0
         |
-          param = f.getAstNode().(Function).getParameter(i)
+          param = f.getParameter(i)
         )
       )
     )
@@ -631,99 +625,111 @@ private class JQLiteObject extends JQuery::ObjectSource::Range {
 }
 
 /**
+ * DEPRECATED: Use `AngularJSCallNode` instead.
  * A call to an AngularJS function.
  *
  * Used for exposing behavior that is similar to the behavior of other libraries.
  */
-abstract class AngularJSCall extends CallExpr {
+deprecated class AngularJSCall extends CallExpr {
+  AngularJSCallNode node;
+
+  AngularJSCall() { this.flow() = node }
+
+  /** Holds if `e` is an argument that this call interprets as HTML. */
+  deprecated predicate interpretsArgumentAsHtml(Expr e) { node.interpretsArgumentAsHtml(e.flow()) }
+
+  /** Holds if `e` is an argument that this call stores globally, e.g. in a cookie. */
+  deprecated predicate storesArgumentGlobally(Expr e) { node.storesArgumentGlobally(e.flow()) }
+
+  /** Holds if `e` is an argument that this call interprets as code. */
+  deprecated predicate interpretsArgumentAsCode(Expr e) { node.interpretsArgumentAsCode(e.flow()) }
+}
+
+/**
+ * A call to an AngularJS function.
+ *
+ * Used for exposing behavior that is similar to the behavior of other libraries.
+ */
+abstract class AngularJSCallNode extends DataFlow::CallNode {
   /**
    * Holds if `e` is an argument that this call interprets as HTML.
    */
-  abstract predicate interpretsArgumentAsHtml(Expr e);
+  abstract predicate interpretsArgumentAsHtml(DataFlow::Node e);
 
   /**
    * Holds if `e` is an argument that this call stores globally, e.g. in a cookie.
    */
-  abstract predicate storesArgumentGlobally(Expr e);
+  abstract predicate storesArgumentGlobally(DataFlow::Node e);
 
   /**
    * Holds if `e` is an argument that this call interprets as code.
    */
-  abstract predicate interpretsArgumentAsCode(Expr e);
+  abstract predicate interpretsArgumentAsCode(DataFlow::Node e);
 }
 
 /**
  * A call to a method on the AngularJS object itself.
  */
-private class AngularMethodCall extends AngularJSCall {
-  MethodCallExpr mce;
+private class AngularMethodCall extends AngularJSCallNode {
+  AngularMethodCall() { this = angular().getAMemberCall(_) }
 
-  AngularMethodCall() {
-    mce = angular().getAMemberCall(_).asExpr() and
-    mce = this
+  override predicate interpretsArgumentAsHtml(DataFlow::Node e) {
+    super.getCalleeName() = "element" and
+    e = super.getArgument(0)
   }
 
-  override predicate interpretsArgumentAsHtml(Expr e) {
-    mce.getMethodName() = "element" and
-    e = mce.getArgument(0)
-  }
+  override predicate storesArgumentGlobally(DataFlow::Node e) { none() }
 
-  override predicate storesArgumentGlobally(Expr e) { none() }
-
-  override predicate interpretsArgumentAsCode(Expr e) { none() }
+  override predicate interpretsArgumentAsCode(DataFlow::Node e) { none() }
 }
 
 /**
  * A call to a builtin service or one of its methods.
  */
-private class BuiltinServiceCall extends AngularJSCall {
-  CallExpr call;
-
+private class BuiltinServiceCall extends AngularJSCallNode {
   BuiltinServiceCall() {
     exists(BuiltinServiceReference service |
       service.getAMethodCall(_) = this or
       service.getACall() = this
-    |
-      call = this
     )
   }
 
-  override predicate interpretsArgumentAsHtml(Expr e) {
+  override predicate interpretsArgumentAsHtml(DataFlow::Node e) {
     exists(ServiceReference service, string methodName |
       service.getName() = "$sce" and
-      call = service.getAMethodCall(methodName)
+      this = service.getAMethodCall(methodName)
     |
       // specialized call
       (methodName = "trustAsHtml" or methodName = "trustAsCss") and
-      e = call.getArgument(0)
+      e = this.getArgument(0)
       or
       // generic call with enum argument
       methodName = "trustAs" and
       exists(DataFlow::PropRead prn |
-        prn.asExpr() = call.getArgument(0) and
+        prn = this.getArgument(0) and
         (prn = service.getAPropertyAccess("HTML") or prn = service.getAPropertyAccess("CSS")) and
-        e = call.getArgument(1)
+        e = this.getArgument(1)
       )
     )
   }
 
-  override predicate storesArgumentGlobally(Expr e) {
+  override predicate storesArgumentGlobally(DataFlow::Node e) {
     exists(ServiceReference service, string serviceName, string methodName |
       service.getName() = serviceName and
-      call = service.getAMethodCall(methodName)
+      this = service.getAMethodCall(methodName)
     |
       // AngularJS caches (only available during runtime, so similar to sessionStorage)
       (serviceName = "$cacheFactory" or serviceName = "$templateCache") and
       methodName = "put" and
-      e = call.getArgument(1)
+      e = this.getArgument(1)
       or
       serviceName = "$cookies" and
       (methodName = "put" or methodName = "putObject") and
-      e = call.getArgument(1)
+      e = this.getArgument(1)
     )
   }
 
-  override predicate interpretsArgumentAsCode(Expr e) {
+  override predicate interpretsArgumentAsCode(DataFlow::Node e) {
     exists(ScopeServiceReference scope, string methodName |
       methodName =
         [
@@ -731,22 +737,21 @@ private class BuiltinServiceCall extends AngularJSCall {
           "$watchGroup"
         ]
     |
-      call = scope.getAMethodCall(methodName) and
-      e = call.getArgument(0)
+      this = scope.getAMethodCall(methodName) and
+      e = this.getArgument(0)
     )
     or
     exists(ServiceReference service | service.getName() = ["$compile", "$parse", "$interpolate"] |
-      call = service.getACall() and
-      e = call.getArgument(0)
+      this = service.getACall() and
+      e = this.getArgument(0)
     )
     or
-    exists(ServiceReference service, CallExpr filterInvocation |
+    exists(ServiceReference service |
       // `$filter('orderBy')(collection, expression)`
       service.getName() = "$filter" and
-      call = service.getACall() and
-      call.getArgument(0).mayHaveStringValue("orderBy") and
-      filterInvocation.getCallee() = call and
-      e = filterInvocation.getArgument(1)
+      this = service.getACall() and
+      this.getArgument(0).mayHaveStringValue("orderBy") and
+      e = this.getACall().getArgument(1)
     )
   }
 }
@@ -754,33 +759,33 @@ private class BuiltinServiceCall extends AngularJSCall {
 /**
  * A link-function used in a custom AngularJS directive.
  */
-class LinkFunction extends Function {
+class LinkFunction extends DataFlow::FunctionNode {
   LinkFunction() { this = any(GeneralDirective d).getALinkFunction() }
 
   /**
    * Gets the scope parameter of this function.
    */
-  Parameter getScopeParameter() { result = this.getParameter(0) }
+  DataFlow::ParameterNode getScopeParameter() { result = this.getParameter(0) }
 
   /**
    * Gets the element parameter of this function (contains a jqLite-wrapped DOM element).
    */
-  Parameter getElementParameter() { result = this.getParameter(1) }
+  DataFlow::ParameterNode getElementParameter() { result = this.getParameter(1) }
 
   /**
    * Gets the attributes parameter of this function.
    */
-  Parameter getAttributesParameter() { result = this.getParameter(2) }
+  DataFlow::ParameterNode getAttributesParameter() { result = this.getParameter(2) }
 
   /**
    * Gets the controller parameter of this function.
    */
-  Parameter getControllerParameter() { result = this.getParameter(3) }
+  DataFlow::ParameterNode getControllerParameter() { result = this.getParameter(3) }
 
   /**
    * Gets the transclude-function parameter of this function.
    */
-  Parameter getTranscludeFnParameter() { result = this.getParameter(4) }
+  DataFlow::ParameterNode getTranscludeFnParameter() { result = this.getParameter(4) }
 }
 
 /**
@@ -807,29 +812,29 @@ class AngularScope extends TAngularScope {
   /**
    * Gets an access to this scope object.
    */
-  Expr getAnAccess() {
+  DataFlow::Node getAnAccess() {
     exists(CustomDirective d | this = d.getAScope() |
-      exists(Parameter p |
+      exists(DataFlow::ParameterNode p |
         p = d.getController().getDependencyParameter("$scope") or
         p = d.getALinkFunction().getParameter(0)
       |
-        result.mayReferToParameter(p)
+        p.flowsTo(result)
       )
       or
       exists(DataFlow::ThisNode dis |
-        dis.flowsToExpr(result) and
-        dis.getBinder().getAstNode() = d.getController().asFunction() and
+        dis.flowsTo(result) and
+        dis.getBinder() = d.getController().asFunction() and
         d.bindsToController()
       )
       or
-      d.hasIsolateScope() and result = d.getMember("scope").asExpr()
+      d.hasIsolateScope() and result = d.getMember("scope")
     )
     or
-    exists(DirectiveController c, DOM::ElementDefinition elem, Parameter p |
+    exists(DirectiveController c, DOM::ElementDefinition elem, DataFlow::ParameterNode p |
       c.boundTo(elem) and
       this.mayApplyTo(elem) and
       p = c.getFactoryFunction().getDependencyParameter("$scope") and
-      result.mayReferToParameter(p)
+      p.flowsTo(result)
     )
   }
 
@@ -1022,15 +1027,12 @@ private class RouteInstantiatedController extends Controller {
 /**
  * Dataflow for the arguments of AngularJS dependency-injected functions.
  */
-private class DependencyInjectedArgumentInitializer extends DataFlow::AnalyzedNode {
+private class DependencyInjectedArgumentInitializer extends DataFlow::AnalyzedNode instanceof DataFlow::ParameterNode {
   DataFlow::AnalyzedNode service;
 
   DependencyInjectedArgumentInitializer() {
-    exists(
-      AngularJS::InjectableFunction f, Parameter param, AngularJS::CustomServiceDefinition def
-    |
-      this = DataFlow::parameterNode(param) and
-      def.getServiceReference() = f.getAResolvedDependency(param) and
+    exists(AngularJS::InjectableFunction f, AngularJS::CustomServiceDefinition def |
+      def.getServiceReference() = f.getAResolvedDependency(this) and
       service = def.getAService()
     )
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -68,7 +68,7 @@ private class TrackStringsInAngularCode extends DataFlow::SourceNode::Range, Dat
  */
 private DataFlow::CallNode angularModuleCall(string name) {
   result = angular().getAMemberCall("module") and
-  result.getArgument(0).asExpr().mayHaveStringValue(name)
+  result.getArgument(0).mayHaveStringValue(name)
 }
 
 /**
@@ -280,7 +280,7 @@ abstract class CustomDirective extends DirectiveInstance {
   InjectableFunction getController() { result = this.getMember("controller") }
 
   /** Gets the template URL of this directive, if any. */
-  string getTemplateUrl() { this.getMember("templateUrl").asExpr().mayHaveStringValue(result) }
+  string getTemplateUrl() { this.getMember("templateUrl").mayHaveStringValue(result) }
 
   /**
    * Gets a template file for this directive, if any.
@@ -298,9 +298,7 @@ abstract class CustomDirective extends DirectiveInstance {
     else result = DirectiveInstance.super.getAScope()
   }
 
-  private string getRestrictionString() {
-    this.getMember("restrict").asExpr().mayHaveStringValue(result)
-  }
+  private string getRestrictionString() { this.getMember("restrict").mayHaveStringValue(result) }
 
   private predicate hasTargetType(DirectiveTargetType type) {
     not exists(this.getRestrictionString()) or
@@ -383,10 +381,12 @@ class GeneralDirective extends CustomDirective, MkCustomDirective {
   override DataFlow::FunctionNode getALinkFunction() { result = this.getLinkFunction(_) }
 
   override predicate bindsToController() {
-    this.getMemberInit("bindToController").asExpr().mayHaveBooleanValue(true)
+    this.getMemberInit("bindToController").mayHaveBooleanValue(true)
   }
 
-  override predicate hasIsolateScope() { this.getMember("scope").asExpr() instanceof ObjectExpr }
+  override predicate hasIsolateScope() {
+    this.getMember("scope") instanceof DataFlow::ObjectLiteralNode
+  }
 }
 
 /**
@@ -930,9 +930,7 @@ class RouteSetup extends DataFlow::CallNode, DependencyInjection {
     |
       result = controllerProperty
       or
-      exists(ControllerDefinition def |
-        controllerProperty.asExpr().mayHaveStringValue(def.getName())
-      |
+      exists(ControllerDefinition def | controllerProperty.mayHaveStringValue(def.getName()) |
         result = def.getAService()
       )
     )
@@ -1012,7 +1010,7 @@ private class RouteInstantiatedController extends Controller {
 
   override predicate boundTo(DOM::ElementDefinition elem) {
     exists(string url, HTML::HtmlFile template |
-      setup.getRouteParam("templateUrl").asExpr().mayHaveStringValue(url) and
+      setup.getRouteParam("templateUrl").mayHaveStringValue(url) and
       template.getAbsolutePath().regexpMatch(".*\\Q" + url + "\\E") and
       elem.getFile() = template
     )
@@ -1020,7 +1018,7 @@ private class RouteInstantiatedController extends Controller {
 
   override predicate boundToAs(DOM::ElementDefinition elem, string name) {
     this.boundTo(elem) and
-    setup.getRouteParam("controllerAs").asExpr().mayHaveStringValue(name)
+    setup.getRouteParam("controllerAs").mayHaveStringValue(name)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/DependencyInjections.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/DependencyInjections.qll
@@ -41,33 +41,35 @@ abstract class DependencyInjection extends DataFlow::ValueNode {
  */
 abstract class InjectableFunction extends DataFlow::ValueNode {
   /** Gets the parameter corresponding to dependency `name`. */
-  abstract Parameter getDependencyParameter(string name);
+  abstract DataFlow::ParameterNode getDependencyParameter(string name);
 
   /**
    * Gets the `i`th dependency declaration, which is also named `name`.
    */
-  abstract AstNode getDependencyDeclaration(int i, string name);
+  abstract DataFlow::Node getDependencyDeclaration(int i, string name);
 
   /**
-   * Gets an ASTNode for the `name` dependency declaration.
+   * Gets a node for the `name` dependency declaration.
    */
-  AstNode getADependencyDeclaration(string name) { result = getDependencyDeclaration(_, name) }
+  DataFlow::Node getADependencyDeclaration(string name) {
+    result = getDependencyDeclaration(_, name)
+  }
 
   /**
-   * Gets the ASTNode for the `i`th dependency declaration.
+   * Gets the dataflow node for the `i`th dependency declaration.
    */
-  AstNode getDependencyDeclaration(int i) { result = getDependencyDeclaration(i, _) }
+  DataFlow::Node getDependencyDeclaration(int i) { result = getDependencyDeclaration(i, _) }
 
   /** Gets the function underlying this injectable function. */
-  abstract Function asFunction();
+  abstract DataFlow::FunctionNode asFunction();
 
-  /** Gets a location where this function is explicitly dependency injected. */
-  abstract AstNode getAnExplicitDependencyInjection();
+  /** Gets a node where this function is explicitly dependency injected. */
+  abstract DataFlow::Node getAnExplicitDependencyInjection();
 
   /**
    * Gets a service corresponding to the dependency-injected `parameter`.
    */
-  ServiceReference getAResolvedDependency(Parameter parameter) {
+  ServiceReference getAResolvedDependency(DataFlow::ParameterNode parameter) {
     exists(string name, InjectableFunctionServiceRequest request |
       this = request.getAnInjectedFunction() and
       parameter = getDependencyParameter(name) and
@@ -79,7 +81,7 @@ abstract class InjectableFunction extends DataFlow::ValueNode {
    * Gets a Custom service corresponding to the dependency-injected `parameter`.
    * (this is a convenience variant of `getAResolvedDependency`)
    */
-  DataFlow::Node getCustomServiceDependency(Parameter parameter) {
+  DataFlow::Node getCustomServiceDependency(DataFlow::ParameterNode parameter) {
     exists(CustomServiceDefinition custom |
       custom.getServiceReference() = getAResolvedDependency(parameter) and
       result = custom.getAService()
@@ -91,100 +93,88 @@ abstract class InjectableFunction extends DataFlow::ValueNode {
  * An injectable function that does not explicitly list its dependencies,
  * instead relying on implicit matching by parameter names.
  */
-private class FunctionWithImplicitDependencyAnnotation extends InjectableFunction {
-  override Function astNode;
-
+private class FunctionWithImplicitDependencyAnnotation extends InjectableFunction instanceof DataFlow::FunctionNode {
   FunctionWithImplicitDependencyAnnotation() {
     this.(DataFlow::FunctionNode).flowsTo(any(DependencyInjection d).getAnInjectableFunction()) and
-    not exists(getAPropertyDependencyInjection(astNode))
+    not exists(getAPropertyDependencyInjection(this))
   }
 
-  override Parameter getDependencyParameter(string name) {
-    result = astNode.getParameterByName(name)
+  override DataFlow::ParameterNode getDependencyParameter(string name) {
+    result = super.getParameterByName(name)
   }
 
-  override Parameter getDependencyDeclaration(int i, string name) {
+  override DataFlow::ParameterNode getDependencyDeclaration(int i, string name) {
     result.getName() = name and
-    result = astNode.getParameter(i)
+    result = super.getParameter(i)
   }
 
-  override Function asFunction() { result = astNode }
+  override DataFlow::FunctionNode asFunction() { result = this }
 
-  override AstNode getAnExplicitDependencyInjection() { none() }
+  override DataFlow::Node getAnExplicitDependencyInjection() { none() }
 }
 
-private DataFlow::PropWrite getAPropertyDependencyInjection(Function function) {
-  exists(DataFlow::FunctionNode ltf |
-    ltf.getAstNode() = function and
-    result = ltf.getAPropertyWrite("$inject")
-  )
+private DataFlow::PropWrite getAPropertyDependencyInjection(DataFlow::FunctionNode function) {
+  result = function.getAPropertyWrite("$inject")
 }
 
 /**
  * An injectable function with an `$inject` property that lists its
  * dependencies.
  */
-private class FunctionWithInjectProperty extends InjectableFunction {
-  override Function astNode;
+private class FunctionWithInjectProperty extends InjectableFunction instanceof DataFlow::FunctionNode {
   DataFlow::ArrayCreationNode dependencies;
 
   FunctionWithInjectProperty() {
     (
       this.(DataFlow::FunctionNode).flowsTo(any(DependencyInjection d).getAnInjectableFunction()) or
-      exists(FunctionWithExplicitDependencyAnnotation f | f.asFunction() = astNode)
+      exists(FunctionWithExplicitDependencyAnnotation f | f.asFunction() = this)
     ) and
     exists(DataFlow::PropWrite pwn |
-      pwn = getAPropertyDependencyInjection(astNode) and
+      pwn = getAPropertyDependencyInjection(this) and
       pwn.getRhs().getALocalSource() = dependencies
     )
   }
 
-  override Parameter getDependencyParameter(string name) {
-    exists(int i | exists(getDependencyDeclaration(i, name)) | result = astNode.getParameter(i))
+  override DataFlow::ParameterNode getDependencyParameter(string name) {
+    exists(int i | exists(getDependencyDeclaration(i, name)) | result = super.getParameter(i))
   }
 
-  override AstNode getDependencyDeclaration(int i, string name) {
-    exists(DataFlow::ValueNode decl |
-      decl = dependencies.getElement(i) and
-      decl.mayHaveStringValue(name) and
-      result = decl.getAstNode()
-    )
+  override DataFlow::Node getDependencyDeclaration(int i, string name) {
+    result = dependencies.getElement(i) and
+    result.mayHaveStringValue(name)
   }
 
-  override Function asFunction() { result = astNode }
+  override DataFlow::FunctionNode asFunction() { result = this }
 
-  override AstNode getAnExplicitDependencyInjection() {
-    result = getAPropertyDependencyInjection(astNode).getAstNode()
+  override DataFlow::Node getAnExplicitDependencyInjection() {
+    result = getAPropertyDependencyInjection(this)
   }
 }
 
 /**
  * An injectable function embedded in an array of dependencies.
  */
-private class FunctionWithExplicitDependencyAnnotation extends InjectableFunction {
+private class FunctionWithExplicitDependencyAnnotation extends InjectableFunction instanceof DataFlow::ArrayCreationNode {
   DataFlow::FunctionNode function;
-  override ArrayExpr astNode;
 
   FunctionWithExplicitDependencyAnnotation() {
     this.(DataFlow::SourceNode).flowsTo(any(DependencyInjection d).getAnInjectableFunction()) and
-    function.flowsToExpr(astNode.getElement(astNode.getSize() - 1))
+    function.flowsTo(super.getElement(super.getSize() - 1))
   }
 
-  override Parameter getDependencyParameter(string name) {
-    exists(int i | astNode.getElement(i).mayHaveStringValue(name) |
-      result = asFunction().getParameter(i)
-    )
+  override DataFlow::ParameterNode getDependencyParameter(string name) {
+    exists(int i | super.getElement(i).mayHaveStringValue(name) | result = function.getParameter(i))
   }
 
-  override AstNode getDependencyDeclaration(int i, string name) {
-    result = astNode.getElement(i) and
-    result.(Expr).mayHaveStringValue(name)
+  override DataFlow::Node getDependencyDeclaration(int i, string name) {
+    result = super.getElement(i) and
+    result.mayHaveStringValue(name)
   }
 
-  override Function asFunction() { result = function.getAstNode() }
+  override DataFlow::FunctionNode asFunction() { result = function }
 
-  override AstNode getAnExplicitDependencyInjection() {
-    result = astNode or
+  override DataFlow::Node getAnExplicitDependencyInjection() {
+    result = this or
     result = function.(InjectableFunction).getAnExplicitDependencyInjection()
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/ServiceDefinitions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/ServiceDefinitions.qll
@@ -244,7 +244,7 @@ abstract class RecipeDefinition extends DataFlow::CallNode, CustomServiceDefinit
       this = moduleRef(_).getAMethodCall(methodName) or
       this = builtinServiceRef("$provide").getAMethodCall(methodName)
     ) and
-    getArgument(0).asExpr().mayHaveStringValue(name)
+    getArgument(0).mayHaveStringValue(name)
   }
 
   override string getName() { result = name }
@@ -281,7 +281,7 @@ private predicate isCustomServiceDefinitionOnModule(
   DataFlow::Node factoryFunction
 ) {
   mce = moduleRef(_).getAMethodCall(moduleMethodName) and
-  mce.getArgument(0).asExpr().mayHaveStringValue(serviceName) and
+  mce.getArgument(0).mayHaveStringValue(serviceName) and
   factoryFunction = mce.getArgument(1)
 }
 
@@ -296,7 +296,7 @@ private predicate isCustomServiceDefinitionOnProvider(
     factoryArgument = mce.getOptionArgument(0, serviceName)
     or
     mce.getNumArgument() = 2 and
-    mce.getArgument(0).asExpr().mayHaveStringValue(serviceName) and
+    mce.getArgument(0).mayHaveStringValue(serviceName) and
     factoryArgument = mce.getArgument(1)
   )
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/ServiceDefinitions.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/AngularJS/ServiceDefinitions.qll
@@ -27,7 +27,7 @@ private newtype TServiceReference =
  */
 abstract class ServiceReference extends TServiceReference {
   /** Gets a textual representation of this element. */
-  string toString() { result = getName() }
+  string toString() { result = this.getName() }
 
   /**
    * Gets the name of this reference.
@@ -51,13 +51,13 @@ abstract class ServiceReference extends TServiceReference {
   /**
    * Gets a call that invokes the referenced service.
    */
-  DataFlow::CallNode getACall() { result.getCalleeNode() = getAnAccess() }
+  DataFlow::CallNode getACall() { result.getCalleeNode() = this.getAnAccess() }
 
   /**
    * Gets a method call that invokes method `methodName` on the referenced service.
    */
   DataFlow::MethodCallNode getAMethodCall(string methodName) {
-    result.getReceiver() = getAnAccess() and
+    result.getReceiver() = this.getAnAccess() and
     result.getMethodName() = methodName
   }
 
@@ -65,7 +65,7 @@ abstract class ServiceReference extends TServiceReference {
    * Gets an access to property `propertyName` on the referenced service.
    */
   DataFlow::PropRef getAPropertyAccess(string propertyName) {
-    result.getBase() = getAnAccess() and
+    result.getBase() = this.getAnAccess() and
     result.getPropertyName() = propertyName
   }
 
@@ -244,17 +244,17 @@ abstract class RecipeDefinition extends DataFlow::CallNode, CustomServiceDefinit
       this = moduleRef(_).getAMethodCall(methodName) or
       this = builtinServiceRef("$provide").getAMethodCall(methodName)
     ) and
-    getArgument(0).mayHaveStringValue(name)
+    this.getArgument(0).mayHaveStringValue(name)
   }
 
   override string getName() { result = name }
 
-  override DataFlow::SourceNode getAFactoryFunction() { result.flowsTo(getArgument(1)) }
+  override DataFlow::SourceNode getAFactoryFunction() { result.flowsTo(this.getArgument(1)) }
 
   override DataFlow::Node getAnInjectableFunction() {
     methodName != "value" and
     methodName != "constant" and
-    result = getAFactoryFunction()
+    result = this.getAFactoryFunction()
   }
 }
 
@@ -269,7 +269,7 @@ abstract class RecipeDefinition extends DataFlow::CallNode, CustomServiceDefinit
  */
 abstract private class CustomSpecialServiceDefinition extends CustomServiceDefinition,
   DependencyInjection {
-  override DataFlow::Node getAnInjectableFunction() { result = getAFactoryFunction() }
+  override DataFlow::Node getAnInjectableFunction() { result = this.getAFactoryFunction() }
 }
 
 /**
@@ -498,7 +498,9 @@ class InjectableFunctionServiceRequest extends ServiceRequestNode {
   /**
    * Gets a name of a requested service.
    */
-  string getAServiceName() { exists(getAnInjectedFunction().getADependencyDeclaration(result)) }
+  string getAServiceName() {
+    exists(this.getAnInjectedFunction().getADependencyDeclaration(result))
+  }
 
   /**
    * Gets a service with the specified name, relative to this request.
@@ -576,7 +578,7 @@ class ServiceRecipeDefinition extends RecipeDefinition {
      */
 
     exists(InjectableFunction f |
-      f = getAFactoryFunction() and
+      f = this.getAFactoryFunction() and
       result = f.asFunction()
     )
   }
@@ -589,7 +591,7 @@ class ServiceRecipeDefinition extends RecipeDefinition {
 class ValueRecipeDefinition extends RecipeDefinition {
   ValueRecipeDefinition() { methodName = "value" }
 
-  override DataFlow::SourceNode getAService() { result = getAFactoryFunction() }
+  override DataFlow::SourceNode getAService() { result = this.getAFactoryFunction() }
 }
 
 /**
@@ -599,7 +601,7 @@ class ValueRecipeDefinition extends RecipeDefinition {
 class ConstantRecipeDefinition extends RecipeDefinition {
   ConstantRecipeDefinition() { methodName = "constant" }
 
-  override DataFlow::SourceNode getAService() { result = getAFactoryFunction() }
+  override DataFlow::SourceNode getAService() { result = this.getAFactoryFunction() }
 }
 
 /**
@@ -622,7 +624,7 @@ class ProviderRecipeDefinition extends RecipeDefinition {
      */
 
     exists(DataFlow::ThisNode thiz, InjectableFunction f |
-      f = getAFactoryFunction() and
+      f = this.getAFactoryFunction() and
       thiz.getBinder() = f.asFunction() and
       result = thiz.getAPropertySource("$get")
     )
@@ -647,7 +649,9 @@ class ConfigMethodDefinition extends ModuleApiCall {
   /**
    * Gets a provided configuration method.
    */
-  InjectableFunction getConfigMethod() { result.(DataFlow::SourceNode).flowsTo(getArgument(0)) }
+  InjectableFunction getConfigMethod() {
+    result.(DataFlow::SourceNode).flowsTo(this.getArgument(0))
+  }
 }
 
 /**
@@ -660,12 +664,12 @@ class RunMethodDefinition extends ModuleApiCall {
   /**
    * Gets a provided run method.
    */
-  InjectableFunction getRunMethod() { result.(DataFlow::SourceNode).flowsTo(getArgument(0)) }
+  InjectableFunction getRunMethod() { result.(DataFlow::SourceNode).flowsTo(this.getArgument(0)) }
 }
 
 /**
  * The `$scope` or `$rootScope` service.
  */
 class ScopeServiceReference extends BuiltinServiceReference {
-  ScopeServiceReference() { getName() = "$scope" or getName() = "$rootScope" }
+  ScopeServiceReference() { this.getName() = "$scope" or this.getName() = "$rootScope" }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Azure.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Azure.qll
@@ -8,13 +8,14 @@ module Azure {
   /**
    * An expression that is used for authentication at Azure`.
    */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
-      exists(CallExpr mce, string methodName |
-        (methodName = "loginWithUsernamePassword" or methodName = "loginWithServicePrincipalSecret") and
-        mce = DataFlow::moduleMember("ms-rest-azure", methodName).getACall().asExpr()
+      exists(DataFlow::CallNode mce |
+        mce =
+          DataFlow::moduleMember("ms-rest-azure",
+            ["loginWithUsernamePassword", "loginWithServicePrincipalSecret"]).getACall()
       |
         this = mce.getArgument(0) and kind = "user name"
         or

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -270,16 +270,16 @@ module ClientRequest {
   }
 
   /** An expression that is used as a credential in a request. */
-  private class AuthorizationHeader extends CredentialsExpr {
+  private class AuthorizationHeader extends CredentialsNode {
     AuthorizationHeader() {
       exists(DataFlow::PropWrite write | write.getPropertyName().regexpMatch("(?i)authorization") |
-        this = write.getRhs().asExpr()
+        this = write.getRhs()
       )
       or
       exists(DataFlow::MethodCallNode call | call.getMethodName() = ["append", "set"] |
         call.getNumArgument() = 2 and
         call.getArgument(0).getStringValue().regexpMatch("(?i)authorization") and
-        this = call.getArgument(1).asExpr()
+        this = call.getArgument(1)
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -101,12 +101,12 @@ module Connect {
   }
 
   /** An expression that is passed as `basicAuthConnect(<user>, <password>)`. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
-      exists(CallExpr call |
-        call = DataFlow::moduleImport("basic-auth-connect").getAnInvocation().asExpr() and
+      exists(DataFlow::CallNode call |
+        call = DataFlow::moduleImport("basic-auth-connect").getAnInvocation() and
         call.getNumArgument() = 2
       |
         this = call.getArgument(0) and kind = "user name"

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -66,7 +66,7 @@ module Connect {
       getMethodName() = "use" and
       (
         // app.use(fun)
-        server.flowsTo(getReceiver())
+        server.ref().flowsToExpr(getReceiver())
         or
         // app.use(...).use(fun)
         this.getReceiver().(RouteSetup).getServer() = server

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -108,22 +108,24 @@ module Connect {
     override string getCredentialsKind() { result = kind }
   }
 
-  class RequestExpr = NodeJSLib::RequestExpr;
+  deprecated class RequestExpr = NodeJSLib::RequestExpr;
+
+  class RequestNode = NodeJSLib::RequestNode;
 
   /**
    * An access to a user-controlled Connect request input.
    */
-  private class RequestInputAccess extends HTTP::RequestInputAccess {
-    RequestExpr request;
+  private class RequestInputAccess extends HTTP::RequestInputAccess instanceof DataFlow::MethodCallNode {
+    RequestNode request;
     string kind;
 
     RequestInputAccess() {
       request.getRouteHandler() instanceof StandardRouteHandler and
-      exists(PropAccess cookies |
+      exists(DataFlow::PropRead cookies |
         // `req.cookies.get(<name>)`
         kind = "cookie" and
         cookies.accesses(request, "cookies") and
-        this.asExpr().(MethodCallExpr).calls(cookies, "get")
+        super.calls(cookies, "get")
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -79,15 +79,23 @@ module Connect {
 
     private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
       t.start() and
-      result = getARouteHandlerExpr().flow().getALocalSource()
+      result = getARouteHandlerNode().getALocalSource()
       or
       exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
     }
 
     override DataFlow::Node getServer() { result = server }
 
-    /** Gets an argument that represents a route handler being registered. */
-    Expr getARouteHandlerExpr() { result = getAnArgument().asExpr() } // TODO: DataFlow::Node
+    /**
+     * DEPRECATED: Use `getARouteHandlerNode` instead.
+     * Gets an argument that represents a route handler being registered.
+     */
+    deprecated Expr getARouteHandlerExpr() { result = getARouteHandlerNode().asExpr() }
+
+    /**
+     * Gets an argument that represents a route handler being registered.
+     */
+    DataFlow::Node getARouteHandlerNode() { result = getAnArgument() }
   }
 
   /** An expression that is passed as `basicAuthConnect(<user>, <password>)`. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -30,29 +30,31 @@ module Connect {
      *
      * `kind` is one of: "error", "request", "response", "next".
      */
-    abstract Parameter getRouteHandlerParameter(string kind);
+    abstract DataFlow::ParameterNode getRouteHandlerParameter(string kind);
 
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
-    override Parameter getRequestParameter() { result = getRouteHandlerParameter("request") }
+    override DataFlow::ParameterNode getRequestParameter() {
+      result = getRouteHandlerParameter("request")
+    }
 
     /**
      * Gets the parameter of the route handler that contains the response object.
      */
-    override Parameter getResponseParameter() { result = getRouteHandlerParameter("response") }
+    override DataFlow::ParameterNode getResponseParameter() {
+      result = getRouteHandlerParameter("response")
+    }
   }
 
   /**
    * A Connect route handler installed by a route setup.
    */
-  class StandardRouteHandler extends RouteHandler {
-    override Function astNode;
-
+  class StandardRouteHandler extends RouteHandler, DataFlow::FunctionNode {
     StandardRouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
 
-    override Parameter getRouteHandlerParameter(string kind) {
-      result = getRouteHandlerParameter(astNode, kind)
+    override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
+      result = getRouteHandlerParameter(this, kind)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -10,10 +10,10 @@ module Connect {
   /**
    * An expression that creates a new Connect server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, CallExpr {
+  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::CallNode {
     ServerDefinition() {
       // `app = connect()`
-      this = DataFlow::moduleImport("connect").getAnInvocation().asExpr()
+      this = DataFlow::moduleImport("connect").getAnInvocation()
     }
   }
 
@@ -69,7 +69,7 @@ module Connect {
         server.ref().flowsToExpr(getReceiver())
         or
         // app.use(...).use(fun)
-        this.getReceiver().(RouteSetup).getServer() = server
+        this.getReceiver().(RouteSetup).getServer() = server.asExpr()
       )
     }
 
@@ -84,7 +84,7 @@ module Connect {
       exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
     }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
 
     /** Gets an argument that represents a route handler being registered. */
     Expr getARouteHandlerExpr() { result = getAnArgument() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Connect.qll
@@ -59,17 +59,17 @@ module Connect {
   /**
    * A call to a Connect method that sets up a route.
    */
-  class RouteSetup extends MethodCallExpr, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
     ServerDefinition server;
 
     RouteSetup() {
       getMethodName() = "use" and
       (
         // app.use(fun)
-        server.ref().flowsToExpr(getReceiver())
+        server.ref().getAMethodCall() = this
         or
         // app.use(...).use(fun)
-        this.getReceiver().(RouteSetup).getServer() = server.asExpr()
+        this.getReceiver().(RouteSetup).getServer() = server
       )
     }
 
@@ -84,10 +84,10 @@ module Connect {
       exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
     }
 
-    override Expr getServer() { result = server.asExpr() }
+    override DataFlow::Node getServer() { result = server }
 
     /** Gets an argument that represents a route handler being registered. */
-    Expr getARouteHandlerExpr() { result = getAnArgument() }
+    Expr getARouteHandlerExpr() { result = getAnArgument().asExpr() } // TODO: DataFlow::Node
   }
 
   /** An expression that is passed as `basicAuthConnect(<user>, <password>)`. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -52,7 +52,7 @@ module ConnectExpressShared {
   /**
    * Holds if `function` appears to match the given signature based on parameter naming.
    */
-  private predicate matchesSignature(Function function, RouteHandlerSignature sig) {
+  private predicate matchesSignature(DataFlow::FunctionNode function, RouteHandlerSignature sig) {
     function.getNumParameter() = sig.getArity() and
     function.getParameter(sig.getParameterIndex("request")).getName() = ["req", "request"] and
     function.getParameter(sig.getParameterIndex("response")).getName() = ["res", "response"] and
@@ -71,8 +71,8 @@ module ConnectExpressShared {
    * so the caller should restrict the function accordingly.
    */
   pragma[inline]
-  private Parameter getRouteHandlerParameter(
-    Function routeHandler, RouteHandlerSignature sig, string kind
+  private DataFlow::ParameterNode getRouteHandlerParameter(
+    DataFlow::FunctionNode routeHandler, RouteHandlerSignature sig, string kind
   ) {
     result = routeHandler.getParameter(sig.getParameterIndex(kind))
   }
@@ -83,7 +83,9 @@ module ConnectExpressShared {
    * `kind` is one of: "error", "request", "response", "next".
    */
   pragma[inline]
-  Parameter getRouteParameterHandlerParameter(Function routeHandler, string kind) {
+  DataFlow::ParameterNode getRouteParameterHandlerParameter(
+    DataFlow::FunctionNode routeHandler, string kind
+  ) {
     result =
       getRouteHandlerParameter(routeHandler, RouteHandlerSignature::requestResponseNextParameter(),
         kind)
@@ -95,7 +97,7 @@ module ConnectExpressShared {
    * `kind` is one of: "error", "request", "response", "next".
    */
   pragma[inline]
-  Parameter getRouteHandlerParameter(Function routeHandler, string kind) {
+  DataFlow::ParameterNode getRouteHandlerParameter(DataFlow::FunctionNode routeHandler, string kind) {
     if routeHandler.getNumParameter() = 4
     then
       // For arity 4 there is ambiguity between (err, req, res, next) and (req, res, next, param)
@@ -115,7 +117,7 @@ module ConnectExpressShared {
    */
   class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
     RouteHandlerCandidate() {
-      matchesSignature(astNode, _) and
+      matchesSignature(this, _) and
       not (
         // heuristic: not a class method (the server invokes this with a function call)
         astNode = any(MethodDefinition def).getBody()

--- a/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
@@ -76,7 +76,7 @@ private predicate canHaveSensitiveCookie(DataFlow::Node node) {
     HeuristicNames::nameIndicatesSensitiveData([s, getCookieName(s)], _)
   )
   or
-  node.asExpr() instanceof SensitiveExpr
+  node instanceof SensitiveNode
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CookieLibraries.qll
@@ -271,30 +271,27 @@ private module ExpressCookies {
   /**
    * A cookie set using `response.cookie` from `express` module (https://expressjs.com/en/api.html#res.cookie).
    */
-  private class InsecureExpressCookieResponse extends CookieWrites::CookieWrite,
-    DataFlow::MethodCallNode {
-    InsecureExpressCookieResponse() { this.asExpr() instanceof Express::SetCookie }
-
+  private class InsecureExpressCookieResponse extends CookieWrites::CookieWrite instanceof Express::SetCookie {
     override predicate isSecure() {
       // A cookie is secure if there are cookie options with the `secure` flag set to `true`.
       // The default is `false`.
-      exists(DataFlow::Node value | value = this.getOptionArgument(2, CookieWrites::secure()) |
+      exists(DataFlow::Node value | value = super.getOptionArgument(2, CookieWrites::secure()) |
         not value.mayHaveBooleanValue(false) // anything but `false` is accepted as being maybe true
       )
     }
 
-    override predicate isSensitive() { canHaveSensitiveCookie(this.getArgument(0)) }
+    override predicate isSensitive() { canHaveSensitiveCookie(super.getArgument(0)) }
 
     override predicate isHttpOnly() {
       // A cookie is httpOnly if there are cookie options with the `httpOnly` flag set to `true`.
       // The default is `false`.
-      exists(DataFlow::Node value | value = this.getOptionArgument(2, CookieWrites::httpOnly()) |
+      exists(DataFlow::Node value | value = super.getOptionArgument(2, CookieWrites::httpOnly()) |
         not value.mayHaveBooleanValue(false) // anything but `false` is accepted as being maybe true
       )
     }
 
     override string getSameSite() {
-      result = getSameSiteValue(this.getOptionArgument(2, "sameSite"))
+      result = getSameSiteValue(super.getOptionArgument(2, "sameSite"))
     }
   }
 
@@ -372,10 +369,10 @@ private class HttpCookieWrite extends CookieWrites::CookieWrite {
 
   HttpCookieWrite() {
     exists(HTTP::CookieDefinition setCookie |
-      this.asExpr() = setCookie.getHeaderArgument() and
+      this = setCookie.getHeaderArgument() and
       not this instanceof DataFlow::ArrayCreationNode
       or
-      this = setCookie.getHeaderArgument().flow().(DataFlow::ArrayCreationNode).getAnElement()
+      this = setCookie.getHeaderArgument().(DataFlow::ArrayCreationNode).getAnElement()
     ) and
     header =
       [

--- a/javascript/ql/lib/semmle/javascript/frameworks/Credentials.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Credentials.qll
@@ -6,10 +6,27 @@
 import javascript
 
 /**
+ * DEPRECATED: Use `CredentialsNode` instead.
  * An expression whose value is used to supply credentials such
  * as a user name, a password, or a key.
  */
-abstract class CredentialsExpr extends Expr {
+deprecated class CredentialsExpr extends Expr {
+  CredentialsNode node;
+
+  CredentialsExpr() { node.asExpr() = this }
+
+  /**
+   * Gets a description of the kind of credential this expression is used as,
+   * such as `"user name"`, `"password"`, `"key"`.
+   */
+  deprecated string getCredentialsKind() { result = node.getCredentialsKind() }
+}
+
+/**
+ * An expression whose value is used to supply credentials such
+ * as a user name, a password, or a key.
+ */
+abstract class CredentialsNode extends DataFlow::Node {
   /**
    * Gets a description of the kind of credential this expression is used as,
    * such as `"user name"`, `"password"`, `"key"`.
@@ -17,12 +34,10 @@ abstract class CredentialsExpr extends Expr {
   abstract string getCredentialsKind();
 }
 
-private class CredentialsFromModel extends CredentialsExpr {
+private class CredentialsFromModel extends CredentialsNode {
   string kind;
 
-  CredentialsFromModel() {
-    this = ModelOutput::getASinkNode("credentials[" + kind + "]").asSink().asExpr()
-  }
+  CredentialsFromModel() { this = ModelOutput::getASinkNode("credentials[" + kind + "]").asSink() }
 
   override string getCredentialsKind() { result = kind }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -46,11 +46,9 @@ abstract class CryptographicKeyCreation extends DataFlow::Node {
 }
 
 /**
- * A key used in a cryptographic algorithm, viewed as a `CredentialsExpr`.
+ * A key used in a cryptographic algorithm, viewed as a `CredentialsNode`.
  */
-class CryptographicKeyCredentialsExpr extends CredentialsExpr {
-  CryptographicKeyCredentialsExpr() { this = any(CryptographicKey k).asExpr() }
-
+class CryptographicKeyCredentialsExpr extends CredentialsNode instanceof CryptographicKey {
   override string getCredentialsKind() { result = "key" }
 }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/CryptoLibraries.qll
@@ -8,11 +8,11 @@ import semmle.javascript.security.CryptoAlgorithms
 /**
  * An application of a cryptographic algorithm.
  */
-abstract class CryptographicOperation extends Expr {
+abstract class CryptographicOperation extends DataFlow::Node {
   /**
    * Gets the input the algorithm is used on, e.g. the plain text input to be encrypted.
    */
-  abstract Expr getInput();
+  abstract DataFlow::Node getInput();
 
   /**
    * Gets the applied algorithm.
@@ -58,8 +58,8 @@ class CryptographicKeyCredentialsExpr extends CredentialsExpr {
  * A model of the asmCrypto library.
  */
 private module AsmCrypto {
-  private class Apply extends CryptographicOperation {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm; // non-functional
 
     Apply() {
@@ -73,17 +73,15 @@ private module AsmCrypto {
        *      ```
        */
 
-      exists(DataFlow::CallNode mce | this = mce.asExpr() |
-        exists(DataFlow::SourceNode asmCrypto, string algorithmName |
-          asmCrypto = DataFlow::globalVarRef("asmCrypto") and
-          algorithm.matchesName(algorithmName) and
-          mce = asmCrypto.getAPropertyRead(algorithmName).getAMemberCall(_) and
-          input = mce.getAnArgument().asExpr()
-        )
+      exists(DataFlow::SourceNode asmCrypto, string algorithmName |
+        asmCrypto = DataFlow::globalVarRef("asmCrypto") and
+        algorithm.matchesName(algorithmName) and
+        this = asmCrypto.getAPropertyRead(algorithmName).getAMemberCall(_) and
+        input = this.getAnArgument()
       )
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -97,9 +95,8 @@ private module BrowserIdCrypto {
     Key() { this = any(Apply apply).getKey() }
   }
 
-  private class Apply extends CryptographicOperation {
+  private class Apply extends CryptographicOperation instanceof DataFlow::MethodCallNode {
     CryptographicAlgorithm algorithm; // non-functional
-    MethodCallExpr mce;
 
     Apply() {
       /*
@@ -118,7 +115,6 @@ private module BrowserIdCrypto {
        *      ```
        */
 
-      this = mce and
       exists(
         DataFlow::SourceNode mod, DataFlow::Node algorithmNameNode, DataFlow::CallNode keygen,
         DataFlow::FunctionNode callback
@@ -128,15 +124,15 @@ private module BrowserIdCrypto {
         algorithmNameNode = keygen.getOptionArgument(0, "algorithm") and
         algorithm.matchesName(algorithmNameNode.getStringValue()) and
         callback = keygen.getCallback(1) and
-        this = mod.getAMemberCall("sign").asExpr()
+        this = mod.getAMemberCall("sign")
       )
     }
 
-    override Expr getInput() { result = mce.getArgument(0) }
+    override DataFlow::Node getInput() { result = super.getArgument(0) }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
 
-    DataFlow::Node getKey() { result.asExpr() = mce.getArgument(1) }
+    DataFlow::Node getKey() { result = super.getArgument(1) }
   }
 }
 
@@ -217,14 +213,12 @@ private module NodeJSCrypto {
     override predicate isSymmetricKey() { none() }
   }
 
-  private class Apply extends CryptographicOperation, MethodCallExpr {
+  private class Apply extends CryptographicOperation instanceof DataFlow::MethodCallNode {
     InstantiatedAlgorithm instantiation;
 
-    Apply() {
-      this = instantiation.getAMethodCall(any(string m | m = "update" or m = "write")).asExpr()
-    }
+    Apply() { this = instantiation.getAMethodCall(any(string m | m = "update" or m = "write")) }
 
-    override Expr getInput() { result = this.getArgument(0) }
+    override DataFlow::Node getInput() { result = super.getArgument(0) }
 
     override CryptographicAlgorithm getAlgorithm() { result = instantiation.getAlgorithm() }
   }
@@ -260,7 +254,7 @@ private module CryptoJS {
   /**
    *  Matches `CryptoJS.<algorithmName>` and `require("crypto-js/<algorithmName>")`
    */
-  private DataFlow::SourceNode getAlgorithmExpr(CryptographicAlgorithm algorithm) {
+  private DataFlow::SourceNode getAlgorithmNode(CryptographicAlgorithm algorithm) {
     exists(string algorithmName | algorithm.matchesName(algorithmName) |
       exists(DataFlow::SourceNode mod | mod = DataFlow::moduleImport("crypto-js") |
         result = mod.getAPropertyRead(algorithmName) or
@@ -274,7 +268,9 @@ private module CryptoJS {
     )
   }
 
-  private DataFlow::CallNode getEncryptionApplication(Expr input, CryptographicAlgorithm algorithm) {
+  private DataFlow::CallNode getEncryptionApplication(
+    DataFlow::Node input, CryptographicAlgorithm algorithm
+  ) {
     /*
      *    ```
      *    var CryptoJS = require("crypto-js");
@@ -288,11 +284,13 @@ private module CryptoJS {
      *    Also matches where `CryptoJS.<algorithmName>` has been replaced by `require("crypto-js/<algorithmName>")`
      */
 
-    result = getAlgorithmExpr(algorithm).getAMemberCall("encrypt") and
-    input = result.getArgument(0).asExpr()
+    result = getAlgorithmNode(algorithm).getAMemberCall("encrypt") and
+    input = result.getArgument(0)
   }
 
-  private DataFlow::CallNode getDirectApplication(Expr input, CryptographicAlgorithm algorithm) {
+  private DataFlow::CallNode getDirectApplication(
+    DataFlow::Node input, CryptographicAlgorithm algorithm
+  ) {
     /*
      *    ```
      *    var CryptoJS = require("crypto-js");
@@ -307,20 +305,20 @@ private module CryptoJS {
      *    Also matches where `CryptoJS.<algorithmName>` has been replaced by `require("crypto-js/<algorithmName>")`
      */
 
-    result = getAlgorithmExpr(algorithm).getACall() and
-    input = result.getArgument(0).asExpr()
+    result = getAlgorithmNode(algorithm).getACall() and
+    input = result.getArgument(0)
   }
 
   private class Apply extends CryptographicOperation {
-    Expr input;
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm; // non-functional
 
     Apply() {
-      this = getEncryptionApplication(input, algorithm).asExpr() or
-      this = getDirectApplication(input, algorithm).asExpr()
+      this = getEncryptionApplication(input, algorithm) or
+      this = getDirectApplication(input, algorithm)
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -328,7 +326,7 @@ private module CryptoJS {
   private class Key extends CryptographicKey {
     Key() {
       exists(DataFlow::SourceNode e, CryptographicAlgorithm algorithm |
-        e = getAlgorithmExpr(algorithm)
+        e = getAlgorithmNode(algorithm)
       |
         exists(string name |
           name = "encrypt" or
@@ -351,7 +349,7 @@ private module CryptoJS {
     CreateKey() {
       // var key = CryptoJS.PBKDF2(password, salt, { keySize: 8 });
       this =
-        getAlgorithmExpr(any(CryptographicAlgorithm algo | algo.getName() = algorithm)).getACall() and
+        getAlgorithmNode(any(CryptographicAlgorithm algo | algo.getName() = algorithm)).getACall() and
       optionArg = 2
       or
       // var key = CryptoJS.algo.PBKDF2.create({ keySize: 8 });
@@ -378,8 +376,8 @@ private module CryptoJS {
  * A model of the TweetNaCl library.
  */
 private module TweetNaCl {
-  private class Apply extends CryptographicOperation instanceof MethodCallExpr {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm;
 
     Apply() {
@@ -400,12 +398,12 @@ private module TweetNaCl {
         name = "sign" and algorithm.matchesName("ed25519")
       |
         (mod = DataFlow::moduleImport("nacl") or mod = DataFlow::moduleImport("nacl-fast")) and
-        this = mod.getAMemberCall(name).asExpr() and
+        this = mod.getAMemberCall(name) and
         super.getArgument(0) = input
       )
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -421,7 +419,7 @@ private module HashJs {
    * - `require("hash.js/lib/hash/<algorithmName>")`()
    * - `require("hash.js/lib/hash/sha/<sha-algorithm-suffix>")`()
    */
-  private DataFlow::CallNode getAlgorithmExpr(CryptographicAlgorithm algorithm) {
+  private DataFlow::CallNode getAlgorithmNode(CryptographicAlgorithm algorithm) {
     exists(string algorithmName | algorithm.matchesName(algorithmName) |
       result = DataFlow::moduleMember("hash.js", algorithmName).getACall()
       or
@@ -438,8 +436,8 @@ private module HashJs {
     )
   }
 
-  private class Apply extends CryptographicOperation instanceof MethodCallExpr {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm; // non-functional
 
     Apply() {
@@ -456,11 +454,11 @@ private module HashJs {
        *      Also matches where `hash.<algorithmName>()` has been replaced by a more specific require a la `require("hash.js/lib/hash/sha/512")`
        */
 
-      this = getAlgorithmExpr(algorithm).getAMemberCall("update").asExpr() and
+      this = getAlgorithmNode(algorithm).getAMemberCall("update") and
       input = super.getArgument(0)
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -492,7 +490,7 @@ private module Forge {
           // `require('forge').cipher.createCipher("3DES-CBC").update("secret", "key");`
           (createName = "createCipher" or createName = "createDecipher") and
           this = mod.getAPropertyRead("cipher").getAMemberCall(createName) and
-          this.getArgument(0).asExpr().mayHaveStringValue(cipherName) and
+          this.getArgument(0).mayHaveStringValue(cipherName) and
           cipherName = cipherPrefix + "-" + cipherSuffix and
           cipherSuffix = ["CBC", "CFB", "CTR", "ECB", "GCM", "OFB"] and
           algorithmName = cipherPrefix and
@@ -531,19 +529,19 @@ private module Forge {
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
 
-  private class Apply extends CryptographicOperation instanceof MethodCallExpr {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm; // non-functional
 
     Apply() {
       exists(Cipher cipher |
-        this = cipher.getAMemberCall("update").asExpr() and
+        this = cipher.getAMemberCall("update") and
         super.getArgument(0) = input and
         algorithm = cipher.getAlgorithm()
       )
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -590,8 +588,8 @@ private module Forge {
  * A model of the md5 library.
  */
 private module Md5 {
-  private class Apply extends CryptographicOperation instanceof CallExpr {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm;
 
     Apply() {
@@ -599,12 +597,12 @@ private module Md5 {
       exists(DataFlow::SourceNode mod |
         mod = DataFlow::moduleImport("md5") and
         algorithm.matchesName("MD5") and
-        this = mod.getACall().asExpr() and
+        this = mod.getACall() and
         super.getArgument(0) = input
       )
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -614,8 +612,8 @@ private module Md5 {
  * A model of the bcrypt, bcryptjs, bcrypt-nodejs libraries.
  */
 private module Bcrypt {
-  private class Apply extends CryptographicOperation instanceof MethodCallExpr {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm;
 
     Apply() {
@@ -632,12 +630,12 @@ private module Bcrypt {
           methodName = "hashSync"
         ) and
         mod = DataFlow::moduleImport(moduleName) and
-        this = mod.getAMemberCall(methodName).asExpr() and
+        this = mod.getAMemberCall(methodName) and
         super.getArgument(0) = input
       )
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }
@@ -647,23 +645,23 @@ private module Bcrypt {
  * A model of the hasha library.
  */
 private module Hasha {
-  private class Apply extends CryptographicOperation instanceof CallExpr {
-    Expr input;
+  private class Apply extends CryptographicOperation instanceof DataFlow::CallNode {
+    DataFlow::Node input;
     CryptographicAlgorithm algorithm;
 
     Apply() {
       // `require('hasha')('unicorn', { algorithm: "md5" });`
-      exists(DataFlow::SourceNode mod, string algorithmName, Expr algorithmNameNode |
+      exists(DataFlow::SourceNode mod, string algorithmName, DataFlow::Node algorithmNameNode |
         mod = DataFlow::moduleImport("hasha") and
-        this = mod.getACall().asExpr() and
+        this = mod.getACall() and
         super.getArgument(0) = input and
         algorithm.matchesName(algorithmName) and
-        super.hasOptionArgument(1, "algorithm", algorithmNameNode) and
+        super.getOptionArgument(1, "algorithm") = algorithmNameNode and
         algorithmNameNode.mayHaveStringValue(algorithmName)
       )
     }
 
-    override Expr getInput() { result = input }
+    override DataFlow::Node getInput() { result = input }
 
     override CryptographicAlgorithm getAlgorithm() { result = algorithm }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/DigitalOcean.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/DigitalOcean.qll
@@ -8,12 +8,12 @@ module DigitalOcean {
   /**
    * An expression that is used for authentication at DigitalOcean: `digitalocean.client(<token>)`.
    */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
-      exists(CallExpr mce |
-        mce = DataFlow::moduleMember("digitalocean", "client").getACall().asExpr()
+      exists(DataFlow::CallNode mce |
+        mce = DataFlow::moduleMember("digitalocean", "client").getACall()
       |
         this = mce.getArgument(0) and kind = "token"
       )

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -737,9 +737,9 @@ module Express {
      */
     private DataFlow::SourceNode getAHeaderSource() { result.flowsTo(this.getArgument(0)) }
 
-    override predicate definesExplicitly(string headerName, Expr headerValue) {
+    override predicate definesHeaderValue(string headerName, DataFlow::Node headerValue) {
       exists(string header |
-        this.getAHeaderSource().hasPropertyWrite(header, DataFlow::valueNode(headerValue)) and
+        this.getAHeaderSource().hasPropertyWrite(header, headerValue) and
         headerName = header.toLowerCase()
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -697,12 +697,12 @@ module Express {
   /**
    * An invocation of the `redirect` method of an HTTP response object.
    */
-  private class RedirectInvocation extends HTTP::RedirectInvocation, MethodCallExpr {
+  private class RedirectInvocation extends HTTP::RedirectInvocation, DataFlow::MethodCallNode {
     ResponseSource response;
 
-    RedirectInvocation() { this = response.ref().getAMethodCall("redirect").asExpr() }
+    RedirectInvocation() { this = response.ref().getAMethodCall("redirect") }
 
-    override Expr getUrlArgument() { result = this.getLastArgument() }
+    override DataFlow::Node getUrlArgument() { result = this.getLastArgument() }
 
     override RouteHandler getRouteHandler() { result = response.getRouteHandler() }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -56,13 +56,11 @@ module Express {
   }
 
   /**
+   * DEPRECATED: Use `isRouter()` instead.
    * An expression that refers to a route.
    */
-  class RouteExpr extends DataFlow::MethodCallNode {
-    RouteExpr() { isRouter(this) }
-
-    /** Gets the router from which this route was created, if it is known. */
-    RouterDefinition getRouter() { isRouter(this, result) }
+  deprecated class RouteExpr extends MethodCallExpr {
+    RouteExpr() { isRouter(this.flow()) }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -766,7 +766,7 @@ module Express {
   private class ResponseSendArgument extends HTTP::ResponseSendArgument {
     ResponseSource response;
 
-    ResponseSendArgument() { this = response.ref().getAMethodCall("send").getArgument(0).asExpr() }
+    ResponseSendArgument() { this = response.ref().getAMethodCall("send").getArgument(0) }
 
     override RouteHandler getRouteHandler() { result = response.getRouteHandler() }
   }
@@ -794,7 +794,7 @@ module Express {
     TemplateObjectInput obj;
 
     TemplateInput() {
-      obj.getALocalSource().(DataFlow::ObjectLiteralNode).hasPropertyWrite(_, this.flow())
+      obj.getALocalSource().(DataFlow::ObjectLiteralNode).hasPropertyWrite(_, this)
     }
 
     override RouteHandler getRouteHandler() { result = obj.getRouteHandler() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -158,7 +158,9 @@ module Express {
      * This differs from `getARouteHandler` in that the argument expression is
      * returned, not its dataflow source.
      */
-    deprecated Expr getRouteHandlerExpr(int index) { result = getRouteHandlerNode(index).asExpr() }
+    deprecated Expr getRouteHandlerExpr(int index) {
+      result = this.getRouteHandlerNode(index).asExpr()
+    }
 
     /**
      * Gets the `n`th handler registered by this setup, with 0 being the first.

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -43,7 +43,7 @@ module Express {
   /**
    * Holds if `e` may refer to the given `router` object.
    */
-  private predicate isRouter(Expr e, RouterDefinition router) { router.flowsTo(e) }
+  private predicate isRouter(Expr e, RouterDefinition router) { router.ref().flowsToExpr(e) } // TODO: DataFlow::Node
 
   /**
    * Holds if `e` may refer to a router object.
@@ -853,21 +853,24 @@ module Express {
     DataFlow::SourceNode ref() { result = this.ref(DataFlow::TypeTracker::end()) }
 
     /**
+     * DEPRECATED: Use `ref().flowsToExpr()` instead.
      * Holds if `sink` may refer to this router.
      */
-    predicate flowsTo(Expr sink) { this.ref().flowsToExpr(sink) }
+    deprecated predicate flowsTo(Expr sink) { this.ref().flowsToExpr(sink) }
 
     /**
      * Gets a `RouteSetup` that was used for setting up a route on this router.
      */
-    private RouteSetup getARouteSetup() { this.flowsTo(result.getReceiver()) }
+    private RouteSetup getARouteSetup() { this.ref().flowsToExpr(result.getReceiver()) }
 
     /**
      * Gets a sub-router registered on this router.
      *
      * Example: `router2` for `router1.use(router2)` or `router1.use("/route2", router2)`
      */
-    RouterDefinition getASubRouter() { result.flowsTo(this.getARouteSetup().getAnArgument()) }
+    RouterDefinition getASubRouter() {
+      result.ref().flowsToExpr(this.getARouteSetup().getAnArgument())
+    }
 
     /**
      * Gets a route handler registered on this router.

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -56,7 +56,7 @@ module Express {
   }
 
   /**
-   * DEPRECATED: Use `isRouter()` instead.
+   * DEPRECATED: Use `RouterDefinition.ref()` or `RouteSetup` instead.
    * An expression that refers to a route.
    */
   deprecated class RouteExpr extends MethodCallExpr {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -199,7 +199,10 @@ module Express {
       )
     }
 
-    override Expr getServer() { result.(Application).getARouteHandler() = this.getARouteHandler() }
+    override Expr getServer() {
+      any(DataFlow::Node n | n.asExpr() = result).(Application).getARouteHandler() =
+        this.getARouteHandler()
+    }
 
     /**
      * Gets the HTTP request type this is registered for, if any.
@@ -823,13 +826,13 @@ module Express {
    * An Express server application.
    */
   private class Application extends HTTP::ServerDefinition {
-    Application() { this = appCreation().asExpr() }
+    Application() { this = appCreation() }
 
     /**
      * Gets a route handler of the application, regardless of nesting.
      */
     override HTTP::RouteHandler getARouteHandler() {
-      result = this.(RouterDefinition).getASubRouter*().getARouteHandler()
+      result = this.asExpr().(RouterDefinition).getASubRouter*().getARouteHandler()
     }
   }
 
@@ -837,6 +840,7 @@ module Express {
    * An Express router.
    */
   class RouterDefinition extends InvokeExpr {
+    // TODO: DataFlow::Node
     RouterDefinition() { this = routerCreation().asExpr() }
 
     private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -995,7 +995,7 @@ module Express {
   }
 
   /** An expression that is passed as `expressBasicAuth({ users: { <user>: <password> }})`. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
@@ -1006,9 +1006,9 @@ module Express {
           usersSrc.flowsTo(call.getOptionArgument(0, "users")) and
           usersSrc.flowsTo(pwn.getBase())
         |
-          this = pwn.getPropertyNameExpr() and kind = "user name"
+          this = pwn.getPropertyNameExpr().flow() and kind = "user name"
           or
-          this = pwn.getRhs().asExpr() and kind = "password"
+          this = pwn.getRhs() and kind = "password"
         )
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -959,7 +959,7 @@ module Express {
      * Example: `fun` for `router1.use(fun)` or `router.use("/route", fun)`
      */
     HTTP::RouteHandler getARouteHandler() {
-      result.(DataFlow::SourceNode).flowsToExpr(this.getARouteSetup().getAnArgument().asExpr())
+      result.(DataFlow::SourceNode).flowsTo(this.getARouteSetup().getAnArgument())
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -298,6 +298,7 @@ module Express {
   }
 
   /**
+   * DEPRECATED: Use `RouteHandlerNode` instead.
    * An expression used as an Express route handler, such as `submitHandler` below:
    * ```
    * app.post('/submit', submitHandler)
@@ -306,12 +307,56 @@ module Express {
    * Unlike `RouterHandler`, this is the argument passed to a setup, as opposed to
    * a function that flows into such an argument.
    */
-  class RouteHandlerExpr extends Expr {
-    // TODO: DataFlow::Node
+  deprecated class RouteHandlerExpr extends Expr {
+    RouteHandlerNode node;
+
+    RouteHandlerExpr() { this.flow() = node }
+
+    /** Gets the setup call that registers this route handler. */
+    deprecated RouteSetup getSetup() { result = node.getSetup() }
+
+    /** Gets the function body of this handler, if it is defined locally. */
+    deprecated RouteHandler getBody() { result = node.getBody() }
+
+    /** Holds if this is not followed by more handlers. */
+    deprecated predicate isLastHandler() { node.isLastHandler() }
+
+    /** Gets a route handler that immediately precedes this in the route stack. */
+    deprecated Express::RouteHandlerExpr getPreviousMiddleware() {
+      result = node.getPreviousMiddleware().asExpr()
+    }
+
+    /** Gets a route handler that may follow immediately after this one in its route stack. */
+    deprecated Express::RouteHandlerExpr getNextMiddleware() {
+      result = node.getNextMiddleware().asExpr()
+    }
+
+    /**
+     * Gets a route handler that precedes this one (not necessarily immediately), may handle
+     * same request method, and matches on the same path or a prefix.
+     */
+    deprecated Express::RouteHandlerExpr getAMatchingAncestor() {
+      result = node.getAMatchingAncestor().asExpr()
+    }
+
+    /** Gets the router being registered as a sub-router here, if any. */
+    deprecated RouterDefinition getAsSubRouter() { result = node.getAsSubRouter() }
+  }
+
+  /**
+   * An expression used as an Express route handler, such as `submitHandler` below:
+   * ```
+   * app.post('/submit', submitHandler)
+   * ```
+   *
+   * Unlike `RouterHandler`, this is the argument passed to a setup, as opposed to
+   * a function that flows into such an argument.
+   */
+  class RouteHandlerNode extends DataFlow::Node {
     RouteSetup setup;
     int index;
 
-    RouteHandlerExpr() { this = setup.getRouteHandlerNode(index).asExpr() }
+    RouteHandlerNode() { this = setup.getRouteHandlerNode(index) }
 
     /**
      * Gets the setup call that registers this route handler.
@@ -322,7 +367,7 @@ module Express {
      * Gets the function body of this handler, if it is defined locally.
      */
     RouteHandler getBody() {
-      exists(DataFlow::SourceNode source | source = this.flow().getALocalSource() |
+      exists(DataFlow::SourceNode source | source = this.getALocalSource() |
         result = source
         or
         DataFlow::functionOneWayForwardingStep(result.(DataFlow::SourceNode).getALocalUse(), source)
@@ -359,11 +404,11 @@ module Express {
      * In this case, the previous from `foo` is `auth` although they do not act on the
      * same requests.
      */
-    Express::RouteHandlerExpr getPreviousMiddleware() {
+    Express::RouteHandlerNode getPreviousMiddleware() {
       index = 0 and
       result = setup.getRouter().getMiddlewareStackAt(setup.asExpr().getAPredecessor())
       or
-      index > 0 and result = setup.getRouteHandlerNode(index - 1).asExpr()
+      index > 0 and result = setup.getRouteHandlerNode(index - 1)
       or
       // Outside the router's original container, use the flow-insensitive model of its middleware stack.
       // Its state is not tracked to CFG nodes outside its original container.
@@ -377,7 +422,7 @@ module Express {
     /**
      * Gets a route handler that may follow immediately after this one in its route stack.
      */
-    Express::RouteHandlerExpr getNextMiddleware() { result.getPreviousMiddleware() = this }
+    Express::RouteHandlerNode getNextMiddleware() { result.getPreviousMiddleware() = this }
 
     /**
      * Gets a route handler that precedes this one (not necessarily immediately), may handle
@@ -390,7 +435,7 @@ module Express {
      * router installs a route handler `r1` on a path that matches the path of a route handler
      * `r2` installed on a subrouter, `r1` will not be recognized as an ancestor of `r2`.
      */
-    Express::RouteHandlerExpr getAMatchingAncestor() {
+    Express::RouteHandlerNode getAMatchingAncestor() {
       result = this.getPreviousMiddleware+() and
       exists(RouteSetup resSetup | resSetup = result.getSetup() |
         // check whether request methods are compatible
@@ -407,7 +452,7 @@ module Express {
       or
       // if this is a sub-router, any previously installed middleware for the same
       // request method will necessarily match
-      exists(RouteHandlerExpr outer |
+      exists(RouteHandlerNode outer |
         setup.getRouter() = outer.getAsSubRouter() and
         outer.getSetup().handlesSameRequestMethodAs(setup) and
         result = outer.getAMatchingAncestor()
@@ -417,7 +462,7 @@ module Express {
     /**
      * Gets the router being registered as a sub-router here, if any.
      */
-    RouterDefinition getAsSubRouter() { isRouter(this.flow(), result) }
+    RouterDefinition getAsSubRouter() { isRouter(this, result) }
   }
 
   /**
@@ -934,22 +979,19 @@ module Express {
      *
      * If `node` is not in the same container where `router` was defined, the predicate has no result.
      */
-    Express::RouteHandlerExpr getMiddlewareStackAt(ControlFlowNode node) {
-      // TODO: DataFlow::Node?
+    Express::RouteHandlerNode getMiddlewareStackAt(ControlFlowNode node) {
       if
         exists(Express::RouteSetup setup | node = setup.asExpr() and setup.getRouter() = this |
           setup.isUseCall()
         )
-      then
-        result =
-          node.(AST::ValueNode).flow().(Express::RouteSetup).getLastRouteHandlerNode().asExpr()
+      then result = node.(AST::ValueNode).flow().(Express::RouteSetup).getLastRouteHandlerNode()
       else result = this.getMiddlewareStackAt(node.getAPredecessor())
     }
 
     /**
      * Gets the final middleware registered on this router.
      */
-    Express::RouteHandlerExpr getMiddlewareStack() {
+    Express::RouteHandlerNode getMiddlewareStack() {
       result = this.getMiddlewareStackAt(this.getContainer().getExit())
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -84,7 +84,7 @@ module Express {
   private class RouterRange extends Routing::Router::Range {
     RouterDefinition def;
 
-    RouterRange() { this = def.flow() }
+    RouterRange() { this = def }
 
     override DataFlow::SourceNode getAReference() { result = def.ref() }
   }
@@ -878,20 +878,17 @@ module Express {
      * Gets a route handler of the application, regardless of nesting.
      */
     override HTTP::RouteHandler getARouteHandler() {
-      result = this.asExpr().(RouterDefinition).getASubRouter*().getARouteHandler()
+      result = this.(RouterDefinition).getASubRouter*().getARouteHandler()
     }
   }
 
-  /**
-   * An Express router.
-   */
-  class RouterDefinition extends InvokeExpr {
-    // TODO: DataFlow::Node
-    RouterDefinition() { this = routerCreation().asExpr() }
+  /** An Express router. */
+  class RouterDefinition extends DataFlow::Node instanceof DataFlow::InvokeNode {
+    RouterDefinition() { this = routerCreation() }
 
     private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
       t.start() and
-      result = DataFlow::exprNode(this)
+      result = this
       or
       exists(string name | result = this.ref(t.continue()).getAMethodCall(name) |
         name = "route" or
@@ -903,12 +900,6 @@ module Express {
 
     /** Gets a data flow node referring to this router. */
     DataFlow::SourceNode ref() { result = this.ref(DataFlow::TypeTracker::end()) }
-
-    /**
-     * DEPRECATED: Use `ref().flowsToExpr()` instead.
-     * Holds if `sink` may refer to this router.
-     */
-    deprecated predicate flowsTo(Expr sink) { this.ref().flowsToExpr(sink) }
 
     /**
      * Gets a `RouteSetup` that was used for setting up a route on this router.

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -517,9 +517,10 @@ module Express {
   /**
    * Holds if `call` is a chainable method call on the response object of `handler`.
    */
-  private predicate isChainableResponseMethodCall(RouteHandler handler, MethodCallExpr call) {
-    // TODO: DataFlow::MethodCallNode
-    exists(string name | call.calls(handler.getAResponseNode().asExpr(), name) |
+  private predicate isChainableResponseMethodCall(
+    RouteHandler handler, DataFlow::MethodCallNode call
+  ) {
+    exists(string name | call.calls(handler.getAResponseNode(), name) |
       name =
         [
           "append", "attachment", "location", "send", "sendStatus", "set", "status", "type", "vary",
@@ -541,7 +542,7 @@ module Express {
     ExplicitResponseSource() {
       this = rh.getResponseParameter()
       or
-      isChainableResponseMethodCall(rh, this.asExpr())
+      isChainableResponseMethodCall(rh, this)
     }
 
     /**
@@ -766,23 +767,22 @@ module Express {
   /**
    * Holds if `e` is an HTTP request object.
    */
-  predicate isRequest(Expr e) { any(RouteHandler rh).getARequestNode().asExpr() = e } // TODO: DataFlow::Node
+  predicate isRequest(DataFlow::Node e) { any(RouteHandler rh).getARequestNode() = e }
 
   /**
    * Holds if `e` is an HTTP response object.
    */
-  predicate isResponse(Expr e) { any(RouteHandler rh).getAResponseNode().asExpr() = e } // TODO: DataFlow::Node
+  predicate isResponse(DataFlow::Node e) { any(RouteHandler rh).getAResponseNode() = e }
 
   /**
    * An access to the HTTP request body.
    */
-  class RequestBodyAccess extends Expr {
-    // TODO: DataFlow::Node
-    RequestBodyAccess() { any(RouteHandler h).getARequestBodyAccess().asExpr() = this }
+  class RequestBodyAccess extends DataFlow::Node {
+    RequestBodyAccess() { any(RouteHandler h).getARequestBodyAccess() = this }
   }
 
   abstract private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
-    HeaderDefinition() { isResponse(this.getReceiver().asExpr()) }
+    HeaderDefinition() { isResponse(this.getReceiver()) }
 
     override RouteHandler getRouteHandler() { this.getReceiver() = result.getAResponseNode() }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Express.qll
@@ -774,14 +774,14 @@ module Express {
   /**
    * An invocation of the `cookie` method on an HTTP response object.
    */
-  class SetCookie extends HTTP::CookieDefinition, MethodCallExpr {
+  class SetCookie extends HTTP::CookieDefinition, DataFlow::MethodCallNode {
     ResponseSource response;
 
-    SetCookie() { this = response.ref().getAMethodCall("cookie").asExpr() }
+    SetCookie() { this = response.ref().getAMethodCall("cookie") }
 
-    override Expr getNameArgument() { result = this.getArgument(0) }
+    override DataFlow::Node getNameArgument() { result = this.getArgument(0) }
 
-    override Expr getValueArgument() { result = this.getArgument(1) }
+    override DataFlow::Node getValueArgument() { result = this.getArgument(1) }
 
     override RouteHandler getRouteHandler() { result = response.getRouteHandler() }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -392,9 +392,9 @@ module Fastify {
      */
     private DataFlow::SourceNode getAHeaderSource() { result.flowsTo(this.getArgument(0)) }
 
-    override predicate definesExplicitly(string headerName, Expr headerValue) {
+    override predicate definesHeaderValue(string headerName, DataFlow::Node headerValue) {
       exists(string header |
-        this.getAHeaderSource().hasPropertyWrite(header, headerValue.flow()) and
+        this.getAHeaderSource().hasPropertyWrite(header, headerValue) and
         headerName = header.toLowerCase()
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -147,15 +147,21 @@ module Fastify {
 
     private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
       t.start() and
-      result = this.getARouteHandlerExpr().getALocalSource()
+      result = this.getARouteHandlerNode().getALocalSource()
       or
       exists(DataFlow::TypeBackTracker t2 | result = this.getARouteHandler(t2).backtrack(t2, t))
     }
 
     override DataFlow::SourceNode getServer() { result = server }
 
-    /** Gets an argument that represents a route handler being registered. */
-    DataFlow::Node getARouteHandlerExpr() {
+    /**
+     * DEPRECATED: Use `getARouteHandlerNode` instead.
+     * Gets an argument that represents a route handler being registered.
+     */
+    deprecated DataFlow::Node getARouteHandlerExpr() { result = this.getARouteHandlerNode() }
+
+    /**  Gets an argument that represents a route handler being registered. */
+    DataFlow::Node getARouteHandlerNode() {
       if methodName = "route"
       then result = this.getOptionArgument(0, getNthHandlerName(_))
       else result = this.getLastArgument()

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -351,14 +351,12 @@ module Fastify {
   /**
    * An invocation of the `redirect` method of an HTTP response object.
    */
-  private class RedirectInvocation extends HTTP::RedirectInvocation, MethodCallExpr {
+  private class RedirectInvocation extends HTTP::RedirectInvocation, DataFlow::MethodCallNode {
     RouteHandler rh;
 
-    RedirectInvocation() {
-      this = rh.getAResponseSource().ref().getAMethodCall("redirect").asExpr()
-    }
+    RedirectInvocation() { this = rh.getAResponseSource().ref().getAMethodCall("redirect") }
 
-    override Expr getUrlArgument() { result = this.getLastArgument() }
+    override DataFlow::Node getUrlArgument() { result = this.getLastArgument() }
 
     override RouteHandler getRouteHandler() { result = rh }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -340,9 +340,9 @@ module Fastify {
     RouteHandler rh;
 
     ResponseSendArgument() {
-      this = rh.getAResponseSource().ref().getAMethodCall("send").getArgument(0).asExpr()
+      this = rh.getAResponseSource().ref().getAMethodCall("send").getArgument(0)
       or
-      this = rh.(DataFlow::FunctionNode).getAReturn().asExpr()
+      this = rh.(DataFlow::FunctionNode).getAReturn()
     }
 
     override RouteHandler getRouteHandler() { result = rh }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -18,9 +18,7 @@ module Fastify {
    * A standard way to create a Fastify server.
    */
   class StandardServerDefinition extends ServerDefinition {
-    StandardServerDefinition() {
-      this = DataFlow::moduleImport("fastify").getAnInvocation().asExpr()
-    }
+    StandardServerDefinition() { this = DataFlow::moduleImport("fastify").getAnInvocation() }
   }
 
   /** Gets a data flow node referring to a fastify server. */
@@ -139,7 +137,7 @@ module Fastify {
     string methodName;
 
     RouteSetup() {
-      this = server(server.flow()).getAMethodCall(methodName).asExpr() and
+      this = server(server).getAMethodCall(methodName).asExpr() and
       methodName = ["route", "get", "head", "post", "put", "delete", "options", "patch"]
     }
 
@@ -154,7 +152,7 @@ module Fastify {
       exists(DataFlow::TypeBackTracker t2 | result = this.getARouteHandler(t2).backtrack(t2, t))
     }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
 
     /** Gets an argument that represents a route handler being registered. */
     DataFlow::Node getARouteHandlerExpr() {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Fastify.qll
@@ -401,9 +401,9 @@ module Fastify {
 
     override RouteHandler getRouteHandler() { result = rh }
 
-    override Expr getNameExpr() {
+    override DataFlow::Node getNameNode() {
       exists(DataFlow::PropWrite write | this.getAHeaderSource().getAPropertyWrite() = write |
-        result = write.getPropertyNameExpr()
+        result = write.getPropertyNameExpr().flow()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
@@ -195,10 +195,8 @@ module Firebase {
     /**
      * A call to a Firebase method that sets up a route.
      */
-    private class RouteSetup extends HTTP::Servers::StandardRouteSetup, CallExpr {
-      RouteSetup() {
-        this = namespace().getAPropertyRead("https").getAMemberCall("onRequest").asExpr()
-      }
+    private class RouteSetup extends HTTP::Servers::StandardRouteSetup, DataFlow::CallNode {
+      RouteSetup() { this = namespace().getAPropertyRead("https").getAMemberCall("onRequest") }
 
       override DataFlow::SourceNode getARouteHandler() {
         result = getARouteHandler(DataFlow::TypeBackTracker::end())
@@ -206,12 +204,12 @@ module Firebase {
 
       private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
         t.start() and
-        result = getArgument(0).flow().getALocalSource()
+        result = getArgument(0).getALocalSource()
         or
         exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
       }
 
-      override Expr getServer() { none() }
+      override DataFlow::Node getServer() { none() }
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
@@ -114,13 +114,13 @@ module Firebase {
     class QueryListenCall extends DataFlow::MethodCallNode {
       QueryListenCall() {
         this = query().getAMethodCall() and
-        (getMethodName() = "on" or getMethodName() = "once")
+        (this.getMethodName() = "on" or this.getMethodName() = "once")
       }
 
       /**
        * Gets the argument in which the callback is passed.
        */
-      DataFlow::Node getCallbackNode() { result = getArgument(1) }
+      DataFlow::Node getCallbackNode() { result = this.getArgument(1) }
     }
 
     /**
@@ -183,13 +183,13 @@ module Firebase {
     class RefBuilderListenCall extends DataFlow::MethodCallNode {
       RefBuilderListenCall() {
         this = ref().getAMethodCall() and
-        getMethodName() = "on" + any(string s)
+        this.getMethodName() = "on" + any(string s)
       }
 
       /**
        * Gets the data flow node holding the listener callback.
        */
-      DataFlow::Node getCallbackNode() { result = getArgument(0) }
+      DataFlow::Node getCallbackNode() { result = this.getArgument(0) }
     }
 
     /**
@@ -199,14 +199,14 @@ module Firebase {
       RouteSetup() { this = namespace().getAPropertyRead("https").getAMemberCall("onRequest") }
 
       override DataFlow::SourceNode getARouteHandler() {
-        result = getARouteHandler(DataFlow::TypeBackTracker::end())
+        result = this.getARouteHandler(DataFlow::TypeBackTracker::end())
       }
 
       private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
         t.start() and
-        result = getArgument(0).getALocalSource()
+        result = this.getArgument(0).getALocalSource()
         or
-        exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
+        exists(DataFlow::TypeBackTracker t2 | result = this.getARouteHandler(t2).backtrack(t2, t))
       }
 
       override DataFlow::Node getServer() { none() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Firebase.qll
@@ -216,15 +216,13 @@ module Firebase {
      * A function used as a route handler.
      */
     private class RouteHandler extends Express::RouteHandler, HTTP::Servers::StandardRouteHandler,
-      DataFlow::ValueNode {
-      override Function astNode;
-
+      DataFlow::FunctionNode {
       RouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
 
-      override Parameter getRouteHandlerParameter(string kind) {
-        kind = "request" and result = astNode.getParameter(0)
+      override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
+        kind = "request" and result = this.getParameter(0)
         or
-        kind = "response" and result = astNode.getParameter(1)
+        kind = "response" and result = this.getParameter(1)
       }
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -174,7 +174,7 @@ module HTTP {
   /**
    * An expression that creates a new server.
    */
-  abstract class ServerDefinition extends Expr {
+  abstract class ServerDefinition extends DataFlow::Node {
     /**
      * Gets a route handler of the server.
      */
@@ -242,7 +242,7 @@ module HTTP {
   /**
    * An expression that sets up a route on a server.
    */
-  abstract class RouteSetup extends Expr { }
+  abstract class RouteSetup extends Expr { } // TODO: DataFlow::Node
 
   /**
    * An expression that may contain a request object.
@@ -275,11 +275,13 @@ module HTTP {
      * A standard server definition.
      */
     abstract class StandardServerDefinition extends ServerDefinition {
-      override RouteHandler getARouteHandler() { result.(StandardRouteHandler).getServer() = this }
+      override RouteHandler getARouteHandler() {
+        result.(StandardRouteHandler).getServer() = this.asExpr()
+      }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
         t.start() and
-        result = DataFlow::exprNode(this)
+        result = this.getALocalSource()
         or
         exists(DataFlow::TypeTracker t2 | result = this.ref(t2).track(t2, t))
       }
@@ -307,6 +309,7 @@ module HTTP {
        * Gets the server this route handler is registered on.
        */
       Expr getServer() {
+        // TODO: DataFlow::Node
         exists(StandardRouteSetup setup | setup.getARouteHandler() = this |
           result = setup.getServer()
         )
@@ -411,7 +414,7 @@ module HTTP {
       /**
        * Gets the server on which this route setup sets up routes.
        */
-      abstract Expr getServer();
+      abstract Expr getServer(); // TODO: DataFlow::Node
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -272,10 +272,14 @@ module HTTP {
         exists(DataFlow::TypeTracker t2 | result = this.ref(t2).track(t2, t))
       }
 
+      /** Gets a data flow node referring to this server. */
+      DataFlow::SourceNode ref() { result = this.ref(DataFlow::TypeTracker::end()) }
+
       /**
+       * DEPRECATED: Use `ref().flowsToExpr()` instead.
        * Holds if `sink` may refer to this server definition.
        */
-      predicate flowsTo(Expr sink) { this.ref(DataFlow::TypeTracker::end()).flowsToExpr(sink) }
+      deprecated predicate flowsTo(Expr sink) { this.ref().flowsToExpr(sink) }
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -133,22 +133,21 @@ module HTTP {
   /**
    * An expression that sets a cookie in an HTTP response.
    */
-  abstract class CookieDefinition extends Expr {
-    // TODO: DataFlow::Node
+  abstract class CookieDefinition extends DataFlow::Node {
     /**
      * Gets the argument, if any, specifying the raw cookie header.
      */
-    Expr getHeaderArgument() { none() } // TODO: DataFlow::Node
+    DataFlow::Node getHeaderArgument() { none() }
 
     /**
      * Gets the argument, if any, specifying the cookie name.
      */
-    Expr getNameArgument() { none() } // TODO: DataFlow::Node
+    DataFlow::Node getNameArgument() { none() }
 
     /**
      * Gets the argument, if any, specifying the cookie value.
      */
-    Expr getValueArgument() { none() } // TODO: DataFlow::Node
+    DataFlow::Node getValueArgument() { none() }
 
     /** Gets the route handler that sets this cookie. */
     abstract RouteHandler getRouteHandler();
@@ -161,12 +160,12 @@ module HTTP {
     HeaderDefinition header;
 
     SetCookieHeader() {
-      this = header.asExpr() and
+      this = header and
       header.getAHeaderName() = "set-cookie"
     }
 
-    override Expr getHeaderArgument() {
-      header.(ExplicitHeaderDefinition).definesHeaderValue("set-cookie", result.flow())
+    override DataFlow::Node getHeaderArgument() {
+      header.(ExplicitHeaderDefinition).definesHeaderValue("set-cookie", result)
     }
 
     override RouteHandler getRouteHandler() { result = header.getRouteHandler() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -12,9 +12,9 @@ module HTTP {
   /**
    * A function invocation that causes a redirect response to be sent.
    */
-  abstract class RedirectInvocation extends InvokeExpr {
+  abstract class RedirectInvocation extends DataFlow::CallNode {
     /** Gets the argument specifying the URL to redirect to. */
-    abstract Expr getUrlArgument();
+    abstract DataFlow::Node getUrlArgument();
 
     /** Gets the route handler this redirect occurs in. */
     abstract RouteHandler getRouteHandler();

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -242,7 +242,7 @@ module HTTP {
   /**
    * An expression that sets up a route on a server.
    */
-  abstract class RouteSetup extends Expr { } // TODO: DataFlow::Node
+  abstract class RouteSetup extends DataFlow::Node { }
 
   /**
    * An expression that may contain a request object.
@@ -275,9 +275,7 @@ module HTTP {
      * A standard server definition.
      */
     abstract class StandardServerDefinition extends ServerDefinition {
-      override RouteHandler getARouteHandler() {
-        result.(StandardRouteHandler).getServer() = this.asExpr()
-      }
+      override RouteHandler getARouteHandler() { result.(StandardRouteHandler).getServer() = this }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
         t.start() and
@@ -308,8 +306,7 @@ module HTTP {
       /**
        * Gets the server this route handler is registered on.
        */
-      Expr getServer() {
-        // TODO: DataFlow::Node
+      DataFlow::Node getServer() {
         exists(StandardRouteSetup setup | setup.getARouteHandler() = this |
           result = setup.getServer()
         )
@@ -414,7 +411,7 @@ module HTTP {
       /**
        * Gets the server on which this route setup sets up routes.
        */
-      abstract Expr getServer(); // TODO: DataFlow::Node
+      abstract DataFlow::Node getServer();
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -68,12 +68,16 @@ module HTTP {
     /**
      * Holds if the header with (lower-case) name `headerName` is set to the value of `headerValue`.
      */
-    abstract predicate definesExplicitly(string headerName, Expr headerValue);
+    abstract predicate definesExplicitly(string headerName, Expr headerValue); // TODO: DataFlow::Node.
 
     /**
+     * DEPRECATED: Use `getNameNode()` instead.
      * Returns the expression used to compute the header name.
      */
-    abstract Expr getNameExpr();
+    deprecated Expr getNameExpr() { result = this.getNameNode().asExpr() }
+
+    /** Returns the expression used to compute the header name. */
+    abstract DataFlow::Node getNameNode();
   }
 
   /**
@@ -201,13 +205,13 @@ module HTTP {
      * Gets an expression that contains a request object handled
      * by this handler.
      */
-    RequestExpr getARequestExpr() { result.getRouteHandler() = this }
+    RequestExpr getARequestExpr() { result.getRouteHandler() = this } // TODO: DataFlow::Node
 
     /**
      * Gets an expression that contains a response object provided
      * by this handler.
      */
-    ResponseExpr getAResponseExpr() { result.getRouteHandler() = this }
+    ResponseExpr getAResponseExpr() { result.getRouteHandler() = this } // TODO: DataFlow::Node
   }
 
   /**
@@ -238,6 +242,7 @@ module HTTP {
    * An expression that may contain a request object.
    */
   abstract class RequestExpr extends Expr {
+    // TODO: DataFlow::Node
     /**
      * Gets the route handler that handles this request.
      */
@@ -248,6 +253,7 @@ module HTTP {
    * An expression that may contain a response object.
    */
   abstract class ResponseExpr extends Expr {
+    // TODO: DataFlow::Node
     /**
      * Gets the route handler that handles this request.
      */
@@ -376,15 +382,14 @@ module HTTP {
     /**
      * A standard header definition.
      */
-    abstract class StandardHeaderDefinition extends ExplicitHeaderDefinition, DataFlow::ValueNode {
-      override MethodCallExpr astNode;
-
+    abstract class StandardHeaderDefinition extends ExplicitHeaderDefinition,
+      DataFlow::MethodCallNode {
       override predicate definesExplicitly(string headerName, Expr headerValue) {
-        headerName = this.getNameExpr().getStringValue().toLowerCase() and
-        headerValue = astNode.getArgument(1)
+        headerName = this.getNameNode().getStringValue().toLowerCase() and
+        headerValue = this.getArgument(1).asExpr()
       }
 
-      override Expr getNameExpr() { result = astNode.getArgument(0) }
+      override DataFlow::Node getNameNode() { result = this.getArgument(0) }
     }
 
     /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HTTP.qll
@@ -117,7 +117,7 @@ module HTTP {
   /**
    * An expression whose value is sent as (part of) the body of an HTTP response.
    */
-  abstract class ResponseBody extends Expr {
+  abstract class ResponseBody extends DataFlow::Node {
     /**
      * Gets the route handler that sends this expression.
      */

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -231,7 +231,7 @@ module Hapi {
     pragma[noinline]
     private DataFlow::Node getRouteHandler() { result = handler }
 
-    Expr getRouteHandlerExpr() { result = handler.asExpr() } // TODO: DataFlow::Node
+    deprecated Expr getRouteHandlerExpr() { result = handler.asExpr() }
 
     override DataFlow::Node getServer() { result = server }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -189,7 +189,7 @@ module Hapi {
     Expr handler;
 
     RouteSetup() {
-      server.flowsTo(getReceiver()) and
+      server.ref().flowsToExpr(getReceiver()) and
       (
         // server.route({ handler: fun })
         getMethodName() = "route" and

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -186,16 +186,16 @@ module Hapi {
   /**
    * A call to a Hapi method that sets up a route.
    */
-  class RouteSetup extends MethodCallExpr, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
     ServerDefinition server;
-    Expr handler;
+    DataFlow::Node handler;
 
     RouteSetup() {
-      server.ref().flowsToExpr(getReceiver()) and
+      server.ref().getAMethodCall() = this and
       (
         // server.route({ handler: fun })
         getMethodName() = "route" and
-        hasOptionArgument(0, "handler", handler)
+        getOptionArgument(0, "handler") = handler
         or
         // server.ext('/', fun)
         getMethodName() = "ext" and
@@ -215,11 +215,11 @@ module Hapi {
     }
 
     pragma[noinline]
-    private DataFlow::Node getRouteHandler() { result = handler.flow() }
+    private DataFlow::Node getRouteHandler() { result = handler }
 
-    Expr getRouteHandlerExpr() { result = handler }
+    Expr getRouteHandlerExpr() { result = handler.asExpr() } // TODO: DataFlow::Node
 
-    override Expr getServer() { result = server.asExpr() }
+    override DataFlow::Node getServer() { result = server }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -74,6 +74,7 @@ module Hapi {
     override RouteHandler getRouteHandler() { result = rh }
   }
 
+  // TODO: DataFlow::Node
   /**
    * A Hapi response expression.
    */
@@ -81,6 +82,7 @@ module Hapi {
     override ResponseSource src;
   }
 
+  // TODO: DataFlow::Node
   /**
    * An Hapi request expression.
    */
@@ -175,7 +177,7 @@ module Hapi {
 
     HeaderDefinition() {
       // request.response.header('Cache-Control', 'no-cache')
-      astNode.calls(res, "header")
+      this.calls(res.flow(), "header")
     }
 
     override RouteHandler getRouteHandler() { result = res.getRouteHandler() }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -25,18 +25,18 @@ module Hapi {
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
-    DataFlow::ParameterNode getRequestParameter() { result = getParameter(0) }
+    DataFlow::ParameterNode getRequestParameter() { result = this.getParameter(0) }
 
     /**
      * Gets the parameter of the route handler that contains the "request toolkit",
      * usually named `h`.
      */
-    DataFlow::ParameterNode getRequestToolkitParameter() { result = getParameter(1) }
+    DataFlow::ParameterNode getRequestToolkitParameter() { result = this.getParameter(1) }
 
     /**
      * Gets a source node referring to the request toolkit parameter, usually named `h`.
      */
-    DataFlow::SourceNode getRequestToolkit() { result = getRequestToolkitParameter() }
+    DataFlow::SourceNode getRequestToolkit() { result = this.getRequestToolkitParameter() }
   }
 
   /**
@@ -203,24 +203,24 @@ module Hapi {
       server.ref().getAMethodCall() = this and
       (
         // server.route({ handler: fun })
-        getMethodName() = "route" and
-        getOptionArgument(0, "handler") = handler
+        this.getMethodName() = "route" and
+        this.getOptionArgument(0, "handler") = handler
         or
         // server.ext('/', fun)
-        getMethodName() = "ext" and
-        handler = getArgument(1)
+        this.getMethodName() = "ext" and
+        handler = this.getArgument(1)
       )
     }
 
     override DataFlow::SourceNode getARouteHandler() {
-      result = getARouteHandler(DataFlow::TypeBackTracker::end())
+      result = this.getARouteHandler(DataFlow::TypeBackTracker::end())
     }
 
     private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
       t.start() and
-      result = getRouteHandler().getALocalSource()
+      result = this.getRouteHandler().getALocalSource()
       or
-      exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
+      exists(DataFlow::TypeBackTracker t2 | result = this.getARouteHandler(t2).backtrack(t2, t))
     }
 
     pragma[noinline]
@@ -268,9 +268,9 @@ module Hapi {
 
     override DataFlow::SourceNode getOutput() { none() }
 
-    override DataFlow::Node getTemplateFileNode() { result = getArgument(0) }
+    override DataFlow::Node getTemplateFileNode() { result = this.getArgument(0) }
 
-    override DataFlow::Node getTemplateParamsNode() { result = getArgument(1) }
+    override DataFlow::Node getTemplateParamsNode() { result = this.getArgument(1) }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -270,7 +270,7 @@ module Hapi {
   private class HandlerReturn extends HTTP::ResponseSendArgument {
     RouteHandler handler;
 
-    HandlerReturn() { this = handler.(DataFlow::FunctionNode).getAReturn().asExpr() }
+    HandlerReturn() { this = handler.(DataFlow::FunctionNode).getAReturn() }
 
     override RouteHandler getRouteHandler() { result = handler }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -19,29 +19,24 @@ module Hapi {
   /**
    * A Hapi route handler.
    */
-  class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::ValueNode {
-    Function function;
-
-    RouteHandler() {
-      function = astNode and
-      exists(RouteSetup setup | this = setup.getARouteHandler())
-    }
+  class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+    RouteHandler() { exists(RouteSetup setup | this = setup.getARouteHandler()) }
 
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
-    Parameter getRequestParameter() { result = function.getParameter(0) }
+    DataFlow::ParameterNode getRequestParameter() { result = getParameter(0) }
 
     /**
      * Gets the parameter of the route handler that contains the "request toolkit",
      * usually named `h`.
      */
-    Parameter getRequestToolkitParameter() { result = function.getParameter(1) }
+    DataFlow::ParameterNode getRequestToolkitParameter() { result = getParameter(1) }
 
     /**
      * Gets a source node referring to the request toolkit parameter, usually named `h`.
      */
-    DataFlow::SourceNode getRequestToolkit() { result = getRequestToolkitParameter().flow() }
+    DataFlow::SourceNode getRequestToolkit() { result = getRequestToolkitParameter() }
   }
 
   /**
@@ -66,7 +61,7 @@ module Hapi {
   private class RequestSource extends HTTP::Servers::RequestSource {
     RouteHandler rh;
 
-    RequestSource() { this = DataFlow::parameterNode(rh.getRequestParameter()) }
+    RequestSource() { this = rh.getRequestParameter() }
 
     /**
      * Gets the route handler that handles this request.

--- a/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Hapi.qll
@@ -9,10 +9,10 @@ module Hapi {
   /**
    * An expression that creates a new Hapi server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, NewExpr {
+  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::NewNode {
     ServerDefinition() {
       // `server = new Hapi.Server()`
-      this = DataFlow::moduleMember("hapi", "Server").getAnInstantiation().asExpr()
+      this = DataFlow::moduleMember("hapi", "Server").getAnInstantiation()
     }
   }
 
@@ -219,7 +219,7 @@ module Hapi {
 
     Expr getRouteHandlerExpr() { result = handler }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/HttpProxy.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/HttpProxy.qll
@@ -83,16 +83,12 @@ private module HttpProxy {
       )
     }
 
-    override Parameter getRequestParameter() {
-      exists(int req | routeHandlingEventHandler(event, req, _) |
-        result = getFunction().getParameter(req)
-      )
+    override DataFlow::ParameterNode getRequestParameter() {
+      exists(int req | routeHandlingEventHandler(event, req, _) | result = getParameter(req))
     }
 
-    override Parameter getResponseParameter() {
-      exists(int res | routeHandlingEventHandler(event, _, res) |
-        result = getFunction().getParameter(res)
-      )
+    override DataFlow::ParameterNode getResponseParameter() {
+      exists(int res | routeHandlingEventHandler(event, _, res) | result = getParameter(res))
     }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/JWT.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/JWT.qll
@@ -40,12 +40,10 @@ private module JsonWebToken {
   }
 
   /**
-   * The private key for a JWT as a `CredentialsExpr`.
+   * The private key for a JWT as a `CredentialsNode`.
    */
-  private class JwtKey extends CredentialsExpr {
-    JwtKey() {
-      this = DataFlow::moduleMember("jsonwebtoken", "sign").getACall().getArgument(1).asExpr()
-    }
+  private class JwtKey extends CredentialsNode {
+    JwtKey() { this = DataFlow::moduleMember("jsonwebtoken", "sign").getACall().getArgument(1) }
 
     override string getCredentialsKind() { result = "key" }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Knex.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Knex.qll
@@ -43,7 +43,7 @@ module Knex {
 
   /** A SQL string passed to a raw Knex method. */
   private class RawKnexSqlString extends SQL::SqlString {
-    RawKnexSqlString() { this = any(RawKnexCall call).getArgument(0).asExpr() }
+    RawKnexSqlString() { this = any(RawKnexCall call).getArgument(0) }
   }
 
   /** A call that triggers a SQL query submission by calling then/stream/asCallback. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -9,10 +9,10 @@ module Koa {
   /**
    * An expression that creates a new Koa application.
    */
-  class AppDefinition extends HTTP::Servers::StandardServerDefinition, InvokeExpr {
+  class AppDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::InvokeNode {
     AppDefinition() {
       // `app = new Koa()` / `app = Koa()`
-      this = DataFlow::moduleImport("koa").getAnInvocation().asExpr()
+      this = DataFlow::moduleImport("koa").getAnInvocation()
     }
   }
 
@@ -401,7 +401,7 @@ module Koa {
       result.(RouteHandler).getARouteHandlerRegistrationObject().flowsToExpr(this.getArgument(0))
     }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -384,24 +384,23 @@ module Koa {
   /**
    * A call to a Koa method that sets up a route.
    */
-  class RouteSetup extends HTTP::Servers::StandardRouteSetup, MethodCallExpr {
+  class RouteSetup extends HTTP::Servers::StandardRouteSetup, DataFlow::MethodCallNode {
     AppDefinition server;
 
     RouteSetup() {
       // app.use(fun)
-      server.ref().flowsToExpr(this.getReceiver()) and
-      this.getMethodName() = "use"
+      server.ref().getAMethodCall("use") = this
     }
 
     override DataFlow::SourceNode getARouteHandler() {
       // `StandardRouteHandler` uses this predicate in it's charpred, so making this predicate return a `RouteHandler` would give an empty recursion.
-      result.flowsToExpr(this.getArgument(0))
+      result.flowsToExpr(this.getArgument(0).asExpr())
       or
       // For the route-handlers that does not depend on this predicate in their charpred.
-      result.(RouteHandler).getARouteHandlerRegistrationObject().flowsToExpr(this.getArgument(0))
+      result.(RouteHandler).getARouteHandlerRegistrationObject().flowsTo(this.getArgument(0))
     }
 
-    override Expr getServer() { result = server.asExpr() }
+    override DataFlow::Node getServer() { result = server }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -422,12 +422,14 @@ module Koa {
   /**
    * An invocation of the `redirect` method of an HTTP response object.
    */
-  private class RedirectInvocation extends HTTP::RedirectInvocation, MethodCallExpr {
+  private class RedirectInvocation extends HTTP::RedirectInvocation, DataFlow::MethodCallNode {
     RouteHandler rh;
 
-    RedirectInvocation() { this.(MethodCallExpr).calls(rh.getAResponseOrContextExpr(), "redirect") }
+    RedirectInvocation() {
+      this.asExpr().(MethodCallExpr).calls(rh.getAResponseOrContextExpr(), "redirect")
+    } // TODO: Improve this.
 
-    override Expr getUrlArgument() { result = this.getArgument(0) }
+    override DataFlow::Node getUrlArgument() { result = this.getArgument(0) }
 
     override RouteHandler getRouteHandler() { result = rh }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -49,7 +49,7 @@ module Koa {
      * Gets an expression that contains the "context" object of
      * a route handler invocation.
      */
-    deprecated Expr getAContextExpr() { result.(ContextExpr).getRouteHandler() = this }
+    deprecated Expr getAContextExpr() { result = this.getAContextNode().asExpr() }
 
     /**
      * Gets an expression that contains the "context" object of
@@ -67,7 +67,7 @@ module Koa {
      * object of a route handler invocation.
      */
     deprecated Expr getAResponseOrContextExpr() {
-      result = this.getAResponseNode().asExpr() or result = this.getAContextExpr()
+      result = this.getAResponseOrContextNode().asExpr()
     }
 
     /**
@@ -83,9 +83,7 @@ module Koa {
      * Gets an expression that contains the context or request
      * object of a route handler invocation.
      */
-    deprecated Expr getARequestOrContextExpr() {
-      result = this.getARequestNode().asExpr() or result = this.getAContextExpr()
-    }
+    deprecated Expr getARequestOrContextExpr() { result = this.getARequestOrContextNode().asExpr() }
 
     /**
      * Gets an expression that contains the context or request
@@ -447,7 +445,7 @@ module Koa {
 
     override DataFlow::SourceNode getARouteHandler() {
       // `StandardRouteHandler` uses this predicate in it's charpred, so making this predicate return a `RouteHandler` would give an empty recursion.
-      result.flowsToExpr(this.getArgument(0).asExpr())
+      result.flowsTo(this.getArgument(0))
       or
       // For the route-handlers that does not depend on this predicate in their charpred.
       result.(RouteHandler).getARouteHandlerRegistrationObject().flowsTo(this.getArgument(0))

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -24,10 +24,10 @@ module Koa {
 
     HeaderDefinition() {
       // ctx.set('Cache-Control', 'no-cache');
-      astNode.calls(rh.getAResponseOrContextExpr(), "set")
+      this.calls(rh.getAResponseOrContextExpr().flow(), "set")
       or
       // ctx.response.header('Cache-Control', 'no-cache')
-      astNode.calls(rh.getAResponseExpr(), "header")
+      this.calls(rh.getAResponseExpr().flow(), "header")
     }
 
     override RouteHandler getRouteHandler() { result = rh }
@@ -59,6 +59,7 @@ module Koa {
      * object of a route handler invocation.
      */
     Expr getAResponseOrContextExpr() {
+      // TODO: DataFlow::Node
       result = this.getAResponseExpr() or result = this.getAContextExpr()
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -118,8 +118,6 @@ module Koa {
      */
     RouteHandler getRouteHandler() { result = rh }
 
-    predicate flowsTo(DataFlow::Node nd) { this.ref().flowsTo(nd) }
-
     private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
       t.start() and
       result = this
@@ -258,7 +256,7 @@ module Koa {
   class ContextExpr extends Expr {
     ContextSource src;
 
-    ContextExpr() { src.flowsTo(DataFlow::valueNode(this)) }
+    ContextExpr() { src.ref().flowsTo(DataFlow::valueNode(this)) }
 
     /**
      * Gets the route handler that provides this response.
@@ -390,7 +388,7 @@ module Koa {
 
     RouteSetup() {
       // app.use(fun)
-      server.flowsTo(this.getReceiver()) and
+      server.ref().flowsToExpr(this.getReceiver()) and
       this.getMethodName() = "use"
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -412,8 +412,7 @@ module Koa {
 
     ResponseSendArgument() {
       exists(DataFlow::PropWrite pwn |
-        pwn.writes(DataFlow::valueNode(rh.getAResponseOrContextExpr()), "body",
-          DataFlow::valueNode(this))
+        pwn.writes(DataFlow::valueNode(rh.getAResponseOrContextExpr()), "body", this)
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Koa.qll
@@ -27,7 +27,7 @@ module Koa {
       this.calls(rh.getAResponseOrContextExpr().flow(), "set")
       or
       // ctx.response.header('Cache-Control', 'no-cache')
-      this.calls(rh.getAResponseExpr().flow(), "header")
+      this.calls(rh.getAResponseNode(), "header")
     }
 
     override RouteHandler getRouteHandler() { result = rh }
@@ -60,7 +60,7 @@ module Koa {
      */
     Expr getAResponseOrContextExpr() {
       // TODO: DataFlow::Node
-      result = this.getAResponseExpr() or result = this.getAContextExpr()
+      result = this.getAResponseNode().asExpr() or result = this.getAContextExpr()
     }
 
     /**
@@ -68,7 +68,8 @@ module Koa {
      * object of a route handler invocation.
      */
     Expr getARequestOrContextExpr() {
-      result = this.getARequestExpr() or result = this.getAContextExpr()
+      // TODO: DataFlow::Node
+      result = this.getARequestNode().asExpr() or result = this.getAContextExpr()
     }
 
     /**
@@ -266,16 +267,32 @@ module Koa {
   }
 
   /**
+   * DEPRECATED: Use `RequestNode` instead.
    * An expression that may hold a Koa request object.
    */
-  class RequestExpr extends HTTP::Servers::StandardRequestExpr {
+  deprecated class RequestExpr extends HTTP::Servers::StandardRequestExpr {
+    RequestExpr() { this.flow() instanceof RequestNode }
+  }
+
+  /**
+   * An expression that may hold a Koa request object.
+   */
+  class RequestNode extends HTTP::Servers::StandardRequestNode {
     override RequestSource src;
+  }
+
+  /**
+   * DEPRECATED: Use `ResponseNode` instead.
+   * An expression that may hold a Koa response object.
+   */
+  deprecated class ResponseExpr extends HTTP::Servers::StandardResponseExpr {
+    ResponseExpr() { this.flow() instanceof ResponseNode }
   }
 
   /**
    * An expression that may hold a Koa response object.
    */
-  class ResponseExpr extends HTTP::Servers::StandardResponseExpr {
+  class ResponseNode extends HTTP::Servers::StandardResponseNode {
     override ResponseSource src;
   }
 
@@ -311,7 +328,7 @@ module Koa {
         this.asExpr().(PropAccess).accesses(e, "params")
         or
         // `ctx.request.body`
-        e instanceof RequestExpr and
+        e.flow() instanceof RequestNode and
         kind = "body" and
         this.asExpr().(PropAccess).accesses(e, "body")
         or

--- a/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
@@ -22,8 +22,8 @@ private module LiveServer {
   class RouteHandler extends Connect::RouteHandler, DataFlow::FunctionNode {
     RouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
 
-    override Parameter getRouteHandlerParameter(string kind) {
-      result = ConnectExpressShared::getRouteHandlerParameter(astNode, kind)
+    override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
+      result = ConnectExpressShared::getRouteHandlerParameter(this, kind)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
@@ -10,9 +10,9 @@ private module LiveServer {
    * An expression that imports the live-server package, seen as a server-definition.
    */
   class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
-    ServerDefinition() { this = DataFlow::moduleImport("live-server").asExpr() }
+    ServerDefinition() { this = DataFlow::moduleImport("live-server") }
 
-    API::Node getImportNode() { result.asSource().asExpr() = this }
+    API::Node getImportNode() { result.asSource() = this }
   }
 
   /**
@@ -49,6 +49,6 @@ private module LiveServer {
       )
     }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LiveServer.qll
@@ -30,18 +30,14 @@ private module LiveServer {
   /**
    * The call to `require("live-server").start()`, seen as a route setup.
    */
-  class RouteSetup extends MethodCallExpr, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends HTTP::Servers::StandardRouteSetup instanceof API::CallNode {
     ServerDefinition server;
-    API::CallNode call;
 
-    RouteSetup() {
-      call = server.getImportNode().getMember("start").getACall() and
-      this = call.asExpr()
-    }
+    RouteSetup() { this = server.getImportNode().getMember("start").getACall() }
 
     override DataFlow::SourceNode getARouteHandler() {
       exists(DataFlow::SourceNode middleware |
-        middleware = call.getParameter(0).getMember("middleware").getAValueReachingSink()
+        middleware = super.getParameter(0).getMember("middleware").getAValueReachingSink()
       |
         result = middleware.getAMemberCall(["push", "unshift"]).getArgument(0).getAFunctionValue()
         or
@@ -49,6 +45,6 @@ private module LiveServer {
       )
     }
 
-    override Expr getServer() { result = server.asExpr() }
+    override DataFlow::Node getServer() { result = server }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Logging.qll
@@ -349,8 +349,8 @@ private module Pino {
     or
     // `pino` is installed as the "log" property on the request object in `Express` and similar libraries.
     // in `Hapi` the property is "logger".
-    exists(HTTP::RequestExpr req, API::Node reqNode |
-      reqNode.asSource() = req.flow().getALocalSource() and
+    exists(HTTP::RequestNode req, API::Node reqNode |
+      reqNode.asSource() = req.getALocalSource() and
       result = reqNode.getMember(["log", "logger"])
     )
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
@@ -62,11 +62,19 @@ private module Micro {
     override HTTP::RouteHandler getRouteHandler() { result = h }
   }
 
-  class MicroRequestExpr extends NodeJSLib::RequestExpr {
+  deprecated class MicroRequestExpr extends NodeJSLib::RequestExpr {
     override MicroRequestSource src;
   }
 
-  class MicroReseponseExpr extends NodeJSLib::ResponseExpr {
+  class MicroRequestNode extends NodeJSLib::RequestNode {
+    override MicroRequestSource src;
+  }
+
+  deprecated class MicroReseponseExpr extends NodeJSLib::ResponseExpr {
+    override MicroResponseSource src;
+  }
+
+  class MicroResponseNode extends NodeJSLib::ResponseNode {
     override MicroResponseSource src;
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Micro.qll
@@ -104,7 +104,7 @@ private module Micro {
 
     MicroSendArgument() {
       send = moduleMember("micro", ["send", "sendError"]).getACall() and
-      this = send.getLastArgument().asExpr()
+      this = send.getLastArgument()
     }
 
     override HTTP::RouteHandler getRouteHandler() {

--- a/javascript/ql/lib/semmle/javascript/frameworks/Nest.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Nest.qll
@@ -349,10 +349,10 @@ module NestJS {
 
     ReturnValueAsResponseSend() {
       handler.isReturnValueReflected() and
-      this = handler.getAReturn().asExpr() and
+      this = handler.getAReturn() and
       // Only returned strings are sinks
       not exists(Type type |
-        type = getType() and
+        type = this.asExpr().getType() and
         not isStringType(type.unfold())
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Nest.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Nest.qll
@@ -56,7 +56,7 @@ module NestJS {
      */
     predicate isReturnValueReflected() {
       getAFunctionDecorator(this) = nestjs().getMember(["Get", "Post"]).getACall() and
-      not hasRedirectDecorator() and
+      not this.hasRedirectDecorator() and
       not getAFunctionDecorator(this) = nestjs().getMember("Render").getACall()
     }
 
@@ -93,7 +93,7 @@ module NestJS {
     NestJSRequestInput() {
       decoratorName =
         ["Query", "Param", "Headers", "Body", "HostParam", "UploadedFile", "UploadedFiles"] and
-      decorator = getADecorator() and
+      decorator = this.getADecorator() and
       decorator = nestjs().getMember(decoratorName).getACall()
     }
 
@@ -105,7 +105,7 @@ module NestJS {
 
     /** Gets a pipe applied to this parameter, not including global pipes. */
     DataFlow::Node getAPipe() {
-      result = getNestRouteHandler().getAPipe()
+      result = this.getNestRouteHandler().getAPipe()
       or
       result = decorator.getArgument(1)
       or
@@ -132,7 +132,7 @@ module NestJS {
       hasSanitizingPipe(this, false)
       or
       hasSanitizingPipe(this, true) and
-      isSanitizingType(getParameter().getType().unfold())
+      isSanitizingType(this.getParameter().getType().unfold())
     }
   }
 
@@ -240,14 +240,14 @@ module NestJS {
       )
     }
 
-    DataFlow::FunctionNode getTransformFunction() { result = getInstanceMethod("transform") }
+    DataFlow::FunctionNode getTransformFunction() { result = this.getInstanceMethod("transform") }
 
-    DataFlow::ParameterNode getInputData() { result = getTransformFunction().getParameter(0) }
+    DataFlow::ParameterNode getInputData() { result = this.getTransformFunction().getParameter(0) }
 
-    DataFlow::Node getOutputData() { result = getTransformFunction().getReturnNode() }
+    DataFlow::Node getOutputData() { result = this.getTransformFunction().getReturnNode() }
 
     NestJSRequestInput getAnAffectedParameter() {
-      [getAnInstanceReference(), getAClassReference()].flowsTo(result.getAPipe())
+      [this.getAnInstanceReference(), this.getAClassReference()].flowsTo(result.getAPipe())
     }
   }
 
@@ -297,16 +297,16 @@ module NestJS {
   private class NestJSRequestInputAsRequestInputAccess extends NestJSRequestInput,
     HTTP::RequestInputAccess {
     NestJSRequestInputAsRequestInputAccess() {
-      not isSanitizedByPipe() and
+      not this.isSanitizedByPipe() and
       not this = any(CustomPipeClass cls).getAnAffectedParameter()
     }
 
-    override HTTP::RouteHandler getRouteHandler() { result = getNestRouteHandler() }
+    override HTTP::RouteHandler getRouteHandler() { result = this.getNestRouteHandler() }
 
-    override string getKind() { result = getInputKind() }
+    override string getKind() { result = this.getInputKind() }
 
     override predicate isUserControlledObject() {
-      not exists(getAPipe()) and // value is not transformed by a pipe
+      not exists(this.getAPipe()) and // value is not transformed by a pipe
       (
         decorator.getNumArgument() = 0
         or
@@ -389,15 +389,15 @@ module NestJS {
     CustomParameterDecorator() { this = nestjs().getMember("createParamDecorator").getACall() }
 
     /** Gets the `context` parameter. */
-    API::Node getExecutionContext() { result = getParameter(0).getParameter(1) }
+    API::Node getExecutionContext() { result = this.getParameter(0).getParameter(1) }
 
     /** Gets a parameter with this decorator applied. */
     DataFlow::ParameterNode getADecoratedParameter() {
-      result.getADecorator() = getReturn().getReturn().getAValueReachableFromSource()
+      result.getADecorator() = this.getReturn().getReturn().getAValueReachableFromSource()
     }
 
     /** Gets a value returned by the decorator's callback, which becomes the value of the decorated parameter. */
-    DataFlow::Node getResult() { result = getParameter(0).getReturn().asSink() }
+    DataFlow::Node getResult() { result = this.getParameter(0).getReturn().asSink() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
@@ -35,11 +35,10 @@ module NextJS {
    */
   Module getAModuleWithFallbackPaths() {
     result = getAPagesModule() and
-    exists(DataFlow::FunctionNode staticPaths, Expr fallback |
+    exists(DataFlow::FunctionNode staticPaths, DataFlow::Node fallback |
       staticPaths = result.getAnExportedValue("getStaticPaths").getAFunctionValue() and
-      fallback =
-        staticPaths.getAReturn().getALocalSource().getAPropertyWrite("fallback").getRhs().asExpr() and
-      not fallback.(BooleanLiteral).getValue() = "false"
+      fallback = staticPaths.getAReturn().getALocalSource().getAPropertyWrite("fallback").getRhs() and
+      not fallback.mayHaveBooleanValue(false)
     )
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Next.qll
@@ -230,10 +230,10 @@ module NextJS {
       )
     }
 
-    override Parameter getRouteHandlerParameter(string kind) {
-      kind = "request" and result = this.getFunction().getParameter(0)
+    override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
+      kind = "request" and result = this.getParameter(0)
       or
-      kind = "response" and result = this.getFunction().getParameter(1)
+      kind = "response" and result = this.getParameter(1)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -496,13 +496,11 @@ private module Mongoose {
   /**
    * An expression passed to `mongoose.createConnection` to supply credentials.
    */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
-      exists(string prop |
-        this = createConnection().getParameter(3).getMember(prop).asSink().asExpr()
-      |
+      exists(string prop | this = createConnection().getParameter(3).getMember(prop).asSink() |
         prop = "user" and kind = "user name"
         or
         prop = "pass" and kind = "password"

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -6,8 +6,8 @@ import javascript
 
 /** Provides classes for modeling NoSql query sinks. */
 module NoSql {
-  /** An expression that is interpreted as a NoSql query. */
-  abstract class Query extends Expr {
+  /** An expression that is interpreted as a NoSQL query. */
+  abstract class Query extends DataFlow::Node {
     /** Gets an expression that is interpreted as a code operator in this query. */
     DataFlow::Node getACodeOperator() { none() }
   }
@@ -84,7 +84,7 @@ private module MongoDB {
   class Query extends NoSql::Query {
     QueryCall qc;
 
-    Query() { this = qc.getAQueryArgument().asExpr() }
+    Query() { this = qc.getAQueryArgument() }
 
     override DataFlow::Node getACodeOperator() { result = qc.getACodeOperator() }
   }
@@ -518,7 +518,7 @@ private module Mongoose {
   class MongoDBQueryPart extends NoSql::Query {
     MongooseFunction f;
 
-    MongoDBQueryPart() { this = f.getQueryArgument().asSink().asExpr() }
+    MongoDBQueryPart() { this = f.getQueryArgument().asSink() }
 
     override DataFlow::Node getACodeOperator() {
       result = getADollarWhereProperty(f.getQueryArgument())
@@ -625,7 +625,7 @@ private module Minimongo {
   class Query extends NoSql::Query {
     QueryCall qc;
 
-    Query() { this = qc.getAQueryArgument().asExpr() }
+    Query() { this = qc.getAQueryArgument() }
 
     override DataFlow::Node getACodeOperator() { result = qc.getACodeOperator() }
   }
@@ -685,7 +685,7 @@ private module MarsDB {
   class Query extends NoSql::Query {
     QueryCall qc;
 
-    Query() { this = qc.getAQueryArgument().asExpr() }
+    Query() { this = qc.getAQueryArgument() }
 
     override DataFlow::Node getACodeOperator() { result = qc.getACodeOperator() }
   }
@@ -770,7 +770,7 @@ private module Redis {
     RedisKeyArgument() {
       exists(string method, int argIndex |
         QuerySignatures::argumentIsAmbiguousKey(method, argIndex) and
-        this = redis().getMember(method).getParameter(argIndex).asSink().asExpr()
+        this = redis().getMember(method).getParameter(argIndex).asSink()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -221,10 +221,10 @@ module NodeJSLib {
     Expr handler;
 
     RouteSetup() {
-      server.flowsTo(this) and
+      server.ref().flowsToExpr(this) and
       handler = this.getLastArgument()
       or
-      server.flowsTo(this.getReceiver()) and
+      server.ref().flowsToExpr(this.getReceiver()) and
       this.(MethodCallExpr).getMethodName().regexpMatch("on(ce)?") and
       this.getArgument(0).getStringValue() = "request" and
       handler = this.getArgument(1)

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -49,8 +49,7 @@ module NodeJSLib {
   /**
    * Holds if `call` is an invocation of `http.createServer` or `https.createServer`.
    */
-  predicate isCreateServer(CallExpr call) {
-    // TODO: DataFlow::Node
+  predicate isCreateServer(DataFlow::CallNode call) {
     exists(string pkg, string fn |
       pkg = "http" and fn = "createServer"
       or
@@ -61,7 +60,7 @@ module NodeJSLib {
       or
       pkg = "http2" and fn = "createSecureServer"
     |
-      call = DataFlow::moduleMember(pkg, fn).getAnInvocation().asExpr()
+      call = DataFlow::moduleMember(pkg, fn).getAnInvocation()
     )
   }
 
@@ -423,7 +422,7 @@ module NodeJSLib {
    * An expression that creates a new Node.js server.
    */
   class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
-    ServerDefinition() { isCreateServer(this.asExpr()) }
+    ServerDefinition() { isCreateServer(this) }
   }
 
   /** An expression that is passed as `http.request({ auth: <expr> }, ...)`. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -114,12 +114,12 @@ module NodeJSLib {
     /**
      * Gets the parameter of the route handler that contains the request object.
      */
-    Parameter getRequestParameter() { result = this.getFunction().getParameter(0) }
+    DataFlow::ParameterNode getRequestParameter() { result = this.getParameter(0) }
 
     /**
      * Gets the parameter of the route handler that contains the response object.
      */
-    Parameter getResponseParameter() { result = this.getFunction().getParameter(1) }
+    DataFlow::ParameterNode getResponseParameter() { result = this.getParameter(1) }
   }
 
   /**
@@ -141,7 +141,7 @@ module NodeJSLib {
   private class StandardResponseSource extends ResponseSource {
     RouteHandler rh;
 
-    StandardResponseSource() { this = DataFlow::parameterNode(rh.getResponseParameter()) }
+    StandardResponseSource() { this = rh.getResponseParameter() }
 
     /**
      * Gets the route handler that provides this response.
@@ -161,7 +161,7 @@ module NodeJSLib {
   private class StandardRequestSource extends RequestSource {
     RouteHandler rh;
 
-    StandardRequestSource() { this = DataFlow::parameterNode(rh.getRequestParameter()) }
+    StandardRequestSource() { this = rh.getRequestParameter() }
 
     /**
      * Gets the route handler that handles this request.

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -280,11 +280,11 @@ module NodeJSLib {
       this.getNumArgument() >= 1
     }
 
-    override predicate definesExplicitly(string headerName, Expr headerValue) {
+    override predicate definesHeaderValue(string headerName, DataFlow::Node headerValue) {
       this.getNumArgument() > 1 and
       exists(DataFlow::SourceNode headers, string header |
         headers.flowsTo(this.getLastArgument()) and
-        headers.hasPropertyWrite(header, DataFlow::valueNode(headerValue)) and
+        headers.hasPropertyWrite(header, headerValue) and
         headerName = header.toLowerCase()
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -50,6 +50,7 @@ module NodeJSLib {
    * Holds if `call` is an invocation of `http.createServer` or `https.createServer`.
    */
   predicate isCreateServer(CallExpr call) {
+    // TODO: DataFlow::Node
     exists(string pkg, string fn |
       pkg = "http" and fn = "createServer"
       or
@@ -248,7 +249,7 @@ module NodeJSLib {
       )
     }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
 
     /**
      * Gets the expression for the handler registered by this setup.
@@ -378,7 +379,7 @@ module NodeJSLib {
    * An expression that creates a new Node.js server.
    */
   class ServerDefinition extends HTTP::Servers::StandardServerDefinition {
-    ServerDefinition() { isCreateServer(this) }
+    ServerDefinition() { isCreateServer(this.asExpr()) }
   }
 
   /** An expression that is passed as `http.request({ auth: <expr> }, ...)`. */

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -290,9 +290,15 @@ module NodeJSLib {
     override DataFlow::Node getServer() { result = server }
 
     /**
+     * DEPRECATED: Use `getRouteHandlerNode` instead.
      * Gets the expression for the handler registered by this setup.
      */
-    Expr getRouteHandlerExpr() { result = handler.asExpr() } // TODO: DataFlow::Node
+    deprecated Expr getRouteHandlerExpr() { result = handler.asExpr() }
+
+    /**
+     * Gets the expression for the handler registered by this setup.
+     */
+    DataFlow::Node getRouteHandlerNode() { result = handler }
   }
 
   abstract private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -426,11 +426,10 @@ module NodeJSLib {
   }
 
   /** An expression that is passed as `http.request({ auth: <expr> }, ...)`. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     Credentials() {
       exists(string http | http = "http" or http = "https" |
-        this =
-          DataFlow::moduleMember(http, "request").getACall().getOptionArgument(0, "auth").asExpr()
+        this = DataFlow::moduleMember(http, "request").getACall().getOptionArgument(0, "auth")
       )
     }
 
@@ -1038,11 +1037,9 @@ module NodeJSLib {
   /**
    * A data flow node that is the username passed to the login callback provided by an HTTP or HTTPS request made by a Node.js process, for example `username` in `http.request(url).on('login', (res, cb) => {cb(username, password)})`.
    */
-  private class ClientRequestLoginUsername extends CredentialsExpr {
+  private class ClientRequestLoginUsername extends CredentialsNode {
     ClientRequestLoginUsername() {
-      exists(ClientRequestLoginCallback callback |
-        this = callback.getACall().getArgument(0).asExpr()
-      )
+      exists(ClientRequestLoginCallback callback | this = callback.getACall().getArgument(0))
     }
 
     override string getCredentialsKind() { result = "Node.js http(s) client login username" }
@@ -1051,11 +1048,9 @@ module NodeJSLib {
   /**
    * A data flow node that is the password passed to the login callback provided by an HTTP or HTTPS request made by a Node.js process, for example `password` in `http.request(url).on('login', (res, cb) => {cb(username, password)})`.
    */
-  private class ClientRequestLoginPassword extends CredentialsExpr {
+  private class ClientRequestLoginPassword extends CredentialsNode {
     ClientRequestLoginPassword() {
-      exists(ClientRequestLoginCallback callback |
-        this = callback.getACall().getArgument(1).asExpr()
-      )
+      exists(ClientRequestLoginCallback callback | this = callback.getACall().getArgument(1))
     }
 
     override string getCredentialsKind() { result = "Node.js http(s) client login password" }

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -363,9 +363,9 @@ module NodeJSLib {
     HTTP::RouteHandler rh;
 
     ResponseSendArgument() {
-      exists(MethodCallExpr mce, string m | m = "write" or m = "end" |
-        mce.calls(any(ResponseExpr e | e.getRouteHandler() = rh), m) and
-        this = mce.getArgument(0) and
+      exists(DataFlow::MethodCallNode mcn, string m | m = "write" or m = "end" |
+        mcn.calls(any(ResponseExpr e | e.getRouteHandler() = rh).flow(), m) and
+        this = mcn.getArgument(0) and
         // don't mistake callback functions as data
         not this.analyze().getAValue() instanceof AbstractFunction
       )

--- a/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NodeJSLib.qll
@@ -259,7 +259,7 @@ module NodeJSLib {
   abstract private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
     ResponseExpr r;
 
-    HeaderDefinition() { astNode.getReceiver() = r }
+    HeaderDefinition() { this.getReceiver().asExpr() = r }
 
     override HTTP::RouteHandler getRouteHandler() { result = r.getRouteHandler() }
   }
@@ -268,7 +268,7 @@ module NodeJSLib {
    * A call to the `setHeader` method of an HTTP response.
    */
   private class SetHeader extends HeaderDefinition {
-    SetHeader() { astNode.getMethodName() = "setHeader" }
+    SetHeader() { this.getMethodName() = "setHeader" }
   }
 
   /**
@@ -276,14 +276,14 @@ module NodeJSLib {
    */
   private class WriteHead extends HeaderDefinition {
     WriteHead() {
-      astNode.getMethodName() = "writeHead" and
-      astNode.getNumArgument() >= 1
+      this.getMethodName() = "writeHead" and
+      this.getNumArgument() >= 1
     }
 
     override predicate definesExplicitly(string headerName, Expr headerValue) {
-      astNode.getNumArgument() > 1 and
+      this.getNumArgument() > 1 and
       exists(DataFlow::SourceNode headers, string header |
-        headers.flowsToExpr(astNode.getLastArgument()) and
+        headers.flowsTo(this.getLastArgument()) and
         headers.hasPropertyWrite(header, DataFlow::valueNode(headerValue)) and
         headerName = header.toLowerCase()
       )

--- a/javascript/ql/lib/semmle/javascript/frameworks/PkgCloud.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/PkgCloud.qll
@@ -31,13 +31,13 @@ module PkgCloud {
   /**
    * An expression that is used for authentication through pkgcloud.
    */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
       exists(string propertyName, DataFlow::InvokeNode invk, int i |
         takesConfigurationObject(invk, i) and
-        this = invk.getOptionArgument(0, propertyName).asExpr()
+        this = invk.getOptionArgument(0, propertyName)
       |
         /*
          * Catch-all support for the following providers:

--- a/javascript/ql/lib/semmle/javascript/frameworks/Request.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Request.qll
@@ -6,7 +6,7 @@ import javascript
 
 module Request {
   /** A credentials expression that is used for authentication. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
@@ -20,9 +20,9 @@ module Request {
           action = mod.getAMemberCall(any(HTTP::RequestMethodName n).toLowerCase())
         )
       |
-        exists(MethodCallExpr auth, int argIndex |
+        exists(DataFlow::MethodCallNode auth, int argIndex |
           // request.get(url).auth('username', 'password', _, 'token');
-          auth = action.getAMemberCall("auth").asExpr() and
+          auth = action.getAMemberCall("auth") and
           this = auth.getArgument(argIndex)
         |
           argIndex = 0 and kind = "user name"
@@ -35,7 +35,7 @@ module Request {
         exists(DataFlow::ObjectLiteralNode auth, string propertyName |
           // request.get(url, { auth: {user: 'username', pass: 'password', bearer: 'token'}})
           auth.flowsTo(action.getOptionArgument(1, "auth")) and
-          auth.hasPropertyWrite(propertyName, DataFlow::valueNode(this))
+          auth.hasPropertyWrite(propertyName, this)
         |
           (propertyName = "user" or propertyName = "username") and
           kind = "user name"

--- a/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
@@ -162,7 +162,7 @@ module Restify {
       server.ref().getAMethodCall(any(HTTP::RequestMethodName m).toLowerCase()) = this
     }
 
-    override DataFlow::SourceNode getARouteHandler() { result.flowsTo(getArgument(1)) }
+    override DataFlow::SourceNode getARouteHandler() { result.flowsTo(this.getArgument(1)) }
 
     override DataFlow::Node getServer() { result = server }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
@@ -142,18 +142,17 @@ module Restify {
   /**
    * A call to a Restify method that sets up a route.
    */
-  class RouteSetup extends MethodCallExpr, HTTP::Servers::StandardRouteSetup {
+  class RouteSetup extends DataFlow::MethodCallNode, HTTP::Servers::StandardRouteSetup {
     ServerDefinition server;
 
     RouteSetup() {
       // server.get('/', fun)
       // server.head('/', fun)
-      server.ref().flowsToExpr(getReceiver()) and
-      getMethodName() = any(HTTP::RequestMethodName m).toLowerCase()
+      server.ref().getAMethodCall(any(HTTP::RequestMethodName m).toLowerCase()) = this
     }
 
-    override DataFlow::SourceNode getARouteHandler() { result.flowsToExpr(getArgument(1)) }
+    override DataFlow::SourceNode getARouteHandler() { result.flowsTo(getArgument(1)) }
 
-    override Expr getServer() { result = server.asExpr() }
+    override DataFlow::Node getServer() { result = server }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
@@ -9,10 +9,10 @@ module Restify {
   /**
    * An expression that creates a new Restify server.
    */
-  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, CallExpr {
+  class ServerDefinition extends HTTP::Servers::StandardServerDefinition, DataFlow::CallNode {
     ServerDefinition() {
       // `server = restify.createServer()`
-      this = DataFlow::moduleMember("restify", "createServer").getACall().asExpr()
+      this = DataFlow::moduleMember("restify", "createServer").getACall()
     }
   }
 
@@ -154,6 +154,6 @@ module Restify {
 
     override DataFlow::SourceNode getARouteHandler() { result.flowsToExpr(getArgument(1)) }
 
-    override Expr getServer() { result = server }
+    override Expr getServer() { result = server.asExpr() }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
@@ -144,7 +144,7 @@ module Restify {
     RouteSetup() {
       // server.get('/', fun)
       // server.head('/', fun)
-      server.flowsTo(getReceiver()) and
+      server.ref().flowsToExpr(getReceiver()) and
       getMethodName() = any(HTTP::RequestMethodName m).toLowerCase()
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Restify.qll
@@ -68,6 +68,7 @@ module Restify {
     override RouteHandler getRouteHandler() { result = rh }
   }
 
+  // TODO: DataFlow::Node
   /**
    * A Node.js HTTP response provided by Restify.
    */
@@ -75,6 +76,7 @@ module Restify {
     ResponseExpr() { src instanceof ResponseSource }
   }
 
+  // TODO: DataFlow::Node
   /**
    * A Node.js HTTP request provided by Restify.
    */
@@ -128,11 +130,13 @@ module Restify {
   private class HeaderDefinition extends HTTP::Servers::StandardHeaderDefinition {
     HeaderDefinition() {
       // response.header('Cache-Control', 'no-cache')
-      astNode.getReceiver() instanceof ResponseExpr and
-      astNode.getMethodName() = "header"
+      this.getReceiver().asExpr() instanceof ResponseExpr and
+      this.getMethodName() = "header"
     }
 
-    override RouteHandler getRouteHandler() { astNode.getReceiver() = result.getAResponseExpr() }
+    override RouteHandler getRouteHandler() {
+      this.getReceiver().asExpr() = result.getAResponseExpr()
+    }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/SQL.qll
@@ -103,13 +103,13 @@ private module MySql {
   }
 
   /** An expression that is passed as user name or password to `mysql.createConnection`. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
       exists(API::Node callee, string prop |
         callee in [createConnection(), createPool()] and
-        this = callee.getParameter(0).getMember(prop).asSink().asExpr() and
+        this = callee.getParameter(0).getMember(prop).asSink() and
         (
           prop = "user" and kind = "user name"
           or
@@ -205,14 +205,14 @@ private module Postgres {
   }
 
   /** An expression that is passed as user name or password when creating a client or a pool. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
       exists(string prop |
-        this = [newClient(), newPool()].getParameter(0).getMember(prop).asSink().asExpr()
+        this = [newClient(), newPool()].getParameter(0).getMember(prop).asSink()
         or
-        this = pgPromise().getParameter(0).getMember(prop).asSink().asExpr()
+        this = pgPromise().getParameter(0).getMember(prop).asSink()
       |
         prop = "user" and kind = "user name"
         or
@@ -485,7 +485,7 @@ private module MsSql {
   }
 
   /** An expression that is passed as user name or password when creating a client or a pool. */
-  class Credentials extends CredentialsExpr {
+  class Credentials extends CredentialsNode {
     string kind;
 
     Credentials() {
@@ -495,7 +495,7 @@ private module MsSql {
           or
           callee = mssql().getMember("ConnectionPool")
         ) and
-        this = callee.getParameter(0).getMember(prop).asSink().asExpr() and
+        this = callee.getParameter(0).getMember(prop).asSink() and
         (
           prop = "user" and kind = "user name"
           or

--- a/javascript/ql/lib/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
+++ b/javascript/ql/lib/semmle/javascript/heuristics/AdditionalRouteHandlers.qll
@@ -29,8 +29,8 @@ private class PromotedExpressCandidate extends Express::RouteHandler,
   HTTP::Servers::StandardRouteHandler {
   PromotedExpressCandidate() { this instanceof ConnectExpressShared::RouteHandlerCandidate }
 
-  override Parameter getRouteHandlerParameter(string kind) {
-    result = ConnectExpressShared::getRouteHandlerParameter(getAstNode(), kind)
+  override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
+    result = ConnectExpressShared::getRouteHandlerParameter(this, kind)
   }
 }
 
@@ -41,7 +41,7 @@ private class PromotedConnectCandidate extends Connect::RouteHandler,
   HTTP::Servers::StandardRouteHandler {
   PromotedConnectCandidate() { this instanceof ConnectExpressShared::RouteHandlerCandidate }
 
-  override Parameter getRouteHandlerParameter(string kind) {
-    result = ConnectExpressShared::getRouteHandlerParameter(getAstNode(), kind)
+  override DataFlow::ParameterNode getRouteHandlerParameter(string kind) {
+    result = ConnectExpressShared::getRouteHandlerParameter(this, kind)
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/BrokenCryptoAlgorithmCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/BrokenCryptoAlgorithmCustomizations.qll
@@ -43,7 +43,7 @@ module BrokenCryptoAlgorithm {
     WeakCryptographicOperationSink() {
       exists(CryptographicOperation application |
         application.getAlgorithm().isWeak() and
-        this.asExpr() = application.getInput()
+        this = application.getInput()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/BrokenCryptoAlgorithmCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/BrokenCryptoAlgorithmCustomizations.qll
@@ -30,10 +30,8 @@ module BrokenCryptoAlgorithm {
    * A sensitive expression, viewed as a data flow source for sensitive information
    * in broken or weak cryptographic algorithms.
    */
-  class SensitiveExprSource extends Source, DataFlow::ValueNode {
-    override SensitiveExpr astNode;
-
-    override string describe() { result = astNode.describe() }
+  class SensitiveExprSource extends Source instanceof SensitiveNode {
+    override string describe() { result = SensitiveNode.super.describe() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
@@ -30,15 +30,13 @@ module CleartextStorage {
    * A sensitive expression, viewed as a data flow source for cleartext storage
    * of sensitive information.
    */
-  class SensitiveExprSource extends Source, DataFlow::ValueNode {
-    override SensitiveExpr astNode;
-
+  class SensitiveExprSource extends Source instanceof SensitiveNode {
     SensitiveExprSource() {
       // storing user names or account names in plaintext isn't usually a problem
-      astNode.getClassification() != SensitiveDataClassification::id()
+      super.getClassification() != SensitiveDataClassification::id()
     }
 
-    override string describe() { result = astNode.describe() }
+    override string describe() { result = SensitiveNode.super.describe() }
   }
 
   /** A call to any function whose name suggests that it encodes or encrypts its arguments. */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
@@ -67,8 +67,6 @@ module CleartextStorage {
    * An expression stored by AngularJS.
    */
   class AngularJSStorageSink extends Sink {
-    AngularJSStorageSink() {
-      any(AngularJS::AngularJSCall call).storesArgumentGlobally(this.asExpr())
-    }
+    AngularJSStorageSink() { any(AngularJS::AngularJSCallNode call).storesArgumentGlobally(this) }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
@@ -52,8 +52,8 @@ module CleartextStorage {
   class CookieStorageSink extends Sink {
     CookieStorageSink() {
       exists(HTTP::CookieDefinition cookieDef |
-        this.asExpr() = cookieDef.getValueArgument() or
-        this.asExpr() = cookieDef.getHeaderArgument()
+        this = cookieDef.getValueArgument() or
+        this = cookieDef.getHeaderArgument()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CleartextStorageCustomizations.qll
@@ -61,9 +61,7 @@ module CleartextStorage {
   /**
    * An expression set as a value of localStorage or sessionStorage.
    */
-  class WebStorageSink extends Sink {
-    WebStorageSink() { this.asExpr() instanceof WebStorageWrite }
-  }
+  class WebStorageSink extends Sink instanceof WebStorageWrite { }
 
   /**
    * An expression stored by AngularJS.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -67,7 +67,7 @@ module ClientSideUrlRedirect {
       methodName = StringOps::substringMethodName() and
       // exclude `location.href.substring(0, ...)` and similar, which can
       // never refer to the query string
-      not mcn.getArgument(0).asExpr().(NumberLiteral).getIntValue() = 0
+      not mcn.getArgument(0).getIntValue() = 0
     )
     or
     exists(DataFlow::MethodCallNode mcn |

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -179,7 +179,7 @@ module ClientSideUrlRedirect {
       )
       or
       // e.g. node.setAttribute("href", sink)
-      any(DomMethodCallExpr call).interpretsArgumentsAsUrl(this.asExpr())
+      any(DomMethodCallNode call).interpretsArgumentsAsUrl(this)
     }
 
     override predicate isXssSink() { any() }
@@ -191,9 +191,9 @@ module ClientSideUrlRedirect {
    */
   class AttributeWriteUrlSink extends ScriptUrlSink, DataFlow::ValueNode {
     AttributeWriteUrlSink() {
-      exists(DomPropWriteNode pw |
+      exists(DomPropertyWrite pw |
         pw.interpretsValueAsJavaScriptUrl() and
-        this = DataFlow::valueNode(pw.getRhs())
+        this = pw.getRhs()
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -121,7 +121,7 @@ module ClientSideUrlRedirect {
       // A redirection using the AngularJS `$location` service
       exists(AngularJS::ServiceReference service |
         service.getName() = "$location" and
-        this.asExpr() = service.getAMethodCall("url").getArgument(0)
+        this = service.getAMethodCall("url").getArgument(0)
       ) and
       xss = false
     }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ClientSideUrlRedirectCustomizations.qll
@@ -104,7 +104,9 @@ module ClientSideUrlRedirect {
       xss = true
       or
       // An assignment to `location`
-      exists(Assignment assgn | isLocation(assgn.getTarget()) and astNode = assgn.getRhs()) and
+      exists(Assignment assgn |
+        isLocationNode(assgn.getTarget().flow()) and astNode = assgn.getRhs()
+      ) and
       xss = true
       or
       // An assignment to `location.href`, `location.protocol` or `location.hostname`

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -37,7 +37,7 @@ module CodeInjection {
    */
   class AngularJSExpressionSink extends Sink, DataFlow::ValueNode {
     AngularJSExpressionSink() {
-      any(AngularJS::AngularJSCall call).interpretsArgumentAsCode(this.asExpr())
+      any(AngularJS::AngularJSCallNode call).interpretsArgumentAsCode(this)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/CorsMisconfigurationForCredentialsCustomizations.qll
@@ -46,12 +46,12 @@ module CorsMisconfigurationForCredentials {
     CorsOriginHeaderWithAssociatedCredentialHeader() {
       exists(
         HTTP::RouteHandler routeHandler, HTTP::ExplicitHeaderDefinition origin,
-        Expr credentialsValue
+        DataFlow::Node credentialsValue
       |
         routeHandler.getAResponseHeader(_) = origin and
         routeHandler.getAResponseHeader(_) = credentials and
-        origin.definesExplicitly("access-control-allow-origin", this.asExpr()) and
-        credentials.definesExplicitly("access-control-allow-credentials", credentialsValue)
+        origin.definesHeaderValue("access-control-allow-origin", this) and
+        credentials.definesHeaderValue("access-control-allow-credentials", credentialsValue)
       |
         credentialsValue.mayHaveBooleanValue(true) or
         credentialsValue.mayHaveStringValue("true")

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -144,6 +144,7 @@ class DomPropWriteNode extends Assignment {
  * A value written to web storage, like `localStorage` or `sessionStorage`.
  */
 class WebStorageWrite extends Expr {
+  // TODO: DataFlow::Node
   WebStorageWrite() {
     exists(DataFlow::SourceNode webStorage |
       webStorage = DataFlow::globalVarRef("localStorage") or

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -143,18 +143,17 @@ class DomPropWriteNode extends Assignment {
 /**
  * A value written to web storage, like `localStorage` or `sessionStorage`.
  */
-class WebStorageWrite extends Expr {
-  // TODO: DataFlow::Node
+class WebStorageWrite extends DataFlow::Node {
   WebStorageWrite() {
     exists(DataFlow::SourceNode webStorage |
       webStorage = DataFlow::globalVarRef("localStorage") or
       webStorage = DataFlow::globalVarRef("sessionStorage")
     |
       // an assignment to `window.localStorage[someProp]`
-      this = webStorage.getAPropertyWrite().getRhs().asExpr()
+      this = webStorage.getAPropertyWrite().getRhs()
       or
       // an invocation of `window.localStorage.setItem`
-      this = webStorage.getAMethodCall("setItem").getArgument(1).asExpr()
+      this = webStorage.getAMethodCall("setItem").getArgument(1)
     )
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -21,14 +21,28 @@ class DomGlobalVariable extends GlobalVariable {
 /** DEPRECATED: Alias for DomGlobalVariable */
 deprecated class DOMGlobalVariable = DomGlobalVariable;
 
-/** Holds if `e` could hold a value that comes from the DOM. */
-predicate isDomValue(Expr e) { DOM::domValueRef().flowsToExpr(e) }
+/**
+ * DEPRECATED: Use `isDomNode` instead.
+ * Holds if `e` could hold a value that comes from the DOM.
+ */
+deprecated predicate isDomValue(Expr e) { isDomNode(e.flow()) }
+
+/**
+ * Holds if `e` could hold a value that comes from the DOM.
+ */
+predicate isDomNode(DataFlow::Node e) { DOM::domValueRef().flowsTo(e) }
+
+/**
+ * DEPRECATED: Use `isLocationNode` instead.
+ * Holds if `e` could refer to the `location` property of a DOM node.
+ */
+deprecated predicate isLocation(Expr e) { isLocationNode(e.flow()) }
 
 /** Holds if `e` could refer to the `location` property of a DOM node. */
-predicate isLocation(Expr e) {
-  e = DOM::domValueRef().getAPropertyReference("location").asExpr()
+predicate isLocationNode(DataFlow::Node e) {
+  e = DOM::domValueRef().getAPropertyReference("location")
   or
-  e.accessesGlobal("location")
+  e = DataFlow::globalVarRef("location")
 }
 
 /**
@@ -53,15 +67,52 @@ deprecated predicate isDocumentUrl(Expr e) { e.flow() = DOM::locationSource() }
 deprecated predicate isDocumentURL = isDocumentUrl/1;
 
 /**
+ * DEPRECATED. In most cases, a sanitizer based on this predicate can be removed, as
+ * taint tracking no longer step through the properties of the location object by default.
+ *
+ * Holds if `pacc` accesses a part of `document.location` that is
+ * not considered user-controlled, that is, anything except
+ * `href`, `hash` and `search`.
+ */
+deprecated predicate isSafeLocationProperty(PropAccess pacc) {
+  exists(string prop | pacc = DOM::locationRef().getAPropertyRead(prop).asExpr() |
+    prop != "href" and prop != "hash" and prop != "search"
+  )
+}
+
+/**
+ * DEPRECATED: Use `DomMethodCallNode` instead.
  * A call to a DOM method.
  */
-class DomMethodCallExpr extends MethodCallExpr {
-  DomMethodCallExpr() { isDomValue(this.getReceiver()) }
+deprecated class DomMethodCallExpr extends MethodCallExpr {
+  DomMethodCallNode node;
+
+  DomMethodCallExpr() { this.flow() = node }
+
+  /** Holds if `arg` is an argument that is interpreted as HTML. */
+  deprecated predicate interpretsArgumentsAsHtml(Expr arg) {
+    node.interpretsArgumentsAsHtml(arg.flow())
+  }
+
+  /** Holds if `arg` is an argument that is used as an URL. */
+  deprecated predicate interpretsArgumentsAsURL(Expr arg) {
+    node.interpretsArgumentsAsURL(arg.flow())
+  }
+
+  /** DEPRECATED: Alias for interpretsArgumentsAsHtml */
+  deprecated predicate interpretsArgumentsAsHTML(Expr arg) { this.interpretsArgumentsAsHtml(arg) }
+}
+
+/**
+ * A call to a DOM method.
+ */
+class DomMethodCallNode extends DataFlow::MethodCallNode {
+  DomMethodCallNode() { isDomNode(this.getReceiver()) }
 
   /**
    * Holds if `arg` is an argument that is interpreted as HTML.
    */
-  predicate interpretsArgumentsAsHtml(Expr arg) {
+  predicate interpretsArgumentsAsHtml(DataFlow::Node arg) {
     exists(int argPos, string name |
       arg = this.getArgument(argPos) and
       name = this.getMethodName()
@@ -86,7 +137,7 @@ class DomMethodCallExpr extends MethodCallExpr {
   /**
    * Holds if `arg` is an argument that is used as an URL.
    */
-  predicate interpretsArgumentsAsUrl(Expr arg) {
+  predicate interpretsArgumentsAsUrl(DataFlow::Node arg) {
     exists(int argPos, string name |
       arg = this.getArgument(argPos) and
       name = this.getMethodName()
@@ -104,30 +155,25 @@ class DomMethodCallExpr extends MethodCallExpr {
   }
 
   /** DEPRECATED: Alias for interpretsArgumentsAsUrl */
-  deprecated predicate interpretsArgumentsAsURL(Expr arg) { this.interpretsArgumentsAsUrl(arg) }
+  deprecated predicate interpretsArgumentsAsURL(DataFlow::Node arg) { this.interpretsArgumentsAsUrl(arg) }
 
   /** DEPRECATED: Alias for interpretsArgumentsAsHtml */
-  deprecated predicate interpretsArgumentsAsHTML(Expr arg) { this.interpretsArgumentsAsHtml(arg) }
+  deprecated predicate interpretsArgumentsAsHTML(DataFlow::Node arg) { this.interpretsArgumentsAsHtml(arg) }
 }
 
 /**
+ * DEPRECATED: Use `DomPropertyWrite` instead.
  * An assignment to a property of a DOM object.
  */
-class DomPropWriteNode extends Assignment {
-  PropAccess lhs;
+deprecated class DomPropWriteNode extends Assignment {
+  DomPropertyWrite node;
 
-  DomPropWriteNode() {
-    lhs = this.getLhs() and
-    isDomValue(lhs.getBase())
-  }
+  DomPropWriteNode() { this.flow() = node }
 
   /**
    * Holds if the assigned value is interpreted as HTML.
    */
-  predicate interpretsValueAsHtml() {
-    lhs.getPropertyName() = "innerHTML" or
-    lhs.getPropertyName() = "outerHTML"
-  }
+  predicate interpretsValueAsHtml() { node.interpretsValueAsHtml() }
 
   /** DEPRECATED: Alias for interpretsValueAsHtml */
   deprecated predicate interpretsValueAsHTML() { this.interpretsValueAsHtml() }
@@ -135,9 +181,34 @@ class DomPropWriteNode extends Assignment {
   /**
    * Holds if the assigned value is interpreted as JavaScript via javascript: protocol.
    */
-  predicate interpretsValueAsJavaScriptUrl() {
-    lhs.getPropertyName() = DOM::getAPropertyNameInterpretedAsJavaScriptUrl()
+  predicate interpretsValueAsJavaScriptUrl() { node.interpretsValueAsJavaScriptUrl() }
+}
+
+/**
+ * An assignment to a property of a DOM object.
+ */
+class DomPropertyWrite extends DataFlow::Node instanceof DataFlow::PropWrite {
+  DomPropertyWrite() { isDomNode(super.getBase()) }
+
+  /**
+   * Holds if the assigned value is interpreted as HTML.
+   */
+  predicate interpretsValueAsHtml() {
+    super.getPropertyName() = "innerHTML" or
+    super.getPropertyName() = "outerHTML"
   }
+
+  /**
+   * Holds if the assigned value is interpreted as JavaScript via javascript: protocol.
+   */
+  predicate interpretsValueAsJavaScriptUrl() {
+    super.getPropertyName() = DOM::getAPropertyNameInterpretedAsJavaScriptUrl()
+  }
+
+  /**
+   * Gets the data flow node corresponding to the value being written,
+   */
+  DataFlow::Node getRhs() { result = super.getRhs() }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -206,7 +206,7 @@ class DomPropertyWrite extends DataFlow::Node instanceof DataFlow::PropWrite {
   }
 
   /**
-   * Gets the data flow node corresponding to the value being written,
+   * Gets the data flow node corresponding to the value being written.
    */
   DataFlow::Node getRhs() { result = super.getRhs() }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -155,10 +155,14 @@ class DomMethodCallNode extends DataFlow::MethodCallNode {
   }
 
   /** DEPRECATED: Alias for interpretsArgumentsAsUrl */
-  deprecated predicate interpretsArgumentsAsURL(DataFlow::Node arg) { this.interpretsArgumentsAsUrl(arg) }
+  deprecated predicate interpretsArgumentsAsURL(DataFlow::Node arg) {
+    this.interpretsArgumentsAsUrl(arg)
+  }
 
   /** DEPRECATED: Alias for interpretsArgumentsAsHtml */
-  deprecated predicate interpretsArgumentsAsHTML(DataFlow::Node arg) { this.interpretsArgumentsAsHtml(arg) }
+  deprecated predicate interpretsArgumentsAsHTML(DataFlow::Node arg) {
+    this.interpretsArgumentsAsHtml(arg)
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DOM.qll
@@ -208,7 +208,11 @@ class DomPropertyWrite extends DataFlow::Node instanceof DataFlow::PropWrite {
   /**
    * Gets the data flow node corresponding to the value being written.
    */
-  DataFlow::Node getRhs() { result = super.getRhs() }
+  DataFlow::Node getRhs() {
+    result = super.getRhs()
+    or
+    result = super.getWriteNode().(AssignAddExpr).getRhs().flow()
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -31,7 +31,7 @@ module DomBasedXss {
       )
       or
       // call to an Angular method that interprets its argument as HTML
-      any(AngularJS::AngularJSCall call).interpretsArgumentAsHtml(this.asExpr())
+      any(AngularJS::AngularJSCallNode call).interpretsArgumentAsHtml(this)
       or
       // call to a WinJS function that interprets its argument as HTML
       exists(DataFlow::MethodCallNode mcn, string m |

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssCustomizations.qll
@@ -130,12 +130,12 @@ module DomBasedXss {
   class DomSink extends Sink {
     DomSink() {
       // Call to a DOM function that inserts its argument into the DOM
-      any(DomMethodCallExpr call).interpretsArgumentsAsHtml(this.asExpr())
+      any(DomMethodCallNode call).interpretsArgumentsAsHtml(this)
       or
       // Assignment to a dangerous DOM property
-      exists(DomPropWriteNode pw |
+      exists(DomPropertyWrite pw |
         pw.interpretsValueAsHtml() and
-        this = DataFlow::valueNode(pw.getRhs())
+        this = pw.getRhs()
       )
       or
       // `html` or `source.html` properties of React Native `WebView`
@@ -159,7 +159,7 @@ module DomBasedXss {
       )
       or
       exists(DataFlow::MethodCallNode ccf |
-        isDomValue(ccf.getReceiver().asExpr()) and
+        isDomNode(ccf.getReceiver()) and
         ccf.getMethodName() = "createContextualFragment" and
         this = ccf.getArgument(0)
       )

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ExternalAPIUsedWithUntrustedDataCustomizations.qll
@@ -165,7 +165,7 @@ module ExternalApiUsedWithUntrustedData {
       not param = base.getReceiver()
     |
       result = param and
-      name = param.asSource().asExpr().(Parameter).getName()
+      name = param.asSource().(DataFlow::ParameterNode).getName()
       or
       param.asSource().asExpr() instanceof DestructuringPattern and
       result = param.getMember(name)

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/HardcodedCredentialsCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/HardcodedCredentialsCustomizations.qll
@@ -33,12 +33,10 @@ module HardcodedCredentials {
   }
 
   /**
-   * A subclass of `Sink` that includes every `CredentialsExpr`
+   * A subclass of `Sink` that includes every `CredentialsNode`
    * as a credentials sink.
    */
-  class DefaultCredentialsSink extends Sink, DataFlow::ValueNode {
-    override CredentialsExpr astNode;
-
-    override string getKind() { result = astNode.getCredentialsKind() }
+  class DefaultCredentialsSink extends Sink instanceof CredentialsNode {
+    override string getKind() { result = super.getCredentialsKind() }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsufficientPasswordHashCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsufficientPasswordHashCustomizations.qll
@@ -30,14 +30,12 @@ module InsufficientPasswordHash {
    * A potential clear-text password, considered as a source for password hashing
    * with insufficient computational effort.
    */
-  class CleartextPasswordSource extends Source, DataFlow::ValueNode {
-    override SensitiveExpr astNode;
-
+  class CleartextPasswordSource extends Source instanceof SensitiveNode {
     CleartextPasswordSource() {
-      astNode.getClassification() = SensitiveDataClassification::password()
+      super.getClassification() = SensitiveDataClassification::password()
     }
 
-    override string describe() { result = astNode.describe() }
+    override string describe() { result = SensitiveNode.super.describe() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsufficientPasswordHashCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsufficientPasswordHashCustomizations.qll
@@ -49,7 +49,7 @@ module InsufficientPasswordHash {
         application.getAlgorithm().isWeak() or
         not application.getAlgorithm() instanceof PasswordHashingAlgorithm
       |
-        this.asExpr() = application.getInput()
+        this = application.getInput()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/MissingRateLimiting.qll
@@ -199,7 +199,7 @@ class RateLimiterFlexibleRateLimiter extends DataFlow::FunctionNode {
       rateLimiterClassName.matches("RateLimiter%") and
       rateLimiterClass = API::moduleImport("rate-limiter-flexible").getMember(rateLimiterClassName) and
       rateLimiterConsume = rateLimiterClass.getInstance().getMember("consume") and
-      request.getParameter() = getRouteHandlerParameter(this.getFunction(), "request") and
+      request = getRouteHandlerParameter(this, "request") and
       request.getAPropertyRead().flowsTo(rateLimiterConsume.getAParameter().asSink())
     )
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/NosqlInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/NosqlInjectionCustomizations.qll
@@ -36,7 +36,5 @@ module NosqlInjection {
   }
 
   /** An expression interpreted as a NoSql query, viewed as a sink. */
-  class NosqlQuerySink extends Sink, DataFlow::ValueNode {
-    override NoSql::Query astNode;
-  }
+  class NosqlQuerySink extends Sink instanceof NoSql::Query { }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/NosqlInjectionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/NosqlInjectionQuery.qll
@@ -45,7 +45,7 @@ class Configuration extends TaintTracking::Configuration {
     inlbl = TaintedObject::label() and
     outlbl = TaintedObject::label() and
     exists(NoSql::Query query, DataFlow::SourceNode queryObj |
-      queryObj.flowsToExpr(query) and
+      queryObj.flowsTo(query) and
       queryObj.flowsTo(trg) and
       src = queryObj.getAPropertyWrite().getRhs()
     )

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/PostMessageStarCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/PostMessageStarCustomizations.qll
@@ -41,9 +41,7 @@ module PostMessageStar {
    * A sensitive expression, viewed as a data flow source for cross-window communication
    * with unrestricted origin.
    */
-  class SensitiveExprSource extends Source, DataFlow::ValueNode {
-    override SensitiveExpr astNode;
-  }
+  class SensitiveExprSource extends Source instanceof SensitiveNode { }
 
   /** A call to any function whose name suggests that it encodes or encrypts its arguments. */
   class ProtectSanitizer extends Sanitizer {

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ReflectedXssCustomizations.qll
@@ -24,10 +24,8 @@ module ReflectedXss {
    * a content type that does not (case-insensitively) contain the string "html". This
    * is to prevent us from flagging plain-text or JSON responses as vulnerable.
    */
-  class HttpResponseSink extends Sink, DataFlow::ValueNode {
-    override HTTP::ResponseSendArgument astNode;
-
-    HttpResponseSink() { not exists(getANonHtmlHeaderDefinition(astNode)) }
+  class HttpResponseSink extends Sink instanceof HTTP::ResponseSendArgument {
+    HttpResponseSink() { not exists(getANonHtmlHeaderDefinition(this)) }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/RemotePropertyInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/RemotePropertyInjectionCustomizations.qll
@@ -57,11 +57,11 @@ module RemotePropertyInjection {
    * header names as properties. This case is already handled by
    * `PropertyWriteSink`.
    */
-  class HeaderNameSink extends Sink, DataFlow::ValueNode {
+  class HeaderNameSink extends Sink {
     HeaderNameSink() {
       exists(HTTP::ExplicitHeaderDefinition hd |
         not hd instanceof Express::SetMultipleHeaders and
-        astNode = hd.getNameExpr()
+        this = hd.getNameNode()
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ServerSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ServerSideUrlRedirectCustomizations.qll
@@ -41,9 +41,9 @@ module ServerSideUrlRedirect {
    * A definition of the HTTP "Location" header, considered as a sink for
    * `Configuration`.
    */
-  class LocationHeaderSink extends Sink, DataFlow::ValueNode {
+  class LocationHeaderSink extends Sink {
     LocationHeaderSink() {
-      any(HTTP::ExplicitHeaderDefinition def).definesExplicitly("location", astNode)
+      any(HTTP::ExplicitHeaderDefinition def).definesHeaderValue("location", this)
     }
   }
 

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ServerSideUrlRedirectCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ServerSideUrlRedirectCustomizations.qll
@@ -33,8 +33,8 @@ module ServerSideUrlRedirect {
   /**
    * An HTTP redirect, considered as a sink for `Configuration`.
    */
-  class RedirectSink extends Sink, DataFlow::ValueNode {
-    RedirectSink() { astNode = any(HTTP::RedirectInvocation redir).getUrlArgument() }
+  class RedirectSink extends Sink {
+    RedirectSink() { this = any(HTTP::RedirectInvocation redir).getUrlArgument() }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/SqlInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/SqlInjectionCustomizations.qll
@@ -28,13 +28,11 @@ module SqlInjection {
   }
 
   /** An SQL expression passed to an API call that executes SQL. */
-  class SqlInjectionExprSink extends Sink, DataFlow::ValueNode {
-    override SQL::SqlString astNode;
-  }
+  class SqlInjectionExprSink extends Sink instanceof SQL::SqlString { }
 
   /** An expression that sanitizes a value for the purposes of string based query injection. */
-  class SanitizerExpr extends Sanitizer, DataFlow::ValueNode {
-    SanitizerExpr() { astNode = any(SQL::SqlSanitizer ss).getOutput() }
+  class SanitizerExpr extends Sanitizer {
+    SanitizerExpr() { this = any(SQL::SqlSanitizer ss).getOutput() }
   }
 
   /** An GraphQL expression passed to an API call that executes GraphQL. */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/StackTraceExposureCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/StackTraceExposureCustomizations.qll
@@ -32,7 +32,5 @@ module StackTraceExposure {
    * An expression that can become part of an HTTP response body, viewed
    * as a data flow sink for stack trace exposure vulnerabilities.
    */
-  class DefaultSink extends Sink, DataFlow::ValueNode {
-    override HTTP::ResponseBody astNode;
-  }
+  class DefaultSink extends Sink instanceof HTTP::ResponseBody { }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -647,12 +647,12 @@ module TaintedPath {
   /**
    * A path argument to the Express `res.render` method.
    */
-  class ExpressRenderSink extends Sink, DataFlow::ValueNode {
+  class ExpressRenderSink extends Sink {
     ExpressRenderSink() {
-      exists(MethodCallExpr mce |
+      exists(DataFlow::MethodCallNode mce |
         Express::isResponse(mce.getReceiver()) and
         mce.getMethodName() = "render" and
-        astNode = mce.getArgument(0)
+        this = mce.getArgument(0)
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TemplateObjectInjectionCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TemplateObjectInjectionCustomizations.qll
@@ -76,8 +76,8 @@ module TemplateObjectInjection {
   predicate usesVulnerableTemplateEngine(Express::RouterDefinition router) {
     // option 1: `app.set("view engine", "theEngine")`.
     // Express will load the engine automatically.
-    exists(MethodCallExpr call |
-      router.flowsTo(call.getReceiver()) and
+    exists(DataFlow::MethodCallNode call |
+      router.ref().getAMethodCall() = call and
       call.getMethodName() = "set" and
       call.getArgument(0).getStringValue() = "view engine" and
       call.getArgument(1).getStringValue() = getAVulnerableTemplateEngine()
@@ -91,11 +91,11 @@ module TemplateObjectInjection {
       DataFlow::MethodCallNode viewEngineCall
     |
       // `app.engine("name", engine)
-      router.flowsTo(registerCall.getReceiver().asExpr()) and
+      router.ref().getAMethodCall() = registerCall and
       registerCall.getMethodName() = ["engine", "register"] and
       engine = registerCall.getArgument(1).getALocalSource() and
       // app.set("view engine", "name")
-      router.flowsTo(viewEngineCall.getReceiver().asExpr()) and
+      router.ref().getAMethodCall() = viewEngineCall and
       viewEngineCall.getMethodName() = "set" and
       viewEngineCall.getArgument(0).getStringValue() = "view engine" and
       // The name set by the `app.engine("name")` call matches `app.set("view engine", "name")`.

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XmlBombCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XmlBombCustomizations.qll
@@ -31,8 +31,8 @@ module XmlBomb {
   /**
    * An access to `document.location`, considered as a flow source for XML bomb vulnerabilities.
    */
-  class LocationAsSource extends Source, DataFlow::ValueNode {
-    LocationAsSource() { isLocation(astNode) }
+  class LocationAsSource extends Source {
+    LocationAsSource() { isLocationNode(this) }
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XxeCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XxeCustomizations.qll
@@ -31,8 +31,8 @@ module Xxe {
   /**
    * An access to `document.location`, considered as a flow source for XXE vulnerabilities.
    */
-  class LocationAsSource extends Source, DataFlow::ValueNode {
-    LocationAsSource() { isLocation(astNode) }
+  class LocationAsSource extends Source {
+    LocationAsSource() { isLocationNode(this) }
   }
 
   /**

--- a/javascript/ql/src/AngularJS/DependencyMismatch.ql
+++ b/javascript/ql/src/AngularJS/DependencyMismatch.ql
@@ -14,7 +14,7 @@
 
 import javascript
 
-from AngularJS::InjectableFunction f, SimpleParameter p, string msg
+from AngularJS::InjectableFunction f, DataFlow::ParameterNode p, string msg
 where
   p = f.asFunction().getAParameter() and
   (

--- a/javascript/ql/src/AngularJS/DisablingSce.ql
+++ b/javascript/ql/src/AngularJS/DisablingSce.ql
@@ -14,7 +14,7 @@
 
 import javascript
 
-from MethodCallExpr mce, AngularJS::BuiltinServiceReference service
+from DataFlow::MethodCallNode mce, AngularJS::BuiltinServiceReference service
 where
   service.getName() = "$sceProvider" and
   mce = service.getAMethodCall("enabled") and

--- a/javascript/ql/src/AngularJS/DoubleCompilation.ql
+++ b/javascript/ql/src/AngularJS/DoubleCompilation.ql
@@ -15,7 +15,7 @@
 
 import javascript
 
-from AngularJS::ServiceReference compile, SimpleParameter elem, CallExpr c
+from AngularJS::ServiceReference compile, DataFlow::ParameterNode elem, DataFlow::CallNode c
 where
   compile.getName() = "$compile" and
   elem =
@@ -24,7 +24,7 @@ where
         .(AngularJS::LinkFunction)
         .getElementParameter() and
   c = compile.getACall() and
-  c.getArgument(0).mayReferToParameter(elem) and
+  elem.flowsTo(c.getArgument(0)) and
   // don't flag $compile calls that specify a `maxPriority`
   c.getNumArgument() < 3
 select c, "This call to $compile may cause double compilation of '" + elem + "'."

--- a/javascript/ql/src/AngularJS/DuplicateDependency.ql
+++ b/javascript/ql/src/AngularJS/DuplicateDependency.ql
@@ -12,16 +12,17 @@
 import javascript
 import semmle.javascript.RestrictedLocations
 
-predicate isRepeatedDependency(AngularJS::InjectableFunction f, string name, AstNode location) {
+predicate isRepeatedDependency(AngularJS::InjectableFunction f, string name, DataFlow::Node node) {
   exists(int i, int j |
     i < j and
     exists(f.getDependencyDeclaration(i, name)) and
-    location = f.getDependencyDeclaration(j, name)
+    node = f.getDependencyDeclaration(j, name)
   )
 }
 
-from AngularJS::InjectableFunction f, AstNode node, string name
+from AngularJS::InjectableFunction f, DataFlow::Node node, string name
 where
   isRepeatedDependency(f, name, node) and
   not count(f.asFunction().getParameterByName(name)) > 1 // avoid duplicating reports from js/duplicate-parameter-name
-select f.asFunction().(FirstLineOf), "This function has a duplicate dependency '$@'.", node, name
+select f.asFunction().getFunction().(FirstLineOf), "This function has a duplicate dependency '$@'.",
+  node, name

--- a/javascript/ql/src/AngularJS/InsecureUrlWhitelist.ql
+++ b/javascript/ql/src/AngularJS/InsecureUrlWhitelist.ql
@@ -23,7 +23,7 @@ predicate isResourceUrlWhitelist(
 ) {
   exists(AngularJS::ServiceReference service |
     service.getName() = "$sceDelegateProvider" and
-    setupCall.asExpr() = service.getAMethodCall("resourceUrlWhitelist") and
+    setupCall = service.getAMethodCall("resourceUrlWhitelist") and
     list.flowsTo(setupCall.getArgument(0))
   )
 }

--- a/javascript/ql/src/AngularJS/RepeatedInjection.ql
+++ b/javascript/ql/src/AngularJS/RepeatedInjection.ql
@@ -12,9 +12,9 @@
 import javascript
 import semmle.javascript.RestrictedLocations
 
-from AngularJS::InjectableFunction f, AstNode explicitInjection
+from AngularJS::InjectableFunction f, DataFlow::Node explicitInjection
 where
   count(f.getAnExplicitDependencyInjection()) > 1 and
   explicitInjection = f.getAnExplicitDependencyInjection()
-select f.asFunction().(FirstLineOf), "This function has $@ defined in multiple places.",
-  explicitInjection, "dependency injections"
+select f.asFunction().getFunction().(FirstLineOf),
+  "This function has $@ defined in multiple places.", explicitInjection, "dependency injections"

--- a/javascript/ql/src/AngularJS/UnusedAngularDependency.ql
+++ b/javascript/ql/src/AngularJS/UnusedAngularDependency.ql
@@ -13,9 +13,9 @@ import javascript
 import Declarations.UnusedParameter
 import semmle.javascript.RestrictedLocations
 
-predicate isUnusedParameter(Function f, string msg, Parameter parameter) {
+predicate isUnusedParameter(DataFlow::FunctionNode f, string msg, Parameter parameter) {
   exists(Variable pv |
-    isUnused(f, parameter, pv, _) and
+    isUnused(f.getFunction(), parameter, pv, _) and
     not isAnAccidentallyUnusedParameter(parameter) and // avoid double alerts
     msg = "Unused dependency " + pv.getName() + "."
   )

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
@@ -135,7 +135,7 @@ DataFlow::CallNode servesAPrivateFolder(string description) {
  */
 Express::RouteSetup getAnExposingExpressSetup(string path) {
   result.isUseCall() and
-  result.getArgument([0 .. 1]) = servesAPrivateFolder(path).getEnclosingExpr()
+  result.getArgument([0 .. 1]) = servesAPrivateFolder(path)
 }
 
 /**
@@ -149,7 +149,7 @@ DataFlow::CallNode getAnExposingServeSetup(string path) {
 
 from DataFlow::Node node, string path
 where
-  node = getAnExposingExpressSetup(path).flow()
+  node = getAnExposingExpressSetup(path)
   or
   node = getAnExposingServeSetup(path)
 select node, "Serves " + path + ", which can contain private information."

--- a/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
+++ b/javascript/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.ql
@@ -19,7 +19,7 @@ import DataFlow::PathGraph
 from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
 where
   cfg.hasFlowPath(source, sink) and
-  not source.getNode().asExpr() instanceof CleartextPasswordExpr // flagged by js/insufficient-password-hash
+  not source.getNode() instanceof CleartextPasswordExpr // flagged by js/insufficient-password-hash
 select sink.getNode(), source, sink,
   "Sensitive data from $@ is used in a broken or weak cryptographic algorithm.", source.getNode(),
   source.getNode().(Source).describe()

--- a/javascript/ql/src/Security/CWE-598/SensitiveGetQuery.ql
+++ b/javascript/ql/src/Security/CWE-598/SensitiveGetQuery.ql
@@ -15,13 +15,13 @@ import javascript
 
 from
   Routing::RouteSetup setup, Routing::RouteHandler handler, HTTP::RequestInputAccess input,
-  SensitiveExpr sensitive
+  SensitiveNode sensitive
 where
   setup.getOwnHttpMethod() = "GET" and
   setup.getAChild+() = handler and
   input.getRouteHandler() = handler.getFunction() and
   input.getKind() = "parameter" and
-  input.(DataFlow::SourceNode).flowsToExpr(sensitive) and
+  input.(DataFlow::SourceNode).flowsTo(sensitive) and
   not sensitive.getClassification() = SensitiveDataClassification::id()
 select input, "$@ for GET requests uses query parameter as sensitive data.", handler,
   "Route handler"

--- a/javascript/ql/src/experimental/poi/PoI.qll
+++ b/javascript/ql/src/experimental/poi/PoI.qll
@@ -77,7 +77,7 @@ private module StandardPoIs {
     UnpromotedRouteSetupPoI() { this = "UnpromotedRouteSetupPoI" }
 
     override predicate is(Node l0) {
-      l0 instanceof HTTP::RouteSetupCandidate and not l0.asExpr() instanceof HTTP::RouteSetup
+      l0 instanceof HTTP::RouteSetupCandidate and not l0 instanceof HTTP::RouteSetup
     }
   }
 

--- a/javascript/ql/src/meta/analysis-quality/UnpromotedRouteSetupCandidate.ql
+++ b/javascript/ql/src/meta/analysis-quality/UnpromotedRouteSetupCandidate.ql
@@ -13,7 +13,7 @@ import CandidateTracking
 
 from HTTP::RouteSetupCandidate setup
 where
-  not setup.asExpr() instanceof HTTP::RouteSetup and
+  not setup instanceof HTTP::RouteSetup and
   exists(HTTP::RouteHandlerCandidate rh |
     track(rh, DataFlow::TypeTracker::end()).flowsTo(setup.getARouteHandlerArg())
   )

--- a/javascript/ql/test/experimental/PoI/TestCustomPoIs.ql
+++ b/javascript/ql/test/experimental/PoI/TestCustomPoIs.ql
@@ -24,7 +24,7 @@ class RouteSetupAndRouterAndRouteHandlerPoI extends ActivePoI {
   RouteSetupAndRouterAndRouteHandlerPoI() { this = "RouteSetupAndRouterAndRouteHandlerPoI" }
 
   override predicate is(Node l0, Node l1, string t1, Node l2, string t2) {
-    l0.(Express::RouteSetup).getRouter().flow() = l1 and
+    l0.(Express::RouteSetup).getRouter() = l1 and
     t1 = "router" and
     l0.(Express::RouteSetup).getARouteHandler() = l2 and
     t2 = "routehandler"

--- a/javascript/ql/test/experimental/PoI/TestCustomPoIs.ql
+++ b/javascript/ql/test/experimental/PoI/TestCustomPoIs.ql
@@ -16,7 +16,7 @@ class RouteHandlerAndSetupPoI extends ActivePoI {
   RouteHandlerAndSetupPoI() { this = "RouteHandlerAndSetupPoI" }
 
   override predicate is(Node l0, Node l1, string t1) {
-    l1.asExpr().(Express::RouteSetup).getARouteHandler() = l0 and t1 = "setup"
+    l1.(Express::RouteSetup).getARouteHandler() = l0 and t1 = "setup"
   }
 }
 
@@ -24,9 +24,9 @@ class RouteSetupAndRouterAndRouteHandlerPoI extends ActivePoI {
   RouteSetupAndRouterAndRouteHandlerPoI() { this = "RouteSetupAndRouterAndRouteHandlerPoI" }
 
   override predicate is(Node l0, Node l1, string t1, Node l2, string t2) {
-    l0.asExpr().(Express::RouteSetup).getRouter().flow() = l1 and
+    l0.(Express::RouteSetup).getRouter().flow() = l1 and
     t1 = "router" and
-    l0.asExpr().(Express::RouteSetup).getARouteHandler() = l2 and
+    l0.(Express::RouteSetup).getARouteHandler() = l2 and
     t2 = "routehandler"
   }
 }

--- a/javascript/ql/test/library-tests/SensitiveActions/tests.ql
+++ b/javascript/ql/test/library-tests/SensitiveActions/tests.ql
@@ -20,4 +20,4 @@ query predicate processTermination(NodeJSLib::ProcessTermination term) { any() }
 
 query predicate sensitiveAction(SensitiveAction ac) { any() }
 
-query predicate sensitiveExpr(SensitiveExpr e) { any() }
+query predicate sensitiveExpr(SensitiveNode e) { any() }

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/dependency-dataflow/ScopeMethodCalls.ql
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/dependency-dataflow/ScopeMethodCalls.ql
@@ -1,5 +1,5 @@
 import javascript
 
-from AngularJS::ScopeServiceReference s, MethodCallExpr mce
+from AngularJS::ScopeServiceReference s, DataFlow::MethodCallNode mce
 where mce = s.getAMethodCall(_)
 select mce

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/dependency-resolution/DependencyResolution_full.ql
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/dependency-resolution/DependencyResolution_full.ql
@@ -1,6 +1,6 @@
 import javascript
 private import AngularJS
 
-from InjectableFunction f, SimpleParameter p, DataFlow::Node nd
+from InjectableFunction f, DataFlow::ParameterNode p, DataFlow::Node nd
 where nd = f.getCustomServiceDependency(p)
 select p.getName(), nd

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/scopes/ScopeAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/scopes/ScopeAccess.expected
@@ -1,46 +1,68 @@
 | isolate scope for directive1 | scope-access.js:4:41:4:45 | scope |
+| isolate scope for directive1 | scope-access.js:4:41:4:45 | scope |
 | isolate scope for directive1 | scope-access.js:5:17:5:21 | scope |
 | isolate scope for directive1 | scope-access.js:7:20:7:21 | {} |
+| isolate scope for directive2 | scope-access.js:12:34:12:39 | $scope |
 | isolate scope for directive2 | scope-access.js:12:34:12:39 | $scope |
 | isolate scope for directive2 | scope-access.js:13:17:13:22 | $scope |
 | isolate scope for directive2 | scope-access.js:15:20:15:21 | {} |
 | isolate scope for directive3 | scope-access.js:20:39:20:44 | $scope |
+| isolate scope for directive3 | scope-access.js:20:39:20:44 | $scope |
 | isolate scope for directive3 | scope-access.js:21:17:21:22 | $scope |
 | isolate scope for directive3 | scope-access.js:23:20:23:21 | {} |
 | isolate scope for directive4 | scope-access.js:28:45:28:45 | a |
+| isolate scope for directive4 | scope-access.js:28:45:28:45 | a |
 | isolate scope for directive4 | scope-access.js:29:17:29:17 | a |
 | isolate scope for directive4 | scope-access.js:31:20:31:21 | {} |
+| isolate scope for directive5 | scope-access.js:36:25:36:24 | this |
 | isolate scope for directive5 | scope-access.js:37:17:37:20 | this |
 | isolate scope for directive5 | scope-access.js:39:20:39:21 | {} |
+| isolate scope for directive6 | scope-access.js:45:25:45:24 | this |
+| isolate scope for directive6 | scope-access.js:46:18:46:26 | return of anonymous function |
 | isolate scope for directive6 | scope-access.js:46:23:46:26 | this |
 | isolate scope for directive6 | scope-access.js:48:20:48:21 | {} |
 | isolate scope for myCustomer | dev-guide-5.js:11:12:13:5 | { // Sc ... y\\n    } |
 | isolate scope for myCustomer | dev-guide-6.js:11:12:13:5 | { // Sc ... y\\n    } |
 | scope for <directive7>...</> | scope-access.js:54:34:54:39 | $scope |
+| scope for <directive7>...</> | scope-access.js:54:34:54:39 | $scope |
 | scope for <directive7>...</> | scope-access.js:55:17:55:22 | $scope |
+| scope for <div>...</> | dev-guide-1.js:4:49:4:54 | $scope |
+| scope for <div>...</> | dev-guide-1.js:4:49:4:54 | $scope |
 | scope for <div>...</> | dev-guide-1.js:4:49:4:54 | $scope |
 | scope for <div>...</> | dev-guide-1.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-1.js:7:3:7:8 | $scope |
+| scope for <div>...</> | dev-guide-1.js:7:21:7:20 | $scope |
 | scope for <div>...</> | dev-guide-1.js:8:5:8:10 | $scope |
 | scope for <div>...</> | dev-guide-1.js:8:34:8:39 | $scope |
 | scope for <div>...</> | dev-guide-2.js:4:66:4:71 | $scope |
+| scope for <div>...</> | dev-guide-2.js:4:66:4:71 | $scope |
 | scope for <div>...</> | dev-guide-2.js:5:3:5:8 | $scope |
+| scope for <div>...</> | dev-guide-2.js:8:51:8:56 | $scope |
 | scope for <div>...</> | dev-guide-2.js:8:51:8:56 | $scope |
 | scope for <div>...</> | dev-guide-2.js:9:3:9:8 | $scope |
 | scope for <div>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <div>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <div>...</> | dev-guide-3.js:4:52:4:57 | $scope |
 | scope for <div>...</> | dev-guide-3.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-3.js:6:3:6:8 | $scope |
+| scope for <div>...</> | dev-guide-3.js:6:25:6:24 | $scope |
 | scope for <div>...</> | dev-guide-3.js:7:5:7:10 | $scope |
 | scope for <div>...</> | dev-guide-4.js:4:52:4:57 | $scope |
+| scope for <div>...</> | dev-guide-4.js:4:52:4:57 | $scope |
 | scope for <div>...</> | dev-guide-4.js:5:3:5:8 | $scope |
+| scope for <div>...</> | dev-guide-4.js:10:51:10:56 | $scope |
 | scope for <div>...</> | dev-guide-4.js:10:51:10:56 | $scope |
 | scope for <div>...</> | dev-guide-4.js:11:3:11:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-5.js:4:47:4:52 | $scope |
+| scope for <div>...</> | dev-guide-5.js:4:47:4:52 | $scope |
+| scope for <div>...</> | dev-guide-5.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-5.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:6:3:6:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:6:3:6:8 | $scope |
+| scope for <div>...</> | dev-guide-6.js:4:47:4:52 | $scope |
+| scope for <div>...</> | dev-guide-6.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-6.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-6.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-6.js:5:3:5:8 | $scope |
@@ -48,45 +70,68 @@
 | scope for <div>...</> | dev-guide-6.js:6:3:6:8 | $scope |
 | scope for <div>...</> | dev-guide-6.js:6:3:6:8 | $scope |
 | scope for <elementthatusescontroller1>...</> | scope-access.js:59:52:59:57 | $scope |
+| scope for <elementthatusescontroller1>...</> | scope-access.js:59:52:59:57 | $scope |
 | scope for <elementthatusescontroller1>...</> | scope-access.js:60:9:60:14 | $scope |
 | scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
 | scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
 | scope for <li>...</> | dev-guide-3.js:5:3:5:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:5:3:5:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:6:3:6:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:6:3:6:8 | $scope |
+| scope for <li>...</> | dev-guide-3.js:6:25:6:24 | $scope |
+| scope for <li>...</> | dev-guide-3.js:6:25:6:24 | $scope |
 | scope for <li>...</> | dev-guide-3.js:7:5:7:10 | $scope |
 | scope for <li>...</> | dev-guide-3.js:7:5:7:10 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:4:49:4:54 | $scope |
+| scope in dev-guide-1.html | dev-guide-1.js:4:49:4:54 | $scope |
+| scope in dev-guide-1.html | dev-guide-1.js:4:49:4:54 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:5:3:5:8 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:7:3:7:8 | $scope |
+| scope in dev-guide-1.html | dev-guide-1.js:7:21:7:20 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:8:5:8:10 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:8:34:8:39 | $scope |
 | scope in dev-guide-2.html | dev-guide-2.js:4:66:4:71 | $scope |
+| scope in dev-guide-2.html | dev-guide-2.js:4:66:4:71 | $scope |
 | scope in dev-guide-2.html | dev-guide-2.js:5:3:5:8 | $scope |
+| scope in dev-guide-2.html | dev-guide-2.js:8:51:8:56 | $scope |
 | scope in dev-guide-2.html | dev-guide-2.js:8:51:8:56 | $scope |
 | scope in dev-guide-2.html | dev-guide-2.js:9:3:9:8 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:4:52:4:57 | $scope |
+| scope in dev-guide-3.html | dev-guide-3.js:4:52:4:57 | $scope |
+| scope in dev-guide-3.html | dev-guide-3.js:4:52:4:57 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:5:3:5:8 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:6:3:6:8 | $scope |
+| scope in dev-guide-3.html | dev-guide-3.js:6:25:6:24 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:7:5:7:10 | $scope |
+| scope in dev-guide-4.html | dev-guide-4.js:4:52:4:57 | $scope |
 | scope in dev-guide-4.html | dev-guide-4.js:4:52:4:57 | $scope |
 | scope in dev-guide-4.html | dev-guide-4.js:5:3:5:8 | $scope |
 | scope in dev-guide-4.html | dev-guide-4.js:10:51:10:56 | $scope |
+| scope in dev-guide-4.html | dev-guide-4.js:10:51:10:56 | $scope |
 | scope in dev-guide-4.html | dev-guide-4.js:11:3:11:8 | $scope |
+| scope in dev-guide-5.html | dev-guide-5.js:4:47:4:52 | $scope |
 | scope in dev-guide-5.html | dev-guide-5.js:4:47:4:52 | $scope |
 | scope in dev-guide-5.html | dev-guide-5.js:5:3:5:8 | $scope |
 | scope in dev-guide-5.html | dev-guide-5.js:6:3:6:8 | $scope |
 | scope in dev-guide-5.html | dev-guide-6.js:4:47:4:52 | $scope |
+| scope in dev-guide-5.html | dev-guide-6.js:4:47:4:52 | $scope |
 | scope in dev-guide-5.html | dev-guide-6.js:5:3:5:8 | $scope |
 | scope in dev-guide-5.html | dev-guide-6.js:6:3:6:8 | $scope |
+| scope in dev-guide-6.html | dev-guide-5.js:4:47:4:52 | $scope |
 | scope in dev-guide-6.html | dev-guide-5.js:4:47:4:52 | $scope |
 | scope in dev-guide-6.html | dev-guide-5.js:5:3:5:8 | $scope |
 | scope in dev-guide-6.html | dev-guide-5.js:6:3:6:8 | $scope |
 | scope in dev-guide-6.html | dev-guide-6.js:4:47:4:52 | $scope |
+| scope in dev-guide-6.html | dev-guide-6.js:4:47:4:52 | $scope |
 | scope in dev-guide-6.html | dev-guide-6.js:5:3:5:8 | $scope |
 | scope in dev-guide-6.html | dev-guide-6.js:6:3:6:8 | $scope |
 | scope in scope-access.html | scope-access.js:54:34:54:39 | $scope |
+| scope in scope-access.html | scope-access.js:54:34:54:39 | $scope |
 | scope in scope-access.html | scope-access.js:55:17:55:22 | $scope |
+| scope in scope-access.html | scope-access.js:59:52:59:57 | $scope |
 | scope in scope-access.html | scope-access.js:59:52:59:57 | $scope |
 | scope in scope-access.html | scope-access.js:60:9:60:14 | $scope |

--- a/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_getNameExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/HeaderDefinition_getNameExpr.qll
@@ -1,5 +1,7 @@
 import javascript
 
-query predicate test_HeaderDefinition_getNameExpr(HTTP::ExplicitHeaderDefinition hd, Expr res) {
-  hd.getRouteHandler() instanceof Express::RouteHandler and res = hd.getNameExpr()
+query predicate test_HeaderDefinition_getNameExpr(
+  HTTP::ExplicitHeaderDefinition hd, DataFlow::Node res
+) {
+  hd.getRouteHandler() instanceof Express::RouteHandler and res = hd.getNameNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RequestExpr.qll
@@ -1,9 +1,9 @@
 import javascript
 
-query predicate test_RequestExpr(Express::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Express::RequestNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }
 
-query predicate test_RequestExprStandalone(Express::RequestExpr e) {
+query predicate test_RequestExprStandalone(Express::RequestNode e) {
   not exists(e.getRouteHandler())
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Express::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Express::ResponseNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteExpr.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_RouteExpr(Express::RouteExpr e, Express::RouterDefinition res) {
-  res = e.getRouter()
-}

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler.qll
@@ -1,5 +1,7 @@
 import javascript
 
-query predicate test_RouteHandler(Express::RouteHandler rh, Parameter res0, Parameter res1) {
+query predicate test_RouteHandler(
+  Express::RouteHandler rh, DataFlow::ParameterNode res0, DataFlow::ParameterNode res1
+) {
   res0 = rh.getRequestParameter() and res1 = rh.getResponseParameter()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandlerExpr(
-  Express::RouteHandlerExpr rhe, Express::RouteSetup res0, boolean isLast
+  Express::RouteHandlerNode rhe, Express::RouteSetup res0, boolean isLast
 ) {
   (if rhe.isLastHandler() then isLast = true else isLast = false) and
   res0 = rhe.getSetup()

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAMatchingAncestor.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAMatchingAncestor.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandlerExpr_getAMatchingAncestor(
-  Express::RouteHandlerExpr expr, Express::RouteHandlerExpr res
+  Express::RouteHandlerNode expr, Express::RouteHandlerNode res
 ) {
   res = expr.getAMatchingAncestor()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAsSubRouter.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getAsSubRouter.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandlerExpr_getAsSubRouter(
-  Express::RouteHandlerExpr expr, Express::RouterDefinition res
+  Express::RouteHandlerNode expr, Express::RouterDefinition res
 ) {
   res = expr.getAsSubRouter()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getBody.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getBody.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandlerExpr_getBody(
-  Express::RouteHandlerExpr rhe, Express::RouteHandler res
+  Express::RouteHandlerNode rhe, Express::RouteHandler res
 ) {
   res = rhe.getBody()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getNextMiddleware.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getNextMiddleware.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandlerExpr_getNextMiddleware(
-  Express::RouteHandlerExpr expr, Express::RouteHandlerExpr res
+  Express::RouteHandlerNode expr, Express::RouteHandlerNode res
 ) {
   res = expr.getNextMiddleware()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getPreviousMiddleware.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandlerExpr_getPreviousMiddleware.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandlerExpr_getPreviousMiddleware(
-  Express::RouteHandlerExpr expr, Express::RouteHandlerExpr res
+  Express::RouteHandlerNode expr, Express::RouteHandlerNode res
 ) {
   res = expr.getPreviousMiddleware()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestBodyAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestBodyAccess.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getARequestBodyAccess(Express::RouteHandler rh, Expr res) {
+query predicate test_RouteHandler_getARequestBodyAccess(Express::RouteHandler rh, DataFlow::Node res) {
   res = rh.getARequestBodyAccess()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getARequestExpr(Express::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(Express::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getAResponseExpr(Express::RouteHandler rh, HTTP::ResponseExpr res) {
-  res = rh.getAResponseExpr()
+query predicate test_RouteHandler_getAResponseExpr(Express::RouteHandler rh, HTTP::ResponseNode res) {
+  res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup.qll
@@ -1,6 +1,6 @@
 import javascript
 
-query predicate test_RouteSetup(Express::RouteSetup rs, Expr res0, boolean isUseCall) {
+query predicate test_RouteSetup(Express::RouteSetup rs, DataFlow::Node res0, boolean isUseCall) {
   (if rs.isUseCall() then isUseCall = true else isUseCall = false) and
   res0 = rs.getServer()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandlerExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getARouteHandlerExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getARouteHandlerExpr(Express::RouteSetup r, Expr res) {
-  res = r.getARouteHandlerExpr()
+query predicate test_RouteSetup_getARouteHandlerExpr(Express::RouteSetup r, DataFlow::Node res) {
+  res = r.getARouteHandlerNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getLastRouteHandlerExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getLastRouteHandlerExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getLastRouteHandlerExpr(Express::RouteSetup r, Expr res) {
-  res = r.getLastRouteHandlerExpr()
+query predicate test_RouteSetup_getLastRouteHandlerExpr(Express::RouteSetup r, DataFlow::Node res) {
+  res = r.getLastRouteHandlerNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouteHandlerExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getRouteHandlerExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getRouteHandlerExpr(Express::RouteSetup r, int i, Expr res) {
-  res = r.getRouteHandlerExpr(i)
+query predicate test_RouteSetup_getRouteHandlerExpr(Express::RouteSetup r, int i, DataFlow::Node res) {
+  res = r.getRouteHandlerNode(i)
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_getServer.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getServer(Express::RouteSetup rs, Expr res) { res = rs.getServer() }
+query predicate test_RouteSetup_getServer(Express::RouteSetup rs, DataFlow::Node res) {
+  res = rs.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_handlesSameRequestMethodAs.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouteSetup_handlesSameRequestMethodAs.qll
@@ -4,7 +4,7 @@ query predicate test_RouteSetup_handlesSameRequestMethodAs(
   Express::RouteSetup rs, Express::RouteSetup rs2
 ) {
   rs.handlesSameRequestMethodAs(rs2) and
-  rs.getLocation().getStartLine() < rs2.getLocation().getStartLine() and
-  rs.getLocation().getFile().getBaseName() = "csurf-example.js" and
-  rs2.getLocation().getFile().getBaseName() = "csurf-example.js"
+  rs.asExpr().getLocation().getStartLine() < rs2.asExpr().getLocation().getStartLine() and
+  rs.asExpr().getLocation().getFile().getBaseName() = "csurf-example.js" and
+  rs2.asExpr().getLocation().getFile().getBaseName() = "csurf-example.js"
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStack.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStack.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouterDefinition_getMiddlewareStack(
-  Express::RouterDefinition r, Express::RouteHandlerExpr res
+  Express::RouterDefinition r, Express::RouteHandlerNode res
 ) {
   res = r.getMiddlewareStack()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStackAt.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/RouterDefinition_getMiddlewareStackAt.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouterDefinition_getMiddlewareStackAt(
-  Express::RouterDefinition r, ControlFlowNode nd, Express::RouteHandlerExpr res
+  Express::RouterDefinition r, ControlFlowNode nd, Express::RouteHandlerNode res
 ) {
   res = r.getMiddlewareStackAt(nd)
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.qll
@@ -1,7 +1,8 @@
 import javascript
 
 query predicate test_StandardRouteHandler(
-  Express::StandardRouteHandler rh, DataFlow::Node res0, SimpleParameter res1, SimpleParameter res2
+  Express::StandardRouteHandler rh, DataFlow::Node res0, DataFlow::ParameterNode res1,
+  DataFlow::ParameterNode res2
 ) {
   res0 = rh.getServer() and res1 = rh.getRequestParameter() and res2 = rh.getResponseParameter()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/StandardRouteHandler.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_StandardRouteHandler(
-  Express::StandardRouteHandler rh, Expr res0, SimpleParameter res1, SimpleParameter res2
+  Express::StandardRouteHandler rh, DataFlow::Node res0, SimpleParameter res1, SimpleParameter res2
 ) {
   res0 = rh.getServer() and res1 = rh.getRequestParameter() and res2 = rh.getResponseParameter()
 }

--- a/javascript/ql/test/library-tests/frameworks/Express/isRequest.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/isRequest.qll
@@ -1,3 +1,3 @@
 import javascript
 
-query predicate test_isRequest(Expr nd) { Express::isRequest(nd) }
+query predicate test_isRequest(DataFlow::Node nd) { Express::isRequest(nd) }

--- a/javascript/ql/test/library-tests/frameworks/Express/isResponse.qll
+++ b/javascript/ql/test/library-tests/frameworks/Express/isResponse.qll
@@ -1,3 +1,3 @@
 import javascript
 
-query predicate test_isResponse(Expr nd) { Express::isResponse(nd) }
+query predicate test_isResponse(DataFlow::Node nd) { Express::isResponse(nd) }

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -1067,36 +1067,51 @@ test_ResponseExpr
 | src/advanced-routehandler-registration.js:24:12:24:14 | res | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:25:12:25:14 | res | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:46:25:46:27 | res | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:46:25:46:27 | res | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:46:25:46:27 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:46:25:46:27 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:47:32:47:34 | res | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:47:32:47:34 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:15:51:17 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:51:15:51:17 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:45:51:47 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:59:25:59:27 | res | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:59:25:59:27 | res | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:59:25:59:27 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:59:25:59:27 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:60:23:60:25 | res | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:60:23:60:25 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:64:15:64:17 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:15:64:17 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:50:64:52 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:68:18:68:20 | res | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:68:18:68:20 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:68:18:68:20 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:69:25:69:27 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:69:25:69:27 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:69:25:69:27 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:69:25:69:27 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:70:23:70:25 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:70:23:70:25 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:15:73:17 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:73:15:73:17 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:52:73:54 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:81:25:81:27 | res | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:81:25:81:27 | res | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:81:25:81:27 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:81:25:81:27 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:82:32:82:34 | res | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:82:32:82:34 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:15:92:17 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:92:15:92:17 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:45:92:47 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:100:25:100:27 | res | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:100:25:100:27 | res | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:100:25:100:27 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:100:25:100:27 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:101:36:101:38 | res | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:101:36:101:38 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:111:15:111:17 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:15:111:17 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:45:111:47 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:123:26:123:28 | res | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) |
@@ -1106,10 +1121,13 @@ test_ResponseExpr
 | src/advanced-routehandler-registration.js:157:33:157:35 | res | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) |
 | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined |
 | src/csurf-example.js:20:33:20:35 | res | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
+| src/csurf-example.js:20:33:20:35 | res | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:22:3:22:5 | res | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
+| src/csurf-example.js:25:37:25:39 | res | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:25:37:25:39 | res | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:26:3:26:5 | res | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:26:3:26:43 | res.sen ...  here') | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
+| src/csurf-example.js:32:45:32:47 | res | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/csurf-example.js:32:45:32:47 | res | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/csurf-example.js:33:5:33:7 | res | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/csurf-example.js:33:5:33:35 | res.sen ...  here') | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
@@ -1117,11 +1135,14 @@ test_ResponseExpr
 | src/csurf-example.js:40:42:40:44 | res | src/csurf-example.js:40:27:40:48 | functio ... res) {} |
 | src/exportedHandler.js:1:49:1:51 | res | src/exportedHandler.js:1:19:1:55 | functio ... res) {} |
 | src/express2.js:3:39:3:41 | res | src/express2.js:3:25:3:55 | functio ... , res } |
+| src/express2.js:3:39:3:41 | res | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:3:46:3:53 | req, res | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:3:51:3:53 | res | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:4:50:4:55 | result | src/express2.js:4:32:4:76 | functio ... esult } |
+| src/express2.js:4:50:4:55 | result | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express2.js:4:60:4:74 | request, result | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express2.js:4:69:4:74 | result | src/express2.js:4:32:4:76 | functio ... esult } |
+| src/express3.js:4:37:4:39 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:4:37:4:39 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:3:5:5 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:3:5:51 | res.hea ... "val")) | src/express3.js:4:23:7:1 | functio ... al");\\n} |
@@ -1129,8 +1150,10 @@ test_ResponseExpr
 | src/express3.js:6:3:6:17 | res.send("val") | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:10:27:10:29 | res | src/express3.js:10:12:10:32 | functio ...  res){} |
 | src/express4.js:4:37:4:39 | res | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:4:37:4:39 | res | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:8:3:8:5 | res | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:8:3:8:20 | res.send(dynamic1) | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express.js:4:37:4:39 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:4:37:4:39 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:5:3:5:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:3:6:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
@@ -1139,17 +1162,21 @@ test_ResponseExpr
 | src/express.js:7:3:7:42 | res.hea ... plain") | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:8:7:8:9 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:11:14:11:16 | arg | src/express.js:4:23:9:1 | functio ... res);\\n} |
+| src/express.js:11:14:11:16 | arg | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:12:3:12:5 | arg | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:12:3:12:54 | arg.hea ... , true) | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:33:16:35 | res | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/express.js:16:33:16:35 | res | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:17:5:17:7 | res | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:17:5:17:24 | res.send("Go away.") | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/express.js:22:44:22:46 | res | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:22:44:22:46 | res | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:31:3:31:5 | res | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:31:3:31:26 | res.coo ...  'bar') | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:37:27:37:29 | res | src/express.js:37:12:37:32 | functio ...  res){} |
 | src/express.js:42:18:42:20 | res | src/express.js:42:12:42:28 | (req, res) => f() |
 | src/express.js:46:36:46:38 | res | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/inheritedFromNode.js:4:29:4:31 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:4:29:4:31 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:5:2:5:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:6:2:6:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
@@ -1159,19 +1186,26 @@ test_ResponseExpr
 | src/middleware-flow.js:24:23:24:25 | res | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
 | src/middleware-flow.js:39:29:39:31 | res | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:24:4:26 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:4:24:4:26 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:8:9:8:11 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:8:9:8:23 | res.send(value) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:38:14:40 | res | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/params.js:14:38:14:40 | res | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/params.js:15:3:15:5 | res | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/params.js:15:3:15:19 | res.send("Hello") | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:37:4:40 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
+| src/responseExprs.js:4:37:4:40 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:5:5:5:8 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
+| src/responseExprs.js:7:37:7:40 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:7:37:7:40 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:8:5:8:8 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:44:10:47 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
+| src/responseExprs.js:10:44:10:47 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
 | src/responseExprs.js:11:5:11:8 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
 | src/responseExprs.js:13:37:13:40 | res4 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
+| src/responseExprs.js:13:37:13:40 | res4 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
 | src/responseExprs.js:14:5:14:8 | res4 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
+| src/responseExprs.js:16:44:16:46 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:16:44:16:46 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:19:5:19:7 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:19:5:19:16 | res.append() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
@@ -1210,6 +1244,8 @@ test_ResponseExpr
 | src/responseExprs.js:37:5:37:28 | f(res.a ... ppend() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:37:7:37:9 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:37:7:37:18 | res.append() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
+| src/responseExprs.js:39:5:41:5 | return of function f | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
+| src/responseExprs.js:39:16:39:21 | resArg | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:39:16:39:21 | resArg | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:40:16:40:21 | resArg | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:40:16:40:30 | resArg.append() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
@@ -1611,36 +1647,51 @@ test_RouteHandler_getAResponseExpr
 | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:12:24:14 | res |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:12:25:14 | res |
 | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:25:46:27 | res |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:47:32:47:34 | res |
+| src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:47:32:47:34 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:15:51:17 | res |
+| src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:15:51:17 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:45:51:47 | res |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:60:23:60:25 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:59:25:59:27 | res |
+| src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:60:23:60:25 | res |
+| src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:15:64:17 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:15:64:17 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:50:64:52 | res |
 | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:18:68:20 | res |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:18:68:20 | res |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:25:69:27 | res |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:25:69:27 | res |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:70:23:70:25 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:18:68:20 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:69:25:69:27 | res |
+| src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:69:25:69:27 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:70:23:70:25 | res |
+| src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:15:73:17 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:15:73:17 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:52:73:54 | res |
 | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:25:81:27 | res |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:82:32:82:34 | res |
+| src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:82:32:82:34 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:15:92:17 | res |
+| src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:15:92:17 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:45:92:47 | res |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:101:36:101:38 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:100:25:100:27 | res |
+| src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:101:36:101:38 | res |
+| src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:45:111:47 | res |
 | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:26:123:28 | res |
@@ -1650,10 +1701,13 @@ test_RouteHandler_getAResponseExpr
 | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:33:157:35 | res |
 | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:20:33:20:35 | res |
+| src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:20:33:20:35 | res |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:22:3:22:5 | res |
+| src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:25:37:25:39 | res |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:25:37:25:39 | res |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:26:3:26:5 | res |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:26:3:26:43 | res.sen ...  here') |
+| src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:32:45:32:47 | res |
 | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:32:45:32:47 | res |
 | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:33:5:33:7 | res |
 | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:33:5:33:35 | res.sen ...  here') |
@@ -1661,11 +1715,14 @@ test_RouteHandler_getAResponseExpr
 | src/csurf-example.js:40:27:40:48 | functio ... res) {} | src/csurf-example.js:40:42:40:44 | res |
 | src/exportedHandler.js:1:19:1:55 | functio ... res) {} | src/exportedHandler.js:1:49:1:51 | res |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:39:3:41 | res |
+| src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:39:3:41 | res |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:46:3:53 | req, res |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:51:3:53 | res |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:50:4:55 | result |
+| src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:50:4:55 | result |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:60:4:74 | request, result |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:69:4:74 | result |
+| src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:37:4:39 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:37:4:39 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:3:5:5 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:3:5:51 | res.hea ... "val")) |
@@ -1673,8 +1730,10 @@ test_RouteHandler_getAResponseExpr
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:6:3:6:17 | res.send("val") |
 | src/express3.js:10:12:10:32 | functio ...  res){} | src/express3.js:10:27:10:29 | res |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:37:4:39 | res |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:37:4:39 | res |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:8:3:8:5 | res |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:8:3:8:20 | res.send(dynamic1) |
+| src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:37:4:39 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:37:4:39 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:5:3:5:5 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:3:6:5 | res |
@@ -1683,17 +1742,21 @@ test_RouteHandler_getAResponseExpr
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:7:3:7:42 | res.hea ... plain") |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:8:7:8:9 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:11:14:11:16 | arg |
+| src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:11:14:11:16 | arg |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:12:3:12:5 | arg |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:12:3:12:54 | arg.hea ... , true) |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:33:16:35 | res |
+| src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:33:16:35 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:17:5:17:7 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:17:5:17:24 | res.send("Go away.") |
+| src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:44:22:46 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:44:22:46 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:31:3:31:5 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:31:3:31:26 | res.coo ...  'bar') |
 | src/express.js:37:12:37:32 | functio ...  res){} | src/express.js:37:27:37:29 | res |
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:18:42:20 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:36:46:38 | res |
+| src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:6:2:6:4 | res |
@@ -1703,19 +1766,26 @@ test_RouteHandler_getAResponseExpr
 | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:23:24:25 | res |
 | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:29:39:31 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:24:4:26 | res |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:24:4:26 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:11 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:23 | res.send(value) |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:38:14:40 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:38:14:40 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:15:3:15:5 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:15:3:15:19 | res.send("Hello") |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:37:4:40 | res1 |
+| src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:5:5:5:8 | res1 |
+| src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:8:5:8:8 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:44:10:47 | res3 |
+| src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:44:10:47 | res3 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:11:5:11:8 | res3 |
 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:13:37:13:40 | res4 |
+| src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:13:37:13:40 | res4 |
 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:14:5:14:8 | res4 |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:16:44:16:46 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:16:44:16:46 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:19:5:19:7 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:19:5:19:16 | res.append() |
@@ -1754,6 +1824,8 @@ test_RouteHandler_getAResponseExpr
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:37:5:37:28 | f(res.a ... ppend() |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:37:7:37:9 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:37:7:37:18 | res.append() |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:39:5:41:5 | return of function f |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:39:16:39:21 | resArg |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:39:16:39:21 | resArg |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:40:16:40:21 | resArg |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:40:16:40:30 | resArg.append() |
@@ -2547,63 +2619,92 @@ test_RouteHandlerExpr_getPreviousMiddleware
 | src/subrouter.js:5:14:5:28 | makeSubRouter() | src/subrouter.js:4:19:4:25 | protect |
 test_RequestExpr
 | src/advanced-routehandler-registration.js:6:7:6:9 | req | src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:6:7:6:9 | req | src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:6:32:6:34 | req | src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:7:7:7:9 | req | src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:7:7:7:9 | req | src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:7:32:7:34 | req | src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:15:7:15:9 | req | src/advanced-routehandler-registration.js:15:6:15:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:15:7:15:9 | req | src/advanced-routehandler-registration.js:15:6:15:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:15:32:15:34 | req | src/advanced-routehandler-registration.js:15:6:15:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:16:7:16:9 | req | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:16:7:16:9 | req | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:16:32:16:34 | req | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:24:7:24:9 | req | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:24:7:24:9 | req | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:24:32:24:34 | req | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:25:7:25:9 | req | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:25:7:25:9 | req | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:25:32:25:34 | req | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:47:27:47:29 | req | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:47:27:47:29 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:10:51:12 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:51:10:51:12 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:40:51:42 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:60:18:60:20 | req | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:60:18:60:20 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:10:64:12 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:64:10:64:12 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:45:64:47 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:68:38:68:40 | req | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:68:38:68:40 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:68:38:68:40 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:70:18:70:20 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:70:18:70:20 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:10:73:12 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:73:10:73:12 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:47:73:49 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:82:27:82:29 | req | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:82:27:82:29 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:10:92:12 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:92:10:92:12 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:40:92:42 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:101:31:101:33 | req | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:101:31:101:33 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:10:111:12 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:111:10:111:12 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:40:111:42 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:123:21:123:23 | req | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:123:21:123:23 | req | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:123:46:123:48 | req | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:124:21:124:23 | req | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:124:21:124:23 | req | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:124:46:124:48 | req | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:146:29:146:31 | req | src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined |
 | src/advanced-routehandler-registration.js:156:22:156:24 | req | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:156:22:156:24 | req | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:156:47:156:49 | req | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:157:28:157:30 | req | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:157:28:157:30 | req | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:157:53:157:55 | req | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) |
 | src/controllers/handler-in-bulk-require.js:1:45:1:47 | req | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined |
+| src/csurf-example.js:20:28:20:30 | req | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:20:28:20:30 | req | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:22:35:22:37 | req | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:25:32:25:34 | req | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
@@ -2612,21 +2713,27 @@ test_RequestExpr
 | src/csurf-example.js:40:37:40:39 | req | src/csurf-example.js:40:27:40:48 | functio ... res) {} |
 | src/exportedHandler.js:1:44:1:46 | req | src/exportedHandler.js:1:19:1:55 | functio ... res) {} |
 | src/express2.js:3:34:3:36 | req | src/express2.js:3:25:3:55 | functio ... , res } |
+| src/express2.js:3:34:3:36 | req | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:3:46:3:48 | req | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:4:41:4:47 | request | src/express2.js:4:32:4:76 | functio ... esult } |
+| src/express2.js:4:41:4:47 | request | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express2.js:4:60:4:66 | request | src/express2.js:4:32:4:76 | functio ... esult } |
+| src/express3.js:4:32:4:34 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:4:32:4:34 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:14:5:16 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:35:5:37 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:10:22:10:24 | req | src/express3.js:10:12:10:32 | functio ...  res){} |
 | src/express4.js:4:32:4:34 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:4:32:4:34 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:5:27:5:29 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:6:18:6:20 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:7:18:7:20 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:4:32:4:34 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
+| src/express.js:4:32:4:34 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:5:16:5:18 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:26:6:28 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:28:16:30 | req | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/express.js:22:39:22:41 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:22:39:22:41 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:23:3:23:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:24:3:24:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -2639,32 +2746,41 @@ test_RequestExpr
 | src/express.js:37:22:37:24 | req | src/express.js:37:12:37:32 | functio ...  res){} |
 | src/express.js:42:13:42:15 | req | src/express.js:42:12:42:28 | (req, res) => f() |
 | src/express.js:46:31:46:33 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/express.js:46:31:46:33 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:47:3:47:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:48:3:48:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:49:3:49:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:50:3:50:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:7:2:7:4 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/middleware-flow.js:5:20:5:22 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
 | src/middleware-flow.js:5:20:5:22 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
 | src/middleware-flow.js:6:5:6:7 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
 | src/middleware-flow.js:7:5:7:7 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
 | src/middleware-flow.js:8:5:8:7 | req | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} |
 | src/middleware-flow.js:17:25:17:27 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
+| src/middleware-flow.js:17:25:17:27 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
 | src/middleware-flow.js:18:9:18:11 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
 | src/middleware-flow.js:19:9:19:11 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
 | src/middleware-flow.js:20:9:20:11 | req | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } |
 | src/middleware-flow.js:23:18:23:20 | req | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:23:18:23:20 | req | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
 | src/middleware-flow.js:23:33:23:35 | req | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } |
 | src/middleware-flow.js:24:18:24:20 | req | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:24:18:24:20 | req | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
 | src/middleware-flow.js:24:33:24:35 | req | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } |
+| src/middleware-flow.js:39:24:39:26 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/middleware-flow.js:39:24:39:26 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/middleware-flow.js:40:5:40:7 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/middleware-flow.js:41:5:41:7 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/middleware-flow.js:42:5:42:7 | req | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} |
 | src/params.js:4:19:4:21 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:4:19:4:21 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:5:17:5:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:6:17:6:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:14:33:14:35 | req | src/params.js:14:24:16:1 | functio ... lo");\\n} |
+| src/passport.js:27:13:27:15 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 | src/passport.js:27:13:27:15 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 | src/passport.js:28:2:28:4 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
@@ -2672,13 +2788,17 @@ test_RequestExpr
 | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
 | src/responseExprs.js:13:32:13:34 | req | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
 | src/responseExprs.js:16:39:16:41 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
+| src/responseExprs.js:16:39:16:41 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:17:5:17:7 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/route-collection.js:2:7:2:9 | req | src/route-collection.js:2:6:2:35 | (req, r ... og(req) |
+| src/route-collection.js:2:7:2:9 | req | src/route-collection.js:2:6:2:35 | (req, r ... og(req) |
 | src/route-collection.js:2:32:2:34 | req | src/route-collection.js:2:6:2:35 | (req, r ... og(req) |
+| src/route-collection.js:3:7:3:9 | req | src/route-collection.js:3:6:3:35 | (req, r ... og(req) |
 | src/route-collection.js:3:7:3:9 | req | src/route-collection.js:3:6:3:35 | (req, r ... og(req) |
 | src/route-collection.js:3:32:3:34 | req | src/route-collection.js:3:6:3:35 | (req, r ... og(req) |
 | src/route.js:5:21:5:23 | req | src/route.js:5:12:5:38 | functio ... ext) {} |
 test_RequestExprStandalone
+| typed_src/tst.ts:5:15:5:15 | x |
 | typed_src/tst.ts:5:15:5:15 | x |
 | typed_src/tst.ts:6:3:6:3 | x |
 test_RouteHandlerExpr_getAsSubRouter
@@ -2690,63 +2810,92 @@ test_Credentials
 | src/auth.js:4:39:4:48 | 'passw0rd' | password |
 test_RouteHandler_getARequestExpr
 | src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:6:7:6:9 | req |
+| src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:6:7:6:9 | req |
 | src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:6:32:6:34 | req |
+| src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:7:7:7:9 | req |
 | src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:7:7:7:9 | req |
 | src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:7:32:7:34 | req |
 | src/advanced-routehandler-registration.js:15:6:15:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:15:7:15:9 | req |
+| src/advanced-routehandler-registration.js:15:6:15:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:15:7:15:9 | req |
 | src/advanced-routehandler-registration.js:15:6:15:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:15:32:15:34 | req |
+| src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:16:7:16:9 | req |
 | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:16:7:16:9 | req |
 | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:16:32:16:34 | req |
 | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:7:24:9 | req |
+| src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:7:24:9 | req |
 | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:32:24:34 | req |
+| src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:7:25:9 | req |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:7:25:9 | req |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:32:25:34 | req |
 | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:20:46:22 | req |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:20:46:22 | req |
 | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:47:27:47:29 | req |
+| src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:46:20:46:22 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:46:20:46:22 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:47:27:47:29 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:10:51:12 | req |
+| src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:10:51:12 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:40:51:42 | req |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:20:59:22 | req |
 | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:20:59:22 | req |
 | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:60:18:60:20 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:59:20:59:22 | req |
+| src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:59:20:59:22 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:60:18:60:20 | req |
+| src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:10:64:12 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:10:64:12 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:45:64:47 | req |
 | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:13:68:15 | req |
+| src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:38:68:40 | req |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:38:68:40 | req |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:20:69:22 | req |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:20:69:22 | req |
 | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:70:18:70:20 | req |
+| src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:38:68:40 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:69:20:69:22 | req |
+| src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:69:20:69:22 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:70:18:70:20 | req |
+| src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:10:73:12 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:10:73:12 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:47:73:49 | req |
 | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:20:81:22 | req |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:20:81:22 | req |
 | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:82:27:82:29 | req |
+| src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:81:20:81:22 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:81:20:81:22 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:82:27:82:29 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:10:92:12 | req |
+| src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:10:92:12 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:40:92:42 | req |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:20:100:22 | req |
 | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:20:100:22 | req |
 | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:101:31:101:33 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:100:20:100:22 | req |
+| src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:100:20:100:22 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:101:31:101:33 | req |
+| src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:10:111:12 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:10:111:12 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:40:111:42 | req |
 | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:21:123:23 | req |
+| src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:21:123:23 | req |
 | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:46:123:48 | req |
+| src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:21:124:23 | req |
 | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:21:124:23 | req |
 | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:46:124:48 | req |
 | src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined | src/advanced-routehandler-registration.js:146:29:146:31 | req |
 | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:22:156:24 | req |
+| src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:22:156:24 | req |
 | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:47:156:49 | req |
+| src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:28:157:30 | req |
 | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:28:157:30 | req |
 | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:53:157:55 | req |
 | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined | src/controllers/handler-in-bulk-require.js:1:45:1:47 | req |
+| src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:20:28:20:30 | req |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:20:28:20:30 | req |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:22:35:22:37 | req |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:25:32:25:34 | req |
@@ -2755,21 +2904,27 @@ test_RouteHandler_getARequestExpr
 | src/csurf-example.js:40:27:40:48 | functio ... res) {} | src/csurf-example.js:40:37:40:39 | req |
 | src/exportedHandler.js:1:19:1:55 | functio ... res) {} | src/exportedHandler.js:1:44:1:46 | req |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:34:3:36 | req |
+| src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:34:3:36 | req |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:46:3:48 | req |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:41:4:47 | request |
+| src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:41:4:47 | request |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:60:4:66 | request |
+| src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:32:4:34 | req |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:32:4:34 | req |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:14:5:16 | req |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:35:5:37 | req |
 | src/express3.js:10:12:10:32 | functio ...  res){} | src/express3.js:10:22:10:24 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:32:4:34 | req |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:32:4:34 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:5:27:5:29 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:6:18:6:20 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:7:18:7:20 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:32:4:34 | req |
+| src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:32:4:34 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:5:16:5:18 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:26:6:28 | req |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:28:16:30 | req |
+| src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:39:22:41 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:39:22:41 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:23:3:23:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:24:3:24:5 | req |
@@ -2782,32 +2937,41 @@ test_RouteHandler_getARequestExpr
 | src/express.js:37:12:37:32 | functio ...  res){} | src/express.js:37:22:37:24 | req |
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:47:3:47:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:48:3:48:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:49:3:49:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req |
+| src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:5:20:5:22 | req |
 | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:5:20:5:22 | req |
 | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:6:5:6:7 | req |
 | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:7:5:7:7 | req |
 | src/middleware-flow.js:5:1:10:1 | functio ... xt();\\n} | src/middleware-flow.js:8:5:8:7 | req |
 | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:25:17:27 | req |
+| src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:17:25:17:27 | req |
 | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:18:9:18:11 | req |
 | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:19:9:19:11 | req |
 | src/middleware-flow.js:17:24:21:5 | (req, r ... ;\\n    } | src/middleware-flow.js:20:9:20:11 | req |
 | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:18:23:20 | req |
+| src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:18:23:20 | req |
 | src/middleware-flow.js:23:17:23:41 | (req, r ... q.db; } | src/middleware-flow.js:23:33:23:35 | req |
 | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:18:24:20 | req |
+| src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:18:24:20 | req |
 | src/middleware-flow.js:24:17:24:41 | (req, r ... q.db; } | src/middleware-flow.js:24:33:24:35 | req |
+| src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:24:39:26 | req |
 | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:39:24:39:26 | req |
 | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:40:5:40:7 | req |
 | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:41:5:41:7 | req |
 | src/middleware-flow.js:39:23:43:1 | (req, r ... s.db;\\n} | src/middleware-flow.js:42:5:42:7 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:19:4:21 | req |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:19:4:21 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:5:17:5:19 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:6:17:6:19 | req |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:33:14:35 | req |
+| src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:27:13:27:15 | req |
 | src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:27:13:27:15 | req |
 | src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:28:2:28:4 | req |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req |
@@ -2815,9 +2979,12 @@ test_RouteHandler_getARequestExpr
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:39:10:41 | req |
 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:13:32:13:34 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:16:39:16:41 | req |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:16:39:16:41 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:17:5:17:7 | req |
 | src/route-collection.js:2:6:2:35 | (req, r ... og(req) | src/route-collection.js:2:7:2:9 | req |
+| src/route-collection.js:2:6:2:35 | (req, r ... og(req) | src/route-collection.js:2:7:2:9 | req |
 | src/route-collection.js:2:6:2:35 | (req, r ... og(req) | src/route-collection.js:2:32:2:34 | req |
+| src/route-collection.js:3:6:3:35 | (req, r ... og(req) | src/route-collection.js:3:7:3:9 | req |
 | src/route-collection.js:3:6:3:35 | (req, r ... og(req) | src/route-collection.js:3:7:3:9 | req |
 | src/route-collection.js:3:6:3:35 | (req, r ... og(req) | src/route-collection.js:3:32:3:34 | req |
 | src/route.js:5:12:5:38 | functio ... ext) {} | src/route.js:5:21:5:23 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -769,49 +769,71 @@ test_RouterDefinition_getMiddlewareStackAt
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:13:1:13:0 | exit node of <toplevel> | src/subrouter.js:5:14:5:28 | makeSubRouter() |
 test_isRequest
 | src/advanced-routehandler-registration.js:6:7:6:9 | req |
+| src/advanced-routehandler-registration.js:6:7:6:9 | req |
 | src/advanced-routehandler-registration.js:6:32:6:34 | req |
+| src/advanced-routehandler-registration.js:7:7:7:9 | req |
 | src/advanced-routehandler-registration.js:7:7:7:9 | req |
 | src/advanced-routehandler-registration.js:7:32:7:34 | req |
 | src/advanced-routehandler-registration.js:15:7:15:9 | req |
+| src/advanced-routehandler-registration.js:15:7:15:9 | req |
 | src/advanced-routehandler-registration.js:15:32:15:34 | req |
+| src/advanced-routehandler-registration.js:16:7:16:9 | req |
 | src/advanced-routehandler-registration.js:16:7:16:9 | req |
 | src/advanced-routehandler-registration.js:16:32:16:34 | req |
 | src/advanced-routehandler-registration.js:24:7:24:9 | req |
+| src/advanced-routehandler-registration.js:24:7:24:9 | req |
 | src/advanced-routehandler-registration.js:24:32:24:34 | req |
+| src/advanced-routehandler-registration.js:25:7:25:9 | req |
 | src/advanced-routehandler-registration.js:25:7:25:9 | req |
 | src/advanced-routehandler-registration.js:25:32:25:34 | req |
 | src/advanced-routehandler-registration.js:46:20:46:22 | req |
+| src/advanced-routehandler-registration.js:46:20:46:22 | req |
 | src/advanced-routehandler-registration.js:47:27:47:29 | req |
+| src/advanced-routehandler-registration.js:51:10:51:12 | req |
 | src/advanced-routehandler-registration.js:51:10:51:12 | req |
 | src/advanced-routehandler-registration.js:51:40:51:42 | req |
 | src/advanced-routehandler-registration.js:59:20:59:22 | req |
+| src/advanced-routehandler-registration.js:59:20:59:22 | req |
 | src/advanced-routehandler-registration.js:60:18:60:20 | req |
+| src/advanced-routehandler-registration.js:64:10:64:12 | req |
 | src/advanced-routehandler-registration.js:64:10:64:12 | req |
 | src/advanced-routehandler-registration.js:64:45:64:47 | req |
 | src/advanced-routehandler-registration.js:68:13:68:15 | req |
+| src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:68:38:68:40 | req |
+| src/advanced-routehandler-registration.js:69:20:69:22 | req |
 | src/advanced-routehandler-registration.js:69:20:69:22 | req |
 | src/advanced-routehandler-registration.js:70:18:70:20 | req |
 | src/advanced-routehandler-registration.js:73:10:73:12 | req |
+| src/advanced-routehandler-registration.js:73:10:73:12 | req |
 | src/advanced-routehandler-registration.js:73:47:73:49 | req |
+| src/advanced-routehandler-registration.js:81:20:81:22 | req |
 | src/advanced-routehandler-registration.js:81:20:81:22 | req |
 | src/advanced-routehandler-registration.js:82:27:82:29 | req |
 | src/advanced-routehandler-registration.js:92:10:92:12 | req |
+| src/advanced-routehandler-registration.js:92:10:92:12 | req |
 | src/advanced-routehandler-registration.js:92:40:92:42 | req |
+| src/advanced-routehandler-registration.js:100:20:100:22 | req |
 | src/advanced-routehandler-registration.js:100:20:100:22 | req |
 | src/advanced-routehandler-registration.js:101:31:101:33 | req |
 | src/advanced-routehandler-registration.js:111:10:111:12 | req |
+| src/advanced-routehandler-registration.js:111:10:111:12 | req |
 | src/advanced-routehandler-registration.js:111:40:111:42 | req |
 | src/advanced-routehandler-registration.js:123:21:123:23 | req |
+| src/advanced-routehandler-registration.js:123:21:123:23 | req |
 | src/advanced-routehandler-registration.js:123:46:123:48 | req |
+| src/advanced-routehandler-registration.js:124:21:124:23 | req |
 | src/advanced-routehandler-registration.js:124:21:124:23 | req |
 | src/advanced-routehandler-registration.js:124:46:124:48 | req |
 | src/advanced-routehandler-registration.js:146:29:146:31 | req |
 | src/advanced-routehandler-registration.js:156:22:156:24 | req |
+| src/advanced-routehandler-registration.js:156:22:156:24 | req |
 | src/advanced-routehandler-registration.js:156:47:156:49 | req |
+| src/advanced-routehandler-registration.js:157:28:157:30 | req |
 | src/advanced-routehandler-registration.js:157:28:157:30 | req |
 | src/advanced-routehandler-registration.js:157:53:157:55 | req |
 | src/controllers/handler-in-bulk-require.js:1:45:1:47 | req |
+| src/csurf-example.js:20:28:20:30 | req |
 | src/csurf-example.js:20:28:20:30 | req |
 | src/csurf-example.js:22:35:22:37 | req |
 | src/csurf-example.js:25:32:25:34 | req |
@@ -820,21 +842,27 @@ test_isRequest
 | src/csurf-example.js:40:37:40:39 | req |
 | src/exportedHandler.js:1:44:1:46 | req |
 | src/express2.js:3:34:3:36 | req |
+| src/express2.js:3:34:3:36 | req |
 | src/express2.js:3:46:3:48 | req |
 | src/express2.js:4:41:4:47 | request |
+| src/express2.js:4:41:4:47 | request |
 | src/express2.js:4:60:4:66 | request |
+| src/express3.js:4:32:4:34 | req |
 | src/express3.js:4:32:4:34 | req |
 | src/express3.js:5:14:5:16 | req |
 | src/express3.js:5:35:5:37 | req |
 | src/express3.js:10:22:10:24 | req |
 | src/express4.js:4:32:4:34 | req |
+| src/express4.js:4:32:4:34 | req |
 | src/express4.js:5:27:5:29 | req |
 | src/express4.js:6:18:6:20 | req |
 | src/express4.js:7:18:7:20 | req |
 | src/express.js:4:32:4:34 | req |
+| src/express.js:4:32:4:34 | req |
 | src/express.js:5:16:5:18 | req |
 | src/express.js:6:26:6:28 | req |
 | src/express.js:16:28:16:30 | req |
+| src/express.js:22:39:22:41 | req |
 | src/express.js:22:39:22:41 | req |
 | src/express.js:23:3:23:5 | req |
 | src/express.js:24:3:24:5 | req |
@@ -847,32 +875,41 @@ test_isRequest
 | src/express.js:37:22:37:24 | req |
 | src/express.js:42:13:42:15 | req |
 | src/express.js:46:31:46:33 | req |
+| src/express.js:46:31:46:33 | req |
 | src/express.js:47:3:47:5 | req |
 | src/express.js:48:3:48:5 | req |
 | src/express.js:49:3:49:5 | req |
 | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:4:24:4:26 | req |
+| src/inheritedFromNode.js:4:24:4:26 | req |
 | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/middleware-flow.js:5:20:5:22 | req |
 | src/middleware-flow.js:5:20:5:22 | req |
 | src/middleware-flow.js:6:5:6:7 | req |
 | src/middleware-flow.js:7:5:7:7 | req |
 | src/middleware-flow.js:8:5:8:7 | req |
 | src/middleware-flow.js:17:25:17:27 | req |
+| src/middleware-flow.js:17:25:17:27 | req |
 | src/middleware-flow.js:18:9:18:11 | req |
 | src/middleware-flow.js:19:9:19:11 | req |
 | src/middleware-flow.js:20:9:20:11 | req |
 | src/middleware-flow.js:23:18:23:20 | req |
+| src/middleware-flow.js:23:18:23:20 | req |
 | src/middleware-flow.js:23:33:23:35 | req |
 | src/middleware-flow.js:24:18:24:20 | req |
+| src/middleware-flow.js:24:18:24:20 | req |
 | src/middleware-flow.js:24:33:24:35 | req |
+| src/middleware-flow.js:39:24:39:26 | req |
 | src/middleware-flow.js:39:24:39:26 | req |
 | src/middleware-flow.js:40:5:40:7 | req |
 | src/middleware-flow.js:41:5:41:7 | req |
 | src/middleware-flow.js:42:5:42:7 | req |
 | src/params.js:4:19:4:21 | req |
+| src/params.js:4:19:4:21 | req |
 | src/params.js:5:17:5:19 | req |
 | src/params.js:6:17:6:19 | req |
 | src/params.js:14:33:14:35 | req |
+| src/passport.js:27:13:27:15 | req |
 | src/passport.js:27:13:27:15 | req |
 | src/passport.js:28:2:28:4 | req |
 | src/responseExprs.js:4:32:4:34 | req |
@@ -880,9 +917,12 @@ test_isRequest
 | src/responseExprs.js:10:39:10:41 | req |
 | src/responseExprs.js:13:32:13:34 | req |
 | src/responseExprs.js:16:39:16:41 | req |
+| src/responseExprs.js:16:39:16:41 | req |
 | src/responseExprs.js:17:5:17:7 | req |
 | src/route-collection.js:2:7:2:9 | req |
+| src/route-collection.js:2:7:2:9 | req |
 | src/route-collection.js:2:32:2:34 | req |
+| src/route-collection.js:3:7:3:9 | req |
 | src/route-collection.js:3:7:3:9 | req |
 | src/route-collection.js:3:32:3:34 | req |
 | src/route.js:5:21:5:23 | req |
@@ -1560,85 +1600,6 @@ test_RouteSetup_getRequestMethod
 | src/routesetups.js:12:1:12:16 | root.post('', h) | POST |
 | src/subrouter.js:9:3:9:35 | router. ... ndler1) | POST |
 | src/subrouter.js:10:3:10:41 | router. ... ndler2) | POST |
-test_RouteExpr
-| src/advanced-routehandler-registration.js:10:3:10:24 | app.get ... es0[p]) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:19:3:19:18 | app.use(handler) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:28:3:28:24 | app.get ... es2[p]) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:37:3:37:12 | app.use(h) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:51:1:51:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:64:1:64:54 | app.use ... , res)) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:73:1:73:56 | app.use ... , res)) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:92:1:92:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:111:1:111:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:116:3:116:31 | app.get ... tes[p]) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:118:1:118:30 | app.get ... utes.a) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:119:1:119:30 | app.get ... utes.b) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:125:29:125:41 | app.get(k, v) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:126:1:126:32 | app.get ... t("a")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:127:1:127:32 | app.get ... t("b")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:135:2:135:53 | app.get ... andler) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:144:1:144:32 | app.use ... , args) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:147:1:147:37 | app.use ... (data)) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:150:2:150:14 | app.get(k, v) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:153:1:153:41 | app.get ... KEY!")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:160:1:160:33 | app.get ... t("c")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:161:1:161:39 | app.get ... own())) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:162:1:162:23 | app.get ... nown()) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/advanced-routehandler-registration.js:163:1:163:33 | app.get ... t("f")) | src/advanced-routehandler-registration.js:2:11:2:19 | express() |
-| src/auth.js:4:1:4:53 | app.use ... d' }})) | src/auth.js:1:13:1:32 | require('express')() |
-| src/csurf-example.js:13:1:13:20 | app.use('/api', api) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:16:1:16:51 | app.use ... lse })) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:17:1:17:23 | app.use ... rser()) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:18:1:18:31 | app.use ... rue })) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:20:1:23:2 | app.get ... ) })\\n}) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:25:1:27:2 | app.pos ... re')\\n}) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:32:3:34:4 | router. ... ')\\n  }) | src/csurf-example.js:30:16:30:35 | new express.Router() |
-| src/csurf-example.js:39:1:39:48 | app.get ... es) {}) | src/csurf-example.js:7:11:7:19 | express() |
-| src/csurf-example.js:40:1:40:49 | app.pos ... es) {}) | src/csurf-example.js:7:11:7:19 | express() |
-| src/express2.js:2:14:2:23 | e.Router() | src/express2.js:2:14:2:23 | e.Router() |
-| src/express2.js:3:1:3:56 | router. ...  res }) | src/express2.js:2:14:2:23 | e.Router() |
-| src/express2.js:3:1:4:77 | router. ... sult }) | src/express2.js:2:14:2:23 | e.Router() |
-| src/express2.js:6:1:6:15 | app.use(router) | src/express2.js:5:11:5:13 | e() |
-| src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:2:11:2:19 | express() |
-| src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:2:11:2:19 | express() |
-| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:2:11:2:19 | express() |
-| src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() |
-| src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() |
-| src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
-| src/express.js:34:1:34:53 | app.get ... andler) | src/express.js:2:11:2:19 | express() |
-| src/express.js:39:1:39:21 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
-| src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
-| src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
-| src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
-| src/middleware-flow.js:13:5:13:25 | router. ... tallDb) | src/middleware-flow.js:2:13:2:21 | express() |
-| src/middleware-flow.js:17:5:21:6 | router. ... \\n    }) | src/middleware-flow.js:2:13:2:21 | express() |
-| src/middleware-flow.js:27:9:27:33 | router. ... ers[p]) | src/middleware-flow.js:2:13:2:21 | express() |
-| src/middleware-flow.js:39:1:43:2 | unrelat ... .db;\\n}) | src/middleware-flow.js:37:22:37:30 | express() |
-| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
-| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:1:12:2 | app.par ...    }\\n}) |
-| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
-| src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
-| src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
-| src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
-| src/responseExprs.js:13:1:15:2 | app.get ... es4;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
-| src/responseExprs.js:16:1:42:2 | app.pos ...    }\\n}) | src/responseExprs.js:2:11:2:19 | express() |
-| src/route.js:2:14:2:29 | express.Router() | src/route.js:2:14:2:29 | express.Router() |
-| src/route.js:4:1:4:31 | router. ... er_id') | src/route.js:2:14:2:29 | express.Router() |
-| src/route.js:4:1:5:39 | router. ... xt) {}) | src/route.js:2:14:2:29 | express.Router() |
-| src/routesetups.js:3:1:3:16 | express.Router() | src/routesetups.js:3:1:3:16 | express.Router() |
-| src/routesetups.js:3:1:4:14 | express ... ('', h) | src/routesetups.js:3:1:3:16 | express.Router() |
-| src/routesetups.js:3:1:5:12 | express ... ('', h) | src/routesetups.js:3:1:3:16 | express.Router() |
-| src/routesetups.js:7:11:7:32 | express ... erver() | src/routesetups.js:7:11:7:32 | express ... erver() |
-| src/routesetups.js:8:1:8:12 | app.error(h) | src/routesetups.js:7:11:7:32 | express ... erver() |
-| src/routesetups.js:10:14:10:29 | express.Router() | src/routesetups.js:10:14:10:29 | express.Router() |
-| src/routesetups.js:11:12:11:28 | router.route('/') | src/routesetups.js:10:14:10:29 | express.Router() |
-| src/routesetups.js:12:1:12:16 | root.post('', h) | src/routesetups.js:10:14:10:29 | express.Router() |
-| src/subrouter.js:4:1:4:26 | app.use ... rotect) | src/subrouter.js:2:11:2:19 | express() |
-| src/subrouter.js:5:1:5:29 | app.use ... uter()) | src/subrouter.js:2:11:2:19 | express() |
-| src/subrouter.js:8:16:8:31 | express.Router() | src/subrouter.js:8:16:8:31 | express.Router() |
-| src/subrouter.js:9:3:9:35 | router. ... ndler1) | src/subrouter.js:8:16:8:31 | express.Router() |
-| src/subrouter.js:10:3:10:41 | router. ... ndler2) | src/subrouter.js:8:16:8:31 | express.Router() |
 test_RouteHandler_getAResponseExpr
 | src/advanced-routehandler-registration.js:6:6:6:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:6:12:6:14 | res |
 | src/advanced-routehandler-registration.js:7:6:7:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:7:12:7:14 | res |
@@ -1840,24 +1801,34 @@ test_isResponse
 | src/advanced-routehandler-registration.js:24:12:24:14 | res |
 | src/advanced-routehandler-registration.js:25:12:25:14 | res |
 | src/advanced-routehandler-registration.js:46:25:46:27 | res |
+| src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:47:32:47:34 | res |
+| src/advanced-routehandler-registration.js:51:15:51:17 | res |
 | src/advanced-routehandler-registration.js:51:15:51:17 | res |
 | src/advanced-routehandler-registration.js:51:45:51:47 | res |
 | src/advanced-routehandler-registration.js:59:25:59:27 | res |
+| src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:60:23:60:25 | res |
+| src/advanced-routehandler-registration.js:64:15:64:17 | res |
 | src/advanced-routehandler-registration.js:64:15:64:17 | res |
 | src/advanced-routehandler-registration.js:64:50:64:52 | res |
 | src/advanced-routehandler-registration.js:68:18:68:20 | res |
 | src/advanced-routehandler-registration.js:69:25:69:27 | res |
+| src/advanced-routehandler-registration.js:69:25:69:27 | res |
 | src/advanced-routehandler-registration.js:70:23:70:25 | res |
+| src/advanced-routehandler-registration.js:73:15:73:17 | res |
 | src/advanced-routehandler-registration.js:73:15:73:17 | res |
 | src/advanced-routehandler-registration.js:73:52:73:54 | res |
 | src/advanced-routehandler-registration.js:81:25:81:27 | res |
+| src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:82:32:82:34 | res |
+| src/advanced-routehandler-registration.js:92:15:92:17 | res |
 | src/advanced-routehandler-registration.js:92:15:92:17 | res |
 | src/advanced-routehandler-registration.js:92:45:92:47 | res |
 | src/advanced-routehandler-registration.js:100:25:100:27 | res |
+| src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:101:36:101:38 | res |
+| src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/advanced-routehandler-registration.js:111:45:111:47 | res |
 | src/advanced-routehandler-registration.js:123:26:123:28 | res |
@@ -1867,10 +1838,13 @@ test_isResponse
 | src/advanced-routehandler-registration.js:157:33:157:35 | res |
 | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res |
 | src/csurf-example.js:20:33:20:35 | res |
+| src/csurf-example.js:20:33:20:35 | res |
 | src/csurf-example.js:22:3:22:5 | res |
+| src/csurf-example.js:25:37:25:39 | res |
 | src/csurf-example.js:25:37:25:39 | res |
 | src/csurf-example.js:26:3:26:5 | res |
 | src/csurf-example.js:26:3:26:43 | res.sen ...  here') |
+| src/csurf-example.js:32:45:32:47 | res |
 | src/csurf-example.js:32:45:32:47 | res |
 | src/csurf-example.js:33:5:33:7 | res |
 | src/csurf-example.js:33:5:33:35 | res.sen ...  here') |
@@ -1878,11 +1852,14 @@ test_isResponse
 | src/csurf-example.js:40:42:40:44 | res |
 | src/exportedHandler.js:1:49:1:51 | res |
 | src/express2.js:3:39:3:41 | res |
+| src/express2.js:3:39:3:41 | res |
 | src/express2.js:3:46:3:53 | req, res |
 | src/express2.js:3:51:3:53 | res |
 | src/express2.js:4:50:4:55 | result |
+| src/express2.js:4:50:4:55 | result |
 | src/express2.js:4:60:4:74 | request, result |
 | src/express2.js:4:69:4:74 | result |
+| src/express3.js:4:37:4:39 | res |
 | src/express3.js:4:37:4:39 | res |
 | src/express3.js:5:3:5:5 | res |
 | src/express3.js:5:3:5:51 | res.hea ... "val")) |
@@ -1890,8 +1867,10 @@ test_isResponse
 | src/express3.js:6:3:6:17 | res.send("val") |
 | src/express3.js:10:27:10:29 | res |
 | src/express4.js:4:37:4:39 | res |
+| src/express4.js:4:37:4:39 | res |
 | src/express4.js:8:3:8:5 | res |
 | src/express4.js:8:3:8:20 | res.send(dynamic1) |
+| src/express.js:4:37:4:39 | res |
 | src/express.js:4:37:4:39 | res |
 | src/express.js:5:3:5:5 | res |
 | src/express.js:6:3:6:5 | res |
@@ -1900,17 +1879,21 @@ test_isResponse
 | src/express.js:7:3:7:42 | res.hea ... plain") |
 | src/express.js:8:7:8:9 | res |
 | src/express.js:11:14:11:16 | arg |
+| src/express.js:11:14:11:16 | arg |
 | src/express.js:12:3:12:5 | arg |
 | src/express.js:12:3:12:54 | arg.hea ... , true) |
 | src/express.js:16:33:16:35 | res |
+| src/express.js:16:33:16:35 | res |
 | src/express.js:17:5:17:7 | res |
 | src/express.js:17:5:17:24 | res.send("Go away.") |
+| src/express.js:22:44:22:46 | res |
 | src/express.js:22:44:22:46 | res |
 | src/express.js:31:3:31:5 | res |
 | src/express.js:31:3:31:26 | res.coo ...  'bar') |
 | src/express.js:37:27:37:29 | res |
 | src/express.js:42:18:42:20 | res |
 | src/express.js:46:36:46:38 | res |
+| src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:6:2:6:4 | res |
@@ -1920,19 +1903,26 @@ test_isResponse
 | src/middleware-flow.js:24:23:24:25 | res |
 | src/middleware-flow.js:39:29:39:31 | res |
 | src/params.js:4:24:4:26 | res |
+| src/params.js:4:24:4:26 | res |
 | src/params.js:8:9:8:11 | res |
 | src/params.js:8:9:8:23 | res.send(value) |
+| src/params.js:14:38:14:40 | res |
 | src/params.js:14:38:14:40 | res |
 | src/params.js:15:3:15:5 | res |
 | src/params.js:15:3:15:19 | res.send("Hello") |
 | src/responseExprs.js:4:37:4:40 | res1 |
+| src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:5:5:5:8 | res1 |
+| src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:8:5:8:8 | res2 |
 | src/responseExprs.js:10:44:10:47 | res3 |
+| src/responseExprs.js:10:44:10:47 | res3 |
 | src/responseExprs.js:11:5:11:8 | res3 |
 | src/responseExprs.js:13:37:13:40 | res4 |
+| src/responseExprs.js:13:37:13:40 | res4 |
 | src/responseExprs.js:14:5:14:8 | res4 |
+| src/responseExprs.js:16:44:16:46 | res |
 | src/responseExprs.js:16:44:16:46 | res |
 | src/responseExprs.js:19:5:19:7 | res |
 | src/responseExprs.js:19:5:19:16 | res.append() |
@@ -1971,6 +1961,8 @@ test_isResponse
 | src/responseExprs.js:37:5:37:28 | f(res.a ... ppend() |
 | src/responseExprs.js:37:7:37:9 | res |
 | src/responseExprs.js:37:7:37:18 | res.append() |
+| src/responseExprs.js:39:5:41:5 | return of function f |
+| src/responseExprs.js:39:16:39:21 | resArg |
 | src/responseExprs.js:39:16:39:21 | resArg |
 | src/responseExprs.js:40:16:40:21 | resArg |
 | src/responseExprs.js:40:16:40:30 | resArg.append() |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.ql
@@ -27,7 +27,6 @@ import RouterDefinition_getASubRouter
 import HeaderDefinition_getNameExpr
 import appCreation
 import RouteSetup_getRequestMethod
-import RouteExpr
 import RouteHandler_getAResponseExpr
 import isResponse
 import ResponseBody

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getNameExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/HeaderDefinition_getNameExpr.qll
@@ -1,5 +1,7 @@
 import javascript
 
-query predicate test_HeaderDefinition_getNameExpr(HTTP::ExplicitHeaderDefinition hd, Expr res) {
-  hd.getRouteHandler() instanceof NodeJSLib::RouteHandler and res = hd.getNameExpr()
+query predicate test_HeaderDefinition_getNameExpr(
+  HTTP::ExplicitHeaderDefinition hd, DataFlow::Node res
+) {
+  hd.getRouteHandler() instanceof NodeJSLib::RouteHandler and res = hd.getNameNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(NodeJSLib::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(NodeJSLib::RequestNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(NodeJSLib::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(NodeJSLib::ResponseNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler(NodeJSLib::RouteHandler rh, Expr res) { res = rh.getServer() }
+query predicate test_RouteHandler(NodeJSLib::RouteHandler rh, DataFlow::Node res) {
+  res = rh.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler_getARequestExpr(NodeJSLib::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(NodeJSLib::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteHandler_getAResponseExpr.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RouteHandler_getAResponseExpr(
-  NodeJSLib::RouteHandler rh, HTTP::ResponseExpr res
+  NodeJSLib::RouteHandler rh, HTTP::ResponseNode res
 ) {
-  res = rh.getAResponseExpr()
+  res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/RouteSetup_getServer.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getServer(NodeJSLib::RouteSetup r, Expr res) { res = r.getServer() }
+query predicate test_RouteSetup_getServer(NodeJSLib::RouteSetup r, DataFlow::Node res) {
+  res = r.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/isCreateServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/isCreateServer.qll
@@ -1,3 +1,3 @@
 import javascript
 
-query predicate test_isCreateServer(CallExpr e) { NodeJSLib::isCreateServer(e) }
+query predicate test_isCreateServer(DataFlow::CallNode e) { NodeJSLib::isCreateServer(e) }

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -45,9 +45,12 @@ test_ResponseExpr
 | createServer.js:3:38:3:40 | res | createServer.js:3:23:3:44 | functio ... res) {} |
 | createServer.js:4:37:4:39 | res | createServer.js:4:31:4:46 | (req, res) => {} |
 | createServer.js:25:52:25:54 | res | createServer.js:25:37:27:5 | functio ... ;\\n    } |
+| createServer.js:25:52:25:54 | res | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | createServer.js:26:9:26:11 | res | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | src/http.js:4:46:4:48 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
+| src/http.js:4:46:4:48 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:7:3:7:5 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
+| src/http.js:12:33:12:35 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:12:33:12:35 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:13:3:13:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:14:3:14:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -55,32 +58,47 @@ test_ResponseExpr
 | src/http.js:55:25:55:27 | res | src/http.js:55:12:55:30 | function(req,res){} |
 | src/http.js:60:27:60:29 | res | src/http.js:60:14:60:32 | function(req,res){} |
 | src/http.js:62:33:62:35 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:62:33:62:35 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:63:3:63:5 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:64:3:64:5 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:68:17:68:19 | res | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/http.js:72:34:72:36 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
+| src/http.js:72:34:72:36 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
+| src/http.js:72:34:72:36 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
+| src/http.js:73:18:73:17 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
 | src/http.js:74:5:74:7 | res | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
 | src/http.js:81:46:81:48 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:81:46:81:48 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:81:46:81:48 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:82:18:82:17 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/http.js:83:5:83:7 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/http.js:85:3:85:5 | res | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/https.js:4:47:4:49 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
+| src/https.js:4:47:4:49 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:7:3:7:5 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
+| src/https.js:12:34:12:36 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:12:34:12:36 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:13:3:13:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:14:3:14:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:3:15:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/indirect2.js:9:19:9:21 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:9:19:9:21 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:10:47:10:49 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:13:33:13:35 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:13:33:13:35 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:13:33:13:35 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect2.js:13:33:13:35 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect2.js:14:3:14:5 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:14:3:14:5 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect2.js:15:3:15:5 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:15:3:15:5 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:16:26:16:28 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:16:26:16:28 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:19:38:19:40 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:25:30:25:32 | res | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:25:30:25:32 | res | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
 | src/indirect.js:26:5:26:7 | res | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:28:29:28:31 | res | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 | src/indirect.js:28:29:28:31 | res | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 | src/indirect.js:29:5:29:7 | res | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 test_HeaderDefinition
@@ -150,9 +168,12 @@ test_RouteHandler_getAResponseExpr
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:38:3:40 | res |
 | createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:37:4:39 | res |
 | createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:25:52:25:54 | res |
+| createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:25:52:25:54 | res |
 | createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:26:9:26:11 | res |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:46:4:48 | res |
+| src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:46:4:48 | res |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:7:3:7:5 | res |
+| src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:33:12:35 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:33:12:35 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:13:3:13:5 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:14:3:14:5 | res |
@@ -160,32 +181,47 @@ test_RouteHandler_getAResponseExpr
 | src/http.js:55:12:55:30 | function(req,res){} | src/http.js:55:25:55:27 | res |
 | src/http.js:60:14:60:32 | function(req,res){} | src/http.js:60:27:60:29 | res |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:33:62:35 | res |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:33:62:35 | res |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:63:3:63:5 | res |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:64:3:64:5 | res |
 | src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:68:17:68:19 | res |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:34:72:36 | res |
+| src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:34:72:36 | res |
+| src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:34:72:36 | res |
+| src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:73:18:73:17 | res |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:74:5:74:7 | res |
 | src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:46:81:48 | res |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:46:81:48 | res |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:46:81:48 | res |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:82:18:82:17 | res |
 | src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:83:5:83:7 | res |
 | src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:85:3:85:5 | res |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:47:4:49 | res |
+| src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:47:4:49 | res |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:7:3:7:5 | res |
+| src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:34:12:36 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:34:12:36 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:13:3:13:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:14:3:14:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:15:3:15:5 | res |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:9:19:9:21 | res |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:9:19:9:21 | res |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:10:47:10:49 | res |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:13:33:13:35 | res |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:13:33:13:35 | res |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:14:3:14:5 | res |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:15:3:15:5 | res |
 | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:13:33:13:35 | res |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:13:33:13:35 | res |
 | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:14:3:14:5 | res |
 | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:15:3:15:5 | res |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:26:16:28 | res |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:26:16:28 | res |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:38:19:40 | res |
 | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:25:30:25:32 | res |
+| src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:25:30:25:32 | res |
 | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:26:5:26:7 | res |
+| src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:28:29:28:31 | res |
 | src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:28:29:28:31 | res |
 | src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:29:5:29:7 | res |
 test_ServerDefinition_getARouteHandler
@@ -294,6 +330,7 @@ test_RequestExpr
 | createServer.js:4:32:4:34 | req | createServer.js:4:31:4:46 | (req, res) => {} |
 | createServer.js:25:47:25:49 | req | createServer.js:25:37:27:5 | functio ... ;\\n    } |
 | src/http.js:4:41:4:43 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
+| src/http.js:4:41:4:43 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:6:26:6:28 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:8:3:8:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:9:3:9:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
@@ -301,22 +338,28 @@ test_RequestExpr
 | src/http.js:55:21:55:23 | req | src/http.js:55:12:55:30 | function(req,res){} |
 | src/http.js:60:23:60:25 | req | src/http.js:60:14:60:32 | function(req,res){} |
 | src/http.js:62:28:62:30 | req | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:62:28:62:30 | req | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:63:17:63:19 | req | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:68:13:68:15 | req | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/http.js:72:29:72:31 | req | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
+| src/http.js:72:29:72:31 | req | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
 | src/http.js:73:3:73:5 | req | src/http.js:72:19:76:1 | functio ... \\n  })\\n} |
 | src/http.js:81:41:81:43 | req | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/http.js:81:41:81:43 | req | src/http.js:81:22:86:1 | functio ... la");\\n} |
 | src/http.js:82:3:82:5 | req | src/http.js:81:22:86:1 | functio ... la");\\n} |
+| src/https.js:4:42:4:44 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:4:42:4:44 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:6:26:6:28 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:8:3:8:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:9:3:9:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:29:12:31 | req | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/indirect2.js:9:14:9:16 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:9:14:9:16 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:10:12:10:14 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:10:42:10:44 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:13:28:13:30 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:13:28:13:30 | req | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
+| src/indirect.js:16:21:16:23 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:16:21:16:23 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:17:28:17:30 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:19:33:19:35 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
@@ -337,6 +380,7 @@ test_RouteHandler_getARequestExpr
 | createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:32:4:34 | req |
 | createServer.js:25:37:27:5 | functio ... ;\\n    } | createServer.js:25:47:25:49 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:41:4:43 | req |
+| src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:41:4:43 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:6:26:6:28 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:8:3:8:5 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:9:3:9:5 | req |
@@ -344,22 +388,28 @@ test_RouteHandler_getARequestExpr
 | src/http.js:55:12:55:30 | function(req,res){} | src/http.js:55:21:55:23 | req |
 | src/http.js:60:14:60:32 | function(req,res){} | src/http.js:60:23:60:25 | req |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:28:62:30 | req |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:28:62:30 | req |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:63:17:63:19 | req |
 | src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:68:13:68:15 | req |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:29:72:31 | req |
+| src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:72:29:72:31 | req |
 | src/http.js:72:19:76:1 | functio ... \\n  })\\n} | src/http.js:73:3:73:5 | req |
 | src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:41:81:43 | req |
+| src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:81:41:81:43 | req |
 | src/http.js:81:22:86:1 | functio ... la");\\n} | src/http.js:82:3:82:5 | req |
+| src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:42:4:44 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:42:4:44 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:6:26:6:28 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:8:3:8:5 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:9:3:9:5 | req |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:29:12:31 | req |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:9:14:9:16 | req |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:9:14:9:16 | req |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:10:12:10:14 | req |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:10:42:10:44 | req |
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:13:28:13:30 | req |
 | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:13:28:13:30 | req |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:21:16:23 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:21:16:23 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:17:28:17:30 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:33:19:35 | req |

--- a/javascript/ql/test/library-tests/frameworks/SQL/Credentials.ql
+++ b/javascript/ql/test/library-tests/frameworks/SQL/Credentials.ql
@@ -1,4 +1,4 @@
 import javascript
 
-from CredentialsExpr ce
+from CredentialsNode ce
 select ce, ce.getCredentialsKind()

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.expected
@@ -9,6 +9,7 @@ test_RouteSetup
 | src/test.js:32:1:35:2 | app.use ... rl);\\n}) |
 test_RequestInputAccess
 | src/test.js:8:5:8:26 | req.coo ... ('foo') | cookie | src/test.js:6:9:9:1 | functio ... oo');\\n} |
+| src/test.js:28:20:28:22 | url | url | src/test.js:28:9:30:1 | functio ... bar);\\n} |
 | src/test.js:33:15:33:21 | req.url | url | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_RouteHandler_getAResponseHeader
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | header1 | src/test.js:7:5:7:32 | res.set ... 1', '') |
@@ -18,13 +19,16 @@ test_HeaderDefinition_defines
 | src/test.js:25:5:25:32 | res.set ... 2', '') | header2 |  |
 test_ResponseExpr
 | src/test.js:6:32:6:34 | res | src/test.js:6:9:9:1 | functio ... oo');\\n} |
+| src/test.js:6:32:6:34 | res | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:7:5:7:7 | res | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:15:27:15:29 | res | src/test.js:15:12:15:32 | functio ...  res){} |
 | src/test.js:19:22:19:24 | res | src/test.js:19:9:19:27 | function(req,res){} |
 | src/test.js:20:23:20:25 | res | src/test.js:20:10:20:28 | function(req,res){} |
 | src/test.js:24:31:24:33 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
+| src/test.js:24:31:24:33 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:25:5:25:7 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:28:42:28:44 | res | src/test.js:28:9:30:1 | functio ... bar);\\n} |
+| src/test.js:32:24:32:26 | res | src/test.js:32:9:35:1 | functio ... url);\\n} |
 | src/test.js:32:24:32:26 | res | src/test.js:32:9:35:1 | functio ... url);\\n} |
 | src/test.js:34:5:34:7 | res | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_HeaderDefinition
@@ -46,13 +50,16 @@ test_ServerDefinition
 | src/test.js:4:11:4:19 | connect() |
 test_RouteHandler_getAResponseExpr
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:6:32:6:34 | res |
+| src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:6:32:6:34 | res |
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:7:5:7:7 | res |
 | src/test.js:15:12:15:32 | functio ...  res){} | src/test.js:15:27:15:29 | res |
 | src/test.js:19:9:19:27 | function(req,res){} | src/test.js:19:22:19:24 | res |
 | src/test.js:20:10:20:28 | function(req,res){} | src/test.js:20:23:20:25 | res |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:31:24:33 | res |
+| src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:31:24:33 | res |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:25:5:25:7 | res |
 | src/test.js:28:9:30:1 | functio ... bar);\\n} | src/test.js:28:42:28:44 | res |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:32:24:32:26 | res |
 | src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:32:24:32:26 | res |
 | src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:34:5:34:7 | res |
 test_RouteSetup_getARouteHandler
@@ -76,6 +83,7 @@ test_RouteHandler
 | src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:4:11:4:19 | connect() |
 test_RequestExpr
 | src/test.js:6:27:6:29 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
+| src/test.js:6:27:6:29 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:8:5:8:7 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:15:22:15:24 | req | src/test.js:15:12:15:32 | functio ...  res){} |
 | src/test.js:19:18:19:20 | req | src/test.js:19:9:19:27 | function(req,res){} |
@@ -83,11 +91,13 @@ test_RequestExpr
 | src/test.js:24:26:24:28 | req | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:28:19:28:39 | {url, q ... ookies} | src/test.js:28:9:30:1 | functio ... bar);\\n} |
 | src/test.js:32:19:32:21 | req | src/test.js:32:9:35:1 | functio ... url);\\n} |
+| src/test.js:32:19:32:21 | req | src/test.js:32:9:35:1 | functio ... url);\\n} |
 | src/test.js:33:15:33:17 | req | src/test.js:32:9:35:1 | functio ... url);\\n} |
 test_Credentials
 | src/test.js:12:19:12:28 | 'username' | user name |
 | src/test.js:12:31:12:40 | 'password' | password |
 test_RouteHandler_getARequestExpr
+| src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:6:27:6:29 | req |
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:6:27:6:29 | req |
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:8:5:8:7 | req |
 | src/test.js:15:12:15:32 | functio ...  res){} | src/test.js:15:22:15:24 | req |
@@ -95,5 +105,6 @@ test_RouteHandler_getARequestExpr
 | src/test.js:20:10:20:28 | function(req,res){} | src/test.js:20:19:20:21 | req |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:26:24:28 | req |
 | src/test.js:28:9:30:1 | functio ... bar);\\n} | src/test.js:28:19:28:39 | {url, q ... ookies} |
+| src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:32:19:32:21 | req |
 | src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:32:19:32:21 | req |
 | src/test.js:32:9:35:1 | functio ... url);\\n} | src/test.js:33:15:33:17 | req |

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.ql
@@ -26,7 +26,9 @@ query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Connect::RouteH
   rh = hd.getRouteHandler()
 }
 
-query predicate test_RouteSetup_getServer(Connect::RouteSetup rs, Expr res) { res = rs.getServer() }
+query predicate test_RouteSetup_getServer(Connect::RouteSetup rs, DataFlow::Node res) {
+  res = rs.getServer()
+}
 
 query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
   hd.getRouteHandler() instanceof Connect::RouteHandler and res = hd.getAHeaderName()
@@ -42,7 +44,9 @@ query predicate test_RouteSetup_getARouteHandler(Connect::RouteSetup r, DataFlow
   res = r.getARouteHandler()
 }
 
-query predicate test_RouteHandler(Connect::RouteHandler rh, Expr res) { res = rh.getServer() }
+query predicate test_RouteHandler(Connect::RouteHandler rh, DataFlow::Node res) {
+  res = rh.getServer()
+}
 
 query predicate test_RequestExpr(HTTP::RequestExpr e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.ql
@@ -18,7 +18,7 @@ query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string 
   hd.defines(name, value) and hd.getRouteHandler() instanceof Connect::RouteHandler
 }
 
-query predicate test_ResponseExpr(HTTP::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(HTTP::ResponseNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }
 
@@ -36,8 +36,8 @@ query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, 
 
 query predicate test_ServerDefinition(Connect::ServerDefinition s) { any() }
 
-query predicate test_RouteHandler_getAResponseExpr(Connect::RouteHandler rh, HTTP::ResponseExpr res) {
-  res = rh.getAResponseExpr()
+query predicate test_RouteHandler_getAResponseExpr(Connect::RouteHandler rh, HTTP::ResponseNode res) {
+  res = rh.getAResponseNode()
 }
 
 query predicate test_RouteSetup_getARouteHandler(Connect::RouteSetup r, DataFlow::SourceNode res) {
@@ -48,7 +48,7 @@ query predicate test_RouteHandler(Connect::RouteHandler rh, DataFlow::Node res) 
   res = rh.getServer()
 }
 
-query predicate test_RequestExpr(HTTP::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(HTTP::RequestNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }
 
@@ -56,6 +56,6 @@ query predicate test_Credentials(Connect::Credentials cr, string res) {
   res = cr.getCredentialsKind()
 }
 
-query predicate test_RouteHandler_getARequestExpr(Connect::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(Connect::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler(Fastify::RouteHandler rh, Expr res) { res = rh.getServer() }
+query predicate test_RouteHandler(Fastify::RouteHandler rh, DataFlow::Node res) {
+  res = rh.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Fastify::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(Fastify::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup_getServer.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getServer(Fastify::RouteSetup rs, Expr res) { res = rs.getServer() }
+query predicate test_RouteSetup_getServer(Fastify::RouteSetup rs, DataFlow::Node res) {
+  res = rs.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
@@ -97,22 +97,27 @@ test_RouteHandler_getARequestExpr
 | src/fastify.js:20:26:20:47 | (reques ... ) => {} | src/fastify.js:20:27:20:33 | request |
 | src/fastify.js:26:17:28:3 | (reques ... nse\\n  } | src/fastify.js:26:18:26:24 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:34:26:34:32 | request |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:34:26:34:32 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:36:5:36:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:37:5:37:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:38:5:38:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:39:5:39:11 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:54:26:54:32 | request |
+| src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:54:26:54:32 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:55:5:55:11 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:56:5:56:11 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:57:5:57:11 | request |
+| src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:65:26:65:32 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:65:26:65:32 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:66:5:66:11 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:67:5:67:11 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:68:5:68:11 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:76:26:76:32 | request |
+| src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:76:26:76:32 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:77:5:77:11 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:78:5:78:11 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:79:5:79:11 | request |
+| src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:87:26:87:32 | request |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:87:26:87:32 | request |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:88:5:88:11 | request |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:89:5:89:11 | request |

--- a/javascript/ql/test/library-tests/frameworks/hapi/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Hapi::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Hapi::RequestNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Hapi::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Hapi::ResponseNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler(Hapi::RouteHandler rh, Expr res) { res = rh.getServer() }
+query predicate test_RouteHandler(Hapi::RouteHandler rh, DataFlow::Node res) {
+  res = rh.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Hapi::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(Hapi::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/hapi/RouteSetup_getServer.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getServer(Hapi::RouteSetup rs, Expr res) { res = rs.getServer() }
+query predicate test_RouteSetup_getServer(Hapi::RouteSetup rs, DataFlow::Node res) {
+  res = rs.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/hapi/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/tests.expected
@@ -48,8 +48,10 @@ test_RouteHandler
 | src/hapi.js:34:12:34:30 | function (req, h){} | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 test_RequestExpr
 | src/hapi.js:13:32:13:38 | request | src/hapi.js:13:14:15:5 | functio ... n\\n    } |
+| src/hapi.js:13:32:13:38 | request | src/hapi.js:13:14:15:5 | functio ... n\\n    } |
 | src/hapi.js:14:9:14:15 | request | src/hapi.js:13:14:15:5 | functio ... n\\n    } |
 | src/hapi.js:17:48:17:54 | request | src/hapi.js:17:30:18:1 | functio ... ndler\\n} |
+| src/hapi.js:20:19:20:25 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:20:19:20:25 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:21:3:21:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:22:3:22:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
@@ -60,8 +62,10 @@ test_RequestExpr
 | src/hapi.js:34:22:34:24 | req | src/hapi.js:34:12:34:30 | function (req, h){} |
 test_RouteHandler_getARequestExpr
 | src/hapi.js:13:14:15:5 | functio ... n\\n    } | src/hapi.js:13:32:13:38 | request |
+| src/hapi.js:13:14:15:5 | functio ... n\\n    } | src/hapi.js:13:32:13:38 | request |
 | src/hapi.js:13:14:15:5 | functio ... n\\n    } | src/hapi.js:14:9:14:15 | request |
 | src/hapi.js:17:30:18:1 | functio ... ndler\\n} | src/hapi.js:17:48:17:54 | request |
+| src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:20:19:20:25 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:20:19:20:25 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:21:3:21:9 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:22:3:22:9 | request |

--- a/javascript/ql/test/library-tests/frameworks/koa/ContextExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/ContextExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ContextExpr(Koa::ContextExpr e, Koa::RouteHandler res) {
+query predicate test_ContextExpr(Koa::ContextNode e, Koa::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RedirectInvocation.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_RedirectInvocation(
-  HTTP::RedirectInvocation redirect, Expr url, HTTP::RouteHandler rh
+  HTTP::RedirectInvocation redirect, DataFlow::Node url, HTTP::RouteHandler rh
 ) {
   redirect.getUrlArgument() = url and
   redirect.getRouteHandler() = rh

--- a/javascript/ql/test/library-tests/frameworks/koa/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Koa::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Koa::RequestNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Koa::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Koa::ResponseNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler.qll
@@ -1,3 +1,3 @@
 import javascript
 
-query predicate test_RouteHandler(Koa::RouteHandler rh, Expr res) { res = rh.getServer() }
+query predicate test_RouteHandler(Koa::RouteHandler rh, DataFlow::Node res) { res = rh.getServer() }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAContextExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAContextExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getAContextExpr(Koa::RouteHandler rh, Expr res) {
-  res = rh.getAContextExpr()
+query predicate test_RouteHandler_getAContextExpr(Koa::RouteHandler rh, DataFlow::Node res) {
+  res = rh.getAContextNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Koa::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(Koa::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getAResponseExpr(Koa::RouteHandler rh, HTTP::ResponseExpr res) {
-  res = rh.getAResponseExpr()
+query predicate test_RouteHandler_getAResponseExpr(Koa::RouteHandler rh, HTTP::ResponseNode res) {
+  res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/koa/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/koa/RouteSetup_getServer.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getServer(Koa::RouteSetup rs, Expr res) { res = rs.getServer() }
+query predicate test_RouteSetup_getServer(Koa::RouteSetup rs, DataFlow::Node res) {
+  res = rs.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -47,6 +47,9 @@ test_ResponseExpr
 | src/koa.js:18:3:18:14 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:44:2:44:13 | ctx.response | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RouteHandler_getAContextExpr
+| src/koa.js:7:1:7:22 | functio ... r1() {} | src/koa.js:7:1:7:0 | this |
+| src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:10:10:10:9 | this |
+| src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:10:28:10:30 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:10:28:10:30 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:11:3:11:6 | this |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:12:3:12:6 | this |
@@ -64,6 +67,7 @@ test_RouteHandler_getAContextExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:26:3:26:5 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:27:3:27:5 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:30:16:30:18 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:30:16:30:18 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:31:2:31:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:32:2:32:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:33:2:33:4 | ctx |
@@ -78,9 +82,11 @@ test_RouteHandler_getAContextExpr
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:43:2:43:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:44:2:44:4 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:47:16:47:18 | ctx |
+| src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:47:16:47:18 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:48:16:48:18 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:51:14:51:16 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:54:16:54:18 | ctx |
+| src/koa.js:59:10:61:1 | functio ... .url;\\n} | src/koa.js:59:10:59:9 | this |
 | src/koa.js:59:10:61:1 | functio ... .url;\\n} | src/koa.js:60:2:60:5 | this |
 test_HeaderDefinition
 | src/koa.js:11:3:11:25 | this.se ... 1', '') | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -157,6 +163,9 @@ test_RouteHandler_getARequestExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:26:3:26:13 | ctx.request |
 | src/koa.js:59:10:61:1 | functio ... .url;\\n} | src/koa.js:60:2:60:13 | this.request |
 test_ContextExpr
+| src/koa.js:7:1:7:0 | this | src/koa.js:7:1:7:22 | functio ... r1() {} |
+| src/koa.js:10:10:10:9 | this | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:10:28:10:30 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:10:28:10:30 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:11:3:11:6 | this | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:12:3:12:6 | this | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -174,6 +183,7 @@ test_ContextExpr
 | src/koa.js:26:3:26:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:27:3:27:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:30:16:30:18 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:30:16:30:18 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:31:2:31:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:32:2:32:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:33:2:33:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
@@ -188,9 +198,11 @@ test_ContextExpr
 | src/koa.js:43:2:43:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:44:2:44:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:47:16:47:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
+| src/koa.js:47:16:47:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 | src/koa.js:48:16:48:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 | src/koa.js:51:14:51:16 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 | src/koa.js:54:16:54:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
+| src/koa.js:59:10:59:9 | this | src/koa.js:59:10:61:1 | functio ... .url;\\n} |
 | src/koa.js:60:2:60:5 | this | src/koa.js:59:10:61:1 | functio ... .url;\\n} |
 test_RedirectInvocation
 | src/koa.js:43:2:43:18 | ctx.redirect(url) | src/koa.js:43:15:43:17 | url | src/koa.js:30:10:45:1 | async c ... url);\\n} |

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -41,6 +41,7 @@ test_HeaderDefinition_defines
 test_ResponseExpr
 | src/koa.js:12:3:12:15 | this.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:14:3:14:14 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:15:7:15:24 | rsp | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:15:13:15:24 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:16:3:16:5 | rsp | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:18:3:18:14 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -111,6 +112,7 @@ test_HeaderAccess
 test_RouteHandler_getAResponseExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:12:3:12:15 | this.response |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:14:3:14:14 | ctx.response |
+| src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:15:7:15:24 | rsp |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:15:13:15:24 | ctx.response |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:16:3:16:5 | rsp |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:18:3:18:14 | ctx.response |

--- a/javascript/ql/test/library-tests/frameworks/restify/RequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RequestExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_RequestExpr(Restify::RequestExpr e, HTTP::RouteHandler res) {
+query predicate test_RequestExpr(Restify::RequestNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/ResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/ResponseExpr.qll
@@ -1,5 +1,5 @@
 import javascript
 
-query predicate test_ResponseExpr(Restify::ResponseExpr e, HTTP::RouteHandler res) {
+query predicate test_ResponseExpr(Restify::ResponseNode e, HTTP::RouteHandler res) {
   res = e.getRouteHandler()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteHandler.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteHandler(Restify::RouteHandler rh, Expr res) { res = rh.getServer() }
+query predicate test_RouteHandler(Restify::RouteHandler rh, DataFlow::Node res) {
+  res = rh.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getARequestExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getARequestExpr(Restify::RouteHandler rh, HTTP::RequestExpr res) {
-  res = rh.getARequestExpr()
+query predicate test_RouteHandler_getARequestExpr(Restify::RouteHandler rh, HTTP::RequestNode res) {
+  res = rh.getARequestNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getAResponseExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteHandler_getAResponseExpr.qll
@@ -1,5 +1,5 @@
 import semmle.javascript.frameworks.Express
 
-query predicate test_RouteHandler_getAResponseExpr(Restify::RouteHandler rh, HTTP::ResponseExpr res) {
-  res = rh.getAResponseExpr()
+query predicate test_RouteHandler_getAResponseExpr(Restify::RouteHandler rh, HTTP::ResponseNode res) {
+  res = rh.getAResponseNode()
 }

--- a/javascript/ql/test/library-tests/frameworks/restify/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/restify/RouteSetup_getServer.qll
@@ -1,3 +1,5 @@
 import javascript
 
-query predicate test_RouteSetup_getServer(Restify::RouteSetup rs, Expr res) { res = rs.getServer() }
+query predicate test_RouteSetup_getServer(Restify::RouteSetup rs, DataFlow::Node res) {
+  res = rs.getServer()
+}

--- a/javascript/ql/test/library-tests/frameworks/restify/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/restify/tests.expected
@@ -18,7 +18,9 @@ test_HeaderDefinition_defines
 | src/test.js:13:5:13:37 | respons ... 2', '') | header2 |  |
 test_ResponseExpr
 | src/test.js:9:46:9:53 | response | src/test.js:9:19:11:1 | functio ... ition\\n} |
+| src/test.js:9:46:9:53 | response | src/test.js:9:19:11:1 | functio ... ition\\n} |
 | src/test.js:10:5:10:12 | response | src/test.js:9:19:11:1 | functio ... ition\\n} |
+| src/test.js:12:46:12:53 | response | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:12:46:12:53 | response | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:13:5:13:12 | response | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 test_HeaderDefinition
@@ -36,7 +38,9 @@ test_ServerDefinition
 | src/test.js:4:15:4:36 | restify ... erver() |
 test_RouteHandler_getAResponseExpr
 | src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:9:46:9:53 | response |
+| src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:9:46:9:53 | response |
 | src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:10:5:10:12 | response |
+| src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:12:46:12:53 | response |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:12:46:12:53 | response |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:13:5:13:12 | response |
 test_RouteSetup_getARouteHandler
@@ -50,6 +54,7 @@ test_RouteHandler
 test_RequestExpr
 | src/test.js:9:37:9:43 | request | src/test.js:9:19:11:1 | functio ... ition\\n} |
 | src/test.js:12:37:12:43 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
+| src/test.js:12:37:12:43 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:14:5:14:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:15:5:15:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:16:5:16:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
@@ -60,6 +65,7 @@ test_RequestExpr
 | src/test.js:21:5:21:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 test_RouteHandler_getARequestExpr
 | src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:9:37:9:43 | request |
+| src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:12:37:12:43 | request |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:12:37:12:43 | request |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:14:5:14:11 | request |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:15:5:15:11 | request |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -116,6 +116,11 @@ nodes
 | classnames.js:15:47:15:63 | clsx(window.name) |
 | classnames.js:15:52:15:62 | window.name |
 | classnames.js:15:52:15:62 | window.name |
+| classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:48:17:64 | clsx(window.name) |
+| classnames.js:17:53:17:63 | window.name |
+| classnames.js:17:53:17:63 | window.name |
 | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
@@ -1187,6 +1192,10 @@ edges
 | classnames.js:15:47:15:63 | clsx(window.name) | classnames.js:15:31:15:78 | `<span  ... <span>` |
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
+| classnames.js:17:48:17:64 | clsx(window.name) | classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:48:17:64 | clsx(window.name) | classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:53:17:63 | window.name | classnames.js:17:48:17:64 | clsx(window.name) |
+| classnames.js:17:53:17:63 | window.name | classnames.js:17:48:17:64 | clsx(window.name) |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
@@ -2182,6 +2191,7 @@ edges
 | classnames.js:11:31:11:79 | `<span  ... <span>` | classnames.js:10:45:10:55 | window.name | classnames.js:11:31:11:79 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:10:45:10:55 | window.name | user-provided value |
 | classnames.js:13:31:13:83 | `<span  ... <span>` | classnames.js:13:57:13:67 | window.name | classnames.js:13:31:13:83 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:13:57:13:67 | window.name | user-provided value |
 | classnames.js:15:31:15:78 | `<span  ... <span>` | classnames.js:15:52:15:62 | window.name | classnames.js:15:31:15:78 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:15:52:15:62 | window.name | user-provided value |
+| classnames.js:17:32:17:79 | `<span  ... <span>` | classnames.js:17:53:17:63 | window.name | classnames.js:17:32:17:79 | `<span  ... <span>` | Cross-site scripting vulnerability due to $@. | classnames.js:17:53:17:63 | window.name | user-provided value |
 | clipboard.ts:15:25:15:28 | html | clipboard.ts:8:18:8:51 | clipboa ... /html') | clipboard.ts:15:25:15:28 | html | Cross-site scripting vulnerability due to $@. | clipboard.ts:8:18:8:51 | clipboa ... /html') | user-provided value |
 | clipboard.ts:24:23:24:58 | e.clipb ... /html') | clipboard.ts:24:23:24:58 | e.clipb ... /html') | clipboard.ts:24:23:24:58 | e.clipb ... /html') | Cross-site scripting vulnerability due to $@. | clipboard.ts:24:23:24:58 | e.clipb ... /html') | user-provided value |
 | clipboard.ts:29:19:29:54 | e.clipb ... /html') | clipboard.ts:29:19:29:54 | e.clipb ... /html') | clipboard.ts:29:19:29:54 | e.clipb ... /html') | Cross-site scripting vulnerability due to $@. | clipboard.ts:29:19:29:54 | e.clipb ... /html') | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -116,6 +116,11 @@ nodes
 | classnames.js:15:47:15:63 | clsx(window.name) |
 | classnames.js:15:52:15:62 | window.name |
 | classnames.js:15:52:15:62 | window.name |
+| classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:48:17:64 | clsx(window.name) |
+| classnames.js:17:53:17:63 | window.name |
+| classnames.js:17:53:17:63 | window.name |
 | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:11:8:51 | html |
 | clipboard.ts:8:18:8:51 | clipboa ... /html') |
@@ -1237,6 +1242,10 @@ edges
 | classnames.js:15:47:15:63 | clsx(window.name) | classnames.js:15:31:15:78 | `<span  ... <span>` |
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
 | classnames.js:15:52:15:62 | window.name | classnames.js:15:47:15:63 | clsx(window.name) |
+| classnames.js:17:48:17:64 | clsx(window.name) | classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:48:17:64 | clsx(window.name) | classnames.js:17:32:17:79 | `<span  ... <span>` |
+| classnames.js:17:53:17:63 | window.name | classnames.js:17:48:17:64 | clsx(window.name) |
+| classnames.js:17:53:17:63 | window.name | classnames.js:17:48:17:64 | clsx(window.name) |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |
 | clipboard.ts:8:11:8:51 | html | clipboard.ts:15:25:15:28 | html |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/classnames.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/classnames.js
@@ -13,4 +13,6 @@ function main() {
     document.body.innerHTML = `<span class="${safeStyle(window.name)}">Hello<span>`; // NOT OK
     document.body.innerHTML = `<span class="${safeStyle('foo')}">Hello<span>`; // OK
     document.body.innerHTML = `<span class="${clsx(window.name)}">Hello<span>`; // NOT OK
+
+    document.body.innerHTML += `<span class="${clsx(window.name)}">Hello<span>`; // NOT OK
 }

--- a/javascript/ql/test/tutorials/Introducing the JavaScript libraries/query20.qll
+++ b/javascript/ql/test/tutorials/Introducing the JavaScript libraries/query20.qll
@@ -1,5 +1,5 @@
 import javascript
 
 query predicate test_query20(SQL::SqlString ss, string res) {
-  ss instanceof AddExpr and res = "Use templating instead of string concatenation."
+  ss.asExpr() instanceof AddExpr and res = "Use templating instead of string concatenation."
 }


### PR DESCRIPTION
Initially I started with refactoring the HTTP models to use dataflow nodes.  
That was done surprisingly quick, so I continued with more library models.  

I've made deprecated aliases where a renaming made sense, and otherwise I just changed the type. 

The `flowsTo` predicates in the HTTP models were confusing when starting to use `DataFlow::Node`. (I initially made mistakes because of that). So I've deprecated those `flowsTo` predicates. 

## Evaluation

[An evaluation looks OK](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/httpNode__nightly-old__code-scanning__3/reports). But there are some new results and some lost results.  

### New results:  
All appear to be TPs, and they are all from recognizing destructuring assignments as property reads, which allows us to recognize more sources.   
Two of the results appeared from refactoring the HTTP models (the `js/path-injection` results).  
And two other appeared from refactoring the `SensitiveExpr` class (the `js/insufficient-password-hash` resutls).  

### Lost results:  

Both lost results are a consequence of a `DataFlow::PropWrite` having no result for `getRhs()` when the AST looks like:  
```JavaScript
obj.prop += value
```   
One appears to be a TP, the other appears to be an FP.  

I should do some followup work to investigate if we can have a sensible result for `getRhs()` in the above example.  (After this PR has merged).  