### PR TITLE
Java: Fix acronym casing in qldoc referring to Java class names.

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/Networking.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Networking.qll
@@ -4,7 +4,7 @@
 
 import semmle.code.java.Type
 
-/** The type `java.net.UrlConnection`. */
+/** The type `java.net.URLConnection`. */
 class TypeUrlConnection extends RefType {
   TypeUrlConnection() { this.hasQualifiedName("java.net", "URLConnection") }
 }
@@ -29,7 +29,7 @@ class TypeUri extends RefType {
   TypeUri() { this.hasQualifiedName("java.net", "URI") }
 }
 
-/** The method `java.net.UrlConnection::getInputStream`. */
+/** The method `java.net.URLConnection::getInputStream`. */
 class UrlConnectionGetInputStreamMethod extends Method {
   UrlConnectionGetInputStreamMethod() {
     this.getDeclaringType() instanceof TypeUrlConnection and

--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -98,7 +98,7 @@ class GetSocketFactory extends Method {
   }
 }
 
-/** The `createSSLEngine` method of the class `javax.net.ssl.SSLContext` */
+/** The `createSSLEngine` method of the class `javax.net.ssl.SSLContext`. */
 class CreateSslEngineMethod extends Method {
   CreateSslEngineMethod() {
     this.hasName("createSSLEngine") and
@@ -120,7 +120,7 @@ class SetHostnameVerifierMethod extends Method {
   }
 }
 
-/** The `setDefaultHostnameVerifier` method of the class `javax.net.ssl.HttpsUrlConnection`. */
+/** The `setDefaultHostnameVerifier` method of the class `javax.net.ssl.HttpsURLConnection`. */
 class SetDefaultHostnameVerifierMethod extends Method {
   SetDefaultHostnameVerifierMethod() {
     this.hasName("setDefaultHostnameVerifier") and
@@ -152,7 +152,7 @@ class SslUnwrapMethod extends Method {
   }
 }
 
-/** The `getSession` method of the class `javax.net.ssl.SSLSession`.select */
+/** The `getSession` method of the class `javax.net.ssl.SSLSession`. */
 class GetSslSessionMethod extends Method {
   GetSslSessionMethod() {
     this.hasName("getSession") and

--- a/java/ql/lib/semmle/code/java/security/XmlParsers.qll
+++ b/java/ql/lib/semmle/code/java/security/XmlParsers.qll
@@ -454,7 +454,7 @@ class SaxParser extends RefType {
 /** DEPRECATED: Alias for SaxParser */
 deprecated class SAXParser = SaxParser;
 
-/** The class `javax.xml.parsers.SaxParserFactory`. */
+/** The class `javax.xml.parsers.SAXParserFactory`. */
 class SaxParserFactory extends RefType {
   SaxParserFactory() { this.hasQualifiedName("javax.xml.parsers", "SAXParserFactory") }
 }
@@ -462,7 +462,7 @@ class SaxParserFactory extends RefType {
 /** DEPRECATED: Alias for SaxParserFactory */
 deprecated class SAXParserFactory = SaxParserFactory;
 
-/** A call to `SaxParser.parse`. */
+/** A call to `SAXParser.parse`. */
 class SaxParserParse extends XmlParserCall {
   SaxParserParse() {
     exists(Method m |
@@ -590,7 +590,7 @@ class SaxReader extends RefType {
 /** DEPRECATED: Alias for SaxReader */
 deprecated class SAXReader = SaxReader;
 
-/** A call to `SaxReader.read`. */
+/** A call to `SAXReader.read`. */
 class SaxReaderRead extends XmlParserCall {
   SaxReaderRead() {
     exists(Method m |
@@ -668,7 +668,7 @@ class SafeSaxReader extends VarAccess {
 deprecated class SafeSAXReader = SafeSaxReader;
 
 /* https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#xmlreader */
-/** The class `org.xml.sax.XmlReader`. */
+/** The class `org.xml.sax.XMLReader`. */
 class XmlReader extends RefType {
   XmlReader() { this.hasQualifiedName("org.xml.sax", "XMLReader") }
 }
@@ -676,7 +676,7 @@ class XmlReader extends RefType {
 /** DEPRECATED: Alias for XmlReader */
 deprecated class XMLReader = XmlReader;
 
-/** A call to `XmlReader.read`. */
+/** A call to `XMLReader.read`. */
 class XmlReaderParse extends XmlParserCall {
   XmlReaderParse() {
     exists(Method m |
@@ -827,7 +827,7 @@ deprecated class CreatedSafeXMLReader = CreatedSafeXmlReader;
  * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxb-unmarshaller
  */
 
-/** The class `javax.xml.transform.sax.SaxSource` */
+/** The class `javax.xml.transform.sax.SAXSource` */
 class SaxSource extends RefType {
   SaxSource() { this.hasQualifiedName("javax.xml.transform.sax", "SAXSource") }
 }
@@ -835,7 +835,7 @@ class SaxSource extends RefType {
 /** DEPRECATED: Alias for SaxSource */
 deprecated class SAXSource = SaxSource;
 
-/** A call to the constructor of `SaxSource` with `XmlReader` and `InputSource`. */
+/** A call to the constructor of `SAXSource` with `XmlReader` and `InputSource`. */
 class ConstructedSaxSource extends ClassInstanceExpr {
   ConstructedSaxSource() {
     this.getConstructedType() instanceof SaxSource and
@@ -858,7 +858,7 @@ class ConstructedSaxSource extends ClassInstanceExpr {
 /** DEPRECATED: Alias for ConstructedSaxSource */
 deprecated class ConstructedSAXSource = ConstructedSaxSource;
 
-/** A call to the `SaxSource.setXMLReader` method. */
+/** A call to the `SAXSource.setXMLReader` method. */
 class SaxSourceSetReader extends MethodAccess {
   SaxSourceSetReader() {
     exists(Method m |

--- a/java/ql/src/experimental/Security/CWE/CWE-611/XXELib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-611/XXELib.qll
@@ -204,7 +204,7 @@ private class SafeDigesterFlowConfig extends DataFlow4::Configuration {
   override int fieldFlowBranchLimit() { result = 0 }
 }
 
-/** The class `java.beans.XmlDecoder`. */
+/** The class `java.beans.XMLDecoder`. */
 class XmlDecoder extends RefType {
   XmlDecoder() { this.hasQualifiedName("java.beans", "XMLDecoder") }
 }
@@ -212,7 +212,7 @@ class XmlDecoder extends RefType {
 /** DEPRECATED: Alias for XmlDecoder */
 deprecated class XMLDecoder = XmlDecoder;
 
-/** A call to `XmlDecoder.readObject`. */
+/** A call to `XMLDecoder.readObject`. */
 class XmlDecoderReadObject extends XmlParserCall {
   XmlDecoderReadObject() {
     exists(Method m |


### PR DESCRIPTION
https://github.com/github/codeql/pull/8323 accidentally renamed a bunch of class names in qldoc referring to Java classes.