### PR TITLE
Ruby: update tree-sitter-ruby

### DIFF
--- a/ruby/Cargo.lock
+++ b/ruby/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ruby"
 version = "0.19.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-ruby.git?rev=1a3936a3545c0bd9344a0bf983fafc7e17443e39#1a3936a3545c0bd9344a0bf983fafc7e17443e39"
+source = "git+https://github.com/tree-sitter/tree-sitter-ruby.git?rev=6334d6ab3d04a5672da695d3b155ca3301511f8d#6334d6ab3d04a5672da695d3b155ca3301511f8d"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/ruby/extractor/Cargo.toml
+++ b/ruby/extractor/Cargo.toml
@@ -11,7 +11,7 @@ flate2 = "1.0"
 node-types = { path = "../node-types" }
 tree-sitter = "0.19"
 tree-sitter-embedded-template = "0.19"
-tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "1a3936a3545c0bd9344a0bf983fafc7e17443e39" }
+tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "6334d6ab3d04a5672da695d3b155ca3301511f8d" }
 clap = "3.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }

--- a/ruby/generator/Cargo.toml
+++ b/ruby/generator/Cargo.toml
@@ -12,4 +12,4 @@ node-types = { path = "../node-types" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 tree-sitter-embedded-template = "0.19"
-tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "1a3936a3545c0bd9344a0bf983fafc7e17443e39" }
+tree-sitter-ruby = { git = "https://github.com/tree-sitter/tree-sitter-ruby.git", rev = "6334d6ab3d04a5672da695d3b155ca3301511f8d" }


### PR DESCRIPTION
This PR should fix parse errors in statements like
```
exit! if condition
```

See also: https://github.com/tree-sitter/tree-sitter-ruby/pull/216