### PR TITLE
Java: Fix Intent Redirection sanitizer

### DIFF
--- a/java/ql/lib/change-notes/2022-04-29-intent-redirection-sanitizer-fix.md
+++ b/java/ql/lib/change-notes/2022-04-29-intent-redirection-sanitizer-fix.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+Fixed a sanitizer of the query `java/android/intent-redirection`. Now, for an intent to be considered
+safe against intent redirection, both its package name and class name must be checked.

--- a/java/ql/lib/semmle/code/java/security/AndroidIntentRedirection.qll
+++ b/java/ql/lib/semmle/code/java/security/AndroidIntentRedirection.qll
@@ -65,16 +65,24 @@ private class DefaultIntentRedirectionSink extends IntentRedirectionSink {
 }
 
 /**
- * A default sanitizer for nodes dominated by calls to `ComponentName.getPackageName`
- * or `ComponentName.getClassName`. These are used to check whether the origin or destination
+ * A default sanitizer for `Intent` nodes dominated by calls to `ComponentName.getPackageName`
+ * and `ComponentName.getClassName`. These are used to check whether the origin or destination
  * components are trusted.
  */
 private class DefaultIntentRedirectionSanitizer extends IntentRedirectionSanitizer {
   DefaultIntentRedirectionSanitizer() {
+    this.getType() instanceof TypeIntent and
     exists(MethodAccess ma, Method m, Guard g, boolean branch |
       ma.getMethod() = m and
       m.getDeclaringType() instanceof TypeComponentName and
-      m.hasName(["getPackageName", "getClassName"]) and
+      m.hasName("getPackageName") and
+      g.isEquality(ma, _, branch) and
+      g.controls(this.asExpr().getBasicBlock(), branch)
+    ) and
+    exists(MethodAccess ma, Method m, Guard g, boolean branch |
+      ma.getMethod() = m and
+      m.getDeclaringType() instanceof TypeComponentName and
+      m.hasName("getClassName") and
       g.isEquality(ma, _, branch) and
       g.controls(this.asExpr().getBasicBlock(), branch)
     )

--- a/java/ql/test/query-tests/security/CWE-940/AndroidIntentRedirectionTest.java
+++ b/java/ql/test/query-tests/security/CWE-940/AndroidIntentRedirectionTest.java
@@ -40,13 +40,23 @@ public class AndroidIntentRedirectionTest extends Activity {
         sendStickyOrderedBroadcastAsUser(intent, null, null, null, 0, null, null); // $ hasAndroidIntentRedirection
         // @formatter:on
 
+        // Sanitizing only the package or the class still allows redirecting
+        // to non-exported activities in the same package
+        // or activities with the same name in other packages, respectively.
         if (intent.getComponent().getPackageName().equals("something")) {
-            startActivity(intent); // Safe - sanitized
+            startActivity(intent); // $ hasAndroidIntentRedirection
         } else {
             startActivity(intent); // $ hasAndroidIntentRedirection
         }
         if (intent.getComponent().getClassName().equals("something")) {
-            startActivity(intent); // Safe - sanitized
+            startActivity(intent); // $ hasAndroidIntentRedirection
+        } else {
+            startActivity(intent); // $ hasAndroidIntentRedirection
+        }
+
+        if (intent.getComponent().getPackageName().equals("something")
+                && intent.getComponent().getClassName().equals("something")) {
+            startActivity(intent); // Safe
         } else {
             startActivity(intent); // $ hasAndroidIntentRedirection
         }
@@ -94,8 +104,7 @@ public class AndroidIntentRedirectionTest extends Activity {
             }
             {
                 Intent fwdIntent = new Intent();
-                ComponentName component =
-                        new ComponentName("", intent.getStringExtra("className"));
+                ComponentName component = new ComponentName("", intent.getStringExtra("className"));
                 fwdIntent.setComponent(component);
                 startActivity(fwdIntent); // $ hasAndroidIntentRedirection
             }


### PR DESCRIPTION
When validating intents to protect against intent redirection, both the package name and the class name must be checked. Otherwise, if only the package name is checked, the intent can be redirected to any of the app's activities (including non-exported ones), whereas if only the class name is checked, the intent can be redirect to an activity with the same name in another app. Both things are dangerous and should be flagged by the intent redirection query.

This PR adds more restrictions to the appropriate intent redirection sanitizer to take the above into account.