### PR TITLE
C#: Exclude model generation queries from all suites

### DIFF
--- a/csharp/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/csharp/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -3,6 +3,7 @@
  * @description Finds public methods that act as sinks as they flow into a a known sink.
  * @kind diagnostic
  * @id cs/utils/model-generator/sink-models
+ * @tags model-generator
  */
 
 private import internal.CaptureModels

--- a/csharp/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/csharp/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -3,6 +3,7 @@
  * @description Finds APIs that act as sources as they expose already known sources.
  * @kind diagnostic
  * @id cs/utils/model-generator/source-models
+ * @tags model-generator
  */
 
 private import internal.CaptureModels

--- a/csharp/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/csharp/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -3,6 +3,7 @@
  * @description Finds applicable summary models to be used by other queries.
  * @kind diagnostic
  * @id cs/utils/model-generator/summary-models
+ * @tags model-generator
  */
 
 private import semmle.code.csharp.dataflow.ExternalFlow

--- a/misc/suite-helpers/code-scanning-selectors.yml
+++ b/misc/suite-helpers/code-scanning-selectors.yml
@@ -28,3 +28,6 @@
       - /^experimental\/.*/
       - Metrics/Summaries/FrameworkCoverage.ql
       - /Diagnostics/Internal/.*/
+- exclude:
+    tags contain:
+      - model-generator

--- a/misc/suite-helpers/security-and-quality-selectors.yml
+++ b/misc/suite-helpers/security-and-quality-selectors.yml
@@ -28,4 +28,6 @@
     query path:
       - /^experimental\/.*/
       - Metrics/Summaries/FrameworkCoverage.ql
-
+- exclude:
+    tags contain:
+      - model-generator

--- a/misc/suite-helpers/security-extended-selectors.yml
+++ b/misc/suite-helpers/security-extended-selectors.yml
@@ -33,3 +33,6 @@
     query path:
       - /^experimental\/.*/
       - Metrics/Summaries/FrameworkCoverage.ql
+- exclude:
+    tags contain:
+      - model-generator


### PR DESCRIPTION
I verified locally that e.g.
```
codeql resolve queries csharp/ql/src/codeql-suites/csharp-code-scanning.qls | grep Model
```
would return the three queries before, but not after.