### PR TITLE
C++: Add `cpp/unused-local-variable` test case with `switch` initializer

### DIFF
--- a/cpp/ql/src/Best Practices/Unused Entities/UnusedLocals.ql
+++ b/cpp/ql/src/Best Practices/Unused Entities/UnusedLocals.ql
@@ -58,5 +58,5 @@ where
   not exists(AsmStmt s | f = s.getEnclosingFunction()) and
   not v.getAnAttribute().getName() = "unused" and
   not any(ErrorExpr e).getEnclosingFunction() = f and // unextracted expr may use `v`
-  not any(ConditionDeclExpr cde).getEnclosingFunction() = f // this case can be removed when the `if (a = b; a)` test case doesn't depend on this exclusion
+  not any(ConditionDeclExpr cde).getEnclosingFunction() = f // this case can be removed when the `if (a = b; a)` and `switch (a = b; a)` test cases don't depend on this exclusion
 select v, "Variable " + v.getName() + " is not used"

--- a/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedLocals/code2.cpp
+++ b/cpp/ql/test/query-tests/Best Practices/Unused Entities/UnusedLocals/code2.cpp
@@ -163,3 +163,16 @@ void test_captured_contructor()
 
 	myFunction2( [obj](){} );
 }
+
+// ---
+
+void test_switch_initializer()
+{
+	bool a = 42, b = 43; // GOOD: a, b are both used
+
+	switch (a = b; a)
+	{
+	default:
+		// ...
+	}
+}


### PR DESCRIPTION
This is similar to the test case with the `if` initializer, and we should not forget about it once we support `if` initialization.