### PR TITLE
Kotlin: Add taint step for String.valueOf(Editable)

### DIFF
--- a/java/ql/lib/change-notes/2022-05-25-string-valueof-editable-step.md
+++ b/java/ql/lib/change-notes/2022-05-25-string-valueof-editable-step.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+Added a flow step for `String.valueOf` calls on tainted `android.text.Editable` objects. 

--- a/java/ql/lib/semmle/code/java/frameworks/android/Widget.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/Widget.qll
@@ -18,12 +18,20 @@ private class DefaultAndroidWidgetSources extends RemoteFlowSource {
 
 private class EditableToStringStep extends AdditionalTaintStep {
   override predicate step(DataFlow::Node n1, DataFlow::Node n2) {
-    exists(MethodAccess toString |
-      toString.getMethod().hasName("toString") and
-      toString.getReceiverType().hasQualifiedName("android.text", "Editable")
-    |
-      n1.asExpr() = toString.getQualifier() and
-      n2.asExpr() = toString
+    exists(MethodAccess ma |
+      ma.getMethod().hasName("toString") and
+      ma.getReceiverType().getASourceSupertype*().hasQualifiedName("android.text", "Editable") and
+      n1.asExpr() = ma.getQualifier() and
+      n2.asExpr() = ma
+      or
+      ma.getMethod().hasQualifiedName("java.lang", "String", "valueOf") and
+      ma.getArgument(0)
+          .getType()
+          .(RefType)
+          .getASourceSupertype*()
+          .hasQualifiedName("android.text", "Editable") and
+      n1.asExpr() = ma.getArgument(0) and
+      n2.asExpr() = ma
     )
   }
 }

--- a/java/ql/test/library-tests/frameworks/android/widget/TestWidget.java
+++ b/java/ql/test/library-tests/frameworks/android/widget/TestWidget.java
@@ -2,10 +2,14 @@ import android.widget.EditText;
 
 public class TestWidget {
 
+    private EditText source() {
+        return null;
+    }
+
     private void sink(Object sink) {}
 
-    public void test(EditText t) {
-        sink(t.getText().toString()); // $ hasTaintFlow
+    public void test() {
+        sink(source().getText().toString()); // $ hasTaintFlow
     }
 }
 

--- a/java/ql/test/library-tests/frameworks/android/widget/TestWidgetKt.kt
+++ b/java/ql/test/library-tests/frameworks/android/widget/TestWidgetKt.kt
@@ -1,0 +1,16 @@
+ import android.text.Editable
+
+ class TestWidget {
+
+    fun source() : Editable? { return null }
+    fun sink(sink : String) {}
+
+    fun test() {
+        val t = source()
+        sink(t.toString()); // $ hasTaintFlow
+
+        val t2 : Any? = source()
+        sink(t2.toString()); // $ MISSING: hasTaintFlow
+    }
+}
+

--- a/java/ql/test/library-tests/frameworks/android/widget/TestWidgetKt.kt
+++ b/java/ql/test/library-tests/frameworks/android/widget/TestWidgetKt.kt
@@ -1,6 +1,6 @@
  import android.text.Editable
 
- class TestWidget {
+ class TestWidgetKt {
 
     fun source() : Editable? { return null }
     fun sink(sink : String) {}

--- a/java/ql/test/library-tests/frameworks/android/widget/options
+++ b/java/ql/test/library-tests/frameworks/android/widget/options
@@ -1,1 +1,2 @@
 //semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/google-android-9.0.0
+//codeql-extractor-kotlin-options: ${testdir}/../../../../stubs/google-android-9.0.0

--- a/java/ql/test/library-tests/frameworks/android/widget/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/widget/test.expected
@@ -1,4 +1,4 @@
-+failures
-+valueOf
-+| TestWidgetKt.kt:10:16:10:25 | valueOf(...) |
-+| TestWidgetKt.kt:13:17:13:26 | valueOf(...) |
+failures
+valueOf
+| TestWidgetKt.kt:10:16:10:25 | valueOf(...) |
+| TestWidgetKt.kt:13:17:13:26 | valueOf(...) |

--- a/java/ql/test/library-tests/frameworks/android/widget/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/widget/test.expected
@@ -1,0 +1,4 @@
++failures
++valueOf
++| TestWidgetKt.kt:10:16:10:25 | valueOf(...) |
++| TestWidgetKt.kt:13:17:13:26 | valueOf(...) |

--- a/java/ql/test/library-tests/frameworks/android/widget/test.ql
+++ b/java/ql/test/library-tests/frameworks/android/widget/test.ql
@@ -2,6 +2,6 @@ import java
 import semmle.code.java.dataflow.FlowSources
 import TestUtilities.InlineFlowTest
 
-class SourceTaintFlowConf extends DefaultTaintFlowConf {
-  override predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
+query predicate valueOf(MethodAccess ma) {
+  ma.getMethod().hasQualifiedName("java.lang", "String", "valueOf")
 }


### PR DESCRIPTION
Kotlin inlines `expr.toString()` as `String.valueOf(expr)` when `expr` is nullable.

This PR extends #8872 by adding a taint step to handle the above when `expr` is an `Editable`.