### PR TITLE
Actions: Fetch CodeQL CLI using `gh` rather than third-party Action

### DIFF
--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -30,20 +30,14 @@ jobs:
       with:
         python-version: 3.8
     - name: Download CodeQL CLI
-      uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c
-      with:
-        repo: "github/codeql-cli-binaries"
-        version: "latest"
-        file: "codeql-linux64.zip"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./codeql/.github/actions/fetch-codeql
     - name: Unzip CodeQL CLI
       run: unzip -d codeql-cli codeql-linux64.zip
     - name: Build code scanning query list
       run: |
-        PATH="$PATH:codeql-cli/codeql" python codeql/misc/scripts/generate-code-scanning-query-list.py > code-scanning-query-list.csv
+        python codeql/misc/scripts/generate-code-scanning-query-list.py > code-scanning-query-list.csv
     - name: Upload code scanning query list
       uses: actions/upload-artifact@v3
       with:
         name: code-scanning-query-list
         path: code-scanning-query-list.csv
-    

--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Download CodeQL CLI
+      # Look under the `codeql` directory , as this is where we checked out the `github/codeql` repo
       uses: ./codeql/.github/actions/fetch-codeql
     - name: Unzip CodeQL CLI
       run: unzip -d codeql-cli codeql-linux64.zip

--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Download CodeQL CLI
-      # Look under the `codeql` directory , as this is where we checked out the `github/codeql` repo
+      # Look under the `codeql` directory, as this is where we checked out the `github/codeql` repo
       uses: ./codeql/.github/actions/fetch-codeql
     - name: Unzip CodeQL CLI
       run: unzip -d codeql-cli codeql-linux64.zip


### PR DESCRIPTION
We recently got a [Dependabot update](https://github.com/github/codeql/pull/9077) for this Action, but it probably makes more sense to remove it and standardise on `.github/actions/fetch-codeql`.