### PR TITLE
QL: Add facilities for data flow

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -383,7 +383,8 @@
     "csharp/ql/test/TestUtilities/InlineExpectationsTest.qll",
     "java/ql/test/TestUtilities/InlineExpectationsTest.qll",
     "python/ql/test/TestUtilities/InlineExpectationsTest.qll",
-    "ruby/ql/test/TestUtilities/InlineExpectationsTest.qll"
+    "ruby/ql/test/TestUtilities/InlineExpectationsTest.qll",
+    "ql/ql/test/TestUtilities/InlineExpectationsTest.qll"
   ],
   "C++ ExternalAPIs": [
     "cpp/ql/src/Security/CWE/CWE-020/ExternalAPIs.qll",

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -79,6 +79,7 @@ class AstNode extends TAstNode {
 
   /** Gets an annotation of this AST node. */
   Annotation getAnAnnotation() {
+    not this instanceof Annotation and // avoid cyclic parent-child relationship
     toQL(this).getParent() = pragma[only_bind_out](toQL(result)).getParent()
   }
 
@@ -125,6 +126,9 @@ class TopLevel extends TTopLevel, AstNode {
   /** Gets a `newtype` defined at the top-level of this module. */
   NewType getANewType() { result = this.getAMember() }
 
+  /** Gets a `select` clause in the top-level of this module. */
+  Select getASelect() { result = this.getAMember() }
+
   override ModuleMember getAChild(string pred) {
     pred = directMember("getAnImport") and result = this.getAnImport()
     or
@@ -137,6 +141,8 @@ class TopLevel extends TTopLevel, AstNode {
     pred = directMember("getANewType") and result = this.getANewType()
     or
     pred = directMember("getQLDoc") and result = this.getQLDoc()
+    or
+    pred = directMember("getASelect") and result = this.getASelect()
   }
 
   QLDoc getQLDocFor(ModuleMember m) {

--- a/ql/ql/src/codeql_ql/ast/Ast.qll
+++ b/ql/ql/src/codeql_ql/ast/Ast.qll
@@ -553,6 +553,9 @@ class VarDef extends TVarDef, AstNode {
 
   Type getType() { none() }
 
+  /** Gets a variable access to this `VarDef` */
+  VarAccess getAnAccess() { result.getDeclaration() = this }
+
   override string getAPrimaryQlClass() { result = "VarDef" }
 
   override string toString() { result = this.getName() }

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodeNumbering.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodeNumbering.qll
@@ -1,0 +1,38 @@
+private import codeql_ql.ast.Ast
+
+pragma[inline]
+private predicate isNumberedNode(AstNode node) {
+  // these are not nested in the location of the parent node, so we can't use their location to order them
+  not node instanceof Annotation and
+  not node instanceof QLDoc
+}
+
+private int getNodeDepth(AstNode node) {
+  node instanceof TopLevel and
+  result = 0
+  or
+  isNumberedNode(node) and
+  result = 1 + getNodeDepth(node.getParent())
+}
+
+/**
+ * Gets the pre-order ID for the given `node`, that is, its visit position
+ * in a pre-order traversal of all nodes.
+ *
+ * The children of a node are ordered left-to-right as they appear in the source code.
+ *
+ * The ID is globally unique for this AST node, also across files.
+ *
+ * At the moment this predicate is only defined for node which are:
+ * - reachable via `getAChild` edges from a `TopLevel`, and
+ * - is not a comment or annotation
+ */
+cached
+int getPreOrderId(AstNode node) {
+  node =
+    rank[result](AstNode n, Location loc, int depth |
+      depth = getNodeDepth(n) and loc = n.getLocation()
+    |
+      n order by loc.getFile().getAbsolutePath(), loc.getStartLine(), loc.getStartColumn(), depth
+    )
+}

--- a/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
+++ b/ql/ql/src/codeql_ql/ast/internal/AstNodes.qll
@@ -204,7 +204,7 @@ QL::AstNode toQL(AST::AstNode n) {
 class TPredicate =
   TCharPred or TClasslessPredicate or TClassPredicate or TDBRelation or TNewTypeBranch;
 
-class TPredOrBuiltin = TPredicate or TNewTypeBranch or TBuiltin;
+class TPredOrBuiltin = TPredicate or TBuiltin;
 
 class TBuiltin = TBuiltinClassless or TBuiltinMember;
 

--- a/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
@@ -13,6 +13,14 @@ class Node extends TNode {
    * Gets the underlying `Expr` or `VarDef` node, if this is an `AstNodeNode`.
    */
   AstNode asAstNode() { astNode(result) = this }
+
+  /**
+   * Gets the predicate containing this data-flow node.
+   *
+   * All data-flow nodes belong in exactly one predicate.
+   * TODO: select clauses
+   */
+  Predicate getEnclosingPredicate() { none() } // overridden in subclasses
 }
 
 /**
@@ -34,6 +42,10 @@ class AstNodeNode extends Node, MkAstNodeNode {
   /** Gets the AST node. */
   AstNode getAstNode() {
     result = ast
+  }
+
+  override Predicate getEnclosingPredicate() {
+    result = ast.getEnclosingPredicate()
   }
 }
 
@@ -71,6 +83,10 @@ class ScopedVariableNode extends Node, MkScopedVariable {
   AstNode getScope() {
     result = scope
   }
+
+  override Predicate getEnclosingPredicate() {
+    result = var.getEnclosingPredicate()
+  }
 }
 
 /**
@@ -101,6 +117,10 @@ class ThisNode extends Node, MkThisNode {
   Predicate getPredicate() {
     result = pred
   }
+
+  override Predicate getEnclosingPredicate() {
+    result = pred
+  }
 }
 
 /**
@@ -129,6 +149,10 @@ class ResultNode extends Node, MkResultNode {
 
   /** Gets the predicate whose 'result' parameter is represented by this node. */
   Predicate getPredicate() {
+    result = pred
+  }
+
+  override Predicate getEnclosingPredicate() {
     result = pred
   }
 }
@@ -170,6 +194,10 @@ class FieldNode extends Node, MkFieldNode {
 
   override Location getLocation() {
     result = pred.getLocation()
+  }
+
+  override Predicate getEnclosingPredicate() {
+    result = pred
   }
 }
 

--- a/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
@@ -1,0 +1,147 @@
+private import codeql_ql.ast.Ast
+private import internal.NodesInternal
+
+/**
+ * An expression or variable in a formula, including some additional nodes
+ * that are not part of the AST.
+ */
+class Node extends TNode {
+  string toString() { none() } // overridden in subclasses
+  Location getLocation() { none() } // overridden in subclasses
+
+  /**
+   * Gets the underlying `Expr` or `VarDef` node, if this is an `AstNodeNode`.
+   */
+  AstNode asAstNode() { astNode(result) = this }
+}
+
+/**
+ * A data-flow node based an `Expr` or `VarDef` AST node.
+ */
+class AstNodeNode extends Node, MkAstNodeNode {
+  private AstNode ast;
+
+  AstNodeNode() { this = MkAstNodeNode(ast) }
+
+  override string toString() {
+    result = ast.toString()
+  }
+
+  override Location getLocation() {
+    result = ast.getLocation()
+  }
+
+  /** Gets the AST node. */
+  AstNode getAstNode() {
+    result = ast
+  }
+}
+
+/**
+ * Gets the data-flow node correspoinding to the given AST node.
+ */
+pragma[inline]
+Node astNode(AstNode node) {
+  result = MkAstNodeNode(node)
+}
+
+/**
+ * A data-flow node representing `this` within a class predicate, charpred, or newtype branch.
+ */
+class ThisNode extends Node, MkThisNode {
+  private Predicate pred;
+
+  ThisNode() { this = MkThisNode(pred) }
+
+  override string toString() {
+    result = "'this' in " + pred.getName()
+  }
+
+  override Location getLocation() {
+    result = pred.getLocation()
+  }
+
+  /** Gets the class predicate, charpred, or newtype branch whose 'this' parameter is represented by this node. */
+  Predicate getPredicate() {
+    result = pred
+  }
+}
+
+/**
+ * Gets the data-flow node representing `this` within the given class predicate, charpred, or newtype branch.
+ */
+pragma[inline]
+Node thisNode(Predicate pred) {
+  result = MkThisNode(pred)
+}
+
+/**
+ * A data-flow node representing `result` within a predicate that has a result.
+ */
+class ResultNode extends Node, MkResultNode {
+  private Predicate pred;
+
+  ResultNode() { this = MkResultNode(pred) }
+
+  override string toString() {
+    result = "'result' in " + pred.getName()
+  }
+
+  override Location getLocation() {
+    result = pred.getLocation()
+  }
+
+  /** Gets the predicate whose 'result' parameter is represented by this node. */
+  Predicate getPredicate() {
+    result = pred
+  }
+}
+
+/**
+ * Gets the data-flow node representing `result` within the given predicate.
+ */
+pragma[inline]
+Node resultNode(Predicate pred) {
+  result = MkResultNode(pred)
+}
+
+/**
+ * A data-flow node representing the view of a field in the enclosing class, as seen
+ * from a charpred or class predicate.
+ */
+class FieldNode extends Node, MkFieldNode {
+  private Predicate pred;
+  private FieldDecl fieldDecl;
+
+  FieldNode() { this = MkFieldNode(pred, fieldDecl) }
+
+  /** Gets the member predicate or charpred for which this node represents access to the field. */
+  Predicate getPredicate() {
+    result = pred
+  }
+
+  FieldDecl getFieldDeclaration() {
+    result = fieldDecl
+  }
+
+  string getFieldName() {
+    result = fieldDecl.getName()
+  }
+
+  override string toString() {
+    result = "'"  + this.getFieldName() + "' in " + pred.getName()
+  }
+
+  override Location getLocation() {
+    result = pred.getLocation()
+  }
+}
+
+/**
+ * Gets the data-flow node representing the given predicate's view of the given field
+ * in the enclosing class.
+ */
+pragma[inline]
+Node fieldNode(Predicate pred, FieldDecl fieldDecl) {
+  result = MkFieldNode(pred, fieldDecl)
+}

--- a/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
@@ -16,6 +16,7 @@ private import internal.GlobalFlow as GlobalFlow
  */
 class Node extends TNode {
   string toString() { none() } // overridden in subclasses
+
   Location getLocation() { none() } // overridden in subclasses
 
   /**
@@ -48,31 +49,21 @@ class AstNodeNode extends Node, MkAstNodeNode {
 
   AstNodeNode() { this = MkAstNodeNode(ast) }
 
-  override string toString() {
-    result = ast.toString()
-  }
+  override string toString() { result = ast.toString() }
 
-  override Location getLocation() {
-    result = ast.getLocation()
-  }
+  override Location getLocation() { result = ast.getLocation() }
 
   /** Gets the AST node. */
-  AstNode getAstNode() {
-    result = ast
-  }
+  AstNode getAstNode() { result = ast }
 
-  override Predicate getEnclosingPredicate() {
-    result = ast.getEnclosingPredicate()
-  }
+  override Predicate getEnclosingPredicate() { result = ast.getEnclosingPredicate() }
 }
 
 /**
  * Gets the data-flow node correspoinding to the given AST node.
  */
 pragma[inline]
-Node astNode(AstNode node) {
-  result = MkAstNodeNode(node)
-}
+Node astNode(AstNode node) { result = MkAstNodeNode(node) }
 
 /**
  * A data-flow node representing a variable within a specific scope.
@@ -84,35 +75,27 @@ class ScopedVariableNode extends Node, MkScopedVariable {
   ScopedVariableNode() { this = MkScopedVariable(var, scope) }
 
   override string toString() {
-    result = "Variable '" + var.getName() + "' scoped to " + scope.getLocation().getStartLine() + ":" + scope.getLocation().getStartColumn()
+    result =
+      "Variable '" + var.getName() + "' scoped to " + scope.getLocation().getStartLine() + ":" +
+        scope.getLocation().getStartColumn()
   }
 
-  override Location getLocation() {
-    result = scope.getLocation()
-  }
+  override Location getLocation() { result = scope.getLocation() }
 
   /** Gets the variable being refined to a specific scope. */
-  VarDef getVariable() {
-    result = var
-  }
+  VarDef getVariable() { result = var }
 
   /** Gets the scope to which this variable has been refined. */
-  AstNode getScope() {
-    result = scope
-  }
+  AstNode getScope() { result = scope }
 
-  override Predicate getEnclosingPredicate() {
-    result = var.getEnclosingPredicate()
-  }
+  override Predicate getEnclosingPredicate() { result = var.getEnclosingPredicate() }
 }
 
 /**
  * Gets the data-flow node corresponding to `var` restricted to `scope`.
  */
 pragma[inline]
-Node scopedVariable(VarDef var, AstNode scope) {
-  result = MkScopedVariable(var, scope)
-}
+Node scopedVariable(VarDef var, AstNode scope) { result = MkScopedVariable(var, scope) }
 
 /**
  * A data-flow node representing `this` within a class predicate, charpred, or newtype branch.
@@ -122,31 +105,21 @@ class ThisNode extends Node, MkThisNode {
 
   ThisNode() { this = MkThisNode(pred) }
 
-  override string toString() {
-    result = "'this' in " + pred.getName()
-  }
+  override string toString() { result = "'this' in " + pred.getName() }
 
-  override Location getLocation() {
-    result = pred.getLocation()
-  }
+  override Location getLocation() { result = pred.getLocation() }
 
   /** Gets the class predicate, charpred, or newtype branch whose 'this' parameter is represented by this node. */
-  Predicate getPredicate() {
-    result = pred
-  }
+  Predicate getPredicate() { result = pred }
 
-  override Predicate getEnclosingPredicate() {
-    result = pred
-  }
+  override Predicate getEnclosingPredicate() { result = pred }
 }
 
 /**
  * Gets the data-flow node representing `this` within the given class predicate, charpred, or newtype branch.
  */
 pragma[inline]
-Node thisNode(Predicate pred) {
-  result = MkThisNode(pred)
-}
+Node thisNode(Predicate pred) { result = MkThisNode(pred) }
 
 /**
  * A data-flow node representing `result` within a predicate that has a result.
@@ -156,31 +129,21 @@ class ResultNode extends Node, MkResultNode {
 
   ResultNode() { this = MkResultNode(pred) }
 
-  override string toString() {
-    result = "'result' in " + pred.getName()
-  }
+  override string toString() { result = "'result' in " + pred.getName() }
 
-  override Location getLocation() {
-    result = pred.getLocation()
-  }
+  override Location getLocation() { result = pred.getLocation() }
 
   /** Gets the predicate whose 'result' parameter is represented by this node. */
-  Predicate getPredicate() {
-    result = pred
-  }
+  Predicate getPredicate() { result = pred }
 
-  override Predicate getEnclosingPredicate() {
-    result = pred
-  }
+  override Predicate getEnclosingPredicate() { result = pred }
 }
 
 /**
  * Gets the data-flow node representing `result` within the given predicate.
  */
 pragma[inline]
-Node resultNode(Predicate pred) {
-  result = MkResultNode(pred)
-}
+Node resultNode(Predicate pred) { result = MkResultNode(pred) }
 
 /**
  * A data-flow node representing the view of a field in the enclosing class, as seen
@@ -193,29 +156,17 @@ class FieldNode extends Node, MkFieldNode {
   FieldNode() { this = MkFieldNode(pred, fieldDecl) }
 
   /** Gets the member predicate or charpred for which this node represents access to the field. */
-  Predicate getPredicate() {
-    result = pred
-  }
+  Predicate getPredicate() { result = pred }
 
-  FieldDecl getFieldDeclaration() {
-    result = fieldDecl
-  }
+  FieldDecl getFieldDeclaration() { result = fieldDecl }
 
-  string getFieldName() {
-    result = fieldDecl.getName()
-  }
+  string getFieldName() { result = fieldDecl.getName() }
 
-  override string toString() {
-    result = "'"  + this.getFieldName() + "' in " + pred.getName()
-  }
+  override string toString() { result = "'" + this.getFieldName() + "' in " + pred.getName() }
 
-  override Location getLocation() {
-    result = pred.getLocation()
-  }
+  override Location getLocation() { result = pred.getLocation() }
 
-  override Predicate getEnclosingPredicate() {
-    result = pred
-  }
+  override Predicate getEnclosingPredicate() { result = pred }
 }
 
 /**
@@ -223,9 +174,7 @@ class FieldNode extends Node, MkFieldNode {
  * in the enclosing class.
  */
 pragma[inline]
-Node fieldNode(Predicate pred, FieldDecl fieldDecl) {
-  result = MkFieldNode(pred, fieldDecl)
-}
+Node fieldNode(Predicate pred, FieldDecl fieldDecl) { result = MkFieldNode(pred, fieldDecl) }
 
 /**
  * A collection of data-flow nodes in the same predicate, locally bound by equalities.
@@ -238,14 +187,10 @@ class SuperNode extends LocalFlow::TSuperNode {
   SuperNode() { this = LocalFlow::MkSuperNode(repr) }
 
   /** Gets a data-flow node that is part of this super node. */
-  Node getANode() {
-    LocalFlow::getRepr(result) = repr
-  }
+  Node getANode() { LocalFlow::getRepr(result) = repr }
 
   /** Gets an AST node from any of the nodes in this super node. */
-  AstNode asAstNode() {
-    result = getANode().asAstNode()
-  }
+  AstNode asAstNode() { result = getANode().asAstNode() }
 
   /**
    * Gets a single node from this super node.
@@ -255,16 +200,12 @@ class SuperNode extends LocalFlow::TSuperNode {
    * - An `AstNodeNode` is preferred over other nodes.
    * - A node occuring earlier is preferred over one occurring later.
    */
-  Node getArbitraryRepr() {
-    result = min(Node n | n = getANode() | n order by getInternalId(n))
-  }
+  Node getArbitraryRepr() { result = min(Node n | n = getANode() | n order by getInternalId(n)) }
 
   /**
    * Gets the predicate containing all nodes that are part of this super node.
    */
-  Predicate getEnclosingPredicate() {
-    result = getANode().getEnclosingPredicate()
-  }
+  Predicate getEnclosingPredicate() { result = getANode().getEnclosingPredicate() }
 
   /** Gets a string representation of this super node. */
   string toString() {
@@ -275,14 +216,10 @@ class SuperNode extends LocalFlow::TSuperNode {
   }
 
   /** Gets the location of an arbitrary node in this super node. */
-  Location getLocation() {
-    result = getArbitraryRepr().getLocation()
-  }
+  Location getLocation() { result = getArbitraryRepr().getLocation() }
 
   /** Gets any member call whose receiver is in the same super node. */
-  MemberCall getALocalMemberCall() {
-    superNode(result.getBase()) = this
-  }
+  MemberCall getALocalMemberCall() { superNode(result.getBase()) = this }
 
   /** Gets any member call whose receiver is in the same super node. */
   MemberCall getALocalMemberCall(string name) {
@@ -382,9 +319,7 @@ class SuperNode extends LocalFlow::TSuperNode {
 
 /** Gets the super node for the given AST node. */
 pragma[inline]
-SuperNode superNode(AstNode node) {
-  result = astNode(node).getSuperNode()
-}
+SuperNode superNode(AstNode node) { result = astNode(node).getSuperNode() }
 
 /**
  * A summary of the steps needed to reach a node in the global data flow graph,

--- a/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
@@ -46,6 +46,42 @@ Node astNode(AstNode node) {
 }
 
 /**
+ * A data-flow node representing a variable within a specific scope.
+ */
+class ScopedVariableNode extends Node, MkScopedVariable {
+  private VarDef var;
+  private AstNode scope;
+
+  ScopedVariableNode() { this = MkScopedVariable(var, scope) }
+
+  override string toString() {
+    result = "Variable '" + var.getName() + "' scoped to " + scope.getLocation().getStartLine() + ":" + scope.getLocation().getStartColumn()
+  }
+
+  override Location getLocation() {
+    result = scope.getLocation()
+  }
+
+  /** Gets the variable being refined to a specific scope. */
+  VarDef getVariable() {
+    result = var
+  }
+
+  /** Gets the scope to which this variable has been refined. */
+  AstNode getScope() {
+    result = scope
+  }
+}
+
+/**
+ * Gets the data-flow node corresponding to `var` restricted to `scope`.
+ */
+pragma[inline]
+Node scopedVariable(VarDef var, AstNode scope) {
+  result = MkScopedVariable(var, scope)
+}
+
+/**
  * A data-flow node representing `this` within a class predicate, charpred, or newtype branch.
  */
 class ThisNode extends Node, MkThisNode {

--- a/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/DataFlow.qll
@@ -1,3 +1,13 @@
+/**
+ * Experimental library for reasoning about data flow.
+ *
+ * Current limitations:
+ * - Global flow does not reason about subclassing, overriding, and dispatch
+ * - `this`, `result`, and local field variables are treated less precisely
+ *   than regular variables (see VarScoping.qll)
+ * - Polarity is not tracked, that is, global flow does not care about negation at all.
+ */
+
 private import codeql_ql.ast.Ast
 private import internal.NodesInternal
 private import internal.DataFlowNumbering
@@ -15,8 +25,10 @@ private import internal.GlobalFlow as GlobalFlow
  * To reason about global data flow, use `SuperNode.track()`.
  */
 class Node extends TNode {
+  /** Gets a string representation of this element. */
   string toString() { none() } // overridden in subclasses
 
+  /** Gets the location of element. */
   Location getLocation() { none() } // overridden in subclasses
 
   /**
@@ -158,8 +170,10 @@ class FieldNode extends Node, MkFieldNode {
   /** Gets the member predicate or charpred for which this node represents access to the field. */
   Predicate getPredicate() { result = pred }
 
+  /** Gets the declaration of the field. */
   FieldDecl getFieldDeclaration() { result = fieldDecl }
 
+  /** Gets the name of the field. */
   string getFieldName() { result = fieldDecl.getName() }
 
   override string toString() { result = "'" + this.getFieldName() + "' in " + pred.getName() }

--- a/ql/ql/src/codeql_ql/dataflow/internal/DataFlowNumbering.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/DataFlowNumbering.qll
@@ -1,0 +1,51 @@
+private import codeql_ql.ast.Ast
+private import codeql_ql.ast.internal.AstNodeNumbering
+private import NodesInternal
+
+/** An arbitrary total ordering of data-flow nodes. */
+private predicate internalOrderingKey(TNode node, int tag, int field1, int field2) {
+  exists(AstNode ast |
+    node = MkAstNodeNode(ast) and
+    tag = 0 and
+    field1 = getPreOrderId(ast) and
+    field2 = 0
+  )
+  or
+  exists(VarDef var, Formula scope |
+    node = MkScopedVariable(var, scope) and
+    tag = 1 and
+    field1 = getPreOrderId(var) and
+    field2 = getPreOrderId(scope)
+  )
+  or
+  exists(Predicate pred |
+    node = MkThisNode(pred) and
+    tag = 2 and
+    field1 = getPreOrderId(pred) and
+    field2 = 0
+  )
+  or
+  exists(Predicate pred |
+    node = MkResultNode(pred) and
+    tag = 3 and
+    field1 = getPreOrderId(pred) and
+    field2 = 0
+  )
+  or
+  exists(Predicate pred, FieldDecl fieldDecl |
+    node = MkFieldNode(pred, fieldDecl) and
+    tag = 4 and
+    field1 = getPreOrderId(pred) and
+    field2 = getPreOrderId(fieldDecl)
+  )
+}
+
+/** Gets an integer unique to `node`. */
+int getInternalId(TNode node) {
+  node =
+    rank[result](TNode n, int tag, int field1, int field2 |
+      internalOrderingKey(n, tag, field1, field2)
+    |
+      n order by tag, field1, field2
+    )
+}

--- a/ql/ql/src/codeql_ql/dataflow/internal/GlobalFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/GlobalFlow.qll
@@ -1,0 +1,242 @@
+/**
+ * Models global flow, that is, flow between predicates and across disjunctions.
+ *
+ * We say an expression `A` "flows to" another expression `B` if some series of transformations
+ * would move/copy them into the same conjunction, where they are bound by equality (or are the same variable).
+ *
+ * The transformations permitted are:
+ * - Apply distributive law to lift a disjunction out: `A and (B or C) -> (A and B) or (A and C)`
+ * - Inline a predicate call.
+ *
+ * Both of these tend to copy expressions, and we just ask if some copy of `A` and some copy of `B` could
+ * end up in the same place.
+ *
+ * For example, `A` flows to both `B` and `C`, but `B` does not flow to `C`:
+ * ```
+ * x = A and (x = B or x = C)
+ * -->
+ * (x = A and x = B) or (x = A and x = C)
+ * ```
+ *
+ * We don't actually perform these exponential-cost transformations, we just use them to specify what "flow" means.
+ *
+ * The problem of determining which expression flows where is reduced to a graph problem.
+ * The edges in the graph represent inlining of a predicate or lifting of a disjunction.
+ * The resulting graph is similar to the call/return edges from procedural languages, but with a
+ * few tweaks -- see `EdgeLabel`.
+ *
+ * Note that the "flows to" relation is symmetric, but variations like "flows to using call steps" are not.
+ * So we use the term "flows to" rather than a more naturally symmetric term like "unifiable with".
+ */
+
+private import codeql_ql.ast.Ast
+private import codeql_ql.dataflow.DataFlow
+private import VarScoping
+
+cached
+private module Cached {
+  /**
+   * An edge or a `Tracker` state.
+   *
+   * An edge represents a call site or a disjunction, and a `Tracker` state is an
+   * edge or one of the special values `NoEdge` or `HasCall`.
+   *
+   * The tracker state could be defined as
+   * ```
+   * newtype TTracker = MkReturn(TEdgeLabel edge) or MkNoEdge() or MkHasCall()
+   * ```
+   * but for efficiency, `TTracker` and `TEdgeLabel` have been merged.
+   */
+  cached
+  newtype TEdgeLabelOrTrackerState =
+    MkCall(Call call) or
+    MkMemberToCharPred(ClassPredicate p) or // implicit call to charpred in a member predicate
+    MkTypeToCharPred(TypeExpr t) or // implicit call to charpred from a type annotation
+    MkDisjunction(DisjunctionOperator disj) or // "call" into a disjunction branch
+    MkNoEdge() or
+    MkHasCall()
+
+  /**
+   * Label for a directed edge (see `EdgeLabel` class).
+   */
+  class TEdgeLabel = MkCall or MkMemberToCharPred or MkTypeToCharPred or MkDisjunction;
+
+  /**
+   * Holds if `argument` is passed to `parameter` via an edge of the given `edge`.
+   */
+  cached
+  predicate directedEdge(Node argument, Node parameter, EdgeLabel edge) {
+    // Argument-passing via an explicit call
+    exists(Call call, Predicate target |
+      call.getTarget() = target and
+      edge = EdgeLabel::call(call)
+    |
+      exists(int i |
+        argument = astNode(call.getArgument(i)) and
+        parameter = astNode(target.getParameter(i))
+      )
+      or
+      argument = astNode(call.(MemberCall).getBase()) and
+      parameter = thisNode(target)
+      or
+      argument = astNode(call) and
+      parameter = resultNode(target)
+    )
+    or
+    // Implicit charpred call in member predicate: passes `this` and each field to the charpred
+    exists(Class cls, ClassPredicate p |
+      p = cls.getAClassPredicate() and
+      edge = EdgeLabel::memberToCharPred(p)
+    |
+      argument = thisNode(p) and
+      parameter = thisNode(cls.getCharPred())
+      or
+      exists(FieldDecl fieldDecl |
+        argument = fieldNode(p, fieldDecl) and
+        parameter = fieldNode(cls.getCharPred(), fieldDecl)
+      )
+    )
+    or
+    // Type test passes the tested value to the charpred of the type
+    exists(TypeExpr type |
+      edge = EdgeLabel::typeToCharPred(type) and
+      parameter = thisNode(type.getResolvedType().getDeclaration().(Class).getCharPred())
+    |
+      exists(VarDecl var |
+        argument = [scopedVariable(var, _), astNode(var)] and
+        type = var.getTypeExpr()
+      )
+      or
+      exists(Predicate p |
+        argument = resultNode(p) and
+        type = p.getReturnTypeExpr()
+      )
+      or
+      exists(InlineCast cast |
+        argument = astNode(cast.getBase()) and
+        type = cast.getTypeExpr()
+      )
+      or
+      exists(InstanceOf expr |
+        argument = astNode(expr.getExpr()) and
+        type = expr.getType()
+      )
+    )
+    or
+    // Flow between differently-scoped copies of the same variable, going into a disjunction
+    exists(VarDef var, AstNode inner, AstNode outer, DisjunctionOperator disjunction |
+      isRefinement(var, inner, outer) and
+      disjunction.getAnOperand() = inner and
+      edge = EdgeLabel::disjunction(disjunction)
+    |
+      // Scoped variable to an inner scoped variable
+      argument = scopedVariable(var, outer) and
+      parameter = scopedVariable(var, inner) and
+      // Avoid loop edge when a VarAccess is also a disjunct (because it's an element of a set literal)
+      argument != parameter
+      or
+      // VarDef to a scoped variable
+      outer = getVarDefScope(var) and
+      argument = astNode(var) and
+      parameter = scopedVariable(var, inner)
+    )
+    or
+    // Flow into a set literal, similar to flow into disjunctions.
+    // If we consider a desugared set literal, `[x,y] -> any(T v | v = x or v = y)`, this edge
+    // corresponds to the edges going from `T v` to its scoped variables.
+    exists(Set set |
+      edge = EdgeLabel::disjunction(set) and
+      argument = astNode(set) and
+      parameter = astNode(set.getAnElement())
+    )
+  }
+
+  /**
+   * Holds if `argument` is passed to `parameter` via an edge of the given `kind`.
+   *
+   * This is identical to `directedEdge` where the operands are mapped to their super nodes.
+   */
+  cached
+  predicate directedEdgeSuper(SuperNode argument, SuperNode parameter, EdgeLabel edge) {
+    directedEdge(argument.getANode(), parameter.getANode(), edge)
+  }
+}
+
+import Cached
+
+/**
+ * Label for a directed edge.
+ *
+ * This is either a call (implicit or explicit) or a disjunction.
+ *
+ * All edges are considered "call" edges in their default orientation (even disjunction edges).
+ * Flipping an edge turns it into a "return" edge (there is no separate label for return edges).
+ *
+ * Data flow allows any number of return edges followed by any number of call edges,
+ * with this additional rule:
+ *
+ * - The first call edge must not have the same label as the last return edge.
+ *
+ * The above rule is the reason this class exists.
+ *
+ * - The rule ensures flow cannot step out of a disjunction, and then
+ *   into another branch of the same disjunction (because they'd use the same label).
+ *
+ * - A byproduct of the rule is that we cannot step directly into the call edge we just came from.
+ *   We lose no real flow from this, as the flow direction can just flip one step earlier.
+ *
+ * - It would not be enough to only enforce this for disjunction edges, because it would
+ *   allow the path to "reset" its last-used edge by stepping out of a call and
+ *   immediately back in again (the kind of flow mentioned above).
+ */
+class EdgeLabel extends TEdgeLabel {
+  /** Gets a location associated with this edge label. */
+  Location getLocation() {
+    exists(Call call | this = EdgeLabel::call(call) | result = call.getLocation())
+    or
+    exists(ClassPredicate p | this = EdgeLabel::memberToCharPred(p) | result = p.getLocation())
+    or
+    exists(TypeExpr t | this = EdgeLabel::typeToCharPred(t) | result = t.getLocation())
+    or
+    exists(DisjunctionOperator disj | this = EdgeLabel::disjunction(disj) |
+      result = disj.getLocation()
+    )
+  }
+
+  /** Gets a string representation of this edge label. */
+  string toString() {
+    exists(Call call | this = EdgeLabel::call(call) |
+      result =
+        call.toString() + ":" + call.getLocation().getStartLine() + ":" +
+          call.getLocation().getStartColumn()
+    )
+    or
+    exists(ClassPredicate p | this = EdgeLabel::memberToCharPred(p) |
+      result = "MemberToCharPred call from " + p.getName()
+    )
+    or
+    exists(TypeExpr t | this = EdgeLabel::typeToCharPred(t) |
+      result = "TypeToCharPred call from " + t.getResolvedType().getName()
+    )
+    or
+    exists(DisjunctionOperator disj | this = EdgeLabel::disjunction(disj) |
+      result =
+        disj.toString() + ":" + disj.getLocation().getStartLine() + ":" +
+          disj.getLocation().getStartColumn()
+    )
+  }
+}
+
+module EdgeLabel {
+  /** Gets the edge label representing the given explicit call. */
+  EdgeLabel call(Call call) { result = MkCall(call) }
+
+  /** Gets the edge label for the implicit call to the charpred in a member predicate. */
+  EdgeLabel memberToCharPred(ClassPredicate p) { result = MkMemberToCharPred(p) }
+
+  /** Gets the edge label for the implicit call to the charpred from a type annotation. */
+  EdgeLabel typeToCharPred(TypeExpr t) { result = MkTypeToCharPred(t) }
+
+  /** Gets the edge label for the edge stepping into the given disjunction. */
+  EdgeLabel disjunction(DisjunctionOperator disj) { result = MkDisjunction(disj) }
+}

--- a/ql/ql/src/codeql_ql/dataflow/internal/LocalFlow.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/LocalFlow.qll
@@ -1,0 +1,102 @@
+/**
+ * Models local flow edges. Each equivalence class in the local flow relation becomes a super node.
+ */
+
+private import codeql_ql.dataflow.DataFlow
+private import codeql_ql.ast.Ast
+private import codeql_ql.ast.internal.AstNodeNumbering
+private import NodesInternal
+private import VarScoping
+private import DataFlowNumbering
+
+private module Cached {
+  /**
+   * Holds if `x` and `y` are bound by an equality (intra-predicate only).
+   *
+   * This edge has no orientation, and is used to construct the equivalence relation.
+   * Each equivalence class becomes a `SuperNode`.
+   */
+  private predicate localEdge(Node x, Node y) {
+    exists(AstNode a, AstNode b |
+      x = astNode(a) and
+      y = astNode(b)
+    |
+      // x ~ any(x)
+      a = b.(Any).getExpr(0)
+      or
+      // v ~ any(T v)
+      a = b.(Any).getArgument(0)
+      or
+      // x ~ x as VAR
+      a = b.(AsExpr).getInnerExpr()
+      or
+      // x ~ x.(Type)
+      a = b.(InlineCast).getBase()
+      or
+      // x = y ==> x ~ y
+      exists(ComparisonFormula compare |
+        compare.getOperator() = "=" and
+        a = compare.getLeftOperand() and
+        b = compare.getRightOperand()
+      )
+    )
+    or
+    // VarAccess -> ScopedVariable
+    exists(VarDef var, VarAccess access, VarAccessOrDisjunct scope |
+      isRefinement(var, access, scope) and
+      x = astNode(access) and
+      y = scopedVariable(var, scope)
+    )
+    or
+    // VarAccess -> VarDef  (if no refinement exists)
+    exists(VarDef var, VarAccess access |
+      isRefinement(var, access, getVarDefScope(var)) and
+      x = astNode(access) and
+      y = astNode(var)
+    )
+    or
+    // result ~ enclosing 'result' node
+    x = resultNode(y.(AstNodeNode).getAstNode().(ResultAccess).getEnclosingPredicate())
+    or
+    // this ~ enclosing 'this' node
+    x = thisNode(y.(AstNodeNode).getAstNode().(ThisAccess).getEnclosingPredicate())
+    or
+    // f ~ enclosing field node for 'f'
+    exists(FieldAccess access |
+      x = astNode(access) and
+      y = fieldNode(access.getEnclosingPredicate(), access.getDeclaration())
+    )
+    or
+    // field declaration ~ field node in the charpred
+    exists(FieldDecl field, Class cls |
+      cls.getAField() = field and
+      x = astNode(field.getVarDecl()) and
+      y = fieldNode(cls.getCharPred(), field)
+    )
+  }
+
+  /** Like `localEdge` but the parameters are mapped to their internal ID. */
+  private predicate rawLocalEdge(int x, int y) {
+    exists(Node a, Node b |
+      localEdge(a, b) and
+      x = getInternalId(a) and
+      y = getInternalId(b)
+    )
+    or
+    // Ensure a representative is generated for singleton components
+    x = getInternalId(_) and
+    y = x
+  }
+
+  /** Gets the representative for the equivalence class containing the node with ID `x`. */
+  private int getRawRepr(int x) = equivalenceRelation(rawLocalEdge/2)(x, result)
+
+  /** Gets the ID for the equivalence class containing `node`. */
+  cached
+  int getRepr(Node node) { result = getRawRepr(getInternalId(node)) }
+
+  cached
+  newtype TSuperNode = MkSuperNode(int repr) { repr = getRepr(_) }
+}
+
+import Cached

--- a/ql/ql/src/codeql_ql/dataflow/internal/NodesInternal.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/NodesInternal.qll
@@ -1,9 +1,14 @@
 private import codeql_ql.ast.Ast
+private import VarScoping
 
 newtype TNode =
   MkAstNodeNode(AstNode node) {
     node instanceof Expr or
     node instanceof VarDef
+  } or
+  MkScopedVariable(VarDef var, AstNode scope) {
+    isRefinement(var, _, scope) and
+    not scope = getVarDefScope(var)
   } or
   MkThisNode(Predicate pred) {
     pred instanceof ClassPredicate or

--- a/ql/ql/src/codeql_ql/dataflow/internal/NodesInternal.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/NodesInternal.qll
@@ -1,0 +1,19 @@
+private import codeql_ql.ast.Ast
+
+newtype TNode =
+  MkAstNodeNode(AstNode node) {
+    node instanceof Expr or
+    node instanceof VarDef
+  } or
+  MkThisNode(Predicate pred) {
+    pred instanceof ClassPredicate or
+    pred instanceof CharPred or
+    pred instanceof NewTypeBranch
+  } or
+  MkResultNode(Predicate pred) { exists(pred.getReturnTypeExpr()) } or
+  MkFieldNode(Predicate pred, FieldDecl fieldDecl) {
+    // TODO: should this be omitted when the field is not referenced?
+    fieldDecl.getVarDecl() = pred.(ClassPredicate).getDeclaringType().getField(_)
+    or
+    fieldDecl.getVarDecl() = pred.(CharPred).getDeclaringType().getField(_)
+  }

--- a/ql/ql/src/codeql_ql/dataflow/internal/VarScoping.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/VarScoping.qll
@@ -1,0 +1,103 @@
+private import codeql_ql.ast.Ast
+private import codeql_ql.ast.internal.AstNodeNumbering
+
+/** Gets the disjunction immediately containing another disjunction `inner`. */
+private Disjunction getOuterDisjunction(Disjunction inner) { result.getAnOperand() = inner }
+
+/**
+ * Get the root of a disjunction tree containing `f`, if any.
+ */
+private Disjunction getRootDisjunction(Disjunction f) {
+  not exists(getOuterDisjunction(result)) and
+  result = getOuterDisjunction(f)
+  or
+  result = getRootDisjunction(getOuterDisjunction(f))
+}
+
+/** Get the root disjunction for `f` if there is one, other gets `f` itself. */
+pragma[inline]
+private AstNode tryGetRootDisjunction(AstNode f) {
+  result = getRootDisjunction(f)
+  or
+  not exists(getRootDisjunction(f)) and
+  result = f
+}
+
+AstNode getADisjunctionOperand(AstNode disjunction) {
+  exists(Disjunction d |
+    result = d.getAnOperand() and
+    // skip intermediate nodes in large disjunctions
+    disjunction = tryGetRootDisjunction(d) and
+    not result instanceof Disjunction
+  )
+  or
+  result = disjunction.(Implication).getAChild()
+  or
+  result = disjunction.(IfFormula).getThenPart()
+  or
+  result = disjunction.(IfFormula).getElsePart()
+  or
+  exists(Forall all |
+    disjunction = all and
+    exists(all.getFormula()) and
+    exists(all.getRange()) and
+    result = [all.getRange(), all.getFormula()]
+  )
+  or
+  result = disjunction.(Set).getAnElement()
+}
+
+/**
+ * A node that acts as a disjunction:
+ * - The root in a tree of `or` operators, or
+ * - An `implies`, `if`, `forall`, or set literal.
+ */
+class DisjunctionOperator extends AstNode {
+  DisjunctionOperator() { exists(getADisjunctionOperand(this)) }
+
+  AstNode getAnOperand() { result = getADisjunctionOperand(this) }
+}
+
+/**
+ * Gets the scope of `var`, such as the predicate or `exists` clause that binds it.
+ */
+AstNode getVarDefScope(VarDef var) {
+  // TODO: not valid for `as` expressions
+  result = var.getParent()
+}
+
+/** A `VarAccess` or disjunct, representing the input to refinement of a variable. */
+class VarAccessOrDisjunct = AstNode;
+
+/**
+ * Walks upwards from an access to `varDef` until encountering either the scope of `varDef`
+ * or a disjunct. When a disjunct is found, the disjunct becomes the new `access`, representing
+ * a refinement we intend to insert there.
+ */
+private AstNode getVarScope(VarDef varDef, VarAccessOrDisjunct access) {
+  access.(VarAccess).getDeclaration() = varDef and
+  result = access
+  or
+  exists(AstNode scope | scope = getVarScope(varDef, access) |
+    not scope = getADisjunctionOperand(_) and
+    not scope = getVarDefScope(varDef) and
+    result = scope.getParent()
+  )
+  or
+  isRefinement(varDef, _, access) and
+  result = tryGetRootDisjunction(access.getParent())
+}
+
+/**
+ * Holds if `inner` should be seen as a refinement of `outer`.
+ *
+ * `outer` is always a disjunct, and `inner` is either a `VarAccess` or another disjunct.
+ */
+predicate isRefinement(VarDef varDef, VarAccessOrDisjunct inner, VarAccessOrDisjunct outer) {
+  getVarScope(varDef, inner) = outer and
+  (
+    outer = getADisjunctionOperand(_)
+    or
+    outer = getVarDefScope(varDef)
+  )
+}

--- a/ql/ql/src/codeql_ql/dataflow/internal/VarScoping.qll
+++ b/ql/ql/src/codeql_ql/dataflow/internal/VarScoping.qll
@@ -1,3 +1,15 @@
+/**
+ * Computes scopes in which it is safe to unify all uses of a given variable.
+ *
+ * It is not accurate to unify variables across a disjunction, so the scope of a variable
+ * is restricted to its nearest enclosing disjunction operand ("disjunct").
+ * At such a disjunct, we introduce a "refinement" of the variable, which is seen as a
+ * redefinition of the variable within that disjunct.
+ *
+ * In principle this should also be done for `this`, `result`, and local field variables
+ * but currently it is not.
+ */
+
 private import codeql_ql.ast.Ast
 private import codeql_ql.ast.internal.AstNodeNumbering
 

--- a/ql/ql/src/queries/reports/FrameworkCoverage.ql
+++ b/ql/ql/src/queries/reports/FrameworkCoverage.ql
@@ -1,0 +1,104 @@
+/**
+ * An experimental and incomplete query for measuring framework coverage
+ * for models implemented in CodeQL.
+ *
+ * Currently only supports JavaScript models, and simply lists the package names
+ * alongside the named features accessed on such a package.
+ */
+
+import ql
+import codeql_ql.ast.internal.AstNodes
+import codeql_ql.dataflow.DataFlow as DataFlow
+
+predicate isExcludedFile(File file) {
+  file.getAbsolutePath().matches(["%ql/experimental/%", "%ql/test/%"])
+}
+
+class PackageImportCall extends PredicateCall {
+  PackageImportCall() {
+    this.getQualifier().getName() = ["API", "DataFlow"] and
+    this.getPredicateName() = ["moduleImport", "moduleMember"] and
+    not isExcludedFile(getLocation().getFile())
+  }
+
+  /** Gets the name of a package referenced by this call */
+  string getAPackageName() { result = DataFlow::superNode(getArgument(0)).getAStringValueNoCall() }
+}
+
+/** Gets a reference to `package` or any transitive member thereof. */
+DataFlow::SuperNode getADerivedRef(string package, DataFlow::Tracker t) {
+  t.start() and
+  result.asAstNode().(PackageImportCall).getAPackageName() = package
+  or
+  exists(DataFlow::Tracker t2 | result = getADerivedRef(package, t2).track(t2, t))
+  or
+  result.asAstNode() = getADerivedCall(package, t)
+}
+
+/** Gets a call which models some aspect of `package`. */
+MemberCall getADerivedCall(string package, DataFlow::Tracker t) {
+  result = getADerivedRef(package, t).getALocalMemberCall() and
+  not result.(Expr).getType().getName() = ["int", "string"]
+}
+
+/**
+ * Gets an expression whose string-value is the name of a member accessed from `package`,
+ * where the underlying package node was tracked here using `t`.
+ */
+Expr getAFeatureUse(string package, DataFlow::Tracker t) {
+  exists(MemberCall call | call = getADerivedCall(package, t) |
+    call.getMemberName() =
+      [
+        "getMember", "getAPropertyRead", "getAPropertyWrite", "getAPropertyReference",
+        "getAPropertySource", "getAMethodCall", "getAMemberCall"
+      ] and
+    result = call.getArgument(0)
+    or
+    call.getMemberName() = "getOptionArgument" and
+    result = call.getArgument(1)
+  )
+  or
+  t.start() and
+  exists(PackageImportCall call |
+    call.getAPackageName() = package and
+    call.getPredicateName() = "moduleMember" and
+    result = call.getArgument(1)
+  )
+}
+
+/**
+ * Gets the name of a feature accessed as `use`.
+ */
+string getAFeatureName(string package, Expr use) {
+  exists(DataFlow::Tracker t |
+    use = getAFeatureUse(package, t) and
+    result = DataFlow::superNode(use).getAStringValueForContext(t)
+  )
+}
+
+query predicate packageFeatures(string package, string features) {
+  // TODO: 'express' still missing features from request objects - likely subclassing-related
+  package = any(PackageImportCall call).getAPackageName() and
+  features = concat(getAFeatureName(package, _), ", ")
+}
+
+/** Holds if `cls` extends an abstract class from another file. */
+predicate isCrossFileContribution(Class cls) {
+  exists(Class sup |
+    cls.getASuperType().getResolvedType().getDeclaration() = sup and
+    sup.isAbstract() and
+    sup.getLocation().getFile() != cls.getLocation().getFile()
+  )
+}
+
+query predicate packageConcepts(string package, Class concept) {
+  package = any(PackageImportCall call).getAPackageName() and
+  getADerivedRef(package, DataFlow::Tracker::endNoCall()).getANode() =
+    DataFlow::thisNode(concept.getCharPred()) and
+  isCrossFileContribution(concept)
+}
+
+query predicate importWithoutPackageName(PackageImportCall call, string path) {
+  not exists(call.getAPackageName()) and
+  path = call.getLocation().getFile().getRelativePath()
+}

--- a/ql/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/ql/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -1,0 +1,365 @@
+/**
+ * Provides a library for writing QL tests whose success or failure is based on expected results
+ * embedded in the test source code as comments, rather than the contents of an `.expected` file
+ * (in that the `.expected` file should always be empty).
+ *
+ * To add this framework to a new language:
+ * - Add a file `InlineExpectationsTestPrivate.qll` that defines a `ExpectationComment` class. This class
+ *   must support a `getContents` method that returns the contents of the given comment, _excluding_
+ *   the comment indicator itself. It should also define `toString` and `getLocation` as usual.
+ *
+ * To create a new inline expectations test:
+ * - Declare a class that extends `InlineExpectationsTest`. In the characteristic predicate of the
+ * new class, bind `this` to a unique string (usually the name of the test).
+ * - Override the `hasActualResult()` predicate to produce the actual results of the query. For each
+ * result, specify a `Location`, a text description of the element for which the result was
+ * reported, a short string to serve as the tag to identify expected results for this test, and the
+ * expected value of the result.
+ * - Override `getARelevantTag()` to return the set of tags that can be produced by
+ * `hasActualResult()`. Often this is just a single tag.
+ *
+ * Example:
+ * ```ql
+ * class ConstantValueTest extends InlineExpectationsTest {
+ *   ConstantValueTest() { this = "ConstantValueTest" }
+ *
+ *   override string getARelevantTag() {
+ *     // We only use one tag for this test.
+ *     result = "const"
+ *   }
+ *
+ *   override predicate hasActualResult(
+ *     Location location, string element, string tag, string value
+ *   ) {
+ *     exists(Expr e |
+ *       tag = "const" and // The tag for this test.
+ *       value = e.getValue() and // The expected value. Will only hold for constant expressions.
+ *       location = e.getLocation() and // The location of the result to be reported.
+ *       element = e.toString() // The display text for the result.
+ *     )
+ *   }
+ * }
+ * ```
+ *
+ * There is no need to write a `select` clause or query predicate. All of the differences between
+ * expected results and actual results will be reported in the `failures()` query predicate.
+ *
+ * To annotate the test source code with an expected result, place a comment starting with a `$` on the
+ * same line as the expected result, with text of the following format as the body of the comment:
+ *
+ * `tag=expected-value`
+ *
+ * Where `tag` is the value of the `tag` parameter from `hasActualResult()`, and `expected-value` is
+ * the value of the `value` parameter from `hasActualResult()`. The `=expected-value` portion may be
+ * omitted, in which case `expected-value` is treated as the empty string. Multiple expectations may
+ * be placed in the same comment. Any actual result that
+ * appears on a line that does not contain a matching expected result comment will be reported with
+ * a message of the form "Unexpected result: tag=value". Any expected result comment for which there
+ * is no matching actual result will be reported with a message of the form
+ * "Missing result: tag=expected-value".
+ *
+ * Example:
+ * ```cpp
+ * int i = x + 5;  // $ const=5
+ * int j = y + (7 - 3)  // $ const=7 const=3 const=4  // The result of the subtraction is a constant.
+ * ```
+ *
+ * For tests that contain known missing and spurious results, it is possible to further
+ * annotate that a particular expected result is known to be spurious, or that a particular
+ * missing result is known to be missing:
+ *
+ * `$ SPURIOUS: tag=expected-value`  // Spurious result
+ * `$ MISSING: tag=expected-value`  // Missing result
+ *
+ * A spurious expectation is treated as any other expected result, except that if there is no
+ * matching actual result, the message will be of the form "Fixed spurious result: tag=value". A
+ * missing expectation is treated as if there were no expected result, except that if a
+ * matching expected result is found, the message will be of the form
+ * "Fixed missing result: tag=value".
+ *
+ * A single line can contain all the expected, spurious and missing results of that line. For instance:
+ * `$ tag1=value1 SPURIOUS: tag2=value2 MISSING: tag3=value3`.
+ *
+ * If the same result value is expected for two or more tags on the same line, there is a shorthand
+ * notation available:
+ *
+ * `tag1,tag2=expected-value`
+ *
+ * is equivalent to:
+ *
+ * `tag1=expected-value tag2=expected-value`
+ */
+
+private import InlineExpectationsTestPrivate
+
+/**
+ * The base class for tests with inline expectations. The test extends this class to provide the actual
+ * results of the query, which are then compared with the expected results in comments to produce a
+ * list of failure messages that point out where the actual results differ from the expected
+ * results.
+ */
+abstract class InlineExpectationsTest extends string {
+  bindingset[this]
+  InlineExpectationsTest() { any() }
+
+  /**
+   * Returns all tags that can be generated by this test. Most tests will only ever produce a single
+   * tag. Any expected result comments for a tag that is not returned by the `getARelevantTag()`
+   * predicate for an active test will be ignored. This makes it possible to write multiple tests in
+   * different `.ql` files that all query the same source code.
+   */
+  abstract string getARelevantTag();
+
+  /**
+   * Returns the actual results of the query that is being tested. Each result consist of the
+   * following values:
+   * - `location` - The source code location of the result. Any expected result comment must appear
+   *   on the start line of this location.
+   * - `element` - Display text for the element on which the result is reported.
+   * - `tag` - The tag that marks this result as coming from this test. This must be one of the tags
+   *   returned by `getARelevantTag()`.
+   * - `value` - The value of the result, which will be matched against the value associated with
+   *   `tag` in any expected result comment on that line.
+   */
+  abstract predicate hasActualResult(Location location, string element, string tag, string value);
+
+  /**
+   * Holds if there is an optional result on the specified location.
+   *
+   * This is similar to `hasActualResult`, but returns results that do not require a matching annotation.
+   * A failure will still arise if there is an annotation that does not match any results, but not vice versa.
+   * Override this predicate to specify optional results.
+   */
+  predicate hasOptionalResult(Location location, string element, string tag, string value) {
+    none()
+  }
+
+  final predicate hasFailureMessage(FailureLocatable element, string message) {
+    exists(ActualResult actualResult |
+      actualResult.getTest() = this and
+      element = actualResult and
+      (
+        exists(FalseNegativeExpectation falseNegative |
+          falseNegative.matchesActualResult(actualResult) and
+          message = "Fixed missing result:" + falseNegative.getExpectationText()
+        )
+        or
+        not exists(ValidExpectation expectation | expectation.matchesActualResult(actualResult)) and
+        message = "Unexpected result: " + actualResult.getExpectationText() and
+        not actualResult.isOptional()
+      )
+    )
+    or
+    exists(ValidExpectation expectation |
+      not exists(ActualResult actualResult | expectation.matchesActualResult(actualResult)) and
+      expectation.getTag() = getARelevantTag() and
+      element = expectation and
+      (
+        expectation instanceof GoodExpectation and
+        message = "Missing result:" + expectation.getExpectationText()
+        or
+        expectation instanceof FalsePositiveExpectation and
+        message = "Fixed spurious result:" + expectation.getExpectationText()
+      )
+    )
+    or
+    exists(InvalidExpectation expectation |
+      element = expectation and
+      message = "Invalid expectation syntax: " + expectation.getExpectation()
+    )
+  }
+}
+
+/**
+ * RegEx pattern to match a comment containing one or more expected results. The comment must have
+ * `$` as its first non-whitespace character. Any subsequent character
+ * is treated as part of the expected results, except that the comment may contain a `//` sequence
+ * to treat the remainder of the line as a regular (non-interpreted) comment.
+ */
+private string expectationCommentPattern() { result = "\\s*\\$((?:[^/]|/[^/])*)(?://.*)?" }
+
+/**
+ * The possible columns in an expectation comment. The `TDefaultColumn` branch represents the first
+ * column in a comment. This column is not precedeeded by a name. `TNamedColumn(name)` represents a
+ * column containing expected results preceeded by the string `name:`.
+ */
+private newtype TColumn =
+  TDefaultColumn() or
+  TNamedColumn(string name) { name = ["MISSING", "SPURIOUS"] }
+
+bindingset[start, content]
+private int getEndOfColumnPosition(int start, string content) {
+  result =
+    min(string name, int cand |
+      exists(TNamedColumn(name)) and
+      cand = content.indexOf(name + ":") and
+      cand >= start
+    |
+      cand
+    )
+  or
+  not exists(string name |
+    exists(TNamedColumn(name)) and
+    content.indexOf(name + ":") >= start
+  ) and
+  result = content.length()
+}
+
+private predicate getAnExpectation(
+  ExpectationComment comment, TColumn column, string expectation, string tags, string value
+) {
+  exists(string content |
+    content = comment.getContents().regexpCapture(expectationCommentPattern(), 1) and
+    (
+      column = TDefaultColumn() and
+      exists(int end |
+        end = getEndOfColumnPosition(0, content) and
+        expectation = content.prefix(end).regexpFind(expectationPattern(), _, _).trim()
+      )
+      or
+      exists(string name, int start, int end |
+        column = TNamedColumn(name) and
+        start = content.indexOf(name + ":") + name.length() + 1 and
+        end = getEndOfColumnPosition(start, content) and
+        expectation = content.substring(start, end).regexpFind(expectationPattern(), _, _).trim()
+      )
+    )
+  ) and
+  tags = expectation.regexpCapture(expectationPattern(), 1) and
+  if exists(expectation.regexpCapture(expectationPattern(), 2))
+  then value = expectation.regexpCapture(expectationPattern(), 2)
+  else value = ""
+}
+
+private string getColumnString(TColumn column) {
+  column = TDefaultColumn() and result = ""
+  or
+  column = TNamedColumn(result)
+}
+
+/**
+ * RegEx pattern to match a single expected result, not including the leading `$`. It consists of one or
+ * more comma-separated tags containing only letters, digits, `-` and `_` (note that the first character
+ * must not be a digit), optionally followed by `=` and the expected value.
+ */
+private string expectationPattern() {
+  exists(string tag, string tags, string value |
+    tag = "[A-Za-z-_][A-Za-z-_0-9]*" and
+    tags = "((?:" + tag + ")(?:\\s*,\\s*" + tag + ")*)" and
+    // In Python, we allow both `"` and `'` for strings, as well as the prefixes `bru`.
+    // For example, `b"foo"`.
+    value = "((?:[bru]*\"[^\"]*\"|[bru]*'[^']*'|\\S+)*)" and
+    result = tags + "(?:=" + value + ")?"
+  )
+}
+
+private newtype TFailureLocatable =
+  TActualResult(
+    InlineExpectationsTest test, Location location, string element, string tag, string value,
+    boolean optional
+  ) {
+    test.hasActualResult(location, element, tag, value) and
+    optional = false
+    or
+    test.hasOptionalResult(location, element, tag, value) and optional = true
+  } or
+  TValidExpectation(ExpectationComment comment, string tag, string value, string knownFailure) {
+    exists(TColumn column, string tags |
+      getAnExpectation(comment, column, _, tags, value) and
+      tag = tags.splitAt(",") and
+      knownFailure = getColumnString(column)
+    )
+  } or
+  TInvalidExpectation(ExpectationComment comment, string expectation) {
+    getAnExpectation(comment, _, expectation, _, _) and
+    not expectation.regexpMatch(expectationPattern())
+  }
+
+class FailureLocatable extends TFailureLocatable {
+  string toString() { none() }
+
+  Location getLocation() { none() }
+
+  final string getExpectationText() { result = getTag() + "=" + getValue() }
+
+  string getTag() { none() }
+
+  string getValue() { none() }
+}
+
+class ActualResult extends FailureLocatable, TActualResult {
+  InlineExpectationsTest test;
+  Location location;
+  string element;
+  string tag;
+  string value;
+  boolean optional;
+
+  ActualResult() { this = TActualResult(test, location, element, tag, value, optional) }
+
+  override string toString() { result = element }
+
+  override Location getLocation() { result = location }
+
+  InlineExpectationsTest getTest() { result = test }
+
+  override string getTag() { result = tag }
+
+  override string getValue() { result = value }
+
+  predicate isOptional() { optional = true }
+}
+
+abstract private class Expectation extends FailureLocatable {
+  ExpectationComment comment;
+
+  override string toString() { result = comment.toString() }
+
+  override Location getLocation() { result = comment.getLocation() }
+}
+
+private class ValidExpectation extends Expectation, TValidExpectation {
+  string tag;
+  string value;
+  string knownFailure;
+
+  ValidExpectation() { this = TValidExpectation(comment, tag, value, knownFailure) }
+
+  override string getTag() { result = tag }
+
+  override string getValue() { result = value }
+
+  string getKnownFailure() { result = knownFailure }
+
+  predicate matchesActualResult(ActualResult actualResult) {
+    getLocation().getStartLine() = actualResult.getLocation().getStartLine() and
+    getLocation().getFile() = actualResult.getLocation().getFile() and
+    getTag() = actualResult.getTag() and
+    getValue() = actualResult.getValue()
+  }
+}
+
+/* Note: These next three classes correspond to all the possible values of type `TColumn`. */
+class GoodExpectation extends ValidExpectation {
+  GoodExpectation() { getKnownFailure() = "" }
+}
+
+class FalsePositiveExpectation extends ValidExpectation {
+  FalsePositiveExpectation() { getKnownFailure() = "SPURIOUS" }
+}
+
+class FalseNegativeExpectation extends ValidExpectation {
+  FalseNegativeExpectation() { getKnownFailure() = "MISSING" }
+}
+
+class InvalidExpectation extends Expectation, TInvalidExpectation {
+  string expectation;
+
+  InvalidExpectation() { this = TInvalidExpectation(comment, expectation) }
+
+  string getExpectation() { result = expectation }
+}
+
+query predicate failures(FailureLocatable element, string message) {
+  exists(InlineExpectationsTest test | test.hasFailureMessage(element, message))
+}

--- a/ql/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
+++ b/ql/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
@@ -1,0 +1,22 @@
+import ql
+private import codeql_ql.ast.internal.TreeSitter
+
+private newtype TExpectationComment = MkExpectationComment(QL::LineComment comment)
+
+/**
+ * Represents a line comment.
+ */
+class ExpectationComment extends TExpectationComment {
+  QL::LineComment comment;
+
+  ExpectationComment() { this = MkExpectationComment(comment) }
+
+  /** Returns the contents of the given comment, _without_ the preceding comment marker (`//`). */
+  string getContents() { result = comment.getValue().suffix(2) }
+
+  /** Gets a textual representation of this element. */
+  string toString() { result = comment.toString() }
+
+  /** Gets the location of this comment. */
+  Location getLocation() { result = comment.getLocation() }
+}

--- a/ql/ql/test/dataflow/getAStringValue/Foo.qll
+++ b/ql/ql/test/dataflow/getAStringValue/Foo.qll
@@ -1,0 +1,79 @@
+predicate isLeft(string s) { none() }
+
+predicate isRight(string s) { none() }
+
+predicate disjunct() {
+  exists(string x |
+    x = "left_1" and
+    isLeft(x) // $ getAStringValue=left_1
+    or
+    x = "right_1" and
+    isRight(x) // $ getAStringValue=right_1
+  )
+}
+
+string sourceLeft2() { result = "left_2" }
+
+predicate sinkLeft2(string x) {
+  isLeft(x) // $ getAStringValue=left_2
+}
+
+string sourceRight2() { result = "right_2" }
+
+predicate sinkRight2(string x) {
+  isRight(x) // $ getAStringValue=right_2
+}
+
+predicate disjunctViaCall() {
+  exists(string x |
+    x = sourceLeft2() and
+    sinkLeft2(x) // $ getAStringValue=left_2
+    or
+    x = sourceRight2() and
+    sinkRight2(x) // $ getAStringValue=right_2
+  )
+}
+
+predicate distribute() {
+  exists(string x |
+    x = "left_3"
+    or
+    x = "right_3"
+  |
+    isLeft(x) // $ getAStringValue=left_3 getAStringValue=right_3
+    or
+    isRight(x) // $ getAStringValue=left_3 getAStringValue=right_3
+  )
+}
+
+predicate distributeSet() {
+  exists(string x | x = ["left_4", "right_4"] |
+    isLeft(x) // $ getAStringValue=left_4 getAStringValue=right_4
+    or
+    isRight(x) // $ getAStringValue=left_4 getAStringValue=right_4
+  )
+}
+
+predicate noFlowBackOut() {
+  exists(string x |
+    isLeft(x) // no value
+  )
+}
+
+class StringClass extends string {
+  StringClass() { this = "StringClass" }
+}
+
+class FieldClass extends int {
+  StringClass field;
+
+  FieldClass() { this = 0 }
+
+  StringClass getField() { result = field }
+}
+
+predicate isStringClass(string s) { none() }
+
+predicate test() {
+  isStringClass(any(FieldClass f).getField()) // $ getAStringValue=StringClass
+}

--- a/ql/ql/test/dataflow/getAStringValue/getAStringValue.ql
+++ b/ql/ql/test/dataflow/getAStringValue/getAStringValue.ql
@@ -1,0 +1,19 @@
+import ql
+import codeql_ql.dataflow.DataFlow
+import TestUtilities.InlineExpectationsTest
+
+class GetAStringValueTest extends InlineExpectationsTest {
+  GetAStringValueTest() { this = "getAStringValue" }
+
+  override string getARelevantTag() { result = "getAStringValue" }
+
+  override predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(Expr e |
+      e = any(Call c).getAnArgument() and
+      tag = "getAStringValue" and
+      value = superNode(e).getAStringValue() and
+      location = e.getLocation() and
+      element = e.toString()
+    )
+  }
+}

--- a/ql/ql/test/printAst/printAst.expected
+++ b/ql/ql/test/printAst/printAst.expected
@@ -265,8 +265,6 @@ edges
 | Foo.qll:6:23:6:36 | ComparisonFormula | Foo.qll:6:23:6:28 | result | semmle.order | 11 |
 | Foo.qll:6:23:6:36 | ComparisonFormula | Foo.qll:6:32:6:36 | String | semmle.label | getRightOperand() |
 | Foo.qll:6:23:6:36 | ComparisonFormula | Foo.qll:6:32:6:36 | String | semmle.order | 13 |
-| Foo.qll:9:1:9:5 | annotation | Foo.qll:9:1:9:5 | annotation | semmle.label | getAnAnnotation() |
-| Foo.qll:9:1:9:5 | annotation | Foo.qll:9:1:9:5 | annotation | semmle.order | 14 |
 | Foo.qll:9:7:11:1 | ClasslessPredicate foo | Foo.qll:9:1:9:5 | annotation | semmle.label | getAnAnnotation() |
 | Foo.qll:9:7:11:1 | ClasslessPredicate foo | Foo.qll:9:1:9:5 | annotation | semmle.order | 14 |
 | Foo.qll:9:7:11:1 | ClasslessPredicate foo | Foo.qll:9:21:9:25 | f | semmle.label | getParameter(_) |


### PR DESCRIPTION
This adds facilities for reasoning about data flow between expression in CodeQL.

As a rule of thumb, "A flows to B" means the two expressions could be unified given a sufficient number of predicate inlinings, followed by DNF conversion. For example, `A` flows to `B` and `C` here, but `B` does not flow to `C`:
```
x = A and (x = B or x = C)

--> (to DNF)

(x = A and x = B) or (x = A and x = C)
```
Since (a copy of) `A,B` end up in the same clause where they bound by equality, `A` flows to `B` and vice versa. Same for `A,C` but not for `B,C`.

"Flows to" is a symmetric relation, but "flows to with call steps" is not, which often comes up in the implementation. This is why I prefer this terminology over something like "unifiable with".

This PR adds type-tracking, but not `DataFlow::Configuration` or support for path queries. Also it doesn't reason about subclassing, overriding, and dispatch (I had to get back to work at some point).

Like with procedural languages, we reduce flow to a graph problem with call and return edges, where we must find paths that do not violate call/return matching. Any call edge can be converted to a return edge simply by flipping it. Disjunctions are modelled as call sites, treating their operands as individual call targets. To avoid spurious flow between different disjuncts, there is an additional restriction not found in procedural languages: A call edge may not follow immediately after a return edge from the same call-site/disjunction. That is, you can't step back into a call you just came out of. This prevents us from stepping out of a disjunction and immediately back into another operand of that disjunction (which would lead to `B->C` flow in the example above). There is some additional justification for this in the comments.

---
This all started with an attempt to measure framework coverage for models implemented in CodeQL (as an alternative to porting all models to MaD). The PR includes the new `FrameworkCoverage.ql` query which spits out [CSV like this](https://gist.github.com/asgerf/f8a9f1b5e64f257344cecf163465333c). It simply measures the named members we recognize from each library (in principle this should be access paths, but there can be infinitely many access paths).

It finds a lot of interesting flows, though it should be clear that this is not currently an accurate report of our framework coverage:
- The limited handling of subclassing/dispatch leads to incompleteness. E.g. for `express` it does not report anything related to request objects.
- Promise-related libraries look like they have a huge number of features.
- JSON parsers all appear to have a feature called `query` because at some point we look up a property called `query` on a JSON object, but it's not logically a feature of the JSON parser itself.
- (A lot of libraries appear to have no features, but this is usually correct because the library itself is a function, which is all we care about)

Still, I think it's good validation for the fundamentals that are there.