### PR TITLE
Improve wording of isAdditionalFlow/TaintStep qldoc

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking4/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/tainttracking5/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking2/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking3/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/tainttracking4/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -112,15 +112,13 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the analysis should assume that data may flow from `node1` to `node2`
-   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
-   * updates the flow state to `state2`.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
     none()

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -112,12 +112,12 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if data may flow from `node1` to `node2` in addition to the normal dataflow steps.
+   * Holds if data may flow from `node1` to `node2` in addition to the normal data-flow steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -112,14 +112,14 @@ abstract class Configuration extends string {
   predicate isBarrierGuard(BarrierGuard guard, FlowState state) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis.
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps.
    */
   predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
   /**
-   * Holds if the additional flow step from `node1` to `node2` must be taken
-   * into account in the analysis. This step is only applicable in `state1` and
+   * Holds if the analysis should assume that data may flow from `node1` to `node2`
+   * in addition to the normal dataflow steps. This step is only applicable in `state1` and
    * updates the flow state to `state2`.
    */
   predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttracking1/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttrackingforlibraries/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttrackingforlibraries/TaintTrackingImpl.qll
@@ -154,7 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -164,7 +164,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow and taint steps.
    * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttrackingforlibraries/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttrackingforlibraries/TaintTrackingImpl.qll
@@ -154,8 +154,7 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,9 +164,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
-   * in addition to the normal dataflow and taint steps. This step is only applicable
-   * in `state1` and updates the flow state to `state2`.
+   * Holds if taint may propagate from `node1` to `node2` in addition to the normal dataflow and taint steps.
+   * This step is only applicable in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(
     DataFlow::Node node1, DataFlow::FlowState state1, DataFlow::Node node2,

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttrackingforlibraries/TaintTrackingImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/tainttrackingforlibraries/TaintTrackingImpl.qll
@@ -154,8 +154,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis.
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps.
    */
   predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) { none() }
 
@@ -165,8 +165,8 @@ abstract class Configuration extends DataFlow::Configuration {
   }
 
   /**
-   * Holds if the additional taint propagation step from `node1` to `node2`
-   * must be taken into account in the analysis. This step is only applicable
+   * Holds if the analysis should assume that taint may flow from `node1` to `node2`
+   * in addition to the normal dataflow and taint steps. This step is only applicable
    * in `state1` and updates the flow state to `state2`.
    */
   predicate isAdditionalTaintStep(


### PR DESCRIPTION
@Marcono1234 at https://github.com/github/codeql/discussions/8616 asked that we avoid using `must` with the possible implication that this is a mandatory "waypoint" / "via" step, rather than an additional step that may or may not be used in a given path.