### PR TITLE
Swift: remove `.codeqlmanifest`

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -15,6 +15,7 @@
         "misc/legacy-support/*/qlpack.yml",
         "misc/suite-helpers/qlpack.yml",
         "ruby/extractor-pack/codeql-extractor.yml",
+        "swift/extractor-pack/codeql-extractor.yml",
         "ql/extractor-pack/codeql-extractor.yml"
     ],
     "versionPolicies": {

--- a/swift/.codeqlmanifest.json
+++ b/swift/.codeqlmanifest.json
@@ -1,7 +1,0 @@
-{
-  "provide": [
-    "ql/lib/qlpack.yml",
-    "ql/test/qlpack.yml",
-    "extractor-pack/codeql-extractor.yml"
-  ]
-}

--- a/swift/README.md
+++ b/swift/README.md
@@ -13,7 +13,7 @@ bazel run //swift:create-extractor-pack
 which will install `swift/extractor-pack`.
 
 Using `--search-path=swift/extractor-pack` will then pick up the Swift extractor. You can also use
-`--search-path=swift`, as the extractor pack is mentioned in `swift/.codeqlmanifest.json`.
+`--search-path=.`, as the extractor pack is mentioned in the root `.codeqlmanifest.json`.
 
 Notice you can run `bazel run :create-extractor-pack` if you already are in the `swift` directory.
 


### PR DESCRIPTION
The extractor pack entry in there has been moved to the root manifest.