### PR TITLE
JS: Add individual per-security-query counting queries

### DIFF
--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountAlertsAndSinks.qll
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountAlertsAndSinks.qll
@@ -1,0 +1,20 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for a particular dataflow config.
+ */
+
+import javascript
+import evaluation.EndToEndEvaluation
+
+query predicate countAlertsAndSinks(int numAlerts, int numSinks) {
+  numAlerts =
+    count(DataFlow::Configuration cfg, DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    ) and
+  numSinks =
+    count(DataFlow::Node sink |
+      exists(DataFlow::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+    )
+}

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountCodeInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountCodeInjection.ql
@@ -1,0 +1,22 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for the `CodeInjection` security query.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.CodeInjectionQuery as CodeInjection
+import evaluation.EndToEndEvaluation
+
+int numAlerts(DataFlow::Configuration cfg) {
+  result =
+    count(DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    )
+}
+
+select numAlerts(any(CodeInjection::Configuration cfg)) as numAlerts,
+  count(DataFlow::Node sink |
+    exists(CodeInjection::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+  ) as numSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountCodeInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountCodeInjection.ql
@@ -5,18 +5,5 @@
  * Count the number of sinks and alerts for the `CodeInjection` security query.
  */
 
-import javascript
 import semmle.javascript.security.dataflow.CodeInjectionQuery as CodeInjection
-import evaluation.EndToEndEvaluation
-
-int numAlerts(DataFlow::Configuration cfg) {
-  result =
-    count(DataFlow::Node source, DataFlow::Node sink |
-      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
-    )
-}
-
-select numAlerts(any(CodeInjection::Configuration cfg)) as numAlerts,
-  count(DataFlow::Node sink |
-    exists(CodeInjection::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
-  ) as numSinks
+import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountCodeInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountCodeInjection.ql
@@ -5,5 +5,5 @@
  * Count the number of sinks and alerts for the `CodeInjection` security query.
  */
 
-import semmle.javascript.security.dataflow.CodeInjectionQuery as CodeInjection
+import semmle.javascript.security.dataflow.CodeInjectionQuery
 import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountNosqlInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountNosqlInjection.ql
@@ -5,18 +5,5 @@
  * Count the number of sinks and alerts for the `NosqlInection` security query.
  */
 
-import javascript
 import semmle.javascript.security.dataflow.NosqlInjectionQuery as NosqlInjection
-import evaluation.EndToEndEvaluation
-
-int numAlerts(DataFlow::Configuration cfg) {
-  result =
-    count(DataFlow::Node source, DataFlow::Node sink |
-      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
-    )
-}
-
-select numAlerts(any(NosqlInjection::Configuration cfg)) as numAlerts,
-  count(DataFlow::Node sink |
-    exists(NosqlInjection::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
-  ) as numSinks
+import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountNosqlInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountNosqlInjection.ql
@@ -1,0 +1,22 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for the `NosqlInection` security query.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.NosqlInjectionQuery as NosqlInjection
+import evaluation.EndToEndEvaluation
+
+int numAlerts(DataFlow::Configuration cfg) {
+  result =
+    count(DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    )
+}
+
+select numAlerts(any(NosqlInjection::Configuration cfg)) as numAlerts,
+  count(DataFlow::Node sink |
+    exists(NosqlInjection::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+  ) as numSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountNosqlInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountNosqlInjection.ql
@@ -5,5 +5,5 @@
  * Count the number of sinks and alerts for the `NosqlInection` security query.
  */
 
-import semmle.javascript.security.dataflow.NosqlInjectionQuery as NosqlInjection
+import semmle.javascript.security.dataflow.NosqlInjectionQuery
 import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountSqlInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountSqlInjection.ql
@@ -1,0 +1,22 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for the `SqlInection` security query.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.SqlInjectionQuery as SqlInjection
+import evaluation.EndToEndEvaluation
+
+int numAlerts(DataFlow::Configuration cfg) {
+  result =
+    count(DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    )
+}
+
+select numAlerts(any(SqlInjection::Configuration cfg)) as numAlerts,
+  count(DataFlow::Node sink |
+    exists(SqlInjection::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+  ) as numSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountSqlInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountSqlInjection.ql
@@ -5,18 +5,5 @@
  * Count the number of sinks and alerts for the `SqlInection` security query.
  */
 
-import javascript
 import semmle.javascript.security.dataflow.SqlInjectionQuery as SqlInjection
-import evaluation.EndToEndEvaluation
-
-int numAlerts(DataFlow::Configuration cfg) {
-  result =
-    count(DataFlow::Node source, DataFlow::Node sink |
-      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
-    )
-}
-
-select numAlerts(any(SqlInjection::Configuration cfg)) as numAlerts,
-  count(DataFlow::Node sink |
-    exists(SqlInjection::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
-  ) as numSinks
+import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountSqlInjection.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountSqlInjection.ql
@@ -5,5 +5,5 @@
  * Count the number of sinks and alerts for the `SqlInection` security query.
  */
 
-import semmle.javascript.security.dataflow.SqlInjectionQuery as SqlInjection
+import semmle.javascript.security.dataflow.SqlInjectionQuery
 import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountTaintedPath.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountTaintedPath.ql
@@ -1,0 +1,22 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for the `TaintedPath` security query.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.TaintedPathQuery as TaintedPath
+import evaluation.EndToEndEvaluation
+
+int numAlerts(DataFlow::Configuration cfg) {
+  result =
+    count(DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    )
+}
+
+select numAlerts(any(TaintedPath::Configuration cfg)) as numAlerts,
+  count(DataFlow::Node sink |
+    exists(TaintedPath::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+  ) as numSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountTaintedPath.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountTaintedPath.ql
@@ -5,18 +5,5 @@
  * Count the number of sinks and alerts for the `TaintedPath` security query.
  */
 
-import javascript
 import semmle.javascript.security.dataflow.TaintedPathQuery as TaintedPath
-import evaluation.EndToEndEvaluation
-
-int numAlerts(DataFlow::Configuration cfg) {
-  result =
-    count(DataFlow::Node source, DataFlow::Node sink |
-      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
-    )
-}
-
-select numAlerts(any(TaintedPath::Configuration cfg)) as numAlerts,
-  count(DataFlow::Node sink |
-    exists(TaintedPath::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
-  ) as numSinks
+import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountTaintedPath.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountTaintedPath.ql
@@ -5,5 +5,5 @@
  * Count the number of sinks and alerts for the `TaintedPath` security query.
  */
 
-import semmle.javascript.security.dataflow.TaintedPathQuery as TaintedPath
+import semmle.javascript.security.dataflow.TaintedPathQuery
 import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXss.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXss.ql
@@ -5,18 +5,5 @@
  * Count the number of sinks and alerts for the `DomBasedXss` security query.
  */
 
-import javascript
 import semmle.javascript.security.dataflow.DomBasedXssQuery as DomBasedXss
-import evaluation.EndToEndEvaluation
-
-int numAlerts(DataFlow::Configuration cfg) {
-  result =
-    count(DataFlow::Node source, DataFlow::Node sink |
-      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
-    )
-}
-
-select numAlerts(any(DomBasedXss::Configuration cfg)) as numAlerts,
-  count(DataFlow::Node sink |
-    exists(DomBasedXss::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
-  ) as numSinks
+import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXss.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXss.ql
@@ -1,0 +1,22 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for the `DomBasedXss` security query.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.DomBasedXssQuery as DomBasedXss
+import evaluation.EndToEndEvaluation
+
+int numAlerts(DataFlow::Configuration cfg) {
+  result =
+    count(DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    )
+}
+
+select numAlerts(any(DomBasedXss::Configuration cfg)) as numAlerts,
+  count(DataFlow::Node sink |
+    exists(DomBasedXss::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+  ) as numSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXss.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXss.ql
@@ -5,5 +5,5 @@
  * Count the number of sinks and alerts for the `DomBasedXss` security query.
  */
 
-import semmle.javascript.security.dataflow.DomBasedXssQuery as DomBasedXss
+import semmle.javascript.security.dataflow.DomBasedXssQuery
 import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXssThroughDom.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXssThroughDom.ql
@@ -5,18 +5,5 @@
  * Count the number of sinks and alerts for the `XssThroughDom` security query.
  */
 
-import javascript
 import semmle.javascript.security.dataflow.XssThroughDomQuery as XssThroughDom
-import evaluation.EndToEndEvaluation
-
-int numAlerts(DataFlow::Configuration cfg) {
-  result =
-    count(DataFlow::Node source, DataFlow::Node sink |
-      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
-    )
-}
-
-select numAlerts(any(XssThroughDom::Configuration cfg)) as numAlerts,
-  count(DataFlow::Node sink |
-    exists(XssThroughDom::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
-  ) as numSinks
+import CountAlertsAndSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXssThroughDom.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXssThroughDom.ql
@@ -1,0 +1,22 @@
+/*
+ * For internal use only.
+ *
+ *
+ * Count the number of sinks and alerts for the `XssThroughDom` security query.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.XssThroughDomQuery as XssThroughDom
+import evaluation.EndToEndEvaluation
+
+int numAlerts(DataFlow::Configuration cfg) {
+  result =
+    count(DataFlow::Node source, DataFlow::Node sink |
+      cfg.hasFlow(source, sink) and not isFlowExcluded(source, sink)
+    )
+}
+
+select numAlerts(any(XssThroughDom::Configuration cfg)) as numAlerts,
+  count(DataFlow::Node sink |
+    exists(XssThroughDom::Configuration cfg | cfg.isSink(sink) or cfg.isSink(sink, _))
+  ) as numSinks

--- a/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXssThroughDom.ql
+++ b/javascript/ql/experimental/adaptivethreatmodeling/modelbuilding/counting/CountXssThroughDom.ql
@@ -5,5 +5,5 @@
  * Count the number of sinks and alerts for the `XssThroughDom` security query.
  */
 
-import semmle.javascript.security.dataflow.XssThroughDomQuery as XssThroughDom
+import semmle.javascript.security.dataflow.XssThroughDomQuery
 import CountAlertsAndSinks


### PR DESCRIPTION
The ATM project uses an AML pipeline to select which CodeQL databases to use as the evaluation databases for each security query being boosted. 

Previously, evaluation sets for _all_ security queries would be produced at once, using the `CountAlertsAndEndpoints.ql` query. However, this query does not scale with adding more security queries, and it is not efficient to create evaluation sets for all queries during every pipeline run (when adding a new query, you simply want to create an evaluation set for that one query, and not the others).

Therefore, after a discussion, it was deemed better to specify one security query that you would like to create an evaluation set for. For this, we would need a way to count alerts and endpoints for a single query. The most simple solution is to add per-query counting queries, `Count{QUERY_NAME}.ql`, which can be used by the selection pipeline.

The selection pipeline has been tested with the `CountCodeInjection.ql` query.