### PR TITLE
Java: Fix join-order.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/Validation.qll
+++ b/java/ql/lib/semmle/code/java/security/Validation.qll
@@ -2,9 +2,6 @@ import semmle.code.java.Expr
 import semmle.code.java.dataflow.SSA
 import semmle.code.java.controlflow.Guards
 
-bindingset[result, i]
-private int unbindInt(int i) { i <= result and i >= result }
-
 /** Holds if the method `method` validates its `arg`-th argument in some way. */
 predicate validationMethod(Method method, int arg) {
   // The method examines the contents of the string argument.
@@ -22,8 +19,8 @@ predicate validationMethod(Method method, int arg) {
   // The method calls another one that verifies the argument.
   exists(Parameter param, MethodAccess call, int recursiveArg |
     method.getParameter(arg) = param and
-    call.getArgument(recursiveArg) = param.getAnAccess() and
-    validationMethod(call.getMethod(), unbindInt(recursiveArg))
+    call.getArgument(pragma[only_bind_into](recursiveArg)) = param.getAnAccess() and
+    validationMethod(pragma[only_bind_into](call.getMethod()), pragma[only_bind_into](recursiveArg))
   )
 }
 


### PR DESCRIPTION
This replaces an old-style unbind with a pair of pragmas, and fixes a join-order to put the delta first.

The optimiser would put the visible loop-invariant parts first, and then proceed to early-join the `NOT ..#prev` to ruin the loop-invariant-ness, which caused each iteration to mostly re-evaluate the same thing. This predicate generally isn't very big, so it wasn't that expensive in wall clock time, but was highlighted by the join-order-badness metric in the nightly dca, so definitely worth fixing.

Before:
```
Evaluated recursive predicate Validation::validationMethod#d07f4830#bf@03a4awmg in 55ms on iteration 1 (delta size: 48).
Tuple counts for Validation::validationMethod#d07f4830#bf@03a4awmg on iteration 1 running pipeline standard:
         95939    ~5%    {3} r1 = Validation::validationMethod#d07f4830#bf#loop_invariant_prefix AND NOT Validation::validationMethod#d07f4830#bf#prev(Lhs.0, Lhs.1)
         95939    ~0%    {3} r2 = SCAN r1 OUTPUT In.2, In.0, In.1
        158865    ~0%    {3} r3 = JOIN r2 WITH variableBinding_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
         87218    ~0%    {4} r4 = JOIN r3 WITH Expr::MethodAccess::getArgument#dispred#f0820431#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Rhs.2
         87207  ~105%    {4} r5 = JOIN r4 WITH Expr::MethodAccess::getMethod#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
            60    ~0%    {5} r6 = JOIN r5 WITH Validation::validationMethod#d07f4830#bf#prev_delta ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.0, Rhs.1
            51    ~0%    {5} r7 = SELECT r6 ON In.2 <= In.4
            48    ~0%    {5} r8 = SELECT r7 ON In.2 >= In.4
            48    ~0%    {2} r9 = SCAN r8 OUTPUT In.0, In.1
                         return r9
```
After:
```
Evaluated recursive predicate Validation::validationMethod#d07f4830#ff@2bae8wi7 in 1ms on iteration 1 (delta size: 77).
Tuple counts for Validation::validationMethod#d07f4830#ff@2bae8wi7 on iteration 1 running pipeline standard:
        429  ~4%    {2} r1 = JOIN Validation::validationMethod#d07f4830#ff#prev_delta WITH Expr::MethodAccess::getMethod#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        429  ~0%    {1} r2 = JOIN r1 WITH Expr::MethodAccess::getArgument#dispred#f0820431#fff ON FIRST 2 OUTPUT Rhs.2
        204  ~8%    {1} r3 = JOIN r2 WITH variableBinding ON FIRST 1 OUTPUT Rhs.1
        102  ~0%    {2} r4 = JOIN r3 WITH Member::Callable::getParameter#dispred#f0820431#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.2
         82  ~0%    {2} r5 = JOIN r4 WITH Member::Method#class#9eba3c33#f ON FIRST 1 OUTPUT Lhs.0, Lhs.1
         77  ~0%    {2} r6 = r5 AND NOT Validation::validationMethod#d07f4830#ff#prev(Lhs.0, Lhs.1)
                    return r6
```