### PR TITLE
Ruby: Fix `isLocalSourceNode` implementation

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -302,6 +302,11 @@ private module Cached {
     or
     n instanceof PostUpdateNodes::ExprPostUpdateNode
     or
+    // TODO: Explain why SynthReturnNode is needed!
+    // if we don't include this, we are not able to find this call:
+    // https://github.com/github/codeql/blob/976daddd36a63bf46836d141d04172e90bb4b33c/ruby/ql/test/library-tests/frameworks/http_clients/NetHttp.rb#L24
+    n instanceof SynthReturnNode
+    or
     // Expressions that can't be reached from another entry definition or expression.
     n instanceof ExprNode and
     not localFlowStepTypeTracker+(any(Node n0 |

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -302,13 +302,7 @@ private module Cached {
     or
     n instanceof PostUpdateNodes::ExprPostUpdateNode
     or
-    // TODO: Explain why SynthReturnNode is needed!
-    // if we don't include this, we are not able to find this call:
-    // https://github.com/github/codeql/blob/976daddd36a63bf46836d141d04172e90bb4b33c/ruby/ql/test/library-tests/frameworks/http_clients/NetHttp.rb#L24
-    n instanceof SynthReturnNode
-    or
-    // Expressions that can't be reached from another entry definition or expression.
-    n instanceof ExprNode and
+    // Nodes that can't be reached from another entry definition or expression.
     not localFlowStepTypeTracker+(any(Node n0 |
         n0 instanceof ExprNode
         or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -303,11 +303,12 @@ private module Cached {
     n instanceof PostUpdateNodes::ExprPostUpdateNode
     or
     // Expressions that can't be reached from another entry definition or expression.
+    n instanceof ExprNode and
     not localFlowStepTypeTracker+(any(Node n0 |
         n0 instanceof ExprNode
         or
         entrySsaDefinition(n0)
-      ), n.(ExprNode))
+      ), n)
     or
     // Ensure all entry SSA definitions are local sources -- for parameters, this
     // is needed by type tracking. Note that when the parameter has a default value,

--- a/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-tracker/TypeTracker.expected
@@ -43,10 +43,6 @@ track
 | type_tracker.rb:12:1:16:3 | self in m | type tracker with call steps | type_tracker.rb:12:1:16:3 | self (m) |
 | type_tracker.rb:12:1:16:3 | self in m | type tracker without call steps | type_tracker.rb:12:1:16:3 | self in m |
 | type_tracker.rb:13:5:13:7 | var | type tracker without call steps | type_tracker.rb:13:5:13:7 | var |
-| type_tracker.rb:13:5:13:23 | ... = ... | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
-| type_tracker.rb:13:5:13:23 | ... = ... | type tracker with call steps | type_tracker.rb:2:5:5:7 | self in field= |
-| type_tracker.rb:13:5:13:23 | ... = ... | type tracker with call steps | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:13:5:13:23 | ... = ... | type tracker without call steps | type_tracker.rb:13:5:13:23 | ... = ... |
 | type_tracker.rb:13:11:13:19 | Container | type tracker without call steps | type_tracker.rb:13:11:13:19 | Container |
 | type_tracker.rb:13:11:13:19 | [post] Container | type tracker without call steps | type_tracker.rb:13:11:13:19 | [post] Container |
 | type_tracker.rb:13:11:13:23 | call to new | type tracker with call steps | type_tracker.rb:2:5:5:7 | self (field=) |
@@ -63,7 +59,6 @@ track
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:14:17:14:23 | "hello" |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps | type_tracker.rb:15:10:15:18 | call to field |
 | type_tracker.rb:14:17:14:23 | "hello" | type tracker without call steps with content field | type_tracker.rb:14:5:14:7 | [post] var |
-| type_tracker.rb:14:17:14:23 | ... = ... | type tracker without call steps | type_tracker.rb:14:17:14:23 | ... = ... |
 | type_tracker.rb:14:17:14:23 | [post] ... = ... | type tracker without call steps | type_tracker.rb:14:17:14:23 | [post] ... = ... |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type tracker without call steps | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:15:5:15:18 | [post] self | type tracker without call steps | type_tracker.rb:15:5:15:18 | [post] self |
@@ -245,14 +240,6 @@ trackEnd
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:12:1:16:3 | self in m |
 | type_tracker.rb:12:1:16:3 | self in m | type_tracker.rb:15:5:15:18 | self |
 | type_tracker.rb:13:5:13:7 | var | type_tracker.rb:13:5:13:7 | var |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:2:5:5:7 | self (field=) |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:2:5:5:7 | self in field= |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:3:9:3:23 | self |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:3:14:3:17 | self |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:7:5:9:7 | self in field |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:13:5:13:23 | ... = ... |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:14:5:14:7 | var |
-| type_tracker.rb:13:5:13:23 | ... = ... | type_tracker.rb:15:10:15:12 | var |
 | type_tracker.rb:13:11:13:19 | Container | type_tracker.rb:13:11:13:19 | Container |
 | type_tracker.rb:13:11:13:19 | [post] Container | type_tracker.rb:13:11:13:19 | [post] Container |
 | type_tracker.rb:13:11:13:23 | call to new | type_tracker.rb:2:5:5:7 | self (field=) |
@@ -280,9 +267,6 @@ trackEnd
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | ... = ... |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:14:17:14:23 | ... = ... |
 | type_tracker.rb:14:17:14:23 | "hello" | type_tracker.rb:15:10:15:18 | call to field |
-| type_tracker.rb:14:17:14:23 | ... = ... | type_tracker.rb:14:5:14:13 | __synth__0 |
-| type_tracker.rb:14:17:14:23 | ... = ... | type_tracker.rb:14:5:14:23 | ... |
-| type_tracker.rb:14:17:14:23 | ... = ... | type_tracker.rb:14:17:14:23 | ... = ... |
 | type_tracker.rb:14:17:14:23 | [post] ... = ... | type_tracker.rb:14:17:14:23 | [post] ... = ... |
 | type_tracker.rb:14:17:14:23 | __synth__0 | type_tracker.rb:14:17:14:23 | __synth__0 |
 | type_tracker.rb:15:5:15:18 | [post] self | type_tracker.rb:15:5:15:18 | [post] self |


### PR DESCRIPTION
The old code was equivalent with the code below, which seems wrong

```
not n instanceof ExprNode
or
n instanceof ExprNode and
localFlowStepTypeTracker+(..., n)
```

From running on real DB I found that this meant that the following node
types were also included as local source nodes:

- `TReturningNode`
- `TSynthReturnNode`
- `TSummaryNode`
- `TSsaDefinitionNode`

It turned out that `TSynthReturnNode` was required for sure (but I don't fully undestand why), while the others don't immediately seems to be. 

@hvitved I've requested a review from you, since you seem to have been touching this code last. If you think it looks good, once we have filled out proper documentation for the TODO I left in the code, we can take it out of draft :+1: