### PR TITLE
C++: Add non-returning function test case using `__builtin_expect`

### DIFF
--- a/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
+++ b/cpp/ql/test/query-tests/jsf/4.13 Functions/AV Rule 114/test.c
@@ -105,3 +105,8 @@ _Noreturn void f15();
 int f16() {
     f15(); // GOOD
 }
+
+int f17() {
+    if (__builtin_expect(1, 0))
+        __builtin_unreachable(); // GOOD
+}


### PR DESCRIPTION
This is a reduced version of the only regression I'm currently seeing in DCA after upgrading EDG. Add a test case now, so this devolves to a test case failure during the upgrade.