### PR TITLE
Ruby: dont import the PathGraph module from Query.qll files

### DIFF
--- a/ruby/ql/lib/codeql/ruby/security/CodeInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CodeInjectionQuery.qll
@@ -5,7 +5,6 @@
  * otherwise `CodeInjectionCustomizations` should be imported instead.
  */
 
-import codeql.ruby.DataFlow::DataFlow::PathGraph
 import codeql.ruby.DataFlow
 import codeql.ruby.TaintTracking
 import CodeInjectionCustomizations::CodeInjection

--- a/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryQuery.qll
@@ -6,7 +6,6 @@
  * otherwise `ServerSideRequestForgeryCustomizations` should be imported instead.
  */
 
-import codeql.ruby.DataFlow::DataFlow::PathGraph
 import codeql.ruby.DataFlow
 import codeql.ruby.TaintTracking
 import ServerSideRequestForgeryCustomizations::ServerSideRequestForgery

--- a/ruby/ql/lib/codeql/ruby/security/UrlRedirectQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UrlRedirectQuery.qll
@@ -6,7 +6,6 @@
  */
 
 private import ruby
-import codeql.ruby.DataFlow::DataFlow::PathGraph
 import codeql.ruby.DataFlow
 import codeql.ruby.TaintTracking
 import UrlRedirectCustomizations

--- a/ruby/ql/lib/codeql/ruby/security/performance/RegExpInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/performance/RegExpInjectionQuery.qll
@@ -5,7 +5,6 @@
  * otherwise `RegExpInjectionCustomizations` should be imported instead.
  */
 
-import codeql.ruby.DataFlow::DataFlow::PathGraph
 import codeql.ruby.DataFlow
 import codeql.ruby.TaintTracking
 import RegExpInjectionCustomizations

--- a/ruby/ql/src/queries/security/cwe-918/ServerSideRequestForgery.ql
+++ b/ruby/ql/src/queries/security/cwe-918/ServerSideRequestForgery.ql
@@ -13,6 +13,7 @@
 import ruby
 import codeql.ruby.DataFlow
 import codeql.ruby.security.ServerSideRequestForgeryQuery
+import DataFlow::PathGraph
 
 from Configuration config, DataFlow::PathNode source, DataFlow::PathNode sink
 where config.hasFlowPath(source, sink)


### PR DESCRIPTION
Most of the time you import the `PathGraph` module from the `.ql` file of a path-query.  
But sometimes you also imported it from the `Query.qll` file (I removed those).  

(I found this from looking at redundant imports, and some of your `PathGraph` imports showed up as redundant). 