### PR TITLE
Python: Modernise weak file permissions query

### DIFF
--- a/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
+++ b/python/ql/src/Security/CWE-732/WeakFilePermissions.ql
@@ -12,6 +12,7 @@
  */
 
 import python
+import semmle.python.ApiGraphs
 
 bindingset[p]
 int world_permission(int p) { result = p % 8 }
@@ -33,20 +34,20 @@ string permissive_permission(int p) {
   world_permission(p) = 0 and result = "group " + access(group_permission(p))
 }
 
-predicate chmod_call(CallNode call, FunctionValue chmod, NumericValue num) {
-  Value::named("os.chmod") = chmod and
-  chmod.getACall() = call and
-  call.getArg(1).pointsTo(num)
+predicate chmod_call(API::CallNode call, string name, int mode) {
+  call = API::moduleImport("os").getMember("chmod").getACall() and
+  mode = call.getParameter(1, "mode").getAValueReachingRhs().asExpr().(IntegerLiteral).getValue() and
+  name = "chmod"
 }
 
-predicate open_call(CallNode call, FunctionValue open, NumericValue num) {
-  Value::named("os.open") = open and
-  open.getACall() = call and
-  call.getArg(2).pointsTo(num)
+predicate open_call(API::CallNode call, string name, int mode) {
+  call = API::moduleImport("os").getMember("open").getACall() and
+  mode = call.getParameter(2, "mode").getAValueReachingRhs().asExpr().(IntegerLiteral).getValue() and
+  name = "open"
 }
 
-from CallNode call, FunctionValue func, NumericValue num, string permission
+from API::CallNode call, string name, int mode, string permission
 where
-  (chmod_call(call, func, num) or open_call(call, func, num)) and
-  permission = permissive_permission(num.getIntValue())
-select call, "Overly permissive mask in " + func.getName() + " sets file to " + permission + "."
+  (chmod_call(call, name, mode) or open_call(call, name, mode)) and
+  permission = permissive_permission(mode)
+select call, "Overly permissive mask in " + name + " sets file to " + permission + "."

--- a/python/ql/test/query-tests/Security/CWE-732-WeakFilePermissions/WeakFilePermissions.expected
+++ b/python/ql/test/query-tests/Security/CWE-732-WeakFilePermissions/WeakFilePermissions.expected
@@ -2,6 +2,5 @@
 | test.py:8:1:8:20 | ControlFlowNode for Attribute() | Overly permissive mask in chmod sets file to world writable. |
 | test.py:9:1:9:21 | ControlFlowNode for Attribute() | Overly permissive mask in chmod sets file to world writable. |
 | test.py:11:1:11:21 | ControlFlowNode for Attribute() | Overly permissive mask in chmod sets file to group readable. |
-| test.py:13:1:13:28 | ControlFlowNode for Attribute() | Overly permissive mask in chmod sets file to group writable. |
 | test.py:14:1:14:19 | ControlFlowNode for Attribute() | Overly permissive mask in chmod sets file to group writable. |
 | test.py:16:1:16:25 | ControlFlowNode for Attribute() | Overly permissive mask in open sets file to world readable. |

--- a/python/ql/test/query-tests/Security/CWE-732-WeakFilePermissions/options
+++ b/python/ql/test/query-tests/Security/CWE-732-WeakFilePermissions/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --max-import-depth=2 -p ../lib
+semmle-extractor-options: --max-import-depth=2 -p ../lib --lang=3


### PR DESCRIPTION
Using API graphs instead of points-to.

Unfortunately, some results will be lost because of this, due to the fact that points-to tracks bitwise operations on small numbers (i.e. flags), whereas API graphs does no such thing. This means using something like `stat.S_IWUSR | stat.S_IWGRP` will not work.

A custom type tracker (like the one used for `re` flags) could be used to recapture this behaviour, but I think that's best left as future work, as it's not clear to me that this query is actually worth the effort it would take to implement this.

---

As this is just modernising a somewhat minor query, I don't think it needs a change note (but I'll happily add one if necessary).