### PR TITLE
QL: point the dataset measure workflow to a merge_stats.py file that exists

### DIFF
--- a/.github/workflows/ql-for-ql-dataset_measure.yml
+++ b/.github/workflows/ql-for-ql-dataset_measure.yml
@@ -77,7 +77,7 @@ jobs:
           path: stats
       - run: |
           python -m pip install --user lxml
-          find stats -name 'stats.xml' -print0 | sort -z | xargs -0 python ql/scripts/merge_stats.py --output ql/ql/src/ql.dbscheme.stats --normalise ql_tokeninfo
+          find stats -name 'stats.xml' -print0 | sort -z | xargs -0 python ruby/scripts/merge_stats.py --output ql/ql/src/ql.dbscheme.stats --normalise ql_tokeninfo
       - uses: actions/upload-artifact@v3
         with:
           name: ql.dbscheme.stats


### PR DESCRIPTION
I just pointed the workflow to the `merge_stats.py` file in the `ruby/` folder. 

This PR is a followup based on [this comment](https://github.com/github/codeql/pull/8871#issuecomment-1110126719). 