### PR TITLE
remove `pip install` mention from README.md

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -19,12 +19,6 @@ Notice you can run `bazel run :create-extractor-pack` if you already are in the 
 
 ## Code generation
 
-Make sure to install the [pip requirements](./codegen/requirements.txt) via
-
-```bash
-python3 -m pip install -r codegen/requirements.txt
-```
-
 Run
 
 ```bash


### PR DESCRIPTION
It is not needed any more since pip requirements were coded in bazel.