### PR TITLE
Exclude internal diagnostics from all selectors

### DIFF
--- a/misc/suite-helpers/lgtm-selectors.yml
+++ b/misc/suite-helpers/lgtm-selectors.yml
@@ -25,3 +25,4 @@
     query path:
       - /^experimental\/.*/
       - Metrics/Summaries/FrameworkCoverage.ql
+      - /Diagnostics/Internal/.*/

--- a/misc/suite-helpers/security-and-quality-selectors.yml
+++ b/misc/suite-helpers/security-and-quality-selectors.yml
@@ -28,6 +28,7 @@
     query path:
       - /^experimental\/.*/
       - Metrics/Summaries/FrameworkCoverage.ql
+      - /Diagnostics/Internal/.*/
 - exclude:
     tags contain:
       - model-generator

--- a/misc/suite-helpers/security-extended-selectors.yml
+++ b/misc/suite-helpers/security-extended-selectors.yml
@@ -33,6 +33,7 @@
     query path:
       - /^experimental\/.*/
       - Metrics/Summaries/FrameworkCoverage.ql
+      - /Diagnostics/Internal/.*/
 - exclude:
     tags contain:
       - model-generator


### PR DESCRIPTION
Thanks to @esbena for pointing this out.

@esbena I did a sweep over all the selectors and added the exclusion rule in all of them (instead of just `security-extended-selectors.yml`). I hope that's not controversial 🤞.