### PR TITLE
C++: Cover variable sized member arrays without a size in `Buffer.qll`

### DIFF
--- a/cpp/ql/lib/change-notes/2022-04-22-no-size-array.md
+++ b/cpp/ql/lib/change-notes/2022-04-22-no-size-array.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `semmle.code.cpp.commons.Buffer` library has been enhanced to handle array members of classes that do not specify a size.


### PR DESCRIPTION
Currently the extractor incorrectly emits <strike>-1</strike> 0 for the array `data` below:
```
struct myStruct { // c
   ...
   char data[]; // v
};
```
This will change with the next version of EDG, and  no size will be emitted anymore. This PR makes sure `Buffer.qll` handles arrays without sizes.

This is a separate PR to ensure these these changes do not get lost in a much larger PR and to be able to check that this doesn't cause any regressions already before the EDG upgrade.