### PR TITLE
Associate certain companion object fields with the parent class

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -135,7 +135,7 @@ open class KotlinFileExtractor(
                     Unit
                 }
                 is IrField -> {
-                    val parentId = useDeclarationParent(declaration.parent, false)?.cast<DbReftype>()
+                    val parentId = useDeclarationParent(getFieldParent(declaration), false)?.cast<DbReftype>()
                     if (parentId != null) {
                         extractField(declaration, parentId)
                     }
@@ -829,10 +829,13 @@ open class KotlinFileExtractor(
                 }
 
                 if (bf != null && extractBackingField) {
-                    val fieldId = extractField(bf, parentId)
-                    tw.writeKtPropertyBackingFields(id, fieldId)
-                    if (p.isDelegated) {
-                        tw.writeKtPropertyDelegates(id, fieldId)
+                    val fieldParentId = useDeclarationParent(getFieldParent(bf), false)
+                    if (fieldParentId != null) {
+                        val fieldId = extractField(bf, fieldParentId.cast())
+                        tw.writeKtPropertyBackingFields(id, fieldId)
+                        if (p.isDelegated) {
+                            tw.writeKtPropertyDelegates(id, fieldId)
+                        }
                     }
                 }
 


### PR DESCRIPTION
Specifically `const`, `lateinit` and `@JvmField` properties get a static field which belongs to the containing class not the companion object, such that Java can address them via the containing class name rather than have to navigate a companion object pointer.