### PR TITLE
JS: remove support for passport in the session-fixation query

### DIFF
--- a/javascript/ql/src/Security/CWE-384/SessionFixation.ql
+++ b/javascript/ql/src/Security/CWE-384/SessionFixation.ql
@@ -19,7 +19,7 @@ import javascript
  */
 pragma[inline]
 predicate isLoginSetup(Express::RouteSetup setup) {
-  // either some path that contains "login" with a write to `req.session`
+  // some path that contains "login" with a write to `req.session`
   setup.getPath().matches("%login%") and
   exists(
     setup
@@ -30,9 +30,7 @@ predicate isLoginSetup(Express::RouteSetup setup) {
         .getAPropertyRead("session")
         .getAPropertyWrite()
   )
-  or
-  // or an authentication method is used (e.g. `passport.authenticate`)
-  setup.getARouteHandler().(DataFlow::CallNode).getCalleeName() = "authenticate"
+  // passport used to be recognized, but they have since added build-in protection against session fixation
 }
 
 /**

--- a/javascript/ql/src/Security/CWE-384/SessionFixation.ql
+++ b/javascript/ql/src/Security/CWE-384/SessionFixation.ql
@@ -30,7 +30,7 @@ predicate isLoginSetup(Express::RouteSetup setup) {
         .getAPropertyRead("session")
         .getAPropertyWrite()
   )
-  // passport used to be recognized, but they have since added build-in protection against session fixation
+  // passport used to be recognized, but they have since added built-in protection against session fixation
 }
 
 /**

--- a/javascript/ql/test/query-tests/Security/CWE-384/SessionFixation.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-384/SessionFixation.expected
@@ -1,2 +1,1 @@
 | tst.js:9:1:14:2 | app.get ... n');\\n}) | Route handler does not invalidate session following login |
-| tst.js:27:1:29:2 | app.get ... n');\\n}) | Route handler does not invalidate session following login |

--- a/javascript/ql/test/query-tests/Security/CWE-384/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-384/tst.js
@@ -24,7 +24,7 @@ app.get('/login2', function (req, res) { // OK
 });
 
 // using passport
-app.get('/passport', passport.authenticate('local'), function (req, res) { // NOT OK - no regenerate
+app.get('/passport', passport.authenticate('local'), function (req, res) { // OK - passport is safe
     res.send('logged in');
 });
 


### PR DESCRIPTION
Passport added protection against session-fixation, so we should no longer detect it using our query.  
See this announcement: https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d, and this helpful comment from the maintainer: https://github.com/github/codeql/pull/7029#issuecomment-1132940870

[Evaluation was uneventful](https://github.com/github/codeql-dca-main/tree/data/erik-krogh/pr-9261-1a8cf23__nightly-old__CustomSuite/reports).  
We loose some results, but that was the point.  