### PR TITLE
Java: Rename `FloatingPointLiteral` to `FloatLiteral`

### DIFF
--- a/java/ql/lib/change-notes/2022-05-16-floating-point-literal-rename.md
+++ b/java/ql/lib/change-notes/2022-05-16-floating-point-literal-rename.md
@@ -1,0 +1,4 @@
+---
+category: deprecated
+---
+* The QL class `FloatingPointLiteral` has been renamed to `FloatLiteral`.

--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -716,20 +716,23 @@ class LongLiteral extends Literal, @longliteral {
   override string getAPrimaryQlClass() { result = "LongLiteral" }
 }
 
+/** DEPRECATED: Alias for FloatLiteral */
+deprecated class FloatingPointLiteral = FloatLiteral;
+
 /**
  * A float literal. For example, `4.2f`.
  *
  * A float literal is never negative; a preceding minus, if any, will always
  * be modeled as separate `MinusExpr`.
  */
-class FloatingPointLiteral extends Literal, @floatingpointliteral {
+class FloatLiteral extends Literal, @floatingpointliteral {
   /**
    * Gets the value of this literal as CodeQL 64-bit `float`. The value will
    * be parsed as Java 32-bit `float` and then converted to a CodeQL `float`.
    */
   float getFloatValue() { result = this.getValue().toFloat() }
 
-  override string getAPrimaryQlClass() { result = "FloatingPointLiteral" }
+  override string getAPrimaryQlClass() { result = "FloatLiteral" }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -49,7 +49,7 @@ module Private {
   /** Class to represent float and double literals. */
   class RealLiteral extends J::Literal {
     RealLiteral() {
-      this instanceof J::FloatingPointLiteral or
+      this instanceof J::FloatLiteral or
       this instanceof J::DoubleLiteral
     }
   }
@@ -191,7 +191,7 @@ private module Impl {
   /** Gets the constant `float` value of non-`ConstantIntegerExpr` expressions. */
   float getNonIntegerValue(Expr e) {
     result = e.(LongLiteral).getValue().toFloat() or
-    result = e.(FloatingPointLiteral).getValue().toFloat() or
+    result = e.(FloatLiteral).getValue().toFloat() or
     result = e.(DoubleLiteral).getValue().toFloat()
   }
 

--- a/java/ql/src/Likely Bugs/Comparison/NoComparisonOnFloats.ql
+++ b/java/ql/src/Likely Bugs/Comparison/NoComparisonOnFloats.ql
@@ -12,16 +12,6 @@
 import semmle.code.java.Type
 import semmle.code.java.Expr
 
-// Either `float`, `double`, `Float`, or `Double`.
-class Floating extends Type {
-  Floating() {
-    exists(string s | s = this.getName().toLowerCase() |
-      s = "float" or
-      s = "double"
-    )
-  }
-}
-
 predicate trivialLiteral(Literal e) {
   e.getValue() = "0.0" or
   e.getValue() = "0" or
@@ -61,7 +51,7 @@ predicate similarVarComparison(EqualityTest e) {
 
 from EqualityTest ee
 where
-  ee.getAnOperand().getType() instanceof Floating and
+  ee.getAnOperand().getType() instanceof FloatingPointType and
   not ee.getAnOperand() instanceof NullLiteral and
   not trivialLiteral(ee.getAnOperand()) and
   not definedConstant(ee.getAnOperand()) and

--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicConstants.qll
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicConstants.qll
@@ -55,7 +55,7 @@ private predicate powerOfTen(float f) {
 }
 
 private predicate floatTrivial(Literal lit) {
-  (lit instanceof FloatingPointLiteral or lit instanceof DoubleLiteral) and
+  (lit instanceof FloatLiteral or lit instanceof DoubleLiteral) and
   exists(float f |
     f = lit.getValue().toFloat() and
     (f.abs() <= 20.0 or powerOfTen(f))

--- a/java/ql/test/kotlin/library-tests/literals/literals.expected
+++ b/java/ql/test/kotlin/library-tests/literals/literals.expected
@@ -15,9 +15,9 @@
 | literals.kt:17:30:17:33 | 15 | LongLiteral |
 | literals.kt:18:30:18:39 | 11 | LongLiteral |
 | literals.kt:19:30:19:38 | 1234567 | LongLiteral |
-| literals.kt:20:32:20:35 | 0.0 | FloatingPointLiteral |
-| literals.kt:21:32:21:37 | 123.4 | FloatingPointLiteral |
-| literals.kt:22:32:22:38 | -123.4 | FloatingPointLiteral |
+| literals.kt:20:32:20:35 | 0.0 | FloatLiteral |
+| literals.kt:21:32:21:37 | 123.4 | FloatLiteral |
+| literals.kt:22:32:22:38 | -123.4 | FloatLiteral |
 | literals.kt:23:34:23:36 | 0.0 | DoubleLiteral |
 | literals.kt:24:34:24:38 | 123.4 | DoubleLiteral |
 | literals.kt:25:34:25:39 | -123.4 | DoubleLiteral |

--- a/java/ql/test/library-tests/fields/PrintAst.expected
+++ b/java/ql/test/library-tests/fields/PrintAst.expected
@@ -3,7 +3,7 @@ fields/FieldTest.java:
 #    3|   1: [Class] FieldTest
 #    4|     4: [FieldDeclaration] float ff, ...;
 #    4|       -1: [TypeAccess] float
-#    4|       1: [FloatingPointLiteral] 2.3f
+#    4|       1: [FloatLiteral] 2.3f
 #    5|     5: [FieldDeclaration] Object obj, ...;
 #    5|       -1: [TypeAccess] Object
 #    5|       0: [NullLiteral] null

--- a/java/ql/test/library-tests/literals/floatLiterals/floatLiterals.ql
+++ b/java/ql/test/library-tests/literals/floatLiterals/floatLiterals.ql
@@ -1,4 +1,4 @@
 import semmle.code.java.Expr
 
-from FloatingPointLiteral lit
+from FloatLiteral lit
 select lit, lit.getValue(), lit.getFloatValue()

--- a/java/ql/test/library-tests/literals/literals-numeric/negativeNumericLiterals.ql
+++ b/java/ql/test/library-tests/literals/literals-numeric/negativeNumericLiterals.ql
@@ -4,6 +4,6 @@ from Literal l
 where
   l instanceof IntegerLiteral or
   l instanceof LongLiteral or
-  l instanceof FloatingPointLiteral or
+  l instanceof FloatLiteral or
   l instanceof DoubleLiteral
 select l, l.getValue(), l.getParent()


### PR DESCRIPTION
Resolves #9170