### PR TITLE
JS: resolve main module when there is a folder with the same name as the main file

### DIFF
--- a/javascript/ql/lib/semmle/javascript/NodeModuleResolutionImpl.qll
+++ b/javascript/ql/lib/semmle/javascript/NodeModuleResolutionImpl.qll
@@ -96,7 +96,7 @@ File resolveMainModule(PackageJson pkg, int priority) {
     or
     result = tryExtensions(main.resolve(), "index", priority)
     or
-    not exists(main.resolve()) and
+    not main.resolve() instanceof File and
     exists(int n | n = main.getNumComponent() |
       result = tryExtensions(main.resolveUpTo(n - 1), getStem(main.getComponent(n - 1)), priority)
     )

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/PrototypePollutingAssignment.expected
@@ -94,6 +94,12 @@ nodes
 | lib.js:108:3:108:10 | obj[one] |
 | lib.js:108:3:108:10 | obj[one] |
 | lib.js:108:7:108:9 | one |
+| sublib/sub.js:1:37:1:40 | path |
+| sublib/sub.js:1:37:1:40 | path |
+| sublib/sub.js:2:3:2:14 | obj[path[0]] |
+| sublib/sub.js:2:3:2:14 | obj[path[0]] |
+| sublib/sub.js:2:7:2:10 | path |
+| sublib/sub.js:2:7:2:13 | path[0] |
 | tst.js:5:9:5:38 | taint |
 | tst.js:5:17:5:38 | String( ... y.data) |
 | tst.js:5:24:5:37 | req.query.data |
@@ -230,6 +236,11 @@ edges
 | lib.js:104:13:104:24 | arguments[1] | lib.js:104:7:104:24 | one |
 | lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
 | lib.js:108:7:108:9 | one | lib.js:108:3:108:10 | obj[one] |
+| sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:7:2:10 | path |
+| sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:7:2:10 | path |
+| sublib/sub.js:2:7:2:10 | path | sublib/sub.js:2:7:2:13 | path[0] |
+| sublib/sub.js:2:7:2:13 | path[0] | sublib/sub.js:2:3:2:14 | obj[path[0]] |
+| sublib/sub.js:2:7:2:13 | path[0] | sublib/sub.js:2:3:2:14 | obj[path[0]] |
 | tst.js:5:9:5:38 | taint | tst.js:8:12:8:16 | taint |
 | tst.js:5:9:5:38 | taint | tst.js:9:12:9:16 | taint |
 | tst.js:5:9:5:38 | taint | tst.js:12:25:12:29 | taint |
@@ -284,6 +295,7 @@ edges
 | lib.js:70:13:70:24 | obj[path[0]] | lib.js:59:18:59:18 | s | lib.js:70:13:70:24 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:59:18:59:18 | s | library input |
 | lib.js:87:10:87:14 | proto | lib.js:83:14:83:25 | arguments[1] | lib.js:87:10:87:14 | proto | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:83:14:83:25 | arguments[1] | library input |
 | lib.js:108:3:108:10 | obj[one] | lib.js:104:13:104:24 | arguments[1] | lib.js:108:3:108:10 | obj[one] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | lib.js:104:13:104:24 | arguments[1] | library input |
+| sublib/sub.js:2:3:2:14 | obj[path[0]] | sublib/sub.js:1:37:1:40 | path | sublib/sub.js:2:3:2:14 | obj[path[0]] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | sublib/sub.js:1:37:1:40 | path | library input |
 | tst.js:8:5:8:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:8:5:8:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |
 | tst.js:9:5:9:17 | object[taint] | tst.js:5:24:5:37 | req.query.data | tst.js:9:5:9:17 | object[taint] | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |
 | tst.js:14:5:14:32 | unsafeG ...  taint) | tst.js:5:24:5:37 | req.query.data | tst.js:14:5:14:32 | unsafeG ...  taint) | This assignment may alter Object.prototype if a malicious '__proto__' string is injected from $@. | tst.js:5:24:5:37 | req.query.data | user controlled input |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/sublib/package.json
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/sublib/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "sublib",
+    "main": "./sub"
+}

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/sublib/sub.js
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/sublib/sub.js
@@ -1,0 +1,3 @@
+module.exports.set = function (obj, path, value) {
+  obj[path[0]][path[1]] = value; // NOT OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/sublib/sub/empty.js
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/sublib/sub/empty.js
@@ -1,0 +1,1 @@
+console.log("foo");


### PR DESCRIPTION
Recognizes the source for CVE-2022-21803 

See the test case to see what I mean.  
There is both a folder and a file that basename `sub`. 
And in that case we should resolve the main module to the file.   

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-9115-3d40207__nightly-old__code-scanning/reports).  