### PR TITLE
JS: add CWE-940 to js/missing-origin-check

### DIFF
--- a/javascript/ql/src/Security/CWE-020/MissingOriginCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/MissingOriginCheck.ql
@@ -9,6 +9,7 @@
  * @tags correctness
  *       security
  *       external/cwe/cwe-020
+ *       external/cwe/cwe-940
  */
 
 import javascript


### PR DESCRIPTION
I took a look at my CWE task board, and it looked like I had forgotten about [CWE-940](https://cwe.mitre.org/data/definitions/940.html).  

[CWE-940](https://cwe.mitre.org/data/definitions/940.html): 
_The software establishes a communication channel to handle an incoming request that has been initiated by an actor, but it does not properly verify that the request is coming from the expected origin._
