### PR TITLE
Kotlin: Add failing test for missing field flow

### DIFF
--- a/java/ql/test/kotlin/library-tests/dataflow/fieldinit/Test.kt
+++ b/java/ql/test/kotlin/library-tests/dataflow/fieldinit/Test.kt
@@ -1,0 +1,9 @@
+class Foo {
+    val prop: String = "src"
+
+    fun bar() {
+       sink(prop)
+    }
+}
+
+fun sink(s: String) {}

--- a/java/ql/test/kotlin/library-tests/dataflow/fieldinit/test.expected
+++ b/java/ql/test/kotlin/library-tests/dataflow/fieldinit/test.expected
@@ -1,0 +1,1 @@
+| Test.kt:2:24:2:28 | src | Test.kt:5:13:5:16 | getProp(...) |

--- a/java/ql/test/kotlin/library-tests/dataflow/fieldinit/test.ql
+++ b/java/ql/test/kotlin/library-tests/dataflow/fieldinit/test.ql
@@ -1,0 +1,19 @@
+import java
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.ExternalFlow
+
+class Conf extends TaintTracking::Configuration {
+  Conf() { this = "qltest:fieldinit" }
+
+  override predicate isSource(DataFlow::Node n) {
+    n.asExpr().(CompileTimeConstantExpr).getStringValue() = "src"
+  }
+
+  override predicate isSink(DataFlow::Node n) {
+    n.asExpr().(Argument).getCall().getCallee().hasName("sink")
+  }
+}
+
+from DataFlow::Node src, DataFlow::Node sink, Conf conf
+where conf.hasFlow(src, sink)
+select src, sink


### PR DESCRIPTION
The `StringLiteral` initializer of a `KtInitializerAssignExpr` seems to not be flowing to the field it's initializing nor its accesses.