### PR TITLE
Java: Sensitive Info Log query improvements

### DIFF
--- a/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/SensitiveLoggingQuery.qll
@@ -6,12 +6,12 @@ import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.SensitiveActions
 import DataFlow
 
-/** A variable that may hold sensitive information, judging by its name. * */
+/** A variable that may hold sensitive information, judging by its name. */
 class CredentialExpr extends Expr {
   CredentialExpr() {
     exists(Variable v | this = v.getAnAccess() |
-      v.getName().regexpMatch([getCommonSensitiveInfoRegex(), "(?i).*(username).*"]) and
-      not v.isFinal()
+      v.getName().regexpMatch(getCommonSensitiveInfoRegex()) and
+      not (v.isFinal() and v.isStatic())
     )
   }
 }

--- a/java/ql/src/change-notes/2022-05-12-sensitive-log-improvements.md
+++ b/java/ql/src/change-notes/2022-05-12-sensitive-log-improvements.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Query `java/sensitive-log` no longer considers usernames as sensitive information. Also, the conditions to consider a variable a constant (and therefore exclude it as user-provided sensitive information) have been tightened.

--- a/java/ql/test/query-tests/security/CWE-532/Test.java
+++ b/java/ql/test/query-tests/security/CWE-532/Test.java
@@ -5,12 +5,18 @@ class Test {
         Logger logger = null;
 
         logger.info("User's password is: " + password); // $ hasTaintFlow
-    }   
+    }
 
     void test2(String authToken) {
         Logger logger = null;
 
-        logger.error("Auth failed for: " + authToken); // $ hasTaintFlow 
+        logger.error("Auth failed for: " + authToken); // $ hasTaintFlow
+    }
+
+    void test3(String username) {
+        Logger logger = null;
+
+        logger.error("Auth failed for: " + username); // Safe
     }
 
 }


### PR DESCRIPTION
Adds two changes to the query `java/sensitive-log`:
* Stop considering usernames sensitive info.
* Require variables to be `static` (in addition to `final`) to be considered constants.