### PR TITLE
CPP: Add query for CWE-670: Always-Incorrect Control Flow Implementation when use SSL_shutdown 

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.cpp
@@ -1,0 +1,11 @@
+...
+SSL_shutdown(ssl); 
+SSL_shutdown(ssl); // BAD
+...
+    switch ((ret = SSL_shutdown(ssl))) {
+    case 1:
+      break;
+    case 0:
+      ERR_clear_error();
+      if (-1 != (ret = SSL_shutdown(ssl))) break; // GOOD
+...

--- a/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.qhelp
@@ -18,6 +18,10 @@
   CERT Coding Standard:
   <a href="https://wiki.sei.cmu.edu/confluence/display/c/EXP12-C.+Do+not+ignore+values+returned+by+functions">EXP12-C. Do not ignore values returned by functions - SEI CERT C Coding Standard - Confluence</a>.
 </li>
+<li>
+  Openssl.org:
+  <a href="https://www.openssl.org/docs/man3.0/man3/SSL_shutdown.html">SSL_shutdown - shut down a TLS/SSL connection</a>.
+</li>
 
 </references>
 </qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.qhelp
@@ -1,0 +1,23 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Incorrect closing of the connection leads to the creation of different states for the server and client, which can be exploited by an attacker.</p>
+
+</overview>
+
+<example>
+<p>The following example shows the incorrect and correct usage of function SSL_shutdown.</p>
+<sample src="DangerousUseSSL_shutdown.cpp" />
+
+</example>
+<references>
+
+<li>
+  CERT Coding Standard:
+  <a href="https://wiki.sei.cmu.edu/confluence/display/c/EXP12-C.+Do+not+ignore+values+returned+by+functions">EXP12-C. Do not ignore values returned by functions - SEI CERT C Coding Standard - Confluence</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql
@@ -1,0 +1,33 @@
+/**
+ * @name Dangerous use SSL_shutdown.
+ * @description Incorrect closing of the connection leads to the creation of different states for the server and client, which can be exploited by an attacker.
+ * @kind problem
+ * @id cpp/dangerous-use-of-ssl_shutdown
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-670
+ */
+
+import cpp
+import semmle.code.cpp.commons.Exclusions
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+
+from FunctionCall fc, FunctionCall fc1
+where
+  fc != fc1 and
+  fc.getASuccessor+() = fc1 and
+  fc.getTarget().hasName("SSL_shutdown") and
+  fc1.getTarget().hasName("SSL_shutdown") and
+  fc1 instanceof ExprInVoidContext and
+  (
+    globalValueNumber(fc.getArgument(0)) = globalValueNumber(fc1.getArgument(0)) or
+    fc.getArgument(0).(VariableAccess).getTarget() = fc1.getArgument(0).(VariableAccess).getTarget()
+  ) and
+  not exists(FunctionCall fctmp |
+    fctmp.getTarget().hasName("SSL_free") and
+    fc.getASuccessor+() = fctmp and
+    fctmp.getASuccessor+() = fc1
+  )
+select fc, "You need to handle the return value SSL_shutdown"

--- a/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql
@@ -2,7 +2,7 @@
  * @name Dangerous use SSL_shutdown.
  * @description Incorrect closing of the connection leads to the creation of different states for the server and client, which can be exploited by an attacker.
  * @kind problem
- * @id cpp/dangerous-use-of-ssl_shutdown
+ * @id cpp/dangerous-use-of-ssl-shutdown
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-670/semmle/tests/DangerousUseSSL_shutdown.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-670/semmle/tests/DangerousUseSSL_shutdown.expected
@@ -1,0 +1,2 @@
+| test.cpp:45:20:45:31 | call to SSL_shutdown | You need to handle the return value SSL_shutdown |
+| test.cpp:61:11:61:22 | call to SSL_shutdown | You need to handle the return value SSL_shutdown |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-670/semmle/tests/DangerousUseSSL_shutdown.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-670/semmle/tests/DangerousUseSSL_shutdown.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-670/DangerousUseSSL_shutdown.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-670/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-670/semmle/tests/test.cpp
@@ -1,0 +1,75 @@
+// it's not exact, but it's enough for an example
+typedef int SSL;
+
+
+int SSL_shutdown(SSL *ssl);
+int SSL_get_error(const SSL *ssl, int ret);
+void ERR_clear_error(void);
+void print_error(char *buff,int code);
+
+int gootTest1(SSL *ssl)
+{
+  int ret;
+    switch ((ret = SSL_shutdown(ssl))) {
+    case 1:
+      break;
+    case 0:
+      ERR_clear_error();
+      if ((ret = SSL_shutdown(ssl)) == 1) break; // GOOD
+    default:
+      print_error("error shutdown",
+        SSL_get_error(ssl, ret));
+      return -1;
+    }
+ return 0;
+}
+int gootTest2(SSL *ssl)
+{
+  int ret;
+    switch ((ret = SSL_shutdown(ssl))) {
+    case 1:
+      break;
+    case 0:
+      ERR_clear_error();
+      if (-1 != (ret = SSL_shutdown(ssl))) break; // GOOD
+    default:
+      print_error("error shutdown",
+        SSL_get_error(ssl, ret));
+      return -1;
+    }
+ return 0;
+}
+int badTest1(SSL *ssl)
+{
+  int ret;
+    switch ((ret = SSL_shutdown(ssl))) {
+    case 1:
+      break;
+    case 0:
+      SSL_shutdown(ssl); // BAD
+      break;
+    default:      
+      print_error("error shutdown",
+        SSL_get_error(ssl, ret));
+      return -1;
+    }
+ return 0;
+}
+int badTest2(SSL *ssl)
+{
+  int ret;
+    ret = SSL_shutdown(ssl);
+    switch (ret) {
+    case 1:
+      break;
+    case 0:
+      SSL_shutdown(ssl); // BAD
+      break;
+    default:
+      print_error("error shutdown",
+        SSL_get_error(ssl, ret));
+      return -1;
+    }
+ return 0;
+}
+


### PR DESCRIPTION
this query looks for improperly closed connections.

CVE-2008-1531

when the situations of calling the second function to close are not processed.