### PR TITLE
JS: Add files as a source for `js/xss-through-dom`

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -162,6 +162,11 @@ module XssThroughDom {
     }
   }
 
+  /** The `files` property of an `<input />` element */
+  class FilesSource extends Source {
+    FilesSource() { this = DOM::domValueRef().getAPropertyRead("files") }
+  }
+
   /**
    * A module for form inputs seen as sources for xss-through-dom.
    */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomQuery.qll
@@ -36,6 +36,11 @@ class Configuration extends TaintTracking::Configuration {
     DomBasedXss::isOptionallySanitizedEdge(pred, succ)
   }
 
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    succ = DataFlow::globalVarRef("URL").getAMemberCall("createObjectURL") and
+    pred = succ.(DataFlow::InvokeNode).getArgument(0)
+  }
+
   override predicate hasFlowPath(DataFlow::SourcePathNode src, DataFlow::SinkPathNode sink) {
     super.hasFlowPath(src, sink) and
     // filtering away readings of `src` that end in a URL sink.

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -129,6 +129,11 @@ nodes
 | xss-through-dom.js:115:16:115:18 | src |
 | xss-through-dom.js:117:26:117:28 | src |
 | xss-through-dom.js:117:26:117:28 | src |
+| xss-through-dom.js:120:23:120:37 | ev.target.files |
+| xss-through-dom.js:120:23:120:37 | ev.target.files |
+| xss-through-dom.js:120:23:120:40 | ev.target.files[0] |
+| xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
+| xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
 edges
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
@@ -207,6 +212,10 @@ edges
 | xss-through-dom.js:114:11:114:52 | src | xss-through-dom.js:117:26:117:28 | src |
 | xss-through-dom.js:114:17:114:52 | documen ... k").src | xss-through-dom.js:114:11:114:52 | src |
 | xss-through-dom.js:114:17:114:52 | documen ... k").src | xss-through-dom.js:114:11:114:52 | src |
+| xss-through-dom.js:120:23:120:37 | ev.target.files | xss-through-dom.js:120:23:120:40 | ev.target.files[0] |
+| xss-through-dom.js:120:23:120:37 | ev.target.files | xss-through-dom.js:120:23:120:40 | ev.target.files[0] |
+| xss-through-dom.js:120:23:120:40 | ev.target.files[0] | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
+| xss-through-dom.js:120:23:120:40 | ev.target.files[0] | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
 #select
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
@@ -242,3 +251,4 @@ edges
 | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:96:17:96:47 | $("#foo ... ].value | DOM text |
 | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" | xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:109:45:109:55 | this.el.src | DOM text |
 | xss-through-dom.js:115:16:115:18 | src | xss-through-dom.js:114:17:114:52 | documen ... k").src | xss-through-dom.js:115:16:115:18 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:114:17:114:52 | documen ... k").src | DOM text |
+| xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name | xss-through-dom.js:120:23:120:37 | ev.target.files | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:120:23:120:37 | ev.target.files | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -134,6 +134,11 @@ nodes
 | xss-through-dom.js:120:23:120:40 | ev.target.files[0] |
 | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
 | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
+| xss-through-dom.js:122:33:122:71 | URL.cre ... les[0]) |
+| xss-through-dom.js:122:33:122:71 | URL.cre ... les[0]) |
+| xss-through-dom.js:122:53:122:67 | ev.target.files |
+| xss-through-dom.js:122:53:122:67 | ev.target.files |
+| xss-through-dom.js:122:53:122:70 | ev.target.files[0] |
 edges
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values |
@@ -216,6 +221,10 @@ edges
 | xss-through-dom.js:120:23:120:37 | ev.target.files | xss-through-dom.js:120:23:120:40 | ev.target.files[0] |
 | xss-through-dom.js:120:23:120:40 | ev.target.files[0] | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
 | xss-through-dom.js:120:23:120:40 | ev.target.files[0] | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name |
+| xss-through-dom.js:122:53:122:67 | ev.target.files | xss-through-dom.js:122:53:122:70 | ev.target.files[0] |
+| xss-through-dom.js:122:53:122:67 | ev.target.files | xss-through-dom.js:122:53:122:70 | ev.target.files[0] |
+| xss-through-dom.js:122:53:122:70 | ev.target.files[0] | xss-through-dom.js:122:33:122:71 | URL.cre ... les[0]) |
+| xss-through-dom.js:122:53:122:70 | ev.target.files[0] | xss-through-dom.js:122:33:122:71 | URL.cre ... les[0]) |
 #select
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
@@ -252,3 +261,4 @@ edges
 | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" | xss-through-dom.js:109:45:109:55 | this.el.src | xss-through-dom.js:109:31:109:70 | "<a src ... oo</a>" | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:109:45:109:55 | this.el.src | DOM text |
 | xss-through-dom.js:115:16:115:18 | src | xss-through-dom.js:114:17:114:52 | documen ... k").src | xss-through-dom.js:115:16:115:18 | src | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:114:17:114:52 | documen ... k").src | DOM text |
 | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name | xss-through-dom.js:120:23:120:37 | ev.target.files | xss-through-dom.js:120:23:120:45 | ev.targ ... 0].name | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:120:23:120:37 | ev.target.files | DOM text |
+| xss-through-dom.js:122:33:122:71 | URL.cre ... les[0]) | xss-through-dom.js:122:53:122:67 | ev.target.files | xss-through-dom.js:122:33:122:71 | URL.cre ... les[0]) | $@ is reinterpreted as HTML without escaping meta-characters. | xss-through-dom.js:122:53:122:67 | ev.target.files | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -118,5 +118,7 @@ class Sub extends Super {
 
     $("input.foo")[0].onchange = function (ev) {
         $("#id").html(ev.target.files[0].name); // NOT OK.
+
+        $("img#id").attr("src", URL.createObjectURL(ev.target.files[0])); // NOT OK
     }
 })();

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/xss-through-dom.js
@@ -115,4 +115,8 @@ class Sub extends Super {
 	$("#id").html(src); // NOT OK.
 
     $("#id").attr("src", src); // OK
+
+    $("input.foo")[0].onchange = function (ev) {
+        $("#id").html(ev.target.files[0].name); // NOT OK.
+    }
 })();


### PR DESCRIPTION
Recognizes the source for CVE-2021-32622  

Also adds a taint-step for `URL.createObjectURL`, also inspired by the same CVE.  
I've just added the step to the `js/xss-throgh-dom`.   
The step is only relevant for XSS, and I think it's mostly relevant for `js/xss-throgh-dom`, so I'm just putting it there for now.    

[Evaluation looks fine](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-8678-0435cee__nightly-old__CustomSuite/reports). One new result that looks like a TP. 