### PR TITLE
Kotlin: Disambiguate the names and trap labels of backing fields of extension properties

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -759,7 +759,8 @@ open class KotlinFileExtractor(
         with("field", f) {
            DeclarationStackAdjuster(f).use {
                declarationStack.push(f)
-               return extractField(useField(f), f.name.asString(), f.type, parentId, tw.getLocation(f), f.visibility, f, isExternalDeclaration(f), f.isFinal)
+               val fNameSuffix = getExtensionReceiverType(f)?.let { it.classFqName?.asString()?.replace(".", "$$") } ?: ""
+               return extractField(useField(f), "${f.name.asString()}$fNameSuffix", f.type, parentId, tw.getLocation(f), f.visibility, f, isExternalDeclaration(f), f.isFinal)
            }
         }
     }

--- a/java/ql/test/kotlin/library-tests/clashing-extension-fields/test.expected
+++ b/java/ql/test/kotlin/library-tests/clashing-extension-fields/test.expected
@@ -1,0 +1,9 @@
+|  |
+| <clinit> |
+| A |
+| B |
+| get |
+| getX |
+| invoke |
+| x$delegatepackagename$$subpackagename$$A |
+| x$delegatepackagename$$subpackagename$$B |

--- a/java/ql/test/kotlin/library-tests/clashing-extension-fields/test.kt
+++ b/java/ql/test/kotlin/library-tests/clashing-extension-fields/test.kt
@@ -1,0 +1,7 @@
+package packagename.subpackagename
+
+public class A { }
+public class B { }
+
+val A.x : String by lazy { "HelloA" }
+val B.x : String by lazy { "HelloB" }

--- a/java/ql/test/kotlin/library-tests/clashing-extension-fields/test.ql
+++ b/java/ql/test/kotlin/library-tests/clashing-extension-fields/test.ql
@@ -1,0 +1,5 @@
+import java
+
+from Class c
+where c.fromSource()
+select c.getAMember().toString()

--- a/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/PrintAst.expected
@@ -31,7 +31,7 @@ delegatedProperties.kt:
 #   87|           0: [MethodAccess] getValue(...)
 #   87|             -2: [TypeAccess] Integer
 #   87|             -1: [TypeAccess] PropertyReferenceDelegatesKt
-#   87|             0: [VarAccess] DelegatedPropertiesKt.extDelegated$delegate
+#   87|             0: [VarAccess] DelegatedPropertiesKt.extDelegated$delegateMyClass
 #   87|               -1: [TypeAccess] DelegatedPropertiesKt
 #    1|             1: [ExtensionReceiverAccess] this
 #   87|             2: [PropertyRefExpr] ...::...
@@ -80,7 +80,7 @@ delegatedProperties.kt:
 #   87|           0: [MethodAccess] setValue(...)
 #   87|             -2: [TypeAccess] Integer
 #   87|             -1: [TypeAccess] PropertyReferenceDelegatesKt
-#   87|             0: [VarAccess] DelegatedPropertiesKt.extDelegated$delegate
+#   87|             0: [VarAccess] DelegatedPropertiesKt.extDelegated$delegateMyClass
 #   87|               -1: [TypeAccess] DelegatedPropertiesKt
 #    1|             1: [ExtensionReceiverAccess] this
 #   87|             2: [PropertyRefExpr] ...::...
@@ -118,7 +118,7 @@ delegatedProperties.kt:
 #   87|                 0: [TypeAccess] MyClass
 #   87|                 1: [TypeAccess] Integer
 #   87|             3: [VarAccess] <set-?>
-#   87|     5: [FieldDeclaration] KMutableProperty0<Integer> extDelegated$delegate;
+#   87|     5: [FieldDeclaration] KMutableProperty0<Integer> extDelegated$delegateMyClass;
 #   87|       -1: [TypeAccess] KMutableProperty0<Integer>
 #   87|         0: [TypeAccess] Integer
 #   87|       0: [PropertyRefExpr] ...::...

