### PR TITLE
JS/RB: have `ApiGraphModelsSpecific.qll` mention all the required predicates

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -4,12 +4,18 @@
  * It must export the following members:
  * ```ql
  * class Unit // a unit type
+ * module AccessPathSyntax // a re-export of the AccessPathSyntax module
+ * class InvokeNode // a type representing an invocation connected to the API graph
  * module API // the API graph module
  * predicate isPackageUsed(string package)
  * API::Node getExtraNodeFromPath(string package, string type, string path, int n)
  * API::Node getExtraSuccessorFromNode(API::Node node, AccessPathToken token)
- * API::Node getExtraSuccessorFromInvoke(API::InvokeNode node, AccessPathToken token)
- * predicate invocationMatchesExtraCallSiteFilter(API::InvokeNode invoke, AccessPathToken token)
+ * API::Node getExtraSuccessorFromInvoke(InvokeNode node, AccessPathToken token)
+ * predicate invocationMatchesExtraCallSiteFilter(InvokeNode invoke, AccessPathToken token)
+ * InvokeNode getAnInvocationOf(API::Node node)
+ * predicate isExtraValidTokenNameInIdentifyingAccessPath(string name)
+ * predicate isExtraValidNoArgumentTokenInIdentifyingAccessPath(string name)
+ * predicate isExtraValidTokenArgumentInIdentifyingAccessPath(string name, string argument)
  * ```
  */
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/data/internal/ApiGraphModelsSpecific.qll
@@ -4,6 +4,7 @@
  * It must export the following members:
  * ```ql
  * class Unit // a unit type
+ * module AccessPathSyntax // a re-export of the AccessPathSyntax module
  * class InvokeNode // a type representing an invocation connected to the API graph
  * module API // the API graph module
  * predicate isPackageUsed(string package)
@@ -12,6 +13,9 @@
  * API::Node getExtraSuccessorFromInvoke(InvokeNode node, AccessPathToken token)
  * predicate invocationMatchesExtraCallSiteFilter(InvokeNode invoke, AccessPathToken token)
  * InvokeNode getAnInvocationOf(API::Node node)
+ * predicate isExtraValidTokenNameInIdentifyingAccessPath(string name)
+ * predicate isExtraValidNoArgumentTokenInIdentifyingAccessPath(string name)
+ * predicate isExtraValidTokenArgumentInIdentifyingAccessPath(string name, string argument)
  * ```
  */
 


### PR DESCRIPTION
There were some predicates/types used by `ApiGraphModels.qll` that were unmentioned in the top comment of `ApiGraphModelsSpecific.qll`.  
So I added all the required types/predicates to the list, and made sure the comment is identical in the two files.  