### PR TITLE
C++: add new Windows pool allocation functions in `Allocation.qll`

### DIFF
--- a/cpp/ql/lib/change-notes/2022-04-25-windows-pool-allocation-functions.md
+++ b/cpp/ql/lib/change-notes/2022-04-25-windows-pool-allocation-functions.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Windows pool allocation functions are now detected as `AllocationFunction`s.

--- a/cpp/ql/lib/change-notes/2022-04-25-windows-pool-allocation-functions.md
+++ b/cpp/ql/lib/change-notes/2022-04-25-windows-pool-allocation-functions.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Windows pool allocation functions are now detected as `AllocationFunction`s.
+* More Windows pool allocation functions are now detected as `AllocationFunction`s.

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Allocation.qll
@@ -42,10 +42,13 @@ private class MallocAllocationFunction extends AllocationFunction {
     this.hasGlobalName([
         // --- Windows Memory Management for Windows Drivers
         "ExAllocatePool", // ExAllocatePool(type, size)
+        "ExAllocatePool2", // ExAllocatePool2(flags, size, tag)
+        "ExAllocatePool3", // ExAllocatePool3(flags, size, tag, extparams, extparamscount)
         "ExAllocatePoolWithTag", // ExAllocatePool(type, size, tag)
         "ExAllocatePoolWithTagPriority", // ExAllocatePoolWithTagPriority(type, size, tag, priority)
         "ExAllocatePoolWithQuota", // ExAllocatePoolWithQuota(type, size)
         "ExAllocatePoolWithQuotaTag", // ExAllocatePoolWithQuotaTag(type, size, tag)
+        "ExAllocatePoolZero", // ExAllocatePoolZero(type, size, tag)
         "IoAllocateMdl", // IoAllocateMdl(address, size, flag, flag, irp)
         "IoAllocateErrorLogEntry", // IoAllocateErrorLogEntry(object, size)
         // --- Windows Global / Local legacy allocation


### PR DESCRIPTION
Add the following Windows pool allocation functions in `Allocation.qll`:

 - [ExAllocatePool2](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool2)
 - [ExAllocatePool3](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepool3)
 - [ExAllocatePoolZero](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exallocatepoolzero)

This improves the detection of bugs on Windows kernel drivers.