### PR TITLE
Swift: replace `getCanonicalPointer` with `std::variant`

### DIFF
--- a/swift/extractor/SwiftTagTraits.h
+++ b/swift/extractor/SwiftTagTraits.h
@@ -1,6 +1,7 @@
 #pragma once
 
-// This file implements the mapping needed by the API defined in the TrapTagTraits.h
+// This file implements the mapping needed by the API defined in the TrapTagTraits.h, so that
+// TrapTagOf/TrapLabelOf provide the tags/labels for specific swift entity types.
 #include <swift/AST/ASTVisitor.h>
 #include "swift/extractor/trap/TrapTagTraits.h"
 #include "swift/extractor/trap/generated/TrapTags.h"

--- a/swift/extractor/trap/TrapLabel.h
+++ b/swift/extractor/trap/TrapLabel.h
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <string>
 
-#include "swift/extractor/trap/TrapTagTraits.h"
 #include "swift/extractor/trap/generated/TrapTags.h"
 
 namespace codeql {

--- a/swift/extractor/trap/TrapLabelStore.h
+++ b/swift/extractor/trap/TrapLabelStore.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <variant>
 #include <cassert>
 #include <optional>
 #include <unordered_map>
@@ -12,50 +13,30 @@
 
 namespace codeql {
 
-// The following is needed to avoid the problem of subclass pointers not necessarily coinciding
-// with superclass ones in case of multiple inheritance
-// The interesting part here is implicit conversion from a derived class pointer to the parameter
-inline const swift::Decl* getCanonicalPointer(const swift::Decl* e) {
-  return e;
-}
-inline const swift::Stmt* getCanonicalPointer(const swift::Stmt* e) {
-  return e;
-}
-inline const swift::Expr* getCanonicalPointer(const swift::Expr* e) {
-  return e;
-}
-inline const swift::Pattern* getCanonicalPointer(const swift::Pattern* e) {
-  return e;
-}
-inline const swift::TypeRepr* getCanonicalPointer(const swift::TypeRepr* e) {
-  return e;
-}
-inline const swift::TypeBase* getCanonicalPointer(const swift::TypeBase* e) {
-  return e;
-}
-
 // The extraction is done in a lazy/on-demand fashion:
 // Each emitted TRAP entry for an AST node gets a TRAP label assigned to it.
 // To avoid re-emission, we store the "AST node <> label" entry in the TrapLabelStore.
+// The template parameters `Ts...` indicate to what entity types we restrict the storage
+template <typename... Ts>
 class TrapLabelStore {
  public:
+  using Handle = std::variant<std::monostate, const Ts*...>;
   template <typename T>
-  std::optional<TrapLabel<ToTag<T>>> get(const T* e) {
-    if (auto found = store_.find(getCanonicalPointer(e)); found != store_.end()) {
-      return TrapLabel<ToTag<T>>::unsafeCreateFromUntyped(found->second);
+  std::optional<TrapLabelOf<T>> get(const T* e) {
+    if (auto found = store_.find(e); found != store_.end()) {
+      return TrapLabelOf<T>::unsafeCreateFromUntyped(found->second);
     }
     return std::nullopt;
   }
 
   template <typename T>
-  void insert(const T* e, TrapLabel<ToTag<T>> l) {
-    auto [_, inserted] = store_.emplace(getCanonicalPointer(e), l);
+  void insert(const T* e, TrapLabelOf<T> l) {
+    auto [_, inserted] = store_.emplace(e, l);
     assert(inserted && "already inserted");
   }
 
  private:
-  // TODO: consider std::variant or llvm::PointerUnion instead of `void *`
-  std::unordered_map<const void*, UntypedTrapLabel> store_;
+  std::unordered_map<Handle, UntypedTrapLabel> store_;
 };
 
 }  // namespace codeql

--- a/swift/extractor/trap/TrapTagTraits.h
+++ b/swift/extractor/trap/TrapTagTraits.h
@@ -16,6 +16,9 @@ struct ToTagOverride : ToTagFunctor<T> {};
 }  // namespace detail
 
 template <typename T>
-using ToTag = typename detail::ToTagOverride<std::remove_const_t<T>>::type;
+using TrapTagOf = typename detail::ToTagOverride<std::remove_const_t<T>>::type;
+
+template <typename T>
+using TrapLabelOf = TrapLabel<TrapTagOf<T>>;
 
 }  // namespace codeql


### PR DESCRIPTION
This turned out easier than expected previously. `llvm::PointerUnion`
was also considered, which would have less memory footprint, but it
would require more effort as it is lacking the same implicit conversions
and operators that `std::variant` provides.

Also renamed `ToTag<E>` to `TrapTagOf<E>` and introduced a derived
convenience functor `TrapLabelOf<E>`.

This is a follow-up to https://github.com/github/codeql/pull/9112