### PR TITLE
Java: Move `NumericType` to `Type.qll`

### DIFF
--- a/java/ql/lib/semmle/code/java/JDK.qll
+++ b/java/ql/lib/semmle/code/java/JDK.qll
@@ -144,18 +144,6 @@ class NumberType extends RefType {
   NumberType() { exists(TypeNumber number | hasDescendant(number, this)) }
 }
 
-/** A numeric type, including both primitive and boxed types. */
-class NumericType extends Type {
-  NumericType() {
-    exists(string name |
-      name = this.(PrimitiveType).getName() or
-      name = this.(BoxedType).getPrimitiveType().getName()
-    |
-      name.regexpMatch("byte|short|int|long|double|float")
-    )
-  }
-}
-
 /** An immutable type. */
 class ImmutableType extends Type {
   ImmutableType() {

--- a/java/ql/lib/semmle/code/java/Type.qll
+++ b/java/ql/lib/semmle/code/java/Type.qll
@@ -1246,6 +1246,18 @@ class CharacterType extends Type {
   }
 }
 
+/** A numeric type, including both primitive and boxed types. */
+class NumericType extends Type {
+  NumericType() {
+    exists(string name |
+      name = this.(PrimitiveType).getName() or
+      name = this.(BoxedType).getPrimitiveType().getName()
+    |
+      name.regexpMatch("byte|short|int|long|double|float")
+    )
+  }
+}
+
 /** A numeric or character type, which may be either a primitive or a boxed type. */
 class NumericOrCharType extends Type {
   NumericOrCharType() {


### PR DESCRIPTION
For consistency moves `NumericType` from `JDK.qll` to `Type.qll`, where all other related type classes are.

I have not added a change note because I assume this change is not externally visible. Though please let me know if a change note is needed.

This change conflicts with #9182; feel free to merge that one first and I will resolve the conflict here afterwards.