### PR TITLE
Swift: Added Bazel install step.

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -4,7 +4,13 @@ The Swift codeql package is an experimental and unsupported work in progress.
 
 ## Usage
 
-Run
+First ensure you have Bazel installed, e.g. with
+
+```bash
+brew install bazelisk
+```
+
+then run
 
 ```bash
 bazel run //swift:create-extractor-pack


### PR DESCRIPTION
Add installing Bazel as a step to the Swift readme.  The step following this won't work without it.