### PR TITLE
Ruby: Add getAPrimaryQlClass to CfgNodes classes

### DIFF
--- a/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/CfgNodes.qll
@@ -11,7 +11,7 @@ private import internal.Splitting
 
 /** An entry node for a given scope. */
 class EntryNode extends CfgNode, TEntryNode {
-  string getAPrimaryQlClass() { result = "EntryNode" }
+  override string getAPrimaryQlClass() { result = "EntryNode" }
 
   private CfgScope scope;
 
@@ -26,7 +26,7 @@ class EntryNode extends CfgNode, TEntryNode {
 
 /** An exit node for a given scope, annotated with the type of exit. */
 class AnnotatedExitNode extends CfgNode, TAnnotatedExitNode {
-  string getAPrimaryQlClass() { result = "AnnotatedExitNode" }
+  override string getAPrimaryQlClass() { result = "AnnotatedExitNode" }
 
   private CfgScope scope;
   private boolean normal;
@@ -53,7 +53,7 @@ class AnnotatedExitNode extends CfgNode, TAnnotatedExitNode {
 
 /** An exit node for a given scope. */
 class ExitNode extends CfgNode, TExitNode {
-  string getAPrimaryQlClass() { result = "ExitNode" }
+  override string getAPrimaryQlClass() { result = "ExitNode" }
 
   private CfgScope scope;
 
@@ -73,7 +73,7 @@ class ExitNode extends CfgNode, TExitNode {
  */
 class AstCfgNode extends CfgNode, TElementNode {
   /** Gets the name of the primary QL class for this node. */
-  string getAPrimaryQlClass() { result = "AstCfgNode" }
+  override string getAPrimaryQlClass() { result = "AstCfgNode" }
 
   private Splits splits;
   AstNode e;

--- a/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
@@ -28,6 +28,9 @@ class CfgScope extends Scope instanceof CfgScope::Range_ {
  * Only nodes that can be reached from an entry point are included in the CFG.
  */
 class CfgNode extends TCfgNode {
+  /** Gets the name of the primary QL class for this node. */
+  string getAPrimaryQlClass() { none() }
+
   /** Gets a textual representation of this control flow node. */
   string toString() { none() }
 


### PR DESCRIPTION
I've excluded the `ChildMapping` classes because
- they're not often directly used
- they cause some test fixtures to bloat
- they can subclass AST classes which have a `final` definition of `getAPrimaryQlClass`