### PR TITLE
C#: Tag telemetry queries with `telemetry`

### DIFF
--- a/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
+++ b/csharp/ql/src/Telemetry/ExternalLibraryUsage.ql
@@ -2,7 +2,7 @@
  * @name External libraries
  * @description A list of external libraries used in the code
  * @kind metric
- * @tags summary
+ * @tags summary telemetry
  * @id csharp/telemetry/external-libs
  */
 

--- a/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -2,7 +2,7 @@
  * @name Supported sinks in external libraries
  * @description A list of 3rd party APIs detected as sinks. Excludes APIs exposed by test libraries.
  * @kind metric
- * @tags summary
+ * @tags summary telemetry
  * @id csharp/telemetry/supported-external-api-sinks
  */
 

--- a/csharp/ql/src/Telemetry/SupportedExternalSources.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalSources.ql
@@ -2,7 +2,7 @@
  * @name Supported sources in external libraries
  * @description A list of 3rd party APIs detected as sources. Excludes APIs exposed by test libraries.
  * @kind metric
- * @tags summary
+ * @tags summary telemetry
  * @id csharp/telemetry/supported-external-api-sources
  */
 

--- a/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
+++ b/csharp/ql/src/Telemetry/SupportedExternalTaint.ql
@@ -2,7 +2,7 @@
  * @name Supported flow steps in external libraries
  * @description A list of 3rd party APIs detected as flow steps. Excludes APIs exposed by test libraries.
  * @kind metric
- * @tags summary
+ * @tags summary telemetry
  * @id csharp/telemetry/supported-external-api-taint
  */
 

--- a/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -2,7 +2,7 @@
  * @name Usage of unsupported APIs coming from external libraries
  * @description A list of 3rd party APIs used in the codebase. Excludes APIs exposed by test libraries.
  * @kind metric
- * @tags summary
+ * @tags summary telemetry
  * @id csharp/telemetry/unsupported-external-api
  */
 


### PR DESCRIPTION
This will exclude the results of these queries from the summary tables produced by `codeql database analyze` in a future version of the CodeQL CLI.