### PR TITLE
Data flow: Do not discard call context when computing reverse lambda flow through jumps

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -216,10 +216,9 @@ private module LambdaFlow {
     or
     // jump step
     exists(Node mid, DataFlowType t0 |
-      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, _) and
+      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
       toReturn = false and
-      toJump = true and
-      lastCall = TDataFlowCallNone()
+      toJump = true
     |
       jumpStepCached(node, mid) and
       t = t0

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -216,10 +216,9 @@ private module LambdaFlow {
     or
     // jump step
     exists(Node mid, DataFlowType t0 |
-      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, _) and
+      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
       toReturn = false and
-      toJump = true and
-      lastCall = TDataFlowCallNone()
+      toJump = true
     |
       jumpStepCached(node, mid) and
       t = t0

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -216,10 +216,9 @@ private module LambdaFlow {
     or
     // jump step
     exists(Node mid, DataFlowType t0 |
-      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, _) and
+      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
       toReturn = false and
-      toJump = true and
-      lastCall = TDataFlowCallNone()
+      toJump = true
     |
       jumpStepCached(node, mid) and
       t = t0

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -216,10 +216,9 @@ private module LambdaFlow {
     or
     // jump step
     exists(Node mid, DataFlowType t0 |
-      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, _) and
+      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
       toReturn = false and
-      toJump = true and
-      lastCall = TDataFlowCallNone()
+      toJump = true
     |
       jumpStepCached(node, mid) and
       t = t0

--- a/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
+++ b/python/ql/lib/semmle/python/dataflow/new/internal/DataFlowImplCommon.qll
@@ -216,10 +216,9 @@ private module LambdaFlow {
     or
     // jump step
     exists(Node mid, DataFlowType t0 |
-      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, _) and
+      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
       toReturn = false and
-      toJump = true and
-      lastCall = TDataFlowCallNone()
+      toJump = true
     |
       jumpStepCached(node, mid) and
       t = t0

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowImplCommon.qll
@@ -216,10 +216,9 @@ private module LambdaFlow {
     or
     // jump step
     exists(Node mid, DataFlowType t0 |
-      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, _) and
+      revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
       toReturn = false and
-      toJump = true and
-      lastCall = TDataFlowCallNone()
+      toJump = true
     |
       jumpStepCached(node, mid) and
       t = t0

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -6,26 +6,15 @@ edges
 | call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
 | call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
 | call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
-| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
-| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
-| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:27:17:27:17 | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:36:23:36:23 | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
-| call_sensitivity.rb:25:25:25:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 | call_sensitivity.rb:27:17:27:17 | x :  | call_sensitivity.rb:27:27:27:27 | x |
 | call_sensitivity.rb:28:25:28:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
-| call_sensitivity.rb:34:25:34:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 | call_sensitivity.rb:36:23:36:23 | x :  | call_sensitivity.rb:36:31:36:31 | x |
 | call_sensitivity.rb:37:25:37:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 | call_sensitivity.rb:39:24:39:24 | x :  | call_sensitivity.rb:39:32:39:32 | x |
 | call_sensitivity.rb:40:26:40:32 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
-| call_sensitivity.rb:43:26:43:32 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 nodes
 | call_sensitivity.rb:5:6:5:12 | "taint" | semmle.label | "taint" |
 | call_sensitivity.rb:7:13:7:13 | x :  | semmle.label | x :  |
@@ -36,36 +25,22 @@ nodes
 | call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
-| call_sensitivity.rb:25:25:25:31 | "taint" :  | semmle.label | "taint" :  |
 | call_sensitivity.rb:27:17:27:17 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:27:27:27:27 | x | semmle.label | x |
 | call_sensitivity.rb:28:25:28:31 | "taint" :  | semmle.label | "taint" :  |
-| call_sensitivity.rb:34:25:34:31 | "taint" :  | semmle.label | "taint" :  |
 | call_sensitivity.rb:36:23:36:23 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:36:31:36:31 | x | semmle.label | x |
 | call_sensitivity.rb:37:25:37:31 | "taint" :  | semmle.label | "taint" :  |
 | call_sensitivity.rb:39:24:39:24 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:39:32:39:32 | x | semmle.label | x |
 | call_sensitivity.rb:40:26:40:32 | "taint" :  | semmle.label | "taint" :  |
-| call_sensitivity.rb:43:26:43:32 | "taint" :  | semmle.label | "taint" :  |
 subpaths
 #select
 | call_sensitivity.rb:5:6:5:12 | "taint" | call_sensitivity.rb:5:6:5:12 | "taint" | call_sensitivity.rb:5:6:5:12 | "taint" | $@ | call_sensitivity.rb:5:6:5:12 | "taint" | "taint" |
 | call_sensitivity.rb:15:28:15:28 | x | call_sensitivity.rb:15:9:15:15 | "taint" :  | call_sensitivity.rb:15:28:15:28 | x | $@ | call_sensitivity.rb:15:9:15:15 | "taint" :  | "taint" :  |
 | call_sensitivity.rb:27:27:27:27 | x | call_sensitivity.rb:28:25:28:31 | "taint" :  | call_sensitivity.rb:27:27:27:27 | x | $@ | call_sensitivity.rb:28:25:28:31 | "taint" :  | "taint" :  |
 | call_sensitivity.rb:36:31:36:31 | x | call_sensitivity.rb:37:25:37:31 | "taint" :  | call_sensitivity.rb:36:31:36:31 | x | $@ | call_sensitivity.rb:37:25:37:31 | "taint" :  | "taint" :  |
-| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:25:25:25:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:25:25:25:31 | "taint" :  | "taint" :  |
-| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:28:25:28:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:28:25:28:31 | "taint" :  | "taint" :  |
-| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:34:25:34:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:34:25:34:31 | "taint" :  | "taint" :  |
-| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:37:25:37:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:37:25:37:31 | "taint" :  | "taint" :  |
 | call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:40:26:40:32 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:40:26:40:32 | "taint" :  | "taint" :  |
-| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:43:26:43:32 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:43:26:43:32 | "taint" :  | "taint" :  |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -5,12 +5,27 @@ edges
 | call_sensitivity.rb:15:20:15:20 | x :  | call_sensitivity.rb:15:28:15:28 | x |
 | call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
 | call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | call_sensitivity.rb:18:17:18:17 | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:27:17:27:17 | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:36:23:36:23 | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | call_sensitivity.rb:39:24:39:24 | x :  |
+| call_sensitivity.rb:25:25:25:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 | call_sensitivity.rb:27:17:27:17 | x :  | call_sensitivity.rb:27:27:27:27 | x |
 | call_sensitivity.rb:28:25:28:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
+| call_sensitivity.rb:34:25:34:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 | call_sensitivity.rb:36:23:36:23 | x :  | call_sensitivity.rb:36:31:36:31 | x |
 | call_sensitivity.rb:37:25:37:31 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
+| call_sensitivity.rb:39:24:39:24 | x :  | call_sensitivity.rb:39:32:39:32 | x |
+| call_sensitivity.rb:40:26:40:32 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
+| call_sensitivity.rb:43:26:43:32 | "taint" :  | call_sensitivity.rb:17:27:17:27 | x :  |
 nodes
 | call_sensitivity.rb:5:6:5:12 | "taint" | semmle.label | "taint" |
 | call_sensitivity.rb:7:13:7:13 | x :  | semmle.label | x :  |
@@ -20,17 +35,37 @@ nodes
 | call_sensitivity.rb:15:28:15:28 | x | semmle.label | x |
 | call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:17:27:17:27 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:18:17:18:17 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:25:25:25:31 | "taint" :  | semmle.label | "taint" :  |
 | call_sensitivity.rb:27:17:27:17 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:27:27:27:27 | x | semmle.label | x |
 | call_sensitivity.rb:28:25:28:31 | "taint" :  | semmle.label | "taint" :  |
+| call_sensitivity.rb:34:25:34:31 | "taint" :  | semmle.label | "taint" :  |
 | call_sensitivity.rb:36:23:36:23 | x :  | semmle.label | x :  |
 | call_sensitivity.rb:36:31:36:31 | x | semmle.label | x |
 | call_sensitivity.rb:37:25:37:31 | "taint" :  | semmle.label | "taint" :  |
+| call_sensitivity.rb:39:24:39:24 | x :  | semmle.label | x :  |
+| call_sensitivity.rb:39:32:39:32 | x | semmle.label | x |
+| call_sensitivity.rb:40:26:40:32 | "taint" :  | semmle.label | "taint" :  |
+| call_sensitivity.rb:43:26:43:32 | "taint" :  | semmle.label | "taint" :  |
 subpaths
 #select
 | call_sensitivity.rb:5:6:5:12 | "taint" | call_sensitivity.rb:5:6:5:12 | "taint" | call_sensitivity.rb:5:6:5:12 | "taint" | $@ | call_sensitivity.rb:5:6:5:12 | "taint" | "taint" |
 | call_sensitivity.rb:15:28:15:28 | x | call_sensitivity.rb:15:9:15:15 | "taint" :  | call_sensitivity.rb:15:28:15:28 | x | $@ | call_sensitivity.rb:15:9:15:15 | "taint" :  | "taint" :  |
 | call_sensitivity.rb:27:27:27:27 | x | call_sensitivity.rb:28:25:28:31 | "taint" :  | call_sensitivity.rb:27:27:27:27 | x | $@ | call_sensitivity.rb:28:25:28:31 | "taint" :  | "taint" :  |
 | call_sensitivity.rb:36:31:36:31 | x | call_sensitivity.rb:37:25:37:31 | "taint" :  | call_sensitivity.rb:36:31:36:31 | x | $@ | call_sensitivity.rb:37:25:37:31 | "taint" :  | "taint" :  |
+| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:25:25:25:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:25:25:25:31 | "taint" :  | "taint" :  |
+| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:28:25:28:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:28:25:28:31 | "taint" :  | "taint" :  |
+| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:34:25:34:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:34:25:34:31 | "taint" :  | "taint" :  |
+| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:37:25:37:31 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:37:25:37:31 | "taint" :  | "taint" :  |
+| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:40:26:40:32 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:40:26:40:32 | "taint" :  | "taint" :  |
+| call_sensitivity.rb:39:32:39:32 | x | call_sensitivity.rb:43:26:43:32 | "taint" :  | call_sensitivity.rb:39:32:39:32 | x | $@ | call_sensitivity.rb:43:26:43:32 | "taint" :  | "taint" :  |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call_sensitivity.rb
@@ -36,3 +36,8 @@ apply_lambda(my_lambda, "taint") # no flow
 my_lambda = lambda { |x| sink x }
 apply_lambda(my_lambda, "taint") # flow
 
+MY_LAMBDA1 = lambda { |x| sink x }
+apply_lambda(MY_LAMBDA1, "taint") # flow
+
+MY_LAMBDA2 = lambda { |x| puts x }
+apply_lambda(MY_LAMBDA2, "taint") # no flow


### PR DESCRIPTION
Since we are computing flow backwards, and we are recording the *first* call seen during reverse flow, it is valid to keep the call context even when we go through a jump step.