### PR TITLE
Ruby: Eliminate bad `isLocalSourceNode` antijoin

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -298,6 +298,20 @@ private module Cached {
     )
   }
 
+  pragma[nomagic]
+  private predicate reachedFromExprOrEntrySsaDef(Node n) {
+    localFlowStepTypeTracker(any(Node n0 |
+        n0 instanceof ExprNode
+        or
+        entrySsaDefinition(n0)
+      ), n)
+    or
+    exists(Node mid |
+      reachedFromExprOrEntrySsaDef(mid) and
+      localFlowStepTypeTracker(mid, n)
+    )
+  }
+
   cached
   predicate isLocalSourceNode(Node n) {
     n instanceof ParameterNode
@@ -305,11 +319,7 @@ private module Cached {
     n instanceof PostUpdateNodes::ExprPostUpdateNode
     or
     // Nodes that can't be reached from another entry definition or expression.
-    not localFlowStepTypeTracker+(any(Node n0 |
-        n0 instanceof ExprNode
-        or
-        entrySsaDefinition(n0)
-      ), n)
+    not reachedFromExprOrEntrySsaDef(n)
     or
     // Ensure all entry SSA definitions are local sources -- for parameters, this
     // is needed by type tracking. Note that when the parameter has a default value,


### PR DESCRIPTION
Gets rid of
```
Tuple counts for DataFlowPrivate::Cached::isLocalSourceNode#462ff392#f#antijoin_rhs@dd2f927s:
        20905019     ~3%    {2} r1 = JOIN DataFlowPrivate::Cached::TExprNode#462ff392#ff_1#higher_order_body WITH boundedFastTC(DataFlowPrivate::Cached::localFlowStepTypeTracker#462ff392#ff_10#higher_order_body,DataFlowPrivate::Cached::TExprNode#462ff392#ff_1#higher_order_body) ON FIRST 1 OUTPUT Rhs.1, Lhs.0

        10420128  ~1496%    {1} r2 = JOIN r1 WITH DataFlowPrivate::Cached::TExprNode#462ff392#ff_1#higher_order_body ON FIRST 1 OUTPUT Lhs.1

          480918     ~8%    {1} r3 = JOIN r1 WITH DataFlowPrivate::Cached::entrySsaDefinition#462ff392#f ON FIRST 1 OUTPUT Lhs.1

        10901046  ~1218%    {1} r4 = r2 UNION r3
                            return r4
```

Pulled out of https://github.com/github/codeql/pull/9175.