### PR TITLE
JS: exclude ATM folder from labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@ Java:
   - change-notes/**/*java.*
 
 JS:
-  - javascript/**/*
+  - any: [ 'javascript/**/*', '!javascript/ql/experimental/adaptivethreatmodeling/**/*' ]
   - change-notes/**/*javascript*
 
 Python:


### PR DESCRIPTION
This pull request changes the configuration of the Pull request labeler  workflow to no longer add the `JS` label on files related to `adaptivethreatmodeling` . The labeler workflow uses a `pull_request_target` trigger which means it will use the workflow definition from the default branch. This means the changes in this PR have no effect until they are merged into the `main` branch.

To test this pull request I pushed the same changes directly to `main` on my [forked repo](https://github.com/aibaars/codeql/commit/c7b2da5e3916473a7b35aceb9602bdb3000819fe) and made a couple of draft pull requests to check that the labeler works as expected:
* https://github.com/aibaars/codeql/pull/14
* https://github.com/aibaars/codeql/pull/15
* https://github.com/aibaars/codeql/pull/16 
* https://github.com/aibaars/codeql/pull/17