### PR TITLE
Data flow: Introduce `expectsContent`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -329,6 +329,9 @@ private module Cached {
   predicate clearsContentCached(Node n, ContentSet c) { clearsContent(n, c) }
 
   cached
+  predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
+
+  cached
   predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -198,6 +198,12 @@ predicate clearsContent(Node n, Content c) {
   none() // stub implementation
 }
 
+/**
+ * Holds if the value that is being tracked is expected to be stored inside content `c`
+ * at node `n`.
+ */
+predicate expectsContent(Node n, ContentSet c) { none() }
+
 /** Gets the type of `n` used for type pruning. */
 Type getNodeType(Node n) {
   suppressUnusedNode(n) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -329,6 +329,9 @@ private module Cached {
   predicate clearsContentCached(Node n, ContentSet c) { clearsContent(n, c) }
 
   cached
+  predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
+
+  cached
   predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
 
   cached

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -279,6 +279,12 @@ predicate clearsContent(Node n, Content c) {
   none() // stub implementation
 }
 
+/**
+ * Holds if the value that is being tracked is expected to be stored inside content `c`
+ * at node `n`.
+ */
+predicate expectsContent(Node n, ContentSet c) { none() }
+
 /** Gets the type of `n` used for type pruning. */
 IRType getNodeType(Node n) {
   suppressUnusedNode(n) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -329,6 +329,9 @@ private module Cached {
   predicate clearsContentCached(Node n, ContentSet c) { clearsContent(n, c) }
 
   cached
+  predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
+
+  cached
   predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
 
   cached

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1715,6 +1715,12 @@ predicate clearsContent(Node n, Content c) {
 }
 
 /**
+ * Holds if the value that is being tracked is expected to be stored inside content `c`
+ * at node `n`.
+ */
+predicate expectsContent(Node n, ContentSet c) { none() }
+
+/**
  * Holds if the node `n` is unreachable when the call context is `call`.
  */
 predicate isUnreachableInCall(Node n, DataFlowCall call) {

--- a/docs/ql-libraries/dataflow/dataflow.md
+++ b/docs/ql-libraries/dataflow/dataflow.md
@@ -509,6 +509,12 @@ use-use steps. If local flow is implemented using def-use steps, then
 
 Note that `clearsContent(n, cs)` is interpreted using `cs.getAReadContent()`.
 
+Dually, there exists a predicate
+```ql
+predicate expectsContent(Node n, ContentSet c);
+```
+which acts as a barrier when data is _not_ stored inside one of `c.getAReadContent()`.
+
 ## Type pruning
 
 The library supports pruning paths when a sequence of value-preserving steps

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImpl6.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -329,6 +329,9 @@ private module Cached {
   predicate clearsContentCached(Node n, ContentSet c) { clearsContent(n, c) }
 
   cached
+  predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
+
+  cached
   predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
 
   cached

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForOnActivityResult.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplForSerializability.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -161,6 +161,12 @@ predicate clearsContent(Node n, Content c) {
 }
 
 /**
+ * Holds if the value that is being tracked is expected to be stored inside content `c`
+ * at node `n`.
+ */
+predicate expectsContent(Node n, ContentSet c) { none() }
+
+/**
  * Gets a representative (boxed) type for `t` for the purpose of pruning
  * possible flow. A single type is used for all numeric types to account for
  * numeric conversions, and otherwise the erasure is used.

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -329,6 +329,9 @@ private module Cached {
   predicate clearsContentCached(Node n, ContentSet c) { clearsContent(n, c) }
 
   cached
+  predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
+
+  cached
   predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
 
   cached

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowPrivate.qll
@@ -814,6 +814,12 @@ predicate clearsContent(Node n, Content c) {
 }
 
 /**
+ * Holds if the value that is being tracked is expected to be stored inside content `c`
+ * at node `n`.
+ */
+predicate expectsContent(Node n, ContentSet c) { none() }
+
+/**
  * Holds if values stored inside attribute `c` are cleared at node `n`.
  *
  * In `obj.foo = x` any old value stored in `foo` is cleared at the pre-update node

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImpl2.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
@@ -329,6 +329,9 @@ private module Cached {
   predicate clearsContentCached(Node n, ContentSet c) { clearsContent(n, c) }
 
   cached
+  predicate expectsContentCached(Node n, ContentSet c) { expectsContent(n, c) }
+
+  cached
   predicate isUnreachableInCallCached(Node n, DataFlowCall call) { isUnreachableInCall(n, call) }
 
   cached

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplForLibraries.qll
@@ -498,7 +498,7 @@ private predicate readSet(NodeEx node1, ContentSet c, NodeEx node2, Configuratio
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration config) {
   exists(ContentSet cs |
     readSet(node1, cs, node2, config) and
@@ -507,7 +507,7 @@ private predicate read(NodeEx node1, Content c, NodeEx node2, Configuration conf
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate clearsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     clearsContentCached(n.asNode(), cs) and
@@ -516,7 +516,7 @@ private predicate clearsContentEx(NodeEx n, Content c) {
 }
 
 // inline to reduce fan-out via `getAReadContent`
-pragma[inline]
+bindingset[c]
 private predicate expectsContentEx(NodeEx n, Content c) {
   exists(ContentSet cs |
     expectsContentCached(n.asNode(), cs) and

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -800,6 +800,12 @@ predicate clearsContent(Node n, ContentSet c) {
   FlowSummaryImpl::Private::Steps::summaryClearsContent(n, c)
 }
 
+/**
+ * Holds if the value that is being tracked is expected to be stored inside content `c`
+ * at node `n`.
+ */
+predicate expectsContent(Node n, ContentSet c) { none() }
+
 private newtype TDataFlowType =
   TTodoDataFlowType() or
   TTodoDataFlowType2() // Add a dummy value to prevent bad functionality-induced joins arising from a type of size 1.


### PR DESCRIPTION
We already have `clearsContent(Node n, ContentSet c)`, and this PR introduces the dual `expectsContent(Node n, ContentSet c)`. It currently has an empty stub implementation for all languages, but it will be used e.g. to give a proper flow summary for Ruby's splat operator.