### PR TITLE
Claim Go 1.18 support

### DIFF
--- a/docs/codeql/support/reusables/versions-compilers.rst
+++ b/docs/codeql/support/reusables/versions-compilers.rst
@@ -16,7 +16,7 @@
    .NET Core up to 3.1
 
    .NET 5, .NET 6","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-   Go (aka Golang), "Go up to 1.17", "Go 1.11 or more recent", ``.go``
+   Go (aka Golang), "Go up to 1.18", "Go 1.11 or more recent", ``.go``
    Java,"Java 7 to 18 [4]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [5]_",``.java``


### PR DESCRIPTION
As of https://github.com/github/codeql-go/pull/686 landing we support extracting generics, dataflow analysis in programs that use generics, etc. Note this hasn't  gone out in a release yet but I would expect it to be in 2.9.2.