### PR TITLE
Use codeql-action/upload-sarif@main in CSV coverage metrics workflow

### DIFF
--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -38,7 +38,7 @@ jobs:
           path: metrics-java.sarif
           retention-days: 20
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@main
         with:
           sarif_file: metrics-java.sarif
   
@@ -65,6 +65,6 @@ jobs:
           path: metrics-csharp.sarif
           retention-days: 20
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@main
         with:
           sarif_file: metrics-csharp.sarif


### PR DESCRIPTION
This brings all uses of the CodeQL Action in this repo apart from QL-for-QL onto the Node 16 Actions runtime.

We didn't receive a Dependabot update here because we use different versions of the CodeQL Action in this repo, and Dependabot updates for Actions are only supported when the same version of the Action is used throughout the repo.