### PR TITLE
Ruby: Simplify flow summary for `fetch`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Array.qll
@@ -741,19 +741,14 @@ module Array {
 
     override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
       (
-        input = "Argument[self].ArrayElement[?]" and
-        output = ["ReturnValue", "Argument[self].ArrayElement[?]"]
-        or
-        exists(ArrayIndex j | input = "Argument[self].ArrayElement[" + j + "]" |
-          j = i and output = "ReturnValue"
-          or
-          j != i and output = "Argument[self].ArrayElement[" + j + "]"
-        )
+        input = "Argument[self].ArrayElement[?," + i + "]" and
+        output = "ReturnValue"
         or
         input = "Argument[0]" and
         output = "Argument[block].Parameter[0]"
         or
-        input = "Argument[1]" and output = "ReturnValue"
+        input = "Argument[1]" and
+        output = "ReturnValue"
       ) and
       preservesValue = true
     }

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -821,18 +821,10 @@ edges
 | array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:471:9:471:9 | a [array element 3] :  |
 | array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:473:9:473:9 | a [array element 3] :  |
 | array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:473:9:473:9 | a [array element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:475:9:475:9 | a [array element 3] :  |
-| array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:475:9:475:9 | a [array element 3] :  |
 | array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:477:9:477:9 | a [array element 3] :  |
 | array_flow.rb:466:19:466:30 | call to source :  | array_flow.rb:477:9:477:9 | a [array element 3] :  |
 | array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:467:9:467:9 | a [array element 4] :  |
 | array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:467:9:467:9 | a [array element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:471:9:471:9 | a [array element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:471:9:471:9 | a [array element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:473:9:473:9 | a [array element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:473:9:473:9 | a [array element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:475:9:475:9 | a [array element 4] :  |
-| array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:475:9:475:9 | a [array element 4] :  |
 | array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
 | array_flow.rb:466:33:466:44 | call to source :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
 | array_flow.rb:467:9:467:9 | a [array element 3] :  | array_flow.rb:467:9:469:7 | call to fetch :  |
@@ -845,38 +837,16 @@ edges
 | array_flow.rb:467:17:467:28 | call to source :  | array_flow.rb:467:35:467:35 | x :  |
 | array_flow.rb:467:35:467:35 | x :  | array_flow.rb:468:14:468:14 | x |
 | array_flow.rb:467:35:467:35 | x :  | array_flow.rb:468:14:468:14 | x |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | array_flow.rb:473:9:473:9 | a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | array_flow.rb:473:9:473:9 | a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | array_flow.rb:475:9:475:9 | a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | array_flow.rb:475:9:475:9 | a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
 | array_flow.rb:471:9:471:9 | a [array element 3] :  | array_flow.rb:471:9:471:18 | call to fetch :  |
 | array_flow.rb:471:9:471:9 | a [array element 3] :  | array_flow.rb:471:9:471:18 | call to fetch :  |
-| array_flow.rb:471:9:471:9 | a [array element 4] :  | array_flow.rb:471:9:471:9 | [post] a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | a [array element 4] :  | array_flow.rb:471:9:471:9 | [post] a [array element 4] :  |
 | array_flow.rb:471:9:471:18 | call to fetch :  | array_flow.rb:472:10:472:10 | b |
 | array_flow.rb:471:9:471:18 | call to fetch :  | array_flow.rb:472:10:472:10 | b |
-| array_flow.rb:473:9:473:9 | [post] a [array element 4] :  | array_flow.rb:475:9:475:9 | a [array element 4] :  |
-| array_flow.rb:473:9:473:9 | [post] a [array element 4] :  | array_flow.rb:475:9:475:9 | a [array element 4] :  |
-| array_flow.rb:473:9:473:9 | [post] a [array element 4] :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
-| array_flow.rb:473:9:473:9 | [post] a [array element 4] :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
 | array_flow.rb:473:9:473:9 | a [array element 3] :  | array_flow.rb:473:9:473:32 | call to fetch :  |
 | array_flow.rb:473:9:473:9 | a [array element 3] :  | array_flow.rb:473:9:473:32 | call to fetch :  |
-| array_flow.rb:473:9:473:9 | a [array element 4] :  | array_flow.rb:473:9:473:9 | [post] a [array element 4] :  |
-| array_flow.rb:473:9:473:9 | a [array element 4] :  | array_flow.rb:473:9:473:9 | [post] a [array element 4] :  |
 | array_flow.rb:473:9:473:32 | call to fetch :  | array_flow.rb:474:10:474:10 | b |
 | array_flow.rb:473:9:473:32 | call to fetch :  | array_flow.rb:474:10:474:10 | b |
 | array_flow.rb:473:20:473:31 | call to source :  | array_flow.rb:473:9:473:32 | call to fetch :  |
 | array_flow.rb:473:20:473:31 | call to source :  | array_flow.rb:473:9:473:32 | call to fetch :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 3] :  | array_flow.rb:477:9:477:9 | a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 3] :  | array_flow.rb:477:9:477:9 | a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 4] :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 4] :  | array_flow.rb:477:9:477:9 | a [array element 4] :  |
-| array_flow.rb:475:9:475:9 | a [array element 3] :  | array_flow.rb:475:9:475:9 | [post] a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | a [array element 3] :  | array_flow.rb:475:9:475:9 | [post] a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | a [array element 4] :  | array_flow.rb:475:9:475:9 | [post] a [array element 4] :  |
-| array_flow.rb:475:9:475:9 | a [array element 4] :  | array_flow.rb:475:9:475:9 | [post] a [array element 4] :  |
 | array_flow.rb:475:9:475:34 | call to fetch :  | array_flow.rb:476:10:476:10 | b |
 | array_flow.rb:475:9:475:34 | call to fetch :  | array_flow.rb:476:10:476:10 | b |
 | array_flow.rb:475:22:475:33 | call to source :  | array_flow.rb:475:9:475:34 | call to fetch :  |
@@ -4346,36 +4316,20 @@ nodes
 | array_flow.rb:468:14:468:14 | x | semmle.label | x |
 | array_flow.rb:470:10:470:10 | b | semmle.label | b |
 | array_flow.rb:470:10:470:10 | b | semmle.label | b |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | semmle.label | [post] a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | [post] a [array element 4] :  | semmle.label | [post] a [array element 4] :  |
 | array_flow.rb:471:9:471:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
 | array_flow.rb:471:9:471:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:471:9:471:9 | a [array element 4] :  | semmle.label | a [array element 4] :  |
-| array_flow.rb:471:9:471:9 | a [array element 4] :  | semmle.label | a [array element 4] :  |
 | array_flow.rb:471:9:471:18 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:471:9:471:18 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:472:10:472:10 | b | semmle.label | b |
 | array_flow.rb:472:10:472:10 | b | semmle.label | b |
-| array_flow.rb:473:9:473:9 | [post] a [array element 4] :  | semmle.label | [post] a [array element 4] :  |
-| array_flow.rb:473:9:473:9 | [post] a [array element 4] :  | semmle.label | [post] a [array element 4] :  |
 | array_flow.rb:473:9:473:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
 | array_flow.rb:473:9:473:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:473:9:473:9 | a [array element 4] :  | semmle.label | a [array element 4] :  |
-| array_flow.rb:473:9:473:9 | a [array element 4] :  | semmle.label | a [array element 4] :  |
 | array_flow.rb:473:9:473:32 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:473:9:473:32 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:473:20:473:31 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:473:20:473:31 | call to source :  | semmle.label | call to source :  |
 | array_flow.rb:474:10:474:10 | b | semmle.label | b |
 | array_flow.rb:474:10:474:10 | b | semmle.label | b |
-| array_flow.rb:475:9:475:9 | [post] a [array element 3] :  | semmle.label | [post] a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 3] :  | semmle.label | [post] a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 4] :  | semmle.label | [post] a [array element 4] :  |
-| array_flow.rb:475:9:475:9 | [post] a [array element 4] :  | semmle.label | [post] a [array element 4] :  |
-| array_flow.rb:475:9:475:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | a [array element 3] :  | semmle.label | a [array element 3] :  |
-| array_flow.rb:475:9:475:9 | a [array element 4] :  | semmle.label | a [array element 4] :  |
-| array_flow.rb:475:9:475:9 | a [array element 4] :  | semmle.label | a [array element 4] :  |
 | array_flow.rb:475:9:475:34 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:475:9:475:34 | call to fetch :  | semmle.label | call to fetch :  |
 | array_flow.rb:475:22:475:33 | call to source :  | semmle.label | call to source :  |


### PR DESCRIPTION
The outputs into `self` are not needed, since that will be handled by ordinary use-use flow at the call sites.