### PR TITLE
JS: Fix cartesian product in TypeConfusionThroughParameterTampering

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/dataflow/TypeConfusionThroughParameterTamperingQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/TypeConfusionThroughParameterTamperingQuery.qll
@@ -40,9 +40,12 @@ private class TypeOfTestBarrier extends DataFlow::BarrierGuardNode, DataFlow::Va
   TypeOfTestBarrier() { TaintTracking::isTypeofGuard(astNode, _, _) }
 
   override predicate blocks(boolean outcome, Expr e) {
-    if TaintTracking::isTypeofGuard(astNode, e, ["string", "object"])
-    then outcome = [true, false] // separation between string/array removes type confusion in both branches
-    else outcome = astNode.getPolarity() // block flow to branch where value is neither string nor array
+    exists(string tag |
+      TaintTracking::isTypeofGuard(astNode, e, tag) and
+      if tag = ["string", "object"]
+      then outcome = [true, false] // separation between string/array removes type confusion in both branches
+      else outcome = astNode.getPolarity() // block flow to branch where value is neither string nor array
+    )
   }
 }
 


### PR DESCRIPTION
Fixes a major regression introduced by https://github.com/github/codeql/pull/9318. It was missed by the initial evaluation sine the regression was introduced during review comments, but was caught by the nightly evaluation runs.

The expression `e` was not bound in the `else` clause.