### PR TITLE
Swift: Extract `isThrowing` and `isAsync`

### DIFF
--- a/swift/codegen/schema.yml
+++ b/swift/codegen/schema.yml
@@ -63,6 +63,7 @@ AnyFunctionType:
   param_types: Type*
   param_labels: string*
   is_throwing: predicate
+  is_async: predicate
 
 AnyGenericType:
   _extends: Type

--- a/swift/extractor/visitors/TypeVisitor.h
+++ b/swift/extractor/visitors/TypeVisitor.h
@@ -211,6 +211,14 @@ class TypeVisitor : public TypeVisitorBase<TypeVisitor> {
       }
       ++i;
     }
+
+    if (type->isThrowing()) {
+      dispatcher_.emit(AnyFunctionTypeIsThrowingTrap{label});
+    }
+
+    if (type->isAsync()) {
+      dispatcher_.emit(AnyFunctionTypeIsAsyncTrap{label});
+    }
   }
 
   void emitBoundGenericType(swift::BoundGenericType* type, TrapLabel<BoundGenericTypeTag> label) {

--- a/swift/ql/lib/codeql/swift/generated/type/AnyFunctionType.qll
+++ b/swift/ql/lib/codeql/swift/generated/type/AnyFunctionType.qll
@@ -27,4 +27,6 @@ class AnyFunctionTypeBase extends @any_function_type, Type {
   int getNumberOfParamLabels() { result = count(getAParamLabel()) }
 
   predicate isThrowing() { any_function_type_is_throwing(this) }
+
+  predicate isAsync() { any_function_type_is_async(this) }
 }

--- a/swift/ql/lib/swift.dbscheme
+++ b/swift/ql/lib/swift.dbscheme
@@ -176,6 +176,11 @@ any_function_type_is_throwing(
   int id: @any_function_type ref
 );
 
+#keyset[id]
+any_function_type_is_async(
+  int id: @any_function_type ref
+);
+
 @any_generic_type =
   @nominal_or_bound_generic_nominal_type
 | @unbound_generic_type

--- a/swift/ql/test/extractor-tests/types/ThrowingAndAsync.expected
+++ b/swift/ql/test/extractor-tests/types/ThrowingAndAsync.expected
@@ -1,0 +1,4 @@
+| types.swift:24:1:26:1 | throwingFunc | () throws -> Int | throws |
+| types.swift:28:1:28:36 | asyncFunction | (Int) async -> () | async |
+| types.swift:30:1:30:54 | throwingAndAsyncFunction | (Int) async throws -> () | async |
+| types.swift:30:1:30:54 | throwingAndAsyncFunction | (Int) async throws -> () | throws |

--- a/swift/ql/test/extractor-tests/types/ThrowingAndAsync.ql
+++ b/swift/ql/test/extractor-tests/types/ThrowingAndAsync.ql
@@ -1,0 +1,12 @@
+import codeql.swift.elements
+
+from FuncDecl f, AnyFunctionType t, string s
+where
+  f.getInterfaceType() = t and
+  f.getLocation().getFile().getName().matches("%swift/ql/test%") and
+  (
+    t.isAsync() and s = "async"
+    or
+    t.isThrowing() and s = "throws"
+  )
+select f, t, s

--- a/swift/ql/test/extractor-tests/types/Types.expected
+++ b/swift/ql/test/extractor-tests/types/Types.expected
@@ -38,3 +38,4 @@
 | types.swift:21:10:21:10 | f | (Int) -> Int |
 | types.swift:21:10:21:13 | call to ... | Int |
 | types.swift:21:12:21:12 | x | Int |
+| types.swift:25:10:25:10 | 42 | Int |

--- a/swift/ql/test/extractor-tests/types/types.swift
+++ b/swift/ql/test/extractor-tests/types/types.swift
@@ -20,3 +20,11 @@ func f(x: Int, y: Int) -> Int {
 func g(_ f: (Int) -> Int, _ x: Int) -> Int {
   return f(x)
 }
+
+func throwingFunc() throws -> Int {
+  return 42
+}
+
+func asyncFunction(x: Int) async { }
+
+func throwingAndAsyncFunction(x: Int) async throws { }


### PR DESCRIPTION
This fills in the `any_function_type_is_throwing` table which is needed to improve CFG precision (I'll open another PR with those changes after this is merged).

I also added an `any_function_type_is_async` table since that was basically a copy-paste of the code required for the `throwing` version. I'm sure we'll need this at some point.