### PR TITLE
JS: Support static accessor calls and fix some FP accessor-calls

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/DataFlow.qll
@@ -589,6 +589,13 @@ module DataFlow {
      * Gets the node where the property write happens in the control flow graph.
      */
     abstract ControlFlowNode getWriteNode();
+
+    /**
+     * If this installs an accessor on an object, as opposed to a regular property,
+     * gets the body of the accessor. `isSetter` is true if installing a setter, and
+     * false is installing a getter.
+     */
+    DataFlow::FunctionNode getInstalledAccessor(boolean isSetter) { none() }
   }
 
   /**
@@ -627,6 +634,17 @@ module DataFlow {
     override string getPropertyName() { result = prop.getName() }
 
     override Node getRhs() { result = valueNode(prop.(ValueProperty).getInit()) }
+
+    override DataFlow::FunctionNode getInstalledAccessor(boolean isSetter) {
+      (
+        prop instanceof PropertySetter and
+        isSetter = true
+        or
+        prop instanceof PropertyGetter and
+        isSetter = false
+      ) and
+      result = valueNode(prop.getInit())
+    }
 
     override ControlFlowNode getWriteNode() { result = prop }
   }
@@ -688,6 +706,17 @@ module DataFlow {
       result = valueNode(prop.getInit())
     }
 
+    override DataFlow::FunctionNode getInstalledAccessor(boolean isSetter) {
+      (
+        prop instanceof SetterMethodDefinition and
+        isSetter = true
+        or
+        prop instanceof GetterMethodDefinition and
+        isSetter = false
+      ) and
+      result = valueNode(prop.getInit())
+    }
+
     override ControlFlowNode getWriteNode() { result = prop }
   }
 
@@ -708,6 +737,17 @@ module DataFlow {
 
     override Node getRhs() {
       not prop instanceof AccessorMethodDefinition and
+      result = valueNode(prop.getInit())
+    }
+
+    override DataFlow::FunctionNode getInstalledAccessor(boolean isSetter) {
+      (
+        prop instanceof SetterMethodDefinition and
+        isSetter = true
+        or
+        prop instanceof GetterMethodDefinition and
+        isSetter = false
+      ) and
       result = valueNode(prop.getInit())
     }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -899,16 +899,30 @@ class ClassNode extends DataFlow::SourceNode instanceof ClassNode::Range {
   FunctionNode getAnInstanceMember() { result = super.getAnInstanceMember(_) }
 
   /**
+   * Gets the static method, getter, or setter declared in this class with the given name and kind.
+   */
+  FunctionNode getStaticMember(string name, MemberKind kind) {
+    result = super.getStaticMember(name, kind)
+  }
+
+  /**
    * Gets the static method declared in this class with the given name.
    */
-  FunctionNode getStaticMethod(string name) { result = super.getStaticMethod(name) }
+  FunctionNode getStaticMethod(string name) {
+    result = this.getStaticMember(name, MemberKind::method())
+  }
+
+  /**
+   * Gets a static method, getter, or setter declared in this class with the given kind.
+   */
+  FunctionNode getAStaticMember(MemberKind kind) { result = super.getAStaticMember(kind) }
 
   /**
    * Gets a static method declared in this class.
    *
    * The constructor is not considered a static method.
    */
-  FunctionNode getAStaticMethod() { result = super.getAStaticMethod() }
+  FunctionNode getAStaticMethod() { result = this.getAStaticMember(MemberKind::method()) }
 
   /**
    * Gets a dataflow node that refers to the superclass of this class.
@@ -1119,18 +1133,34 @@ module ClassNode {
     abstract FunctionNode getAnInstanceMember(MemberKind kind);
 
     /**
+     * Gets the static member of this class with the given name and kind.
+     */
+    cached
+    abstract FunctionNode getStaticMember(string name, MemberKind kind);
+
+    /**
+     * DEPRECATED. Override `getStaticMember` instead.
+     *
      * Gets the static method of this class with the given name.
      */
     cached
