### PR TITLE
Kotlin: Adjust diagnostic message severity

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/ExternalDeclExtractor.kt
@@ -21,7 +21,7 @@ class ExternalDeclExtractor(val logger: FileLogger, val invocationTrapFile: Stri
 
     fun extractLater(d: IrDeclaration, signature: String): Boolean {
         if (d !is IrClass && !isExternalFileClassMember(d)) {
-            logger.warnElement("External declaration is neither a class, nor a top-level declaration", d)
+            logger.errorElement("External declaration is neither a class, nor a top-level declaration", d)
             return false
         }
         val ret = externalDeclsDone.add(d)
@@ -64,7 +64,7 @@ class ExternalDeclExtractor(val logger: FileLogger, val invocationTrapFile: Stri
 
                             val containingClass = getContainingClassOrSelf(irDecl)
                             if (containingClass == null) {
-                                logger.warnElement("Unable to get containing class", irDecl)
+                                logger.errorElement("Unable to get containing class", irDecl)
                                 return
                             }
                             val binaryPath = getIrClassBinaryPath(containingClass)

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -270,7 +270,7 @@ open class KotlinFileExtractor(
                 if (kind == ClassKind.ENUM_CLASS) {
                     tw.writeIsEnumType(classId)
                 } else if (kind != ClassKind.CLASS && kind != ClassKind.OBJECT) {
-                    logger.warnElement("Unrecognised class kind $kind", c)
+                    logger.errorElement("Unrecognised class kind $kind", c)
                 }
             }
 
@@ -549,7 +549,7 @@ open class KotlinFileExtractor(
             val constructorId = useFunction<DbConstructor>(enclosingConstructor)
             val enclosingClass = enclosingConstructor.parentClassOrNull
             if (enclosingClass == null) {
-                logger.warnElement("Constructor's parent is not a class", enclosingConstructor)
+                logger.errorElement("Constructor's parent is not a class", enclosingConstructor)
                 return
             }
 
@@ -807,13 +807,13 @@ open class KotlinFileExtractor(
                     }
                 } else {
                     if (p.modality != Modality.FINAL || !isExternalDeclaration(p)) {
-                        logger.errorElement("IrProperty without a getter", p)
+                        logger.warnElement("IrProperty without a getter", p)
                     }
                 }
 
                 if (setter != null) {
                     if (!p.isVar) {
-                        logger.errorElement("!isVar property with a setter", p)
+                        logger.warnElement("!isVar property with a setter", p)
                     }
                     val setterId = extractFunction(setter, parentId, extractBody = extractFunctionBodies, extractMethodAndParameterTypeAccesses = extractFunctionBodies, typeSubstitution, classTypeArgsIncludingOuterClasses)?.cast<DbMethod>()
                     if (setterId != null) {
@@ -821,7 +821,7 @@ open class KotlinFileExtractor(
                     }
                 } else {
                     if (p.isVar && !isExternalDeclaration(p)) {
-                        logger.errorElement("isVar property without a setter", p)
+                        logger.warnElement("isVar property without a setter", p)
                     }
                 }
 
@@ -1657,7 +1657,7 @@ open class KotlinFileExtractor(
                 // as they can't be extracted as external dependencies.
                 isBuiltinCallInternal(c, "less") -> {
                     if(c.origin != IrStatementOrigin.LT) {
-                        logger.errorElement("Unexpected origin for LT: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for LT: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbLtexpr>()
                     val type = useType(c.type)
@@ -1667,7 +1667,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "lessOrEqual") -> {
                     if(c.origin != IrStatementOrigin.LTEQ) {
-                        logger.errorElement("Unexpected origin for LTEQ: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for LTEQ: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbLeexpr>()
                     val type = useType(c.type)
@@ -1677,7 +1677,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "greater") -> {
                     if(c.origin != IrStatementOrigin.GT) {
-                        logger.errorElement("Unexpected origin for GT: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for GT: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbGtexpr>()
                     val type = useType(c.type)
@@ -1687,7 +1687,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "greaterOrEqual") -> {
                     if(c.origin != IrStatementOrigin.GTEQ) {
-                        logger.errorElement("Unexpected origin for GTEQ: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for GTEQ: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbGeexpr>()
                     val type = useType(c.type)
@@ -1697,7 +1697,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "EQEQ") -> {
                     if(c.origin != IrStatementOrigin.EQEQ) {
-                        logger.errorElement("Unexpected origin for EQEQ: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for EQEQ: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbValueeqexpr>()
                     val type = useType(c.type)
@@ -1707,7 +1707,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "EQEQEQ") -> {
                     if(c.origin != IrStatementOrigin.EQEQEQ) {
-                        logger.errorElement("Unexpected origin for EQEQEQ: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for EQEQEQ: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbEqexpr>()
                     val type = useType(c.type)
@@ -1717,7 +1717,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "ieee754equals") -> {
                     if(c.origin != IrStatementOrigin.EQEQ) {
-                        logger.errorElement("Unexpected origin for ieee754equals: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for ieee754equals: ${c.origin}", c)
                     }
                     val id = tw.getFreshIdLabel<DbEqexpr>()
                     val type = useType(c.type)
@@ -1727,7 +1727,7 @@ open class KotlinFileExtractor(
                 }
                 isBuiltinCallInternal(c, "CHECK_NOT_NULL") -> {
                     if(c.origin != IrStatementOrigin.EXCLEXCL) {
-                        logger.errorElement("Unexpected origin for CHECK_NOT_NULL: ${c.origin}", c)
+                        logger.warnElement("Unexpected origin for CHECK_NOT_NULL: ${c.origin}", c)
                     }
 
                     val id = tw.getFreshIdLabel<DbNotnullexpr>()
@@ -2394,7 +2394,7 @@ open class KotlinFileExtractor(
                     val stmtParent = parent.stmt(e, callable)
                     val irConstructor = declarationStack.peek() as? IrConstructor
                     if (irConstructor == null) {
-                        logger.warnElement("IrInstanceInitializerCall outside constructor", e)
+                        logger.errorElement("IrInstanceInitializerCall outside constructor", e)
                         return
                     }
                     extractInstanceInitializerBlock(stmtParent, irConstructor)
@@ -3368,7 +3368,7 @@ open class KotlinFileExtractor(
     ) {
         with("function reference", functionReferenceExpr) {
             val target = functionReferenceExpr.reflectionTarget ?: run {
-                logger.errorElement("Expected to find reflection target for function reference. Using underlying symbol instead.", functionReferenceExpr)
+                logger.warnElement("Expected to find reflection target for function reference. Using underlying symbol instead.", functionReferenceExpr)
                 functionReferenceExpr.symbol
             }
 


### PR DESCRIPTION
Make extraction messages `warning` if code is still extracted regardless of the reported issue. Make extraction messages `error` if some code is not extracted.