### PR TITLE
QL: Allow class + `Base` in `ql/primary-ql-class-consistency`

### DIFF
--- a/ql/ql/src/queries/style/GetAPrimaryQlClassConsistency.ql
+++ b/ql/ql/src/queries/style/GetAPrimaryQlClassConsistency.ql
@@ -10,18 +10,31 @@
 
 import ql
 
-from ClassPredicate pred, String constant
+/**
+ * Gets a string that is allowed to be returned from the `getAPrimaryQlClass` implementation
+ * in class `c`.
+ *
+ * For most languages this is just the name of `c`, but QL for Swift implements
+ * the `getAPrimaryQlClass` predicate for a class `Foo` in another class `FooBase`.
+ */
+string getAnAllowedResultForClass(Class c) {
+  result = c.getName()
+  or
+  c.getName() = result + "Base"
+}
+
+from ClassPredicate pred, String constant, Class c
 where
-  exists(string className, string constantName |
-    pred.getParent().getName() = className and
-    pred.getName() = "getAPrimaryQlClass" and
+  c = pred.getParent() and
+  pred.getName() = "getAPrimaryQlClass" and
+  exists(string constantName |
     constant = pred.getBody().(ComparisonFormula).getRightOperand() and
     constant.getValue() = constantName and
     // might be "Foo::classname", detect by matching with a regexp
-    not constantName.regexpMatch(".*\\b" + className + "$") and
+    not constantName.regexpMatch(".*\\b" + getAnAllowedResultForClass(c) + "$") and
     // ignore constants with "?" in them
     not constantName.regexpMatch(".*\\?.*")
   )
 select pred,
-  "The getAPrimaryQlClass predicate $@ instead of the class name \"" + pred.getParent().getName() +
-    "\".", constant, "results in \"" + constant.getValue() + "\""
+  "The getAPrimaryQlClass predicate $@ instead of the class name \"" + c.getName() + "\".",
+  constant, "results in \"" + constant.getValue() + "\""


### PR DESCRIPTION
This should hopefully mean fewer false positives for `ql/primary-ql-class-consistency` in Swift.