### PR TITLE
C#: Port the existing compiler-tracing.spec files to Lua.

### DIFF
--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -1,10 +1,7 @@
 function RegisterExtractorPack()
     local extractor = GetPlatformToolsDirectory() ..
                           'Semmle.Extraction.CSharp.Driver'
-    if OperatingSystem == 'windows' then
-        extractor = GetPlatformToolsDirectory() ..
-                        'Semmle.Extraction.CSharp.Driver.exe'
-    end
+    if OperatingSystem == 'windows' then extractor = extractor .. '.exe' end
     local windowsMatchers = {
         CreatePatternMatcher({'^dotnet%.exe$'}, MatchCompilerName, extractor,
                              {prepend = {'--dotnetexec', '--cil'}}),

--- a/csharp/tools/tracing-config.lua
+++ b/csharp/tools/tracing-config.lua
@@ -1,0 +1,55 @@
+function RegisterExtractorPack()
+    local extractor = GetPlatformToolsDirectory() ..
+                          'Semmle.Extraction.CSharp.Driver'
+    if OperatingSystem == 'windows' then
+        extractor = GetPlatformToolsDirectory() ..
+                        'Semmle.Extraction.CSharp.Driver.exe'
+    end
+    local windowsMatchers = {
+        CreatePatternMatcher({'^dotnet%.exe$'}, MatchCompilerName, extractor,
+                             {prepend = {'--dotnetexec', '--cil'}}),
+        CreatePatternMatcher({'^csc.*%.exe$'}, MatchCompilerName, extractor, {
+            prepend = {'--compiler', '"${compiler}"', '--cil'}
+        }),
+        CreatePatternMatcher({'^fakes.*%.exe$', 'moles.*%.exe'},
+                             MatchCompilerName, nil, {trace = false})
+    }
+    local posixMatchers = {
+        CreatePatternMatcher({'^mcs%.exe$', '^csc%.exe$'}, MatchCompilerName,
+                             extractor, {
+            prepend = {'--compiler', '"${compiler}"', '--cil'}
+        }),
+        CreatePatternMatcher({'^mono', '^dotnet$'}, MatchCompilerName,
+                             extractor, {prepend = {'--dotnetexec', '--cil'}}),
+        function(compilerName, compilerPath, compilerArguments, _languageId)
+            if MatchCompilerName('^msbuild$', compilerName, compilerPath,
+                                 compilerArguments) or
+                MatchCompilerName('^xbuild$', compilerName, compilerPath,
+                                  compilerArguments) then
+                return {
+                    replace = true,
+                    invocations = {
+                        {
+                            path = compilerPath,
+                            transformedArguments = {
+                                nativeArgumentPointer = compilerArguments['nativeArgumentPointer'],
+                                append = {'/p:UseSharedCompilation=false'},
+                                prepend = {}
+                            }
+                        }
+                    }
+                }
+            end
+        end
+    }
+    if OperatingSystem == 'windows' then
+        return windowsMatchers
+    else
+        return posixMatchers
+    end
+
+end
+
+-- Return a list of minimum supported versions of the configuration file format
+-- return one entry per supported major version.
+function GetCompatibleVersions() return {'1.0.0'} end


### PR DESCRIPTION
Right now, this is an unmodified port, without the additional functionality for `dotnet build` that we envision.

This means that we can switch back and forth between Lua and legacy tracing (ideally) without user-impacting differences.