### PR TITLE
Ruby: fix graph query tests by defining total ordering

### DIFF
--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -1,23 +1,3 @@
-calls.rb:
-#  102| Hash
-#-----| super -> Object
-
-#   77| Integer
-#-----| super -> Numeric
-
-#   86| Kernel
-
-#   90| Module
-#-----| super -> Object
-
-#   97| Object
-#-----| include -> Kernel
-#-----| super -> BasicObject
-#-----| prepend -> A
-
-#  106| Array
-#-----| super -> Object
-
 #-----| BasicObject
 
 #-----| Class
@@ -48,16 +28,36 @@ calls.rb:
 #-----| TrueClass
 #-----| super -> Object
 
+calls.rb:
 #   15| M
 
 #   29| C
-#-----| super -> Object
 #-----| include -> M
+#-----| super -> Object
 
 #   51| D
 #-----| super -> C
 
+#   77| Integer
+#-----| super -> Numeric
+
 #   82| String
+#-----| super -> Object
+
+#   86| Kernel
+
+#   90| Module
+#-----| super -> Object
+
+#   97| Object
+#-----| super -> BasicObject
+#-----| include -> Kernel
+#-----| prepend -> A
+
+#  102| Hash
+#-----| super -> Object
+
+#  106| Array
 #-----| super -> Object
 
 #  144| S
@@ -86,39 +86,10 @@ modules.rb:
 
 #    4| Foo
 
-#   37| Bar
-#-----| super -> Object
-
-#   60| MyModuleInGlobalScope
-
-#   63| Test
-
-#   83| Other
-
-#   88| IncludeTest
-#-----| include -> Test
-
-#   95| IncludeTest2
-#-----| include -> Test
-
-#  101| PrependTest
-#-----| prepend -> Test
-
-#  107| MM
-
-#  112| YY
-#-----| super -> Object
-
-#  115| XX
-
-private.rb:
-#    1| E
-#-----| super -> Object
-
-#   42| F
-
-modules.rb:
 #    5| Foo::Bar
+
+#    6| Foo::Bar::ClassInFooBar
+#-----| super -> Object
 
 #   19| Foo::ClassInFoo
 #-----| super -> Object
@@ -126,21 +97,62 @@ modules.rb:
 #   30| Foo::ClassInAnotherDefinitionOfFoo
 #-----| super -> Object
 
-#  116| XX::YY
-#-----| super -> YY
+#   37| Bar
+#-----| super -> Object
+
+#   49| Foo::Bar::ClassInAnotherDefinitionOfFooBar
+#-----| super -> Object
+
+#   60| MyModuleInGlobalScope
+
+#   63| Test
 
 #   65| Test::Foo1
 
+#   66| Test::Foo1::Bar
+#-----| super -> Object
+
 #   70| Test::Foo2
+
+#   71| Test::Foo2::Foo2
+
+#   72| Test::Foo2::Foo2::Bar
+#-----| super -> Object
 
 #   76| Test::Foo3
 
+#   83| Other
+
 #   84| Other::Foo1
 
-#    6| Foo::Bar::ClassInFooBar
+#   88| IncludeTest
+#-----| include -> Test
+
+#   91| Test::Foo1::Y
+
+#   95| IncludeTest2
+#-----| include -> Test
+
+#   97| Test::Foo1::Z
+
+#  101| PrependTest
+#-----| prepend -> Test
+
+#  103| Test::Foo2::Y
+
+#  107| MM
+
+#  108| MM::MM
+
+#  112| YY
 #-----| super -> Object
 
-#   71| Test::Foo2::Foo2
+#  115| XX
+
+#  116| XX::YY
+#-----| super -> YY
+
+#  120| Test::Foo1::Bar::Baz
 
 modules_rec.rb:
 #    1| B::A
@@ -149,22 +161,8 @@ modules_rec.rb:
 #    4| A::B
 #-----| super -> Object
 
