### PR TITLE
Kotlin: Add support for InlineExpectationsTest

### DIFF
--- a/java/ql/lib/semmle/code/java/Javadoc.qll
+++ b/java/ql/lib/semmle/code/java/Javadoc.qll
@@ -153,6 +153,15 @@ class KtComment extends Top, @ktcomment {
   /** Gets the full text of this comment. */
   string getText() { ktComments(this, _, result) }
 
+  /** Holds if this comment is an EOL comment. */
+  predicate isEolComment() { ktComments(this, 1, _) }
+
+  /** Holds if this comment is a block comment. */
+  predicate isBlockComment() { ktComments(this, 2, _) }
+
+  /** Holds if this comment is a KDoc comment. */
+  predicate isDocComment() { ktComments(this, 3, _) }
+
   /** Gets the sections of this comment. */
   KtCommentSection getSections() { ktCommentSections(result, this, _) }
 

--- a/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
@@ -16,7 +16,7 @@ private class JavadocExpectationComment extends Javadoc, ExpectationComment {
 }
 
 private class KtExpectationComment extends KtComment, ExpectationComment {
-  override string getContents() {
-    result = this.getText().regexpCapture("(?://|/\\*)(.*)(?:\\*/)?", 1)
-  }
+  KtExpectationComment() { this.isEolComment() }
+
+  override string getContents() { result = this.getText().suffix(2).trim() }
 }

--- a/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
+++ b/java/ql/test/TestUtilities/InlineExpectationsTestPrivate.qll
@@ -4,9 +4,19 @@ import java
  * A class representing line comments in Java, which is simply Javadoc restricted
  * to EOL comments, with an extra accessor used by the InlineExpectations core code
  */
-class ExpectationComment extends Javadoc {
-  ExpectationComment() { isEolComment(this) }
-
+abstract class ExpectationComment extends Top {
   /** Gets the contents of the given comment, _without_ the preceding comment marker (`//`). */
-  string getContents() { result = this.getChild(0).toString() }
+  abstract string getContents();
+}
+
+private class JavadocExpectationComment extends Javadoc, ExpectationComment {
+  JavadocExpectationComment() { isEolComment(this) }
+
+  override string getContents() { result = this.getChild(0).toString() }
+}
+
+private class KtExpectationComment extends KtComment, ExpectationComment {
+  override string getContents() {
+    result = this.getText().regexpCapture("(?://|/\\*)(.*)(?:\\*/)?", 1)
+  }
 }


### PR DESCRIPTION
Gives `InlineExpectationsTest` the ability to recognize Kotlin comments, allowing its use in `.kt` tests.