### PR TITLE
Python: Flask: Improve `request.files` modeing

### DIFF
--- a/python/ql/lib/change-notes/2022-05-02-flask-request-files-modeling.md
+++ b/python/ql/lib/change-notes/2022-05-02-flask-request-files-modeling.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+The modeling of `request.files` in Flask has been fixed, so we now properly handle
+assignments to local variables (such as `files = request.files; files['key'].filename`).

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -411,21 +411,16 @@ module Flask {
   /** An `FileStorage` instance that originates from a flask request. */
   private class FlaskRequestFileStorageInstances extends Werkzeug::FileStorage::InstanceSource {
     FlaskRequestFileStorageInstances() {
-      // TODO: this currently only works in local-scope, since writing type-trackers for
-      // this is a little too much effort. Once API-graphs are available for more
-      // things, we can rewrite this.
-      //
       // TODO: This approach for identifying member-access is very adhoc, and we should
       // be able to do something more structured for providing modeling of the members
       // of a container-object.
-      exists(DataFlow::Node files | files = request().getMember("files").getAUse() |
-        this.asCfgNode().(SubscriptNode).getObject() = files.asCfgNode()
+      exists(API::Node files | files = request().getMember("files") |
+        this.asCfgNode().(SubscriptNode).getObject() = files.getAUse().asCfgNode()
         or
-        this.(DataFlow::MethodCallNode).calls(files, "get")
+        this = files.getMember("get").getACall()
         or
-        exists(DataFlow::MethodCallNode getlistCall | getlistCall.calls(files, "getlist") |
-          this.asCfgNode().(SubscriptNode).getObject() = getlistCall.asCfgNode()
-        )
+        this.asCfgNode().(SubscriptNode).getObject() =
+          files.getMember("getlist").getReturn().getAUse().asCfgNode()
       )
     }
   }

--- a/python/ql/lib/semmle/python/frameworks/Flask.qll
+++ b/python/ql/lib/semmle/python/frameworks/Flask.qll
@@ -418,7 +418,7 @@ module Flask {
       // TODO: This approach for identifying member-access is very adhoc, and we should
       // be able to do something more structured for providing modeling of the members
       // of a container-object.
-      exists(DataFlow::AttrRead files | files = request().getMember("files").getAnImmediateUse() |
+      exists(DataFlow::Node files | files = request().getMember("files").getAUse() |
         this.asCfgNode().(SubscriptNode).getObject() = files.asCfgNode()
         or
         this.(DataFlow::MethodCallNode).calls(files, "get")

--- a/python/ql/test/library-tests/frameworks/flask/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/taint_test.py
@@ -189,6 +189,7 @@ def test_taint(name = "World!", number="0", foo="foo"):  # $requestHandler route
     a = request.args
     b = a
     gl = b.getlist
+    files = request.files
     ensure_tainted(
         request.args, # $ tainted
         a, # $ tainted
@@ -202,6 +203,8 @@ def test_taint(name = "World!", number="0", foo="foo"):  # $requestHandler route
         a.getlist('key'), # $ tainted
         b.getlist('key'), # $ tainted
         gl('key'), # $ tainted
+
+        files.get('key').filename, # $ MISSING: tainted
     )
 
     # aliasing tests

--- a/python/ql/test/library-tests/frameworks/flask/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/flask/taint_test.py
@@ -204,7 +204,7 @@ def test_taint(name = "World!", number="0", foo="foo"):  # $requestHandler route
         b.getlist('key'), # $ tainted
         gl('key'), # $ tainted
 
-        files.get('key').filename, # $ MISSING: tainted
+        files.get('key').filename, # $ tainted
     )
 
     # aliasing tests


### PR DESCRIPTION
Spotted when looking over [this part](https://github.com/github/codeql/pull/8693/files/4e5afab08232e8d724f054e8360d19d817893f30..50bfc8eaa09592b22826d50ee6f7a0e896c4f9de#diff-8b08a136e9cfca3a648e75cd69ebe5ebd15b9911381e3b0ac8fb5a73354b8255L424) of @erik-krogh s API graph refactoring PR.