### PR TITLE
Ruby: Data flow for hash-splat expressions in hash literals

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/FlowSummaryImplSpecific.qll
@@ -94,6 +94,9 @@ SummaryComponent interpretComponentSpecific(AccessPathToken c) {
     ppos.isAny()
     or
     ppos.isPositionalLowerBound(AccessPath::parseLowerBound(arg))
+    or
+    arg = "hash-splat" and
+    ppos.isHashSplat()
   )
   or
   result = interpretElementArg(c.getAnArgument("Element"))

--- a/ruby/ql/lib/codeql/ruby/frameworks/core/Hash.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/core/Hash.qll
@@ -65,6 +65,22 @@ module Hash {
     }
   }
 
+  private class HashLiteralHashSplatSummary extends SummarizedCallable {
+    HashLiteralHashSplatSummary() { this = "Hash.[**]" }
+
+    final override MethodCall getACall() {
+      result = API::getTopLevelMember("Hash").getAMethodCall("[]").getExprNode().getExpr() and
+      result.getAnArgument() instanceof HashSplatExpr
+    }
+
+    override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+      // { **hash }
+      input = "Argument[hash-splat].WithElement[any]" and
+      output = "ReturnValue" and
+      preservesValue = true
+    }
+  }
+
   /**
    * `Hash[]` called on an existing hash, e.g.
    *

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -508,6 +508,24 @@ edges
 | hash_flow.rb:721:9:721:12 | hash [element :c] :  | hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  |
 | hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  | hash_flow.rb:722:10:722:10 | b [element] :  |
 | hash_flow.rb:722:10:722:10 | b [element] :  | hash_flow.rb:722:10:722:13 | ...[...] |
+| hash_flow.rb:729:15:729:25 | call to taint :  | hash_flow.rb:738:16:738:20 | hash1 [element :a] :  |
+| hash_flow.rb:731:15:731:25 | call to taint :  | hash_flow.rb:738:16:738:20 | hash1 [element :c] :  |
+| hash_flow.rb:734:15:734:25 | call to taint :  | hash_flow.rb:738:44:738:48 | hash2 [element :d] :  |
+| hash_flow.rb:736:15:736:25 | call to taint :  | hash_flow.rb:738:44:738:48 | hash2 [element :f] :  |
+| hash_flow.rb:738:14:738:20 | ** ... [element :a] :  | hash_flow.rb:739:10:739:13 | hash [element :a] :  |
+| hash_flow.rb:738:14:738:20 | ** ... [element :c] :  | hash_flow.rb:741:10:741:13 | hash [element :c] :  |
+| hash_flow.rb:738:16:738:20 | hash1 [element :a] :  | hash_flow.rb:738:14:738:20 | ** ... [element :a] :  |
+| hash_flow.rb:738:16:738:20 | hash1 [element :c] :  | hash_flow.rb:738:14:738:20 | ** ... [element :c] :  |
+| hash_flow.rb:738:29:738:39 | call to taint :  | hash_flow.rb:745:10:745:13 | hash [element :g] :  |
+| hash_flow.rb:738:42:738:48 | ** ... [element :d] :  | hash_flow.rb:742:10:742:13 | hash [element :d] :  |
+| hash_flow.rb:738:42:738:48 | ** ... [element :f] :  | hash_flow.rb:744:10:744:13 | hash [element :f] :  |
+| hash_flow.rb:738:44:738:48 | hash2 [element :d] :  | hash_flow.rb:738:42:738:48 | ** ... [element :d] :  |
+| hash_flow.rb:738:44:738:48 | hash2 [element :f] :  | hash_flow.rb:738:42:738:48 | ** ... [element :f] :  |
+| hash_flow.rb:739:10:739:13 | hash [element :a] :  | hash_flow.rb:739:10:739:17 | ...[...] |
+| hash_flow.rb:741:10:741:13 | hash [element :c] :  | hash_flow.rb:741:10:741:17 | ...[...] |
+| hash_flow.rb:742:10:742:13 | hash [element :d] :  | hash_flow.rb:742:10:742:17 | ...[...] |
+| hash_flow.rb:744:10:744:13 | hash [element :f] :  | hash_flow.rb:744:10:744:17 | ...[...] |
+| hash_flow.rb:745:10:745:13 | hash [element :g] :  | hash_flow.rb:745:10:745:17 | ...[...] |
 nodes
 | hash_flow.rb:11:15:11:24 | call to taint :  | semmle.label | call to taint :  |
 | hash_flow.rb:13:12:13:21 | call to taint :  | semmle.label | call to taint :  |
@@ -1062,6 +1080,29 @@ nodes
 | hash_flow.rb:721:9:721:31 | call to fetch_values [element] :  | semmle.label | call to fetch_values [element] :  |
 | hash_flow.rb:722:10:722:10 | b [element] :  | semmle.label | b [element] :  |
 | hash_flow.rb:722:10:722:13 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:729:15:729:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:731:15:731:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:734:15:734:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:736:15:736:25 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:738:14:738:20 | ** ... [element :a] :  | semmle.label | ** ... [element :a] :  |
+| hash_flow.rb:738:14:738:20 | ** ... [element :c] :  | semmle.label | ** ... [element :c] :  |
+| hash_flow.rb:738:16:738:20 | hash1 [element :a] :  | semmle.label | hash1 [element :a] :  |
+| hash_flow.rb:738:16:738:20 | hash1 [element :c] :  | semmle.label | hash1 [element :c] :  |
+| hash_flow.rb:738:29:738:39 | call to taint :  | semmle.label | call to taint :  |
+| hash_flow.rb:738:42:738:48 | ** ... [element :d] :  | semmle.label | ** ... [element :d] :  |
+| hash_flow.rb:738:42:738:48 | ** ... [element :f] :  | semmle.label | ** ... [element :f] :  |
+| hash_flow.rb:738:44:738:48 | hash2 [element :d] :  | semmle.label | hash2 [element :d] :  |
+| hash_flow.rb:738:44:738:48 | hash2 [element :f] :  | semmle.label | hash2 [element :f] :  |
+| hash_flow.rb:739:10:739:13 | hash [element :a] :  | semmle.label | hash [element :a] :  |
+| hash_flow.rb:739:10:739:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:741:10:741:13 | hash [element :c] :  | semmle.label | hash [element :c] :  |
+| hash_flow.rb:741:10:741:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:742:10:742:13 | hash [element :d] :  | semmle.label | hash [element :d] :  |
+| hash_flow.rb:742:10:742:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:744:10:744:13 | hash [element :f] :  | semmle.label | hash [element :f] :  |
+| hash_flow.rb:744:10:744:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:745:10:745:13 | hash [element :g] :  | semmle.label | hash [element :g] :  |
+| hash_flow.rb:745:10:745:17 | ...[...] | semmle.label | ...[...] |
 subpaths
 #select
 | hash_flow.rb:22:10:22:17 | ...[...] | hash_flow.rb:11:15:11:24 | call to taint :  | hash_flow.rb:22:10:22:17 | ...[...] | $@ | hash_flow.rb:11:15:11:24 | call to taint :  | call to taint :  |
@@ -1229,3 +1270,8 @@ subpaths
 | hash_flow.rb:720:10:720:13 | ...[...] | hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:720:10:720:13 | ...[...] | $@ | hash_flow.rb:715:15:715:25 | call to taint :  | call to taint :  |
 | hash_flow.rb:722:10:722:13 | ...[...] | hash_flow.rb:715:15:715:25 | call to taint :  | hash_flow.rb:722:10:722:13 | ...[...] | $@ | hash_flow.rb:715:15:715:25 | call to taint :  | call to taint :  |
 | hash_flow.rb:722:10:722:13 | ...[...] | hash_flow.rb:717:15:717:25 | call to taint :  | hash_flow.rb:722:10:722:13 | ...[...] | $@ | hash_flow.rb:717:15:717:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:739:10:739:17 | ...[...] | hash_flow.rb:729:15:729:25 | call to taint :  | hash_flow.rb:739:10:739:17 | ...[...] | $@ | hash_flow.rb:729:15:729:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:741:10:741:17 | ...[...] | hash_flow.rb:731:15:731:25 | call to taint :  | hash_flow.rb:741:10:741:17 | ...[...] | $@ | hash_flow.rb:731:15:731:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:742:10:742:17 | ...[...] | hash_flow.rb:734:15:734:25 | call to taint :  | hash_flow.rb:742:10:742:17 | ...[...] | $@ | hash_flow.rb:734:15:734:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:744:10:744:17 | ...[...] | hash_flow.rb:736:15:736:25 | call to taint :  | hash_flow.rb:744:10:744:17 | ...[...] | $@ | hash_flow.rb:736:15:736:25 | call to taint :  | call to taint :  |
+| hash_flow.rb:745:10:745:17 | ...[...] | hash_flow.rb:738:29:738:39 | call to taint :  | hash_flow.rb:745:10:745:17 | ...[...] | $@ | hash_flow.rb:738:29:738:39 | call to taint :  | call to taint :  |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash_flow.rb
@@ -723,3 +723,27 @@ def m44(x)
 end
 
 m44(:c)
+
+def m45()
+    hash1 = {
+        :a => taint(45.1),
+        :b => 1,
+        :c => taint(45.2)
+    }
+    hash2 = {
+        :d => taint(45.3),
+        :e => 2,
+        :f => taint(45.4)
+    }
+    hash = { **hash1, :g => taint(45.5), **hash2, :h => 3 }
+    sink(hash[:a]) # $ hasValueFlow=45.1
+    sink(hash[:b])
+    sink(hash[:c]) # $ hasValueFlow=45.2
+    sink(hash[:d]) # $ hasValueFlow=45.3
+    sink(hash[:e])
+    sink(hash[:f]) # $ hasValueFlow=45.4
+    sink(hash[:g]) # $ hasValueFlow=45.5
+    sink(hash[:h])
+end
+
+m45()


### PR DESCRIPTION
Support for
```rb
hash1 = { :foo => taint }
hash = { :bar => no_taint, **hash1 }
sink(hash[:foo]} # bad
sink(hash[:bar]} # good
```