### PR TITLE
Ruby: rename CfgScope::Range_ to CfgScopeImpl

### DIFF
--- a/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/ControlFlowGraph.qll
@@ -9,7 +9,7 @@ private import internal.Splitting
 private import internal.Completion
 
 /** An AST node with an associated control-flow graph. */
-class CfgScope extends Scope instanceof CfgScope::Range_ {
+class CfgScope extends Scope instanceof CfgScopeImpl {
   /** Gets the CFG scope that this scope is nested under, if any. */
   final CfgScope getOuterCfgScope() {
     exists(AstNode parent |

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
@@ -41,61 +41,59 @@ private import codeql.ruby.controlflow.ControlFlowGraph
 private import Completion
 import ControlFlowGraphImplShared
 
-module CfgScope {
-  abstract class Range_ extends AstNode {
-    abstract predicate entry(AstNode first);
+abstract class CfgScopeImpl extends AstNode {
+  abstract predicate entry(AstNode first);
 
-    abstract predicate exit(AstNode last, Completion c);
+  abstract predicate exit(AstNode last, Completion c);
+}
+
+private class ToplevelScope extends CfgScopeImpl, Toplevel {
+  final override predicate entry(AstNode first) { first(this, first) }
+
+  final override predicate exit(AstNode last, Completion c) { last(this, last, c) }
+}
+
+private class EndBlockScope extends CfgScopeImpl, EndBlock {
+  final override predicate entry(AstNode first) {
+    first(this.(Trees::EndBlockTree).getBodyChild(0, _), first)
   }
 
-  private class ToplevelScope extends Range_, Toplevel {
-    final override predicate entry(AstNode first) { first(this, first) }
+  final override predicate exit(AstNode last, Completion c) {
+    last(this.(Trees::EndBlockTree).getLastBodyChild(), last, c)
+    or
+    last(this.(Trees::EndBlockTree).getBodyChild(_, _), last, c) and
+    not c instanceof NormalCompletion
+  }
+}
 
-    final override predicate exit(AstNode last, Completion c) { last(this, last, c) }
+private class BodyStmtCallableScope extends CfgScopeImpl, ASTInternal::TBodyStmt, Callable {
+  final override predicate entry(AstNode first) { this.(Trees::BodyStmtTree).firstInner(first) }
+
+  final override predicate exit(AstNode last, Completion c) {
+    this.(Trees::BodyStmtTree).lastInner(last, c)
+  }
+}
+
+private class BraceBlockScope extends CfgScopeImpl, BraceBlock {
+  final override predicate entry(AstNode first) {
+    first(this.(Trees::BraceBlockTree).getBodyChild(0, _), first)
   }
 
-  private class EndBlockScope extends Range_, EndBlock {
-    final override predicate entry(AstNode first) {
-      first(this.(Trees::EndBlockTree).getBodyChild(0, _), first)
-    }
-
-    final override predicate exit(AstNode last, Completion c) {
-      last(this.(Trees::EndBlockTree).getLastBodyChild(), last, c)
-      or
-      last(this.(Trees::EndBlockTree).getBodyChild(_, _), last, c) and
-      not c instanceof NormalCompletion
-    }
-  }
-
-  private class BodyStmtCallableScope extends Range_, ASTInternal::TBodyStmt, Callable {
-    final override predicate entry(AstNode first) { this.(Trees::BodyStmtTree).firstInner(first) }
-
-    final override predicate exit(AstNode last, Completion c) {
-      this.(Trees::BodyStmtTree).lastInner(last, c)
-    }
-  }
-
-  private class BraceBlockScope extends Range_, BraceBlock {
-    final override predicate entry(AstNode first) {
-      first(this.(Trees::BraceBlockTree).getBodyChild(0, _), first)
-    }
-
-    final override predicate exit(AstNode last, Completion c) {
-      last(this.(Trees::BraceBlockTree).getLastBodyChild(), last, c)
-      or
-      last(this.(Trees::BraceBlockTree).getBodyChild(_, _), last, c) and
-      not c instanceof NormalCompletion
-    }
+  final override predicate exit(AstNode last, Completion c) {
+    last(this.(Trees::BraceBlockTree).getLastBodyChild(), last, c)
+    or
+    last(this.(Trees::BraceBlockTree).getBodyChild(_, _), last, c) and
+    not c instanceof NormalCompletion
   }
 }
 
 /** Holds if `first` is first executed when entering `scope`. */
 pragma[nomagic]
-predicate succEntry(CfgScope::Range_ scope, AstNode first) { scope.entry(first) }
+predicate succEntry(CfgScopeImpl scope, AstNode first) { scope.entry(first) }
 
 /** Holds if `last` with completion `c` can exit `scope`. */
 pragma[nomagic]
-predicate succExit(CfgScope::Range_ scope, AstNode last, Completion c) { scope.exit(last, c) }
+predicate succExit(CfgScopeImpl scope, AstNode last, Completion c) { scope.exit(last, c) }
 
 /** Defines the CFG by dispatch on the various AST types. */
 module Trees {
@@ -1431,7 +1429,7 @@ module Trees {
 
 private Scope parent(Scope n) {
   result = n.getOuterScope() and
-  not n instanceof CfgScope::Range_
+  not n instanceof CfgScopeImpl
 }
 
 cached

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImplSpecific.qll
@@ -35,12 +35,12 @@ predicate getCfgScope = Impl::getCfgScope/1;
 
 /** Holds if `first` is first executed when entering `scope`. */
 predicate scopeFirst(CfgScope scope, ControlFlowElement first) {
-  scope.(Impl::CfgScope::Range_).entry(first)
+  scope.(Impl::CfgScopeImpl).entry(first)
 }
 
 /** Holds if `scope` is exited when `last` finishes with completion `c`. */
 predicate scopeLast(CfgScope scope, ControlFlowElement last, Completion c) {
-  scope.(Impl::CfgScope::Range_).exit(last, c)
+  scope.(Impl::CfgScopeImpl).exit(last, c)
 }
 
 /** The maximum number of splits allowed for a given node. */


### PR DESCRIPTION
For consistency with our other uses of the range pattern.
