### PR TITLE
C++: Fix two performance issues

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/StackVariableReachability.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/StackVariableReachability.qll
@@ -80,7 +80,11 @@ abstract class StackVariableReachability extends string {
         j > i and
         sink = bb.getNode(j) and
         this.isSink(sink, v) and
-        not exists(int k | this.isBarrier(bb.getNode(k), v) | k in [i + 1 .. j - 1])
+        not exists(int k, ControlFlowNode node |
+          node = bb.getNode(k) and this.isBarrier(pragma[only_bind_into](node), v)
+        |
+          k in [i + 1 .. j - 1]
+        )
       )
       or
       not exists(int k | this.isBarrier(bb.getNode(k), v) | k > i) and

--- a/cpp/ql/lib/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/Overflow.qll
@@ -25,6 +25,7 @@ predicate guardedAbs(Operation e, Expr use) {
  * Holds if the value of `use` is guarded to be less than something, and `e`
  * is in code controlled by that guard (where the guard condition held).
  */
+pragma[nomagic]
 predicate guardedLesser(Operation e, Expr use) {
   exists(GuardCondition c | c.ensuresLt(use, _, _, e.getBasicBlock(), true))
   or
@@ -35,6 +36,7 @@ predicate guardedLesser(Operation e, Expr use) {
  * Holds if the value of `use` is guarded to be greater than something, and `e`
  * is in code controlled by that guard (where the guard condition held).
  */
+pragma[nomagic]
 predicate guardedGreater(Operation e, Expr use) {
   exists(GuardCondition c | c.ensuresLt(use, _, _, e.getBasicBlock(), false))
   or


### PR DESCRIPTION
Two unrelated performance fixes:

- The first commit fixes a case of bad magic:
```ql
Tuple counts for m#Overflow::guardedLesser#a1017054#bb/2@5d4bacm0 after 16.8s:
  253512    ~0%     {2} r1 = JOIN Expr::Operation::getAnOperand#dispred#f0820431#ff_10#join_rhs WITH Access::Access::getTarget#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1 'e'
  136449963 ~1%     {2} r2 = JOIN r1 WITH Overflow::varUse#a1017054#ff ON FIRST 1 OUTPUT Lhs.1 'e', Rhs.1 'use'
  return r2
```

- The second commit fixes a bad join order in an antijoin. Here are the tuple counts on PHP:

Before:
```ql
StackVariableReachability::StackVariableReachability::reaches#f0820431#ffff#antijoin_rhs#1/7@ebd0f4gr after 11s:
    14077    ~3%        {7} r1 = JOIN StackVariableReachability::StackVariableReachability::reaches#f0820431#ffff#shared#2 WITH BasicBlocks::Cached::basic_block_member#8748103a#fff ON FIRST 2 OUTPUT Lhs.5 'arg4', Lhs.2 'arg0', Lhs.3 'arg1', Lhs.1 'arg2', Lhs.4 'arg3', Lhs.0 'arg5', Rhs.2 'arg6'
    14077    ~0%        {9} r2 = JOIN r1 WITH UninitializedLocal::UninitialisedLocalReachability#class#9d706ecd#f ON FIRST 1 OUTPUT Lhs.1 'arg0', Lhs.2 'arg1', Lhs.3 'arg2', Lhs.4 'arg3', Lhs.0 'arg4', Lhs.5 'arg5', Lhs.6 'arg6', (Lhs.4 'arg3' + 1), (Lhs.6 'arg6' - 1)
    69840066 ~0%        {10} r3 = JOIN r2 WITH PRIMITIVE range#bbf ON Lhs.7,Lhs.8
    69840066 ~1%        {8} r4 = SCAN r3 OUTPUT In.2 'arg2', In.9, In.0 'arg0', In.1 'arg1', In.3 'arg3', In.4 'arg4', In.5 'arg5', In.6 'arg6'
    69840066 ~0%        {8} r5 = JOIN r4 WITH BasicBlocks::Cached::basic_block_member#8748103a#fff_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2 'arg0', Lhs.3 'arg1', Lhs.0 'arg2', Lhs.4 'arg3', Lhs.5 'arg4', Lhs.6 'arg5', Lhs.7 'arg6'
    510644   ~4082%     {7} r6 = JOIN r5 WITH StackVariableReachability::StackVariableReachability::isBarrier#dispred#f0820431#cpe#23#fb ON FIRST 2 OUTPUT Lhs.1 'arg0', Lhs.2 'arg1', Lhs.3 'arg2', Lhs.4 'arg3', Lhs.5 'arg4', Lhs.6 'arg5', Lhs.7 'arg6'
                        return r6
```

After:
```ql
Tuple counts for StackVariableReachability::StackVariableReachability::reaches#f0820431#ffff#antijoin_rhs#1/7@48142f9v after 421ms:
  1126663 ~4%        {8} r1 = JOIN StackVariableReachability::StackVariableReachability::reaches#f0820431#ffff#shared#2 WITH StackVariableReachability::StackVariableReachability::isBarrier#dispred#f0820431#cpe#23#fb_10#join_rhs ON FIRST 1 OUTPUT Lhs.4 'arg4', Lhs.0 'arg0', Lhs.1 'arg1', Lhs.2 'arg2', Lhs.3 'arg3', Lhs.5 'arg5', Lhs.6 'arg6', Rhs.1
  1126663 ~0%        {10} r2 = JOIN r1 WITH UninitializedLocal::UninitialisedLocalReachability#class#9d706ecd#f ON FIRST 1 OUTPUT Lhs.7, Lhs.3 'arg2', Lhs.1 'arg0', Lhs.2 'arg1', Lhs.4 'arg3', Lhs.0 'arg4', Lhs.5 'arg5', Lhs.6 'arg6', (Lhs.4 'arg3' + 1), (Lhs.6 'arg6' - 1)
  1024183 ~0%        {10} r3 = JOIN r2 WITH BasicBlocks::Cached::basic_block_member#8748103a#fff ON FIRST 2 OUTPUT Lhs.2 'arg0', Lhs.3 'arg1', Lhs.1 'arg2', Lhs.4 'arg3', Lhs.5 'arg4', Lhs.6 'arg5', Lhs.7 'arg6', Lhs.8, Lhs.9, Rhs.2
  510644  ~0%        {10} r4 = JOIN r3 WITH PRIMITIVE range#bbb ON Lhs.7,Lhs.8,Lhs.9
  510644  ~4082%     {7} r5 = SCAN r4 OUTPUT In.0 'arg0', In.1 'arg1', In.2 'arg2', In.3 'arg3', In.4 'arg4', In.5 'arg5', In.6 'arg6'
                      return r5
```