### PR TITLE
Ruby: Exclude `SplatExpr` from taint tracking

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -86,7 +86,11 @@ private module Cached {
     exists(CfgNodes::ExprNodes::OperationCfgNode op |
       op = nodeTo.asExpr() and
       op.getAnOperand() = nodeFrom.asExpr() and
-      not op.getExpr() instanceof AssignExpr
+      not op.getExpr() =
+        any(Expr e |
+          e instanceof AssignExpr or
+          e instanceof SplatExpr
+        )
     )
     or
     // string interpolation of `nodeFrom` into `nodeTo`

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -10,9 +10,6 @@ edges
 | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:2:9:2:20 | * ... :  |
 | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:2:9:2:20 | * ... [array element 0] :  |
 | array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:2:9:2:20 | * ... [array element 0] :  |
-| array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:3:10:3:10 | a :  |
-| array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:4:10:4:10 | a :  |
-| array_flow.rb:2:10:2:20 | call to source :  | array_flow.rb:5:10:5:10 | a :  |
 | array_flow.rb:3:10:3:10 | a :  | array_flow.rb:3:10:3:13 | ...[...] |
 | array_flow.rb:3:10:3:10 | a [array element 0] :  | array_flow.rb:3:10:3:13 | ...[...] |
 | array_flow.rb:3:10:3:10 | a [array element 0] :  | array_flow.rb:3:10:3:13 | ...[...] |


### PR DESCRIPTION
`SplatExpr`s are modelled using flow summaries, so there is no need to include them explicitly in `defaultAdditionalTaintStep`.