### PR TITLE
JS: use syntactically correct JS in poly-redos example

### DIFF
--- a/javascript/ql/src/Performance/PolynomialReDoS.qhelp
+++ b/javascript/ql/src/Performance/PolynomialReDoS.qhelp
@@ -71,7 +71,7 @@
 		</p>
 
 		<sample language="javascript">
-			^0\.\d+E?\d+$ // BAD
+			/^0\.\d+E?\d+$/.test(str) // BAD
 		</sample>
 
 		<p>


### PR DESCRIPTION
The example got rendered wrong on LGTM for some reason: https://lgtm.com/rules/1511427506129/  

With this change the code is syntactically correct JS, which should hopefully get it to render correctly.  