### PR TITLE
C++: Improve performance of Printf::callsVariadicFormatter.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Printf.qll
@@ -168,7 +168,7 @@ private predicate callsVariadicFormatter(
 ) {
   // calls a variadic formatter with `formatParamIndex`, `outputParamIndex` linked
   exists(FunctionCall fc, int format, int output |
-    variadicFormatter(fc.getTarget(), type, format, output) and
+    variadicFormatter(pragma[only_bind_into](fc.getTarget()), type, format, output) and
     fc.getEnclosingFunction() = f and
     fc.getArgument(format) = f.getParameter(formatParamIndex).getAnAccess() and
     fc.getArgument(output) = f.getParameter(outputParamIndex).getAnAccess()
@@ -176,7 +176,7 @@ private predicate callsVariadicFormatter(
   or
   // calls a variadic formatter with only `formatParamIndex` linked
   exists(FunctionCall fc, string calledType, int format, int output |
-    variadicFormatter(fc.getTarget(), calledType, format, output) and
+    variadicFormatter(pragma[only_bind_into](fc.getTarget()), calledType, format, output) and
     fc.getEnclosingFunction() = f and
     fc.getArgument(format) = f.getParameter(formatParamIndex).getAnAccess() and
     not fc.getArgument(output) = f.getParameter(_).getAnAccess() and


### PR DESCRIPTION
Improve performance of `cpp/cleartext-storage-buffer`, which regressed a month or so ago.  The difference isn't huge, though the fix is in library code so it could affect other queries as well.

Locally on `wireshark` (with cache warmed up by `cpp/system-data-exposure`) this change improves performance from 55s -> 45s.  It appears to have eliminated entirely the following pre-computation:

```
[2022-06-01 10:56:39] Evaluated non-recursive predicate Printf::callsVariadicFormatter#b0c2256f#bfff#join_rhs#1@3c8b9cg6 in 1308ms (size: 993161).
Tuple counts for Printf::callsVariadicFormatter#b0c2256f#bfff#join_rhs#1@3c8b9cg6:
         650340  ~1%    {4} r1 = SCAN Function::Function::getParameter#dispred#f0820431#bff OUTPUT In.2, -1, In.0, In.1
        1428098  ~6%    {4} r2 = JOIN r1 WITH Access::Access::getTarget#dispred#f0820431#ff_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, -1, Lhs.2, Lhs.3
         996581  ~0%    {5} r3 = JOIN r2 WITH Call::Call::getArgument#dispred#f0820431#fff_201#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.2, -1, Lhs.3, Rhs.2
         996566  ~2%    {5} r4 = JOIN r3 WITH Expr::Expr::getEnclosingFunction#dispred#f0820431#bb ON FIRST 2 OUTPUT Lhs.0, -1, Lhs.1, Lhs.3, Lhs.4
         993161  ~5%    {6} r5 = JOIN r4 WITH Call::FunctionCall::getTarget#dispred#f0820431#ff ON FIRST 1 OUTPUT Rhs.1, Lhs.4, -1, Lhs.2, Lhs.3, Lhs.0
                        return r5
```
seemingly without affecting the recusion - before:
```
[2022-06-01 10:56:51] Completed evaluation of a recursive layer containing 2 different predicates (took 70ms). Predicates evaluated:
Printf::callsVariadicFormatter#b0c2256f#bfff@0950fw3s (took 19ms) (size: 127)
Printf::variadicFormatter#b0c2256f#bfff@0950fx3s (took 48ms) (size: 54)
```
after:
```
[2022-06-01 11:42:23] Completed evaluation of a recursive layer containing 2 different predicates (took 52ms). Predicates evaluated:
Printf::callsVariadicFormatter#b0c2256f#ffff@0b44ewig (took 19ms) (size: 127)
Printf::variadicFormatter#b0c2256f#ffff@0b44exig (took 32ms) (size: 54)
```
Confirmed on `kamailio` 103s -> 96s.  I'll do a DCA run as well to check nothing is impacted negatively...