-    abstract FunctionNode getStaticMethod(string name);
+    deprecated FunctionNode getStaticMethod(string name) { none() }
 
     /**
+     * Gets a static member of this class of the given kind.
+     */
+    cached
+    abstract FunctionNode getAStaticMember(MemberKind kind);
+
+    /**
+     * DEPRECATED. Override `getAStaticMember` instead.
+     *
      * Gets a static method of this class.
      *
      * The constructor is not considered a static method.
      */
     cached
-    abstract FunctionNode getAStaticMethod();
+    deprecated FunctionNode getAStaticMethod() { none() }
 
     /**
      * Gets a dataflow node representing a class to be used as the super-class
@@ -1186,23 +1216,27 @@ module ClassNode {
       result = this.getConstructor().getReceiver().getAPropertySource()
     }
 
-    override FunctionNode getStaticMethod(string name) {
+    override FunctionNode getStaticMember(string name, MemberKind kind) {
       exists(MethodDeclaration method |
         method = astNode.getMethod(name) and
         method.isStatic() and
+        kind = MemberKind::of(method) and
         result = method.getBody().flow()
       )
       or
+      kind.isMethod() and
       result = this.getAPropertySource(name)
     }
 
-    override FunctionNode getAStaticMethod() {
+    override FunctionNode getAStaticMember(MemberKind kind) {
       exists(MethodDeclaration method |
         method = astNode.getAMethod() and
         method.isStatic() and
+        kind = MemberKind::of(method) and
         result = method.getBody().flow()
       )
       or
+      kind.isMethod() and
       result = this.getAPropertySource()
     }
 
@@ -1300,9 +1334,15 @@ module ClassNode {
       )
     }
 
-    override FunctionNode getStaticMethod(string name) { result = this.getAPropertySource(name) }
+    override FunctionNode getStaticMember(string name, MemberKind kind) {
+      kind.isMethod() and
+      result = this.getAPropertySource(name)
+    }
 
-    override FunctionNode getAStaticMethod() { result = this.getAPropertySource() }
+    override FunctionNode getAStaticMember(MemberKind kind) {
+      kind.isMethod() and
+      result = this.getAPropertySource()
+    }
 
     /**
      * Gets a reference to the prototype of this class.

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -200,6 +200,12 @@ module CallGraph {
       or
       ref = getAnInstanceMemberAssignment(cls, name) and
       result = cls.getInstanceMember(name, DataFlow::MemberKind::setter())
+      or
+      ref = cls.getAClassReference().getAPropertyRead(name) and
+      result = cls.getStaticMember(name, DataFlow::MemberKind::getter())
+      or
+      ref = cls.getAClassReference().getAPropertyWrite(name) and
+      result = cls.getStaticMember(name, DataFlow::MemberKind::setter())
     )
     or
     exists(DataFlow::ObjectLiteralNode object, string name |

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -190,30 +190,42 @@ module CallGraph {
   }
 
   /**
+   * Holds if `ref` installs an accessor on an object. Such property writes should not
+   * be considered calls to an accessor.
+   */
+  pragma[nomagic]
+  private predicate isAccessorInstallation(DataFlow::PropWrite write) {
+    exists(write.getInstalledAccessor(_))
+  }
+
+  /**
    * Gets a getter or setter invoked as a result of the given property access.
    */
   cached
   DataFlow::FunctionNode getAnAccessorCallee(DataFlow::PropRef ref) {
-    exists(DataFlow::ClassNode cls, string name |
-      ref = cls.getAnInstanceMemberAccess(name) and
-      result = cls.getInstanceMember(name, DataFlow::MemberKind::getter())
+    not isAccessorInstallation(ref) and
+    (
+      exists(DataFlow::ClassNode cls, string name |
+        ref = cls.getAnInstanceMemberAccess(name) and
+        result = cls.getInstanceMember(name, DataFlow::MemberKind::getter())
+        or
+        ref = getAnInstanceMemberAssignment(cls, name) and
+        result = cls.getInstanceMember(name, DataFlow::MemberKind::setter())
+        or
+        ref = cls.getAClassReference().getAPropertyRead(name) and
+        result = cls.getStaticMember(name, DataFlow::MemberKind::getter())
+        or
+        ref = cls.getAClassReference().getAPropertyWrite(name) and
+        result = cls.getStaticMember(name, DataFlow::MemberKind::setter())
+      )
       or
-      ref = getAnInstanceMemberAssignment(cls, name) and
-      result = cls.getInstanceMember(name, DataFlow::MemberKind::setter())
-      or
-      ref = cls.getAClassReference().getAPropertyRead(name) and
-      result = cls.getStaticMember(name, DataFlow::MemberKind::getter())
-      or
-      ref = cls.getAClassReference().getAPropertyWrite(name) and
-      result = cls.getStaticMember(name, DataFlow::MemberKind::setter())
-    )
-    or
-    exists(DataFlow::ObjectLiteralNode object, string name |
-      ref = getAnAllocationSiteRef(object).getAPropertyRead(name) and
-      result = object.getPropertyGetter(name)
-      or
-      ref = getAnAllocationSiteRef(object).getAPropertyWrite(name) and
-      result = object.getPropertySetter(name)
+      exists(DataFlow::ObjectLiteralNode object, string name |
+        ref = getAnAllocationSiteRef(object).getAPropertyRead(name) and
+        result = object.getPropertyGetter(name)
+        or
+        ref = getAnAllocationSiteRef(object).getAPropertyWrite(name) and
+        result = object.getPropertySetter(name)
+      )
     )
   }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -139,7 +139,7 @@ private module CachedSteps {
    * Holds if `invk` may invoke `f`.
    */
   cached
-  predicate calls(DataFlow::SourceNode invk, Function f) {
+  predicate calls(DataFlow::Node invk, Function f) {
     f = invk.(DataFlow::InvokeNode).getACallee(0)
     or
     f = invk.(DataFlow::PropRef).getAnAccessorCallee().getFunction()

--- a/javascript/ql/src/change-notes/2022-04-21-static-accessors.md
+++ b/javascript/ql/src/change-notes/2022-04-21-static-accessors.md
@@ -1,0 +1,6 @@
+---
+category: minorAnalysis
+---
+* The call graph now deals more precisely with calls to accessors (getters and setters).
+  Previously, calls to static accessors were not resolved, and some method calls were
+  incorrectly seen as calls to an accessor. Both issues have been fixed.

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -1,5 +1,5 @@
 spuriousCallee
 missingCallee
-| constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 |
-| constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 |
+| constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
+| constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 badAnnotation

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -3,3 +3,14 @@ missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 badAnnotation
+accessorCall
+| accessors.js:5:3:5:12 | get f() {} | accessors.js:8:8:8:13 | (x) {} |
+| accessors.js:8:3:8:13 | set f(x) {} | accessors.js:8:8:8:13 | (x) {} |
+| accessors.js:12:1:12:5 | obj.f | accessors.js:5:8:5:12 | () {} |
+| accessors.js:15:1:15:5 | obj.f | accessors.js:8:8:8:13 | (x) {} |
+| accessors.js:19:3:19:19 | static get f() {} | accessors.js:22:15:22:20 | (x) {} |
+| accessors.js:22:3:22:20 | static set f(x) {} | accessors.js:22:15:22:20 | (x) {} |
+| accessors.js:26:1:26:3 | C.f | accessors.js:19:15:19:19 | () {} |
+| accessors.js:29:1:29:3 | C.f | accessors.js:22:15:22:20 | (x) {} |
+| accessors.js:41:1:41:9 | new D().f | accessors.js:34:8:34:12 | () {} |
+| accessors.js:44:1:44:9 | new D().f | accessors.js:37:8:37:13 | (x) {} |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -10,3 +10,6 @@ accessorCall
 | accessors.js:29:1:29:3 | C.f | accessors.js:22:15:22:20 | (x) {} |
 | accessors.js:41:1:41:9 | new D().f | accessors.js:34:8:34:12 | () {} |
 | accessors.js:44:1:44:9 | new D().f | accessors.js:37:8:37:13 | (x) {} |
+| accessors.js:48:1:48:5 | obj.f | accessors.js:5:8:5:12 | () {} |
+| accessors.js:51:1:51:3 | C.f | accessors.js:19:15:19:19 | () {} |
+| accessors.js:54:1:54:9 | new D().f | accessors.js:34:8:34:12 | () {} |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -4,12 +4,8 @@ missingCallee
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 badAnnotation
 accessorCall
-| accessors.js:5:3:5:12 | get f() {} | accessors.js:8:8:8:13 | (x) {} |
-| accessors.js:8:3:8:13 | set f(x) {} | accessors.js:8:8:8:13 | (x) {} |
 | accessors.js:12:1:12:5 | obj.f | accessors.js:5:8:5:12 | () {} |
 | accessors.js:15:1:15:5 | obj.f | accessors.js:8:8:8:13 | (x) {} |
-| accessors.js:19:3:19:19 | static get f() {} | accessors.js:22:15:22:20 | (x) {} |
-| accessors.js:22:3:22:20 | static set f(x) {} | accessors.js:22:15:22:20 | (x) {} |
 | accessors.js:26:1:26:3 | C.f | accessors.js:19:15:19:19 | () {} |
 | accessors.js:29:1:29:3 | C.f | accessors.js:22:15:22:20 | (x) {} |
 | accessors.js:41:1:41:9 | new D().f | accessors.js:34:8:34:12 | () {} |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -25,7 +25,7 @@ class AnnotatedFunction extends Function {
 }
 
 /** A function annotated with `calls:NAME` */
-class AnnotatedCall extends DataFlow::SourceNode {
+class AnnotatedCall extends DataFlow::Node {
   string calls;
   string kind;
 

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -90,3 +90,7 @@ query predicate badAnnotation(string name) {
   not name = any(AnnotatedCall cl).getCallTargetName() and
   name = any(AnnotatedFunction cl).getCalleeName()
 }
+
+query predicate accessorCall(DataFlow::PropRef ref, Function target) {
+  FlowSteps::calls(ref, target)
+}

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -25,16 +25,28 @@ class AnnotatedFunction extends Function {
 }
 
 /** A function annotated with `calls:NAME` */
-class AnnotatedCall extends InvokeExpr {
+class AnnotatedCall extends DataFlow::SourceNode {
   string calls;
+  string kind;
 
-  AnnotatedCall() { calls = getAnnotation(this, "calls") }
+  AnnotatedCall() {
+    this instanceof DataFlow::InvokeNode and
+    calls = getAnnotation(this.asExpr(), kind) and
+    kind = "calls"
+    or
+    this instanceof DataFlow::PropRef and
+    calls = getAnnotation(this.getAstNode(), kind) and
+    kind = "callsAccessor"
+  }
 
   string getCallTargetName() { result = calls }
 
-  AnnotatedFunction getAnExpectedCallee() { result.getCalleeName() = getCallTargetName() }
+  AnnotatedFunction getAnExpectedCallee(string kind_) {
+    result.getCalleeName() = getCallTargetName() and
+    kind = kind_
+  }
 
-  int getBoundArgs() { result = getAnnotation(this, "boundArgs").toInt() }
+  int getBoundArgs() { result = getAnnotation(this.getAstNode(), "boundArgs").toInt() }
 
   int getBoundArgsOrMinusOne() {
     result = getBoundArgs()
@@ -42,25 +54,31 @@ class AnnotatedCall extends InvokeExpr {
     not exists(getBoundArgs()) and
     result = -1
   }
+
+  string getKind() {
+    result = kind
+  }
 }
 
 predicate callEdge(AnnotatedCall call, AnnotatedFunction target, int boundArgs) {
-  FlowSteps::calls(call.flow(), target) and boundArgs = -1
+  FlowSteps::calls(call, target) and boundArgs = -1
   or
-  FlowSteps::callsBound(call.flow(), target, boundArgs)
+  FlowSteps::callsBound(call, target, boundArgs)
 }
 
-query predicate spuriousCallee(AnnotatedCall call, AnnotatedFunction target, int boundArgs) {
+query predicate spuriousCallee(AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind) {
   callEdge(call, target, boundArgs) and
+  kind = call.getKind() and
   not (
-    target = call.getAnExpectedCallee() and
+    target = call.getAnExpectedCallee(kind) and
     boundArgs = call.getBoundArgsOrMinusOne()
   )
 }
 
-query predicate missingCallee(AnnotatedCall call, AnnotatedFunction target, int boundArgs) {
+query predicate missingCallee(AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind) {
   not callEdge(call, target, boundArgs) and
-  target = call.getAnExpectedCallee() and
+  kind = call.getKind() and
+  target = call.getAnExpectedCallee(kind) and
   boundArgs = call.getBoundArgsOrMinusOne()
 }
 

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -55,9 +55,7 @@ class AnnotatedCall extends DataFlow::Node {
     result = -1
   }
 
-  string getKind() {
-    result = kind
-  }
+  string getKind() { result = kind }
 }
 
 predicate callEdge(AnnotatedCall call, AnnotatedFunction target, int boundArgs) {
@@ -66,7 +64,9 @@ predicate callEdge(AnnotatedCall call, AnnotatedFunction target, int boundArgs) 
   FlowSteps::callsBound(call, target, boundArgs)
 }
 
-query predicate spuriousCallee(AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind) {
+query predicate spuriousCallee(
+  AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind
+) {
   callEdge(call, target, boundArgs) and
   kind = call.getKind() and
   not (
@@ -75,7 +75,9 @@ query predicate spuriousCallee(AnnotatedCall call, AnnotatedFunction target, int
   )
 }
 
-query predicate missingCallee(AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind) {
+query predicate missingCallee(
+  AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind
+) {
   not callEdge(call, target, boundArgs) and
   kind = call.getKind() and
   target = call.getAnExpectedCallee(kind) and

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/accessors.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/accessors.js
@@ -42,3 +42,13 @@ new D().f;
 
 /** callsAccessor:D.f.set */
 new D().f = 1;
+
+// Avoid regular calls being seen as calls to the accessor itself
+/** calls:NONE */
+obj.f();
+
+/** calls:NONE */
+C.f();
+
+/** calls:NONE */
+new D().f();

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/accessors.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/accessors.js
@@ -1,0 +1,44 @@
+import 'dummy';
+
+let obj = {
+  /** name:obj.f.get */
+  get f() {},
+
+  /** name:obj.f.set */
+  set f(x) {}
+};
+
+/** callsAccessor:obj.f.get */
+obj.f;
+
+/** callsAccessor:obj.f.set */
+obj.f = 1;
+
+class C {
+  /** name:C.f.get */
+  static get f() {}
+
+  /** name:C.f.set */
+  static set f(x) {}
+}
+
+/** callsAccessor:C.f.get */
+C.f;
+
+/** callsAccessor:C.f.set */
+C.f = 1;
+
+
+class D {
+  /** name:D.f.get */
+  get f() {}
+
+  /** name:D.f.set */
+  set f(x) {}
+}
+
+/** callsAccessor:D.f.get */
+new D().f;
+
+/** callsAccessor:D.f.set */
+new D().f = 1;

--- a/javascript/ql/test/library-tests/ClassNode/tests.expected
+++ b/javascript/ql/test/library-tests/ClassNode/tests.expected
@@ -24,6 +24,7 @@ getAReceiverNode
 | tst.js:23:1:23:15 | function D() {} | tst.js:25:13:25:12 | this |
 | tst.js:23:1:23:15 | function D() {} | tst.js:26:13:26:12 | this |
 | tst.js:23:1:23:15 | function D() {} | tst.js:27:4:27:3 | this |
+| tst.js:30:1:34:1 | class S ... x) {}\\n} | tst.js:30:21:30:20 | this |
 getFieldTypeAnnotation
 | fields.ts:1:1:3:1 | class B ... mber;\\n} | baseField | fields.ts:2:16:2:21 | number |
 | fields.ts:5:1:13:1 | class F ... > {};\\n} | x | fields.ts:6:27:6:32 | number |
@@ -53,6 +54,11 @@ instanceMethod
 | tst.js:15:1:15:15 | function B() {} | foo | tst.js:17:19:17:31 | function() {} | B |
 | tst.js:19:1:19:15 | function C() {} | bar | tst.js:21:19:21:31 | function() {} | C |
 | tst.js:23:1:23:15 | function D() {} | m | tst.js:27:4:27:8 | () {} | D |
+staticMember
+| tst.js:3:1:10:1 | class A ... () {}\\n} | staticMethod | method | tst.js:5:22:5:26 | () {} | A |
+| tst.js:30:1:34:1 | class S ... x) {}\\n} | getter | getter | tst.js:32:20:32:24 | () {} | StaticMembers |
+| tst.js:30:1:34:1 | class S ... x) {}\\n} | method | method | tst.js:31:16:31:20 | () {} | StaticMembers |
+| tst.js:30:1:34:1 | class S ... x) {}\\n} | setter | setter | tst.js:33:20:33:25 | (x) {} | StaticMembers |
 superClass
 | fields.ts:5:1:13:1 | class F ... > {};\\n} | fields.ts:1:1:3:1 | class B ... mber;\\n} | Foo | Base |
 | tst.js:13:1:13:21 | class A ... ds A {} | tst.js:3:1:10:1 | class A ... () {}\\n} | A2 | A |

