### PR TITLE
C++: Fixes some typos and increases the XXE query precision.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -30,7 +30,7 @@ abstract class XXEFlowState extends DataFlow::FlowState {
  * An `Expr` that changes the configuration of an XML object, transforming the
  * `XXEFlowState` that flows through it.
  */
-abstract class XXEFlowStateTranformer extends Expr {
+abstract class XXEFlowStateTransformer extends Expr {
   /**
    * Gets the flow state that `flowstate` is transformed into.
    *
@@ -119,10 +119,10 @@ class XercesFlowState extends XXEFlowState {
  * `SAXParser.setDisableDefaultEntityResolution`. Transforms the flow
  * state through the qualifier according to the setting in the parameter.
  */
-class DisableDefaultEntityResolutionTranformer extends XXEFlowStateTranformer {
+class DisableDefaultEntityResolutionTransformer extends XXEFlowStateTransformer {
   Expr newValue;
 
-  DisableDefaultEntityResolutionTranformer() {
+  DisableDefaultEntityResolutionTransformer() {
     exists(Call call, Function f |
       call.getTarget() = f and
       (
@@ -154,10 +154,10 @@ class DisableDefaultEntityResolutionTranformer extends XXEFlowStateTranformer {
  * `AbstractDOMParser.setCreateEntityReferenceNodes`. Transforms the flow
  * state through the qualifier according to the setting in the parameter.
  */
-class CreateEntityReferenceNodesTranformer extends XXEFlowStateTranformer {
+class CreateEntityReferenceNodesTransformer extends XXEFlowStateTransformer {
   Expr newValue;
 
-  CreateEntityReferenceNodesTranformer() {
+  CreateEntityReferenceNodesTransformer() {
     exists(Call call, Function f |
       call.getTarget() = f and
       f.getClassAndName("setCreateEntityReferenceNodes") instanceof AbstractDOMParserClass and
@@ -195,10 +195,10 @@ class FeatureDisableDefaultEntityResolution extends Variable {
  * specifying the feature `XMLUni::fgXercesDisableDefaultEntityResolution`.
  * Transforms the flow state through the qualifier according to this setting.
  */
-class SetFeatureTranformer extends XXEFlowStateTranformer {
+class SetFeatureTransformer extends XXEFlowStateTransformer {
   Expr newValue;
 
-  SetFeatureTranformer() {
+  SetFeatureTransformer() {
     exists(Call call, Function f |
       call.getTarget() = f and
       f.getClassAndName("setFeature") instanceof Sax2XmlReader and
@@ -246,10 +246,10 @@ class DomConfigurationSetParameter extends Function {
  * `DOMConfiguration` pointer returned by `DOMLSParser.getDomConfig` - and it
  * is *that* qualifier we want to transform the flow state of.
  */
-class DomConfigurationSetParameterTranformer extends XXEFlowStateTranformer {
+class DomConfigurationSetParameterTransformer extends XXEFlowStateTransformer {
   Expr newValue;
 
-  DomConfigurationSetParameterTranformer() {
+  DomConfigurationSetParameterTransformer() {
     exists(FunctionCall getDomConfigCall, FunctionCall setParameterCall |
       // this is the qualifier of a call to `DOMLSParser.getDomConfig`.
       getDomConfigCall.getTarget() instanceof GetDomConfig and
@@ -429,15 +429,15 @@ class XXEConfiguration extends DataFlow::Configuration {
   override predicate isAdditionalFlowStep(
     DataFlow::Node node1, string state1, DataFlow::Node node2, string state2
   ) {
-    // create additional flow steps for `XXEFlowStateTranformer`s
-    state2 = node2.asConvertedExpr().(XXEFlowStateTranformer).transform(state1) and
+    // create additional flow steps for `XXEFlowStateTransformer`s
+    state2 = node2.asConvertedExpr().(XXEFlowStateTransformer).transform(state1) and
     DataFlow::simpleLocalFlowStep(node1, node2)
   }
 
   override predicate isBarrier(DataFlow::Node node, string flowstate) {
     // when the flowstate is transformed at a call node, block the original
     // flowstate value.
-    node.asConvertedExpr().(XXEFlowStateTranformer).transform(flowstate) != flowstate
+    node.asConvertedExpr().(XXEFlowStateTransformer).transform(flowstate) != flowstate
   }
 }
 

--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -7,7 +7,7 @@
  * @id cpp/external-entity-expansion
  * @problem.severity warning
  * @security-severity 9.1
- * @precision medium
+ * @precision high
  * @tags security
  *       external/cwe/cwe-611
  */

--- a/cpp/ql/src/change-notes/2022-05-12-external-entity-expansion.md
+++ b/cpp/ql/src/change-notes/2022-05-12-external-entity-expansion.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "XML external entity expansion" (`cpp/external-entity-expansion`) query precision has been increased to `high`.


### PR DESCRIPTION
Fixes some typos and increases the XXE query precision to `@high`.

The latter is justified by results on 207 LGTM projects: https://lgtm.com/query/5698038244523748150/
 - the first two projects with results use `libxml2` and fail to follow the advice in https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
 - the third and fourth use the Xerces `SAX2XMLReader` (`XMLReaderFactory::createXMLReader`) interface and fails to set `fgXercesDisableDefaultEntityResolution`.
 - the fifth has examples of both Xerces `SAX2XMLReader` and `createLSParser`.  In all cases results are failing to set `fgXercesDisableDefaultEntityResolution`, though note that for `createLSParser` the need to do this is inferred rather than directly stated by the OWASP doc.

There's also an all-LGTM run linked from the internal issue.  26 projects with results, I've checked at least one result from each project and found no surprises.  `pwsafe/pwsafe` sets `pSAX2Parser->setFeature(XMLUni::fgXercesLoadExternalDTD, false);`, which is interesting, at a glance I'm a little surprised the OWASP guidelines don't require doing this.  I've added this to my list of extensions to potentially look into.

It is of course possible there are other safety mechanisms that the OWASP doc doesn't describe and we are unaware of - I do not claim to be an expert in either library.  Aside from that limitation I have confidence in this query.