### PR TITLE
C++: Some enhancements to SensitiveExprs.qll

### DIFF
--- a/cpp/ql/lib/change-notes/2022-03-31-sensitive-exprs.md
+++ b/cpp/ql/lib/change-notes/2022-03-31-sensitive-exprs.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `semmle.code.cpp.security.SensitiveExprs` library has been enhanced with some additional rules for detecting credentials.

--- a/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
@@ -14,8 +14,11 @@ import cpp
  */
 bindingset[s]
 private predicate suspicious(string s) {
-  s.matches(["%password%", "%passwd%", "%trusted%"]) and
-  not s.matches(["%hash%", "%crypt%", "%file%", "%path%"])
+  s.matches([
+      "%password%", "%passwd%", "%accountid%", "%account%key%", "%accnt%key%", "%license%key%",
+      "%trusted%"
+    ]) and
+  not s.matches(["%hash%", "%crypt%", "%file%", "%path%", "%invalid%"])
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/SensitiveExprs.qll
@@ -14,10 +14,7 @@ import cpp
  */
 bindingset[s]
 private predicate suspicious(string s) {
-  s.matches([
-      "%password%", "%passwd%", "%accountid%", "%account%key%", "%accnt%key%", "%license%key%",
-      "%trusted%"
-    ]) and
+  s.regexpMatch(".*(password|passwd|accountid|account.?key|accnt.?key|license.?key|trusted).*") and
   not s.matches(["%hash%", "%crypt%", "%file%", "%path%", "%invalid%"])
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextFileWrite.expected
@@ -7,6 +7,7 @@ edges
 nodes
 | test2.cpp:43:36:43:43 | password | semmle.label | password |
 | test2.cpp:44:37:44:45 | thepasswd | semmle.label | thepasswd |
+| test2.cpp:45:38:45:47 | accountkey | semmle.label | accountkey |
 | test2.cpp:50:41:50:53 | passwd_config | semmle.label | passwd_config |
 | test2.cpp:52:40:52:58 | * ... | semmle.label | * ... |
 | test2.cpp:52:44:52:57 | password_tries | semmle.label | password_tries |
@@ -29,6 +30,7 @@ subpaths
 #select
 | test2.cpp:43:2:43:8 | call to fprintf | test2.cpp:43:36:43:43 | password | test2.cpp:43:36:43:43 | password | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:43:36:43:43 | password | this source. |
 | test2.cpp:44:2:44:8 | call to fprintf | test2.cpp:44:37:44:45 | thepasswd | test2.cpp:44:37:44:45 | thepasswd | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:44:37:44:45 | thepasswd | this source. |
+| test2.cpp:45:2:45:8 | call to fprintf | test2.cpp:45:38:45:47 | accountkey | test2.cpp:45:38:45:47 | accountkey | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:45:38:45:47 | accountkey | this source. |
 | test2.cpp:50:2:50:8 | call to fprintf | test2.cpp:50:41:50:53 | passwd_config | test2.cpp:50:41:50:53 | passwd_config | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:50:41:50:53 | passwd_config | this source. |
 | test2.cpp:54:2:54:8 | call to fprintf | test2.cpp:54:41:54:52 | widepassword | test2.cpp:54:41:54:52 | widepassword | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:54:41:54:52 | widepassword | this source. |
 | test2.cpp:55:2:55:8 | call to fprintf | test2.cpp:55:40:55:51 | widepassword | test2.cpp:55:40:55:51 | widepassword | This write into file 'log' may contain unencrypted data from $@ | test2.cpp:55:40:55:51 | widepassword | this source. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -236,6 +236,7 @@ nodes
 | test3.cpp:515:18:515:35 | my_bank_account_no | semmle.label | my_bank_account_no |
 | test3.cpp:516:18:516:29 | employerName | semmle.label | employerName |
 | test3.cpp:517:18:517:29 | medical_info | semmle.label | medical_info |
+| test3.cpp:518:18:518:28 | license_key | semmle.label | license_key |
 | test3.cpp:526:44:526:54 | my_latitude | semmle.label | my_latitude |
 | test3.cpp:527:15:527:20 | buffer | semmle.label | buffer |
 | test3.cpp:532:45:532:58 | home_longitude | semmle.label | home_longitude |
@@ -288,6 +289,7 @@ subpaths
 | test3.cpp:515:2:515:5 | call to send | test3.cpp:515:18:515:35 | my_bank_account_no | test3.cpp:515:18:515:35 | my_bank_account_no | This operation transmits 'my_bank_account_no', which may contain unencrypted sensitive data from $@ | test3.cpp:515:18:515:35 | my_bank_account_no | my_bank_account_no |
 | test3.cpp:516:2:516:5 | call to send | test3.cpp:516:18:516:29 | employerName | test3.cpp:516:18:516:29 | employerName | This operation transmits 'employerName', which may contain unencrypted sensitive data from $@ | test3.cpp:516:18:516:29 | employerName | employerName |
 | test3.cpp:517:2:517:5 | call to send | test3.cpp:517:18:517:29 | medical_info | test3.cpp:517:18:517:29 | medical_info | This operation transmits 'medical_info', which may contain unencrypted sensitive data from $@ | test3.cpp:517:18:517:29 | medical_info | medical_info |
+| test3.cpp:518:2:518:5 | call to send | test3.cpp:518:18:518:28 | license_key | test3.cpp:518:18:518:28 | license_key | This operation transmits 'license_key', which may contain unencrypted sensitive data from $@ | test3.cpp:518:18:518:28 | license_key | license_key |
 | test3.cpp:527:3:527:6 | call to send | test3.cpp:526:44:526:54 | my_latitude | test3.cpp:527:15:527:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:526:44:526:54 | my_latitude | my_latitude |
 | test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:532:45:532:58 | home_longitude | home_longitude |
 | test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:551:47:551:58 | salaryString | salaryString |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test2.cpp
@@ -42,7 +42,7 @@ void tests(FILE *log, myStruct &s)
 {
 	fprintf(log, "password = %s\n", s.password); // BAD
 	fprintf(log, "thepasswd = %s\n", s.thepasswd); // BAD
-	fprintf(log, "accountkey = %s\n", s.accountkey); // DUBIOUS [NOT REPORTED]
+	fprintf(log, "accountkey = %s\n", s.accountkey); // BAD
 	fprintf(log, "password_hash = %s\n", s.password_hash); // GOOD
 	fprintf(log, "encrypted_passwd = %s\n", s.encrypted_passwd); // GOOD
 	fprintf(log, "password_file = %s\n", s.password_file); // GOOD

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -515,7 +515,7 @@ void tests2(person_info *pi)
 	send(val(), pi->my_bank_account_no, strlen(pi->my_bank_account_no), val()); // BAD
 	send(val(), pi->employerName, strlen(pi->employerName), val()); // BAD
 	send(val(), pi->medical_info, strlen(pi->medical_info), val()); // BAD
-	send(val(), pi->license_key, strlen(pi->license_key), val()); // BAD [NOT DETECTED]
+	send(val(), pi->license_key, strlen(pi->license_key), val()); // BAD
 	send(val(), pi->license_key_hash, strlen(pi->license_key_hash), val()); // GOOD
 	send(val(), pi->my_zip_file, strlen(pi->my_zip_file), val()); // GOOD
 


### PR DESCRIPTION
While working on https://github.com/github/codeql/pull/8580, I noticed some extra expressions that `SensitiveExprs.qll` ought to catch.  This PR adds these, and updates the library from using `match` to `regexpMatch` for similar reasons as in that PR.