### PR TITLE
QLdoc check: handle new languages gracefully

### DIFF
--- a/.github/workflows/check-qldoc.yml
+++ b/.github/workflows/check-qldoc.yml
@@ -37,6 +37,9 @@ jobs:
           done
           git checkout HEAD^
           for pack_dir in ${changed_lib_packs}; do
+            # When we add a new language, pack_dir would not exist in HEAD^.
+            # In this case the right thing to do is to skip the check.
+            [[ ! -d "${pack_dir}" ]] && continue
             lang="${pack_dir%/ql/lib}"
             gh codeql generate library-doc-coverage --output="${RUNNER_TEMP}/${lang}-baseline.txt" --dir="${pack_dir}"
             awk -F, '{gsub(/"/,""); if ($4==0 && $6=="public") print "\""$3"\"" }' "${RUNNER_TEMP}/${lang}-current.txt" | sort -u > "${RUNNER_TEMP}/current-undocumented.txt"


### PR DESCRIPTION
This PR fixes `Check QLdoc coverage` failures when we add a new language.
