### PR TITLE
Data flow: Fix bad join in `prohibitsUseUseFlow`

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/FlowSummaryImpl.qll
@@ -777,10 +777,10 @@ module Private {
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
       exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
         p = summaryArgParam0(_, arg, sc) and
-        p.isParameterOf(_, ppos) and
+        p.isParameterOf(_, pragma[only_bind_into](ppos)) and
         summaryLocalStep(p, mid, true) and
         summaryLocalStep(mid, ret, true) and
-        isParameterPostUpdate(ret, _, ppos)
+        isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
       |
         summaryClearsContent(mid, _) or
         summaryExpectsContent(mid, _)

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -777,10 +777,10 @@ module Private {
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
       exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
         p = summaryArgParam0(_, arg, sc) and
-        p.isParameterOf(_, ppos) and
+        p.isParameterOf(_, pragma[only_bind_into](ppos)) and
         summaryLocalStep(p, mid, true) and
         summaryLocalStep(mid, ret, true) and
-        isParameterPostUpdate(ret, _, ppos)
+        isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
       |
         summaryClearsContent(mid, _) or
         summaryExpectsContent(mid, _)

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImpl.qll
@@ -777,10 +777,10 @@ module Private {
     predicate prohibitsUseUseFlow(ArgNode arg, SummarizedCallable sc) {
       exists(ParamNode p, Node mid, ParameterPosition ppos, Node ret |
         p = summaryArgParam0(_, arg, sc) and
-        p.isParameterOf(_, ppos) and
+        p.isParameterOf(_, pragma[only_bind_into](ppos)) and
         summaryLocalStep(p, mid, true) and
         summaryLocalStep(mid, ret, true) and
-        isParameterPostUpdate(ret, _, ppos)
+        isParameterPostUpdate(ret, _, pragma[only_bind_into](ppos))
       |
         summaryClearsContent(mid, _) or
         summaryExpectsContent(mid, _)


### PR DESCRIPTION
Before
```
Tuple counts for FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow#1de78b88#ff@fdf8bdrq:
              6099   ~0%    {2} r1 = SCAN FlowSummaryImpl::Private::isParameterPostUpdate#1de78b88#fff OUTPUT In.2, In.0
         787252695   ~2%    {3} r2 = JOIN r1 WITH project#DataFlowImplCommon::ParamNode::isParameterOf#dispred#f0820431#fff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, true, Lhs.1
        5360462712   ~0%    {4} r3 = JOIN r2 WITH FlowSummaryImpl::Private::Steps::summaryLocalStep#1de78b88#ffb_021#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2, true, Lhs.0
              7132   ~2%    {2} r4 = JOIN r3 WITH FlowSummaryImpl::Private::Steps::summaryLocalStep#1de78b88#ffb ON FIRST 3 OUTPUT Lhs.0, Lhs.3

              5869  ~25%    {1} r5 = JOIN r4 WITH DataFlowImplCommon::Cached::clearsContentCached#4f8df883#ff ON FIRST 1 OUTPUT Lhs.1

              1263   ~9%    {1} r6 = JOIN r4 WITH DataFlowImplCommon::Cached::expectsContentCached#4f8df883#ff ON FIRST 1 OUTPUT Lhs.1

              7132  ~52%    {1} r7 = r5 UNION r6
             29593  ~26%    {2} r8 = JOIN r7 WITH project#FlowSummaryImpl::Private::Steps::summaryArgParam0#1de78b88#ffff#2_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.2
                            return r8
```

After
```
Tuple counts for FlowSummaryImpl::Private::Steps::prohibitsUseUseFlow#1de78b88#ff@aa7a37lj:
         6099   ~4%    {3} r1 = SCAN FlowSummaryImpl::Private::isParameterPostUpdate#1de78b88#fff OUTPUT In.0, true, In.2
         8434   ~5%    {2} r2 = JOIN r1 WITH FlowSummaryImpl::Private::Steps::summaryLocalStep#1de78b88#ffb_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2

         5869   ~5%    {3} r3 = JOIN r2 WITH DataFlowImplCommon::Cached::clearsContentCached#4f8df883#ff ON FIRST 1 OUTPUT Lhs.0, true, Lhs.1

         1278   ~6%    {3} r4 = JOIN r2 WITH DataFlowImplCommon::Cached::expectsContentCached#4f8df883#ff ON FIRST 1 OUTPUT Lhs.0, true, Lhs.1

         7147   ~6%    {3} r5 = r3 UNION r4
         7147  ~57%    {2} r6 = JOIN r5 WITH FlowSummaryImpl::Private::Steps::summaryLocalStep#1de78b88#ffb_120#join_rhs ON FIRST 2 OUTPUT Rhs.2, Lhs.2
         5892  ~26%    {1} r7 = JOIN r6 WITH project#DataFlowImplCommon::ParamNode::isParameterOf#dispred#f0820431#fff ON FIRST 2 OUTPUT Lhs.0
        29589  ~26%    {2} r8 = JOIN r7 WITH project#FlowSummaryImpl::Private::Steps::summaryArgParam0#1de78b88#ffff#2_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Rhs.2
                       return r8
```