-modules.rb:
-#  108| MM::MM
-
-#   49| Foo::Bar::ClassInAnotherDefinitionOfFooBar
+private.rb:
+#    1| E
 #-----| super -> Object
 
-#   66| Test::Foo1::Bar
-#-----| super -> Object
-
-#   91| Test::Foo1::Y
-
-#   97| Test::Foo1::Z
-
-#  103| Test::Foo2::Y
-
-#   72| Test::Foo2::Foo2::Bar
-#-----| super -> Object
-
-#  120| Test::Foo1::Bar::Baz
+#   42| F

--- a/ruby/ql/test/library-tests/modules/ancestors.ql
+++ b/ruby/ql/test/library-tests/modules/ancestors.ql
@@ -7,15 +7,46 @@ import ruby
 
 query predicate nodes(Module node, string key, string value) {
   key = "semmle.label" and value = node.toString()
+  or
+  key = "semmle.order" and
+  value =
+    any(int i |
+      node =
+        rank[i](Module m, Location l |
+          l = m.getLocation()
+        |
+          m
+          order by
+            l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+            l.getStartColumn(), l.getEndLine(), l.getEndColumn(), m.toString()
+        )
+    ).toString()
+}
+
+Module getATarget(Module source, string value) {
+  result = source.getSuperClass() and value = "super"
+  or
+  result = source.getAPrependedModule() and value = "prepend"
+  or
+  result = source.getAnIncludedModule() and value = "include"
 }
 
 query predicate edges(Module source, Module target, string key, string value) {
   key = "semmle.label" and
-  (
-    target = source.getSuperClass() and value = "super"
-    or
-    target = source.getAPrependedModule() and value = "prepend"
-    or
-    target = source.getAnIncludedModule() and value = "include"
-  )
+  target = getATarget(source, value)
+  or
+  key = "semmle.order" and
+  value =
+    any(int i |
+      target =
+        rank[i](Module t, Location l |
+          t = getATarget(source, _) and
+          l = t.getLocation()
+        |
+          t
+          order by
+            l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+            l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString()
+        )
+    ).toString()
 }

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -1,21 +1,3 @@
-calls.rb:
-#  102| Hash
-#-----|  -> Object
-
-#   77| Integer
-#-----|  -> Numeric
-
-#   86| Kernel
-
-#   90| Module
-#-----|  -> Object
-
-#   97| Object
-#-----|  -> BasicObject
-
-#  106| Array
-#-----|  -> Object
-
 #-----| BasicObject
 
 #-----| Class
@@ -46,6 +28,7 @@ calls.rb:
 #-----| TrueClass
 #-----|  -> Object
 
+calls.rb:
 #   15| M
 
 #   29| C
@@ -54,15 +37,32 @@ calls.rb:
 #   51| D
 #-----|  -> C
 
+#   77| Integer
+#-----|  -> Numeric
+
 #   82| String
+#-----|  -> Object
+
+#   86| Kernel
+
+#   90| Module
+#-----|  -> Object
+
+#   97| Object
+#-----|  -> BasicObject
+
+#  102| Hash
+#-----|  -> Object
+
+#  106| Array
 #-----|  -> Object
 
 #  144| S
 #-----|  -> Object
 
 #  150| A
-#-----|  -> S
 #-----|  -> B
+#-----|  -> S
 
 #  155| B
 #-----|  -> S
@@ -81,36 +81,10 @@ modules.rb:
 
 #    4| Foo
 
-#   37| Bar
-#-----|  -> Object
-
-#   60| MyModuleInGlobalScope
-
-#   63| Test
-
-#   83| Other
-
-#   88| IncludeTest
-
-#   95| IncludeTest2
-
-#  101| PrependTest
-
-#  107| MM
-
-#  112| YY
-#-----|  -> Object
-
-#  115| XX
-
-private.rb:
-#    1| E
-#-----|  -> Object
-
-#   42| F
-
-modules.rb:
 #    5| Foo::Bar
