### PR TITLE
Java: Add `Callable.getErasureStringSignature()`

### DIFF
--- a/java/ql/test/library-tests/method-signatures/Test.java
+++ b/java/ql/test/library-tests/method-signatures/Test.java
@@ -1,4 +1,5 @@
 import java.lang.annotation.*;
+import java.util.function.Function;
 
 public class Test {
 
@@ -9,5 +10,13 @@ public class Test {
 
   public void annotations(@NotNull byte[] b1, byte @NotNull [] b2, @NotNull String s, Class<@NotNull String> c, @NotNull Test.Inner ti, Class<? extends @NotNull String> wc, Class<String>[] classes, @NotNull byte b, @NotNull String[] sArray, String @NotNull [] sArray2) { }
 
-}
+  public <T, R> R typeVariables(Function<? super T, ? extends R> f) {
+    return null;
+  }
 
+  @SafeVarargs
+  static <E> void varargs(E... elements) { }
+
+  @SafeVarargs
+  static <E extends Number> void varargsWithBound(E... elements) { }
+}

--- a/java/ql/test/library-tests/method-signatures/signatures.expected
+++ b/java/ql/test/library-tests/method-signatures/signatures.expected
@@ -1,1 +1,4 @@
-| Test.java:10:15:10:25 | annotations | annotations(byte[],byte[],java.lang.String,java.lang.Class,Test.Inner,java.lang.Class,java.lang.Class[],byte,java.lang.String[],java.lang.String[]) |
+| Test.java:11:15:11:25 | annotations | annotations(byte[],byte[],java.lang.String,java.lang.Class,Test.Inner,java.lang.Class,java.lang.Class[],byte,java.lang.String[],java.lang.String[]) | annotations(byte[], byte[], String, Class<String>, Inner, Class<? extends String>, Class<String>[], byte, String[], String[]) | annotations(byte[], byte[], String, Class, Inner, Class, Class[], byte, String[], String[]) |
+| Test.java:13:19:13:31 | typeVariables | typeVariables(java.util.function.Function) | typeVariables(Function<? super T,? extends R>) | typeVariables(Function) |
+| Test.java:18:19:18:25 | varargs | varargs(java.lang.Object[]) | varargs(E[]) | varargs(Object[]) |
+| Test.java:21:34:21:49 | varargsWithBound | varargsWithBound(java.lang.Number[]) | varargsWithBound(E[]) | varargsWithBound(Number[]) |

--- a/java/ql/test/library-tests/method-signatures/signatures.ql
+++ b/java/ql/test/library-tests/method-signatures/signatures.ql
@@ -2,4 +2,4 @@ import java
 
 from Method m
 where m.getFile().getBaseName() = "Test.java"
-select m, m.getSignature()
+select m, m.getSignature(), m.getStringSignature(), m.getErasureStringSignature()


### PR DESCRIPTION
I assume the intention behind `Callable.getStringSignature()` is to provide a concise representation of the signature. However, there are two problems with the representation of parameter types:
- It depends on `Type.toString()` which has no guaranteed format
- For parameterized types, it includes all type arguments
  - This makes usage quite verbose, e.g. `doSomething(Function<? super Integer,? extends String>)`
  - The type arguments are separated only by a comma, but not by a space (unlike the callable parameter types)

This defeats the purpose of `getStringSignature()` a bit. This could be solved by adjusting the `getStringSignature()` implementation, but I chose to instead add a separate predicate called `getErasureStringSignature()`.

Open questions:
- Should the existing `getStringSignature()`, `hasStringSignature(string)` and `paramsString()` be deprecated?
-  With the new `getErasureStringSignature()`, might the erasure for type variables be too error-prone? E.g. you have to know how the erasure is determined and check the bounds for the variable. On the other hand, the question is to what extend the name of a type variable can be considered an implementation detail (which might change between versions).

Any feedback is appreciated!