### PR TITLE
Docs: Update references to github/codeql-go

### DIFF
--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -20,11 +20,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         path: codeql 
-    - name: Clone github/codeql-go
-      uses: actions/checkout@v3
-      with:
-        repository: 'github/codeql-go'
-        path: codeql-go
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodeQL
 
-This open source repository contains the standard CodeQL libraries and queries that power [GitHub Advanced Security](https://github.com/features/security/code) and the other application security products that [GitHub](https://github.com/features/security/) makes available to its customers worldwide. For the queries, libraries, and extractor that power Go analysis, visit the [CodeQL for Go repository](https://github.com/github/codeql-go).
+This open source repository contains the standard CodeQL libraries and queries that power [GitHub Advanced Security](https://github.com/features/security/code) and the other application security products that [GitHub](https://github.com/features/security/) makes available to its customers worldwide.
 
 ## How do I learn CodeQL and run queries?
 

--- a/docs/codeql/codeql-cli/about-ql-packs.rst
+++ b/docs/codeql/codeql-cli/about-ql-packs.rst
@@ -6,8 +6,7 @@ About QL packs
 QL packs are used to organize the files used in CodeQL analysis. They
 contain queries, library files, query suites, and important metadata.
 
-The `CodeQL repository <https://github.com/github/codeql>`__ contains QL packs for
-C/C++, C#, Go, Java, JavaScript, Python, and Ruby.
+The `CodeQL repository <https://github.com/github/codeql>`__ contains standard QL packs for all supported languages.
 You can also make custom QL packs to contain your own queries and libraries.
 
 QL pack structure

--- a/docs/codeql/codeql-cli/about-ql-packs.rst
+++ b/docs/codeql/codeql-cli/about-ql-packs.rst
@@ -7,10 +7,8 @@ QL packs are used to organize the files used in CodeQL analysis. They
 contain queries, library files, query suites, and important metadata.
 
 The `CodeQL repository <https://github.com/github/codeql>`__ contains QL packs for
-C/C++, C#, Java, JavaScript, Python, and Ruby. The `CodeQL for Go
-<https://github.com/github/codeql-go/>`__ repository contains a QL pack for Go
-analysis. You can also make custom QL packs to contain your own queries and
-libraries.
+C/C++, C#, Go, Java, JavaScript, Python, and Ruby.
+You can also make custom QL packs to contain your own queries and libraries.
 
 QL pack structure
 -----------------

--- a/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
+++ b/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
@@ -193,8 +193,7 @@ further options on the command line.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `CodeQL repository <https://github.com/github/codeql>`__ contains
-the queries and libraries required for CodeQL analysis of C/C++, C#, Go, Java,
-JavaScript/TypeScript, Python, and Ruby.
+the queries and libraries required for CodeQL analysis of all supported languages.
 Clone a copy of this repository into ``codeql-home``.
 
 By default, the root of the cloned repository will be called ``codeql``.
@@ -212,9 +211,9 @@ For Go analysis, run ``codeql-repo/go/scripts/install-deps.sh`` to install its d
    These have been moved to the ``github/codeql`` repository.
    It is no longer necessary to clone the ``github/codeql-go`` into a separate ``codeql-home/codeql-go`` folder.
 
-   For more information, see `this announcement <https://github.com/github/codeql-go/issues/741>`__.
+   For more information, see the `Relocation announcement <https://github.com/github/codeql-go/issues/741>`__.
 
-Within these repositories, the queries and libraries are organized into QL
+Within this repository, the queries and libraries are organized into QL
 packs. Along with the queries themselves, QL packs contain important metadata
 that tells the CodeQL CLI how to process the query files. For more information,
 see ":doc:`About QL packs <about-ql-packs>`."

--- a/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
+++ b/docs/codeql/codeql-cli/getting-started-with-the-codeql-cli.rst
@@ -193,7 +193,7 @@ further options on the command line.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `CodeQL repository <https://github.com/github/codeql>`__ contains
-the queries and libraries required for CodeQL analysis of C/C++, C#, Java,
+the queries and libraries required for CodeQL analysis of C/C++, C#, Go, Java,
 JavaScript/TypeScript, Python, and Ruby.
 Clone a copy of this repository into ``codeql-home``.
 
@@ -203,15 +203,16 @@ CLI that you will extract in step 4. If you use git on the command line, you can
 clone and rename the repository in a single step by running
 ``git clone git@github.com:github/codeql.git codeql-repo`` in the ``codeql-home`` folder.
 
-The CodeQL libraries and queries for Go analysis live in the `CodeQL for Go
-repository <https://github.com/github/codeql-go/>`__. Clone a copy of this
-repository into ``codeql-home``, and run ``codeql-go/scripts/install-deps.sh``
-to install its dependencies.
+For Go analysis, run ``codeql-repo/go/scripts/install-deps.sh`` to install its dependencies.
 
-The cloned repositories should have a sibling relationship.
-For example, if the root of the cloned CodeQL repository is
-``$HOME/codeql-home/codeql-repo``, then the root of the cloned CodeQL for Go
-repository should be ``$HOME/codeql-home/codeql-go``.
+.. pull-quote:: Note
+
+   The CodeQL libraries and queries for Go analysis used to live in a
+   separate `CodeQL for Go repository <https://github.com/github/codeql-go/>`__.
+   These have been moved to the ``github/codeql`` repository.
+   It is no longer necessary to clone the ``github/codeql-go`` into a separate ``codeql-home/codeql-go`` folder.
+
+   For more information, see `this announcement <https://github.com/github/codeql-go/issues/741>`__.
 
 Within these repositories, the queries and libraries are organized into QL
 packs. Along with the queries themselves, QL packs contain important metadata

--- a/docs/codeql/codeql-for-visual-studio-code/exploring-the-structure-of-your-source-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/exploring-the-structure-of-your-source-code.rst
@@ -28,7 +28,7 @@ Viewing the abstract syntax tree of a source file
    
    .. pull-quote:: Note
 
-      If you don't have an appropriate ``printAST.ql`` query in your workspace, the **CodeQL: View AST** command won't work. To fix this, you can update your copy of the `CodeQL <https://github.com/github/codeql>`__ repository (or `CodeQL for Go <https://github.com/github/codeql-go>`__ repository) from ``main``. If you do this, you may need to upgrade your databases. Also, query caches may be discarded and your next query runs could be slower.
+      If you don't have an appropriate ``printAST.ql`` query in your workspace, the **CodeQL: View AST** command won't work. To fix this, you can update your copy of the `CodeQL <https://github.com/github/codeql>`__ repository from ``main``. If you do this, you may need to upgrade your databases. Also, query caches may be discarded and your next query runs could be slower.
 
 3. Once the query has run, the AST viewer displays the structure of the source file.
 4. To see the nested structure, click the arrows and expand the nodes.

--- a/docs/codeql/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code.rst
@@ -69,8 +69,7 @@ There are two ways to do this:
    This ensures that the queries and libraries you write in VS Code also work in the query console on LGTM Enterprise.
 
    If you prefer to add the CodeQL queries and libraries to an :ref:`existing workspace <existing-workspace>` instead of the starter workspace, then you should
-   clone the appropriate branch of the `general CodeQL repository <https://github.com/github/codeql>`__ and the
-   `CodeQL repository for Go <https://github.com/github/codeql-go>`__ and add them to your workspace.
+   clone the appropriate branch of the `general CodeQL repository <https://github.com/github/codeql>`__ and add it to your workspace.
 
 .. _starter-workspace:
 
@@ -78,8 +77,7 @@ Using the starter workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The starter workspace is a Git repository. It contains:
 
-* The `repository of CodeQL libraries and queries <https://github.com/github/codeql>`__ for C/C++, C#, Java, JavaScript, Python, and Ruby. This is included as a submodule, so it can be updated without affecting your custom queries.
-* The `repository of CodeQL libraries and queries <https://github.com/github/codeql-go>`__ for Go. This is also included as a submodule.
+* The `repository of CodeQL libraries and queries <https://github.com/github/codeql>`__ for C/C++, C#, Go, Java, JavaScript, Python, and Ruby. This is included as a submodule, so it can be updated without affecting your custom queries.
 * A series of folders named ``codeql-custom-queries-<language>``. These are ready for you to start developing your own custom queries for each language, using the standard libraries. There are some example queries to get you started.
 
 To use the starter workspace:
@@ -113,10 +111,6 @@ For example, to make a custom CodeQL folder called ``my-custom-cpp-pack`` depend
     libraryPathDependencies: codeql/cpp-all
 
 For more information about why you need to add a ``qlpack.yml`` file, see ":ref:`About QL packs <about-ql-packs>`."
-
-.. pull-quote:: Note
-
-   The CodeQL libraries for Go are not included in the ``github/codeql`` repository, but are stored separately. To analyze Go projects, clone the repository at https://github.com/github/codeql-go and add it to your workspace as above.
 
 Further reading
 ----------------

--- a/docs/codeql/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code.rst
+++ b/docs/codeql/codeql-for-visual-studio-code/setting-up-codeql-in-visual-studio-code.rst
@@ -69,7 +69,7 @@ There are two ways to do this:
    This ensures that the queries and libraries you write in VS Code also work in the query console on LGTM Enterprise.
 
    If you prefer to add the CodeQL queries and libraries to an :ref:`existing workspace <existing-workspace>` instead of the starter workspace, then you should
-   clone the appropriate branch of the `general CodeQL repository <https://github.com/github/codeql>`__ and add it to your workspace.
+   clone the appropriate branch of the `CodeQL repository <https://github.com/github/codeql>`__ and add it to your workspace.
 
 .. _starter-workspace:
 
@@ -77,7 +77,7 @@ Using the starter workspace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The starter workspace is a Git repository. It contains:
 
-* The `repository of CodeQL libraries and queries <https://github.com/github/codeql>`__ for C/C++, C#, Go, Java, JavaScript, Python, and Ruby. This is included as a submodule, so it can be updated without affecting your custom queries.
+* The `repository of CodeQL libraries and queries <https://github.com/github/codeql>`__ all supported languages. This is included as a submodule, so it can be updated without affecting your custom queries.
 * A series of folders named ``codeql-custom-queries-<language>``. These are ready for you to start developing your own custom queries for each language, using the standard libraries. There are some example queries to get you started.
 
 To use the starter workspace:

--- a/docs/codeql/codeql-language-guides/modeling-data-flow-in-go-libraries.rst
+++ b/docs/codeql/codeql-language-guides/modeling-data-flow-in-go-libraries.rst
@@ -7,8 +7,8 @@ When analyzing a Go program, CodeQL does not examine the source code for
 external packages. To track the flow of untrusted data through a library, you
 can create a model of the library.
 
-You can find existing models in the ``ql/lib/semmle/go/frameworks/`` folder of the
-`CodeQL for Go repository <https://github.com/github/codeql-go/tree/main/ql/lib/semmle/go/frameworks>`__.
+You can find existing models in the ``go/ql/lib/semmle/go/frameworks/`` folder of the
+`CodeQL repository <https://github.com/github/codeql/tree/main/go/ql/lib/semmle/go/frameworks>`__.
 To add a new model, you should make a new file in that folder, named after the library.
 
 Sources
@@ -102,8 +102,8 @@ Data-flow sinks are specified by queries rather than by library models.
 However, you can use library models to indicate when functions belong to
 special categories. Queries can then use these categories when specifying
 sinks. Classes representing these special categories are contained in
-``ql/lib/semmle/go/Concepts.qll`` in the `CodeQL for Go repository
-<https://github.com/github/codeql-go/blob/main/ql/lib/semmle/go/Concepts.qll>`__.
+``go/ql/lib/semmle/go/Concepts.qll`` in the `CodeQL repository
+<https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/Concepts.qll>`__.
 ``Concepts.qll`` includes classes for logger mechanisms,
 HTTP response writers, HTTP redirects, and marshaling and unmarshaling
 functions.

--- a/docs/codeql/query-help/go.rst
+++ b/docs/codeql/query-help/go.rst
@@ -3,6 +3,6 @@ CodeQL query help for Go
 
 .. include:: ../reusables/query-help-overview.rst
 
-For shorter queries that you can use as building blocks when writing your own queries, see the `example queries in the CodeQL for Go repository <https://github.com/github/codeql-go/tree/main/ql/examples>`__.
+For shorter queries that you can use as building blocks when writing your own queries, see the `example queries in the CodeQL repository <https://github.com/github/codeql/tree/main/go/ql/examples>`__.
 
 .. include:: toc-go.rst

--- a/docs/codeql/reusables/go-further-reading.rst
+++ b/docs/codeql/reusables/go-further-reading.rst
@@ -1,3 +1,3 @@
-- `CodeQL queries for Go <https://github.com/github/codeql-go/tree/main/ql/src>`__
-- `Example queries for Go <https://github.com/github/codeql-go/tree/main/ql/examples>`__
+- `CodeQL queries for Go <https://github.com/github/codeql/tree/main/go/ql/src>`__
+- `Example queries for Go <https://github.com/github/codeql/tree/main/go/ql/examples>`__
 - `CodeQL library reference for Go <https://codeql.github.com/codeql-standard-libraries/go/>`__

--- a/docs/codeql/writing-codeql-queries/about-codeql-queries.rst
+++ b/docs/codeql/writing-codeql-queries/about-codeql-queries.rst
@@ -121,7 +121,7 @@ Select clauses for diagnostic queries (``@kind diagnostic``) and summary metric 
 Viewing the standard CodeQL queries
 ***********************************
 
-One of the easiest ways to get started writing your own queries is to modify an existing query. To view the standard CodeQL queries, or to try out other examples, visit the `CodeQL <https://github.com/github/codeql>`__ and `CodeQL for Go <https://github.com/github/codeql-go>`__ repositories on GitHub. 
+One of the easiest ways to get started writing your own queries is to modify an existing query. To view the standard CodeQL queries, or to try out other examples, visit the `CodeQL <https://github.com/github/codeql>`__ repository on GitHub.
 
 You can also find examples of queries developed to find security vulnerabilities and bugs in open source software projects on the `GitHub Security Lab website <https://securitylab.github.com/research>`__ and in the associated `repository <https://github.com/github/securitylab>`__.
 

--- a/docs/codeql/writing-codeql-queries/creating-path-queries.rst
+++ b/docs/codeql/writing-codeql-queries/creating-path-queries.rst
@@ -116,7 +116,7 @@ Declaring sources and sinks
 You must provide information about the ``source`` and ``sink`` in your path query. These are objects that correspond to the nodes of the paths that you are exploring.
 The name and the type of the ``source`` and the ``sink`` must be declared in the ``from`` statement of the query, and the types must be compatible with the nodes of the graph computed by the ``edges`` predicate.
 
-If you are querying C/C++, C#, Java, JavaScript, Python, or Ruby code (and you have used ``import DataFlow::PathGraph`` in your query), the definitions of the ``source`` and ``sink`` are accessed via the ``Configuration`` class in the data flow library. You should declare all three of these objects in the ``from`` statement.
+If you are querying C/C++, C#, Go, Java, JavaScript, Python, or Ruby code (and you have used ``import DataFlow::PathGraph`` in your query), the definitions of the ``source`` and ``sink`` are accessed via the ``Configuration`` class in the data flow library. You should declare all three of these objects in the ``from`` statement.
 For example:
 
 .. code-block:: ql

--- a/go/CONTRIBUTING.md
+++ b/go/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 2. Ensure that `<extraction-root>/codeql` is in your `PATH`.
 
-3. Clone this repository into `<extraction-root>/codeql-go` and change to this directory.
+3. Clone this repository (`github/codeql`) into `<extraction-root>/codeql-repo` and change to the directory `<extraction-root>/codeql-repo/go`.
 
 4. To build, run `make`.
 

--- a/go/README.md
+++ b/go/README.md
@@ -33,9 +33,9 @@ interface](https://codeql.github.com/docs/codeql-cli/) to create a database your
 download a pre-built database from [LGTM.com](https://lgtm.com/). You can then run any of the
 queries contained in this repository either on the command line or using the VS Code extension.
 
-Note that the [lgtm.com](https://github.com/github/codeql-go/tree/lgtm.com) branch of this
+Note that the [lgtm.com](https://github.com/github/codeql/tree/lgtm.com) branch of this
 repository corresponds to the version of the queries that is currently deployed on LGTM.com.
-The [main](https://github.com/github/codeql-go/tree/main) branch may contain changes that
+The [main](https://github.com/github/codeql/tree/main) branch may contain changes that
 have not been deployed yet, so you may need to upgrade databases downloaded from LGTM.com before
 running queries on them.
 

--- a/go/docs/language/learn-ql/go/library-modeling-go.rst
+++ b/go/docs/language/learn-ql/go/library-modeling-go.rst
@@ -5,8 +5,8 @@ When analyzing a Go program, CodeQL does not examine the source code for
 external packages. To track the flow of untrusted data through a library, you
 can create a model of the library.
 
-You can find existing models in the ``ql/src/semmle/go/frameworks/`` folder of the
-`CodeQL for Go repository <https://github.com/github/codeql-go/tree/main/ql/src/semmle/go/frameworks>`__.
+You can find existing models in the ``go/ql/lib/semmle/go/frameworks/`` folder of the
+`CodeQL repository <https://github.com/github/codeql/tree/main/go/ql/lib/semmle/go/frameworks>`__.
 To add a new model, you should make a new file in that folder, named after the library.
 
 Sources
@@ -100,8 +100,8 @@ Data-flow sinks are specified by queries rather than by library models.
 However, you can use library models to indicate when functions belong to
 special categories. Queries can then use these categories when specifying
 sinks. Classes representing these special categories are contained in
-``ql/src/semmle/go/Concepts.qll`` in the `CodeQL for Go repository
-<https://github.com/github/codeql-go/blob/main/ql/src/semmle/go/Concepts.qll>`__.
+``go/ql/lib/semmle/go/Concepts.qll`` in the `CodeQL for Go repository
+<https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/Concepts.qll>`__.
 ``Concepts.qll`` includes classes for logger mechanisms,
 HTTP response writers, HTTP redirects, and marshaling and unmarshaling
 functions.


### PR DESCRIPTION
This PR is based on https://github.com/github/codeql/pull/8631, which should be merged first.

---

`github/codeql-go` is being merged into `github/codeql` (this is done by the base PR).
Update references to `codeql-go` within the CodeQL CLI docs.
Add Go to the list of mentioned languages where applicable.

Leave an explanatory note in the setup instructions about the previous requirement to check out `github/codeql-go`, and mention this is no longer necessary.

The remaining references are to historical commits, which will continue to exist.