### PR TITLE
Remove @xcorail from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,12 +5,6 @@
 /python/ @github/codeql-python
 /ruby/ @github/codeql-ruby
 
-/cpp/**/experimental/**/* @github/codeql-c-analysis
-/csharp/**/experimental/**/* @github/codeql-csharp
-/java/**/experimental/**/* @github/codeql-java
-/javascript/**/experimental/**/* @github/codeql-javascript
-/python/**/experimental/**/* @github/codeql-python
-/ruby/**/experimental/**/* @github/codeql-ruby
 
 # ML-powered queries
 /javascript/ql/experimental/adaptivethreatmodeling/ @github/codeql-ml-powered-queries-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,12 +6,12 @@
 /ruby/ @github/codeql-ruby
 
 # Make @xcorail (GitHub Security Lab) a code owner for experimental queries so he gets pinged when we promote a query out of experimental
-/cpp/**/experimental/**/* @github/codeql-c-analysis @xcorail
-/csharp/**/experimental/**/* @github/codeql-csharp @xcorail
-/java/**/experimental/**/* @github/codeql-java @xcorail
-/javascript/**/experimental/**/* @github/codeql-javascript @xcorail
-/python/**/experimental/**/* @github/codeql-python @xcorail
-/ruby/**/experimental/**/* @github/codeql-ruby @xcorail
+/cpp/**/experimental/**/* @github/codeql-c-analysis
+/csharp/**/experimental/**/* @github/codeql-csharp
+/java/**/experimental/**/* @github/codeql-java
+/javascript/**/experimental/**/* @github/codeql-javascript
+/python/**/experimental/**/* @github/codeql-python
+/ruby/**/experimental/**/* @github/codeql-ruby
 
 # ML-powered queries
 /javascript/ql/experimental/adaptivethreatmodeling/ @github/codeql-ml-powered-queries-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,6 @@
 /python/ @github/codeql-python
 /ruby/ @github/codeql-ruby
 
-
 # ML-powered queries
 /javascript/ql/experimental/adaptivethreatmodeling/ @github/codeql-ml-powered-queries-reviewers
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,6 @@
 /python/ @github/codeql-python
 /ruby/ @github/codeql-ruby
 
-# Make @xcorail (GitHub Security Lab) a code owner for experimental queries so he gets pinged when we promote a query out of experimental
 /cpp/**/experimental/**/* @github/codeql-c-analysis
 /csharp/**/experimental/**/* @github/codeql-csharp
 /java/**/experimental/**/* @github/codeql-java


### PR DESCRIPTION
Since @xcorail didn't have write access to this repo, that caused troubles with the CODEOWNERS file.