### PR TITLE
JS: fix bad join in XmlParsers.qll

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/XmlParsers.qll
@@ -330,6 +330,7 @@ module XML {
       none()
     }
 
+    pragma[noinline]
     override DataFlow::Node getAResult() {
       result =
         parser


### PR DESCRIPTION
Some very large benchmarks failed to terminate due to this.  
(For some reason only when running `js/prototype-pollution-utility`?)