### PR TITLE
Make security-related TaintTracking Configuration public

### DIFF
--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -11,6 +11,9 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.ExternalProcess
 import semmle.code.java.security.CommandArguments
 
+/**
+ * A taint-tracking configuration for unvalidated user input that is used to run an external process.
+ */
 class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking::Configuration {
   RemoteUserInputToArgumentToExecFlowConfig() {
     this = "ExecCommon::RemoteUserInputToArgumentToExecFlowConfig"

--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -11,7 +11,7 @@ import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.ExternalProcess
 import semmle.code.java.security.CommandArguments
 
-private class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking::Configuration {
+class RemoteUserInputToArgumentToExecFlowConfig extends TaintTracking::Configuration {
   RemoteUserInputToArgumentToExecFlowConfig() {
     this = "ExecCommon::RemoteUserInputToArgumentToExecFlowConfig"
   }

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -10,6 +10,9 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.QueryInjection
 
+/**
+ * A taint-tracking configuration for unvalidated user input that is used in SQL queries.
+ */
 class QueryInjectionFlowConfig extends TaintTracking::Configuration {
   QueryInjectionFlowConfig() { this = "SqlInjectionLib::QueryInjectionFlowConfig" }
 

--- a/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SqlInjectionQuery.qll
@@ -1,10 +1,16 @@
-/** Definitions used by the queries for database query injection. */
+/**
+ * Provides taint tracking and dataflow configurations to be used in Sql injection queries.
+ *
+ * Do not import this from a library file, in order to reduce the risk of
+ * unintentionally bringing a TaintTracking::Configuration into scope in an unrelated
+ * query.
+ */
 
 import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.security.QueryInjection
 
-private class QueryInjectionFlowConfig extends TaintTracking::Configuration {
+class QueryInjectionFlowConfig extends TaintTracking::Configuration {
   QueryInjectionFlowConfig() { this = "SqlInjectionLib::QueryInjectionFlowConfig" }
 
   override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -14,7 +14,7 @@
 
 import java
 import semmle.code.java.dataflow.FlowSources
-import SqlInjectionLib
+import semmle.code.java.security.SqlInjectionQuery
 import DataFlow::PathGraph
 
 from QueryInjectionSink query, DataFlow::PathNode source, DataFlow::PathNode sink

--- a/java/ql/src/Security/CWE/CWE-089/SqlTaintedLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTaintedLocal.ql
@@ -14,7 +14,7 @@
 
 import semmle.code.java.Expr
 import semmle.code.java.dataflow.FlowSources
-import SqlInjectionLib
+import semmle.code.java.security.SqlInjectionQuery
 import DataFlow::PathGraph
 
 class LocalUserInputToQueryInjectionFlowConfig extends TaintTracking::Configuration {

--- a/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
@@ -14,7 +14,7 @@
 
 import java
 import semmle.code.java.security.SqlUnescapedLib
-import SqlInjectionLib
+import semmle.code.java.security.SqlInjectionQuery
 
 class UncontrolledStringBuilderSource extends DataFlow::ExprNode {
   UncontrolledStringBuilderSource() {


### PR DESCRIPTION
Make security-related taint tracking configuration public so they can be imported for sink identification

- Update Sql Injection queries
- Update CommandLineQuery
