### PR TITLE
Kotlin: Fix test to correctly highlight lack of flow from field init

### DIFF
--- a/java/ql/test/kotlin/library-tests/field-initializer-flow/test.expected
+++ b/java/ql/test/kotlin/library-tests/field-initializer-flow/test.expected
@@ -1,4 +1,3 @@
 isFinalField
 | test.kt:3:3:3:18 | x |
 #select
-| test.kt:3:3:3:18 | this.x | test.kt:6:10:6:10 | getX(...) |

--- a/java/ql/test/kotlin/library-tests/field-initializer-flow/test.ql
+++ b/java/ql/test/kotlin/library-tests/field-initializer-flow/test.ql
@@ -4,9 +4,7 @@ import semmle.code.java.dataflow.DataFlow
 class Config extends DataFlow::Configuration {
   Config() { this = "Config" }
 
-  override predicate isSource(DataFlow::Node n) {
-    n.asExpr().(CompileTimeConstantExpr).getStringValue() = "Source"
-  }
+  override predicate isSource(DataFlow::Node n) { n.asExpr().(StringLiteral).getValue() = "Source" }
 
   override predicate isSink(DataFlow::Node n) {
     n.asExpr().(Argument).getCall().getCallee().getName() = "sink"


### PR DESCRIPTION
Fixes a field initialization flow test that was deceitfully showing flow from a field access to  another field access, rather than from the field initialization as was intended.

This now correctly highlights the lack of flow, which will be fixed in a different PR once we decide on the appropriate solution.