### PR TITLE
Clarify `min`, `max` and `rank` documentation

### DIFF
--- a/docs/codeql/ql-language-reference/expressions.rst
+++ b/docs/codeql/ql-language-reference/expressions.rst
@@ -228,7 +228,8 @@ The following aggregates are available in QL:
 - ``min`` and ``max``: These aggregates determine the smallest (``min``) or largest (``max``)
   value of ``<expression>`` among the possible assignments to the aggregation variables. 
   ``<expression>`` must be of numeric type or of type ``string``, or an explicit order must be defined with ``order by``.
-    
+  When using ``order by``, more than one result may exist in case of ties.
+  
   For example, the following aggregation returns the name of the ``.js`` file (or files) with the 
   largest number of lines, using the number of lines of code to break ties:
 
@@ -300,6 +301,7 @@ The following aggregates are available in QL:
   ``<expression>`` must be of numeric type or of type ``string``, or an explicit order must be defined with ``order by``.
   The aggregation returns the value that is ranked in the position specified by the **rank expression**.
   You must include this rank expression in brackets after the keyword ``rank``.
+  When using ``order by``, more than one result may exist in case of ties.
 
   For example, the following aggregation returns the value that is ranked 4th out of all the
   possible values. In this case, ``8`` is the 4th integer in the range from ``5`` through

--- a/docs/codeql/ql-language-reference/expressions.rst
+++ b/docs/codeql/ql-language-reference/expressions.rst
@@ -227,7 +227,7 @@ The following aggregates are available in QL:
 
 - ``min`` and ``max``: These aggregates determine the smallest (``min``) or largest (``max``)
   value of ``<expression>`` among the possible assignments to the aggregation variables. 
-  In this case, ``<expression>`` must be of numeric type or of type ``string``.
+  ``<expression>`` must be of numeric type or of type ``string``, or an explicit order must be defined with ``order by``.
     
   For example, the following aggregation returns the name of the ``.js`` file (or files) with the 
   largest number of lines, using the number of lines of code to break ties:
@@ -297,8 +297,8 @@ The following aggregates are available in QL:
 .. index:: rank
 
 - ``rank``: This aggregate takes the possible values of ``<expression>`` and ranks them. 
-  In this case, ``<expression>`` must be of numeric type or of type ``string``. The aggregation
-  returns the value that is ranked in the position specified by the **rank expression**.
+  ``<expression>`` must be of numeric type or of type ``string``, or an explicit order must be defined with ``order by``.
+  The aggregation returns the value that is ranked in the position specified by the **rank expression**.
   You must include this rank expression in brackets after the keyword ``rank``.
 
   For example, the following aggregation returns the value that is ranked 4th out of all the


### PR DESCRIPTION
Currently the documentation sounds like the `<expression>` must always be "of numeric type or of type `string`", however that is incorrect, as also described correctly by the [full language specification](https://codeql.github.com/docs/ql-language-reference/ql-language-specification/#aggregations):
> The type of the expression in a `max`, `min` or `rank` aggregation **without an ordering directive expression** must be an orderable type

(emphasis mine)

For example the following is valid:
```codeql
import java

select min(File f | f.getExtension() = "java" | f order by f.getTotalNumberOfLines())
```
```codeql
import java

select rank[5](File f | f.getExtension() = "java" | f order by f.getTotalNumberOfLines())
```
