### PR TITLE
C/C++ : Wrong Uint access

### DIFF
--- a/cpp/ql/src/experimental/Best Practices/WrongUintAccess.qhelp
+++ b/cpp/ql/src/experimental/Best Practices/WrongUintAccess.qhelp
@@ -1,0 +1,18 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Find access to an array with a Uint16 when the array has a size lower than 256.</p>
+</overview>
+
+<recommendation>
+<p>Use a Uint8 instead</p>
+</recommendation>
+
+<example>
+<sample src="WrongUintAcess.cpp" />
+</example>
+
+</qhelp>

--- a/cpp/ql/src/experimental/Best Practices/WrongUintAccess.ql
+++ b/cpp/ql/src/experimental/Best Practices/WrongUintAccess.ql
@@ -1,0 +1,23 @@
+/**
+ * @id cpp/wrong-uint-access
+ * @name Wrong Uint
+ * @descripion Acess an array of size lower than 256 with a uint16.
+ * @kind problem
+ * @problem.severity recommendation
+ * @tags efficiency
+ */
+
+import cpp
+import semmle.code.cpp.controlflow.SSA
+
+from
+  Variable E, ArrayExpr useExpr, ArrayType defExpr, VariableDeclarationEntry def, VariableAccess use
+where
+  def = defExpr.getATypeNameUse() and
+  E = def.getDeclaration() and
+  use = useExpr.getArrayBase() and
+  E = use.getTarget() and
+  useExpr.getArrayOffset().getType() instanceof UInt16_t and
+  defExpr.getArraySize() <= 256
+select useExpr, "Using a UInt16_t to acess the array $@ of size " + defExpr.getArraySize() + ".", E,
+  E.getName()

--- a/cpp/ql/src/experimental/Best Practices/WrongUintAcess.cpp
+++ b/cpp/ql/src/experimental/Best Practices/WrongUintAcess.cpp
@@ -1,0 +1,7 @@
+void test()
+{
+    uint16_t j = 256;
+    char testSubject[122];
+
+    testSubject[j] = 12; // You can use a uint8 here
+}


### PR DESCRIPTION
This request find all array access that use the wrong kind of Uint. For instance, 
```
Uint_16t i = 16;
char test[100]; 
test = 100;
```
This query found results on Suricata. It's also part of a project to find bug or bad behaviour in Suricata.
