### PR TITLE
Add CODEOWNERS for Actions workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,3 +31,9 @@
 # Documentation etc
 /*.md @github/code-scanning-product
 /LICENSE @github/code-scanning-product
+
+# Workflows
+/.github/workflows/ @github/codeql-ci-reviewers
+/.github/workflows/js-ml-tests.yml @github/codeql-ml-powered-queries-reviewers
+/.github/workflows/ql-for-ql-* @github/codeql-ql-for-ql-reviewers
+/.github/workflows/ruby-* @github/codeql-ruby


### PR DESCRIPTION
This will help with for instance getting automatically generated Dependabot updates reviewed.  `@github/codeql-ci-reviewers` is the default reviewer, and we should add more specific reviewer teams when possible.