### PR TITLE
Kotlin: fix cases where type variables were used out of scope

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -173,19 +173,7 @@ open class KotlinFileExtractor(
 
     fun extractTypeParameter(tp: IrTypeParameter, apparentIndex: Int): Label<out DbTypevariable>? {
         with("type parameter", tp) {
-            val parentId: Label<out DbClassorinterfaceorcallable>? = when (val parent = tp.parent) {
-                is IrFunction -> useFunction(parent)
-                is IrClass -> useClassSource(parent)
-                else -> {
-                    logger.errorElement("Unexpected type parameter parent", tp)
-                    null
-                }
-            }
-
-            if (parentId == null) {
-                return null
-            }
-
+            val parentId = getTypeParameterParentLabel(tp) ?: return null
             val id = tw.getLabelFor<DbTypevariable>(getTypeParameterLabel(tp))
 
             // Note apparentIndex does not necessarily equal `tp.index`, because at least constructor type parameters

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -215,6 +215,17 @@ open class KotlinUsesExtractor(
     fun makeTypeGenericSubstitutionMap(c: IrClass, argsIncludingOuterClasses: List<IrTypeArgument>) =
         getTypeParametersInScope(c).map({ it.symbol }).zip(argsIncludingOuterClasses.map { it.withQuestionMark(true) }).toMap()
 
+    fun makeGenericSubstitutionFunction(c: IrClass, argsIncludingOuterClasses: List<IrTypeArgument>) =
+        makeTypeGenericSubstitutionMap(c, argsIncludingOuterClasses).let {
+            { x: IrType, useContext: TypeContext, pluginContext: IrPluginContext ->
+                x.substituteTypeAndArguments(
+                    it,
+                    useContext,
+                    pluginContext
+                )
+            }
+        }
+
     // The Kotlin compiler internal representation of Outer<A, B>.Inner<C, D>.InnerInner<E, F>.someFunction<G, H>.LocalClass<I, J> is LocalClass<I, J, G, H, E, F, C, D, A, B>. This function returns [A, B, C, D, E, F, G, H, I, J].
     fun orderTypeArgsLeftToRight(c: IrClass, argsIncludingOuterClasses: List<IrTypeArgument>?): List<IrTypeArgument>? {
         if(argsIncludingOuterClasses.isNullOrEmpty())

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -253,10 +253,12 @@ open class KotlinUsesExtractor(
         val extractClass = substituteClass ?: c
 
         // `KFunction1<T1,T2>` is substituted by `KFunction<T>`. The last type argument is the return type.
+        // Similarly Function23 and above get replaced by kotlin.jvm.functions.FunctionN with only one type arg, the result type.
         // References to SomeGeneric<T1, T2, ...> where SomeGeneric is declared SomeGeneric<T1, T2, ...> are extracted
         // as if they were references to the unbound type SomeGeneric.
         val extractedTypeArgs = when {
-            c.symbol.isKFunction() && typeArgs != null && typeArgs.isNotEmpty() -> listOf(typeArgs.last())
+            extractClass.symbol.isKFunction() && typeArgs != null && typeArgs.isNotEmpty() -> listOf(typeArgs.last())
+            extractClass.fqNameWhenAvailable == FqName("kotlin.jvm.functions.FunctionN") && typeArgs != null && typeArgs.isNotEmpty() -> listOf(typeArgs.last())
             typeArgs != null && isUnspecialised(c, typeArgs) -> listOf()
             else -> typeArgs
         }

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -1083,8 +1083,21 @@ open class KotlinUsesExtractor(
         return classTypeResult.id
     }
 
+    fun getTypeParameterParentLabel(param: IrTypeParameter) =
+        param.parent.let {
+            when (it) {
+                is IrClass -> useClassSource(it)
+                is IrFunction -> useFunction(it, noReplace = true)
+                else -> { logger.error("Unexpected type parameter parent $it"); null }
+            }
+        }
+
     fun getTypeParameterLabel(param: IrTypeParameter): String {
-        val parentLabel = useDeclarationParent(param.parent, false)
+        // Use this instead of `useDeclarationParent` so we can use useFunction with noReplace = true,
+        // ensuring that e.g. a method-scoped type variable declared on kotlin.String.transform <R> gets
+        // a different name to the corresponding java.lang.String.transform <R>, even though useFunction
+        // will usually replace references to one function with the other.
+        val parentLabel = getTypeParameterParentLabel(param)
         return "@\"typevar;{$parentLabel};${param.name}\""
     }
 

--- a/java/ql/consistency-queries/typeParametersInScope.ql
+++ b/java/ql/consistency-queries/typeParametersInScope.ql
@@ -1,9 +1,7 @@
 import java
 
 class InstantiatedType extends ParameterizedType {
-  InstantiatedType() {
-    typeArgs(_, _, this)
-  }
+  InstantiatedType() { typeArgs(_, _, this) }
 }
 
 Type getAMentionedType(RefType type) {

--- a/java/ql/consistency-queries/typeParametersInScope.ql
+++ b/java/ql/consistency-queries/typeParametersInScope.ql
@@ -49,4 +49,5 @@ TypeVariable getATypeVariableInScope(RefType type) {
 from ClassOrInterface typeUser, TypeVariable outOfScope
 where
   outOfScope = getATypeUsedInClass(typeUser) and not outOfScope = getATypeVariableInScope(typeUser)
-select "Type " + typeUser + " uses out-of-scope type variable " + outOfScope + ". Note the Java extractor is known to sometimes do this; the Kotlin extractor should not."
+select "Type " + typeUser + " uses out-of-scope type variable " + outOfScope +
+    ". Note the Java extractor is known to sometimes do this; the Kotlin extractor should not."

--- a/java/ql/consistency-queries/typeParametersInScope.ql
+++ b/java/ql/consistency-queries/typeParametersInScope.ql
@@ -1,11 +1,17 @@
 import java
 
+class InstantiatedType extends ParameterizedType {
+  InstantiatedType() {
+    typeArgs(_, _, this)
+  }
+}
+
 Type getAMentionedType(RefType type) {
   result = type
   or
   result = getAMentionedType(type).(Array).getElementType()
   or
-  result = getAMentionedType(type).(ParameterizedType).getATypeArgument()
+  result = getAMentionedType(type).(InstantiatedType).getATypeArgument()
   or
   result = getAMentionedType(type).(NestedType).getEnclosingType()
 }
@@ -29,7 +35,7 @@ TypeVariable getATypeVariableInScope(RefType type) {
   or
   result = type.(GenericType).getATypeParameter()
   or
-  result = getAMentionedType(type.(ParameterizedType).getATypeArgument())
+  result = getAMentionedType(type.(InstantiatedType).getATypeArgument())
   or
   result = getATypeVariableInScope(type.getEnclosingType())
 }

--- a/java/ql/consistency-queries/typeParametersInScope.ql
+++ b/java/ql/consistency-queries/typeParametersInScope.ql
@@ -36,5 +36,5 @@ TypeVariable getATypeVariableInScope(RefType type) {
 
 from ClassOrInterface typeUser, TypeVariable outOfScope
 where
-  outOfScope = getAMentionedType(typeUser) and not outOfScope = getATypeVariableInScope(typeUser)
+  outOfScope = getATypeUsedInClass(typeUser) and not outOfScope = getATypeVariableInScope(typeUser)
 select "Type " + typeUser + " uses out-of-scope type variable " + outOfScope

--- a/java/ql/consistency-queries/typeParametersInScope.ql
+++ b/java/ql/consistency-queries/typeParametersInScope.ql
@@ -49,4 +49,4 @@ TypeVariable getATypeVariableInScope(RefType type) {
 from ClassOrInterface typeUser, TypeVariable outOfScope
 where
   outOfScope = getATypeUsedInClass(typeUser) and not outOfScope = getATypeVariableInScope(typeUser)
-select "Type " + typeUser + " uses out-of-scope type variable " + outOfScope
+select "Type " + typeUser + " uses out-of-scope type variable " + outOfScope + ". Note the Java extractor is known to sometimes do this; the Kotlin extractor should not."

--- a/java/ql/consistency-queries/typeParametersInScope.ql
+++ b/java/ql/consistency-queries/typeParametersInScope.ql
@@ -30,14 +30,22 @@ Type getATypeUsedInClass(RefType type) {
   result = getAMentionedType(getATypeUsedInClass(type))
 }
 
+Element getEnclosingElementStar(RefType e) {
+  result = e
+  or
+  result.contains(e)
+}
+
 TypeVariable getATypeVariableInScope(RefType type) {
-  result = type.getACallable().(GenericCallable).getATypeParameter()
-  or
-  result = type.(GenericType).getATypeParameter()
-  or
-  result = getAMentionedType(type.(InstantiatedType).getATypeArgument())
-  or
-  result = getATypeVariableInScope(type.getEnclosingType())
+  exists(Element e | e = getEnclosingElementStar(type) |
+    result = e.(RefType).getACallable().(GenericCallable).getATypeParameter()
+    or
+    result = e.(GenericType).getATypeParameter()
+    or
+    result = e.(GenericCallable).getATypeParameter()
+    or
+    result = getAMentionedType(e.(InstantiatedType).getATypeArgument())
+  )
 }
 
 from ClassOrInterface typeUser, TypeVariable outOfScope

--- a/java/ql/test/kotlin/library-tests/dataflow/func/util.kt
+++ b/java/ql/test/kotlin/library-tests/dataflow/func/util.kt
@@ -1,23 +1,23 @@
 class Processor {
-    fun <R> process(f: () -> R) : R {
+    fun <R1> process(f: () -> R1) : R1 {
         return f()
     }
 
-    fun <T, R> process(f: (T) -> R, arg: T) : R {
+    fun <T, R2> process(f: (T) -> R2, arg: T) : R2 {
         return f(arg)
     }
 
-    fun <T0, T1, R> process(f: (T0, T1) -> R, arg0: T0, arg1: T1) : R {
+    fun <T0, T1, R3> process(f: (T0, T1) -> R3, arg0: T0, arg1: T1) : R3 {
         return f(arg0, arg1)
     }
 
-    fun <T, R> process(
-        f: (T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T) -> R,
-        a: T, b: T) : R {
+    fun <T, R4> process(
+        f: (T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T,T) -> R4,
+        a: T, b: T) : R4 {
         return f(a,b,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a)
     }
 
-    fun <T, R> processExt(f: T.(T) -> R, ext: T, arg: T) : R {
+    fun <T, R5> processExt(f: T.(T) -> R5, ext: T, arg: T) : R5 {
         return ext.f(arg)
     }
 }

--- a/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
@@ -4867,20 +4867,20 @@ samConversion.kt:
 #    2|                           0: [VarAccess] this.<fn>
 #    2|                             -1: [ThisAccess] this
 #    2|                           1: [VarAccess] <fn>
-#    2|                   1: [FieldDeclaration] Function1<Integer,Boolean> <fn>;
-#    2|                     -1: [TypeAccess] Function1<Integer,Boolean>
-#    2|                       0: [TypeAccess] Integer
-#    2|                       1: [TypeAccess] Boolean
-#   17|                   3: [Method] accept
-#   17|                     3: [TypeAccess] boolean
+#    2|                   1: [Method] accept
+#    2|                     3: [TypeAccess] boolean
 #-----|                     4: (Parameters)
-#   17|                       0: [Parameter] i
-#   17|                         0: [TypeAccess] int
+#    2|                       0: [Parameter] i
+#    2|                         0: [TypeAccess] int
 #    2|                     5: [BlockStmt] { ... }
 #    2|                       0: [ReturnStmt] return ...
 #    2|                         0: [MethodAccess] invoke(...)
 #    2|                           -1: [VarAccess] <fn>
 #    2|                           0: [VarAccess] i
+#    2|                   1: [FieldDeclaration] Function1<Integer,Boolean> <fn>;
+#    2|                     -1: [TypeAccess] Function1<Integer,Boolean>
+#    2|                       0: [TypeAccess] Integer
+#    2|                       1: [TypeAccess] Boolean
 #    2|                 -3: [TypeAccess] IntPredicate
 #    2|                 0: [LambdaExpr] ...->...
 #    2|                   -4: [AnonymousClass] new Function1<Integer,Boolean>(...) { ... }
@@ -4918,24 +4918,24 @@ samConversion.kt:
 #    4|                           0: [VarAccess] this.<fn>
 #    4|                             -1: [ThisAccess] this
 #    4|                           1: [VarAccess] <fn>
-#    4|                   1: [FieldDeclaration] Function2<Integer,Integer,Unit> <fn>;
-#    4|                     -1: [TypeAccess] Function2<Integer,Integer,Unit>
-#    4|                       0: [TypeAccess] Integer
-#    4|                       1: [TypeAccess] Integer
-#    4|                       2: [TypeAccess] Unit
-#   23|                   3: [Method] fn1
-#   23|                     3: [TypeAccess] Unit
+#    4|                   1: [Method] fn1
+#    4|                     3: [TypeAccess] Unit
 #-----|                     4: (Parameters)
-#   23|                       0: [Parameter] i
-#   23|                         0: [TypeAccess] int
-#   23|                       1: [Parameter] j
-#   23|                         0: [TypeAccess] int
+#    4|                       0: [Parameter] i
+#    4|                         0: [TypeAccess] int
+#    4|                       1: [Parameter] j
+#    4|                         0: [TypeAccess] int
 #    4|                     5: [BlockStmt] { ... }
 #    4|                       0: [ReturnStmt] return ...
 #    4|                         0: [MethodAccess] invoke(...)
 #    4|                           -1: [VarAccess] <fn>
 #    4|                           0: [VarAccess] i
 #    4|                           1: [VarAccess] j
+#    4|                   1: [FieldDeclaration] Function2<Integer,Integer,Unit> <fn>;
+#    4|                     -1: [TypeAccess] Function2<Integer,Integer,Unit>
+#    4|                       0: [TypeAccess] Integer
+#    4|                       1: [TypeAccess] Integer
+#    4|                       2: [TypeAccess] Unit
 #    4|                 -3: [TypeAccess] InterfaceFn1
 #    4|                 0: [LambdaExpr] ...->...
 #    4|                   -4: [AnonymousClass] new Function2<Integer,Integer,Unit>(...) { ... }
@@ -4972,24 +4972,24 @@ samConversion.kt:
 #    5|                           0: [VarAccess] this.<fn>
 #    5|                             -1: [ThisAccess] this
 #    5|                           1: [VarAccess] <fn>
-#    5|                   1: [FieldDeclaration] Function2<Integer,Integer,Unit> <fn>;
-#    5|                     -1: [TypeAccess] Function2<Integer,Integer,Unit>
-#    5|                       0: [TypeAccess] Integer
-#    5|                       1: [TypeAccess] Integer
-#    5|                       2: [TypeAccess] Unit
-#   23|                   3: [Method] fn1
-#   23|                     3: [TypeAccess] Unit
+#    5|                   1: [Method] fn1
+#    5|                     3: [TypeAccess] Unit
 #-----|                     4: (Parameters)
-#   23|                       0: [Parameter] i
-#   23|                         0: [TypeAccess] int
-#   23|                       1: [Parameter] j
-#   23|                         0: [TypeAccess] int
+#    5|                       0: [Parameter] i
+#    5|                         0: [TypeAccess] int
+#    5|                       1: [Parameter] j
+#    5|                         0: [TypeAccess] int
 #    5|                     5: [BlockStmt] { ... }
 #    5|                       0: [ReturnStmt] return ...
 #    5|                         0: [MethodAccess] invoke(...)
 #    5|                           -1: [VarAccess] <fn>
 #    5|                           0: [VarAccess] i
 #    5|                           1: [VarAccess] j
+#    5|                   1: [FieldDeclaration] Function2<Integer,Integer,Unit> <fn>;
+#    5|                     -1: [TypeAccess] Function2<Integer,Integer,Unit>
+#    5|                       0: [TypeAccess] Integer
+#    5|                       1: [TypeAccess] Integer
+#    5|                       2: [TypeAccess] Unit
 #    5|                 -3: [TypeAccess] InterfaceFn1
 #    5|                 0: [MemberRefExpr] ...::...
 #    5|                   -4: [AnonymousClass] new Function2<Integer,Integer,Unit>(...) { ... }
@@ -5026,24 +5026,24 @@ samConversion.kt:
 #    7|                           0: [VarAccess] this.<fn>
 #    7|                             -1: [ThisAccess] this
 #    7|                           1: [VarAccess] <fn>
-#    7|                   1: [FieldDeclaration] Function2<String,Integer,Boolean> <fn>;
-#    7|                     -1: [TypeAccess] Function2<String,Integer,Boolean>
-#    7|                       0: [TypeAccess] String
-#    7|                       1: [TypeAccess] Integer
-#    7|                       2: [TypeAccess] Boolean
-#   27|                   3: [ExtensionMethod] ext
-#   27|                     3: [TypeAccess] boolean
+#    7|                   1: [ExtensionMethod] ext
+#    7|                     3: [TypeAccess] boolean
 #-----|                     4: (Parameters)
-#   27|                       0: [Parameter] <this>
-#   27|                         0: [TypeAccess] String
-#   27|                       1: [Parameter] i
-#   27|                         0: [TypeAccess] int
+#    7|                       0: [Parameter] <this>
+#    7|                         0: [TypeAccess] String
+#    7|                       1: [Parameter] i
+#    7|                         0: [TypeAccess] int
 #    7|                     5: [BlockStmt] { ... }
 #    7|                       0: [ReturnStmt] return ...
 #    7|                         0: [MethodAccess] invoke(...)
 #    7|                           -1: [VarAccess] <fn>
 #    7|                           0: [ExtensionReceiverAccess] this
 #    7|                           1: [VarAccess] i
+#    7|                   1: [FieldDeclaration] Function2<String,Integer,Boolean> <fn>;
+#    7|                     -1: [TypeAccess] Function2<String,Integer,Boolean>
+#    7|                       0: [TypeAccess] String
+#    7|                       1: [TypeAccess] Integer
+#    7|                       2: [TypeAccess] Boolean
 #    7|                 -3: [TypeAccess] InterfaceFnExt1
 #    7|                 0: [LambdaExpr] ...->...
 #    7|                   -4: [AnonymousClass] new Function2<String,Integer,Boolean>(...) { ... }
@@ -5082,20 +5082,20 @@ samConversion.kt:
 #    9|                           0: [VarAccess] this.<fn>
 #    9|                             -1: [ThisAccess] this
 #    9|                           1: [VarAccess] <fn>
-#    9|                   1: [FieldDeclaration] Function1<Integer,Boolean> <fn>;
-#    9|                     -1: [TypeAccess] Function1<Integer,Boolean>
-#    9|                       0: [TypeAccess] Integer
-#    9|                       1: [TypeAccess] Boolean
-#   17|                   3: [Method] accept
-#   17|                     3: [TypeAccess] boolean
+#    9|                   1: [Method] accept
+#    9|                     3: [TypeAccess] boolean
 #-----|                     4: (Parameters)
-#   17|                       0: [Parameter] i
-#   17|                         0: [TypeAccess] int
+#    9|                       0: [Parameter] i
+#    9|                         0: [TypeAccess] int
 #    9|                     5: [BlockStmt] { ... }
 #    9|                       0: [ReturnStmt] return ...
 #    9|                         0: [MethodAccess] invoke(...)
 #    9|                           -1: [VarAccess] <fn>
 #    9|                           0: [VarAccess] i
+#    9|                   1: [FieldDeclaration] Function1<Integer,Boolean> <fn>;
+#    9|                     -1: [TypeAccess] Function1<Integer,Boolean>
+#    9|                       0: [TypeAccess] Integer
+#    9|                       1: [TypeAccess] Boolean
 #    9|                 -3: [TypeAccess] IntPredicate
 #    9|                 0: [WhenExpr] when ...
 #    9|                   0: [WhenBranch] ... -> ...
@@ -5347,55 +5347,65 @@ samConversion.kt:
 #   42|               0: [TypeAccess] BigArityPredicate
 #   42|               1: [ClassInstanceExpr] new (...)
 #   42|                 -4: [AnonymousClass] new BigArityPredicate(...) { ... }
-#   31|                   1: [Method] accept
-#   31|                     3: [TypeAccess] boolean
+#   42|                   1: [Constructor] 
 #-----|                     4: (Parameters)
-#   31|                       0: [Parameter] i0
-#   31|                         0: [TypeAccess] int
-#   31|                       1: [Parameter] i1
-#   31|                         0: [TypeAccess] int
-#   31|                       2: [Parameter] i2
-#   31|                         0: [TypeAccess] int
-#   31|                       3: [Parameter] i3
-#   31|                         0: [TypeAccess] int
-#   31|                       4: [Parameter] i4
-#   31|                         0: [TypeAccess] int
-#   31|                       5: [Parameter] i5
-#   31|                         0: [TypeAccess] int
-#   31|                       6: [Parameter] i6
-#   31|                         0: [TypeAccess] int
-#   31|                       7: [Parameter] i7
-#   31|                         0: [TypeAccess] int
-#   31|                       8: [Parameter] i8
-#   31|                         0: [TypeAccess] int
-#   31|                       9: [Parameter] i9
-#   31|                         0: [TypeAccess] int
-#   32|                       10: [Parameter] i10
-#   32|                         0: [TypeAccess] int
-#   32|                       11: [Parameter] i11
-#   32|                         0: [TypeAccess] int
-#   32|                       12: [Parameter] i12
-#   32|                         0: [TypeAccess] int
-#   32|                       13: [Parameter] i13
-#   32|                         0: [TypeAccess] int
-#   32|                       14: [Parameter] i14
-#   32|                         0: [TypeAccess] int
-#   32|                       15: [Parameter] i15
-#   32|                         0: [TypeAccess] int
-#   32|                       16: [Parameter] i16
-#   32|                         0: [TypeAccess] int
-#   32|                       17: [Parameter] i17
-#   32|                         0: [TypeAccess] int
-#   32|                       18: [Parameter] i18
-#   32|                         0: [TypeAccess] int
-#   32|                       19: [Parameter] i19
-#   32|                         0: [TypeAccess] int
-#   33|                       20: [Parameter] i20
-#   33|                         0: [TypeAccess] int
-#   33|                       21: [Parameter] i21
-#   33|                         0: [TypeAccess] int
-#   33|                       22: [Parameter] i22
-#   33|                         0: [TypeAccess] int
+#   42|                       0: [Parameter] <fn>
+#   42|                     5: [BlockStmt] { ... }
+#   42|                       0: [SuperConstructorInvocationStmt] super(...)
+#   42|                       1: [ExprStmt] <Expr>;
+#   42|                         0: [AssignExpr] ...=...
+#   42|                           0: [VarAccess] this.<fn>
+#   42|                             -1: [ThisAccess] this
+#   42|                           1: [VarAccess] <fn>
+#   42|                   1: [Method] accept
+#   42|                     3: [TypeAccess] boolean
+#-----|                     4: (Parameters)
+#   42|                       0: [Parameter] i0
+#   42|                         0: [TypeAccess] int
+#   42|                       1: [Parameter] i1
+#   42|                         0: [TypeAccess] int
+#   42|                       2: [Parameter] i2
+#   42|                         0: [TypeAccess] int
+#   42|                       3: [Parameter] i3
+#   42|                         0: [TypeAccess] int
+#   42|                       4: [Parameter] i4
+#   42|                         0: [TypeAccess] int
+#   42|                       5: [Parameter] i5
+#   42|                         0: [TypeAccess] int
+#   42|                       6: [Parameter] i6
+#   42|                         0: [TypeAccess] int
+#   42|                       7: [Parameter] i7
+#   42|                         0: [TypeAccess] int
+#   42|                       8: [Parameter] i8
+#   42|                         0: [TypeAccess] int
+#   42|                       9: [Parameter] i9
+#   42|                         0: [TypeAccess] int
+#   42|                       10: [Parameter] i10
+#   42|                         0: [TypeAccess] int
+#   42|                       11: [Parameter] i11
+#   42|                         0: [TypeAccess] int
+#   42|                       12: [Parameter] i12
+#   42|                         0: [TypeAccess] int
+#   42|                       13: [Parameter] i13
+#   42|                         0: [TypeAccess] int
+#   42|                       14: [Parameter] i14
+#   42|                         0: [TypeAccess] int
+#   42|                       15: [Parameter] i15
+#   42|                         0: [TypeAccess] int
+#   42|                       16: [Parameter] i16
+#   42|                         0: [TypeAccess] int
+#   42|                       17: [Parameter] i17
+#   42|                         0: [TypeAccess] int
+#   42|                       18: [Parameter] i18
+#   42|                         0: [TypeAccess] int
+#   42|                       19: [Parameter] i19
+#   42|                         0: [TypeAccess] int
+#   42|                       20: [Parameter] i20
+#   42|                         0: [TypeAccess] int
+#   42|                       21: [Parameter] i21
+#   42|                         0: [TypeAccess] int
+#   42|                       22: [Parameter] i22
+#   42|                         0: [TypeAccess] int
 #   42|                     5: [BlockStmt] { ... }
 #   42|                       0: [ReturnStmt] return ...
 #   42|                         0: [MethodAccess] invoke(...)
@@ -5427,17 +5437,7 @@ samConversion.kt:
 #   42|                               22: [VarAccess] i22
 #   42|                             -1: [TypeAccess] Object
 #   42|                             0: [IntegerLiteral] 23
-#   42|                   2: [Constructor] 
-#-----|                     4: (Parameters)
-#   42|                       0: [Parameter] <fn>
-#   42|                     5: [BlockStmt] { ... }
-#   42|                       0: [SuperConstructorInvocationStmt] super(...)
-#   42|                       1: [ExprStmt] <Expr>;
-#   42|                         0: [AssignExpr] ...=...
-#   42|                           0: [VarAccess] this.<fn>
-#   42|                             -1: [ThisAccess] this
-#   42|                           1: [VarAccess] <fn>
-#   42|                   2: [FieldDeclaration] FunctionN<Boolean> <fn>;
+#   42|                   1: [FieldDeclaration] FunctionN<Boolean> <fn>;
 #   42|                     -1: [TypeAccess] FunctionN<Boolean>
 #   42|                       0: [TypeAccess] Boolean
 #   42|                 -3: [TypeAccess] BigArityPredicate
@@ -5448,55 +5448,65 @@ samConversion.kt:
 #   43|               0: [TypeAccess] BigArityPredicate
 #   43|               1: [ClassInstanceExpr] new (...)
 #   43|                 -4: [AnonymousClass] new BigArityPredicate(...) { ... }
-#   31|                   1: [Method] accept
-#   31|                     3: [TypeAccess] boolean
+#   43|                   1: [Constructor] 
 #-----|                     4: (Parameters)
-#   31|                       0: [Parameter] i0
-#   31|                         0: [TypeAccess] int
-#   31|                       1: [Parameter] i1
-#   31|                         0: [TypeAccess] int
-#   31|                       2: [Parameter] i2
-#   31|                         0: [TypeAccess] int
-#   31|                       3: [Parameter] i3
-#   31|                         0: [TypeAccess] int
-#   31|                       4: [Parameter] i4
-#   31|                         0: [TypeAccess] int
-#   31|                       5: [Parameter] i5
-#   31|                         0: [TypeAccess] int
-#   31|                       6: [Parameter] i6
-#   31|                         0: [TypeAccess] int
-#   31|                       7: [Parameter] i7
-#   31|                         0: [TypeAccess] int
-#   31|                       8: [Parameter] i8
-#   31|                         0: [TypeAccess] int
-#   31|                       9: [Parameter] i9
-#   31|                         0: [TypeAccess] int
-#   32|                       10: [Parameter] i10
-#   32|                         0: [TypeAccess] int
-#   32|                       11: [Parameter] i11
-#   32|                         0: [TypeAccess] int
-#   32|                       12: [Parameter] i12
-#   32|                         0: [TypeAccess] int
-#   32|                       13: [Parameter] i13
-#   32|                         0: [TypeAccess] int
-#   32|                       14: [Parameter] i14
-#   32|                         0: [TypeAccess] int
-#   32|                       15: [Parameter] i15
-#   32|                         0: [TypeAccess] int
-#   32|                       16: [Parameter] i16
-#   32|                         0: [TypeAccess] int
-#   32|                       17: [Parameter] i17
-#   32|                         0: [TypeAccess] int
-#   32|                       18: [Parameter] i18
-#   32|                         0: [TypeAccess] int
-#   32|                       19: [Parameter] i19
-#   32|                         0: [TypeAccess] int
-#   33|                       20: [Parameter] i20
-#   33|                         0: [TypeAccess] int
-#   33|                       21: [Parameter] i21
-#   33|                         0: [TypeAccess] int
-#   33|                       22: [Parameter] i22
-#   33|                         0: [TypeAccess] int
+#   43|                       0: [Parameter] <fn>
+#   43|                     5: [BlockStmt] { ... }
+#   43|                       0: [SuperConstructorInvocationStmt] super(...)
+#   43|                       1: [ExprStmt] <Expr>;
+#   43|                         0: [AssignExpr] ...=...
+#   43|                           0: [VarAccess] this.<fn>
+#   43|                             -1: [ThisAccess] this
+#   43|                           1: [VarAccess] <fn>
+#   43|                   1: [Method] accept
+#   43|                     3: [TypeAccess] boolean
+#-----|                     4: (Parameters)
+#   43|                       0: [Parameter] i0
+#   43|                         0: [TypeAccess] int
+#   43|                       1: [Parameter] i1
+#   43|                         0: [TypeAccess] int
+#   43|                       2: [Parameter] i2
+#   43|                         0: [TypeAccess] int
+#   43|                       3: [Parameter] i3
+#   43|                         0: [TypeAccess] int
+#   43|                       4: [Parameter] i4
+#   43|                         0: [TypeAccess] int
+#   43|                       5: [Parameter] i5
+#   43|                         0: [TypeAccess] int
+#   43|                       6: [Parameter] i6
+#   43|                         0: [TypeAccess] int
+#   43|                       7: [Parameter] i7
+#   43|                         0: [TypeAccess] int
+#   43|                       8: [Parameter] i8
+#   43|                         0: [TypeAccess] int
+#   43|                       9: [Parameter] i9
+#   43|                         0: [TypeAccess] int
+#   43|                       10: [Parameter] i10
+#   43|                         0: [TypeAccess] int
+#   43|                       11: [Parameter] i11
+#   43|                         0: [TypeAccess] int
+#   43|                       12: [Parameter] i12
+#   43|                         0: [TypeAccess] int
+#   43|                       13: [Parameter] i13
+#   43|                         0: [TypeAccess] int
+#   43|                       14: [Parameter] i14
+#   43|                         0: [TypeAccess] int
+#   43|                       15: [Parameter] i15
+#   43|                         0: [TypeAccess] int
+#   43|                       16: [Parameter] i16
+#   43|                         0: [TypeAccess] int
+#   43|                       17: [Parameter] i17
+#   43|                         0: [TypeAccess] int
+#   43|                       18: [Parameter] i18
+#   43|                         0: [TypeAccess] int
+#   43|                       19: [Parameter] i19
+#   43|                         0: [TypeAccess] int
+#   43|                       20: [Parameter] i20
+#   43|                         0: [TypeAccess] int
+#   43|                       21: [Parameter] i21
+#   43|                         0: [TypeAccess] int
+#   43|                       22: [Parameter] i22
+#   43|                         0: [TypeAccess] int
 #   43|                     5: [BlockStmt] { ... }
 #   43|                       0: [ReturnStmt] return ...
 #   43|                         0: [MethodAccess] invoke(...)
@@ -5528,17 +5538,7 @@ samConversion.kt:
 #   43|                               22: [VarAccess] i22
 #   43|                             -1: [TypeAccess] Object
 #   43|                             0: [IntegerLiteral] 23
-#   43|                   2: [Constructor] 
-#-----|                     4: (Parameters)
-#   43|                       0: [Parameter] <fn>
-#   43|                     5: [BlockStmt] { ... }
-#   43|                       0: [SuperConstructorInvocationStmt] super(...)
-#   43|                       1: [ExprStmt] <Expr>;
-#   43|                         0: [AssignExpr] ...=...
-#   43|                           0: [VarAccess] this.<fn>
-#   43|                             -1: [ThisAccess] this
-#   43|                           1: [VarAccess] <fn>
-#   43|                   2: [FieldDeclaration] FunctionN<Boolean> <fn>;
+#   43|                   1: [FieldDeclaration] FunctionN<Boolean> <fn>;
 #   43|                     -1: [TypeAccess] FunctionN<Boolean>
 #   43|                       0: [TypeAccess] Boolean
 #   43|                 -3: [TypeAccess] BigArityPredicate
@@ -5740,20 +5740,20 @@ samConversion.kt:
 #   46|                           0: [VarAccess] this.<fn>
 #   46|                             -1: [ThisAccess] this
 #   46|                           1: [VarAccess] <fn>
-#   46|                   1: [FieldDeclaration] Function1<Integer,Boolean> <fn>;
-#   46|                     -1: [TypeAccess] Function1<Integer,Boolean>
-#   46|                       0: [TypeAccess] Integer
-#   46|                       1: [TypeAccess] Boolean
-#   50|                   3: [Method] fn
-#   50|                     3: [TypeAccess] boolean
+#   46|                   1: [Method] fn
+#   46|                     3: [TypeAccess] boolean
 #-----|                     4: (Parameters)
-#   50|                       0: [Parameter] i
-#   50|                         0: [TypeAccess] T
+#   46|                       0: [Parameter] i
+#   46|                         0: [TypeAccess] Integer
 #   46|                     5: [BlockStmt] { ... }
 #   46|                       0: [ReturnStmt] return ...
 #   46|                         0: [MethodAccess] invoke(...)
 #   46|                           -1: [VarAccess] <fn>
 #   46|                           0: [VarAccess] i
+#   46|                   1: [FieldDeclaration] Function1<Integer,Boolean> <fn>;
+#   46|                     -1: [TypeAccess] Function1<Integer,Boolean>
+#   46|                       0: [TypeAccess] Integer
+#   46|                       1: [TypeAccess] Boolean
 #   46|                 -3: [TypeAccess] SomePredicate<Integer>
 #   46|                   0: [TypeAccess] Integer
 #   46|                 0: [LambdaExpr] ...->...

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.expected
@@ -2889,14 +2889,16 @@
 | samConversion.kt:2:18:2:45 | (...)... | samConversion.kt:1:1:14:1 | main | CastExpr |
 | samConversion.kt:2:18:2:45 | ...=... | samConversion.kt:2:18:2:45 |  | AssignExpr |
 | samConversion.kt:2:18:2:45 | <fn> | samConversion.kt:2:18:2:45 |  | VarAccess |
-| samConversion.kt:2:18:2:45 | <fn> | samConversion.kt:17:5:17:31 | accept | VarAccess |
+| samConversion.kt:2:18:2:45 | <fn> | samConversion.kt:2:18:2:45 | accept | VarAccess |
 | samConversion.kt:2:18:2:45 | Boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:2:18:2:45 | Function1<Integer,Boolean> | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:2:18:2:45 | IntPredicate | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:2:18:2:45 | IntPredicate | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:2:18:2:45 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:2:18:2:45 | i | samConversion.kt:17:5:17:31 | accept | VarAccess |
-| samConversion.kt:2:18:2:45 | invoke(...) | samConversion.kt:17:5:17:31 | accept | MethodAccess |
+| samConversion.kt:2:18:2:45 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:2:18:2:45 | i | samConversion.kt:2:18:2:45 | accept | VarAccess |
+| samConversion.kt:2:18:2:45 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:2:18:2:45 | invoke(...) | samConversion.kt:2:18:2:45 | accept | MethodAccess |
 | samConversion.kt:2:18:2:45 | new (...) | samConversion.kt:1:1:14:1 | main | ClassInstanceExpr |
 | samConversion.kt:2:18:2:45 | this | samConversion.kt:2:18:2:45 |  | ThisAccess |
 | samConversion.kt:2:18:2:45 | this.<fn> | samConversion.kt:2:18:2:45 |  | VarAccess |
@@ -2915,16 +2917,19 @@
 | samConversion.kt:4:14:4:42 | (...)... | samConversion.kt:1:1:14:1 | main | CastExpr |
 | samConversion.kt:4:14:4:42 | ...=... | samConversion.kt:4:14:4:42 |  | AssignExpr |
 | samConversion.kt:4:14:4:42 | <fn> | samConversion.kt:4:14:4:42 |  | VarAccess |
-| samConversion.kt:4:14:4:42 | <fn> | samConversion.kt:23:5:23:27 | fn1 | VarAccess |
+| samConversion.kt:4:14:4:42 | <fn> | samConversion.kt:4:14:4:42 | fn1 | VarAccess |
 | samConversion.kt:4:14:4:42 | Function2<Integer,Integer,Unit> | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:4:14:4:42 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:4:14:4:42 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:4:14:4:42 | InterfaceFn1 | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:4:14:4:42 | InterfaceFn1 | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:4:14:4:42 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:4:14:4:42 | i | samConversion.kt:23:5:23:27 | fn1 | VarAccess |
-| samConversion.kt:4:14:4:42 | invoke(...) | samConversion.kt:23:5:23:27 | fn1 | MethodAccess |
-| samConversion.kt:4:14:4:42 | j | samConversion.kt:23:5:23:27 | fn1 | VarAccess |
+| samConversion.kt:4:14:4:42 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:4:14:4:42 | i | samConversion.kt:4:14:4:42 | fn1 | VarAccess |
+| samConversion.kt:4:14:4:42 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:4:14:4:42 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:4:14:4:42 | invoke(...) | samConversion.kt:4:14:4:42 | fn1 | MethodAccess |
+| samConversion.kt:4:14:4:42 | j | samConversion.kt:4:14:4:42 | fn1 | VarAccess |
 | samConversion.kt:4:14:4:42 | new (...) | samConversion.kt:1:1:14:1 | main | ClassInstanceExpr |
 | samConversion.kt:4:14:4:42 | this | samConversion.kt:4:14:4:42 |  | ThisAccess |
 | samConversion.kt:4:14:4:42 | this.<fn> | samConversion.kt:4:14:4:42 |  | VarAccess |
@@ -2941,16 +2946,19 @@
 | samConversion.kt:5:14:5:32 | (...)... | samConversion.kt:1:1:14:1 | main | CastExpr |
 | samConversion.kt:5:14:5:32 | ...=... | samConversion.kt:5:14:5:32 |  | AssignExpr |
 | samConversion.kt:5:14:5:32 | <fn> | samConversion.kt:5:14:5:32 |  | VarAccess |
-| samConversion.kt:5:14:5:32 | <fn> | samConversion.kt:23:5:23:27 | fn1 | VarAccess |
+| samConversion.kt:5:14:5:32 | <fn> | samConversion.kt:5:14:5:32 | fn1 | VarAccess |
 | samConversion.kt:5:14:5:32 | Function2<Integer,Integer,Unit> | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:5:14:5:32 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:5:14:5:32 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:5:14:5:32 | InterfaceFn1 | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:5:14:5:32 | InterfaceFn1 | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:5:14:5:32 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:5:14:5:32 | i | samConversion.kt:23:5:23:27 | fn1 | VarAccess |
-| samConversion.kt:5:14:5:32 | invoke(...) | samConversion.kt:23:5:23:27 | fn1 | MethodAccess |
-| samConversion.kt:5:14:5:32 | j | samConversion.kt:23:5:23:27 | fn1 | VarAccess |
+| samConversion.kt:5:14:5:32 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:5:14:5:32 | i | samConversion.kt:5:14:5:32 | fn1 | VarAccess |
+| samConversion.kt:5:14:5:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:5:14:5:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:5:14:5:32 | invoke(...) | samConversion.kt:5:14:5:32 | fn1 | MethodAccess |
+| samConversion.kt:5:14:5:32 | j | samConversion.kt:5:14:5:32 | fn1 | VarAccess |
 | samConversion.kt:5:14:5:32 | new (...) | samConversion.kt:1:1:14:1 | main | ClassInstanceExpr |
 | samConversion.kt:5:14:5:32 | this | samConversion.kt:5:14:5:32 |  | ThisAccess |
 | samConversion.kt:5:14:5:32 | this.<fn> | samConversion.kt:5:14:5:32 |  | VarAccess |
@@ -2967,18 +2975,21 @@
 | samConversion.kt:7:13:7:46 | (...)... | samConversion.kt:1:1:14:1 | main | CastExpr |
 | samConversion.kt:7:13:7:46 | ...=... | samConversion.kt:7:13:7:46 |  | AssignExpr |
 | samConversion.kt:7:13:7:46 | <fn> | samConversion.kt:7:13:7:46 |  | VarAccess |
-| samConversion.kt:7:13:7:46 | <fn> | samConversion.kt:27:5:27:35 | ext | VarAccess |
+| samConversion.kt:7:13:7:46 | <fn> | samConversion.kt:7:13:7:46 | ext | VarAccess |
 | samConversion.kt:7:13:7:46 | Boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:7:13:7:46 | Function2<String,Integer,Boolean> | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:7:13:7:46 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:7:13:7:46 | InterfaceFnExt1 | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:7:13:7:46 | InterfaceFnExt1 | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:7:13:7:46 | String | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:7:13:7:46 | i | samConversion.kt:27:5:27:35 | ext | VarAccess |
-| samConversion.kt:7:13:7:46 | invoke(...) | samConversion.kt:27:5:27:35 | ext | MethodAccess |
+| samConversion.kt:7:13:7:46 | String | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:7:13:7:46 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:7:13:7:46 | i | samConversion.kt:7:13:7:46 | ext | VarAccess |
+| samConversion.kt:7:13:7:46 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:7:13:7:46 | invoke(...) | samConversion.kt:7:13:7:46 | ext | MethodAccess |
 | samConversion.kt:7:13:7:46 | new (...) | samConversion.kt:1:1:14:1 | main | ClassInstanceExpr |
 | samConversion.kt:7:13:7:46 | this | samConversion.kt:7:13:7:46 |  | ThisAccess |
-| samConversion.kt:7:13:7:46 | this | samConversion.kt:27:5:27:35 | ext | ExtensionReceiverAccess |
+| samConversion.kt:7:13:7:46 | this | samConversion.kt:7:13:7:46 | ext | ExtensionReceiverAccess |
 | samConversion.kt:7:13:7:46 | this.<fn> | samConversion.kt:7:13:7:46 |  | VarAccess |
 | samConversion.kt:7:29:7:46 | ...->... | samConversion.kt:1:1:14:1 | main | LambdaExpr |
 | samConversion.kt:7:29:7:46 | Boolean | samConversion.kt:1:1:14:1 | main | TypeAccess |
@@ -2995,14 +3006,16 @@
 | samConversion.kt:9:13:13:6 | (...)... | samConversion.kt:1:1:14:1 | main | CastExpr |
 | samConversion.kt:9:13:13:6 | ...=... | samConversion.kt:9:13:13:6 |  | AssignExpr |
 | samConversion.kt:9:13:13:6 | <fn> | samConversion.kt:9:13:13:6 |  | VarAccess |
-| samConversion.kt:9:13:13:6 | <fn> | samConversion.kt:17:5:17:31 | accept | VarAccess |
+| samConversion.kt:9:13:13:6 | <fn> | samConversion.kt:9:13:13:6 | accept | VarAccess |
 | samConversion.kt:9:13:13:6 | Boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:9:13:13:6 | Function1<Integer,Boolean> | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:9:13:13:6 | IntPredicate | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:9:13:13:6 | IntPredicate | samConversion.kt:1:1:14:1 | main | TypeAccess |
 | samConversion.kt:9:13:13:6 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:9:13:13:6 | i | samConversion.kt:17:5:17:31 | accept | VarAccess |
-| samConversion.kt:9:13:13:6 | invoke(...) | samConversion.kt:17:5:17:31 | accept | MethodAccess |
+| samConversion.kt:9:13:13:6 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:9:13:13:6 | i | samConversion.kt:9:13:13:6 | accept | VarAccess |
+| samConversion.kt:9:13:13:6 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:9:13:13:6 | invoke(...) | samConversion.kt:9:13:13:6 | accept | MethodAccess |
 | samConversion.kt:9:13:13:6 | new (...) | samConversion.kt:1:1:14:1 | main | ClassInstanceExpr |
 | samConversion.kt:9:13:13:6 | this | samConversion.kt:9:13:13:6 |  | ThisAccess |
 | samConversion.kt:9:13:13:6 | this.<fn> | samConversion.kt:9:13:13:6 |  | VarAccess |
@@ -3032,100 +3045,39 @@
 | samConversion.kt:12:22:12:22 | 2 | samConversion.kt:11:12:13:5 | invoke | IntegerLiteral |
 | samConversion.kt:12:27:12:27 | 1 | samConversion.kt:11:12:13:5 | invoke | IntegerLiteral |
 | samConversion.kt:17:5:17:31 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:17:5:17:31 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:17:5:17:31 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:17:16:17:21 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:17:16:17:21 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:17:16:17:21 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:20:1:20:27 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:20:9:20:14 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:20:17:20:22 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:23:5:23:27 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:23:5:23:27 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:23:5:23:27 | Unit | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:23:13:23:18 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:23:13:23:18 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:23:13:23:18 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:23:21:23:26 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:23:21:23:26 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:23:21:23:26 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:27:5:27:35 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:27:5:27:35 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:27:9:27:14 | String | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:27:9:27:14 | String | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:27:20:27:25 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:27:20:27:25 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:5:33:53 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:5:33:53 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:5:33:53 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:16:31:22 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:16:31:22 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:16:31:22 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:25:31:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:25:31:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:25:31:31 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:34:31:40 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:34:31:40 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:34:31:40 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:43:31:49 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:43:31:49 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:43:31:49 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:52:31:58 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:52:31:58 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:52:31:58 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:61:31:67 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:61:31:67 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:61:31:67 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:70:31:76 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:70:31:76 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:70:31:76 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:79:31:85 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:79:31:85 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:79:31:85 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:88:31:94 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:88:31:94 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:88:31:94 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:97:31:103 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:31:97:31:103 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:31:97:31:103 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:16:32:23 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:16:32:23 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:16:32:23 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:26:32:33 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:26:32:33 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:26:32:33 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:36:32:43 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:36:32:43 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:36:32:43 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:46:32:53 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:46:32:53 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:46:32:53 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:56:32:63 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:56:32:63 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:56:32:63 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:66:32:73 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:66:32:73 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:66:32:73 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:76:32:83 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:76:32:83 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:76:32:83 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:86:32:93 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:86:32:93 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:86:32:93 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:96:32:103 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:96:32:103 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:96:32:103 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:106:32:113 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:32:106:32:113 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:32:106:32:113 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:33:16:33:23 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:33:16:33:23 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:33:16:33:23 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:33:26:33:33 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:33:26:33:33 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:33:26:33:33 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:33:36:33:43 | int | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:33:36:33:43 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:33:36:33:43 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:36:1:38:52 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:36:8:36:14 | int | file://:0:0:0:0 | <none> | TypeAccess |
@@ -3276,86 +3228,134 @@
 | samConversion.kt:41:13:41:16 | int | samConversion.kt:41:13:41:16 | invoke | TypeAccess |
 | samConversion.kt:41:13:41:16 | int | samConversion.kt:41:13:41:16 | invoke | TypeAccess |
 | samConversion.kt:42:5:42:32 | b | samConversion.kt:40:1:47:1 | fn | LocalVariableDeclExpr |
-| samConversion.kt:42:13:42:32 | 23 | samConversion.kt:31:5:33:53 | accept | IntegerLiteral |
+| samConversion.kt:42:13:42:32 | 23 | samConversion.kt:42:13:42:32 | accept | IntegerLiteral |
 | samConversion.kt:42:13:42:32 | (...)... | samConversion.kt:40:1:47:1 | fn | CastExpr |
 | samConversion.kt:42:13:42:32 | ...=... | samConversion.kt:42:13:42:32 |  | AssignExpr |
-| samConversion.kt:42:13:42:32 | <fn> | samConversion.kt:31:5:33:53 | accept | VarAccess |
 | samConversion.kt:42:13:42:32 | <fn> | samConversion.kt:42:13:42:32 |  | VarAccess |
+| samConversion.kt:42:13:42:32 | <fn> | samConversion.kt:42:13:42:32 | accept | VarAccess |
 | samConversion.kt:42:13:42:32 | BigArityPredicate | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:42:13:42:32 | BigArityPredicate | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:42:13:42:32 | Boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:42:13:42:32 | FunctionN<Boolean> | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:42:13:42:32 | Object | samConversion.kt:31:5:33:53 | accept | TypeAccess |
-| samConversion.kt:42:13:42:32 | i0 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i1 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i2 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i3 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i4 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i5 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i6 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i7 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i8 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i9 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i10 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i11 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i12 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i13 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i14 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i15 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i16 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i17 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i18 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i19 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i20 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i21 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | i22 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:42:13:42:32 | invoke(...) | samConversion.kt:31:5:33:53 | accept | MethodAccess |
+| samConversion.kt:42:13:42:32 | Object | samConversion.kt:42:13:42:32 | accept | TypeAccess |
+| samConversion.kt:42:13:42:32 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | i0 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i1 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i2 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i3 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i4 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i5 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i6 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i7 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i8 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i9 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i10 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i11 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i12 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i13 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i14 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i15 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i16 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i17 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i18 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i19 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i20 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i21 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | i22 | samConversion.kt:42:13:42:32 | accept | VarAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:42:13:42:32 | invoke(...) | samConversion.kt:42:13:42:32 | accept | MethodAccess |
 | samConversion.kt:42:13:42:32 | new (...) | samConversion.kt:40:1:47:1 | fn | ClassInstanceExpr |
-| samConversion.kt:42:13:42:32 | new Object[] | samConversion.kt:31:5:33:53 | accept | ArrayCreationExpr |
+| samConversion.kt:42:13:42:32 | new Object[] | samConversion.kt:42:13:42:32 | accept | ArrayCreationExpr |
 | samConversion.kt:42:13:42:32 | this | samConversion.kt:42:13:42:32 |  | ThisAccess |
 | samConversion.kt:42:13:42:32 | this.<fn> | samConversion.kt:42:13:42:32 |  | VarAccess |
-| samConversion.kt:42:13:42:32 | {...} | samConversion.kt:31:5:33:53 | accept | ArrayInit |
+| samConversion.kt:42:13:42:32 | {...} | samConversion.kt:42:13:42:32 | accept | ArrayInit |
 | samConversion.kt:42:31:42:31 | a | samConversion.kt:40:1:47:1 | fn | VarAccess |
 | samConversion.kt:43:5:45:68 | c | samConversion.kt:40:1:47:1 | fn | LocalVariableDeclExpr |
-| samConversion.kt:43:13:45:68 | 23 | samConversion.kt:31:5:33:53 | accept | IntegerLiteral |
+| samConversion.kt:43:13:45:68 | 23 | samConversion.kt:43:13:45:68 | accept | IntegerLiteral |
 | samConversion.kt:43:13:45:68 | (...)... | samConversion.kt:40:1:47:1 | fn | CastExpr |
 | samConversion.kt:43:13:45:68 | ...=... | samConversion.kt:43:13:45:68 |  | AssignExpr |
-| samConversion.kt:43:13:45:68 | <fn> | samConversion.kt:31:5:33:53 | accept | VarAccess |
 | samConversion.kt:43:13:45:68 | <fn> | samConversion.kt:43:13:45:68 |  | VarAccess |
+| samConversion.kt:43:13:45:68 | <fn> | samConversion.kt:43:13:45:68 | accept | VarAccess |
 | samConversion.kt:43:13:45:68 | BigArityPredicate | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:43:13:45:68 | BigArityPredicate | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:43:13:45:68 | Boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:43:13:45:68 | FunctionN<Boolean> | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:43:13:45:68 | Object | samConversion.kt:31:5:33:53 | accept | TypeAccess |
-| samConversion.kt:43:13:45:68 | i0 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i1 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i2 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i3 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i4 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i5 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i6 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i7 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i8 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i9 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i10 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i11 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i12 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i13 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i14 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i15 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i16 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i17 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i18 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i19 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i20 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i21 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | i22 | samConversion.kt:31:5:33:53 | accept | VarAccess |
-| samConversion.kt:43:13:45:68 | invoke(...) | samConversion.kt:31:5:33:53 | accept | MethodAccess |
+| samConversion.kt:43:13:45:68 | Object | samConversion.kt:43:13:45:68 | accept | TypeAccess |
+| samConversion.kt:43:13:45:68 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | i0 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i1 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i2 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i3 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i4 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i5 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i6 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i7 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i8 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i9 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i10 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i11 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i12 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i13 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i14 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i15 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i16 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i17 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i18 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i19 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i20 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i21 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | i22 | samConversion.kt:43:13:45:68 | accept | VarAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | int | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:43:13:45:68 | invoke(...) | samConversion.kt:43:13:45:68 | accept | MethodAccess |
 | samConversion.kt:43:13:45:68 | new (...) | samConversion.kt:40:1:47:1 | fn | ClassInstanceExpr |
-| samConversion.kt:43:13:45:68 | new Object[] | samConversion.kt:31:5:33:53 | accept | ArrayCreationExpr |
+| samConversion.kt:43:13:45:68 | new Object[] | samConversion.kt:43:13:45:68 | accept | ArrayCreationExpr |
 | samConversion.kt:43:13:45:68 | this | samConversion.kt:43:13:45:68 |  | ThisAccess |
 | samConversion.kt:43:13:45:68 | this.<fn> | samConversion.kt:43:13:45:68 |  | VarAccess |
-| samConversion.kt:43:13:45:68 | {...} | samConversion.kt:31:5:33:53 | accept | ArrayInit |
+| samConversion.kt:43:13:45:68 | {...} | samConversion.kt:43:13:45:68 | accept | ArrayInit |
 | samConversion.kt:43:31:45:68 | 0 | samConversion.kt:43:31:45:68 | invoke | IntegerLiteral |
 | samConversion.kt:43:31:45:68 | 1 | samConversion.kt:43:31:45:68 | invoke | IntegerLiteral |
 | samConversion.kt:43:31:45:68 | 2 | samConversion.kt:43:31:45:68 | invoke | IntegerLiteral |
@@ -3505,16 +3505,18 @@
 | samConversion.kt:46:13:46:44 | (...)... | samConversion.kt:40:1:47:1 | fn | CastExpr |
 | samConversion.kt:46:13:46:44 | ...=... | samConversion.kt:46:13:46:44 |  | AssignExpr |
 | samConversion.kt:46:13:46:44 | <fn> | samConversion.kt:46:13:46:44 |  | VarAccess |
-| samConversion.kt:46:13:46:44 | <fn> | samConversion.kt:50:5:50:25 | fn | VarAccess |
+| samConversion.kt:46:13:46:44 | <fn> | samConversion.kt:46:13:46:44 | fn | VarAccess |
 | samConversion.kt:46:13:46:44 | Boolean | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:46:13:46:44 | Function1<Integer,Boolean> | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:46:13:46:44 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:46:13:46:44 | Integer | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:46:13:46:44 | Integer | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:46:13:46:44 | Integer | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:46:13:46:44 | SomePredicate<Integer> | samConversion.kt:40:1:47:1 | fn | TypeAccess |
 | samConversion.kt:46:13:46:44 | SomePredicate<Integer> | samConversion.kt:40:1:47:1 | fn | TypeAccess |
-| samConversion.kt:46:13:46:44 | i | samConversion.kt:50:5:50:25 | fn | VarAccess |
-| samConversion.kt:46:13:46:44 | invoke(...) | samConversion.kt:50:5:50:25 | fn | MethodAccess |
+| samConversion.kt:46:13:46:44 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
+| samConversion.kt:46:13:46:44 | i | samConversion.kt:46:13:46:44 | fn | VarAccess |
+| samConversion.kt:46:13:46:44 | invoke(...) | samConversion.kt:46:13:46:44 | fn | MethodAccess |
 | samConversion.kt:46:13:46:44 | new (...) | samConversion.kt:40:1:47:1 | fn | ClassInstanceExpr |
 | samConversion.kt:46:13:46:44 | this | samConversion.kt:46:13:46:44 |  | ThisAccess |
 | samConversion.kt:46:13:46:44 | this.<fn> | samConversion.kt:46:13:46:44 |  | VarAccess |
@@ -3526,8 +3528,6 @@
 | samConversion.kt:46:34:46:34 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:46:39:46:42 | true | samConversion.kt:46:32:46:44 | invoke | BooleanLiteral |
 | samConversion.kt:50:5:50:25 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:50:5:50:25 | boolean | file://:0:0:0:0 | <none> | TypeAccess |
-| samConversion.kt:50:12:50:15 | T | file://:0:0:0:0 | <none> | TypeAccess |
 | samConversion.kt:50:12:50:15 | T | file://:0:0:0:0 | <none> | TypeAccess |
 | whenExpr.kt:1:1:9:1 | int | file://:0:0:0:0 | <none> | TypeAccess |
 | whenExpr.kt:1:14:1:19 | int | file://:0:0:0:0 | <none> | TypeAccess |

--- a/java/ql/test/kotlin/library-tests/function-n/test.expected
+++ b/java/ql/test/kotlin/library-tests/function-n/test.expected
@@ -1,0 +1,3 @@
+| test.kt:4:5:4:138 | f1 | FunctionN<String> | String |
+| test.kt:5:5:5:134 | f2 | FunctionN<T1> | T1 |
+| test.kt:6:5:6:110 | f3 | FunctionN<T3> | T3 |

--- a/java/ql/test/kotlin/library-tests/function-n/test.kt
+++ b/java/ql/test/kotlin/library-tests/function-n/test.kt
@@ -1,0 +1,8 @@
+class TakesLambdas {
+
+  fun <T1, T2, T3> test(
+    f1: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) -> String,
+    f2: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) -> T1,
+    f3: (T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2, T2) -> T3) { }
+
+}

--- a/java/ql/test/kotlin/library-tests/function-n/test.ql
+++ b/java/ql/test/kotlin/library-tests/function-n/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from Parameter p
+where p.getCallable().fromSource()
+select p, p.getType().toString(), p.getType().(ParameterizedType).getATypeArgument().toString()

--- a/java/ql/test/library-tests/frameworks/guava/generated/collect/CONSISTENCY/typeParametersInScope.expected
+++ b/java/ql/test/library-tests/frameworks/guava/generated/collect/CONSISTENCY/typeParametersInScope.expected
@@ -1,0 +1,1 @@
+| Type Test uses out-of-scope type variable K |

--- a/java/ql/test/library-tests/frameworks/guava/generated/collect/CONSISTENCY/typeParametersInScope.expected
+++ b/java/ql/test/library-tests/frameworks/guava/generated/collect/CONSISTENCY/typeParametersInScope.expected
@@ -1,1 +1,1 @@
-| Type Test uses out-of-scope type variable K |
+| Type Test uses out-of-scope type variable K. Note the Java extractor is known to sometimes do this; the Kotlin extractor should not. |


### PR DESCRIPTION
* Substitute type parameters when creating a SAM class instance that satisfies a generic instance
* In the process, fix source-locations of SAM class instances to indicate the instantiation site, not the interface being satisfied
* Fix generic arg extraction when Function23+ get rewritten to FunctionN in the JVM lowering
* Fix the type-parameter-out-of-scope test to detect these situations in future

~This is temporarily based on https://github.com/github/codeql/pull/9122 -- the real diff is https://github.com/smowton/codeql/compare/smowton/admin/update-kotlin...smowton:smowton/fix/type-variable-in-scope-consistency~