### PR TITLE
Kotlin: Don't use capture_output or text

### DIFF
--- a/java/kotlin-extractor/build.py
+++ b/java/kotlin-extractor/build.py
@@ -56,7 +56,10 @@ def run_process(cmd, capture_output=False):
         cmd = ' '.join(map(quote_for_batch, cmd))
         print("Converted to Windows command: " + cmd)
     try:
-        return subprocess.run(cmd, check=True, capture_output=capture_output)
+        if capture_output:
+            return subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        else:
+            return subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
         print("In: " + os.getcwd(), file=sys.stderr)
         shell_cmd = cmd if is_windows() else shlex.join(cmd)

--- a/java/kotlin-extractor/kotlin_plugin_versions.py
+++ b/java/kotlin-extractor/kotlin_plugin_versions.py
@@ -24,7 +24,7 @@ many_versions_tuples = [version_string_to_tuple(v) for v in many_versions]
 
 def get_single_version(fakeVersionOutput = None):
     # TODO: `shell=True` is a workaround to get CI working on Windows. It breaks the build on Linux.
-    versionOutput = subprocess.run(['kotlinc', '-version'], capture_output=True, text=True, shell=is_windows()).stderr if fakeVersionOutput is None else fakeVersionOutput
+    versionOutput = subprocess.run(['kotlinc', '-version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, shell=is_windows()).stderr if fakeVersionOutput is None else fakeVersionOutput
     m = re.match(r'.* kotlinc-jvm ([0-9]+\.[0-9]+\.[0-9]+) .*', versionOutput)
     if m is None:
         raise Exception('Cannot detect version of kotlinc (got ' + str(versionOutput) + ')')


### PR DESCRIPTION
Older python versions don't support it