### PR TITLE
C++: Add support for SAX2XMLReader in the CWE-611 XXE query.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -185,8 +185,9 @@ class FeatureDisableDefaultEntityResolution extends Variable {
 }
 
 /**
- * A flow state transformer for a call to `SAX2XMLReader.setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, *)`. Transforms the flow
- * state through the qualifier according to this setting.
+ * A flow state transformer for a call to `SAX2XMLReader.setFeature`
+ * specifying the feature `XMLUni::fgXercesDisableDefaultEntityResolution`.
+ * Transforms the flow state through the qualifier according to this setting.
  */
 class SetFeatureTranformer extends XXEFlowStateTranformer {
   Expr newValue;

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -60,15 +60,15 @@ class XercesDOMParserClass extends Class {
 /**
  * The `SAXParser` class.
  */
-class SAXParserClass extends Class {
-  SAXParserClass() { this.hasName("SAXParser") }
+class SaxParserClass extends Class {
+  SaxParserClass() { this.hasName("SAXParser") }
 }
 
 /**
  * The `SAX2XMLReader` class.
  */
-class SAX2XMLReader extends Class {
-  SAX2XMLReader() { this.hasName("SAX2XMLReader") }
+class Sax2XmlReader extends Class {
+  Sax2XmlReader() { this.hasName("SAX2XMLReader") }
 }
 
 /**
@@ -120,7 +120,7 @@ class DisableDefaultEntityResolutionTranformer extends XXEFlowStateTranformer {
       call.getTarget() = f and
       (
         f.getDeclaringType() instanceof AbstractDOMParserClass or
-        f.getDeclaringType() instanceof SAXParserClass
+        f.getDeclaringType() instanceof SaxParserClass
       ) and
       f.hasName("setDisableDefaultEntityResolution") and
       this = call.getQualifier() and
@@ -195,7 +195,7 @@ class SetFeatureTranformer extends XXEFlowStateTranformer {
   SetFeatureTranformer() {
     exists(Call call, Function f |
       call.getTarget() = f and
-      f.getDeclaringType() instanceof SAX2XMLReader and
+      f.getDeclaringType() instanceof Sax2XmlReader and
       f.hasName("setFeature") and
       this = call.getQualifier() and
       globalValueNumber(call.getArgument(0)).getAnExpr().(VariableAccess).getTarget() instanceof
@@ -225,8 +225,8 @@ class SetFeatureTranformer extends XXEFlowStateTranformer {
 class ParseFunction extends Function {
   ParseFunction() {
     this.getClassAndName("parse") instanceof AbstractDOMParserClass or
-    this.getClassAndName("parse") instanceof SAXParserClass or
-    this.getClassAndName("parse") instanceof SAX2XMLReader
+    this.getClassAndName("parse") instanceof SaxParserClass or
+    this.getClassAndName("parse") instanceof Sax2XmlReader
   }
 }
 
@@ -245,10 +245,10 @@ class CreateLSParser extends Function {
  * The `createXMLReader` function that returns a newly created `SAX2XMLReader`
  * object.
  */
-class CreateXMLReader extends Function {
-  CreateXMLReader() {
+class CreateXmlReader extends Function {
+  CreateXmlReader() {
     this.hasName("createXMLReader") and
-    this.getUnspecifiedType().(PointerType).getBaseType() instanceof SAX2XMLReader // returns a `SAX2XMLReader *`.
+    this.getUnspecifiedType().(PointerType).getBaseType() instanceof Sax2XmlReader // returns a `SAX2XMLReader *`.
   }
 }
 
@@ -314,7 +314,7 @@ class XXEConfiguration extends DataFlow::Configuration {
     // source is the write on `this` of a call to the `SAXParser`
     // constructor.
     exists(CallInstruction call |
-      call.getStaticCallTarget() = any(SAXParserClass c).getAConstructor() and
+      call.getStaticCallTarget() = any(SaxParserClass c).getAConstructor() and
       node.asInstruction().(WriteSideEffectInstruction).getDestinationAddress() =
         call.getThisArgument() and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
@@ -322,7 +322,7 @@ class XXEConfiguration extends DataFlow::Configuration {
     or
     // source is the result of a call to `createXMLReader`.
     exists(Call call |
-      call.getTarget() instanceof CreateXMLReader and
+      call.getTarget() instanceof CreateXmlReader and
       call = node.asExpr() and
       encodeXercesFlowState(flowstate, 0, 1) // default configuration
     )

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -153,8 +153,7 @@ class CreateEntityReferenceNodesTranformer extends XXEFlowStateTranformer {
   CreateEntityReferenceNodesTranformer() {
     exists(Call call, Function f |
       call.getTarget() = f and
-      f.getDeclaringType() instanceof AbstractDOMParserClass and
-      f.hasName("setCreateEntityReferenceNodes") and
+      f.getClassAndName("setCreateEntityReferenceNodes") instanceof AbstractDOMParserClass and
       this = call.getQualifier() and
       newValue = call.getArgument(0)
     )
@@ -195,8 +194,7 @@ class SetFeatureTranformer extends XXEFlowStateTranformer {
   SetFeatureTranformer() {
     exists(Call call, Function f |
       call.getTarget() = f and
-      f.getDeclaringType() instanceof Sax2XmlReader and
-      f.hasName("setFeature") and
+      f.getClassAndName("setFeature") instanceof Sax2XmlReader and
       this = call.getQualifier() and
       globalValueNumber(call.getArgument(0)).getAnExpr().(VariableAccess).getTarget() instanceof
         FeatureDisableDefaultEntityResolution and

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -1,6 +1,9 @@
 edges
 | tests2.cpp:20:17:20:31 | SAXParser output argument | tests2.cpp:22:2:22:2 | p |
 | tests2.cpp:33:17:33:31 | SAXParser output argument | tests2.cpp:37:2:37:2 | p |
+| tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p |
+| tests3.cpp:60:21:60:53 | call to createXMLReader | tests3.cpp:63:2:63:2 | p |
+| tests3.cpp:67:21:67:53 | call to createXMLReader | tests3.cpp:70:2:70:2 | p |
 | tests.cpp:15:23:15:43 | XercesDOMParser output argument | tests.cpp:17:2:17:2 | p |
 | tests.cpp:28:23:28:43 | XercesDOMParser output argument | tests.cpp:31:2:31:2 | p |
 | tests.cpp:35:19:35:19 | VariableAddress [post update] | tests.cpp:37:2:37:2 | p |
@@ -32,6 +35,12 @@ nodes
 | tests2.cpp:22:2:22:2 | p | semmle.label | p |
 | tests2.cpp:33:17:33:31 | SAXParser output argument | semmle.label | SAXParser output argument |
 | tests2.cpp:37:2:37:2 | p | semmle.label | p |
+| tests3.cpp:23:21:23:53 | call to createXMLReader | semmle.label | call to createXMLReader |
+| tests3.cpp:25:2:25:2 | p | semmle.label | p |
+| tests3.cpp:60:21:60:53 | call to createXMLReader | semmle.label | call to createXMLReader |
+| tests3.cpp:63:2:63:2 | p | semmle.label | p |
+| tests3.cpp:67:21:67:53 | call to createXMLReader | semmle.label | call to createXMLReader |
+| tests3.cpp:70:2:70:2 | p | semmle.label | p |
 | tests4.cpp:26:34:26:48 | (int)... | semmle.label | (int)... |
 | tests4.cpp:36:34:36:50 | (int)... | semmle.label | (int)... |
 | tests4.cpp:46:34:46:68 | ... \| ... | semmle.label | ... \| ... |
@@ -76,6 +85,9 @@ subpaths
 #select
 | tests2.cpp:22:2:22:2 | p | tests2.cpp:20:17:20:31 | SAXParser output argument | tests2.cpp:22:2:22:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | SAXParser output argument | XML parser |
 | tests2.cpp:37:2:37:2 | p | tests2.cpp:33:17:33:31 | SAXParser output argument | tests2.cpp:37:2:37:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | SAXParser output argument | XML parser |
+| tests3.cpp:25:2:25:2 | p | tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | call to createXMLReader | XML parser |
+| tests3.cpp:63:2:63:2 | p | tests3.cpp:60:21:60:53 | call to createXMLReader | tests3.cpp:63:2:63:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:60:21:60:53 | call to createXMLReader | XML parser |
+| tests3.cpp:70:2:70:2 | p | tests3.cpp:67:21:67:53 | call to createXMLReader | tests3.cpp:70:2:70:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:67:21:67:53 | call to createXMLReader | XML parser |
 | tests4.cpp:26:34:26:48 | (int)... | tests4.cpp:26:34:26:48 | (int)... | tests4.cpp:26:34:26:48 | (int)... | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:26:34:26:48 | (int)... | XML parser |
 | tests4.cpp:36:34:36:50 | (int)... | tests4.cpp:36:34:36:50 | (int)... | tests4.cpp:36:34:36:50 | (int)... | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:36:34:36:50 | (int)... | XML parser |
 | tests4.cpp:46:34:46:68 | ... \| ... | tests4.cpp:46:34:46:68 | ... \| ... | tests4.cpp:46:34:46:68 | ... \| ... | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:46:34:46:68 | ... \| ... | XML parser |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests.h
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests.h
@@ -21,5 +21,6 @@ class XMLUni
 {
 public:
 	static const XMLCh fgXercesDisableDefaultEntityResolution[];
+	static const XMLCh fgXercesHarmlessOption[];
 };
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests3.cpp
@@ -55,3 +55,28 @@ void test3_5(InputSource &data) {
 	test3_5_init();
 	p_3_5->parse(data); // GOOD
 }
+
+void test3_6(InputSource &data) {
+	SAX2XMLReader *p = XMLReaderFactory::createXMLReader();
+
+	p->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, false);
+	p->parse(data); // BAD (parser not correctly configured) [NOT DETECTED]
+}
+
+void test3_7(InputSource &data) {
+	SAX2XMLReader *p = XMLReaderFactory::createXMLReader();
+
+	p->setFeature(XMLUni::fgXercesHarmlessOption, true);
+	p->parse(data); // BAD (parser not correctly configured) [NOT DETECTED]
+}
+
+void test3_8(InputSource &data) {
+	SAX2XMLReader *p = XMLReaderFactory::createXMLReader();
+	const XMLCh *feature = XMLUni::fgXercesDisableDefaultEntityResolution;
+
+	p->setFeature(feature, true);
+	p->parse(data); // GOOD
+}
+
+
+

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests3.cpp
@@ -60,14 +60,14 @@ void test3_6(InputSource &data) {
 	SAX2XMLReader *p = XMLReaderFactory::createXMLReader();
 
 	p->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, false);
-	p->parse(data); // BAD (parser not correctly configured) [NOT DETECTED]
+	p->parse(data); // BAD (parser not correctly configured)
 }
 
 void test3_7(InputSource &data) {
 	SAX2XMLReader *p = XMLReaderFactory::createXMLReader();
 
 	p->setFeature(XMLUni::fgXercesHarmlessOption, true);
-	p->parse(data); // BAD (parser not correctly configured) [NOT DETECTED]
+	p->parse(data); // BAD (parser not correctly configured)
 }
 
 void test3_8(InputSource &data) {


### PR DESCRIPTION
Support for `SAX2XMLReader` in the CWE-611 XXE query.

Change note covered by the one in recent PR https://github.com/github/codeql/pull/8948.