### PR TITLE
C++: Use `isSanitizerOut(DataFlow::Node node)` in `cpp/command-line-injection`

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
+++ b/cpp/ql/src/Security/CWE/CWE-078/ExecTainted.ql
@@ -116,8 +116,8 @@ class ExecTaintConfiguration extends TaintTracking::Configuration {
     state instanceof ConcatState
   }
 
-  override predicate isSanitizerOut(DataFlow::Node node, DataFlow::FlowState state) {
-    isSink(node, state) // Prevent duplicates along a call chain, since `shellCommand` will include wrappers
+  override predicate isSanitizerOut(DataFlow::Node node) {
+    isSink(node, _) // Prevent duplicates along a call chain, since `shellCommand` will include wrappers
   }
 }
 


### PR DESCRIPTION
After discussion in https://github.com/github/codeql/pull/8435

I performed a DCA experiment and did a comparative run on all LGTM C/C++ projects, neither showed any regressions.

Still to do: DCA experiment with the `nightly` query set.