### PR TITLE
Java: rename existing getUrl predicate to getRepositoryUrl

### DIFF
--- a/java/ql/lib/change-notes/2022-04-06-getUrl-deprecation.md
+++ b/java/ql/lib/change-notes/2022-04-06-getUrl-deprecation.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+* The `getUrl` predicate of `DeclaredRepository` in `MavenPom.qll` has been renamed to `getRepositoryUrl`. 

--- a/java/ql/lib/semmle/code/xml/MavenPom.qll
+++ b/java/ql/lib/semmle/code/xml/MavenPom.qll
@@ -380,7 +380,7 @@ class DeclaredRepository extends PomElement {
    * Gets the url for this repository. If the `url` tag is present, this will
    * be the string contents of that tag.
    */
-  string getUrl() { result = this.getAChild("url").(PomElement).getValue() }
+  string getRepositoryUrl() { result = this.getAChild("url").(PomElement).getValue() }
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-1104/MavenPomDependsOnBintray.ql
+++ b/java/ql/src/Security/CWE/CWE-1104/MavenPomDependsOnBintray.ql
@@ -14,10 +14,10 @@ import java
 import semmle.code.xml.MavenPom
 
 predicate isBintrayRepositoryUsage(DeclaredRepository repository) {
-  repository.getUrl().matches("%.bintray.com%")
+  repository.getRepositoryUrl().matches("%.bintray.com%")
 }
 
 from DeclaredRepository repository
 where isBintrayRepositoryUsage(repository)
 select repository,
-  "Downloading or uploading artifacts to deprecated repository " + repository.getUrl()
+  "Downloading or uploading artifacts to deprecated repository " + repository.getRepositoryUrl()

--- a/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
+++ b/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
@@ -17,11 +17,11 @@ import java
 import semmle.code.xml.MavenPom
 
 predicate isInsecureRepositoryUsage(DeclaredRepository repository) {
-  repository.getUrl().regexpMatch("(?i)^(http|ftp)://(?!localhost[:/]).*")
+  repository.getRepositoryUrl().regexpMatch("(?i)^(http|ftp)://(?!localhost[:/]).*")
 }
 
 from DeclaredRepository repository
 where isInsecureRepositoryUsage(repository)
 select repository,
   "Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository " +
-    repository.getUrl()
+    repository.getRepositoryUrl()


### PR DESCRIPTION
I would like to eventually make all our code follow our own style guide.  

That involves changing the location providing predicate `getURL` to `getUrl`.   
(See [providing locations in CodeQL](https://codeql.github.com/docs/writing-codeql-queries/providing-locations-in-codeql-queries/#providing-urls)).  

However, that change would cause issues in `MavenPom.qll` where a `getUrl()` predicate is already used for something else.   
With my change the frontend would read the existing `getUrl` as a predicate that provides a location, and that would cause the `MavenPomDependsOnBintray.ql` query to break. 

I would therefore like to rename it. 