### PR TITLE
Add auto-remediation to InsecureDependencyResolution.qhelp

### DIFF
--- a/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.qhelp
+++ b/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.qhelp
@@ -21,6 +21,11 @@ against your project's users.
 
 <p>Always use HTTPS or SFTP to download artifacts from artifact servers.</p>
 
+<p>This vulnerability can be automatically remediated with this
+<a href="https://docs.openrewrite.org/reference/recipes/maven/security/usehttpsforrepositories">OpenRewrite Recipe</a>
+or via
+<a href="https://app.moderne.io/recipes/org.openrewrite.maven.security.UseHttpsForRepositories">Moderne</a>.
+
 </recommendation>
 
 <example>


### PR DESCRIPTION
Adds an automated remediation suggestion to `InsecureDependencyResolution.qhelp`.

I authored an open rewrite recipe that can be leveraged, free for OSS, to automatically remediate this security vulnerability. The source for this recipe can be found here: https://github.com/openrewrite/rewrite/blob/cfd371c295950ee3f3ee4b15f43cb13c37ed130f/rewrite-maven/src/main/java/org/openrewrite/maven/security/UseHttpsForRepositories.java