### PR TITLE
Java: Timing attack

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-208/SafeComparison.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/SafeComparison.java
@@ -1,0 +1,5 @@
+private boolean safeComparison(String pwd, HttpServletRequest request) {
+      String password = request.getParameter("password");
+      return MessageDigest.isEqual(password.getBytes(StandardCharsets.UTF_8), pwd.getBytes(StandardCharsets.UTF_8));
+}
+

--- a/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstSensitiveInfo.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstSensitiveInfo.qhelp
@@ -1,0 +1,45 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+A constant-time algorithm should be used for checking the value of sensitive info.
+In other words, the comparison time should not depend on the content of the input. 
+Otherwise timing information could be used to infer the info's expected, secret value.
+</p>
+</overview>
+
+
+<recommendation>
+<p>
+Use <code>MessageDigest.isEqual()</code> method to check the value of sensitive info.
+If this method is used, then the calculation time depends only on the length of input byte arrays,
+and does not depend on the contents of the arrays.
+</p>
+</recommendation>
+<example>
+<p>
+The following example uses <code>String.equals()</code> method for validating a password.
+This method implements a non-constant-time algorithm:
+</p>
+<sample src="UnsafeComparison.java" />
+
+<p>
+The next example uses a safe constant-time algorithm for validating a password:
+</p>
+<sample src="SafeComparison.java" />
+</example>
+
+<references>
+<li>
+  Wikipedia:
+  <a href="https://en.wikipedia.org/wiki/Timing_attack">Timing attack</a>.
+</li>
+
+<li>
+  Java API Specification:
+  <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/MessageDigest.html#isEqual(byte[],byte[])">MessageDigest.isEqual() method</a>
+</li>
+</references>
+
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstSensitiveInfo.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/TimingAttackAgainstSensitiveInfo.ql
@@ -1,0 +1,81 @@
+/**
+ * @name Timing attack against sensitive info
+ * @description Use of a non-constant-time verification routine to check the value of an sensitive info,
+ *              possibly allowing a timing attack to infer the info's expected value.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/timing-attack-against-sensitive-info
+ * @tags security
+ *       external/cwe/cwe-208
+ */
+
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+private string suspicious() {
+  result =
+    [
+      "%password%", "%passwd%", "%pwd%", "%refresh%token%", "%secret%token", "%secret%key",
+      "%passcode%", "%passphrase%", "%token%", "%secret%", "%credential%", "%key%"
+    ]
+}
+
+/** A variable that may hold sensitive information, judging by its name. * */
+class CredentialExpr extends Expr {
+  CredentialExpr() {
+    exists(Variable v | this = v.getAnAccess() |
+      v.getName().toLowerCase().matches(suspicious()) and
+      not v.isFinal()
+    )
+  }
+}
+
+/** Methods that use a non-constant-time algorithm for comparing inputs. */
+private class NonConstantTimeEqualsCall extends MethodAccess {
+  NonConstantTimeEqualsCall() {
+    this.getMethod()
+        .hasQualifiedName("java.lang", "String", ["equals", "contentEquals", "equalsIgnoreCase"]) or
+    this.getMethod().hasQualifiedName("java.nio", "ByteBuffer", ["equals", "compareTo"])
+  }
+}
+
+/** A static method that uses a non-constant-time algorithm for comparing inputs. */
+private class NonConstantTimeComparisonCall extends StaticMethodAccess {
+  NonConstantTimeComparisonCall() {
+    this.getMethod().hasQualifiedName("java.util", "Arrays", ["equals", "deepEquals"]) or
+    this.getMethod().hasQualifiedName("java.util", "Objects", "deepEquals") or
+    this.getMethod()
+        .hasQualifiedName("org.apache.commons.lang3", "StringUtils",
+          ["equals", "equalsAny", "equalsAnyIgnoreCase", "equalsIgnoreCase"])
+  }
+}
+
+private predicate isNonConstantEqualsCallArgument(Expr e) {
+  exists(NonConstantTimeEqualsCall call | e = [call.getQualifier(), call.getArgument(0)])
+}
+
+private predicate isNonConstantComparisonCallArgument(Expr p) {
+  exists(NonConstantTimeComparisonCall call | p = [call.getArgument(0), call.getArgument(1)])
+}
+
+class NonConstantTimeComparisonConfig extends TaintTracking::Configuration {
+  NonConstantTimeComparisonConfig() { this = "NonConstantTimeComparisonConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    source.asExpr() instanceof CredentialExpr
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    isNonConstantEqualsCallArgument(sink.asExpr()) or
+    isNonConstantComparisonCallArgument(sink.asExpr())
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, NonConstantTimeComparisonConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Possible timing attack against $@ validation.",
+  source.getNode()

--- a/java/ql/src/experimental/Security/CWE/CWE-208/UnsafeComparison.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-208/UnsafeComparison.java
@@ -1,0 +1,5 @@
+private boolean UnsafeComparison(String pwd, HttpServletRequest request) {
+    String password = request.getParameter("password");
+    return password.equals(pwd);        
+}
+

--- a/java/ql/test/experimental/query-tests/security/CWE-208/TimingAttackAgainstSensitiveInfo/Test.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-208/TimingAttackAgainstSensitiveInfo/Test.java
@@ -1,0 +1,17 @@
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.lang.String;
+import javax.servlet.http.HttpServletRequest;
+
+public class Test {
+    private boolean UnsafeComparison(String pwd, HttpServletRequest request) {
+        String password = request.getParameter("password");
+        return password.equals(pwd);        
+    }
+     
+    private boolean safeComparison(String pwd, HttpServletRequest request) {
+          String password = request.getParameter("password");
+          return MessageDigest.isEqual(password.getBytes(StandardCharsets.UTF_8), pwd.getBytes(StandardCharsets.UTF_8));
+    }
+
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-208/TimingAttackAgainstSensitiveInfo/TimingAttackAgainstSensitiveInfo.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-208/TimingAttackAgainstSensitiveInfo/TimingAttackAgainstSensitiveInfo.expected
@@ -1,0 +1,8 @@
+edges
+nodes
+| Test.java:10:16:10:23 | password | semmle.label | password |
+| Test.java:10:32:10:34 | pwd | semmle.label | pwd |
+subpaths
+#select
+| Test.java:10:16:10:23 | password | Test.java:10:16:10:23 | password | Test.java:10:16:10:23 | password | Possible timing attack against $@ validation. | Test.java:10:16:10:23 | password |
+| Test.java:10:32:10:34 | pwd | Test.java:10:32:10:34 | pwd | Test.java:10:32:10:34 | pwd | Possible timing attack against $@ validation. | Test.java:10:32:10:34 | pwd |

--- a/java/ql/test/experimental/query-tests/security/CWE-208/TimingAttackAgainstSensitiveInfo/TimingAttackAgainstSensitiveInfo.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-208/TimingAttackAgainstSensitiveInfo/TimingAttackAgainstSensitiveInfo.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-208/TimingAttackAgainstSensitiveInfo.ql


### PR DESCRIPTION
A constant-time algorithm should be used for checking the value of info. In other words, the comparison time should not depend on the content of the input, Otherwise, an attacker may be able to implement a timing attacks that may reveal the value of sensitive info