### PR TITLE
Swift: CFG for `yield`

### DIFF
--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImpl.qll
@@ -203,6 +203,14 @@ module Stmts {
     }
   }
 
+  private class YieldStmtTree extends AstStandardPostOrderTree {
+    override YieldStmt ast;
+
+    final override ControlFlowElement getChildElement(int i) {
+      result.asAstNode() = ast.getResult(i).getFullyConverted()
+    }
+  }
+
   private class FailTree extends AstLeafTree {
     override FailStmt ast;
   }

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -5139,6 +5139,11 @@ cfg.swift:
 #  394| enter set
 #-----|  -> set
 
+#  394| exit (unnamed function decl)
+
+#  394| exit (unnamed function decl) (normal)
+#-----|  -> exit (unnamed function decl)
+
 #  394| exit get
 
 #  394| exit get (normal)
@@ -5155,6 +5160,9 @@ cfg.swift:
 #-----|  -> value
 
 #  394| value
+
+#  394| yield ...
+#-----|  -> exit (unnamed function decl) (normal)
 
 #  395| deinit
 #-----|  -> self


### PR DESCRIPTION
We could be a lot smarter about how we generate the CFG (and in the future: dataflow) for `yield` statements, but coroutines aren't actually supported at the user level yet (see https://forums.swift.org/t/modify-accessors/31872). It's still generated by the compiler, which is why I decided we shouldn't ignore it in the CFG.