### PR TITLE
CPP: Add query for CWE-552 Files Accessible to External Parties when using rename

### DIFF
--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.cpp
@@ -2,6 +2,8 @@
 ...
   if (rename(from,to)==0) // BAD
     return;
+  f1 = fopen(from, "r");
+  f2 = fopen(to, "w");
 ...
   if (rename(from,to)==0) // GOOD
     return;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.cpp
@@ -1,0 +1,13 @@
+
+...
+  if (rename(from,to)==0) // BAD
+    return;
+  f1 = fopen(from, "r");
+  f2 = fopen(to, "w");
+...
+  if (rename(from,to)==0) // GOOD
+    return;
+  f1 = fopen(from, "r");
+  fd = open(to, O_WRONLY|O_CREAT|to_oflags, S_IRUSR|S_IWUSR);
+  f2 = fdopen(fd, "w");
+...

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.cpp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.cpp
@@ -2,8 +2,6 @@
 ...
   if (rename(from,to)==0) // BAD
     return;
-  f1 = fopen(from, "r");
-  f2 = fopen(to, "w");
 ...
   if (rename(from,to)==0) // GOOD
     return;

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>If the rename function did not work correctly, simply overwriting the destination file can lead to errors. Use access to the destination file with permission setting.</p>
+<p>If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file.</p>
 
 </overview>
 

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.qhelp
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.qhelp
@@ -1,0 +1,23 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>If the rename function did not work correctly, simply overwriting the destination file can lead to errors. Use access to the destination file with permission setting.</p>
+
+</overview>
+
+<example>
+<p>The following example shows the erroneous and corrected ways to work with the rename function.</p>
+<sample src="DangerousUseRename.cpp" />
+
+</example>
+<references>
+
+<li>
+  CERT Coding Standard:
+  <a href="https://wiki.sei.cmu.edu/confluence/display/c/FIO15-C.+Ensure+that+file+operations+are+performed+in+a+secure+directory">FIO15-C. Ensure that file operations are performed in a secure directory - SEI CERT C Coding Standard - Confluence</a>.
+</li>
+
+</references>
+</qhelp>

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -13,29 +13,20 @@
 import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
