### PR TITLE
C#: Operator flow

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Callable.qll
@@ -460,6 +460,11 @@ class Operator extends Callable, Member, Attributable, @operator {
   override string toString() { result = Callable.super.toString() }
 
   override Parameter getRawParameter(int i) { result = this.getParameter(i) }
+
+  override predicate hasQualifiedName(string qualifier, string name) {
+    super.hasQualifiedName(qualifier, _) and
+    name = this.getFunctionName()
+  }
 }
 
 /** A clone method on a record. */

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2066,13 +2066,14 @@ module Csv {
 
   /** Computes the first 6 columns for CSV rows of `c`. */
   string asPartialModel(DataFlowCallable c) {
-    exists(string namespace, string type |
+    exists(string namespace, string type, string name |
       c.getDeclaringType().hasQualifiedName(namespace, type) and
+      c.hasQualifiedName(_, name) and
       result =
         namespace + ";" //
           + type + ";" //
           + getCallableOverride(c) + ";" //
-          + c.getName() + ";" //
+          + name + ";" //
           + "(" + parameterQualifiedTypeNamesToString(c) + ")" //
           + /* ext + */ ";" //
     )

--- a/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
@@ -21,6 +21,7 @@ class Type = CS::Type;
  */
 private predicate isRelevantForModels(CS::Callable api) {
   [api.(CS::Modifiable), api.(CS::Accessor).getDeclaration()].isEffectivelyPublic() and
+  not api instanceof CS::ConversionOperator and
   not api instanceof Util::MainMethod
 }
 

--- a/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
+++ b/csharp/ql/src/utils/model-generator/internal/CaptureModelsSpecific.qll
@@ -22,7 +22,8 @@ class Type = CS::Type;
 private predicate isRelevantForModels(CS::Callable api) {
   [api.(CS::Modifiable), api.(CS::Accessor).getDeclaration()].isEffectivelyPublic() and
   not api instanceof CS::ConversionOperator and
-  not api instanceof Util::MainMethod
+  not api instanceof Util::MainMethod and
+  api.getDeclaringType().getNamespace().getQualifiedName() != ""
 }
 
 /**

--- a/csharp/ql/test/utils/model-generator/CaptureSummaryModels.expected
+++ b/csharp/ql/test/utils/model-generator/CaptureSummaryModels.expected
@@ -28,3 +28,5 @@
 | Summaries;IEnumerableFlow;false;ReturnFieldInIEnumerable;();Argument[Qualifier];ReturnValue;taint |
 | Summaries;IEnumerableFlow;false;ReturnIEnumerable;(System.Collections.Generic.IEnumerable<System.String>);Argument[0].Element;ReturnValue;taint |
 | Summaries;IEnumerableFlow;false;ReturnIEnumerableElement;(System.Collections.Generic.IEnumerable<System.Object>);Argument[0].Element;ReturnValue;taint |
+| Summaries;OperatorFlow;false;OperatorFlow;(System.Object);Argument[0];Argument[Qualifier];taint |
+| Summaries;OperatorFlow;false;op_Addition;(Summaries.OperatorFlow,Summaries.OperatorFlow);Argument[0];ReturnValue;taint |

--- a/csharp/ql/test/utils/model-generator/Summaries.cs
+++ b/csharp/ql/test/utils/model-generator/Summaries.cs
@@ -172,3 +172,38 @@ public class DerivedClass2Flow : BaseClassFlow
         return input0;
     }
 }
+
+public class OperatorFlow
+{
+    public readonly object Field;
+
+    public OperatorFlow(object o)
+    {
+        Field = o;
+    }
+
+    // Flow Summary.
+    public static OperatorFlow operator +(OperatorFlow a, OperatorFlow b)
+    {
+        return a;
+    }
+
+    // No flow summary.
+    public static OperatorFlow operator ++(OperatorFlow a)
+    {
+        return new OperatorFlow(new object());
+    }
+
+    // No flow summary as this is an implicit conversion operator.
+    public static implicit operator OperatorFlow(int i)
+    {
+        return new OperatorFlow(i);
+    }
+
+    // No flow summary as this is an explicit conversion operator.
+    public static explicit operator OperatorFlow(byte b)
+    {
+        return new OperatorFlow(b);
+    }
+
+}


### PR DESCRIPTION
In this PR, we make
* Support for flow models for operators. This requires that we use the operator function name as the qualified name.
* Exclude conversion operators from model generation (there is always flow through conversion operators in library code - see TaintTrackingPrivate.ql).
* Exclude methods, where a namespace is not identified.