--- a/javascript/ql/test/library-tests/ClassNode/tests.ql
+++ b/javascript/ql/test/library-tests/ClassNode/tests.ql
@@ -24,6 +24,12 @@ query predicate instanceMethod(
   cls.getInstanceMethod(name) = inst and clsName = cls.getName()
 }
 
+query predicate staticMember(
+  DataFlow::ClassNode cls, string name, string kind, DataFlow::FunctionNode inst, string clsName
+) {
+  cls.getStaticMember(name, kind) = inst and clsName = cls.getName()
+}
+
 query predicate superClass(
   DataFlow::ClassNode cls, DataFlow::ClassNode sup, string clsName, string supName
 ) {

--- a/javascript/ql/test/library-tests/ClassNode/tst.js
+++ b/javascript/ql/test/library-tests/ClassNode/tst.js
@@ -26,3 +26,9 @@ D.prototype = {
   set setter(x) {},
   m() {}
 }
+
+class StaticMembers {
+  static method() {}
+  static get getter() {}
+  static set setter(x) {}
+}


### PR DESCRIPTION
Fixes two problems with our call graph for accessors, and adds support for calls to static accessors declared on a class.

This PR deals with two bugs:
- `ClassNode.getStaticMethod` previously included static accessors. This lead to some FP call edges as a result from confusing accessors and methods.
- A `PropWrite` node exists for accessors, representing the installation of an accessor. We accidentally saw these as potential calls to the setter. 

It is addressed as follows:
- Introduced `ClassNode.getStaticMember`, analogous to `ClassNode.getInstanceMember`, and made `getStaticMethod` only include methods.
- Added accessor-calls to static accessors to the call graph, and made sure static method calls aren't seen as calls to an accessor.
- Added `PropWrite.isAccessorInstallation` to distinguish between ordinary property assignments and accessor installation. Accessor installations are no longer seen as potential calls to a setter.

[Evaluation](https://github.com/github/codeql-dca-main/blob/data/asgerf/static-accessor__default__code-scanning__2/reports/alert-meta-comparison.md) on default slugs:
- 3811 new call edges (calls to static accessors, and method calls whose receiver came from such a call)
- 1687 removed FP call edges (from method calls and accessor installations being seen as accessor calls)
- [Performance](https://github.com/github/codeql-dca-main/tree/data/asgerf/static-accessor__default__code-scanning__2/reports) looks OK, it's not without some cost, but acceptable given the nature of the fix