-/** Holds if the function argument is used in opening the file for reading. */
-predicate findFileForRead(FunctionCall fc, FunctionCall fc1) {
-  fc1.getTarget().hasGlobalOrStdOrBslName(["open", "fopen"]) and
+/** Holds if the function argument is used in opening the file for reading or writing. */
+predicate findFileForReadOrWrite(FunctionCall fc, FunctionCall fc1,string mode) {
+  fc1.getTarget().hasName(["open", "fopen"]) and
   globalValueNumber(fc1.getArgument(0)) = globalValueNumber(fc.getArgument(0)) and
-  fc1.getArgument(1).getValue() = "r" and
-  fc.getASuccessor+() = fc1
-}
-
-/** Holds if the function argument is used in opening the file for writing. */
-predicate findFileForWrite(FunctionCall fc, FunctionCall fc1) {
-  fc1.getTarget().hasGlobalOrStdOrBslName(["open", "fopen"]) and
-  globalValueNumber(fc1.getArgument(0)) = globalValueNumber(fc.getArgument(1)) and
-  fc1.getNumberOfArguments() = 2 and
-  fc1.getArgument(1).getValue() = "w" and
+  fc1.getArgument(1).getValue() = mode and
   fc.getASuccessor+() = fc1
 }
 
 from FunctionCall fc
 where
-  fc.getTarget().hasGlobalOrStdOrBslName("rename") and
+  fc.getTarget().hasName("rename") and
   exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall fc1, FunctionCall fc2 |
-    findFileForRead(fc, fc1) and
-    findFileForWrite(fc, fc2) and
+    findFileForReadOrWrite(fc, fc1, "r") and
+    findFileForReadOrWrite(fc, fc2, "w") and
     ec.getValue() = "0" and
     ecd = ifst.getCondition().getAChild*() and
     (

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -2,7 +2,7 @@
  * @name Dangerous use of rename
  * @description If the rename function did not work correctly, simply overwriting the destination file can lead to errors.
  * @kind problem
- * @id cpp/dangerous-use-rename
+ * @id cpp/dangerous-manual-copy-after-rename
  * @problem.severity warning
  * @precision medium
  * @tags correctness

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -31,7 +31,8 @@ where
     ecd = ifst.getCondition().getAChild*() and
     (
       globalValueNumber(ecd) = globalValueNumber(fc) and
-      not ecd.getParent() instanceof ComparisonOperation
+      not ecd.getParent() instanceof ComparisonOperation and
+      not ecd.getParent() instanceof NotExpr
       or
       exists(Expr evp |
         globalValueNumber(evp) = globalValueNumber(fc) and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -1,6 +1,6 @@
 /**
  * @name Dangerous use of rename
- * @description If the rename function did not work correctly, simply overwriting the destination file can lead to errors.
+ * @description If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file.
  * @kind problem
  * @id cpp/dangerous-manual-copy-after-rename
  * @problem.severity warning
@@ -55,4 +55,4 @@ where
     )
   )
 select fc,
-  "If the rename function did not work correctly, simply overwriting the destination file can lead to errors."
+  "If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file."

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -1,0 +1,66 @@
+/**
+ * @name Dangerous use rename.
+ * @description If the rename function did not work correctly, simply overwriting the destination file can lead to errors.
+ * @kind problem
+ * @id cpp/dangerous-use-rename
+ * @problem.severity warning
+ * @precision medium
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-552
+ */
+
+import cpp
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+
+/** Holds if the function argument is used in opening the file for reading. */
+predicate findFileForRead(FunctionCall fc, FunctionCall fc1) {
+  fc1.getTarget().hasGlobalOrStdOrBslName(["open", "fopen"]) and
+  globalValueNumber(fc1.getArgument(0)) = globalValueNumber(fc.getArgument(0)) and
+  fc1.getArgument(1).getValue() = "r" and
+  fc.getASuccessor+() = fc1
+}
+
+/** Holds if the function argument is used in opening the file for writing. */
+predicate findFileForWrite(FunctionCall fc, FunctionCall fc1) {
+  fc1.getTarget().hasGlobalOrStdOrBslName(["open", "fopen"]) and
+  globalValueNumber(fc1.getArgument(0)) = globalValueNumber(fc.getArgument(1)) and
+  fc1.getNumberOfArguments() = 2 and
+  fc1.getArgument(1).getValue() = "w" and
+  fc.getASuccessor+() = fc1
+}
+
+from FunctionCall fc
+where
+  fc.getTarget().hasGlobalOrStdOrBslName("rename") and
+  exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall fc1, FunctionCall fc2 |
+    findFileForRead(fc, fc1) and
+    findFileForWrite(fc, fc2) and
+    ec.getValue() = "0" and
+    ecd = ifst.getCondition().getAChild*() and
+    (
+      globalValueNumber(ecd) = globalValueNumber(fc) and
+      not ecd.getParent() instanceof ComparisonOperation
+      or
+      exists(Expr evp |
+        globalValueNumber(evp) = globalValueNumber(fc) and
+        ecd.(ComparisonOperation).hasOperands(evp, _)
+      )
+    ) and
+    (
+      ecd.(EQExpr).hasOperands(_, ec) and
+      forall(Expr st | st = ifst.getThen().getASuccessor*() | st != fc1) and
+      forall(Expr st | st = ifst.getThen().getASuccessor*() | st != fc2)
+      or
+      (
+        not ecd instanceof EQExpr
+        or
+        not ecd.(EQExpr).getLeftOperand().getValue() = "0" and
+        not ecd.(EQExpr).getRightOperand().getValue() = "0"
+      ) and
+      ifst.getThen() = fc1.getEnclosingStmt().getParentStmt*() and
+      ifst.getThen() = fc2.getEnclosingStmt().getParentStmt*()
+    )
+  )
+select fc,
+  "If the rename function did not work correctly, simply overwriting the destination file can lead to errors."

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -23,26 +23,26 @@ predicate findFileForReadOrWrite(FunctionCall fc, FunctionCall fc1, string mode,
 
 from FunctionCall renameCall
 where
-  fc.getTarget().hasName("rename") and
+  renameCall.getTarget().hasName("rename") and
   exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall readCall, FunctionCall writeCall |
-    findFileForReadOrWrite(fc, fc1, "r", 0) and
-    findFileForReadOrWrite(fc, fc2, "w", 1) and
+    findFileForReadOrWrite(renameCall, readCall, "r", 0) and
+    findFileForReadOrWrite(renameCall, writeCall, "w", 1) and
     ec.getValue() = "0" and
     ecd = ifst.getCondition().getAChild*() and
     (
-      globalValueNumber(ecd) = globalValueNumber(fc) and
+      globalValueNumber(ecd) = globalValueNumber(renameCall) and
       not ecd.getParent() instanceof ComparisonOperation and
       not ecd.getParent() instanceof NotExpr
       or
       exists(Expr evp |
-        globalValueNumber(evp) = globalValueNumber(fc) and
+        globalValueNumber(evp) = globalValueNumber(renameCall) and
         ecd.(ComparisonOperation).hasOperands(evp, _)
       )
     ) and
     (
       ecd.(EQExpr).hasOperands(_, ec) and
-      forall(Expr st | st = ifst.getThen().getASuccessor*() | st != fc1) and
-      forall(Expr st | st = ifst.getThen().getASuccessor*() | st != fc2)
+      forall(Expr st | st = ifst.getThen().getASuccessor*() | st != readCall) and
+      forall(Expr st | st = ifst.getThen().getASuccessor*() | st != writeCall)
       or
       (
         not ecd instanceof EQExpr
@@ -50,9 +50,9 @@ where
         not ecd.(EQExpr).getLeftOperand().getValue() = "0" and
         not ecd.(EQExpr).getRightOperand().getValue() = "0"
       ) and
-      ifst.getThen() = fc1.getEnclosingStmt().getParentStmt*() and
-      ifst.getThen() = fc2.getEnclosingStmt().getParentStmt*()
+      ifst.getThen() = readCall.getEnclosingStmt().getParentStmt*() and
+      ifst.getThen() = writeCall.getEnclosingStmt().getParentStmt*()
     )
   )
-select fc,
+select renameCall,
   "If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file."

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -27,7 +27,6 @@ where
   exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall readCall, FunctionCall writeCall |
     findFileForReadOrWrite(renameCall, readCall, "r", 0) and
     findFileForReadOrWrite(renameCall, writeCall, "w", 1) and
-    ec.getValue() = "0" and
     ecd = ifst.getCondition().getAChild*() and
     (
       globalValueNumber(ecd) = globalValueNumber(renameCall) and
@@ -40,6 +39,7 @@ where
       )
     ) and
     (
+      ec.getValue() = "0" and
       ecd.(EQExpr).hasOperands(_, ec) and
       forall(Expr st | st = ifst.getThen().getASuccessor*() | st != readCall) and
       forall(Expr st | st = ifst.getThen().getASuccessor*() | st != writeCall)

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -21,10 +21,10 @@ predicate findFileForReadOrWrite(FunctionCall fc, FunctionCall fc1, string mode,
   fc.getASuccessor+() = fc1
 }
 
-from FunctionCall fc
+from FunctionCall renameCall
 where
   fc.getTarget().hasName("rename") and
-  exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall fc1, FunctionCall fc2 |
+  exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall readCall, FunctionCall writeCall |
     findFileForReadOrWrite(fc, fc1, "r", 0) and
     findFileForReadOrWrite(fc, fc2, "w", 1) and
     ec.getValue() = "0" and

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -14,9 +14,9 @@ import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
 /** Holds if the function argument is used in opening the file for reading or writing. */
-predicate findFileForReadOrWrite(FunctionCall fc, FunctionCall fc1,string mode) {
+predicate findFileForReadOrWrite(FunctionCall fc, FunctionCall fc1, string mode, int na) {
   fc1.getTarget().hasName(["open", "fopen"]) and
-  globalValueNumber(fc1.getArgument(0)) = globalValueNumber(fc.getArgument(0)) and
+  globalValueNumber(fc1.getArgument(0)) = globalValueNumber(fc.getArgument(na)) and
   fc1.getArgument(1).getValue() = mode and
   fc.getASuccessor+() = fc1
 }
@@ -25,8 +25,8 @@ from FunctionCall fc
 where
   fc.getTarget().hasName("rename") and
   exists(IfStmt ifst, Expr ec, Expr ecd, FunctionCall fc1, FunctionCall fc2 |
-    findFileForReadOrWrite(fc, fc1, "r") and
-    findFileForReadOrWrite(fc, fc2, "w") and
+    findFileForReadOrWrite(fc, fc1, "r", 0) and
+    findFileForReadOrWrite(fc, fc2, "w", 1) and
     ec.getValue() = "0" and
     ecd = ifst.getCondition().getAChild*() and
     (

--- a/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-552/DangerousUseRename.ql
@@ -1,5 +1,5 @@
 /**
- * @name Dangerous use rename.
+ * @name Dangerous use of rename
  * @description If the rename function did not work correctly, simply overwriting the destination file can lead to errors.
  * @kind problem
  * @id cpp/dangerous-use-rename

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.expected
@@ -1,4 +1,3 @@
-| test.cpp:40:8:40:13 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
 | test.cpp:56:7:56:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
 | test.cpp:92:7:92:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
 | test.cpp:128:9:128:14 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.expected
@@ -1,5 +1,5 @@
-| test.cpp:56:7:56:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
-| test.cpp:92:7:92:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
-| test.cpp:128:9:128:14 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
-| test.cpp:146:9:146:14 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
-| test.cpp:165:7:165:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
+| test.cpp:56:7:56:12 | call to rename | If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file. |
+| test.cpp:92:7:92:12 | call to rename | If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file. |
+| test.cpp:128:9:128:14 | call to rename | If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file. |
+| test.cpp:146:9:146:14 | call to rename | If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file. |
+| test.cpp:165:7:165:12 | call to rename | If the rename function did not work correctly, attempting to copy the contents of a source file by opening the target file without assessing permissions creates a mechanism for deleting an arbitrary system file. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.expected
@@ -1,0 +1,6 @@
+| test.cpp:40:8:40:13 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
+| test.cpp:56:7:56:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
+| test.cpp:92:7:92:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
+| test.cpp:128:9:128:14 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
+| test.cpp:146:9:146:14 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |
+| test.cpp:165:7:165:12 | call to rename | If the rename function did not work correctly, simply overwriting the destination file can lead to errors. |

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.qlref
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/DangerousUseRename.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-552/DangerousUseRename.ql

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
@@ -26,7 +26,7 @@ void test1(const char *from,const char *to)
   f1 = fopen(from, "r");
   count = fread(data, 1, 1000, f1);
   fclose(f1);
-  rename(from,to); // GOOD
+  rename(from,to); // BAD [NOT DETECTED]
   f2 = fopen(to, "w");
   fclose(f2);
 }

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
@@ -37,7 +37,7 @@ void test2(const char *from,const char *to)
   char data[1000];
   int count;
   
-  if (!rename(from,to)) { // BAD
+  if (!rename(from,to)) { // GOOD
     f1 = fopen(from, "r");
     count = fread(data, 1, 1000, f1);
     fclose(f1);

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
@@ -1,0 +1,174 @@
+#define NULL 0
+
+typedef struct {} FILE;
+typedef	unsigned int	uint_t; 
+typedef	uint_t	mode_t;	
+typedef unsigned long size_t;
+
+FILE *fdopen(int handle, char *mode);
+FILE *fopen(const char *pathname, const char *mode);
+int fclose(FILE *stream);
+int open(const char *pathname, int flags);
+int open(const char *pathname, int flags, mode_t mode);
+int close(int file);
+FILE *fdopen(int handle, char *mode);
+int rename(const char *from, const char *to);
+bool remove(const char *path);
+int fread(char *buf, int size, int count, FILE *fp);
+size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream);
+
+void test1(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  f1 = fopen(from, "r");
+  count = fread(data, 1, 1000, f1);
+  fclose(f1);
+  rename(from,to); // GOOD
+  f2 = fopen(to, "w");
+  fclose(f2);
+}
+void test2(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  
+  if (!rename(from,to)) { // BAD
+    f1 = fopen(from, "r");
+    count = fread(data, 1, 1000, f1);
+    fclose(f1);
+    f2 = fopen(to, "w");
+    fwrite(data, count, 1, f2);
+    fclose(f2);
+  }
+}
+void test3(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  
+  if (rename(from,to)==-1) { // BAD : some time left to recreate the file
+    f1 = fopen(from, "r");
+    count = fread(data, 1, 1000, f1);
+    fclose(f1);
+    remove(to);
+    f2 = fopen(to, "w");
+    fwrite(data, count, 1, f2);
+    fclose(f2);
+  }
+}
+void test4(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  int fd;
+
+  if (rename(from,to)<0) { // GOOD
+    f1 = fopen(from, "r");
+    count = fread(data, 1, 1000, f1);
+    fclose(f1);
+    fd = open(to, 00000301, 0600);
+    f2 = fdopen(fd, "w");
+    fwrite(data, count, 1, f2);
+    fclose(f2);
+  }
+}
+
+void test5(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  
+  if (rename(from,to)==0) // BAD
+    return;
+  f1 = fopen(from, "r");
+  count = fread(data, 1, 1000, f1);
+  fclose(f1);
+  remove(to);
+  f2 = fopen(to, "w");
+  fwrite(data, count, 1, f2);
+  fclose(f2);
+}
+
+void test6(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  
+  if (rename(from,to)==0) { // GOOD
+    f1 = fopen(from, "r");
+    count = fread(data, 1, 1000, f1);
+    fclose(f1);
+    remove(to);
+    f2 = fopen(to, "w");
+    fwrite(data, count, 1, f2);
+    fclose(f2);
+  }
+  return;
+}
+void test7(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  int ret;
+  ret = rename(from,to); // BAD
+  if (ret==0)
+    return;
+  f1 = fopen(from, "r");
+  count = fread(data, 1, 1000, f1);
+  fclose(f1);
+  remove(to);
+  f2 = fopen(to, "w");
+  fwrite(data, count, 1, f2);
+  fclose(f2);
+}
+void test8(const char *from,const char *to,int flag)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  int ret;
+  ret = rename(from,to); // BAD
+  if (flag==5&&ret==0)
+    return;
+  f1 = fopen(from, "r");
+  count = fread(data, 1, 1000, f1);
+  fclose(f1);
+  remove(to);
+  f2 = fopen(to, "w");
+  fwrite(data, count, 1, f2);
+  fclose(f2);
+}
+void test9(const char *from,const char *to)
+{
+  FILE *f1 = NULL;
+  FILE *f2 = NULL;
+  char data[1000];
+  int count;
+  int fd;
+
+  if (rename(from,to)) { // BAD
+    f1 = fopen(from, "r");
+    count = fread(data, 1, 1000, f1);
+    fclose(f1);
+    remove(to);
+    f2 = fopen(to, "w");
+    fwrite(data, count, 1, f2);
+    fclose(f2);
+  }
+}

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-552/semmle/tests/test.cpp
@@ -71,7 +71,7 @@ void test4(const char *from,const char *to)
   int count;
   int fd;
 
-  if (rename(from,to)<0) { // GOOD
+  if (rename(from,to)<0) { // GOOD : opening a file for writing occurs using access flags.
     f1 = fopen(from, "r");
     count = fread(data, 1, 1000, f1);
     fclose(f1);


### PR DESCRIPTION
this query is looking for a mishandling situation rename. when a file is torn off from the program name and overwritten, this situation can lead to various actions, such as using links.

CVE-2012-0787