### PR TITLE
C#: Port the java FrameworkCoverage query.

### DIFF
--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup CodeQL
         uses: ./.github/actions/fetch-codeql
       - name: Create empty database

--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup CodeQL
         uses: ./.github/actions/fetch-codeql
       - name: Create empty database
-      run: |
+        run: |
           DATABASE="${{ runner.temp }}/csharp-database"
           PROJECT="${{ runner.temp }}/csharp-project"
           dotnet new classlib --language=C# --output="$PROJECT"

--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -14,7 +14,7 @@ on:
       - ".github/workflows/csv-coverage-metrics.yml"
 
 jobs:
-  publish:
+  publish-java:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,13 +31,40 @@ jobs:
       - name: Capture coverage information
         run: |
           DATABASE="${{ runner.temp }}/java-database"
-          codeql database analyze --format=sarif-latest --output=metrics.sarif -- "$DATABASE" ./java/ql/src/Metrics/Summaries/FrameworkCoverage.ql
+          codeql database analyze --format=sarif-latest --output=metrics-java.sarif -- "$DATABASE" ./java/ql/src/Metrics/Summaries/FrameworkCoverage.ql
       - uses: actions/upload-artifact@v3
         with:
-          name: metrics.sarif
-          path: metrics.sarif
+          name: metrics-java.sarif
+          path: metrics-java.sarif
           retention-days: 20
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v1
         with:
-          sarif_file: metrics.sarif
+          sarif_file: metrics-java.sarif
+  
+  publish-csharp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup CodeQL
+        uses: ./.github/actions/fetch-codeql
+      - name: Create empty database
+      run: |
+          DATABASE="${{ runner.temp }}/csharp-database"
+          PROJECT="${{ runner.temp }}/csharp-project"
+          dotnet new classlib --language=C# --output="$PROJECT"
+          codeql database create "$DATABASE" --language=csharp --source-root="$PROJECT" --command 'dotnet build /t:rebuild csharp-project.csproj /p:UseSharedCompilation=false'
+      - name: Capture coverage information
+        run: |
+          DATABASE="${{ runner.temp }}/csharp-database"
+          codeql database analyze --format=sarif-latest --output=metrics-csharp.sarif -- "$DATABASE" ./csharp/ql/src/Metrics/Summaries/FrameworkCoverage.ql
+      - uses: actions/upload-artifact@v3
+        with:
+          name: metrics-csharp.sarif
+          path: metrics-csharp.sarif
+          retention-days: 20
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: metrics-csharp.sarif

--- a/csharp/ql/src/Metrics/Summaries/FrameworkCoverage.ql
+++ b/csharp/ql/src/Metrics/Summaries/FrameworkCoverage.ql
@@ -1,0 +1,18 @@
+/**
+ * @id csharp/summary/framework-coverage
+ * @name Metrics of framework coverage
+ * @description Expose metrics for the number of API endpoints covered by CSV models.
+ * @kind metric
+ * @tags summary
+ */
+
+import csharp
+import semmle.code.csharp.dataflow.ExternalFlow
+
+from string namespaceAndType, int rows
+where
+  exists(string namespace, string type |
+    namespaceAndType = namespace + ";" + type and
+    rows = strictsum(int n, string kind | modelCoverage(namespace, _, kind, type, n) | n)
+  )
+select namespaceAndType, rows


### PR DESCRIPTION
In this PR we
- Port the Java FrameworkCoverage query to C#.
- Include the generation in the "publish" workflow (like for java).