### PR TITLE
C#: remove version from downgrades pack

### DIFF
--- a/csharp/downgrades/qlpack.yml
+++ b/csharp/downgrades/qlpack.yml
@@ -1,5 +1,4 @@
 name: codeql/csharp-downgrades
 groups: csharp
-version: 0.1.0-dev
 downgrades: .
 library: true


### PR DESCRIPTION
This PR removes the `version` field from the C# downgrades pack.  C# is the only downgrades pack that has a `version` field, and this change brings it in line with all the other downgrades packs.

Downgrades are bundled with the extractor and are not published independently.  So it does not need a version number.  Generally it is good practice to omit the version number for a downgrades pack because that reduces the likelihood that it might be accidentally published.
