### PR TITLE
Fix non-US spellings and the corresponding query

### DIFF
--- a/cpp/ql/lib/change-notes/2022-05-11-deprecated-analysed-string.md
+++ b/cpp/ql/lib/change-notes/2022-05-11-deprecated-analysed-string.md
@@ -1,4 +1,4 @@
 ---
  category: deprecated
- ---
+---
  * The `AnalysedString` class in the `StringAnalysis` module has been replaced with `AnalyzedString`, to follow our style guide. The old name still exists as a deprecated alias.

--- a/cpp/ql/lib/change-notes/2022-05-11-deprecated-analysed-string.md
+++ b/cpp/ql/lib/change-notes/2022-05-11-deprecated-analysed-string.md
@@ -1,0 +1,4 @@
+---
+ category: deprecated
+ ---
+ * The `AnalysedString` class in the `StringAnalysis` module has been replaced with `AnalyzedString`, to follow our style guide. The old name still exists as a deprecated alias.

--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -1312,7 +1312,7 @@ class FormatLiteral extends Literal {
         len =
           min(int v |
             v = this.getPrecision(n) or
-            v = this.getUse().getFormatArgument(n).(AnalysedString).getMaxLength() - 1 // (don't count null terminator)
+            v = this.getUse().getFormatArgument(n).(AnalyzedString).getMaxLength() - 1 // (don't count null terminator)
           ) and
         reason = TValueFlowAnalysis()
       )

