### PR TITLE
Java: Update capture models meta data.

### DIFF
--- a/java/ql/src/utils/model-generator/CaptureSinkModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSinkModels.ql
@@ -1,7 +1,9 @@
 /**
  * @name Capture sink models.
  * @description Finds public methods that act as sinks as they flow into a a known sink.
+ * @kind diagnostic
  * @id java/utils/model-generator/sink-models
+ * @tags model-generator
  */
 
 private import internal.CaptureModels

--- a/java/ql/src/utils/model-generator/CaptureSourceModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSourceModels.ql
@@ -1,7 +1,9 @@
 /**
  * @name Capture source models.
  * @description Finds APIs that act as sources as they expose already known sources.
- * @id java/utils/model-generator/sink-models
+ * @kind diagnostic
+ * @id java/utils/model-generator/source-models
+ * @tags model-generator
  */
 
 private import internal.CaptureModels

--- a/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
+++ b/java/ql/src/utils/model-generator/CaptureSummaryModels.ql
@@ -1,7 +1,9 @@
 /**
  * @name Capture summary models.
  * @description Finds applicable summary models to be used by other queries.
+ * @kind diagnostic
  * @id java/utils/model-generator/summary-models
+ * @tags model-generator
  */
 
 private import internal.CaptureModels


### PR DESCRIPTION
The meta data for the capture models queries needs to be updated , such that they are
- Excluded from the many of standard selectors (model-generator tag).
- Kind is set to diagnostic which allows us to create a query suite that can be used with DCA.