### PR TITLE
C++: Add support for createLSParser to the CWE-611 XXE query.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -164,6 +164,13 @@ class ParseFunction extends Function {
 }
 
 /**
+ * The `createLSParser` function that returns a newly created `LSParser` object.
+ */
+class CreateLSParser extends Function {
+  CreateLSParser() { this.hasName("createLSParser") }
+}
+
+/**
  * Configuration for tracking XML objects and their states.
  */
 class XXEConfiguration extends DataFlow::Configuration {
@@ -176,6 +183,13 @@ class XXEConfiguration extends DataFlow::Configuration {
       call.getStaticCallTarget() = any(XercesDOMParserClass c).getAConstructor() and
       node.asInstruction().(WriteSideEffectInstruction).getDestinationAddress() =
         call.getThisArgument() and
+      encodeXercesDOMFlowState(flowstate, 0, 1) // default configuration
+    )
+    or
+    // source is the result of a call to `createLSParser`.
+    exists(Call call |
+      call.getTarget() instanceof CreateLSParser and
+      call = node.asExpr() and
       encodeXercesDOMFlowState(flowstate, 0, 1) // default configuration
     )
   }
@@ -208,5 +222,4 @@ class XXEConfiguration extends DataFlow::Configuration {
 from XXEConfiguration conf, DataFlow::PathNode source, DataFlow::PathNode sink
 where conf.hasFlowPath(source, sink)
 select sink, source, sink,
-  "This $@ is not configured to prevent an XML external entity (XXE) attack.", source,
-  "XML parser"
+  "This $@ is not configured to prevent an XML external entity (XXE) attack.", source, "XML parser"

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -169,7 +169,7 @@ class ParseFunction extends Function {
 class CreateLSParser extends Function {
   CreateLSParser() {
     this.hasName("createLSParser") and
-    this.getType().(PointerType).getBaseType().getName() = "DOMLSParser" // returns a `DOMLSParser *`.
+    this.getUnderlyingType().(PointerType).getBaseType().getName() = "DOMLSParser" // returns a `DOMLSParser *`.
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -169,7 +169,7 @@ class ParseFunction extends Function {
 class CreateLSParser extends Function {
   CreateLSParser() {
     this.hasName("createLSParser") and
-    this.getUnderlyingType().(PointerType).getBaseType().getName() = "DOMLSParser" // returns a `DOMLSParser *`.
+    this.getUnspecifiedType().(PointerType).getBaseType().getName() = "DOMLSParser" // returns a `DOMLSParser *`.
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -167,7 +167,10 @@ class ParseFunction extends Function {
  * The `createLSParser` function that returns a newly created `LSParser` object.
  */
 class CreateLSParser extends Function {
-  CreateLSParser() { this.hasName("createLSParser") }
+  CreateLSParser() {
+    this.hasName("createLSParser") and
+    this.getType().(PointerType).getBaseType().getName() = "DOMLSParser" // returns a `DOMLSParser *`.
+  }
 }
 
 /**

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -91,7 +91,7 @@ class XercesDOMParserFlowState extends XXEFlowState {
 }
 
 /**
- * Flow state transformer for a call to
+ * A flow state transformer for a call to
  * `AbstractDOMParser.setDisableDefaultEntityResolution`. Transforms the flow
  * state through the qualifier according to the setting in the parameter.
  */
@@ -124,7 +124,7 @@ class DisableDefaultEntityResolutionTranformer extends XXEFlowStateTranformer {
 }
 
 /**
- * Flow state transformer for a call to
+ * A flow state transformer for a call to
  * `AbstractDOMParser.setCreateEntityReferenceNodes`. Transforms the flow
  * state through the qualifier according to the setting in the parameter.
  */
@@ -171,7 +171,7 @@ class CreateLSParser extends Function {
 }
 
 /**
- * Configuration for tracking XML objects and their states.
+ * A configuration for tracking XML objects and their states.
  */
 class XXEConfiguration extends DataFlow::Configuration {
   XXEConfiguration() { this = "XXEConfiguration" }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -25,7 +25,7 @@ edges
 | tests.cpp:140:23:140:43 | XercesDOMParser output argument | tests.cpp:146:18:146:18 | q |
 | tests.cpp:144:18:144:18 | q | tests.cpp:130:39:130:39 | p |
 | tests.cpp:146:18:146:18 | q | tests.cpp:134:39:134:39 | p |
-| tests.cpp:150:16:150:29 | call to createLSParser | tests.cpp:152:2:152:2 | p |
+| tests.cpp:150:19:150:32 | call to createLSParser | tests.cpp:152:2:152:2 | p |
 nodes
 | tests.cpp:33:23:33:43 | XercesDOMParser output argument | semmle.label | XercesDOMParser output argument |
 | tests.cpp:35:2:35:2 | p | semmle.label | p |
@@ -62,7 +62,7 @@ nodes
 | tests.cpp:140:23:140:43 | XercesDOMParser output argument | semmle.label | XercesDOMParser output argument |
 | tests.cpp:144:18:144:18 | q | semmle.label | q |
 | tests.cpp:146:18:146:18 | q | semmle.label | q |
-| tests.cpp:150:16:150:29 | call to createLSParser | semmle.label | call to createLSParser |
+| tests.cpp:150:19:150:32 | call to createLSParser | semmle.label | call to createLSParser |
 | tests.cpp:152:2:152:2 | p | semmle.label | p |
 subpaths
 #select
@@ -77,4 +77,4 @@ subpaths
 | tests.cpp:122:3:122:3 | q | tests.cpp:118:24:118:44 | XercesDOMParser output argument | tests.cpp:122:3:122:3 | q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:118:24:118:44 | XercesDOMParser output argument | XML parser |
 | tests.cpp:131:2:131:2 | p | tests.cpp:140:23:140:43 | XercesDOMParser output argument | tests.cpp:131:2:131:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:140:23:140:43 | XercesDOMParser output argument | XML parser |
 | tests.cpp:135:2:135:2 | p | tests.cpp:140:23:140:43 | XercesDOMParser output argument | tests.cpp:135:2:135:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:140:23:140:43 | XercesDOMParser output argument | XML parser |
-| tests.cpp:152:2:152:2 | p | tests.cpp:150:16:150:29 | call to createLSParser | tests.cpp:152:2:152:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:150:16:150:29 | call to createLSParser | XML parser |
+| tests.cpp:152:2:152:2 | p | tests.cpp:150:19:150:32 | call to createLSParser | tests.cpp:152:2:152:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:150:19:150:32 | call to createLSParser | XML parser |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -25,6 +25,7 @@ edges
 | tests.cpp:140:23:140:43 | XercesDOMParser output argument | tests.cpp:146:18:146:18 | q |
 | tests.cpp:144:18:144:18 | q | tests.cpp:130:39:130:39 | p |
 | tests.cpp:146:18:146:18 | q | tests.cpp:134:39:134:39 | p |
+| tests.cpp:150:16:150:29 | call to createLSParser | tests.cpp:152:2:152:2 | p |
 nodes
 | tests.cpp:33:23:33:43 | XercesDOMParser output argument | semmle.label | XercesDOMParser output argument |
 | tests.cpp:35:2:35:2 | p | semmle.label | p |
@@ -61,6 +62,8 @@ nodes
 | tests.cpp:140:23:140:43 | XercesDOMParser output argument | semmle.label | XercesDOMParser output argument |
 | tests.cpp:144:18:144:18 | q | semmle.label | q |
 | tests.cpp:146:18:146:18 | q | semmle.label | q |
+| tests.cpp:150:16:150:29 | call to createLSParser | semmle.label | call to createLSParser |
+| tests.cpp:152:2:152:2 | p | semmle.label | p |
 subpaths
 #select
 | tests.cpp:35:2:35:2 | p | tests.cpp:33:23:33:43 | XercesDOMParser output argument | tests.cpp:35:2:35:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:33:23:33:43 | XercesDOMParser output argument | XML parser |
@@ -74,3 +77,4 @@ subpaths
 | tests.cpp:122:3:122:3 | q | tests.cpp:118:24:118:44 | XercesDOMParser output argument | tests.cpp:122:3:122:3 | q | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:118:24:118:44 | XercesDOMParser output argument | XML parser |
 | tests.cpp:131:2:131:2 | p | tests.cpp:140:23:140:43 | XercesDOMParser output argument | tests.cpp:131:2:131:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:140:23:140:43 | XercesDOMParser output argument | XML parser |
 | tests.cpp:135:2:135:2 | p | tests.cpp:140:23:140:43 | XercesDOMParser output argument | tests.cpp:135:2:135:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:140:23:140:43 | XercesDOMParser output argument | XML parser |
+| tests.cpp:152:2:152:2 | p | tests.cpp:150:16:150:29 | call to createLSParser | tests.cpp:152:2:152:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:150:16:150:29 | call to createLSParser | XML parser |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests.cpp
@@ -149,7 +149,7 @@ void test10(InputSource &data) {
 void test11(InputSource &data) {
 	LSParser *p = createLSParser();
 
-	p->parse(data); // BAD (parser not correctly configured) [NOT DETECTED]
+	p->parse(data); // BAD (parser not correctly configured)
 }
 
 void test12(InputSource &data) {

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests.cpp
@@ -22,10 +22,10 @@ public:
 	XercesDOMParser();
 };
 
-class LSParser: public AbstractDOMParser {
+class DOMLSParser : public AbstractDOMParser {
 };
 
-LSParser *createLSParser();
+DOMLSParser *createLSParser();
 
 // ---
 
@@ -147,20 +147,20 @@ void test10(InputSource &data) {
 }
 
 void test11(InputSource &data) {
-	LSParser *p = createLSParser();
+	DOMLSParser *p = createLSParser();
 
 	p->parse(data); // BAD (parser not correctly configured)
 }
 
 void test12(InputSource &data) {
-	LSParser *p = createLSParser();
+	DOMLSParser *p = createLSParser();
 
 	p->setDisableDefaultEntityResolution(true);
 	p->parse(data); // GOOD
 }
 
-LSParser *g_p1 = createLSParser();
-LSParser *g_p2 = createLSParser();
+DOMLSParser *g_p1 = createLSParser();
+DOMLSParser *g_p2 = createLSParser();
 InputSource *g_data;
 
 void test13() {


### PR DESCRIPTION
Add support for `createLSParser` to the CWE-611 XXE query.

This particular extension is straightforward and we already have test cases.