### PR TITLE
Update CODEOWNERS for documentation and license changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,3 +27,7 @@
 # Bazel
 **/*.bazel @github/codeql-ci-reviewers
 **/*.bzl @github/codeql-ci-reviewers
+
+# Documentation etc
+/*.md @github/code-scanning-product
+/LICENSE @github/code-scanning-product


### PR DESCRIPTION
To make sure the right people are pinged when a change like #5893 are made. The PM team will pull in our friends in documentation (cc @felicitymay) if/when needed.

I used @github/code-scanning-product (rather than @github/codeql-product) so the ping would include @jf205 and myself. We only see a couple of changes per year to those files, so hopefully this shouldn't cause too much noise for the other PMs in @github/code-scanning-product.