### PR TITLE
Kotlin: Fix extraction of reflective call generated by Parcelize

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -1371,6 +1371,23 @@ open class KotlinFileExtractor(
         return fn
     }
 
+    private fun findTopLevelPropertyOrWarn(propertyFilter: String, type: String, warnAgainstElement: IrElement): IrProperty? {
+
+        val prop = pluginContext.referenceProperties(FqName(propertyFilter))
+            .firstOrNull { it.owner.parentClassOrNull?.fqNameWhenAvailable?.asString() == type }
+            ?.owner
+
+        if (prop != null) {
+            if (prop.parentClassOrNull != null) {
+                extractExternalClassLater(prop.parentAsClass)
+            }
+        } else {
+            logger.errorElement("Couldn't find JVM intrinsic property $propertyFilter in $type", warnAgainstElement)
+        }
+
+        return prop
+    }
+
     val javaLangString by lazy {
         val result = pluginContext.referenceClass(FqName("java.lang.String"))?.owner
         result?.let { extractExternalClassLater(it) }
@@ -1882,6 +1899,27 @@ open class KotlinFileExtractor(
                             tw.writeStatementEnclosingExpr(dimId, enclosingStmt)
                             tw.writeNamestrings(dim.toString(), dim.toString(), dimId)
                         }
+                    }
+                }
+                isBuiltinCall(c, "<get-java>", "kotlin.jvm") -> {
+                    // Special case for KClass<*>.java, which is used in the Parcelize plugin. In normal cases, this is already rewritten to the property referenced below:
+                    findTopLevelPropertyOrWarn("kotlin.jvm.java", "kotlin.jvm.JvmClassMappingKt", c)?.let { javaProp ->
+                        val getter = javaProp.getter
+                        if (getter == null) {
+                            logger.error("Couldn't find getter of `kotlin.jvm.JvmClassMappingKt::java`")
+                            return
+                        }
+
+                        val ext = c.extensionReceiver
+                        if (ext == null) {
+                            logger.errorElement("No extension receiver found for `KClass::java` call", c)
+                            return
+                        }
+
+                        val argType = (ext.type as? IrSimpleType)?.arguments?.firstOrNull()?.typeOrNull
+                        val typeArguments = if (argType == null) listOf() else listOf(argType)
+
+                        extractRawMethodAccess(getter, c, callable, parent, idx, enclosingStmt, listOf(), null, ext, typeArguments)
                     }
                 }
                 isFunction(target, "kotlin", "(some array type)", { isArrayType(it) }, "iterator") && c.origin == IrStatementOrigin.FOR_LOOP_ITERATOR -> {


### PR DESCRIPTION
This PR fixes the extraction of the `java` property call in `C::class.java` generated by the Parcelize plugin. Generally, these calls are properly associated to `kotlin.jvm.JvmClassMappingKt::java`, and therefore need no special handling. However, with the Parcelize plugin this is not the case.

I'm planning on merging this fix without integration test. It feels way more effort to add the test than the benefit.