### PR TITLE
C++: Fix issue with extremely long comments in AutogeneratedFile.qll

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/AutogeneratedFile.qll
+++ b/cpp/ql/lib/semmle/code/cpp/AutogeneratedFile.qll
@@ -106,6 +106,8 @@ private int fileHeaderLimit(File f) {
         )
         or
         line = f.getMetrics().getNumberOfLines()
+        or
+        line = 1000
       )
   )
 }

--- a/cpp/ql/lib/semmle/code/cpp/AutogeneratedFile.qll
+++ b/cpp/ql/lib/semmle/code/cpp/AutogeneratedFile.qll
@@ -84,6 +84,7 @@ private int fileHeaderLimit(File f) {
     fc = fileFirstComment(f) and
     result =
       min(int line |
+        // code ending the initial comments
         exists(DeclarationEntry de, Location l |
           l = de.getLocation() and
           l.getFile() = f and
@@ -105,8 +106,12 @@ private int fileHeaderLimit(File f) {
           line > fc
         )
         or
+        // end of the file
         line = f.getMetrics().getNumberOfLines()
         or
+        // rarely, we've seen extremely long sequences of initial comments
+        // (and/or limitations in the above constraints) cause an overflow of
+        // the maximum string length. So don't look past 1000 lines regardless.
         line = 1000
       )
   )


### PR DESCRIPTION
The issue was that `AutoGeneratedFile.qll` produces a concatenation of all comments (believed to be) at the beginning of a file.  This is usually only one or a few comments, but can [very rarely](https://lgtm.com/projects/g/dcreager/libcork/snapshot/8d8ae8145a675ea75f43c1a0ca20745116738ec1/files/_lgtm_build_dir/tests/u128-tests-add.c.in?sort=name&dir=ASC&mode=heatmap#L0) include a huge amount of data leading to a "String too long" error during evaluation.  The fix is to limit it to a maximum of 1000 lines (which may seem excessive, but think I remember seeing files containing license + header + autogenerated comment at around line 100).

In principle this change can affect results, in practice it should do so only extremely rarely (where the 1000 line cutoff matters).  Here's a confirmation that results are not widely affected: https://lgtm.com/query/8370470901454194727/