### PR TITLE
Revert "Clarify `min`, `max` and `rank` documentation"

### DIFF
--- a/docs/codeql/ql-language-reference/expressions.rst
+++ b/docs/codeql/ql-language-reference/expressions.rst
@@ -227,9 +227,8 @@ The following aggregates are available in QL:
 
 - ``min`` and ``max``: These aggregates determine the smallest (``min``) or largest (``max``)
   value of ``<expression>`` among the possible assignments to the aggregation variables. 
-  ``<expression>`` must be of numeric type or of type ``string``, or an explicit order must be defined with ``order by``.
-  When using ``order by``, more than one result may exist in case of ties.
-  
+  In this case, ``<expression>`` must be of numeric type or of type ``string``.
+    
   For example, the following aggregation returns the name of the ``.js`` file (or files) with the 
   largest number of lines, using the number of lines of code to break ties:
 
@@ -298,10 +297,9 @@ The following aggregates are available in QL:
 .. index:: rank
 
 - ``rank``: This aggregate takes the possible values of ``<expression>`` and ranks them. 
-  ``<expression>`` must be of numeric type or of type ``string``, or an explicit order must be defined with ``order by``.
-  The aggregation returns the value that is ranked in the position specified by the **rank expression**.
+  In this case, ``<expression>`` must be of numeric type or of type ``string``. The aggregation
+  returns the value that is ranked in the position specified by the **rank expression**.
   You must include this rank expression in brackets after the keyword ``rank``.
-  When using ``order by``, more than one result may exist in case of ties.
 
   For example, the following aggregation returns the value that is ranked 4th out of all the
   possible values. In this case, ``8`` is the 4th integer in the range from ``5`` through


### PR DESCRIPTION
Reverts github/codeql#8760