--- a/cpp/ql/lib/semmle/code/cpp/commons/StringAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/StringAnalysis.qll
@@ -44,7 +44,7 @@ class AnalyzedString extends Expr {
    * can be calculated.
    */
   int getMaxLength() {
-    // take the longest AnalysedString it's value could 'flow' from; however if even one doesn't
+    // take the longest AnalyzedString its value could 'flow' from; however if even one doesn't
     // return a value (this essentially means 'infinity') we can't return a value either.
     result =
       max(AnalyzedString expr, int toMax |

--- a/cpp/ql/lib/semmle/code/cpp/commons/StringAnalysis.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/StringAnalysis.qll
@@ -27,11 +27,14 @@ predicate canValueFlow(Expr fromExpr, Expr toExpr) {
   fromExpr = toExpr.(ConditionalExpr).getElse()
 }
 
+/** DEPRECATED: Alias for AnalyzedString */
+deprecated class AnalysedString = AnalyzedString;
+
 /**
- * An analysed null terminated string.
+ * An analyzed null terminated string.
  */
-class AnalysedString extends Expr {
-  AnalysedString() {
+class AnalyzedString extends Expr {
+  AnalyzedString() {
     this.getUnspecifiedType() instanceof ArrayType or
     this.getUnspecifiedType() instanceof PointerType
   }
@@ -44,12 +47,12 @@ class AnalysedString extends Expr {
     // take the longest AnalysedString it's value could 'flow' from; however if even one doesn't
     // return a value (this essentially means 'infinity') we can't return a value either.
     result =
-      max(AnalysedString expr, int toMax |
+      max(AnalyzedString expr, int toMax |
         canValueFlow*(expr, this) and toMax = expr.(StringLiteral).getOriginalLength()
       |
         toMax
       ) and // maximum length
-    forall(AnalysedString expr | canValueFlow(expr, this) | exists(expr.getMaxLength())) // all sources return a value (recursive)
+    forall(AnalyzedString expr | canValueFlow(expr, this) | exists(expr.getMaxLength())) // all sources return a value (recursive)
   }
 }
 

--- a/cpp/ql/lib/semmle/code/cpp/security/BufferWrite.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/BufferWrite.qll
@@ -201,7 +201,7 @@ class StrCatBW extends BufferWriteCall {
     // when result exists, it is an exact flow analysis
     reason instanceof ValueFlowAnalysis and
     result =
-      this.getArgument(this.getParamSrc()).(AnalysedString).getMaxLength() * this.getCharSize()
+      this.getArgument(this.getParamSrc()).(AnalyzedString).getMaxLength() * this.getCharSize()
   }
 
   override int getMaxData(BufferWriteEstimationReason reason) {

--- a/cpp/ql/lib/semmle/code/cpp/security/BufferWrite.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/BufferWrite.qll
@@ -155,7 +155,7 @@ class StrCopyBW extends BufferWriteCall {
     // when result exists, it is an exact flow analysis
     reason instanceof ValueFlowAnalysis and
     result =
-      this.getArgument(this.getParamSrc()).(AnalysedString).getMaxLength() * this.getCharSize()
+      this.getArgument(this.getParamSrc()).(AnalyzedString).getMaxLength() * this.getCharSize()
   }
 
   override int getMaxData(BufferWriteEstimationReason reason) {

--- a/cpp/ql/test/library-tests/string_analysis/StringAnalysis.ql
+++ b/cpp/ql/test/library-tests/string_analysis/StringAnalysis.ql
@@ -5,7 +5,7 @@
 
 import cpp
 
-from AnalysedString s, string str
+from AnalyzedString s, string str
 where
   if s.(StringLiteral).getUnspecifiedType().(DerivedType).getBaseType() instanceof Wchar_t
   then str = "[?]"

--- a/java/ql/lib/semmle/code/java/dataflow/StringPrefixes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/StringPrefixes.qll
@@ -34,7 +34,7 @@ private import semmle.code.java.StringFormat
  * A string constant that contains a prefix whose possibly-appended strings are
  * returned by `getAnAppendedExpression`.
  *
- * Extend this class to specify prefixes whose possibly-appended strings should be analysed.
+ * Extend this class to specify prefixes whose possibly-appended strings should be analyzed.
  */
 abstract class InterestingPrefix extends CompileTimeConstantExpr {
   /**

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -4,7 +4,7 @@
 
 import javascript
 
-/** Provices classes for modelling NoSQL query sinks. */
+/** Provides classes for modeling NoSQL query sinks. */
 module NoSql {
   /** An expression that is interpreted as a NoSQL query. */
   abstract class Query extends Expr {

--- a/python/ql/lib/semmle/python/objects/ObjectInternal.qll
+++ b/python/ql/lib/semmle/python/objects/ObjectInternal.qll
@@ -49,7 +49,7 @@ class ObjectInternal extends TObject {
   abstract ObjectInternal getClass();
 
   /**
-   * True if this "object" can be meaningfully analysed to determine the boolean value of
+   * True if this "object" can be meaningfully analyzed to determine the boolean value of
    * equality tests on it.
    * For example, `None` or `int` can be, but `int()` or an unknown string cannot.
    */

--- a/python/ql/lib/semmle/python/objects/Sequences.qll
+++ b/python/ql/lib/semmle/python/objects/Sequences.qll
@@ -70,7 +70,7 @@ abstract class TupleObjectInternal extends SequenceObjectInternal {
   override ObjectInternal getClass() { result = ObjectInternal::builtin("tuple") }
 
   /**
-   * True if this "object" can be meaningfully analysed for
+   * True if this "object" can be meaningfully analyzed for
    * truth or false in comparisons. For example, `None` or `int` can be, but `int()`
    * or an unknown string cannot.
    */

--- a/ql/ql/src/codeql_ql/style/docs/NonUSSpellingQuery.qll
+++ b/ql/ql/src/codeql_ql/style/docs/NonUSSpellingQuery.qll
@@ -18,7 +18,7 @@ predicate contains_non_us_spelling(string s, string wrong, string right) {
     wrong != "analyse"
     or
     // analyses (as a noun) is fine
-    s.regexpMatch(".*analyse[^s].*") and
+    s.regexpReplaceAll("[\\r\\n]", " ").regexpMatch(".*analyse[^s].*") and
     wrong = "analyse"
   )
 }


### PR DESCRIPTION
The query was missing multi-line comments containing 'analyse', because `.` does not match newline characters in `regexpMatch`.