### PR TITLE
QL: Improve camel case query

### DIFF
--- a/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
+++ b/ql/ql/src/codeql_ql/style/AcronymsShouldBeCamelCaseQuery.qll
@@ -68,5 +68,6 @@ predicate shouldBePascalCased(string name, AstNode node, string kind) {
   // allowed upper-case acronyms.
   not name.regexpMatch(".*(PEP|AES|DES|EOF).*") and
   not (name.regexpMatch("T[A-Z]{3}[^A-Z].*") and node instanceof NewTypeBranch) and
+  not (name.regexpMatch("T[A-Z]{3}[^A-Z].*") and node instanceof NewType) and
   not name.toUpperCase() = name // We are OK with fully-uppercase names.
 }

--- a/ql/ql/src/queries/style/AcronymsShouldBeCamelCase.ql
+++ b/ql/ql/src/queries/style/AcronymsShouldBeCamelCase.ql
@@ -14,4 +14,4 @@ import codeql_ql.style.AcronymsShouldBeCamelCaseQuery
 
 from string name, AstNode node
 where shouldBePascalCased(name, node, _)
-select node, "Acronyms should be PascalCase/camelCase"
+select node, "Acronyms in " + name + " should be PascalCase/camelCase"

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.expected
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.expected
@@ -1,4 +1,4 @@
-| Test.qll:2:1:2:27 | ClasslessPredicate isXML | Acronyms should be PascalCase/camelCase |
-| Test.qll:8:1:10:15 | NewType TXMLElements | Acronyms should be PascalCase/camelCase |
-| Test.qll:10:3:10:15 | NewTypeBranch TXMLElement | Acronyms should be PascalCase/camelCase |
-| Test.qll:13:1:14:16 | NewType TIRFunction | Acronyms should be PascalCase/camelCase |
+| Test.qll:2:1:2:27 | ClasslessPredicate isXML | Acronyms in isXML should be PascalCase/camelCase |
+| Test.qll:8:1:10:15 | NewType TXMLElements | Acronyms in TXMLElements should be PascalCase/camelCase |
+| Test.qll:10:3:10:15 | NewTypeBranch TXMLElement | Acronyms in TXMLElement should be PascalCase/camelCase |
+| Test.qll:13:1:14:16 | NewType TIRFunction | Acronyms in TIRFunction should be PascalCase/camelCase |

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.expected
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.expected
@@ -1,4 +1,3 @@
 | Test.qll:2:1:2:27 | ClasslessPredicate isXML | Acronyms in isXML should be PascalCase/camelCase |
 | Test.qll:8:1:10:15 | NewType TXMLElements | Acronyms in TXMLElements should be PascalCase/camelCase |
 | Test.qll:10:3:10:15 | NewTypeBranch TXMLElement | Acronyms in TXMLElement should be PascalCase/camelCase |
-| Test.qll:13:1:14:16 | NewType TIRFunction | Acronyms in TIRFunction should be PascalCase/camelCase |

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.expected
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.expected
@@ -1,0 +1,4 @@
+| Test.qll:2:1:2:27 | ClasslessPredicate isXML | Acronyms should be PascalCase/camelCase |
+| Test.qll:8:1:10:15 | NewType TXMLElements | Acronyms should be PascalCase/camelCase |
+| Test.qll:10:3:10:15 | NewTypeBranch TXMLElement | Acronyms should be PascalCase/camelCase |
+| Test.qll:13:1:14:16 | NewType TIRFunction | Acronyms should be PascalCase/camelCase |

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.qlref
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/AcronymsShouldBeCamelCase.qlref
@@ -1,0 +1,1 @@
+queries/style/AcronymsShouldBeCamelCase.ql

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
@@ -9,6 +9,6 @@ newtype TXMLElements =
   TXmlElement() or // GOOD
   TXMLElement() // BAD
 
-// GOOD [ FALSE POSITIVE ]
+// GOOD
 newtype TIRFunction =
   MkIRFunction()

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
@@ -10,5 +10,4 @@ newtype TXMLElements =
   TXMLElement() // BAD
 
 // GOOD
-newtype TIRFunction =
-  MkIRFunction()
+newtype TIRFunction = MkIRFunction()

--- a/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
+++ b/ql/ql/test/queries/style/AcronymsShouldBeCamelCase/Test.qll
@@ -1,0 +1,14 @@
+// BAD
+predicate isXML() { any() }
+
+// GOOD [ AES is exceptional ]
+predicate isAES() { any() }
+
+// BAD
+newtype TXMLElements =
+  TXmlElement() or // GOOD
+  TXMLElement() // BAD
+
+// GOOD [ FALSE POSITIVE ]
+newtype TIRFunction =
+  MkIRFunction()


### PR DESCRIPTION
* Improve displayed message. In the PR interface it was not always clear which name was referred to, especially in the case of classes, which can be many lines long
* Filter out `NewType` like `NewTypeBranch`. This showed up, e.g., here https://github.com/github/codeql/security/code-scanning/29265