### PR TITLE
Kotlin: Use 'which' to find kotlinc

### DIFF
--- a/java/kotlin-extractor/build.py
+++ b/java/kotlin-extractor/build.py
@@ -35,8 +35,12 @@ def is_windows():
         return True
     return False
 
+# kotlinc might be kotlinc.bat or kotlinc.cmd on Windows, so we use `which` to find out what it is
+kotlinc = shutil.which('kotlinc')
+if kotlinc is None:
+    print("Cannot build the Kotlin extractor: no kotlinc found on your PATH", file = sys.stderr)
+    sys.exit(1)
 
-kotlinc = 'kotlinc.bat' if is_windows() else 'kotlinc'
 javac = 'javac'
 kotlin_dependency_folder = args.dependencies
 
@@ -200,10 +204,6 @@ def compile_standalone(version):
             'codeql-extractor-kotlin-standalone-%s.jar' % (version),
             'build/temp_src',
             version)
-
-if shutil.which(kotlinc) == None:
-    print("Cannot build the Kotlin extractor: no '%s' found on your PATH" % kotlinc, file = sys.stderr)
-    sys.exit(1)
 
 if args.many:
     for version in kotlin_plugin_versions.many_versions:


### PR DESCRIPTION
This means we handle kotlinc.batr and kotlinc.cmd on Windows.