### PR TITLE
C++: Remove import order workarounds

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/Overflow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/Overflow.qll
@@ -5,8 +5,6 @@
 
 import cpp
 import semmle.code.cpp.controlflow.Dominance
-// `GlobalValueNumbering` is only imported to prevent IR re-evaluation.
-private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 import semmle.code.cpp.controlflow.Guards

--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -14,9 +14,6 @@
  */
 
 import cpp
-// We don't actually use the global value numbering library in this query, but without it we end up
-// recomputing the IR.
-private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.dataflow.MustFlow
 import PathGraph

--- a/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
+++ b/cpp/ql/src/Likely Bugs/OO/UnsafeUseOfThis.ql
@@ -15,9 +15,6 @@
  */
 
 import cpp
-// We don't actually use the global value numbering library in this query, but without it we end up
-// recomputing the IR.
-import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.dataflow.MustFlow
 import PathGraph


### PR DESCRIPTION
These workarounds are no longer needed from CodeQL CLI 2.9.0.

So far I've checked that there's no re-evaluation by looking through the output of

```sh
codeql query compile --dump-dil cpp/ql/src/codeql-suites/cpp-security-and-quality.qls > dil.log 2>&1
```

Comparing this output before and after removing the imports, I can see that some auto-generated names change (suffixes like `#2` come and go), but that's not a problem on its own. The important thing is that there's no change in how many distinct copies of each predicate we evaluate. For this, I compared the output of the following command before and after, finding that there were no changes.

```sh
grep '^query ' dil.log |grep -v '^query #select' |sed 's/ =.*//' |sort -u |sed 's/#.*//' |uniq -c |sort -n
```

I'll start a DCA run to double-check. @alexet, can you validate whether my approach is sound? (I'm sure there's a better way to check for re-evaluation than these shell one-liners)