### PR TITLE
Ruby: fix typo in edge key for graph query

### DIFF
--- a/ruby/ql/test/library-tests/modules/superclasses.ql
+++ b/ruby/ql/test/library-tests/modules/superclasses.ql
@@ -24,8 +24,8 @@ query predicate nodes(Module node, string key, string value) {
 }
 
 query predicate edges(Module source, Module target, string key, string value) {
-  key = "semmle.value" and
-  value = "superclass" and
+  key = "semmle.label" and
+  value = "" and
   target = source.getSuperClass()
   or
   key = "semmle.order" and


### PR DESCRIPTION
I introduced a (fairly harmless) typo in #8879 – the key name is `semmle.label`, not `semmle.value`. In fixing it, I've changed the corresponding value to the empty string, so that the test output doesn't change.