### PR TITLE
C#: Add more tests for `cs/useless-cast-to-self`

### DIFF
--- a/csharp/ql/test/query-tests/Language Abuse/UselessCastToSelf/UselessCastToSelf.cs
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessCastToSelf/UselessCastToSelf.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq.Expressions;
 
 class Test
 {
@@ -8,6 +9,8 @@ class Test
         var bad1 = (int)1;
         var bad2 = (Test)this;
         var bad3 = this as Test;
+        func = (Func<int, int?>)(x => x); // MISSING
+        exprFunc = (Expression<Func<int, int?>>)(x => x);
 
         // GOOD
         var good1 = (object)1;
@@ -17,6 +20,8 @@ class Test
         var good5 = (Action<int>)(x => { });
         var good6 = (Action<int>)(delegate (int x) { });
         var good7 = (Action<int>)((int x) => { });
+        func = x => x;
+        exprFunc = x => x;
     }
 
     enum Enum
@@ -27,4 +32,7 @@ class Test
         D = 9 | (32 << A),
         E = 9 | (32 << (int)A) // BAD
     }
+
+    private Func<int, int?> func;
+    private Expression<Func<int, int?>> exprFunc;
 }

--- a/csharp/ql/test/query-tests/Language Abuse/UselessCastToSelf/UselessCastToSelf.expected
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessCastToSelf/UselessCastToSelf.expected
@@ -1,5 +1,6 @@
-| UselessCastToSelf.cs:8:20:8:25 | (...) ... | This cast is redundant because the expression already has type Int32. |
-| UselessCastToSelf.cs:9:20:9:29 | (...) ... | This cast is redundant because the expression already has type Test. |
-| UselessCastToSelf.cs:10:20:10:31 | ... as ... | This cast is redundant because the expression already has type Test. |
-| UselessCastToSelf.cs:26:17:26:22 | (...) ... | This cast is redundant because the expression already has type Int32. |
-| UselessCastToSelf.cs:28:24:28:29 | (...) ... | This cast is redundant because the expression already has type Int32. |
+| UselessCastToSelf.cs:9:20:9:25 | (...) ... | This cast is redundant because the expression already has type Int32. |
+| UselessCastToSelf.cs:10:20:10:29 | (...) ... | This cast is redundant because the expression already has type Test. |
+| UselessCastToSelf.cs:11:20:11:31 | ... as ... | This cast is redundant because the expression already has type Test. |
+| UselessCastToSelf.cs:13:20:13:56 | (...) ... | This cast is redundant because the expression already has type Expression<Func<Int32,Nullable<Int32>>>. |
+| UselessCastToSelf.cs:31:17:31:22 | (...) ... | This cast is redundant because the expression already has type Int32. |
+| UselessCastToSelf.cs:33:24:33:29 | (...) ... | This cast is redundant because the expression already has type Int32. |

--- a/csharp/ql/test/query-tests/Language Abuse/UselessCastToSelf/options
+++ b/csharp/ql/test/query-tests/Language Abuse/UselessCastToSelf/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: /nostdlib /noconfig
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj


### PR DESCRIPTION
We had a false positive report [here](https://github.com/github/codeql/issues/8627). However, the casts in the report are in fact redundant, at least when using [C# 10](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/lambda-expressions#natural-type-of-a-lambda-expression) (which is what our extractor is based on). So this PR adds some tests to document the redundant casts, and in fact it revealed a false negative as well (which we should fix later).