### PR TITLE
ATM: add `workflow_dispatch` to ATM JS tests

### DIFF
--- a/.github/workflows/js-ml-tests.yml
+++ b/.github/workflows/js-ml-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - "javascript/ql/experimental/adaptivethreatmodeling/**"
       - .github/workflows/js-ml-tests.yml
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
This is so we can trigger scheduled runs of these tests