### PR TITLE
Java: Add Editable.toString flow step

### DIFF
--- a/java/ql/lib/change-notes/2022-04-26-android-editable-tostring-flow-step.md
+++ b/java/ql/lib/change-notes/2022-04-26-android-editable-tostring-flow-step.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+Added a flow step for `toString` calls on tainted `android.text.Editable` objects. 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Widget.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Widget.qll
@@ -16,6 +16,18 @@ private class DefaultAndroidWidgetSources extends RemoteFlowSource {
   override string getSourceType() { result = "Android widget source" }
 }
 
+private class EditableToStringStep extends AdditionalTaintStep {
+  override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
+    exists(MethodAccess toString |
+      toString.getMethod().hasName("toString") and
+      toString.getReceiverType().hasQualifiedName("android.text", "Editable")
+    |
+      n1.asExpr() = toString.getQualifier() and
+      n2.asExpr() = toString
+    )
+  }
+}
+
 private class AndroidWidgetSummaryModels extends SummaryModelCsv {
   override predicate row(string row) {
     row = "android.widget;EditText;true;getText;;;Argument[-1];ReturnValue;taint"

--- a/java/ql/lib/semmle/code/java/security/CleartextStorageAndroidDatabaseQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageAndroidDatabaseQuery.qll
@@ -11,20 +11,6 @@ private class LocalDatabaseCleartextStorageSink extends CleartextStorageSink {
   LocalDatabaseCleartextStorageSink() { localDatabaseInput(_, this.asExpr()) }
 }
 
-private class LocalDatabaseCleartextStorageStep extends CleartextStorageAdditionalTaintStep {
-  override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
-    // EditText.getText() return type is parsed as `Object`, so we need to
-    // add a taint step for `Object.toString` to model `editText.getText().toString()`
-    exists(MethodAccess ma, Method m |
-      ma.getMethod() = m and
-      m.getDeclaringType() instanceof TypeObject and
-      m.hasName("toString")
-    |
-      n1.asExpr() = ma.getQualifier() and n2.asExpr() = ma
-    )
-  }
-}
-
 /** The creation of an object that can be used to store data in a local database. */
 class LocalDatabaseOpenMethodAccess extends Storable, Call {
   LocalDatabaseOpenMethodAccess() {

--- a/java/ql/lib/semmle/code/java/security/CleartextStorageQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CleartextStorageQuery.qll
@@ -85,18 +85,3 @@ private class EncryptedValueFlowConfig extends DataFlow4::Configuration {
 
   override predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof SensitiveExpr }
 }
-
-/** A taint step for `EditText.toString` in Android. */
-private class AndroidEditTextCleartextStorageStep extends CleartextStorageAdditionalTaintStep {
-  override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
-    // EditText.getText() return type is parsed as `Object`, so we need to
-    // add a taint step for `Object.toString` to model `editText.getText().toString()`
-    exists(MethodAccess ma, Method m |
-      ma.getMethod() = m and
-      m.getDeclaringType() instanceof TypeObject and
-      m.hasName("toString")
-    |
-      n1.asExpr() = ma.getQualifier() and n2.asExpr() = ma
-    )
-  }
-}

--- a/java/ql/test/library-tests/frameworks/android/widget/TestWidget.java
+++ b/java/ql/test/library-tests/frameworks/android/widget/TestWidget.java
@@ -1,0 +1,11 @@
+import android.widget.EditText;
+
+public class TestWidget {
+
+    private void sink(Object sink) {}
+
+    public void test(EditText t) {
+        sink(t.getText().toString()); // $ hasTaintFlow
+    }
+}
+

--- a/java/ql/test/library-tests/frameworks/android/widget/options
+++ b/java/ql/test/library-tests/frameworks/android/widget/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0

--- a/java/ql/test/library-tests/frameworks/android/widget/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/widget/test.ql
@@ -1,0 +1,7 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import TestUtilities.InlineFlowTest
+
+class SourceTaintFlowConf extends DefaultTaintFlowConf {
+  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/app/RemoteAction.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/app/RemoteAction.java
@@ -1,0 +1,30 @@
+// Generated automatically from android.app.RemoteAction for testing purposes
+
+package android.app;
+
+import android.app.PendingIntent;
+import android.graphics.drawable.Icon;
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.io.PrintWriter;
+
+public class RemoteAction implements Parcelable
+{
+    protected RemoteAction() {}
+    public CharSequence getContentDescription(){ return null; }
+    public CharSequence getTitle(){ return null; }
+    public Icon getIcon(){ return null; }
+    public PendingIntent getActionIntent(){ return null; }
+    public RemoteAction clone(){ return null; }
+    public RemoteAction(Icon p0, CharSequence p1, CharSequence p2, PendingIntent p3){}
+    public boolean equals(Object p0){ return false; }
+    public boolean isEnabled(){ return false; }
+    public boolean shouldShowIcon(){ return false; }
+    public int describeContents(){ return 0; }
+    public int hashCode(){ return 0; }
+    public static Parcelable.Creator<RemoteAction> CREATOR = null;
+    public void dump(String p0, PrintWriter p1){}
+    public void setEnabled(boolean p0){}
+    public void setShouldShowIcon(boolean p0){}
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/Editable.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/Editable.java
@@ -1,0 +1,29 @@
+// Generated automatically from android.text.Editable for testing purposes
+
+package android.text;
+
+import android.text.GetChars;
+import android.text.InputFilter;
+import android.text.Spannable;
+
+public interface Editable extends Appendable, CharSequence, GetChars, Spannable
+{
+    Editable append(CharSequence p0);
+    Editable append(CharSequence p0, int p1, int p2);
+    Editable append(char p0);
+    Editable delete(int p0, int p1);
+    Editable insert(int p0, CharSequence p1);
+    Editable insert(int p0, CharSequence p1, int p2, int p3);
+    Editable replace(int p0, int p1, CharSequence p2);
+    Editable replace(int p0, int p1, CharSequence p2, int p3, int p4);
+    InputFilter[] getFilters();
+    static public class Factory
+    {
+        public Editable newEditable(CharSequence p0){ return null; }
+        public Factory(){}
+        public static Editable.Factory getInstance(){ return null; }
+    }
+    void clear();
+    void clearSpans();
+    void setFilters(InputFilter[] p0);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/GetChars.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/GetChars.java
@@ -1,0 +1,9 @@
+// Generated automatically from android.text.GetChars for testing purposes
+
+package android.text;
+
+
+public interface GetChars extends CharSequence
+{
+    void getChars(int p0, int p1, char[] p2, int p3);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/InputFilter.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/InputFilter.java
@@ -1,0 +1,10 @@
+// Generated automatically from android.text.InputFilter for testing purposes
+
+package android.text;
+
+import android.text.Spanned;
+
+public interface InputFilter
+{
+    CharSequence filter(CharSequence p0, int p1, int p2, Spanned p3, int p4, int p5);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/Layout.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/Layout.java
@@ -1,0 +1,83 @@
+// Generated automatically from android.text.Layout for testing purposes
+
+package android.text;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.text.TextPaint;
+
+abstract public class Layout
+{
+    protected Layout() {}
+    protected Layout(CharSequence p0, TextPaint p1, int p2, Layout.Alignment p3, float p4, float p5){}
+    protected final boolean isSpanned(){ return false; }
+    public abstract Layout.Directions getLineDirections(int p0);
+    public abstract boolean getLineContainsTab(int p0);
+    public abstract int getBottomPadding();
+    public abstract int getEllipsisCount(int p0);
+    public abstract int getEllipsisStart(int p0);
+    public abstract int getLineCount();
+    public abstract int getLineDescent(int p0);
+    public abstract int getLineStart(int p0);
+    public abstract int getLineTop(int p0);
+    public abstract int getParagraphDirection(int p0);
+    public abstract int getTopPadding();
+    public boolean isRtlCharAt(int p0){ return false; }
+    public final CharSequence getText(){ return null; }
+    public final Layout.Alignment getAlignment(){ return null; }
+    public final Layout.Alignment getParagraphAlignment(int p0){ return null; }
+    public final TextPaint getPaint(){ return null; }
+    public final float getSpacingAdd(){ return 0; }
+    public final float getSpacingMultiplier(){ return 0; }
+    public final int getLineAscent(int p0){ return 0; }
+    public final int getLineBaseline(int p0){ return 0; }
+    public final int getLineBottom(int p0){ return 0; }
+    public final int getLineEnd(int p0){ return 0; }
+    public final int getParagraphLeft(int p0){ return 0; }
+    public final int getParagraphRight(int p0){ return 0; }
+    public final int getWidth(){ return 0; }
+    public final void increaseWidthTo(int p0){}
+    public float getLineLeft(int p0){ return 0; }
+    public float getLineMax(int p0){ return 0; }
+    public float getLineRight(int p0){ return 0; }
+    public float getLineWidth(int p0){ return 0; }
+    public float getPrimaryHorizontal(int p0){ return 0; }
+    public float getSecondaryHorizontal(int p0){ return 0; }
+    public int getEllipsizedWidth(){ return 0; }
+    public int getHeight(){ return 0; }
+    public int getLineBounds(int p0, Rect p1){ return 0; }
+    public int getLineForOffset(int p0){ return 0; }
+    public int getLineForVertical(int p0){ return 0; }
+    public int getLineVisibleEnd(int p0){ return 0; }
+    public int getOffsetForHorizontal(int p0, float p1){ return 0; }
+    public int getOffsetToLeftOf(int p0){ return 0; }
+    public int getOffsetToRightOf(int p0){ return 0; }
+    public static float DEFAULT_LINESPACING_ADDITION = 0;
+    public static float DEFAULT_LINESPACING_MULTIPLIER = 0;
+    public static float getDesiredWidth(CharSequence p0, TextPaint p1){ return 0; }
+    public static float getDesiredWidth(CharSequence p0, int p1, int p2, TextPaint p3){ return 0; }
+    public static int BREAK_STRATEGY_BALANCED = 0;
+    public static int BREAK_STRATEGY_HIGH_QUALITY = 0;
+    public static int BREAK_STRATEGY_SIMPLE = 0;
+    public static int DIR_LEFT_TO_RIGHT = 0;
+    public static int DIR_RIGHT_TO_LEFT = 0;
+    public static int HYPHENATION_FREQUENCY_FULL = 0;
+    public static int HYPHENATION_FREQUENCY_NONE = 0;
+    public static int HYPHENATION_FREQUENCY_NORMAL = 0;
+    public static int JUSTIFICATION_MODE_INTER_WORD = 0;
+    public static int JUSTIFICATION_MODE_NONE = 0;
+    public void draw(Canvas p0){}
+    public void draw(Canvas p0, Path p1, Paint p2, int p3){}
+    public void getCursorPath(int p0, Path p1, CharSequence p2){}
+    public void getSelectionPath(int p0, int p1, Path p2){}
+    static public class Directions
+    {
+    }
+    static public enum Alignment
+    {
+        ALIGN_CENTER, ALIGN_NORMAL, ALIGN_OPPOSITE;
+        private Alignment() {}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/NoCopySpan.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/NoCopySpan.java
@@ -1,0 +1,8 @@
+// Generated automatically from android.text.NoCopySpan for testing purposes
+
+package android.text;
+
+
+public interface NoCopySpan
+{
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/ParcelableSpan.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/ParcelableSpan.java
@@ -1,0 +1,10 @@
+// Generated automatically from android.text.ParcelableSpan for testing purposes
+
+package android.text;
+
+import android.os.Parcelable;
+
+public interface ParcelableSpan extends Parcelable
+{
+    int getSpanTypeId();
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/PrecomputedText.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/PrecomputedText.java
@@ -1,0 +1,41 @@
+// Generated automatically from android.text.PrecomputedText for testing purposes
+
+package android.text;
+
+import android.graphics.Rect;
+import android.text.Spannable;
+import android.text.TextDirectionHeuristic;
+import android.text.TextPaint;
+
+public class PrecomputedText implements Spannable
+{
+    protected PrecomputedText() {}
+    public <T> T[] getSpans(int p0, int p1, Class<T> p2){ return null; }
+    public CharSequence subSequence(int p0, int p1){ return null; }
+    public PrecomputedText.Params getParams(){ return null; }
+    public String toString(){ return null; }
+    public char charAt(int p0){ return '0'; }
+    public float getWidth(int p0, int p1){ return 0; }
+    public int getParagraphCount(){ return 0; }
+    public int getParagraphEnd(int p0){ return 0; }
+    public int getParagraphStart(int p0){ return 0; }
+    public int getSpanEnd(Object p0){ return 0; }
+    public int getSpanFlags(Object p0){ return 0; }
+    public int getSpanStart(Object p0){ return 0; }
+    public int length(){ return 0; }
+    public int nextSpanTransition(int p0, int p1, Class p2){ return 0; }
+    public static PrecomputedText create(CharSequence p0, PrecomputedText.Params p1){ return null; }
+    public void getBounds(int p0, int p1, Rect p2){}
+    public void removeSpan(Object p0){}
+    public void setSpan(Object p0, int p1, int p2, int p3){}
+    static public class Params
+    {
+        public String toString(){ return null; }
+        public TextDirectionHeuristic getTextDirection(){ return null; }
+        public TextPaint getTextPaint(){ return null; }
+        public boolean equals(Object p0){ return false; }
+        public int getBreakStrategy(){ return 0; }
+        public int getHyphenationFrequency(){ return 0; }
+        public int hashCode(){ return 0; }
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/TextDirectionHeuristic.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/TextDirectionHeuristic.java
@@ -1,0 +1,10 @@
+// Generated automatically from android.text.TextDirectionHeuristic for testing purposes
+
+package android.text;
+
+
+public interface TextDirectionHeuristic
+{
+    boolean isRtl(CharSequence p0, int p1, int p2);
+    boolean isRtl(char[] p0, int p1, int p2);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/TextUtils.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/TextUtils.java
@@ -1,0 +1,75 @@
+// Generated automatically from android.text.TextUtils for testing purposes
+
+package android.text;
+
+import android.content.Context;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.text.Spannable;
+import android.text.Spanned;
+import android.text.TextPaint;
+import android.util.Printer;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class TextUtils
+{
+    protected TextUtils() {}
+    public static CharSequence commaEllipsize(CharSequence p0, TextPaint p1, float p2, String p3, String p4){ return null; }
+    public static CharSequence concat(CharSequence... p0){ return null; }
+    public static CharSequence ellipsize(CharSequence p0, TextPaint p1, float p2, TextUtils.TruncateAt p3){ return null; }
+    public static CharSequence ellipsize(CharSequence p0, TextPaint p1, float p2, TextUtils.TruncateAt p3, boolean p4, TextUtils.EllipsizeCallback p5){ return null; }
+    public static CharSequence expandTemplate(CharSequence p0, CharSequence... p1){ return null; }
+    public static CharSequence getReverse(CharSequence p0, int p1, int p2){ return null; }
+    public static CharSequence listEllipsize(Context p0, List<CharSequence> p1, String p2, TextPaint p3, float p4, int p5){ return null; }
+    public static CharSequence makeSafeForPresentation(String p0, int p1, float p2, int p3){ return null; }
+    public static CharSequence replace(CharSequence p0, String[] p1, CharSequence[] p2){ return null; }
+    public static CharSequence stringOrSpannedString(CharSequence p0){ return null; }
+    public static Parcelable.Creator<CharSequence> CHAR_SEQUENCE_CREATOR = null;
+    public static String htmlEncode(String p0){ return null; }
+    public static String join(CharSequence p0, Iterable p1){ return null; }
+    public static String join(CharSequence p0, Object[] p1){ return null; }
+    public static String substring(CharSequence p0, int p1, int p2){ return null; }
+    public static String[] split(String p0, Pattern p1){ return null; }
+    public static String[] split(String p0, String p1){ return null; }
+    public static boolean equals(CharSequence p0, CharSequence p1){ return false; }
+    public static boolean isDigitsOnly(CharSequence p0){ return false; }
+    public static boolean isEmpty(CharSequence p0){ return false; }
+    public static boolean isGraphic(CharSequence p0){ return false; }
+    public static boolean isGraphic(char p0){ return false; }
+    public static boolean regionMatches(CharSequence p0, int p1, CharSequence p2, int p3, int p4){ return false; }
+    public static int CAP_MODE_CHARACTERS = 0;
+    public static int CAP_MODE_SENTENCES = 0;
+    public static int CAP_MODE_WORDS = 0;
+    public static int SAFE_STRING_FLAG_FIRST_LINE = 0;
+    public static int SAFE_STRING_FLAG_SINGLE_LINE = 0;
+    public static int SAFE_STRING_FLAG_TRIM = 0;
+    public static int getCapsMode(CharSequence p0, int p1, int p2){ return 0; }
+    public static int getLayoutDirectionFromLocale(Locale p0){ return 0; }
+    public static int getOffsetAfter(CharSequence p0, int p1){ return 0; }
+    public static int getOffsetBefore(CharSequence p0, int p1){ return 0; }
+    public static int getTrimmedLength(CharSequence p0){ return 0; }
+    public static int indexOf(CharSequence p0, CharSequence p1){ return 0; }
+    public static int indexOf(CharSequence p0, CharSequence p1, int p2){ return 0; }
+    public static int indexOf(CharSequence p0, CharSequence p1, int p2, int p3){ return 0; }
+    public static int indexOf(CharSequence p0, char p1){ return 0; }
+    public static int indexOf(CharSequence p0, char p1, int p2){ return 0; }
+    public static int indexOf(CharSequence p0, char p1, int p2, int p3){ return 0; }
+    public static int lastIndexOf(CharSequence p0, char p1){ return 0; }
+    public static int lastIndexOf(CharSequence p0, char p1, int p2){ return 0; }
+    public static int lastIndexOf(CharSequence p0, char p1, int p2, int p3){ return 0; }
+    public static void copySpansFrom(Spanned p0, int p1, int p2, Class p3, Spannable p4, int p5){}
+    public static void dumpSpans(CharSequence p0, Printer p1, String p2){}
+    public static void getChars(CharSequence p0, int p1, int p2, char[] p3, int p4){}
+    public static void writeToParcel(CharSequence p0, Parcel p1, int p2){}
+    static public enum TruncateAt
+    {
+        END, MARQUEE, MIDDLE, START;
+        private TruncateAt() {}
+    }
+    static public interface EllipsizeCallback
+    {
+        void ellipsized(int p0, int p1);
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/TextWatcher.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/TextWatcher.java
@@ -1,0 +1,13 @@
+// Generated automatically from android.text.TextWatcher for testing purposes
+
+package android.text;
+
+import android.text.Editable;
+import android.text.NoCopySpan;
+
+public interface TextWatcher extends NoCopySpan
+{
+    void afterTextChanged(Editable p0);
+    void beforeTextChanged(CharSequence p0, int p1, int p2, int p3);
+    void onTextChanged(CharSequence p0, int p1, int p2, int p3);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/method/KeyListener.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/method/KeyListener.java
@@ -1,0 +1,16 @@
+// Generated automatically from android.text.method.KeyListener for testing purposes
+
+package android.text.method;
+
+import android.text.Editable;
+import android.view.KeyEvent;
+import android.view.View;
+
+public interface KeyListener
+{
+    boolean onKeyDown(View p0, Editable p1, int p2, KeyEvent p3);
+    boolean onKeyOther(View p0, Editable p1, KeyEvent p2);
+    boolean onKeyUp(View p0, Editable p1, int p2, KeyEvent p3);
+    int getInputType();
+    void clearMetaKeyState(View p0, Editable p1, int p2);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/method/MovementMethod.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/method/MovementMethod.java
@@ -1,0 +1,21 @@
+// Generated automatically from android.text.method.MovementMethod for testing purposes
+
+package android.text.method;
+
+import android.text.Spannable;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.widget.TextView;
+
+public interface MovementMethod
+{
+    boolean canSelectArbitrarily();
+    boolean onGenericMotionEvent(TextView p0, Spannable p1, MotionEvent p2);
+    boolean onKeyDown(TextView p0, Spannable p1, int p2, KeyEvent p3);
+    boolean onKeyOther(TextView p0, Spannable p1, KeyEvent p2);
+    boolean onKeyUp(TextView p0, Spannable p1, int p2, KeyEvent p3);
+    boolean onTouchEvent(TextView p0, Spannable p1, MotionEvent p2);
+    boolean onTrackballEvent(TextView p0, Spannable p1, MotionEvent p2);
+    void initialize(TextView p0, Spannable p1);
+    void onTakeFocus(TextView p0, Spannable p1, int p2);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/method/TransformationMethod.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/method/TransformationMethod.java
@@ -1,0 +1,12 @@
+// Generated automatically from android.text.method.TransformationMethod for testing purposes
+
+package android.text.method;
+
+import android.graphics.Rect;
+import android.view.View;
+
+public interface TransformationMethod
+{
+    CharSequence getTransformation(CharSequence p0, View p1);
+    void onFocusChanged(View p0, CharSequence p1, boolean p2, int p3, Rect p4);
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/text/style/URLSpan.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/text/style/URLSpan.java
@@ -1,0 +1,20 @@
+// Generated automatically from android.text.style.URLSpan for testing purposes
+
+package android.text.style;
+
+import android.os.Parcel;
+import android.text.ParcelableSpan;
+import android.text.style.ClickableSpan;
+import android.view.View;
+
+public class URLSpan extends ClickableSpan implements ParcelableSpan
+{
+    protected URLSpan() {}
+    public String getURL(){ return null; }
+    public URLSpan(Parcel p0){}
+    public URLSpan(String p0){}
+    public int describeContents(){ return 0; }
+    public int getSpanTypeId(){ return 0; }
+    public void onClick(View p0){}
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/ConversationAction.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/ConversationAction.java
@@ -1,0 +1,31 @@
+// Generated automatically from android.view.textclassifier.ConversationAction for testing purposes
+
+package android.view.textclassifier;
+
+import android.app.RemoteAction;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class ConversationAction implements Parcelable
+{
+    protected ConversationAction() {}
+    public Bundle getExtras(){ return null; }
+    public CharSequence getTextReply(){ return null; }
+    public RemoteAction getAction(){ return null; }
+    public String getType(){ return null; }
+    public float getConfidenceScore(){ return 0; }
+    public int describeContents(){ return 0; }
+    public static Parcelable.Creator<ConversationAction> CREATOR = null;
+    public static String TYPE_CALL_PHONE = null;
+    public static String TYPE_CREATE_REMINDER = null;
+    public static String TYPE_OPEN_URL = null;
+    public static String TYPE_SEND_EMAIL = null;
+    public static String TYPE_SEND_SMS = null;
+    public static String TYPE_SHARE_LOCATION = null;
+    public static String TYPE_TEXT_REPLY = null;
+    public static String TYPE_TRACK_FLIGHT = null;
+    public static String TYPE_VIEW_CALENDAR = null;
+    public static String TYPE_VIEW_MAP = null;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/ConversationActions.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/ConversationActions.java
@@ -1,0 +1,51 @@
+// Generated automatically from android.view.textclassifier.ConversationActions for testing purposes
+
+package android.view.textclassifier;
+
+import android.app.Person;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.textclassifier.ConversationAction;
+import android.view.textclassifier.TextClassifier;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class ConversationActions implements Parcelable
+{
+    protected ConversationActions() {}
+    public ConversationActions(List<ConversationAction> p0, String p1){}
+    public List<ConversationAction> getConversationActions(){ return null; }
+    public String getId(){ return null; }
+    public int describeContents(){ return 0; }
+    public static Parcelable.Creator<ConversationActions> CREATOR = null;
+    public void writeToParcel(Parcel p0, int p1){}
+    static public class Message implements Parcelable
+    {
+        protected Message() {}
+        public Bundle getExtras(){ return null; }
+        public CharSequence getText(){ return null; }
+        public Person getAuthor(){ return null; }
+        public ZonedDateTime getReferenceTime(){ return null; }
+        public int describeContents(){ return 0; }
+        public static Parcelable.Creator<ConversationActions.Message> CREATOR = null;
+        public static Person PERSON_USER_OTHERS = null;
+        public static Person PERSON_USER_SELF = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+    static public class Request implements Parcelable
+    {
+        protected Request() {}
+        public Bundle getExtras(){ return null; }
+        public List<ConversationActions.Message> getConversation(){ return null; }
+        public List<String> getHints(){ return null; }
+        public String getCallingPackageName(){ return null; }
+        public TextClassifier.EntityConfig getTypeConfig(){ return null; }
+        public int describeContents(){ return 0; }
+        public int getMaxSuggestions(){ return 0; }
+        public static Parcelable.Creator<ConversationActions.Request> CREATOR = null;
+        public static String HINT_FOR_IN_APP = null;
+        public static String HINT_FOR_NOTIFICATION = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/SelectionEvent.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/SelectionEvent.java
@@ -1,0 +1,61 @@
+// Generated automatically from android.view.textclassifier.SelectionEvent for testing purposes
+
+package android.view.textclassifier;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.textclassifier.TextClassification;
+import android.view.textclassifier.TextClassificationSessionId;
+import android.view.textclassifier.TextSelection;
+
+public class SelectionEvent implements Parcelable
+{
+    public String getEntityType(){ return null; }
+    public String getPackageName(){ return null; }
+    public String getResultId(){ return null; }
+    public String getWidgetType(){ return null; }
+    public String getWidgetVersion(){ return null; }
+    public String toString(){ return null; }
+    public TextClassificationSessionId getSessionId(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public int describeContents(){ return 0; }
+    public int getEnd(){ return 0; }
+    public int getEventIndex(){ return 0; }
+    public int getEventType(){ return 0; }
+    public int getInvocationMethod(){ return 0; }
+    public int getSmartEnd(){ return 0; }
+    public int getSmartStart(){ return 0; }
+    public int getStart(){ return 0; }
+    public int hashCode(){ return 0; }
+    public long getDurationSincePreviousEvent(){ return 0; }
+    public long getDurationSinceSessionStart(){ return 0; }
+    public long getEventTime(){ return 0; }
+    public static Parcelable.Creator<SelectionEvent> CREATOR = null;
+    public static SelectionEvent createSelectionActionEvent(int p0, int p1, int p2){ return null; }
+    public static SelectionEvent createSelectionActionEvent(int p0, int p1, int p2, TextClassification p3){ return null; }
+    public static SelectionEvent createSelectionModifiedEvent(int p0, int p1){ return null; }
+    public static SelectionEvent createSelectionModifiedEvent(int p0, int p1, TextClassification p2){ return null; }
+    public static SelectionEvent createSelectionModifiedEvent(int p0, int p1, TextSelection p2){ return null; }
+    public static SelectionEvent createSelectionStartedEvent(int p0, int p1){ return null; }
+    public static boolean isTerminal(int p0){ return false; }
+    public static int ACTION_ABANDON = 0;
+    public static int ACTION_COPY = 0;
+    public static int ACTION_CUT = 0;
+    public static int ACTION_DRAG = 0;
+    public static int ACTION_OTHER = 0;
+    public static int ACTION_OVERTYPE = 0;
+    public static int ACTION_PASTE = 0;
+    public static int ACTION_RESET = 0;
+    public static int ACTION_SELECT_ALL = 0;
+    public static int ACTION_SHARE = 0;
+    public static int ACTION_SMART_SHARE = 0;
+    public static int EVENT_AUTO_SELECTION = 0;
+    public static int EVENT_SELECTION_MODIFIED = 0;
+    public static int EVENT_SELECTION_STARTED = 0;
+    public static int EVENT_SMART_SELECTION_MULTI = 0;
+    public static int EVENT_SMART_SELECTION_SINGLE = 0;
+    public static int INVOCATION_LINK = 0;
+    public static int INVOCATION_MANUAL = 0;
+    public static int INVOCATION_UNKNOWN = 0;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassification.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassification.java
@@ -1,0 +1,48 @@
+// Generated automatically from android.view.textclassifier.TextClassification for testing purposes
+
+package android.view.textclassifier;
+
+import android.app.RemoteAction;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.os.LocaleList;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.View;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class TextClassification implements Parcelable
+{
+    protected TextClassification() {}
+    public Bundle getExtras(){ return null; }
+    public CharSequence getLabel(){ return null; }
+    public Drawable getIcon(){ return null; }
+    public Intent getIntent(){ return null; }
+    public List<RemoteAction> getActions(){ return null; }
+    public String getEntity(int p0){ return null; }
+    public String getId(){ return null; }
+    public String getText(){ return null; }
+    public String toString(){ return null; }
+    public View.OnClickListener getOnClickListener(){ return null; }
+    public float getConfidenceScore(String p0){ return 0; }
+    public int describeContents(){ return 0; }
+    public int getEntityCount(){ return 0; }
+    public static Parcelable.Creator<TextClassification> CREATOR = null;
+    public void writeToParcel(Parcel p0, int p1){}
+    static public class Request implements Parcelable
+    {
+        protected Request() {}
+        public Bundle getExtras(){ return null; }
+        public CharSequence getText(){ return null; }
+        public LocaleList getDefaultLocales(){ return null; }
+        public String getCallingPackageName(){ return null; }
+        public ZonedDateTime getReferenceTime(){ return null; }
+        public int describeContents(){ return 0; }
+        public int getEndIndex(){ return 0; }
+        public int getStartIndex(){ return 0; }
+        public static Parcelable.Creator<TextClassification.Request> CREATOR = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassificationContext.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassificationContext.java
@@ -1,0 +1,18 @@
+// Generated automatically from android.view.textclassifier.TextClassificationContext for testing purposes
+
+package android.view.textclassifier;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class TextClassificationContext implements Parcelable
+{
+    protected TextClassificationContext() {}
+    public String getPackageName(){ return null; }
+    public String getWidgetType(){ return null; }
+    public String getWidgetVersion(){ return null; }
+    public String toString(){ return null; }
+    public int describeContents(){ return 0; }
+    public static Parcelable.Creator<TextClassificationContext> CREATOR = null;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassificationSessionId.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassificationSessionId.java
@@ -1,0 +1,17 @@
+// Generated automatically from android.view.textclassifier.TextClassificationSessionId for testing purposes
+
+package android.view.textclassifier;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class TextClassificationSessionId implements Parcelable
+{
+    public String getValue(){ return null; }
+    public String toString(){ return null; }
+    public boolean equals(Object p0){ return false; }
+    public int describeContents(){ return 0; }
+    public int hashCode(){ return 0; }
+    public static Parcelable.Creator<TextClassificationSessionId> CREATOR = null;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassifier.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassifier.java
@@ -1,0 +1,68 @@
+// Generated automatically from android.view.textclassifier.TextClassifier for testing purposes
+
+package android.view.textclassifier;
+
+import android.os.LocaleList;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.textclassifier.ConversationActions;
+import android.view.textclassifier.SelectionEvent;
+import android.view.textclassifier.TextClassification;
+import android.view.textclassifier.TextClassifierEvent;
+import android.view.textclassifier.TextLanguage;
+import android.view.textclassifier.TextLinks;
+import android.view.textclassifier.TextSelection;
+import java.util.Collection;
+
+public interface TextClassifier
+{
+    default ConversationActions suggestConversationActions(ConversationActions.Request p0){ return null; }
+    default TextClassification classifyText(CharSequence p0, int p1, int p2, LocaleList p3){ return null; }
+    default TextClassification classifyText(TextClassification.Request p0){ return null; }
+    default TextLanguage detectLanguage(TextLanguage.Request p0){ return null; }
+    default TextLinks generateLinks(TextLinks.Request p0){ return null; }
+    default TextSelection suggestSelection(CharSequence p0, int p1, int p2, LocaleList p3){ return null; }
+    default TextSelection suggestSelection(TextSelection.Request p0){ return null; }
+    default boolean isDestroyed(){ return false; }
+    default int getMaxGenerateLinksTextLength(){ return 0; }
+    default void destroy(){}
+    default void onSelectionEvent(SelectionEvent p0){}
+    default void onTextClassifierEvent(TextClassifierEvent p0){}
+    static String EXTRA_FROM_TEXT_CLASSIFIER = null;
+    static String HINT_TEXT_IS_EDITABLE = null;
+    static String HINT_TEXT_IS_NOT_EDITABLE = null;
+    static String TYPE_ADDRESS = null;
+    static String TYPE_DATE = null;
+    static String TYPE_DATE_TIME = null;
+    static String TYPE_EMAIL = null;
+    static String TYPE_FLIGHT_NUMBER = null;
+    static String TYPE_OTHER = null;
+    static String TYPE_PHONE = null;
+    static String TYPE_UNKNOWN = null;
+    static String TYPE_URL = null;
+    static String WIDGET_TYPE_CLIPBOARD = null;
+    static String WIDGET_TYPE_CUSTOM_EDITTEXT = null;
+    static String WIDGET_TYPE_CUSTOM_TEXTVIEW = null;
+    static String WIDGET_TYPE_CUSTOM_UNSELECTABLE_TEXTVIEW = null;
+    static String WIDGET_TYPE_EDITTEXT = null;
+    static String WIDGET_TYPE_EDIT_WEBVIEW = null;
+    static String WIDGET_TYPE_NOTIFICATION = null;
+    static String WIDGET_TYPE_TEXTVIEW = null;
+    static String WIDGET_TYPE_UNKNOWN = null;
+    static String WIDGET_TYPE_UNSELECTABLE_TEXTVIEW = null;
+    static String WIDGET_TYPE_WEBVIEW = null;
+    static TextClassifier NO_OP = null;
+    static public class EntityConfig implements Parcelable
+    {
+        protected EntityConfig() {}
+        public Collection<String> getHints(){ return null; }
+        public Collection<String> resolveEntityListModifications(Collection<String> p0){ return null; }
+        public boolean shouldIncludeTypesFromTextClassifier(){ return false; }
+        public int describeContents(){ return 0; }
+        public static Parcelable.Creator<TextClassifier.EntityConfig> CREATOR = null;
+        public static TextClassifier.EntityConfig create(Collection<String> p0, Collection<String> p1, Collection<String> p2){ return null; }
+        public static TextClassifier.EntityConfig createWithExplicitEntityList(Collection<String> p0){ return null; }
+        public static TextClassifier.EntityConfig createWithHints(Collection<String> p0){ return null; }
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassifierEvent.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextClassifierEvent.java
@@ -1,0 +1,54 @@
+// Generated automatically from android.view.textclassifier.TextClassifierEvent for testing purposes
+
+package android.view.textclassifier;
+
+import android.icu.util.ULocale;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.textclassifier.TextClassificationContext;
+
+abstract public class TextClassifierEvent implements Parcelable
+{
+    protected TextClassifierEvent() {}
+    public Bundle getExtras(){ return null; }
+    public String getModelName(){ return null; }
+    public String getResultId(){ return null; }
+    public String toString(){ return null; }
+    public String[] getEntityTypes(){ return null; }
+    public TextClassificationContext getEventContext(){ return null; }
+    public ULocale getLocale(){ return null; }
+    public float[] getScores(){ return null; }
+    public int describeContents(){ return 0; }
+    public int getEventCategory(){ return 0; }
+    public int getEventIndex(){ return 0; }
+    public int getEventType(){ return 0; }
+    public int[] getActionIndices(){ return null; }
+    public static Parcelable.Creator<TextClassifierEvent> CREATOR = null;
+    public static int CATEGORY_CONVERSATION_ACTIONS = 0;
+    public static int CATEGORY_LANGUAGE_DETECTION = 0;
+    public static int CATEGORY_LINKIFY = 0;
+    public static int CATEGORY_SELECTION = 0;
+    public static int TYPE_ACTIONS_GENERATED = 0;
+    public static int TYPE_ACTIONS_SHOWN = 0;
+    public static int TYPE_AUTO_SELECTION = 0;
+    public static int TYPE_COPY_ACTION = 0;
+    public static int TYPE_CUT_ACTION = 0;
+    public static int TYPE_LINKS_GENERATED = 0;
+    public static int TYPE_LINK_CLICKED = 0;
+    public static int TYPE_MANUAL_REPLY = 0;
+    public static int TYPE_OTHER_ACTION = 0;
+    public static int TYPE_OVERTYPE = 0;
+    public static int TYPE_PASTE_ACTION = 0;
+    public static int TYPE_SELECTION_DESTROYED = 0;
+    public static int TYPE_SELECTION_DRAG = 0;
+    public static int TYPE_SELECTION_MODIFIED = 0;
+    public static int TYPE_SELECTION_RESET = 0;
+    public static int TYPE_SELECTION_STARTED = 0;
+    public static int TYPE_SELECT_ALL = 0;
+    public static int TYPE_SHARE_ACTION = 0;
+    public static int TYPE_SMART_ACTION = 0;
+    public static int TYPE_SMART_SELECTION_MULTI = 0;
+    public static int TYPE_SMART_SELECTION_SINGLE = 0;
+    public void writeToParcel(Parcel p0, int p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextLanguage.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextLanguage.java
@@ -1,0 +1,32 @@
+// Generated automatically from android.view.textclassifier.TextLanguage for testing purposes
+
+package android.view.textclassifier;
+
+import android.icu.util.ULocale;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class TextLanguage implements Parcelable
+{
+    protected TextLanguage() {}
+    public Bundle getExtras(){ return null; }
+    public String getId(){ return null; }
+    public String toString(){ return null; }
+    public ULocale getLocale(int p0){ return null; }
+    public float getConfidenceScore(ULocale p0){ return 0; }
+    public int describeContents(){ return 0; }
+    public int getLocaleHypothesisCount(){ return 0; }
+    public static Parcelable.Creator<TextLanguage> CREATOR = null;
+    public void writeToParcel(Parcel p0, int p1){}
+    static public class Request implements Parcelable
+    {
+        protected Request() {}
+        public Bundle getExtras(){ return null; }
+        public CharSequence getText(){ return null; }
+        public String getCallingPackageName(){ return null; }
+        public int describeContents(){ return 0; }
+        public static Parcelable.Creator<TextLanguage.Request> CREATOR = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextSelection.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/view/textclassifier/TextSelection.java
@@ -1,0 +1,40 @@
+// Generated automatically from android.view.textclassifier.TextSelection for testing purposes
+
+package android.view.textclassifier;
+
+import android.os.Bundle;
+import android.os.LocaleList;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.textclassifier.TextClassification;
+
+public class TextSelection implements Parcelable
+{
+    protected TextSelection() {}
+    public Bundle getExtras(){ return null; }
+    public String getEntity(int p0){ return null; }
+    public String getId(){ return null; }
+    public String toString(){ return null; }
+    public TextClassification getTextClassification(){ return null; }
+    public float getConfidenceScore(String p0){ return 0; }
+    public int describeContents(){ return 0; }
+    public int getEntityCount(){ return 0; }
+    public int getSelectionEndIndex(){ return 0; }
+    public int getSelectionStartIndex(){ return 0; }
+    public static Parcelable.Creator<TextSelection> CREATOR = null;
+    public void writeToParcel(Parcel p0, int p1){}
+    static public class Request implements Parcelable
+    {
+        protected Request() {}
+        public Bundle getExtras(){ return null; }
+        public CharSequence getText(){ return null; }
+        public LocaleList getDefaultLocales(){ return null; }
+        public String getCallingPackageName(){ return null; }
+        public boolean shouldIncludeTextClassification(){ return false; }
+        public int describeContents(){ return 0; }
+        public int getEndIndex(){ return 0; }
+        public int getStartIndex(){ return 0; }
+        public static Parcelable.Creator<TextSelection.Request> CREATOR = null;
+        public void writeToParcel(Parcel p0, int p1){}
+    }
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/widget/EditText.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/widget/EditText.java
@@ -1,0 +1,29 @@
+// Generated automatically from android.widget.EditText for testing purposes
+
+package android.widget;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.method.MovementMethod;
+import android.util.AttributeSet;
+
+public class EditText extends TextView
+{
+    protected EditText() { super(null); }
+    protected MovementMethod getDefaultMovementMethod(){ return null; }
+    protected boolean getDefaultEditable(){ return false; }
+    public CharSequence getAccessibilityClassName(){ return null; }
+    public EditText(Context p0){ super(null); }
+    public EditText(Context p0, AttributeSet p1){ super(null); }
+    public EditText(Context p0, AttributeSet p1, int p2){ super(null); }
+    public EditText(Context p0, AttributeSet p1, int p2, int p3){ super(null); }
+    public Editable getText(){ return null; }
+    public boolean getFreezesText(){ return false; }
+    public void extendSelection(int p0){}
+    public void selectAll(){}
+    public void setEllipsize(TextUtils.TruncateAt p0){}
+    public void setSelection(int p0){}
+    public void setSelection(int p0, int p1){}
+    public void setText(CharSequence p0, TextView.BufferType p1){}
+}

--- a/java/ql/test/stubs/google-android-9.0.0/android/widget/Scroller.java
+++ b/java/ql/test/stubs/google-android-9.0.0/android/widget/Scroller.java
@@ -1,0 +1,34 @@
+// Generated automatically from android.widget.Scroller for testing purposes
+
+package android.widget;
+
+import android.content.Context;
+import android.view.animation.Interpolator;
+
+public class Scroller
+{
+    protected Scroller() {}
+    public Scroller(Context p0){}
+    public Scroller(Context p0, Interpolator p1){}
+    public Scroller(Context p0, Interpolator p1, boolean p2){}
+    public boolean computeScrollOffset(){ return false; }
+    public final boolean isFinished(){ return false; }
+    public final int getCurrX(){ return 0; }
+    public final int getCurrY(){ return 0; }
+    public final int getDuration(){ return 0; }
+    public final int getFinalX(){ return 0; }
+    public final int getFinalY(){ return 0; }
+    public final int getStartX(){ return 0; }
+    public final int getStartY(){ return 0; }
+    public final void forceFinished(boolean p0){}
+    public final void setFriction(float p0){}
+    public float getCurrVelocity(){ return 0; }
+    public int timePassed(){ return 0; }
+    public void abortAnimation(){}
+    public void extendDuration(int p0){}
+    public void fling(int p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7){}
+    public void setFinalX(int p0){}
+    public void setFinalY(int p0){}
+    public void startScroll(int p0, int p1, int p2, int p3){}
+    public void startScroll(int p0, int p1, int p2, int p3, int p4){}
+}


### PR DESCRIPTION
Adds a general flow step to support taint propagation when the contents of a text field in Android are accessed like:

```java
editText.getText().toString()
```

This generalization allows us to remove specific query taint steps that had the same goal.
