### PR TITLE
Devcontainer: Install test dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,8 @@
     "rust-lang.rust",
     "bungcip.better-toml",
     "github.vscode-codeql",
+    "hbenl.vscode-test-explorer",
+    "ms-vscode.test-adapter-converter",
     "slevesque.vscode-zipexplorer"
   ],
   "settings": {


### PR DESCRIPTION
These _should_ get installed automatically if missing, but in my
experience this can be a bit flaky. Installing them here should make
this a bit more robust.