### PR TITLE
JS: collapse a few small stages

### DIFF
--- a/javascript/ql/lib/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/lib/semmle/javascript/NodeJS.qll
@@ -3,6 +3,7 @@
 import javascript
 private import NodeModuleResolutionImpl
 private import semmle.javascript.DynamicPropertyAccess as DynamicPropertyAccess
+private import semmle.javascript.internal.CachedStages
 
 /**
  * A Node.js module.
@@ -113,6 +114,7 @@ class NodeModule extends Module {
   }
 
   override DataFlow::Node getABulkExportedNode() {
+    Stages::Imports::ref() and
     exists(DataFlow::PropWrite write |
       write.getBase().asExpr() = this.getModuleVariable().getAnAccess() and
       write.getPropertyName() = "exports" and

--- a/javascript/ql/lib/semmle/javascript/internal/CachedStages.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/CachedStages.qll
@@ -176,6 +176,8 @@ module Stages {
       exists(DataFlow::moduleImport(_))
       or
       exists(any(ReExportDeclaration d).getReExportedModule())
+      or
+      exists(any(Module m).getABulkExportedNode())
     }
   }
 
@@ -276,6 +278,9 @@ module Stages {
             .getInstance()
             .getReceiver()
             .getPromisedError()
+            .getADecoratedClass()
+            .getADecoratedMember()
+            .getADecoratedParameter()
       )
     }
   }


### PR DESCRIPTION
The `getABulkExportedNode`, `.getADecoratedClass()`, `.getADecoratedMember()`, and `.getADecoratedParameter()` all had their own stage.  

I know it doesn't matter much anymore, but I've thrown them into an existing stage where they fit naturally.  