### PR TITLE
Ruby: tweak join order in `API::Impl::edge`

### DIFF
--- a/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
+++ b/ruby/ql/lib/codeql/ruby/ApiGraphs.qll
@@ -572,11 +572,13 @@ module API {
       // `pred` is a use of class A
       // `succ` is a use of class B
       // there exists a class declaration B < A
-      exists(ClassDeclaration c, DataFlow::Node a, DataFlow::Node b |
+      exists(DataFlow::Node a, DataFlow::Node b |
         use(pred, a) and
         use(succ, b) and
-        resolveConstant(b.asExpr().getExpr()) = resolveConstantWriteAccess(c) and
-        c.getSuperclassExpr() = a.asExpr().getExpr() and
+        resolveConstant(b.asExpr().getExpr()) =
+          resolveConstantWriteAccess(any(ClassDeclaration c |
+              c.getSuperclassExpr() = a.asExpr().getExpr()
+            )) and
         lbl = Label::subclass()
       )
       or


### PR DESCRIPTION
I still feel pretty new at this, so I'm not sure if this is a valuable change (is a nine-digit tuple count worth worrying about?), or if it's the right way of doing it.

### Before
```
          1327277   ~0%    {3} r31 = JOIN r30 WITH CfgNodes::ExprCfgNode::getExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           533064   ~0%    {3} r32 = JOIN r31 WITH Module::Cached::resolveConstant#fe82a56b#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                       
        112542045   ~0%    {3} r33 = JOIN r32 WITH project#Module::ResolveImpl::resolveConstantWriteAccessNonRec#fe82a56b#ffff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                       
           164888   ~0%    {3} r34 = JOIN r32 WITH project#Module::ResolveImpl::resolveConstantWriteAccessRec#fe82a56b#ffff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                       
        112706933   ~0%    {3} r35 = r33 UNION r34
           153405  ~15%    {3} r36 = JOIN r35 WITH Module::ClassDeclaration::getSuperclassExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           146264  ~17%    {3} r37 = JOIN r36 WITH CfgNodes::ExprCfgNode::getExpr#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           144159   ~8%    {3} r38 = JOIN r37 WITH DataFlowPrivate::Cached::TExprNode#462ff392#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           142934  ~18%    {3} r39 = JOIN r38 WITH ApiGraphs::API::Impl::MkUse#3116a2f3#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                       
           326113   ~8%    {3} r40 = r28 UNION r39
          3434003   ~5%    {3} r41 = r24 UNION r40
          5340923   ~3%    {3} r42 = r15 UNION r41
                           return r42
```

### After
```
        1327277   ~0%    {3} r31 = JOIN r30 WITH CfgNodes::ExprCfgNode::getExpr#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
          15400   ~1%    {3} r32 = JOIN r31 WITH Module::ClassDeclaration::getSuperclassExpr#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                     
          14884   ~0%    {3} r33 = JOIN r32 WITH project#Module::ResolveImpl::resolveConstantWriteAccessNonRec#fe82a56b#ffff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                     
           3402   ~0%    {3} r34 = JOIN r32 WITH project#Module::ResolveImpl::resolveConstantWriteAccessRec#fe82a56b#ffff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                     
          18286  ~20%    {3} r35 = r33 UNION r34
         153260  ~16%    {3} r36 = JOIN r35 WITH Module::Cached::resolveConstant#fe82a56b#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
         153324  ~15%    {3} r37 = JOIN r36 WITH CfgNodes::ExprCfgNode::getExpr#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
         153309  ~25%    {3} r38 = JOIN r37 WITH DataFlowPrivate::Cached::TExprNode#462ff392#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
         153309  ~26%    {3} r39 = JOIN r38 WITH ApiGraphs::API::Impl::MkUse#3116a2f3#ff ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
                     
         336488  ~12%    {3} r40 = r28 UNION r39
        3444378   ~5%    {3} r41 = r24 UNION r40
        5351298   ~3%    {3} r42 = r15 UNION r41
                         return r42
```