--- a/java/ql/test/kotlin/library-tests/exprs/delegatedProperties.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/delegatedProperties.expected
@@ -16,7 +16,7 @@ delegatedProperties
 | delegatedProperties.kt:77:5:77:49 | delegatedToTopLevel | delegatedToTopLevel | non-local | delegatedProperties.kt:77:34:77:49 | delegatedToTopLevel$delegate | delegatedProperties.kt:77:37:77:49 | ...::... |
 | delegatedProperties.kt:79:5:79:38 | max | max | non-local | delegatedProperties.kt:79:18:79:38 | max$delegate | delegatedProperties.kt:79:21:79:38 | ...::... |
 | delegatedProperties.kt:82:9:82:54 | delegatedToMember3 | delegatedToMember3 | local | delegatedProperties.kt:82:37:82:54 | KMutableProperty0<Integer> delegatedToMember3$delegate | delegatedProperties.kt:82:40:82:54 | ...::... |
-| delegatedProperties.kt:87:1:87:46 | extDelegated | extDelegated | non-local | delegatedProperties.kt:87:31:87:46 | extDelegated$delegate | delegatedProperties.kt:87:34:87:46 | ...::... |
+| delegatedProperties.kt:87:1:87:46 | extDelegated | extDelegated | non-local | delegatedProperties.kt:87:31:87:46 | extDelegated$delegateMyClass | delegatedProperties.kt:87:34:87:46 | ...::... |
 delegatedPropertyTypes
 | delegatedProperties.kt:6:9:9:9 | prop1 | file://:0:0:0:0 | int | file://<external>/Lazy.class:0:0:0:0 | Lazy<Integer> |
 | delegatedProperties.kt:19:9:19:51 | varResource1 | file://:0:0:0:0 | int | delegatedProperties.kt:45:1:51:1 | ResourceDelegate |

--- a/java/ql/test/kotlin/library-tests/exprs/exprs.expected
+++ b/java/ql/test/kotlin/library-tests/exprs/exprs.expected
@@ -830,9 +830,9 @@
 | delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt | delegatedProperties.kt:87:31:87:46 | set | TypeAccess |
 | delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt | delegatedProperties.kt:87:31:87:46 | set | TypeAccess |
 | delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt | delegatedProperties.kt:87:31:87:46 | setExtDelegated | TypeAccess |
-| delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt.extDelegated$delegate | delegatedProperties.kt:0:0:0:0 | <clinit> | VarAccess |
-| delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt.extDelegated$delegate | delegatedProperties.kt:87:31:87:46 | getExtDelegated | VarAccess |
-| delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt.extDelegated$delegate | delegatedProperties.kt:87:31:87:46 | setExtDelegated | VarAccess |
+| delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt.extDelegated$delegateMyClass | delegatedProperties.kt:0:0:0:0 | <clinit> | VarAccess |
+| delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt.extDelegated$delegateMyClass | delegatedProperties.kt:87:31:87:46 | getExtDelegated | VarAccess |
+| delegatedProperties.kt:87:31:87:46 | DelegatedPropertiesKt.extDelegated$delegateMyClass | delegatedProperties.kt:87:31:87:46 | setExtDelegated | VarAccess |
 | delegatedProperties.kt:87:31:87:46 | Integer | delegatedProperties.kt:87:31:87:46 | getExtDelegated | TypeAccess |
 | delegatedProperties.kt:87:31:87:46 | Integer | delegatedProperties.kt:87:31:87:46 | setExtDelegated | TypeAccess |
 | delegatedProperties.kt:87:31:87:46 | Integer | file://:0:0:0:0 | <none> | TypeAccess |


### PR DESCRIPTION
Otherwise we name the `$delegate` fields of `val A.x : String by lazy { "A" }` and `val B.x : String ...` alike, both in name and trap label.