+
+#    6| Foo::Bar::ClassInFooBar
+#-----|  -> Object
 
 #   19| Foo::ClassInFoo
 #-----|  -> Object
@@ -118,21 +92,59 @@ modules.rb:
 #   30| Foo::ClassInAnotherDefinitionOfFoo
 #-----|  -> Object
 
-#  116| XX::YY
-#-----|  -> YY
+#   37| Bar
+#-----|  -> Object
+
+#   49| Foo::Bar::ClassInAnotherDefinitionOfFooBar
+#-----|  -> Object
+
+#   60| MyModuleInGlobalScope
+
+#   63| Test
 
 #   65| Test::Foo1
 
+#   66| Test::Foo1::Bar
+#-----|  -> Object
+
 #   70| Test::Foo2
+
+#   71| Test::Foo2::Foo2
+
+#   72| Test::Foo2::Foo2::Bar
+#-----|  -> Object
 
 #   76| Test::Foo3
 
+#   83| Other
+
 #   84| Other::Foo1
 
-#    6| Foo::Bar::ClassInFooBar
+#   88| IncludeTest
+
+#   91| Test::Foo1::Y
+
+#   95| IncludeTest2
+
+#   97| Test::Foo1::Z
+
+#  101| PrependTest
+
+#  103| Test::Foo2::Y
+
+#  107| MM
+
+#  108| MM::MM
+
+#  112| YY
 #-----|  -> Object
 
-#   71| Test::Foo2::Foo2
+#  115| XX
+
+#  116| XX::YY
+#-----|  -> YY
+
+#  120| Test::Foo1::Bar::Baz
 
 modules_rec.rb:
 #    1| B::A
@@ -141,22 +153,8 @@ modules_rec.rb:
 #    4| A::B
 #-----|  -> Object
 
-modules.rb:
-#  108| MM::MM
-
-#   49| Foo::Bar::ClassInAnotherDefinitionOfFooBar
+private.rb:
+#    1| E
 #-----|  -> Object
 
-#   66| Test::Foo1::Bar
-#-----|  -> Object
-
-#   91| Test::Foo1::Y
-
-#   97| Test::Foo1::Z
-
-#  103| Test::Foo2::Y
-
-#   72| Test::Foo2::Foo2::Bar
-#-----|  -> Object
-
-#  120| Test::Foo1::Bar::Baz
+#   42| F

--- a/ruby/ql/test/library-tests/modules/superclasses.ql
+++ b/ruby/ql/test/library-tests/modules/superclasses.ql
@@ -7,6 +7,39 @@ import ruby
 
 query predicate nodes(Module node, string key, string value) {
   key = "semmle.label" and value = node.toString()
+  or
+  key = "semmle.order" and
+  value =
+    any(int i |
+      node =
+        rank[i](Module m, Location l |
+          l = m.getLocation()
+        |
+          m
+          order by
+            l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+            l.getStartColumn(), l.getEndLine(), l.getEndColumn(), m.toString()
+        )
+    ).toString()
 }
 
-query predicate edges(Module source, Module target) { target = source.getSuperClass() }
+query predicate edges(Module source, Module target, string key, string value) {
+  key = "semmle.value" and
+  value = "superclass" and
+  target = source.getSuperClass()
+  or
+  key = "semmle.order" and
+  value =
+    any(int i |
+      target =
+        rank[i](Module t, Location l |
+          t = source.getSuperClass() and
+          l = source.getLocation()
+        |
+          t
+          order by
+            l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+            l.getStartColumn(), l.getEndLine(), l.getEndColumn(), t.toString()
+        )
+    ).toString()
+}


### PR DESCRIPTION
These tests using graph queries didn't specify any ordering, so they were subject to the whims of the evaluator's internal implementation details, and started failing with a recent CodeQL CLI update.

Now they pass with both the old and new CLIs.

cc @erik-krogh 