### PR TITLE
Ruby: Make `ActiveRecordInstance` public and fix some misidentifications

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -321,6 +321,7 @@ class ActiveRecordInstance extends DataFlow::Node {
 
   ActiveRecordInstance() { this = instantiation or instantiation.flowsTo(this) }
 
+  /** Gets the `ActiveRecordModelClass` that this is an instance of. */
   ActiveRecordModelClass getClass() { result = instantiation.getClass() }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveRecord.qll
@@ -313,8 +313,10 @@ private class ActiveRecordModelClassSelfReference extends ActiveRecordModelInsta
   final override ActiveRecordModelClass getClass() { result = cls }
 }
 
-// A (locally tracked) active record model object
-private class ActiveRecordInstance extends DataFlow::Node {
+/**
+ * An instance of an `ActiveRecord` model object.
+ */
+class ActiveRecordInstance extends DataFlow::Node {
   private ActiveRecordModelInstantiation instantiation;
 
   ActiveRecordInstance() { this = instantiation or instantiation.flowsTo(this) }

--- a/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
@@ -2,6 +2,14 @@ activeRecordModelClasses
 | ActiveRecordInjection.rb:1:1:3:3 | UserGroup |
 | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:19:1:25:3 | Admin |
+activeRecordInstances
+| ActiveRecordInjection.rb:10:5:10:68 | call to find |
+| ActiveRecordInjection.rb:15:5:15:40 | call to find_by |
+| ActiveRecordInjection.rb:79:5:81:7 | if ... |
+| ActiveRecordInjection.rb:79:43:80:40 | then ... |
+| ActiveRecordInjection.rb:80:7:80:40 | call to find_by |
+| ActiveRecordInjection.rb:85:5:85:33 | call to find_by |
+| ActiveRecordInjection.rb:88:5:88:34 | call to find |
 activeRecordSqlExecutionRanges
 | ActiveRecordInjection.rb:10:33:10:67 | "name='#{...}' and pass='#{...}'" |
 | ActiveRecordInjection.rb:23:16:23:24 | condition |

--- a/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
+++ b/ruby/ql/test/library-tests/frameworks/ActiveRecord.expected
@@ -45,9 +45,8 @@ potentiallyUnsafeSqlExecutingMethodCall
 | ActiveRecordInjection.rb:75:5:75:29 | call to order |
 | ActiveRecordInjection.rb:80:7:80:40 | call to find_by |
 activeRecordModelInstantiations
-| ActiveRecordInjection.rb:8:3:11:5 | self (authenticate) | ActiveRecordInjection.rb:5:1:17:3 | User |
+| ActiveRecordInjection.rb:10:5:10:68 | call to find | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:15:5:15:40 | call to find_by | ActiveRecordInjection.rb:1:1:3:3 | UserGroup |
-| ActiveRecordInjection.rb:20:3:24:5 | self (delete_by) | ActiveRecordInjection.rb:19:1:25:3 | Admin |
 | ActiveRecordInjection.rb:80:7:80:40 | call to find_by | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:85:5:85:33 | call to find_by | ActiveRecordInjection.rb:5:1:17:3 | User |
 | ActiveRecordInjection.rb:88:5:88:34 | call to find | ActiveRecordInjection.rb:5:1:17:3 | User |

--- a/ruby/ql/test/library-tests/frameworks/ActiveRecord.ql
+++ b/ruby/ql/test/library-tests/frameworks/ActiveRecord.ql
@@ -3,6 +3,8 @@ import codeql.ruby.frameworks.ActiveRecord
 
 query predicate activeRecordModelClasses(ActiveRecordModelClass cls) { any() }
 
+query predicate activeRecordInstances(ActiveRecordInstance i) { any() }
+
 query predicate activeRecordSqlExecutionRanges(ActiveRecordSqlExecutionRange range) { any() }
 
 query predicate activeRecordModelClassMethodCalls(ActiveRecordModelClassMethodCall call) { any() }


### PR DESCRIPTION
The first commit here fixes some cases where we misidentified `self` in a `SingletonMethod` belonging to an active record model class as referring to an instance of that class, rather than referring to the class itself. This bug had also masked cases where we were missing instances of `ActiveRecordModelClass`es, for example, in:
```
class User < ApplicationRecord
  def self.get_some_user
    find(:first)
  end
end
```
We have a call to `find` with an implicit `self` receiver that refers to the `User` class - this was not something that was accounted for in `ActiveRecordModelFinderCall` before, but now is.

The second commit makes `ActiveRecordInstance` publicly available, as it's been requested as a potentially useful class for use in queries.