### PR TITLE
Java: Fix reflection predicate for `getMethod` having non-public method result

### DIFF
--- a/java/ql/lib/semmle/code/java/Reflection.qll
+++ b/java/ql/lib/semmle/code/java/Reflection.qll
@@ -355,9 +355,11 @@ class ReflectiveMethodAccess extends ClassMethodAccess {
       then
         // The method must be declared on the type itself.
         result.getDeclaringType() = this.getInferredClassType()
-      else
-        // The method may be declared on an inferred type or a super-type.
+      else (
+        // The method must be public, and declared or inherited by the inferred class type.
+        result.isPublic() and
         this.getInferredClassType().inherits(result)
+      )
     ) and
     // Only consider instances where the method name is provided as a `StringLiteral`.
     result.hasName(this.getArgument(0).(StringLiteral).getValue())


### PR DESCRIPTION
[`Class.getMethod`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Class.html#getMethod(java.lang.String,java.lang.Class...)) only has `public` methods as result; the check for this was previously missing.

(For `getField` that check already exists, see a few lines below.)