### PR TITLE
Swift: changes required for TBD node rework

### DIFF
--- a/swift/codegen/cppgen.py
+++ b/swift/codegen/cppgen.py
@@ -27,7 +27,7 @@ def _get_field(cls: schema.Class, p: schema.Property, trap_affix: str) -> cpp.Fi
         if not p.is_predicate:
             trap_name = inflection.pluralize(trap_name)
     args = dict(
-        name=p.name + ("_" if p.name in cpp.cpp_keywords else ""),
+        field_name=p.name + ("_" if p.name in cpp.cpp_keywords else ""),
         type=_get_type(p.type, trap_affix),
         is_optional=p.is_optional,
         is_repeated=p.is_repeated,

--- a/swift/codegen/lib/cpp.py
+++ b/swift/codegen/lib/cpp.py
@@ -17,7 +17,7 @@ cpp_keywords = {"alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel", "
 
 _field_overrides = [
     (re.compile(r"(start|end)_(line|column)|index|width|num_.*"), {"type": "unsigned"}),
-    (re.compile(r"(.*)_"), lambda m: {"name": m[1]}),
+    (re.compile(r"(.*)_"), lambda m: {"field_name": m[1]}),
 ]
 
 
@@ -31,7 +31,7 @@ def get_field_override(field: str):
 
 @dataclass
 class Field:
-    name: str
+    field_name: str
     type: str
     is_optional: bool = False
     is_repeated: bool = False
@@ -44,12 +44,8 @@ class Field:
             self.type = f"std::optional<{self.type}>"
         if self.is_repeated:
             self.type = f"std::vector<{self.type}>"
-
-    @property
-    def cpp_name(self):
-        if self.name in cpp_keywords:
-            return self.name + "_"
-        return self.name
+        if self.field_name in cpp_keywords:
+            self.field_name += "_"
 
     # using @property breaks pystache internals here
     def get_streamer(self):
@@ -63,8 +59,6 @@ class Field:
     @property
     def is_single(self):
         return not (self.is_optional or self.is_repeated or self.is_predicate)
-
-
 
 
 @dataclass

--- a/swift/codegen/lib/schema.py
+++ b/swift/codegen/lib/schema.py
@@ -92,7 +92,6 @@ def load(path):
         data = yaml.load(input, Loader=yaml.SafeLoader)
     grouper = _DirSelector(data.get("_directories", {}).items())
     classes = {root_class_name: Class(root_class_name)}
-    assert root_class_name not in data
     classes.update((cls, Class(cls, dir=grouper.get(cls))) for cls in data if not cls.startswith("_"))
     for name, info in data.items():
         if name.startswith("_"):
@@ -110,7 +109,7 @@ def load(path):
                     classes[base].derived.add(name)
             elif k == "_dir":
                 cls.dir = pathlib.Path(v)
-        if not cls.bases:
+        if not cls.bases and cls.name != root_class_name:
             cls.bases.add(root_class_name)
             classes[root_class_name].derived.add(name)
 

--- a/swift/codegen/templates/cpp_classes.mustache
+++ b/swift/codegen/templates/cpp_classes.mustache
@@ -14,7 +14,7 @@ namespace {{namespace}} {
 
 struct {{name}}{{#final}} : Binding<{{name}}Tag>{{#bases}}, {{ref.name}}{{/bases}}{{/final}}{{^final}}{{#has_bases}}: {{#bases}}{{^first}}, {{/first}}{{ref.name}}{{/bases}}{{/has_bases}}{{/final}} {
   {{#fields}}
-  {{type}} {{name}}{};
+  {{type}} {{field_name}}{};
   {{/fields}}
   {{#final}}
 
@@ -27,27 +27,27 @@ struct {{name}}{{#final}} : Binding<{{name}}Tag>{{#bases}}, {{ref.name}}{{/bases
  protected:
   void emit({{^final}}{{trap_affix}}Label<{{name}}Tag> id, {{/final}}std::ostream& out) const {
     {{#trap_name}}
-    out << {{.}}{{trap_affix}}{id{{#single_fields}}, {{name}}{{/single_fields}}} << '\n';
+    out << {{.}}{{trap_affix}}{id{{#single_fields}}, {{field_name}}{{/single_fields}}} << '\n';
     {{/trap_name}}
     {{#bases}}
     {{ref.name}}::emit(id, out);
     {{/bases}}
     {{#fields}}
     {{#is_predicate}}
-    if ({{name}}) out << {{trap_name}}{{trap_affix}}{id} << '\n';
+    if ({{field_name}}) out << {{trap_name}}{{trap_affix}}{id} << '\n';
     {{/is_predicate}}
     {{#is_optional}}
     {{^is_repeated}}
-    if ({{name}}) out << {{trap_name}}{{trap_affix}}{id, *{{name}}} << '\n';
+    if ({{field_name}}) out << {{trap_name}}{{trap_affix}}{id, *{{field_name}}} << '\n';
     {{/is_repeated}}
     {{/is_optional}}
     {{#is_repeated}}
-    for (auto i = 0u; i < {{name}}.size(); ++i) {
+    for (auto i = 0u; i < {{field_name}}.size(); ++i) {
       {{^is_optional}}
-      out << {{trap_name}}{{trap_affix}}{id, i, {{name}}[i]};
+      out << {{trap_name}}{{trap_affix}}{id, i, {{field_name}}[i]};
       {{/is_optional}}
       {{#is_optional}}
-      if ({{name}}[i]) out << {{trap_name}}{{trap_affix}}{id, i, *{{name}}[i]};
+      if ({{field_name}}[i]) out << {{trap_name}}{{trap_affix}}{id, i, *{{field_name}}[i]};
       {{/is_optional}}
     }
     {{/is_repeated}}

--- a/swift/codegen/templates/ql_class.mustache
+++ b/swift/codegen/templates/ql_class.mustache
@@ -8,6 +8,8 @@ class {{name}}Base extends {{db_id}}{{#bases}}, {{.}}{{/bases}} {
   {{#root}}
   string toString() { none() } // overridden by subclasses
 
+  string getPrimaryQlClass() { none() } // overridden by subclasses
+
   {{name}}Base getResolveStep() { none() } // overridden by subclasses
 
   {{name}}Base resolve() {
@@ -17,7 +19,7 @@ class {{name}}Base extends {{db_id}}{{#bases}}, {{.}}{{/bases}} {
   }
   {{/root}}
   {{#final}}
-  override string toString() { result = "{{name}}" }
+  override string getPrimaryQlClass() { result = "{{name}}" }
   {{/final}}
   {{#properties}}
 
@@ -32,6 +34,12 @@ class {{name}}Base extends {{db_id}}{{#bases}}, {{.}}{{/bases}} {
     {{tablename}}({{#tableparams}}{{^first}}, {{/first}}{{param}}{{/tableparams}})
     {{/type_is_class}}
   }
+  {{#is_optional}}
+
+  predicate has{{singular}}({{#is_repeated}}int index{{/is_repeated}}) {
+    exists({{getter}}({{#is_repeated}}index{{/is_repeated}}))
+  }
+  {{/is_optional}}
   {{#is_repeated}}
 
   {{type}} {{indefinite_getter}}() {

--- a/swift/codegen/templates/trap_traps.mustache
+++ b/swift/codegen/templates/trap_traps.mustache
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "{{include_dir}}/{{trap_affix}}Label.h"
+#include "{{include_dir}}/{{trap_affix}}TagTraits.h"
 #include "./{{trap_affix}}Tags.h"
 
 namespace {{namespace}} {
@@ -15,19 +16,25 @@ namespace {{namespace}} {
 struct {{name}}{{trap_affix}} {
   static constexpr bool is_binding = {{#id}}true{{/id}}{{^id}}false{{/id}};
 {{#id}}
-  {{type}} getBoundLabel() const { return {{cpp_name}}; }
+  {{type}} getBoundLabel() const { return {{field_name}}; }
 {{/id}}
 
 {{#fields}}
-  {{type}} {{cpp_name}}{};
+  {{type}} {{field_name}}{};
 {{/fields}}
 };
 
 inline std::ostream &operator<<(std::ostream &out, const {{name}}{{trap_affix}} &e) {
   out << "{{table_name}}("{{#fields}}{{^first}} << ", "{{/first}}
-      << {{#get_streamer}}e.{{cpp_name}}{{/get_streamer}}{{/fields}} << ")";
+      << {{#get_streamer}}e.{{field_name}}{{/get_streamer}}{{/fields}} << ")";
   return out;
 }
-{{/traps}}
+{{#id}}
 
+template <>
+struct TagToBindingTrapFunctor<typename {{type}}::Tag> {
+  using type = {{name}}{{trap_affix}};
+};
+{{/id}}
+{{/traps}}
 }

--- a/swift/codegen/test/test_cpp.py
+++ b/swift/codegen/test/test_cpp.py
@@ -7,14 +7,14 @@ from swift.codegen.lib import cpp
 
 
 @pytest.mark.parametrize("keyword", cpp.cpp_keywords)
-def test_field_keyword_cpp_name(keyword):
+def test_field_keyword_name(keyword):
     f = cpp.Field(keyword, "int")
-    assert f.cpp_name == keyword + "_"
+    assert f.field_name == keyword + "_"
 
 
-def test_field_cpp_name():
+def test_field_name():
     f = cpp.Field("foo", "int")
-    assert f.cpp_name == "foo"
+    assert f.field_name == "foo"
 
 
 @pytest.mark.parametrize("type,expected", [

--- a/swift/codegen/test/test_schema.py
+++ b/swift/codegen/test/test_schema.py
@@ -155,5 +155,17 @@ A:
     ]
 
 
+def test_element_properties(load):
+    ret = load("""
+Element:
+    x: string
+""")
+    assert ret.classes == [
+        schema.Class(root_name, properties=[
+            schema.SingleProperty('x', 'string'),
+         ]),
+    ]
+
+
 if __name__ == '__main__':
     sys.exit(pytest.main([__file__] + sys.argv[1:]))

--- a/swift/codegen/trapgen.py
+++ b/swift/codegen/trapgen.py
@@ -28,7 +28,7 @@ def get_cpp_type(schema_type: str, trap_affix: str):
 
 def get_field(c: dbscheme.Column, trap_affix: str):
     args = {
-        "name": c.schema_name,
+        "field_name": c.schema_name,
         "type": c.type,
     }
     args.update(cpp.get_field_override(c.schema_name))

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -27,7 +27,7 @@ class UntypedTrapLabel {
   friend bool operator==(UntypedTrapLabel lhs, UntypedTrapLabel rhs) { return lhs.id_ == rhs.id_; }
 };
 
-template <typename Tag>
+template <typename TagParam>
 class TrapLabel : public UntypedTrapLabel {
   template <typename OtherTag>
   friend class TrapLabel;
@@ -35,6 +35,8 @@ class TrapLabel : public UntypedTrapLabel {
   using UntypedTrapLabel::UntypedTrapLabel;
 
  public:
+  using Tag = TagParam;
+
   TrapLabel() = default;
 
   template <typename OtherTag>

--- a/swift/extractor/trap/TrapTagTraits.h
+++ b/swift/extractor/trap/TrapTagTraits.h
@@ -2,7 +2,7 @@
 
 #include <type_traits>
 
-namespace codeql::trap {
+namespace codeql {
 
 template <typename T>
 struct ToTagFunctor;
@@ -12,4 +12,10 @@ struct ToTagOverride : ToTagFunctor<T> {};
 template <typename T>
 using ToTag = typename ToTagOverride<std::remove_const_t<T>>::type;
 
-}  // namespace codeql::trap
+template <typename T>
+struct TagToBindingTrapFunctor;
+
+template <typename Tag>
+using TagToBindingTrap = typename TagToBindingTrapFunctor<Tag>::type;
+
+}  // namespace codeql

--- a/swift/ql/lib/codeql/swift/generated/Element.qll
+++ b/swift/ql/lib/codeql/swift/generated/Element.qll
@@ -2,6 +2,8 @@
 class ElementBase extends @element {
   string toString() { none() } // overridden by subclasses
 
+  string getPrimaryQlClass() { none() } // overridden by subclasses
+
   ElementBase getResolveStep() { none() } // overridden by subclasses
 
   ElementBase resolve() {

--- a/swift/ql/lib/codeql/swift/generated/File.qll
+++ b/swift/ql/lib/codeql/swift/generated/File.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.Element
 
 class FileBase extends @file, Element {
-  override string toString() { result = "File" }
+  override string getPrimaryQlClass() { result = "File" }
 
   string getName() { files(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/Location.qll
+++ b/swift/ql/lib/codeql/swift/generated/Location.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.Element
 import codeql.swift.elements.File
 
 class LocationBase extends @location, Element {
-  override string toString() { result = "Location" }
+  override string getPrimaryQlClass() { result = "Location" }
 
   File getFile() {
     exists(File x |

--- a/swift/ql/lib/codeql/swift/generated/UnknownAstNode.qll
+++ b/swift/ql/lib/codeql/swift/generated/UnknownAstNode.qll
@@ -6,7 +6,7 @@ import codeql.swift.elements.stmt.Stmt
 import codeql.swift.elements.typerepr.TypeRepr
 
 class UnknownAstNodeBase extends @unknown_ast_node, Decl, Expr, Pattern, Stmt, TypeRepr {
-  override string toString() { result = "UnknownAstNode" }
+  override string getPrimaryQlClass() { result = "UnknownAstNode" }
 
   string getName() { unknown_ast_nodes(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/AbstractFunctionDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/AbstractFunctionDecl.qll
@@ -14,6 +14,8 @@ class AbstractFunctionDeclBase extends @abstract_function_decl, GenericContext, 
     )
   }
 
+  predicate hasBody() { exists(getBody()) }
+
   ParamDecl getParam(int index) {
     exists(ParamDecl x |
       abstract_function_decl_params(this, index, x) and

--- a/swift/ql/lib/codeql/swift/generated/decl/AccessorDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/AccessorDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.FuncDecl
 
 class AccessorDeclBase extends @accessor_decl, FuncDecl {
-  override string toString() { result = "AccessorDecl" }
+  override string getPrimaryQlClass() { result = "AccessorDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/AssociatedTypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/AssociatedTypeDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.AbstractTypeParamDecl
 
 class AssociatedTypeDeclBase extends @associated_type_decl, AbstractTypeParamDecl {
-  override string toString() { result = "AssociatedTypeDecl" }
+  override string getPrimaryQlClass() { result = "AssociatedTypeDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ClassDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ClassDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.NominalTypeDecl
 
 class ClassDeclBase extends @class_decl, NominalTypeDecl {
-  override string toString() { result = "ClassDecl" }
+  override string getPrimaryQlClass() { result = "ClassDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ConcreteFuncDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ConcreteFuncDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.FuncDecl
 
 class ConcreteFuncDeclBase extends @concrete_func_decl, FuncDecl {
-  override string toString() { result = "ConcreteFuncDecl" }
+  override string getPrimaryQlClass() { result = "ConcreteFuncDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ConcreteVarDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ConcreteVarDecl.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.decl.VarDecl
 
 class ConcreteVarDeclBase extends @concrete_var_decl, VarDecl {
-  override string toString() { result = "ConcreteVarDecl" }
+  override string getPrimaryQlClass() { result = "ConcreteVarDecl" }
 
   int getIntroducerInt() { concrete_var_decls(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ConstructorDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ConstructorDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.AbstractFunctionDecl
 
 class ConstructorDeclBase extends @constructor_decl, AbstractFunctionDecl {
-  override string toString() { result = "ConstructorDecl" }
+  override string getPrimaryQlClass() { result = "ConstructorDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/DestructorDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/DestructorDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.AbstractFunctionDecl
 
 class DestructorDeclBase extends @destructor_decl, AbstractFunctionDecl {
-  override string toString() { result = "DestructorDecl" }
+  override string getPrimaryQlClass() { result = "DestructorDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/EnumCaseDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/EnumCaseDecl.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.decl.Decl
 import codeql.swift.elements.decl.EnumElementDecl
 
 class EnumCaseDeclBase extends @enum_case_decl, Decl {
-  override string toString() { result = "EnumCaseDecl" }
+  override string getPrimaryQlClass() { result = "EnumCaseDecl" }
 
   EnumElementDecl getElement(int index) {
     exists(EnumElementDecl x |

--- a/swift/ql/lib/codeql/swift/generated/decl/EnumDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/EnumDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.NominalTypeDecl
 
 class EnumDeclBase extends @enum_decl, NominalTypeDecl {
-  override string toString() { result = "EnumDecl" }
+  override string getPrimaryQlClass() { result = "EnumDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/EnumElementDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/EnumElementDecl.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.decl.ParamDecl
 import codeql.swift.elements.decl.ValueDecl
 
 class EnumElementDeclBase extends @enum_element_decl, ValueDecl {
-  override string toString() { result = "EnumElementDecl" }
+  override string getPrimaryQlClass() { result = "EnumElementDecl" }
 
   string getName() { enum_element_decls(this, result) }
 

--- a/swift/ql/lib/codeql/swift/generated/decl/ExtensionDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ExtensionDecl.qll
@@ -4,5 +4,5 @@ import codeql.swift.elements.decl.GenericContext
 import codeql.swift.elements.decl.IterableDeclContext
 
 class ExtensionDeclBase extends @extension_decl, Decl, GenericContext, IterableDeclContext {
-  override string toString() { result = "ExtensionDecl" }
+  override string getPrimaryQlClass() { result = "ExtensionDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/GenericTypeParamDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/GenericTypeParamDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.AbstractTypeParamDecl
 
 class GenericTypeParamDeclBase extends @generic_type_param_decl, AbstractTypeParamDecl {
-  override string toString() { result = "GenericTypeParamDecl" }
+  override string getPrimaryQlClass() { result = "GenericTypeParamDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/IfConfigDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/IfConfigDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.Decl
 
 class IfConfigDeclBase extends @if_config_decl, Decl {
-  override string toString() { result = "IfConfigDecl" }
+  override string getPrimaryQlClass() { result = "IfConfigDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ImportDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ImportDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.Decl
 
 class ImportDeclBase extends @import_decl, Decl {
-  override string toString() { result = "ImportDecl" }
+  override string getPrimaryQlClass() { result = "ImportDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/InfixOperatorDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/InfixOperatorDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.OperatorDecl
 
 class InfixOperatorDeclBase extends @infix_operator_decl, OperatorDecl {
-  override string toString() { result = "InfixOperatorDecl" }
+  override string getPrimaryQlClass() { result = "InfixOperatorDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/MissingMemberDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/MissingMemberDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.Decl
 
 class MissingMemberDeclBase extends @missing_member_decl, Decl {
-  override string toString() { result = "MissingMemberDecl" }
+  override string getPrimaryQlClass() { result = "MissingMemberDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ModuleDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ModuleDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.TypeDecl
 
 class ModuleDeclBase extends @module_decl, TypeDecl {
-  override string toString() { result = "ModuleDecl" }
+  override string getPrimaryQlClass() { result = "ModuleDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/OpaqueTypeDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/OpaqueTypeDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.GenericTypeDecl
 
 class OpaqueTypeDeclBase extends @opaque_type_decl, GenericTypeDecl {
-  override string toString() { result = "OpaqueTypeDecl" }
+  override string getPrimaryQlClass() { result = "OpaqueTypeDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ParamDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ParamDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.VarDecl
 
 class ParamDeclBase extends @param_decl, VarDecl {
-  override string toString() { result = "ParamDecl" }
+  override string getPrimaryQlClass() { result = "ParamDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/PatternBindingDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/PatternBindingDecl.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.pattern.Pattern
 
 class PatternBindingDeclBase extends @pattern_binding_decl, Decl {
-  override string toString() { result = "PatternBindingDecl" }
+  override string getPrimaryQlClass() { result = "PatternBindingDecl" }
 
   Expr getInit(int index) {
     exists(Expr x |
@@ -12,6 +12,8 @@ class PatternBindingDeclBase extends @pattern_binding_decl, Decl {
       result = x.resolve()
     )
   }
+
+  predicate hasInit(int index) { exists(getInit(index)) }
 
   Expr getAnInit() { result = getInit(_) }
 

--- a/swift/ql/lib/codeql/swift/generated/decl/PostfixOperatorDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/PostfixOperatorDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.OperatorDecl
 
 class PostfixOperatorDeclBase extends @postfix_operator_decl, OperatorDecl {
-  override string toString() { result = "PostfixOperatorDecl" }
+  override string getPrimaryQlClass() { result = "PostfixOperatorDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/PoundDiagnosticDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/PoundDiagnosticDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.Decl
 
 class PoundDiagnosticDeclBase extends @pound_diagnostic_decl, Decl {
-  override string toString() { result = "PoundDiagnosticDecl" }
+  override string getPrimaryQlClass() { result = "PoundDiagnosticDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/PrecedenceGroupDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/PrecedenceGroupDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.Decl
 
 class PrecedenceGroupDeclBase extends @precedence_group_decl, Decl {
-  override string toString() { result = "PrecedenceGroupDecl" }
+  override string getPrimaryQlClass() { result = "PrecedenceGroupDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/PrefixOperatorDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/PrefixOperatorDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.OperatorDecl
 
 class PrefixOperatorDeclBase extends @prefix_operator_decl, OperatorDecl {
-  override string toString() { result = "PrefixOperatorDecl" }
+  override string getPrimaryQlClass() { result = "PrefixOperatorDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/ProtocolDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/ProtocolDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.NominalTypeDecl
 
 class ProtocolDeclBase extends @protocol_decl, NominalTypeDecl {
-  override string toString() { result = "ProtocolDecl" }
+  override string getPrimaryQlClass() { result = "ProtocolDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/StructDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/StructDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.NominalTypeDecl
 
 class StructDeclBase extends @struct_decl, NominalTypeDecl {
-  override string toString() { result = "StructDecl" }
+  override string getPrimaryQlClass() { result = "StructDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/SubscriptDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/SubscriptDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.AbstractStorageDecl
 
 class SubscriptDeclBase extends @subscript_decl, AbstractStorageDecl {
-  override string toString() { result = "SubscriptDecl" }
+  override string getPrimaryQlClass() { result = "SubscriptDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/decl/TopLevelCodeDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/TopLevelCodeDecl.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.BraceStmt
 import codeql.swift.elements.decl.Decl
 
 class TopLevelCodeDeclBase extends @top_level_code_decl, Decl {
-  override string toString() { result = "TopLevelCodeDecl" }
+  override string getPrimaryQlClass() { result = "TopLevelCodeDecl" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |

--- a/swift/ql/lib/codeql/swift/generated/decl/TypeAliasDecl.qll
+++ b/swift/ql/lib/codeql/swift/generated/decl/TypeAliasDecl.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.decl.GenericTypeDecl
 
 class TypeAliasDeclBase extends @type_alias_decl, GenericTypeDecl {
-  override string toString() { result = "TypeAliasDecl" }
+  override string getPrimaryQlClass() { result = "TypeAliasDecl" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/AnyHashableErasureExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/AnyHashableErasureExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class AnyHashableErasureExprBase extends @any_hashable_erasure_expr, ImplicitConversionExpr {
-  override string toString() { result = "AnyHashableErasureExpr" }
+  override string getPrimaryQlClass() { result = "AnyHashableErasureExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/AppliedPropertyWrapperExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/AppliedPropertyWrapperExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class AppliedPropertyWrapperExprBase extends @applied_property_wrapper_expr, Expr {
-  override string toString() { result = "AppliedPropertyWrapperExpr" }
+  override string getPrimaryQlClass() { result = "AppliedPropertyWrapperExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ArchetypeToSuperExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ArchetypeToSuperExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ArchetypeToSuperExprBase extends @archetype_to_super_expr, ImplicitConversionExpr {
-  override string toString() { result = "ArchetypeToSuperExpr" }
+  override string getPrimaryQlClass() { result = "ArchetypeToSuperExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/Argument.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/Argument.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.Element
 import codeql.swift.elements.expr.Expr
 
 class ArgumentBase extends @argument, Element {
-  override string toString() { result = "Argument" }
+  override string getPrimaryQlClass() { result = "Argument" }
 
   string getLabel() { arguments(this, result, _) }
 

--- a/swift/ql/lib/codeql/swift/generated/expr/ArrayExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ArrayExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.CollectionExpr
 import codeql.swift.elements.expr.Expr
 
 class ArrayExprBase extends @array_expr, CollectionExpr {
-  override string toString() { result = "ArrayExpr" }
+  override string getPrimaryQlClass() { result = "ArrayExpr" }
 
   Expr getElement(int index) {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/ArrayToPointerExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ArrayToPointerExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ArrayToPointerExprBase extends @array_to_pointer_expr, ImplicitConversionExpr {
-  override string toString() { result = "ArrayToPointerExpr" }
+  override string getPrimaryQlClass() { result = "ArrayToPointerExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ArrowExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ArrowExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class ArrowExprBase extends @arrow_expr, Expr {
-  override string toString() { result = "ArrowExpr" }
+  override string getPrimaryQlClass() { result = "ArrowExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/AssignExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/AssignExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class AssignExprBase extends @assign_expr, Expr {
-  override string toString() { result = "AssignExpr" }
+  override string getPrimaryQlClass() { result = "AssignExpr" }
 
   Expr getDest() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/AutoClosureExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/AutoClosureExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.AbstractClosureExpr
 import codeql.swift.elements.stmt.BraceStmt
 
 class AutoClosureExprBase extends @auto_closure_expr, AbstractClosureExpr {
-  override string toString() { result = "AutoClosureExpr" }
+  override string getPrimaryQlClass() { result = "AutoClosureExpr" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |

--- a/swift/ql/lib/codeql/swift/generated/expr/AwaitExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/AwaitExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.IdentityExpr
 
 class AwaitExprBase extends @await_expr, IdentityExpr {
-  override string toString() { result = "AwaitExpr" }
+  override string getPrimaryQlClass() { result = "AwaitExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/BinaryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/BinaryExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ApplyExpr
 
 class BinaryExprBase extends @binary_expr, ApplyExpr {
-  override string toString() { result = "BinaryExpr" }
+  override string getPrimaryQlClass() { result = "BinaryExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/BindOptionalExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/BindOptionalExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class BindOptionalExprBase extends @bind_optional_expr, Expr {
-  override string toString() { result = "BindOptionalExpr" }
+  override string getPrimaryQlClass() { result = "BindOptionalExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/BooleanLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/BooleanLiteralExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.BuiltinLiteralExpr
 
 class BooleanLiteralExprBase extends @boolean_literal_expr, BuiltinLiteralExpr {
-  override string toString() { result = "BooleanLiteralExpr" }
+  override string getPrimaryQlClass() { result = "BooleanLiteralExpr" }
 
   boolean getValue() { boolean_literal_exprs(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/BridgeFromObjCExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/BridgeFromObjCExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class BridgeFromObjCExprBase extends @bridge_from_obj_c_expr, ImplicitConversionExpr {
-  override string toString() { result = "BridgeFromObjCExpr" }
+  override string getPrimaryQlClass() { result = "BridgeFromObjCExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/BridgeToObjCExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/BridgeToObjCExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class BridgeToObjCExprBase extends @bridge_to_obj_c_expr, ImplicitConversionExpr {
-  override string toString() { result = "BridgeToObjCExpr" }
+  override string getPrimaryQlClass() { result = "BridgeToObjCExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/CallExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CallExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ApplyExpr
 
 class CallExprBase extends @call_expr, ApplyExpr {
-  override string toString() { result = "CallExpr" }
+  override string getPrimaryQlClass() { result = "CallExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/CaptureListExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CaptureListExpr.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.decl.PatternBindingDecl
 
 class CaptureListExprBase extends @capture_list_expr, Expr {
-  override string toString() { result = "CaptureListExpr" }
+  override string getPrimaryQlClass() { result = "CaptureListExpr" }
 
   PatternBindingDecl getBindingDecl(int index) {
     exists(PatternBindingDecl x |

--- a/swift/ql/lib/codeql/swift/generated/expr/ClassMetatypeToObjectExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ClassMetatypeToObjectExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ClassMetatypeToObjectExprBase extends @class_metatype_to_object_expr, ImplicitConversionExpr {
-  override string toString() { result = "ClassMetatypeToObjectExpr" }
+  override string getPrimaryQlClass() { result = "ClassMetatypeToObjectExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ClosureExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ClosureExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.AbstractClosureExpr
 import codeql.swift.elements.stmt.BraceStmt
 
 class ClosureExprBase extends @closure_expr, AbstractClosureExpr {
-  override string toString() { result = "ClosureExpr" }
+  override string getPrimaryQlClass() { result = "ClosureExpr" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |

--- a/swift/ql/lib/codeql/swift/generated/expr/CodeCompletionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CodeCompletionExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class CodeCompletionExprBase extends @code_completion_expr, Expr {
-  override string toString() { result = "CodeCompletionExpr" }
+  override string getPrimaryQlClass() { result = "CodeCompletionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/CoerceExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CoerceExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ExplicitCastExpr
 
 class CoerceExprBase extends @coerce_expr, ExplicitCastExpr {
-  override string toString() { result = "CoerceExpr" }
+  override string getPrimaryQlClass() { result = "CoerceExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/CollectionUpcastConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CollectionUpcastConversionExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class CollectionUpcastConversionExprBase extends @collection_upcast_conversion_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "CollectionUpcastConversionExpr" }
+  override string getPrimaryQlClass() { result = "CollectionUpcastConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ConditionalBridgeFromObjCExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ConditionalBridgeFromObjCExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ConditionalBridgeFromObjCExprBase extends @conditional_bridge_from_obj_c_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "ConditionalBridgeFromObjCExpr" }
+  override string getPrimaryQlClass() { result = "ConditionalBridgeFromObjCExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ConditionalCheckedCastExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ConditionalCheckedCastExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.CheckedCastExpr
 
 class ConditionalCheckedCastExprBase extends @conditional_checked_cast_expr, CheckedCastExpr {
-  override string toString() { result = "ConditionalCheckedCastExpr" }
+  override string getPrimaryQlClass() { result = "ConditionalCheckedCastExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ConstructorRefCallExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ConstructorRefCallExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.SelfApplyExpr
 
 class ConstructorRefCallExprBase extends @constructor_ref_call_expr, SelfApplyExpr {
-  override string toString() { result = "ConstructorRefCallExpr" }
+  override string getPrimaryQlClass() { result = "ConstructorRefCallExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/CovariantFunctionConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CovariantFunctionConversionExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class CovariantFunctionConversionExprBase extends @covariant_function_conversion_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "CovariantFunctionConversionExpr" }
+  override string getPrimaryQlClass() { result = "CovariantFunctionConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/CovariantReturnConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/CovariantReturnConversionExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class CovariantReturnConversionExprBase extends @covariant_return_conversion_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "CovariantReturnConversionExpr" }
+  override string getPrimaryQlClass() { result = "CovariantReturnConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DeclRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DeclRefExpr.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.type.Type
 
 class DeclRefExprBase extends @decl_ref_expr, Expr {
-  override string toString() { result = "DeclRefExpr" }
+  override string getPrimaryQlClass() { result = "DeclRefExpr" }
 
   Decl getDecl() {
     exists(Decl x |

--- a/swift/ql/lib/codeql/swift/generated/expr/DefaultArgumentExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DefaultArgumentExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.decl.ParamDecl
 
 class DefaultArgumentExprBase extends @default_argument_expr, Expr {
-  override string toString() { result = "DefaultArgumentExpr" }
+  override string getPrimaryQlClass() { result = "DefaultArgumentExpr" }
 
   ParamDecl getParamDecl() {
     exists(ParamDecl x |
@@ -20,4 +20,6 @@ class DefaultArgumentExprBase extends @default_argument_expr, Expr {
       result = x.resolve()
     )
   }
+
+  predicate hasCallerSideDefault() { exists(getCallerSideDefault()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DerivedToBaseExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DerivedToBaseExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class DerivedToBaseExprBase extends @derived_to_base_expr, ImplicitConversionExpr {
-  override string toString() { result = "DerivedToBaseExpr" }
+  override string getPrimaryQlClass() { result = "DerivedToBaseExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DestructureTupleExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DestructureTupleExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class DestructureTupleExprBase extends @destructure_tuple_expr, ImplicitConversionExpr {
-  override string toString() { result = "DestructureTupleExpr" }
+  override string getPrimaryQlClass() { result = "DestructureTupleExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DictionaryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DictionaryExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.CollectionExpr
 import codeql.swift.elements.expr.Expr
 
 class DictionaryExprBase extends @dictionary_expr, CollectionExpr {
-  override string toString() { result = "DictionaryExpr" }
+  override string getPrimaryQlClass() { result = "DictionaryExpr" }
 
   Expr getElement(int index) {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/DifferentiableFunctionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DifferentiableFunctionExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class DifferentiableFunctionExprBase extends @differentiable_function_expr, ImplicitConversionExpr {
-  override string toString() { result = "DifferentiableFunctionExpr" }
+  override string getPrimaryQlClass() { result = "DifferentiableFunctionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DifferentiableFunctionExtractOriginalExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DifferentiableFunctionExtractOriginalExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class DifferentiableFunctionExtractOriginalExprBase extends @differentiable_function_extract_original_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "DifferentiableFunctionExtractOriginalExpr" }
+  override string getPrimaryQlClass() { result = "DifferentiableFunctionExtractOriginalExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DiscardAssignmentExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DiscardAssignmentExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class DiscardAssignmentExprBase extends @discard_assignment_expr, Expr {
-  override string toString() { result = "DiscardAssignmentExpr" }
+  override string getPrimaryQlClass() { result = "DiscardAssignmentExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DotSelfExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DotSelfExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.IdentityExpr
 
 class DotSelfExprBase extends @dot_self_expr, IdentityExpr {
-  override string toString() { result = "DotSelfExpr" }
+  override string getPrimaryQlClass() { result = "DotSelfExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DotSyntaxBaseIgnoredExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DotSyntaxBaseIgnoredExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class DotSyntaxBaseIgnoredExprBase extends @dot_syntax_base_ignored_expr, Expr {
-  override string toString() { result = "DotSyntaxBaseIgnoredExpr" }
+  override string getPrimaryQlClass() { result = "DotSyntaxBaseIgnoredExpr" }
 
   Expr getQualifier() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/DotSyntaxCallExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DotSyntaxCallExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.SelfApplyExpr
 
 class DotSyntaxCallExprBase extends @dot_syntax_call_expr, SelfApplyExpr {
-  override string toString() { result = "DotSyntaxCallExpr" }
+  override string getPrimaryQlClass() { result = "DotSyntaxCallExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DynamicMemberRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DynamicMemberRefExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.DynamicLookupExpr
 
 class DynamicMemberRefExprBase extends @dynamic_member_ref_expr, DynamicLookupExpr {
-  override string toString() { result = "DynamicMemberRefExpr" }
+  override string getPrimaryQlClass() { result = "DynamicMemberRefExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DynamicSubscriptExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DynamicSubscriptExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.DynamicLookupExpr
 
 class DynamicSubscriptExprBase extends @dynamic_subscript_expr, DynamicLookupExpr {
-  override string toString() { result = "DynamicSubscriptExpr" }
+  override string getPrimaryQlClass() { result = "DynamicSubscriptExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/DynamicTypeExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/DynamicTypeExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class DynamicTypeExprBase extends @dynamic_type_expr, Expr {
-  override string toString() { result = "DynamicTypeExpr" }
+  override string getPrimaryQlClass() { result = "DynamicTypeExpr" }
 
   Expr getBaseExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/EditorPlaceholderExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/EditorPlaceholderExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class EditorPlaceholderExprBase extends @editor_placeholder_expr, Expr {
-  override string toString() { result = "EditorPlaceholderExpr" }
+  override string getPrimaryQlClass() { result = "EditorPlaceholderExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/EnumIsCaseExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/EnumIsCaseExpr.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.typerepr.TypeRepr
 
 class EnumIsCaseExprBase extends @enum_is_case_expr, Expr {
-  override string toString() { result = "EnumIsCaseExpr" }
+  override string getPrimaryQlClass() { result = "EnumIsCaseExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/ErasureExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ErasureExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ErasureExprBase extends @erasure_expr, ImplicitConversionExpr {
-  override string toString() { result = "ErasureExpr" }
+  override string getPrimaryQlClass() { result = "ErasureExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ErrorExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ErrorExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class ErrorExprBase extends @error_expr, Expr {
-  override string toString() { result = "ErrorExpr" }
+  override string getPrimaryQlClass() { result = "ErrorExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ExistentialMetatypeToObjectExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ExistentialMetatypeToObjectExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ExistentialMetatypeToObjectExprBase extends @existential_metatype_to_object_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "ExistentialMetatypeToObjectExpr" }
+  override string getPrimaryQlClass() { result = "ExistentialMetatypeToObjectExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/Expr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/Expr.qll
@@ -9,4 +9,6 @@ class ExprBase extends @expr, AstNode {
       result = x.resolve()
     )
   }
+
+  predicate hasType() { exists(getType()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/FloatLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/FloatLiteralExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.NumberLiteralExpr
 
 class FloatLiteralExprBase extends @float_literal_expr, NumberLiteralExpr {
-  override string toString() { result = "FloatLiteralExpr" }
+  override string getPrimaryQlClass() { result = "FloatLiteralExpr" }
 
   string getStringValue() { float_literal_exprs(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ForceTryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ForceTryExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.AnyTryExpr
 
 class ForceTryExprBase extends @force_try_expr, AnyTryExpr {
-  override string toString() { result = "ForceTryExpr" }
+  override string getPrimaryQlClass() { result = "ForceTryExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ForceValueExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ForceValueExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class ForceValueExprBase extends @force_value_expr, Expr {
-  override string toString() { result = "ForceValueExpr" }
+  override string getPrimaryQlClass() { result = "ForceValueExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/ForcedCheckedCastExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ForcedCheckedCastExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.CheckedCastExpr
 
 class ForcedCheckedCastExprBase extends @forced_checked_cast_expr, CheckedCastExpr {
-  override string toString() { result = "ForcedCheckedCastExpr" }
+  override string getPrimaryQlClass() { result = "ForcedCheckedCastExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ForeignObjectConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ForeignObjectConversionExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ForeignObjectConversionExprBase extends @foreign_object_conversion_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "ForeignObjectConversionExpr" }
+  override string getPrimaryQlClass() { result = "ForeignObjectConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/FunctionConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/FunctionConversionExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class FunctionConversionExprBase extends @function_conversion_expr, ImplicitConversionExpr {
-  override string toString() { result = "FunctionConversionExpr" }
+  override string getPrimaryQlClass() { result = "FunctionConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/IfExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/IfExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class IfExprBase extends @if_expr, Expr {
-  override string toString() { result = "IfExpr" }
+  override string getPrimaryQlClass() { result = "IfExpr" }
 
   Expr getCondition() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/InOutExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/InOutExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class InOutExprBase extends @in_out_expr, Expr {
-  override string toString() { result = "InOutExpr" }
+  override string getPrimaryQlClass() { result = "InOutExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/InOutToPointerExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/InOutToPointerExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class InOutToPointerExprBase extends @in_out_to_pointer_expr, ImplicitConversionExpr {
-  override string toString() { result = "InOutToPointerExpr" }
+  override string getPrimaryQlClass() { result = "InOutToPointerExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/InjectIntoOptionalExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/InjectIntoOptionalExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class InjectIntoOptionalExprBase extends @inject_into_optional_expr, ImplicitConversionExpr {
-  override string toString() { result = "InjectIntoOptionalExpr" }
+  override string getPrimaryQlClass() { result = "InjectIntoOptionalExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/IntegerLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/IntegerLiteralExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.NumberLiteralExpr
 
 class IntegerLiteralExprBase extends @integer_literal_expr, NumberLiteralExpr {
-  override string toString() { result = "IntegerLiteralExpr" }
+  override string getPrimaryQlClass() { result = "IntegerLiteralExpr" }
 
   string getStringValue() { integer_literal_exprs(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/InterpolatedStringLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/InterpolatedStringLiteralExpr.qll
@@ -5,7 +5,7 @@ import codeql.swift.elements.expr.OpaqueValueExpr
 import codeql.swift.elements.expr.TapExpr
 
 class InterpolatedStringLiteralExprBase extends @interpolated_string_literal_expr, LiteralExpr {
-  override string toString() { result = "InterpolatedStringLiteralExpr" }
+  override string getPrimaryQlClass() { result = "InterpolatedStringLiteralExpr" }
 
   OpaqueValueExpr getInterpolationExpr() {
     exists(OpaqueValueExpr x |
@@ -14,12 +14,16 @@ class InterpolatedStringLiteralExprBase extends @interpolated_string_literal_exp
     )
   }
 
+  predicate hasInterpolationExpr() { exists(getInterpolationExpr()) }
+
   Expr getInterpolationCountExpr() {
     exists(Expr x |
       interpolated_string_literal_expr_interpolation_count_exprs(this, x) and
       result = x.resolve()
     )
   }
+
+  predicate hasInterpolationCountExpr() { exists(getInterpolationCountExpr()) }
 
   Expr getLiteralCapacityExpr() {
     exists(Expr x |
@@ -28,10 +32,14 @@ class InterpolatedStringLiteralExprBase extends @interpolated_string_literal_exp
     )
   }
 
+  predicate hasLiteralCapacityExpr() { exists(getLiteralCapacityExpr()) }
+
   TapExpr getAppendingExpr() {
     exists(TapExpr x |
       interpolated_string_literal_expr_appending_exprs(this, x) and
       result = x.resolve()
     )
   }
+
+  predicate hasAppendingExpr() { exists(getAppendingExpr()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/IsExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/IsExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.CheckedCastExpr
 
 class IsExprBase extends @is_expr, CheckedCastExpr {
-  override string toString() { result = "IsExpr" }
+  override string getPrimaryQlClass() { result = "IsExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/KeyPathApplicationExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/KeyPathApplicationExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class KeyPathApplicationExprBase extends @key_path_application_expr, Expr {
-  override string toString() { result = "KeyPathApplicationExpr" }
+  override string getPrimaryQlClass() { result = "KeyPathApplicationExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/KeyPathDotExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/KeyPathDotExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class KeyPathDotExprBase extends @key_path_dot_expr, Expr {
-  override string toString() { result = "KeyPathDotExpr" }
+  override string getPrimaryQlClass() { result = "KeyPathDotExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/KeyPathExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/KeyPathExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class KeyPathExprBase extends @key_path_expr, Expr {
-  override string toString() { result = "KeyPathExpr" }
+  override string getPrimaryQlClass() { result = "KeyPathExpr" }
 
   Expr getParsedRoot() {
     exists(Expr x |
@@ -11,10 +11,14 @@ class KeyPathExprBase extends @key_path_expr, Expr {
     )
   }
 
+  predicate hasParsedRoot() { exists(getParsedRoot()) }
+
   Expr getParsedPath() {
     exists(Expr x |
       key_path_expr_parsed_paths(this, x) and
       result = x.resolve()
     )
   }
+
+  predicate hasParsedPath() { exists(getParsedPath()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/LazyInitializerExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/LazyInitializerExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class LazyInitializerExprBase extends @lazy_initializer_expr, Expr {
-  override string toString() { result = "LazyInitializerExpr" }
+  override string getPrimaryQlClass() { result = "LazyInitializerExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/LinearFunctionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/LinearFunctionExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class LinearFunctionExprBase extends @linear_function_expr, ImplicitConversionExpr {
-  override string toString() { result = "LinearFunctionExpr" }
+  override string getPrimaryQlClass() { result = "LinearFunctionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/LinearFunctionExtractOriginalExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/LinearFunctionExtractOriginalExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class LinearFunctionExtractOriginalExprBase extends @linear_function_extract_original_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "LinearFunctionExtractOriginalExpr" }
+  override string getPrimaryQlClass() { result = "LinearFunctionExtractOriginalExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/LinearToDifferentiableFunctionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/LinearToDifferentiableFunctionExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class LinearToDifferentiableFunctionExprBase extends @linear_to_differentiable_function_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "LinearToDifferentiableFunctionExpr" }
+  override string getPrimaryQlClass() { result = "LinearToDifferentiableFunctionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/LoadExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/LoadExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class LoadExprBase extends @load_expr, ImplicitConversionExpr {
-  override string toString() { result = "LoadExpr" }
+  override string getPrimaryQlClass() { result = "LoadExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/MagicIdentifierLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/MagicIdentifierLiteralExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.BuiltinLiteralExpr
 
 class MagicIdentifierLiteralExprBase extends @magic_identifier_literal_expr, BuiltinLiteralExpr {
-  override string toString() { result = "MagicIdentifierLiteralExpr" }
+  override string getPrimaryQlClass() { result = "MagicIdentifierLiteralExpr" }
 
   string getKind() { magic_identifier_literal_exprs(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/MakeTemporarilyEscapableExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/MakeTemporarilyEscapableExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.expr.OpaqueValueExpr
 
 class MakeTemporarilyEscapableExprBase extends @make_temporarily_escapable_expr, Expr {
-  override string toString() { result = "MakeTemporarilyEscapableExpr" }
+  override string getPrimaryQlClass() { result = "MakeTemporarilyEscapableExpr" }
 
   OpaqueValueExpr getEscapingClosure() {
     exists(OpaqueValueExpr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/MemberRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/MemberRefExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.expr.LookupExpr
 
 class MemberRefExprBase extends @member_ref_expr, LookupExpr {
-  override string toString() { result = "MemberRefExpr" }
+  override string getPrimaryQlClass() { result = "MemberRefExpr" }
 
   Expr getBaseExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/MetatypeConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/MetatypeConversionExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class MetatypeConversionExprBase extends @metatype_conversion_expr, ImplicitConversionExpr {
-  override string toString() { result = "MetatypeConversionExpr" }
+  override string getPrimaryQlClass() { result = "MetatypeConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/NilLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/NilLiteralExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.LiteralExpr
 
 class NilLiteralExprBase extends @nil_literal_expr, LiteralExpr {
-  override string toString() { result = "NilLiteralExpr" }
+  override string getPrimaryQlClass() { result = "NilLiteralExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ObjCSelectorExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ObjCSelectorExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.decl.AbstractFunctionDecl
 import codeql.swift.elements.expr.Expr
 
 class ObjCSelectorExprBase extends @obj_c_selector_expr, Expr {
-  override string toString() { result = "ObjCSelectorExpr" }
+  override string getPrimaryQlClass() { result = "ObjCSelectorExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/ObjectLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ObjectLiteralExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.LiteralExpr
 
 class ObjectLiteralExprBase extends @object_literal_expr, LiteralExpr {
-  override string toString() { result = "ObjectLiteralExpr" }
+  override string getPrimaryQlClass() { result = "ObjectLiteralExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/OneWayExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OneWayExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class OneWayExprBase extends @one_way_expr, Expr {
-  override string toString() { result = "OneWayExpr" }
+  override string getPrimaryQlClass() { result = "OneWayExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/OpaqueValueExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OpaqueValueExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class OpaqueValueExprBase extends @opaque_value_expr, Expr {
-  override string toString() { result = "OpaqueValueExpr" }
+  override string getPrimaryQlClass() { result = "OpaqueValueExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/OpenExistentialExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OpenExistentialExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.expr.OpaqueValueExpr
 
 class OpenExistentialExprBase extends @open_existential_expr, Expr {
-  override string toString() { result = "OpenExistentialExpr" }
+  override string getPrimaryQlClass() { result = "OpenExistentialExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/OptionalEvaluationExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OptionalEvaluationExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class OptionalEvaluationExprBase extends @optional_evaluation_expr, Expr {
-  override string toString() { result = "OptionalEvaluationExpr" }
+  override string getPrimaryQlClass() { result = "OptionalEvaluationExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/OptionalTryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OptionalTryExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.AnyTryExpr
 
 class OptionalTryExprBase extends @optional_try_expr, AnyTryExpr {
-  override string toString() { result = "OptionalTryExpr" }
+  override string getPrimaryQlClass() { result = "OptionalTryExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/OtherConstructorDeclRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OtherConstructorDeclRefExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class OtherConstructorDeclRefExprBase extends @other_constructor_decl_ref_expr, Expr {
-  override string toString() { result = "OtherConstructorDeclRefExpr" }
+  override string getPrimaryQlClass() { result = "OtherConstructorDeclRefExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/OverloadedDeclRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/OverloadedDeclRefExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.OverloadSetRefExpr
 
 class OverloadedDeclRefExprBase extends @overloaded_decl_ref_expr, OverloadSetRefExpr {
-  override string toString() { result = "OverloadedDeclRefExpr" }
+  override string getPrimaryQlClass() { result = "OverloadedDeclRefExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ParenExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ParenExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.IdentityExpr
 
 class ParenExprBase extends @paren_expr, IdentityExpr {
-  override string toString() { result = "ParenExpr" }
+  override string getPrimaryQlClass() { result = "ParenExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/PointerToPointerExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/PointerToPointerExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class PointerToPointerExprBase extends @pointer_to_pointer_expr, ImplicitConversionExpr {
-  override string toString() { result = "PointerToPointerExpr" }
+  override string getPrimaryQlClass() { result = "PointerToPointerExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/PostfixUnaryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/PostfixUnaryExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ApplyExpr
 
 class PostfixUnaryExprBase extends @postfix_unary_expr, ApplyExpr {
-  override string toString() { result = "PostfixUnaryExpr" }
+  override string getPrimaryQlClass() { result = "PostfixUnaryExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/PrefixUnaryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/PrefixUnaryExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ApplyExpr
 
 class PrefixUnaryExprBase extends @prefix_unary_expr, ApplyExpr {
-  override string toString() { result = "PrefixUnaryExpr" }
+  override string getPrimaryQlClass() { result = "PrefixUnaryExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/PropertyWrapperValuePlaceholderExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/PropertyWrapperValuePlaceholderExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class PropertyWrapperValuePlaceholderExprBase extends @property_wrapper_value_placeholder_expr, Expr {
-  override string toString() { result = "PropertyWrapperValuePlaceholderExpr" }
+  override string getPrimaryQlClass() { result = "PropertyWrapperValuePlaceholderExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/ProtocolMetatypeToObjectExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/ProtocolMetatypeToObjectExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class ProtocolMetatypeToObjectExprBase extends @protocol_metatype_to_object_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "ProtocolMetatypeToObjectExpr" }
+  override string getPrimaryQlClass() { result = "ProtocolMetatypeToObjectExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/RebindSelfInConstructorExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/RebindSelfInConstructorExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.decl.VarDecl
 
 class RebindSelfInConstructorExprBase extends @rebind_self_in_constructor_expr, Expr {
-  override string toString() { result = "RebindSelfInConstructorExpr" }
+  override string getPrimaryQlClass() { result = "RebindSelfInConstructorExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/RegexLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/RegexLiteralExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.LiteralExpr
 
 class RegexLiteralExprBase extends @regex_literal_expr, LiteralExpr {
-  override string toString() { result = "RegexLiteralExpr" }
+  override string getPrimaryQlClass() { result = "RegexLiteralExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/SequenceExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/SequenceExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class SequenceExprBase extends @sequence_expr, Expr {
-  override string toString() { result = "SequenceExpr" }
+  override string getPrimaryQlClass() { result = "SequenceExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/StringLiteralExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/StringLiteralExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.BuiltinLiteralExpr
 
 class StringLiteralExprBase extends @string_literal_expr, BuiltinLiteralExpr {
-  override string toString() { result = "StringLiteralExpr" }
+  override string getPrimaryQlClass() { result = "StringLiteralExpr" }
 
   string getValue() { string_literal_exprs(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/StringToPointerExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/StringToPointerExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class StringToPointerExprBase extends @string_to_pointer_expr, ImplicitConversionExpr {
-  override string toString() { result = "StringToPointerExpr" }
+  override string getPrimaryQlClass() { result = "StringToPointerExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/SubscriptExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/SubscriptExpr.qll
@@ -5,7 +5,7 @@ import codeql.swift.elements.decl.GenericContext
 import codeql.swift.elements.expr.LookupExpr
 
 class SubscriptExprBase extends @subscript_expr, GenericContext, LookupExpr {
-  override string toString() { result = "SubscriptExpr" }
+  override string getPrimaryQlClass() { result = "SubscriptExpr" }
 
   Expr getBaseExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/SuperRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/SuperRefExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.decl.VarDecl
 
 class SuperRefExprBase extends @super_ref_expr, Expr {
-  override string toString() { result = "SuperRefExpr" }
+  override string getPrimaryQlClass() { result = "SuperRefExpr" }
 
   VarDecl getSelf() {
     exists(VarDecl x |

--- a/swift/ql/lib/codeql/swift/generated/expr/TapExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/TapExpr.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.decl.VarDecl
 
 class TapExprBase extends @tap_expr, Expr {
-  override string toString() { result = "TapExpr" }
+  override string getPrimaryQlClass() { result = "TapExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |
@@ -12,6 +12,8 @@ class TapExprBase extends @tap_expr, Expr {
       result = x.resolve()
     )
   }
+
+  predicate hasSubExpr() { exists(getSubExpr()) }
 
   VarDecl getVar() {
     exists(VarDecl x |

--- a/swift/ql/lib/codeql/swift/generated/expr/TryExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/TryExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.AnyTryExpr
 
 class TryExprBase extends @try_expr, AnyTryExpr {
-  override string toString() { result = "TryExpr" }
+  override string getPrimaryQlClass() { result = "TryExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/TupleElementExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/TupleElementExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class TupleElementExprBase extends @tuple_element_expr, Expr {
-  override string toString() { result = "TupleElementExpr" }
+  override string getPrimaryQlClass() { result = "TupleElementExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/TupleExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/TupleExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class TupleExprBase extends @tuple_expr, Expr {
-  override string toString() { result = "TupleExpr" }
+  override string getPrimaryQlClass() { result = "TupleExpr" }
 
   Expr getElement(int index) {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/expr/TypeExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/TypeExpr.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.typerepr.TypeRepr
 
 class TypeExprBase extends @type_expr, Expr {
-  override string toString() { result = "TypeExpr" }
+  override string getPrimaryQlClass() { result = "TypeExpr" }
 
   TypeRepr getTypeRepr() {
     exists(TypeRepr x |
@@ -11,4 +11,6 @@ class TypeExprBase extends @type_expr, Expr {
       result = x.resolve()
     )
   }
+
+  predicate hasTypeRepr() { exists(getTypeRepr()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnderlyingToOpaqueExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnderlyingToOpaqueExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class UnderlyingToOpaqueExprBase extends @underlying_to_opaque_expr, ImplicitConversionExpr {
-  override string toString() { result = "UnderlyingToOpaqueExpr" }
+  override string getPrimaryQlClass() { result = "UnderlyingToOpaqueExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnevaluatedInstanceExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnevaluatedInstanceExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class UnevaluatedInstanceExprBase extends @unevaluated_instance_expr, ImplicitConversionExpr {
-  override string toString() { result = "UnevaluatedInstanceExpr" }
+  override string getPrimaryQlClass() { result = "UnevaluatedInstanceExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedDeclRefExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedDeclRefExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class UnresolvedDeclRefExprBase extends @unresolved_decl_ref_expr, Expr {
-  override string toString() { result = "UnresolvedDeclRefExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedDeclRefExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedDotExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedDotExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class UnresolvedDotExprBase extends @unresolved_dot_expr, Expr {
-  override string toString() { result = "UnresolvedDotExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedDotExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedMemberChainResultExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedMemberChainResultExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.IdentityExpr
 
 class UnresolvedMemberChainResultExprBase extends @unresolved_member_chain_result_expr, IdentityExpr {
-  override string toString() { result = "UnresolvedMemberChainResultExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedMemberChainResultExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedMemberExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedMemberExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class UnresolvedMemberExprBase extends @unresolved_member_expr, Expr {
-  override string toString() { result = "UnresolvedMemberExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedMemberExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedPatternExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedPatternExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class UnresolvedPatternExprBase extends @unresolved_pattern_expr, Expr {
-  override string toString() { result = "UnresolvedPatternExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedPatternExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedSpecializeExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedSpecializeExpr.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.expr.Expr
 
 class UnresolvedSpecializeExprBase extends @unresolved_specialize_expr, Expr {
-  override string toString() { result = "UnresolvedSpecializeExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedSpecializeExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/UnresolvedTypeConversionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/UnresolvedTypeConversionExpr.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.expr.ImplicitConversionExpr
 
 class UnresolvedTypeConversionExprBase extends @unresolved_type_conversion_expr,
   ImplicitConversionExpr {
-  override string toString() { result = "UnresolvedTypeConversionExpr" }
+  override string getPrimaryQlClass() { result = "UnresolvedTypeConversionExpr" }
 }

--- a/swift/ql/lib/codeql/swift/generated/expr/VarargExpansionExpr.qll
+++ b/swift/ql/lib/codeql/swift/generated/expr/VarargExpansionExpr.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.expr.Expr
 
 class VarargExpansionExprBase extends @vararg_expansion_expr, Expr {
-  override string toString() { result = "VarargExpansionExpr" }
+  override string getPrimaryQlClass() { result = "VarargExpansionExpr" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/pattern/AnyPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/AnyPattern.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.pattern.Pattern
 
 class AnyPatternBase extends @any_pattern, Pattern {
-  override string toString() { result = "AnyPattern" }
+  override string getPrimaryQlClass() { result = "AnyPattern" }
 }

--- a/swift/ql/lib/codeql/swift/generated/pattern/BindingPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/BindingPattern.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.pattern.Pattern
 
 class BindingPatternBase extends @binding_pattern, Pattern {
-  override string toString() { result = "BindingPattern" }
+  override string getPrimaryQlClass() { result = "BindingPattern" }
 
   Pattern getSubPattern() {
     exists(Pattern x |

--- a/swift/ql/lib/codeql/swift/generated/pattern/BoolPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/BoolPattern.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.pattern.Pattern
 
 class BoolPatternBase extends @bool_pattern, Pattern {
-  override string toString() { result = "BoolPattern" }
+  override string getPrimaryQlClass() { result = "BoolPattern" }
 
   boolean getValue() { bool_patterns(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/pattern/EnumElementPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/EnumElementPattern.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.decl.EnumElementDecl
 import codeql.swift.elements.pattern.Pattern
 
 class EnumElementPatternBase extends @enum_element_pattern, Pattern {
-  override string toString() { result = "EnumElementPattern" }
+  override string getPrimaryQlClass() { result = "EnumElementPattern" }
 
   EnumElementDecl getElement() {
     exists(EnumElementDecl x |
@@ -18,4 +18,6 @@ class EnumElementPatternBase extends @enum_element_pattern, Pattern {
       result = x.resolve()
     )
   }
+
+  predicate hasSubPattern() { exists(getSubPattern()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/pattern/ExprPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/ExprPattern.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.pattern.Pattern
 
 class ExprPatternBase extends @expr_pattern, Pattern {
-  override string toString() { result = "ExprPattern" }
+  override string getPrimaryQlClass() { result = "ExprPattern" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/pattern/IsPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/IsPattern.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.pattern.Pattern
 import codeql.swift.elements.typerepr.TypeRepr
 
 class IsPatternBase extends @is_pattern, Pattern {
-  override string toString() { result = "IsPattern" }
+  override string getPrimaryQlClass() { result = "IsPattern" }
 
   TypeRepr getCastTypeRepr() {
     exists(TypeRepr x |
@@ -12,10 +12,14 @@ class IsPatternBase extends @is_pattern, Pattern {
     )
   }
 
+  predicate hasCastTypeRepr() { exists(getCastTypeRepr()) }
+
   Pattern getSubPattern() {
     exists(Pattern x |
       is_pattern_sub_patterns(this, x) and
       result = x.resolve()
     )
   }
+
+  predicate hasSubPattern() { exists(getSubPattern()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/pattern/NamedPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/NamedPattern.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.pattern.Pattern
 
 class NamedPatternBase extends @named_pattern, Pattern {
-  override string toString() { result = "NamedPattern" }
+  override string getPrimaryQlClass() { result = "NamedPattern" }
 
   string getName() { named_patterns(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/pattern/OptionalSomePattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/OptionalSomePattern.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.pattern.Pattern
 
 class OptionalSomePatternBase extends @optional_some_pattern, Pattern {
-  override string toString() { result = "OptionalSomePattern" }
+  override string getPrimaryQlClass() { result = "OptionalSomePattern" }
 
   Pattern getSubPattern() {
     exists(Pattern x |

--- a/swift/ql/lib/codeql/swift/generated/pattern/ParenPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/ParenPattern.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.pattern.Pattern
 
 class ParenPatternBase extends @paren_pattern, Pattern {
-  override string toString() { result = "ParenPattern" }
+  override string getPrimaryQlClass() { result = "ParenPattern" }
 
   Pattern getSubPattern() {
     exists(Pattern x |

--- a/swift/ql/lib/codeql/swift/generated/pattern/TuplePattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/TuplePattern.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.pattern.Pattern
 
 class TuplePatternBase extends @tuple_pattern, Pattern {
-  override string toString() { result = "TuplePattern" }
+  override string getPrimaryQlClass() { result = "TuplePattern" }
 
   Pattern getElement(int index) {
     exists(Pattern x |

--- a/swift/ql/lib/codeql/swift/generated/pattern/TypedPattern.qll
+++ b/swift/ql/lib/codeql/swift/generated/pattern/TypedPattern.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.pattern.Pattern
 import codeql.swift.elements.typerepr.TypeRepr
 
 class TypedPatternBase extends @typed_pattern, Pattern {
-  override string toString() { result = "TypedPattern" }
+  override string getPrimaryQlClass() { result = "TypedPattern" }
 
   Pattern getSubPattern() {
     exists(Pattern x |
@@ -18,4 +18,6 @@ class TypedPatternBase extends @typed_pattern, Pattern {
       result = x.resolve()
     )
   }
+
+  predicate hasTypeRepr() { exists(getTypeRepr()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/BraceStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/BraceStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.AstNode
 import codeql.swift.elements.stmt.Stmt
 
 class BraceStmtBase extends @brace_stmt, Stmt {
-  override string toString() { result = "BraceStmt" }
+  override string getPrimaryQlClass() { result = "BraceStmt" }
 
   AstNode getElement(int index) {
     exists(AstNode x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/BreakStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/BreakStmt.qll
@@ -2,9 +2,11 @@
 import codeql.swift.elements.stmt.Stmt
 
 class BreakStmtBase extends @break_stmt, Stmt {
-  override string toString() { result = "BreakStmt" }
+  override string getPrimaryQlClass() { result = "BreakStmt" }
 
   string getTargetName() { break_stmt_target_names(this, result) }
+
+  predicate hasTargetName() { exists(getTargetName()) }
 
   Stmt getTarget() {
     exists(Stmt x |
@@ -12,4 +14,6 @@ class BreakStmtBase extends @break_stmt, Stmt {
       result = x.resolve()
     )
   }
+
+  predicate hasTarget() { exists(getTarget()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/CaseLabelItem.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/CaseLabelItem.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.pattern.Pattern
 
 class CaseLabelItemBase extends @case_label_item, AstNode {
-  override string toString() { result = "CaseLabelItem" }
+  override string getPrimaryQlClass() { result = "CaseLabelItem" }
 
   Pattern getPattern() {
     exists(Pattern x |
@@ -19,4 +19,6 @@ class CaseLabelItemBase extends @case_label_item, AstNode {
       result = x.resolve()
     )
   }
+
+  predicate hasGuard() { exists(getGuard()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/CaseStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/CaseStmt.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.stmt.Stmt
 import codeql.swift.elements.decl.VarDecl
 
 class CaseStmtBase extends @case_stmt, Stmt {
-  override string toString() { result = "CaseStmt" }
+  override string getPrimaryQlClass() { result = "CaseStmt" }
 
   Stmt getBody() {
     exists(Stmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/ConditionElement.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/ConditionElement.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.Locatable
 import codeql.swift.elements.pattern.Pattern
 
 class ConditionElementBase extends @condition_element, Locatable {
-  override string toString() { result = "ConditionElement" }
+  override string getPrimaryQlClass() { result = "ConditionElement" }
 
   Expr getBoolean() {
     exists(Expr x |
@@ -13,6 +13,8 @@ class ConditionElementBase extends @condition_element, Locatable {
     )
   }
 
+  predicate hasBoolean() { exists(getBoolean()) }
+
   Pattern getPattern() {
     exists(Pattern x |
       condition_element_patterns(this, x) and
@@ -20,10 +22,14 @@ class ConditionElementBase extends @condition_element, Locatable {
     )
   }
 
+  predicate hasPattern() { exists(getPattern()) }
+
   Expr getInitializer() {
     exists(Expr x |
       condition_element_initializers(this, x) and
       result = x.resolve()
     )
   }
+
+  predicate hasInitializer() { exists(getInitializer()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/ContinueStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/ContinueStmt.qll
@@ -2,9 +2,11 @@
 import codeql.swift.elements.stmt.Stmt
 
 class ContinueStmtBase extends @continue_stmt, Stmt {
-  override string toString() { result = "ContinueStmt" }
+  override string getPrimaryQlClass() { result = "ContinueStmt" }
 
   string getTargetName() { continue_stmt_target_names(this, result) }
+
+  predicate hasTargetName() { exists(getTargetName()) }
 
   Stmt getTarget() {
     exists(Stmt x |
@@ -12,4 +14,6 @@ class ContinueStmtBase extends @continue_stmt, Stmt {
       result = x.resolve()
     )
   }
+
+  predicate hasTarget() { exists(getTarget()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/DeferStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/DeferStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.BraceStmt
 import codeql.swift.elements.stmt.Stmt
 
 class DeferStmtBase extends @defer_stmt, Stmt {
-  override string toString() { result = "DeferStmt" }
+  override string getPrimaryQlClass() { result = "DeferStmt" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/DoCatchStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/DoCatchStmt.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.stmt.LabeledStmt
 import codeql.swift.elements.stmt.Stmt
 
 class DoCatchStmtBase extends @do_catch_stmt, LabeledStmt {
-  override string toString() { result = "DoCatchStmt" }
+  override string getPrimaryQlClass() { result = "DoCatchStmt" }
 
   Stmt getBody() {
     exists(Stmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/DoStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/DoStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.BraceStmt
 import codeql.swift.elements.stmt.LabeledStmt
 
 class DoStmtBase extends @do_stmt, LabeledStmt {
-  override string toString() { result = "DoStmt" }
+  override string getPrimaryQlClass() { result = "DoStmt" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/FailStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/FailStmt.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.stmt.Stmt
 
 class FailStmtBase extends @fail_stmt, Stmt {
-  override string toString() { result = "FailStmt" }
+  override string getPrimaryQlClass() { result = "FailStmt" }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/FallthroughStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/FallthroughStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.CaseStmt
 import codeql.swift.elements.stmt.Stmt
 
 class FallthroughStmtBase extends @fallthrough_stmt, Stmt {
-  override string toString() { result = "FallthroughStmt" }
+  override string getPrimaryQlClass() { result = "FallthroughStmt" }
 
   CaseStmt getFallthroughSource() {
     exists(CaseStmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/ForEachStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/ForEachStmt.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.stmt.LabeledStmt
 
 class ForEachStmtBase extends @for_each_stmt, LabeledStmt {
-  override string toString() { result = "ForEachStmt" }
+  override string getPrimaryQlClass() { result = "ForEachStmt" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |
@@ -26,4 +26,6 @@ class ForEachStmtBase extends @for_each_stmt, LabeledStmt {
       result = x.resolve()
     )
   }
+
+  predicate hasWhere() { exists(getWhere()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/GuardStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/GuardStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.BraceStmt
 import codeql.swift.elements.stmt.LabeledConditionalStmt
 
 class GuardStmtBase extends @guard_stmt, LabeledConditionalStmt {
-  override string toString() { result = "GuardStmt" }
+  override string getPrimaryQlClass() { result = "GuardStmt" }
 
   BraceStmt getBody() {
     exists(BraceStmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/IfStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/IfStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.LabeledConditionalStmt
 import codeql.swift.elements.stmt.Stmt
 
 class IfStmtBase extends @if_stmt, LabeledConditionalStmt {
-  override string toString() { result = "IfStmt" }
+  override string getPrimaryQlClass() { result = "IfStmt" }
 
   Stmt getThen() {
     exists(Stmt x |
@@ -18,4 +18,6 @@ class IfStmtBase extends @if_stmt, LabeledConditionalStmt {
       result = x.resolve()
     )
   }
+
+  predicate hasElse() { exists(getElse()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/LabeledStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/LabeledStmt.qll
@@ -3,4 +3,6 @@ import codeql.swift.elements.stmt.Stmt
 
 class LabeledStmtBase extends @labeled_stmt, Stmt {
   string getLabel() { labeled_stmt_labels(this, result) }
+
+  predicate hasLabel() { exists(getLabel()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/PoundAssertStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/PoundAssertStmt.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.stmt.Stmt
 
 class PoundAssertStmtBase extends @pound_assert_stmt, Stmt {
-  override string toString() { result = "PoundAssertStmt" }
+  override string getPrimaryQlClass() { result = "PoundAssertStmt" }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/RepeatWhileStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/RepeatWhileStmt.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.stmt.LabeledStmt
 import codeql.swift.elements.stmt.Stmt
 
 class RepeatWhileStmtBase extends @repeat_while_stmt, LabeledStmt {
-  override string toString() { result = "RepeatWhileStmt" }
+  override string getPrimaryQlClass() { result = "RepeatWhileStmt" }
 
   Expr getCondition() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/ReturnStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/ReturnStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.stmt.Stmt
 
 class ReturnStmtBase extends @return_stmt, Stmt {
-  override string toString() { result = "ReturnStmt" }
+  override string getPrimaryQlClass() { result = "ReturnStmt" }
 
   Expr getResult() {
     exists(Expr x |
@@ -11,4 +11,6 @@ class ReturnStmtBase extends @return_stmt, Stmt {
       result = x.resolve()
     )
   }
+
+  predicate hasResult() { exists(getResult()) }
 }

--- a/swift/ql/lib/codeql/swift/generated/stmt/StmtCondition.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/StmtCondition.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.AstNode
 import codeql.swift.elements.stmt.ConditionElement
 
 class StmtConditionBase extends @stmt_condition, AstNode {
-  override string toString() { result = "StmtCondition" }
+  override string getPrimaryQlClass() { result = "StmtCondition" }
 
   ConditionElement getElement(int index) {
     exists(ConditionElement x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/SwitchStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/SwitchStmt.qll
@@ -4,7 +4,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.stmt.LabeledStmt
 
 class SwitchStmtBase extends @switch_stmt, LabeledStmt {
-  override string toString() { result = "SwitchStmt" }
+  override string getPrimaryQlClass() { result = "SwitchStmt" }
 
   Expr getExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/ThrowStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/ThrowStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.expr.Expr
 import codeql.swift.elements.stmt.Stmt
 
 class ThrowStmtBase extends @throw_stmt, Stmt {
-  override string toString() { result = "ThrowStmt" }
+  override string getPrimaryQlClass() { result = "ThrowStmt" }
 
   Expr getSubExpr() {
     exists(Expr x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/WhileStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/WhileStmt.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.stmt.LabeledConditionalStmt
 import codeql.swift.elements.stmt.Stmt
 
 class WhileStmtBase extends @while_stmt, LabeledConditionalStmt {
-  override string toString() { result = "WhileStmt" }
+  override string getPrimaryQlClass() { result = "WhileStmt" }
 
   Stmt getBody() {
     exists(Stmt x |

--- a/swift/ql/lib/codeql/swift/generated/stmt/YieldStmt.qll
+++ b/swift/ql/lib/codeql/swift/generated/stmt/YieldStmt.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.stmt.Stmt
 
 class YieldStmtBase extends @yield_stmt, Stmt {
-  override string toString() { result = "YieldStmt" }
+  override string getPrimaryQlClass() { result = "YieldStmt" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/AnyGenericType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/AnyGenericType.qll
@@ -10,6 +10,8 @@ class AnyGenericTypeBase extends @any_generic_type, Type {
     )
   }
 
+  predicate hasParent() { exists(getParent()) }
+
   Decl getDeclaration() {
     exists(Decl x |
       any_generic_types(this, x) and

--- a/swift/ql/lib/codeql/swift/generated/type/ArraySliceType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ArraySliceType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.UnarySyntaxSugarType
 
 class ArraySliceTypeBase extends @array_slice_type, UnarySyntaxSugarType {
-  override string toString() { result = "ArraySliceType" }
+  override string getPrimaryQlClass() { result = "ArraySliceType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BoundGenericClassType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BoundGenericClassType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BoundGenericType
 
 class BoundGenericClassTypeBase extends @bound_generic_class_type, BoundGenericType {
-  override string toString() { result = "BoundGenericClassType" }
+  override string getPrimaryQlClass() { result = "BoundGenericClassType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BoundGenericEnumType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BoundGenericEnumType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BoundGenericType
 
 class BoundGenericEnumTypeBase extends @bound_generic_enum_type, BoundGenericType {
-  override string toString() { result = "BoundGenericEnumType" }
+  override string getPrimaryQlClass() { result = "BoundGenericEnumType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BoundGenericStructType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BoundGenericStructType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BoundGenericType
 
 class BoundGenericStructTypeBase extends @bound_generic_struct_type, BoundGenericType {
-  override string toString() { result = "BoundGenericStructType" }
+  override string getPrimaryQlClass() { result = "BoundGenericStructType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinBridgeObjectType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinBridgeObjectType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinBridgeObjectTypeBase extends @builtin_bridge_object_type, BuiltinType {
-  override string toString() { result = "BuiltinBridgeObjectType" }
+  override string getPrimaryQlClass() { result = "BuiltinBridgeObjectType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinDefaultActorStorageType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinDefaultActorStorageType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinDefaultActorStorageTypeBase extends @builtin_default_actor_storage_type, BuiltinType {
-  override string toString() { result = "BuiltinDefaultActorStorageType" }
+  override string getPrimaryQlClass() { result = "BuiltinDefaultActorStorageType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinExecutorType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinExecutorType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinExecutorTypeBase extends @builtin_executor_type, BuiltinType {
-  override string toString() { result = "BuiltinExecutorType" }
+  override string getPrimaryQlClass() { result = "BuiltinExecutorType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinFloatType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinFloatType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinFloatTypeBase extends @builtin_float_type, BuiltinType {
-  override string toString() { result = "BuiltinFloatType" }
+  override string getPrimaryQlClass() { result = "BuiltinFloatType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinIntegerLiteralType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinIntegerLiteralType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.AnyBuiltinIntegerType
 
 class BuiltinIntegerLiteralTypeBase extends @builtin_integer_literal_type, AnyBuiltinIntegerType {
-  override string toString() { result = "BuiltinIntegerLiteralType" }
+  override string getPrimaryQlClass() { result = "BuiltinIntegerLiteralType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinIntegerType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinIntegerType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.AnyBuiltinIntegerType
 
 class BuiltinIntegerTypeBase extends @builtin_integer_type, AnyBuiltinIntegerType {
-  override string toString() { result = "BuiltinIntegerType" }
+  override string getPrimaryQlClass() { result = "BuiltinIntegerType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinJobType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinJobType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinJobTypeBase extends @builtin_job_type, BuiltinType {
-  override string toString() { result = "BuiltinJobType" }
+  override string getPrimaryQlClass() { result = "BuiltinJobType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinNativeObjectType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinNativeObjectType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinNativeObjectTypeBase extends @builtin_native_object_type, BuiltinType {
-  override string toString() { result = "BuiltinNativeObjectType" }
+  override string getPrimaryQlClass() { result = "BuiltinNativeObjectType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinRawPointerType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinRawPointerType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinRawPointerTypeBase extends @builtin_raw_pointer_type, BuiltinType {
-  override string toString() { result = "BuiltinRawPointerType" }
+  override string getPrimaryQlClass() { result = "BuiltinRawPointerType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinRawUnsafeContinuationType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinRawUnsafeContinuationType.qll
@@ -3,5 +3,5 @@ import codeql.swift.elements.type.BuiltinType
 
 class BuiltinRawUnsafeContinuationTypeBase extends @builtin_raw_unsafe_continuation_type,
   BuiltinType {
-  override string toString() { result = "BuiltinRawUnsafeContinuationType" }
+  override string getPrimaryQlClass() { result = "BuiltinRawUnsafeContinuationType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinUnsafeValueBufferType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinUnsafeValueBufferType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinUnsafeValueBufferTypeBase extends @builtin_unsafe_value_buffer_type, BuiltinType {
-  override string toString() { result = "BuiltinUnsafeValueBufferType" }
+  override string getPrimaryQlClass() { result = "BuiltinUnsafeValueBufferType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/BuiltinVectorType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/BuiltinVectorType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.BuiltinType
 
 class BuiltinVectorTypeBase extends @builtin_vector_type, BuiltinType {
-  override string toString() { result = "BuiltinVectorType" }
+  override string getPrimaryQlClass() { result = "BuiltinVectorType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ClassType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ClassType.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.decl.ClassDecl
 import codeql.swift.elements.type.NominalType
 
 class ClassTypeBase extends @class_type, NominalType {
-  override string toString() { result = "ClassType" }
+  override string getPrimaryQlClass() { result = "ClassType" }
 
   ClassDecl getDecl() {
     exists(ClassDecl x |

--- a/swift/ql/lib/codeql/swift/generated/type/DependentMemberType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/DependentMemberType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class DependentMemberTypeBase extends @dependent_member_type, Type {
-  override string toString() { result = "DependentMemberType" }
+  override string getPrimaryQlClass() { result = "DependentMemberType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/DictionaryType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/DictionaryType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.SyntaxSugarType
 
 class DictionaryTypeBase extends @dictionary_type, SyntaxSugarType {
-  override string toString() { result = "DictionaryType" }
+  override string getPrimaryQlClass() { result = "DictionaryType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/DynamicSelfType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/DynamicSelfType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class DynamicSelfTypeBase extends @dynamic_self_type, Type {
-  override string toString() { result = "DynamicSelfType" }
+  override string getPrimaryQlClass() { result = "DynamicSelfType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/EnumType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/EnumType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.NominalType
 
 class EnumTypeBase extends @enum_type, NominalType {
-  override string toString() { result = "EnumType" }
+  override string getPrimaryQlClass() { result = "EnumType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ErrorType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ErrorType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class ErrorTypeBase extends @error_type, Type {
-  override string toString() { result = "ErrorType" }
+  override string getPrimaryQlClass() { result = "ErrorType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ExistentialMetatypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ExistentialMetatypeType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.AnyMetatypeType
 
 class ExistentialMetatypeTypeBase extends @existential_metatype_type, AnyMetatypeType {
-  override string toString() { result = "ExistentialMetatypeType" }
+  override string getPrimaryQlClass() { result = "ExistentialMetatypeType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ExistentialType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ExistentialType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class ExistentialTypeBase extends @existential_type, Type {
-  override string toString() { result = "ExistentialType" }
+  override string getPrimaryQlClass() { result = "ExistentialType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/FunctionType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/FunctionType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.AnyFunctionType
 
 class FunctionTypeBase extends @function_type, AnyFunctionType {
-  override string toString() { result = "FunctionType" }
+  override string getPrimaryQlClass() { result = "FunctionType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/GenericFunctionType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/GenericFunctionType.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.type.AnyFunctionType
 import codeql.swift.elements.type.GenericTypeParamType
 
 class GenericFunctionTypeBase extends @generic_function_type, AnyFunctionType {
-  override string toString() { result = "GenericFunctionType" }
+  override string getPrimaryQlClass() { result = "GenericFunctionType" }
 
   GenericTypeParamType getGenericParam(int index) {
     exists(GenericTypeParamType x |

--- a/swift/ql/lib/codeql/swift/generated/type/GenericTypeParamType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/GenericTypeParamType.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.type.SubstitutableType
 
 class GenericTypeParamTypeBase extends @generic_type_param_type, SubstitutableType {
-  override string toString() { result = "GenericTypeParamType" }
+  override string getPrimaryQlClass() { result = "GenericTypeParamType" }
 
   string getName() { generic_type_param_types(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/InOutType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/InOutType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class InOutTypeBase extends @in_out_type, Type {
-  override string toString() { result = "InOutType" }
+  override string getPrimaryQlClass() { result = "InOutType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/LValueType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/LValueType.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.type.Type
 
 class LValueTypeBase extends @l_value_type, Type {
-  override string toString() { result = "LValueType" }
+  override string getPrimaryQlClass() { result = "LValueType" }
 
   Type getObjectType() {
     exists(Type x |

--- a/swift/ql/lib/codeql/swift/generated/type/MetatypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/MetatypeType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.AnyMetatypeType
 
 class MetatypeTypeBase extends @metatype_type, AnyMetatypeType {
-  override string toString() { result = "MetatypeType" }
+  override string getPrimaryQlClass() { result = "MetatypeType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ModuleType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ModuleType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class ModuleTypeBase extends @module_type, Type {
-  override string toString() { result = "ModuleType" }
+  override string getPrimaryQlClass() { result = "ModuleType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/NestedArchetypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/NestedArchetypeType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ArchetypeType
 
 class NestedArchetypeTypeBase extends @nested_archetype_type, ArchetypeType {
-  override string toString() { result = "NestedArchetypeType" }
+  override string getPrimaryQlClass() { result = "NestedArchetypeType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/OpaqueTypeArchetypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/OpaqueTypeArchetypeType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ArchetypeType
 
 class OpaqueTypeArchetypeTypeBase extends @opaque_type_archetype_type, ArchetypeType {
-  override string toString() { result = "OpaqueTypeArchetypeType" }
+  override string getPrimaryQlClass() { result = "OpaqueTypeArchetypeType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/OpenedArchetypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/OpenedArchetypeType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ArchetypeType
 
 class OpenedArchetypeTypeBase extends @opened_archetype_type, ArchetypeType {
-  override string toString() { result = "OpenedArchetypeType" }
+  override string getPrimaryQlClass() { result = "OpenedArchetypeType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/OptionalType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/OptionalType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.UnarySyntaxSugarType
 
 class OptionalTypeBase extends @optional_type, UnarySyntaxSugarType {
-  override string toString() { result = "OptionalType" }
+  override string getPrimaryQlClass() { result = "OptionalType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ParenType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ParenType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.SugarType
 
 class ParenTypeBase extends @paren_type, SugarType {
-  override string toString() { result = "ParenType" }
+  override string getPrimaryQlClass() { result = "ParenType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/PlaceholderType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/PlaceholderType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class PlaceholderTypeBase extends @placeholder_type, Type {
-  override string toString() { result = "PlaceholderType" }
+  override string getPrimaryQlClass() { result = "PlaceholderType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/PrimaryArchetypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/PrimaryArchetypeType.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.type.ArchetypeType
 import codeql.swift.elements.type.GenericTypeParamType
 
 class PrimaryArchetypeTypeBase extends @primary_archetype_type, ArchetypeType {
-  override string toString() { result = "PrimaryArchetypeType" }
+  override string getPrimaryQlClass() { result = "PrimaryArchetypeType" }
 
   GenericTypeParamType getInterfaceType() {
     exists(GenericTypeParamType x |

--- a/swift/ql/lib/codeql/swift/generated/type/ProtocolCompositionType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ProtocolCompositionType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class ProtocolCompositionTypeBase extends @protocol_composition_type, Type {
-  override string toString() { result = "ProtocolCompositionType" }
+  override string getPrimaryQlClass() { result = "ProtocolCompositionType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/ProtocolType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/ProtocolType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.NominalType
 
 class ProtocolTypeBase extends @protocol_type, NominalType {
-  override string toString() { result = "ProtocolType" }
+  override string getPrimaryQlClass() { result = "ProtocolType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/SequenceArchetypeType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/SequenceArchetypeType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ArchetypeType
 
 class SequenceArchetypeTypeBase extends @sequence_archetype_type, ArchetypeType {
-  override string toString() { result = "SequenceArchetypeType" }
+  override string getPrimaryQlClass() { result = "SequenceArchetypeType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/SilBlockStorageType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/SilBlockStorageType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class SilBlockStorageTypeBase extends @sil_block_storage_type, Type {
-  override string toString() { result = "SilBlockStorageType" }
+  override string getPrimaryQlClass() { result = "SilBlockStorageType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/SilBoxType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/SilBoxType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class SilBoxTypeBase extends @sil_box_type, Type {
-  override string toString() { result = "SilBoxType" }
+  override string getPrimaryQlClass() { result = "SilBoxType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/SilFunctionType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/SilFunctionType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class SilFunctionTypeBase extends @sil_function_type, Type {
-  override string toString() { result = "SilFunctionType" }
+  override string getPrimaryQlClass() { result = "SilFunctionType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/SilTokenType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/SilTokenType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class SilTokenTypeBase extends @sil_token_type, Type {
-  override string toString() { result = "SilTokenType" }
+  override string getPrimaryQlClass() { result = "SilTokenType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/StructType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/StructType.qll
@@ -3,7 +3,7 @@ import codeql.swift.elements.type.NominalType
 import codeql.swift.elements.decl.StructDecl
 
 class StructTypeBase extends @struct_type, NominalType {
-  override string toString() { result = "StructType" }
+  override string getPrimaryQlClass() { result = "StructType" }
 
   StructDecl getDecl() {
     exists(StructDecl x |

--- a/swift/ql/lib/codeql/swift/generated/type/TupleType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/TupleType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class TupleTypeBase extends @tuple_type, Type {
-  override string toString() { result = "TupleType" }
+  override string getPrimaryQlClass() { result = "TupleType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/TypeAliasType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/TypeAliasType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.SugarType
 
 class TypeAliasTypeBase extends @type_alias_type, SugarType {
-  override string toString() { result = "TypeAliasType" }
+  override string getPrimaryQlClass() { result = "TypeAliasType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/TypeVariableType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/TypeVariableType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class TypeVariableTypeBase extends @type_variable_type, Type {
-  override string toString() { result = "TypeVariableType" }
+  override string getPrimaryQlClass() { result = "TypeVariableType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/UnboundGenericType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/UnboundGenericType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.AnyGenericType
 
 class UnboundGenericTypeBase extends @unbound_generic_type, AnyGenericType {
-  override string toString() { result = "UnboundGenericType" }
+  override string getPrimaryQlClass() { result = "UnboundGenericType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/UnknownType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/UnknownType.qll
@@ -2,7 +2,7 @@
 import codeql.swift.elements.type.Type
 
 class UnknownTypeBase extends @unknown_type, Type {
-  override string toString() { result = "UnknownType" }
+  override string getPrimaryQlClass() { result = "UnknownType" }
 
   string getName() { unknown_types(this, result) }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/UnmanagedStorageType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/UnmanagedStorageType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ReferenceStorageType
 
 class UnmanagedStorageTypeBase extends @unmanaged_storage_type, ReferenceStorageType {
-  override string toString() { result = "UnmanagedStorageType" }
+  override string getPrimaryQlClass() { result = "UnmanagedStorageType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/UnownedStorageType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/UnownedStorageType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ReferenceStorageType
 
 class UnownedStorageTypeBase extends @unowned_storage_type, ReferenceStorageType {
-  override string toString() { result = "UnownedStorageType" }
+  override string getPrimaryQlClass() { result = "UnownedStorageType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/UnresolvedType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/UnresolvedType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.Type
 
 class UnresolvedTypeBase extends @unresolved_type, Type {
-  override string toString() { result = "UnresolvedType" }
+  override string getPrimaryQlClass() { result = "UnresolvedType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/VariadicSequenceType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/VariadicSequenceType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.UnarySyntaxSugarType
 
 class VariadicSequenceTypeBase extends @variadic_sequence_type, UnarySyntaxSugarType {
-  override string toString() { result = "VariadicSequenceType" }
+  override string getPrimaryQlClass() { result = "VariadicSequenceType" }
 }

--- a/swift/ql/lib/codeql/swift/generated/type/WeakStorageType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/WeakStorageType.qll
@@ -2,5 +2,5 @@
 import codeql.swift.elements.type.ReferenceStorageType
 
 class WeakStorageTypeBase extends @weak_storage_type, ReferenceStorageType {
-  override string toString() { result = "WeakStorageType" }
+  override string getPrimaryQlClass() { result = "WeakStorageType" }
 }


### PR DESCRIPTION
These changes are required to allow a new type-safe approach to TBD
nodes, that will come in a separate commit.

This introduces:
* the possibility to add properties to the root `Element`
* a functor taking tags to the corresponding binding trap entry
* `hasProp()` methods for optional properties in QL
* `getPrimaryQlClass()` method