### PR TITLE
C++: More enhancements to PrivateData.qll

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
@@ -22,14 +22,16 @@ private string privateNames() {
       // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
       // Government identifiers, such as Social Security Numbers
       "social.?security|" +
-      // Contact information, such as home addresses and telephone numbers
-      "post.?code|zip.?code|telephone|" +
+      // Contact information, such as home addresses
+      "post.?code|zip.?code|" +
+      // and telephone numbers
+      "telephone|mobile|" +
       // Geographic location - where the user is (or was)
       "latitude|longitude|" +
       // Financial data - such as credit card numbers, salary, bank accounts, and debts
       "credit.?card|salary|bank.?account|" +
       // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
-      "email|mobile|employer|" +
+      "email|employer|" +
       // Health - medical conditions, insurance status, prescription records
       "medical" +
       // ---

--- a/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/PrivateData.qll
@@ -21,19 +21,21 @@ private string privateNames() {
     ".*(" +
       // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
       // Government identifiers, such as Social Security Numbers
-      "social.?security|" +
+      "social.?security|national.?insurance|" +
       // Contact information, such as home addresses
-      "post.?code|zip.?code|" +
+      "post.?code|zip.?code|home.?address|" +
       // and telephone numbers
-      "telephone|mobile|" +
+      "telephone|home.?phone|mobile|fax.?no|fax.?number|" +
       // Geographic location - where the user is (or was)
       "latitude|longitude|" +
       // Financial data - such as credit card numbers, salary, bank accounts, and debts
-      "credit.?card|salary|bank.?account|" +
+      "credit.?card|debit.?card|salary|bank.?account|" +
       // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
-      "email|employer|" +
+      "email|" +
       // Health - medical conditions, insurance status, prescription records
-      "medical" +
+      "birthday|birth.?date|date.?of.?birth|medical|" +
+      // Relationships - work and family
+      "employer|spouse" +
       // ---
       ").*"
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/CleartextTransmission.expected
@@ -96,6 +96,8 @@ edges
 | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer |
 | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer |
 | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer |
+| test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str |
+| test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:21:48:27 | call to encrypt |
 | test.cpp:41:23:41:43 | cleartext password! | test.cpp:48:29:48:39 | thePassword |
 | test.cpp:66:23:66:43 | cleartext password! | test.cpp:76:21:76:27 | call to encrypt |
@@ -245,6 +247,10 @@ nodes
 | test3.cpp:552:15:552:20 | buffer | semmle.label | buffer |
 | test3.cpp:556:19:556:30 | salaryString | semmle.label | salaryString |
 | test3.cpp:559:15:559:20 | buffer | semmle.label | buffer |
+| test3.cpp:571:8:571:21 | call to get_home_phone | semmle.label | call to get_home_phone |
+| test3.cpp:572:14:572:16 | str | semmle.label | str |
+| test3.cpp:577:8:577:23 | call to get_home_address | semmle.label | call to get_home_address |
+| test3.cpp:578:14:578:16 | str | semmle.label | str |
 | test.cpp:41:23:41:43 | cleartext password! | semmle.label | cleartext password! |
 | test.cpp:48:21:48:27 | call to encrypt | semmle.label | call to encrypt |
 | test.cpp:48:29:48:39 | thePassword | semmle.label | thePassword |
@@ -294,3 +300,5 @@ subpaths
 | test3.cpp:533:3:533:6 | call to send | test3.cpp:532:45:532:58 | home_longitude | test3.cpp:533:15:533:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:532:45:532:58 | home_longitude | home_longitude |
 | test3.cpp:552:3:552:6 | call to send | test3.cpp:551:47:551:58 | salaryString | test3.cpp:552:15:552:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:551:47:551:58 | salaryString | salaryString |
 | test3.cpp:559:3:559:6 | call to send | test3.cpp:556:19:556:30 | salaryString | test3.cpp:559:15:559:20 | buffer | This operation transmits 'buffer', which may contain unencrypted sensitive data from $@ | test3.cpp:556:19:556:30 | salaryString | salaryString |
+| test3.cpp:572:2:572:5 | call to send | test3.cpp:571:8:571:21 | call to get_home_phone | test3.cpp:572:14:572:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@ | test3.cpp:571:8:571:21 | call to get_home_phone | call to get_home_phone |
+| test3.cpp:578:2:578:5 | call to send | test3.cpp:577:8:577:23 | call to get_home_address | test3.cpp:578:14:578:16 | str | This operation transmits 'str', which may contain unencrypted sensitive data from $@ | test3.cpp:577:8:577:23 | call to get_home_address | call to get_home_address |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -559,3 +559,21 @@ void tests2(person_info *pi)
 		send(val(), buffer, strlen(buffer), val()); // BAD
 	}
 }
+
+const char *get_home_phone();
+const char *get_home();
+const char *get_home_address();
+
+void tests3()
+{
+	const char *str;
+
+	str = get_home_phone();
+	send(val(), str, strlen(str), val()); // BAD [NOT DETECTED]
+
+	str = get_home();
+	send(val(), str, strlen(str), val()); // GOOD (probably not personal info)
+
+	str = get_home_address();
+	send(val(), str, strlen(str), val()); // BAD [NOT DETECTED]
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-311/semmle/tests/test3.cpp
@@ -569,11 +569,11 @@ void tests3()
 	const char *str;
 
 	str = get_home_phone();
-	send(val(), str, strlen(str), val()); // BAD [NOT DETECTED]
+	send(val(), str, strlen(str), val()); // BAD
 
 	str = get_home();
 	send(val(), str, strlen(str), val()); // GOOD (probably not personal info)
 
 	str = get_home_address();
-	send(val(), str, strlen(str), val()); // BAD [NOT DETECTED]
+	send(val(), str, strlen(str), val()); // BAD
 }


### PR DESCRIPTION
Add more patterns for detecting private data to `PrivateData.qll`, as there were some obvious gaps.  All improvements have been briefly tried out with ad-hoc LGTM queries, to avoid expressions that would produce many false positives (which is easy to do).

There is still _much_ more we could do here, especially in the fields of medical, family and financial information - but with the present design abbreviations (`mob`, `DOB`, `IBAN` and so forth) tend to produce too many false positives, so things might have to become a little more sophisticated in order to support that.

---

Doesn't really need a change note as the library was only added last week in https://github.com/github/codeql/pull/8580 (and that did have a change note).