### PR TITLE
ATM: sample negative examples down to 10%

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointDataTraining.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointDataTraining.ql
@@ -9,7 +9,6 @@ import ExtractEndpointData as ExtractEndpointData
 
 bindingset[rate]
 DataFlow::Node getSampleFromSampleRate(float rate) {
-  // result = getSample((rate * numOfNodesWithLocations()).ceil())
   exists(int r |
     result =
       rank[r](DataFlow::Node n, string path, int a, int b, int c, int d |
@@ -19,20 +18,6 @@ DataFlow::Node getSampleFromSampleRate(float rate) {
       ) and
     r % (1 / rate).ceil() = 0
   )
-}
-
-// TODO don't merge
-predicate endpointsOld(
-  DataFlow::Node endpoint, string queryName, string key, string value, string valueType
-) {
-  ExtractEndpointData::endpoints(endpoint, queryName, key, value, valueType) and
-  // only select endpoints that are either Sink or NotASink
-  ExtractEndpointData::endpoints(endpoint, queryName, "sinkLabel", ["Sink", "NotASink"], "string") and
-  // do not select endpoints filtered out by end-to-end evaluation
-  ExtractEndpointData::endpoints(endpoint, queryName, "isExcludedFromEndToEndEvaluation", "false",
-    "boolean") and
-  // only select endpoints that can be part of a tainted flow
-  ExtractEndpointData::endpoints(endpoint, queryName, "isConstantExpression", "false", "boolean")
 }
 
 query predicate endpoints(
@@ -56,12 +41,4 @@ query predicate endpoints(
 query predicate tokenFeatures(DataFlow::Node endpoint, string featureName, string featureValue) {
   endpoints(endpoint, _, _, _, _) and
   ExtractEndpointData::tokenFeatures(endpoint, featureName, featureValue)
-}
-
-// TODO don't merge
-predicate stats(string queryName, string label, int old, int new) {
-  queryName = any(ExtractEndpointData::Query q).getName() and
-  label = ["NotASink", "Sink"] and
-  old = count(DataFlow::Node n | endpointsOld(n, queryName, "sinkLabel", label, _)) and
-  new = count(DataFlow::Node n | endpoints(n, queryName, "sinkLabel", label, _))
 }

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointDataTraining.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/extraction/ExtractEndpointDataTraining.ql
@@ -7,7 +7,22 @@
 import javascript
 import ExtractEndpointData as ExtractEndpointData
 
-query predicate endpoints(
+bindingset[rate]
+DataFlow::Node getSampleFromSampleRate(float rate) {
+  // result = getSample((rate * numOfNodesWithLocations()).ceil())
+  exists(int r |
+    result =
+      rank[r](DataFlow::Node n, string path, int a, int b, int c, int d |
+        n.asExpr().getLocation().hasLocationInfo(path, a, b, c, d)
+      |
+        n order by path, a, b, c, d
+      ) and
+    r % (1 / rate).ceil() = 0
+  )
+}
+
+// TODO don't merge
+predicate endpointsOld(
   DataFlow::Node endpoint, string queryName, string key, string value, string valueType
 ) {
   ExtractEndpointData::endpoints(endpoint, queryName, key, value, valueType) and
@@ -20,7 +35,33 @@ query predicate endpoints(
   ExtractEndpointData::endpoints(endpoint, queryName, "isConstantExpression", "false", "boolean")
 }
 
+query predicate endpoints(
+  DataFlow::Node endpoint, string queryName, string key, string value, string valueType
+) {
+  ExtractEndpointData::endpoints(endpoint, queryName, key, value, valueType) and
+  // only select endpoints that are either Sink or NotASink
+  (
+    ExtractEndpointData::endpoints(endpoint, queryName, "sinkLabel", "Sink", "string")
+    or
+    ExtractEndpointData::endpoints(endpoint, queryName, "sinkLabel", "NotASink", "string") and
+    endpoint = getSampleFromSampleRate(0.1)
+  ) and
+  // do not select endpoints filtered out by end-to-end evaluation
+  ExtractEndpointData::endpoints(endpoint, queryName, "isExcludedFromEndToEndEvaluation", "false",
+    "boolean") and
+  // only select endpoints that can be part of a tainted flow
+  ExtractEndpointData::endpoints(endpoint, queryName, "isConstantExpression", "false", "boolean")
+}
+
 query predicate tokenFeatures(DataFlow::Node endpoint, string featureName, string featureValue) {
   endpoints(endpoint, _, _, _, _) and
   ExtractEndpointData::tokenFeatures(endpoint, featureName, featureValue)
+}
+
+// TODO don't merge
+predicate stats(string queryName, string label, int old, int new) {
+  queryName = any(ExtractEndpointData::Query q).getName() and
+  label = ["NotASink", "Sink"] and
+  old = count(DataFlow::Node n | endpointsOld(n, queryName, "sinkLabel", label, _)) and
+  new = count(DataFlow::Node n | endpoints(n, queryName, "sinkLabel", label, _))
 }


### PR DESCRIPTION
This reduces the number of negative samples to 10% of total eligible nodes.

To give an example of the effect this has for `angular/angular`:

| # | Query Name | Label | #Endpoints Before | #Endpoints After |
|--|--|--|--|--|
| 1 | SqlInjection | Sink | 2 | 2 |
| 2 | SqlInjection | NotASink | 4016 | 358 |
| 3 | NosqlInjection | Sink | 0 | 0 |
| 4 | NosqlInjection | NotASink | 4016 | 358 |
| 5 | TaintedPath | Sink | 295 | 295 |
| 6 | TaintedPath | NotASink | 4016 | 358 |
| 7 | Xss | Sink | 48 | 48 |
| 8 | Xss | NotASink | 4016 | 358 |

Context: https://github.com/github/ml-ql-adaptive-threat-modeling/issues/1871