### PR TITLE
Enable Dependabot updates for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
     directory: "ruby/autobuilder"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch', 'version-update:semver-minor']


### PR DESCRIPTION
This will automatically create update PRs for workflow files referencing Actions that have since had a major update.