### PR TITLE
QL: add query warning about `count(...) = 0`. 

### DIFF
--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -81,11 +81,11 @@ class ExcludeTarFilePy extends Sanitizer {
 
 /* Any call to an extractall method */
 class ExtractAllSink extends TaintSink {
-  CallNode call;
-
   ExtractAllSink() {
-    this = call.getFunction().(AttrNode).getObject("extractall") and
-    not exists(call.getAnArg())
+    exists(CallNode call |
+      this = call.getFunction().(AttrNode).getObject("extractall") and
+      not exists(call.getAnArg())
+    )
   }
 
   override predicate sinks(TaintKind kind) { kind instanceof OpenTarFile }

--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -85,7 +85,7 @@ class ExtractAllSink extends TaintSink {
 
   ExtractAllSink() {
     this = call.getFunction().(AttrNode).getObject("extractall") and
-    count(call.getAnArg()) = 0
+    not exists(call.getAnArg())
   }
 
   override predicate sinks(TaintKind kind) { kind instanceof OpenTarFile }

--- a/python/ql/src/analysis/Consistency.ql
+++ b/python/ql/src/analysis/Consistency.ql
@@ -194,7 +194,7 @@ predicate function_object_consistency(string clsname, string problem, string wha
   exists(FunctionObject func | clsname = func.getAQlClass() |
     what = func.getName() and
     (
-      count(func.descriptiveString()) = 0 and problem = "no descriptiveString()"
+      not exists(func.descriptiveString()) and problem = "no descriptiveString()"
       or
       exists(int c | c = strictcount(func.descriptiveString()) and c > 1 |
         problem = c + "descriptiveString()s"

--- a/ql/ql/src/queries/performance/ClassPredicateDoesntMentionThis.ql
+++ b/ql/ql/src/queries/performance/ClassPredicateDoesntMentionThis.ql
@@ -40,7 +40,7 @@ predicate isLiteralComparison(ComparisonFormula eq) {
       or
       exists(NewTypeBranch nt |
         rhs.(Call).getTarget() = nt and
-        count(nt.getField(_)) = 0
+        not exists(nt.getField(_))
       )
     )
   )
@@ -69,7 +69,7 @@ predicate isSingleton(Type ty) {
   or
   isSingleton(ty.getASuperType())
   or
-  exists(NewTypeBranch br | count(br.getField(_)) = 0 |
+  exists(NewTypeBranch br | not exists(br.getField(_)) |
     ty.(NewTypeBranchType).getDeclaration() = br
     or
     br = unique(NewTypeBranch br2 | br2 = ty.(NewTypeType).getDeclaration().getABranch())

--- a/ql/ql/src/queries/style/CountingToZero.ql
+++ b/ql/ql/src/queries/style/CountingToZero.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Counting zero elements
+ * @description Use not exists instead of checking that there is zero elements in a set.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/counting-to-zero
+ * @precision high
+ */
+
+import ql
+
+from ComparisonFormula comp, int c, string msg
+where
+  c = 0 and // [0, 1] and // skipping the 1 case for now, as it seems too noisy.
+  comp.getOperator() = ["=", "!="] and
+  comp.getAnOperand().(Integer).getValue() = c and
+  comp.getAnOperand().(Aggregate).getKind() = ["count", "strictcount"] and
+  if c = 0
+  then msg = "Use not exists(..) instead of checking that there is zero elements in a set."
+  else msg = "Use unique(.. | |) instead of checking that there is one element in a set."
+select comp, msg


### PR DESCRIPTION
You should use `not exists(..)` instead of `count(...) = 0`. 

With `count(..) = 0` the evaluator will first check how many elements exists in a set, and afterwards check if that count equals 0.   
Using `not exists(..)` instead allows the optimizer to skip the counting.   
(I checked the RA, the optimizer does not optimize `count(..)  = 0` to `not exists(..)`). 

I originally made because I had the idea to replace `count(x)= 1` with `exists(unique(| | x))`, but I didn't like the results I got from that, so I've disabled that part of the query for now.  
(The `count(x) = 1` query got 200+ results). 

---- 

[Evaluation was ueventful](https://github.com/github/codeql-dca-main/tree/data/PR-9082-2-python__1/reports).  