### PR TITLE
JS: API graph support for accessors (and classes members)

### DIFF
--- a/javascript/ql/test/ApiGraphs/accessors/VerifyAssertions.ql
+++ b/javascript/ql/test/ApiGraphs/accessors/VerifyAssertions.ql
@@ -1,0 +1,1 @@
+import ApiGraphs.VerifyAssertions

--- a/javascript/ql/test/ApiGraphs/accessors/index.js
+++ b/javascript/ql/test/ApiGraphs/accessors/index.js
@@ -1,28 +1,28 @@
 const foo = require('foo');
 
 foo({
-    myMethod(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+    myMethod(x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getMember("myMethod").getParameter(0) */
         console.log(x);
     }
 });
 
 foo({
     get myMethod() {
-        return function(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+        return function (x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getMember("myMethod").getParameter(0) */
             console.log(x)
         }
     }
 });
 
 class C {
-    static myMethod(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+    static myMethod(x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getMember("myMethod").getParameter(0) */
         console.log(x);
     }
 }
 foo(C);
 
 class D {
-    myMethod(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+    myMethod(x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getMember("myMethod").getParameter(0) */
         console.log(x);
     }
 }
@@ -30,7 +30,7 @@ foo(new D());
 
 class E {
     get myMethod() {
-        return function(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+        return function (x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getMember("myMethod").getParameter(0) */
             console.log(x);
         }
     }
@@ -39,7 +39,7 @@ foo(new E());
 
 class F {
     static get myMethod() {
-        return function(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+        return function (x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getMember("myMethod").getParameter(0) */
             console.log(x);
         }
     }
@@ -49,7 +49,7 @@ foo(F);
 // Cases where the class is instantiated in `foo`:
 
 class G {
-    myMethod2(x) { /* use (parameter 0 (member myMethod2 (instance (parameter 0 (member exports (module foo)))))) */
+    myMethod2(x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getInstance().getMember("myMethod2").getParameter(0) */
         console.log(x);
     }
 }
@@ -57,7 +57,7 @@ foo(G);
 
 class H {
     get myMethod2() {
-        return function (x) { /* use (parameter 0 (member myMethod2 (instance (parameter 0 (member exports (module foo)))))) */
+        return function (x) { /* use=moduleImport("foo").getMember("exports").getParameter(0).getInstance().getMember("myMethod2").getParameter(0) */
             console.log(x);
         }
     }

--- a/javascript/ql/test/ApiGraphs/accessors/index.js
+++ b/javascript/ql/test/ApiGraphs/accessors/index.js
@@ -1,0 +1,65 @@
+const foo = require('foo');
+
+foo({
+    myMethod(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+        console.log(x);
+    }
+});
+
+foo({
+    get myMethod() {
+        return function(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+            console.log(x)
+        }
+    }
+});
+
+class C {
+    static myMethod(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+        console.log(x);
+    }
+}
+foo(C);
+
+class D {
+    myMethod(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+        console.log(x);
+    }
+}
+foo(new D());
+
+class E {
+    get myMethod() {
+        return function(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+            console.log(x);
+        }
+    }
+}
+foo(new E());
+
+class F {
+    static get myMethod() {
+        return function(x) { /* use (parameter 0 (member myMethod (parameter 0 (member exports (module foo))))) */
+            console.log(x);
+        }
+    }
+}
+foo(F);
+
+// Cases where the class is instantiated in `foo`:
+
+class G {
+    myMethod2(x) { /* use (parameter 0 (member myMethod2 (instance (parameter 0 (member exports (module foo)))))) */
+        console.log(x);
+    }
+}
+foo(G);
+
+class H {
+    get myMethod2() {
+        return function (x) { /* use (parameter 0 (member myMethod2 (instance (parameter 0 (member exports (module foo)))))) */
+            console.log(x);
+        }
+    }
+}
+foo(H);


### PR DESCRIPTION
Generates API graph edges in two cases:
- When an object escapes, generates `getMember` edges to the return-value of getters.
- When an instance of a class escapes, generates `getMember` edges to the instance members of the class (including getters, as above).
  - Previously, such edges were generated only when the class itself escapes, not when an _instance_ of the class escapes.

Makes the example in https://github.com/github/codeql/pull/8606 actually work in JS.

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/api-graph-acces__default__code-scanning__9/reports) looks reasonable.